### PR TITLE
feat(activity): WorkspaceActivityEvent table + recordActivity helper (T3)

### DIFF
--- a/prisma/migrations/20260512211246_add_workspace_activity_event/migration.sql
+++ b/prisma/migrations/20260512211246_add_workspace_activity_event/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "WorkspaceActivityEvent" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "entityType" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WorkspaceActivityEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WorkspaceActivityEvent_workspaceId_createdAt_idx" ON "WorkspaceActivityEvent"("workspaceId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "WorkspaceActivityEvent_workspaceId_userId_createdAt_idx" ON "WorkspaceActivityEvent"("workspaceId", "userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "WorkspaceActivityEvent" ADD CONSTRAINT "WorkspaceActivityEvent_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkspaceActivityEvent" ADD CONSTRAINT "WorkspaceActivityEvent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -157,6 +157,8 @@ model User {
   recurringTasksCreated       RecurringTask[]             @relation("RecurringTaskCreator")
   // Project activity audit log
   projectActivitiesAuthored   ProjectActivity[]           @relation("ProjectActivityAuthor")
+  // Workspace home activity feed
+  workspaceActivityEvents     WorkspaceActivityEvent[]
 
   // Onboarding: Attribution
   attributionSource String? // "google", "twitter", "linkedin", "friend", "youtube", "podcast", "other"
@@ -335,9 +337,33 @@ model Workspace {
   reminderLogs                     ReminderLog[]
   pendingDriveUploads              PendingDriveUpload[]
 
+  // Workspace home activity feed
+  activityEvents WorkspaceActivityEvent[]
+
   @@index([slug])
   @@index([ownerId])
   @@index([type])
+}
+
+// Append-only log of significant workspace events.
+// Powers heatmap, activity feed, and weekly review sparkline. Writes are
+// fire-and-forget from call sites via `recordActivity()` — see
+// src/server/services/activity/.
+model WorkspaceActivityEvent {
+  id          String   @id @default(cuid())
+  workspaceId String
+  userId      String
+  entityType  String // "action" | "action_comment" | "ticket" | "ticket_comment"
+  entityId    String // intentionally not a foreign key — events outlive the entity
+  action      String // "created" | "updated" | "status_changed" | "completed" | "commented"
+  metadata    Json?
+  createdAt   DateTime @default(now())
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  user      User      @relation(fields: [userId], references: [id])
+
+  @@index([workspaceId, createdAt])
+  @@index([workspaceId, userId, createdAt])
 }
 
 model WorkspaceUser {

--- a/src/server/services/activity/__tests__/recordActivity.test.ts
+++ b/src/server/services/activity/__tests__/recordActivity.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for recordActivity — the load-bearing primitive that any future
+ * write site calls to log a workspace activity event.
+ *
+ * Uses mockDeep<PrismaClient>() so the test runs in milliseconds and CANNOT
+ * touch a real DB. The recordActivity helper accepts a db argument explicitly,
+ * which keeps these tests independent of `~/server/db` (no module mocking
+ * needed). Per CLAUDE.md "Test database safety", any test under
+ * `/services/` MUST stay mocked.
+ *
+ * We mock `~/env` rather than mutate process.env, because t3-env caches its
+ * Proxy at module-load time — stubbing process.env after the fact has no
+ * effect on the existing `env.NODE_ENV` value.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+// Mocked env — the test toggles fakeEnv.NODE_ENV directly. The mock factory
+// returns a getter so each access reads the current value.
+const fakeEnv = { NODE_ENV: "test" as "development" | "test" | "production" };
+vi.mock("~/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === "NODE_ENV") return fakeEnv.NODE_ENV;
+        return undefined;
+      },
+    },
+  ),
+}));
+
+import { recordActivity } from "../recordActivity";
+
+const dbMock: DeepMockProxy<PrismaClient> = mockDeep<PrismaClient>();
+
+describe("recordActivity", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockReset(dbMock);
+    fakeEnv.NODE_ENV = "test";
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      // silence
+    });
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      // silence
+    });
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("writes an event with the exact shape provided", async () => {
+    dbMock.workspaceActivityEvent.create.mockResolvedValue({
+      id: "evt-1",
+      workspaceId: "ws-1",
+      userId: "user-1",
+      entityType: "action",
+      entityId: "action-42",
+      action: "created",
+      metadata: { source: "test" },
+      createdAt: new Date(),
+    });
+
+    const ok = await recordActivity(dbMock, {
+      workspaceId: "ws-1",
+      userId: "user-1",
+      entityType: "action",
+      entityId: "action-42",
+      action: "created",
+      metadata: { source: "test" },
+    });
+
+    expect(ok).toBe(true);
+    expect(dbMock.workspaceActivityEvent.create).toHaveBeenCalledTimes(1);
+    expect(dbMock.workspaceActivityEvent.create).toHaveBeenCalledWith({
+      data: {
+        workspaceId: "ws-1",
+        userId: "user-1",
+        entityType: "action",
+        entityId: "action-42",
+        action: "created",
+        metadata: { source: "test" },
+      },
+    });
+  });
+
+  it("omitting metadata still writes the row", async () => {
+    dbMock.workspaceActivityEvent.create.mockResolvedValue({
+      id: "evt-2",
+      workspaceId: "ws-1",
+      userId: "user-1",
+      entityType: "ticket",
+      entityId: "ticket-9",
+      action: "status_changed",
+      metadata: null,
+      createdAt: new Date(),
+    });
+
+    const ok = await recordActivity(dbMock, {
+      workspaceId: "ws-1",
+      userId: "user-1",
+      entityType: "ticket",
+      entityId: "ticket-9",
+      action: "status_changed",
+    });
+
+    expect(ok).toBe(true);
+    const data = dbMock.workspaceActivityEvent.create.mock.calls[0]![0]!.data;
+    expect(data.metadata).toBeUndefined();
+  });
+
+  it("never throws to the caller when the DB write fails", async () => {
+    dbMock.workspaceActivityEvent.create.mockRejectedValue(
+      new Error("simulated DB failure"),
+    );
+
+    const ok = await recordActivity(dbMock, {
+      workspaceId: "ws-1",
+      userId: "user-1",
+      entityType: "action",
+      entityId: "action-1",
+      action: "updated",
+    });
+
+    expect(ok).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[recordActivity] failed to write event",
+      expect.objectContaining({ error: "simulated DB failure" }),
+    );
+  });
+
+  it("throws when workspaceId is missing in development", async () => {
+    fakeEnv.NODE_ENV = "development";
+
+    await expect(
+      recordActivity(dbMock, {
+        workspaceId: "",
+        userId: "user-1",
+        entityType: "action",
+        entityId: "action-1",
+        action: "created",
+      }),
+    ).rejects.toThrow(/workspaceId is required/);
+
+    expect(dbMock.workspaceActivityEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("logs and swallows when workspaceId is missing in production", async () => {
+    fakeEnv.NODE_ENV = "production";
+
+    const ok = await recordActivity(dbMock, {
+      workspaceId: "",
+      userId: "user-1",
+      entityType: "action",
+      entityId: "action-1",
+      action: "created",
+    });
+
+    expect(ok).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[recordActivity] missing workspaceId — skipping",
+      expect.objectContaining({ entityType: "action", entityId: "action-1" }),
+    );
+    expect(dbMock.workspaceActivityEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("logs and swallows when workspaceId is missing in test (non-dev fallback)", async () => {
+    fakeEnv.NODE_ENV = "test";
+
+    const ok = await recordActivity(dbMock, {
+      workspaceId: "",
+      userId: "user-1",
+      entityType: "action",
+      entityId: "action-1",
+      action: "created",
+    });
+
+    expect(ok).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(dbMock.workspaceActivityEvent.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/activity/recordActivity.ts
+++ b/src/server/services/activity/recordActivity.ts
@@ -1,0 +1,88 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import { env } from "~/env";
+
+/**
+ * Significant workspace events that feed the home-page heatmap, activity feed,
+ * and weekly-review sparkline. Each value is stored as the `action` column on
+ * `WorkspaceActivityEvent` — keep this list in sync with the column comment.
+ */
+export type ActivityAction =
+  | "created"
+  | "updated"
+  | "status_changed"
+  | "completed"
+  | "commented";
+
+/**
+ * Entity types we currently log activity for. New writers append new values
+ * here as they instrument additional surfaces.
+ */
+export type ActivityEntityType =
+  | "action"
+  | "action_comment"
+  | "ticket"
+  | "ticket_comment";
+
+export interface RecordActivityInput {
+  workspaceId: string;
+  userId: string;
+  entityType: ActivityEntityType;
+  entityId: string;
+  action: ActivityAction;
+  metadata?: Prisma.InputJsonValue;
+}
+
+/**
+ * Append one row to `WorkspaceActivityEvent`. This is a fire-and-forget
+ * primitive for write sites — it MUST NOT throw, because instrumentation
+ * failures should never break the user's mutation.
+ *
+ * Behavior:
+ * - Missing `workspaceId` is a programmer error. In development we throw to
+ *   make it loud during testing; in any other environment we log and swallow
+ *   so production users aren't blocked.
+ * - DB write failures are caught and logged; the caller's promise resolves
+ *   normally.
+ *
+ * Returns true on a successful write, false otherwise. Callers can ignore the
+ * return value — it exists for tests and observability.
+ */
+export async function recordActivity(
+  db: PrismaClient,
+  input: RecordActivityInput,
+): Promise<boolean> {
+  if (!input.workspaceId) {
+    if (env.NODE_ENV === "development") {
+      throw new Error(
+        "[recordActivity] workspaceId is required — instrumentation call site is missing it",
+      );
+    }
+    console.warn(
+      "[recordActivity] missing workspaceId — skipping",
+      { entityType: input.entityType, entityId: input.entityId, action: input.action },
+    );
+    return false;
+  }
+
+  try {
+    await db.workspaceActivityEvent.create({
+      data: {
+        workspaceId: input.workspaceId,
+        userId: input.userId,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        action: input.action,
+        metadata: input.metadata,
+      },
+    });
+    return true;
+  } catch (error) {
+    console.error("[recordActivity] failed to write event", {
+      entityType: input.entityType,
+      entityId: input.entityId,
+      action: input.action,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Slice 3 of 9 toward the Workspace Home — Activity Dashboard. Introduces the append-only activity log that the heatmap, feed, and weekly-review sparkline will all read from.

- New `WorkspaceActivityEvent` model with composite indexes `(workspaceId, createdAt)` and `(workspaceId, userId, createdAt)` matching the access patterns of downstream readers.
- `entityId` is intentionally NOT a foreign key — events outlive the entity they reference (e.g. a deleted action's "completed" event stays visible in the feed).
- `recordActivity()` service at `src/server/services/activity/recordActivity.ts` is the single write path. Future write sites (T7) call this; never write to the table directly.

## Helper guarantees

- **Never throws to its caller.** DB write failures are caught and logged so instrumentation can never break the user's mutation.
- **Missing workspaceId throws in development** (loud signal for devs writing new instrumentation), **logs-and-swallows** in test / production (don't break the user just because we lost the workspaceId).
- Returns `boolean` for tests and observability — callers can ignore.

## Branch state

Originally stacked on #113 (T1). Since T1 has now merged to `develop`, this branch was rebased onto `origin/develop` with `git rebase --onto origin/develop feat/workspace-home-layout-t1 feat/workspace-activity-event-t3` — dropping the duplicate T1 commit. The PR base is now `develop` directly, and the diff is a clean single commit.

## Test plan

- [x] 6 unit tests with mocked Prisma (`mockDeep<PrismaClient>()`) — happy path, missing-metadata path, DB-failure swallow, dev-throw, prod-swallow, test-env swallow
- [x] `npm run check` (typecheck + lint) passes
- [x] All 378 unit tests pass after rebase
- [x] Pre-commit hook: migration check + no-hardcoded-colors check pass

Closes Exponential ticket cmp33e2dy0005l5047xqiqzxi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)