### PR TITLE
feat(activity): WorkspaceActivityEvent backfill endpoint + service (T8)

### DIFF
--- a/src/server/api/routers/__tests__/workspace.integration.test.ts
+++ b/src/server/api/routers/__tests__/workspace.integration.test.ts
@@ -221,4 +221,40 @@ describe("workspace router", () => {
       expect(updated.homeLayout).toBe("activity");
     });
   });
+
+  describe("backfillActivity", () => {
+    it("owner can trigger backfill on an empty workspace", async () => {
+      const owner = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "bf-rpc-owner" });
+
+      const caller = createTestCaller(owner.id);
+      const result = await caller.workspace.backfillActivity({ workspaceId: ws.id });
+
+      expect(result.skipped).toBe(false);
+      expect(result.total).toBe(0);
+    });
+
+    it("admin cannot trigger backfill (owner-only)", async () => {
+      const owner = await createUser(db);
+      const admin = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "bf-rpc-admin" });
+      await addWorkspaceMember(db, ws.id, admin.id, "admin");
+
+      const adminCaller = createTestCaller(admin.id);
+      await expect(
+        adminCaller.workspace.backfillActivity({ workspaceId: ws.id }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it("non-member cannot trigger backfill", async () => {
+      const owner = await createUser(db);
+      const stranger = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "bf-rpc-stranger" });
+
+      const strangerCaller = createTestCaller(stranger.id);
+      await expect(
+        strangerCaller.workspace.backfillActivity({ workspaceId: ws.id }),
+      ).rejects.toThrow(TRPCError);
+    });
+  });
 });

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -10,6 +10,7 @@ import {
 import { sendTeamInvitationEmail } from "~/server/services/EmailService";
 import { uploadToBlob, deleteFromBlob } from "~/lib/blob";
 import { getWorkspaceHomeStats } from "~/server/services/activity/workspaceHomeStats";
+import { backfillWorkspaceActivity } from "~/server/services/activity/backfillActivity";
 
 export const workspaceRouter = createTRPCRouter({
   // API endpoint for browser extension - uses API key authentication
@@ -1361,6 +1362,42 @@ export const workspaceRouter = createTRPCRouter({
       return getWorkspaceHomeStats(ctx.db, {
         workspaceId: input.workspaceId,
         userId: ctx.session.user.id,
+      });
+    }),
+
+  // One-time backfill of WorkspaceActivityEvent from existing entity
+  // timestamps so the heatmap and activity feed look alive on day one.
+  // Owner-only; idempotent unless `force` is set. See
+  // `src/server/services/activity/backfillActivity.ts` for the source table
+  // mapping and metadata strategy.
+  backfillActivity: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        force: z.boolean().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const member = await ctx.db.workspaceUser.findUnique({
+        where: {
+          userId_workspaceId: {
+            userId: ctx.session.user.id,
+            workspaceId: input.workspaceId,
+          },
+        },
+        select: { role: true },
+      });
+
+      if (!member || member.role !== "owner") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only workspace owners can run the activity backfill",
+        });
+      }
+
+      return backfillWorkspaceActivity(ctx.db, {
+        workspaceId: input.workspaceId,
+        force: input.force,
       });
     }),
 });

--- a/src/server/services/activity/__tests__/backfillActivity.integration.test.ts
+++ b/src/server/services/activity/__tests__/backfillActivity.integration.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Integration tests for the WorkspaceActivityEvent backfill service.
+ *
+ * Uses the testcontainer Postgres set up by `~/test/test-db` — these tests
+ * exercise the real DB because the backfill writes timestamped rows in
+ * batches via Prisma's `createMany`, and we want to assert the persisted
+ * rows actually carry the correct `createdAt` values (which a mocked
+ * Prisma can't verify).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestDb } from "~/test/test-db";
+import { createUser, createWorkspace } from "~/test/factories";
+import { backfillWorkspaceActivity } from "../backfillActivity";
+
+describe("backfillWorkspaceActivity (integration)", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("emits a `completed` event for actions with completedAt", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id, slug: "bf-ws-1" });
+
+    const createdAt = new Date("2026-03-14T10:00:00Z");
+    const completedAt = new Date("2026-03-15T10:00:00Z");
+    await db.action.create({
+      data: {
+        name: "Old completed action",
+        status: "COMPLETED",
+        createdById: user.id,
+        workspaceId: ws.id,
+        createdAt,
+        completedAt,
+      },
+    });
+
+    const result = await backfillWorkspaceActivity(db, { workspaceId: ws.id });
+
+    expect(result.skipped).toBe(false);
+    expect(result.counts.action).toBe(1);
+    // Every action also gets a `created` event at its createdAt.
+    expect(result.counts.actionCreated).toBe(1);
+
+    const completedRows = await db.workspaceActivityEvent.findMany({
+      where: { workspaceId: ws.id, action: "completed" },
+    });
+    expect(completedRows).toHaveLength(1);
+    expect(completedRows[0]!.createdAt.toISOString()).toBe(completedAt.toISOString());
+    expect(completedRows[0]!.entityType).toBe("action");
+    expect(completedRows[0]!.userId).toBe(user.id);
+  });
+
+  it("emits a `created` event for every action at its createdAt", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id, slug: "bf-ws-2" });
+
+    const createdAt = new Date("2026-03-10T10:00:00Z");
+    // Open action — no completedAt
+    await db.action.create({
+      data: {
+        name: "Still open",
+        status: "ACTIVE",
+        createdById: user.id,
+        workspaceId: ws.id,
+        createdAt,
+      },
+    });
+
+    const result = await backfillWorkspaceActivity(db, { workspaceId: ws.id });
+
+    expect(result.counts.actionCreated).toBe(1);
+    expect(result.counts.action).toBe(0); // never completed
+
+    const createdRow = await db.workspaceActivityEvent.findFirst({
+      where: { workspaceId: ws.id, action: "created", entityType: "action" },
+    });
+    expect(createdRow?.createdAt.toISOString()).toBe(createdAt.toISOString());
+  });
+
+  it("scopes events to the correct workspace and doesn't cross over", async () => {
+    const userA = await createUser(db);
+    const userB = await createUser(db);
+    const wsA = await createWorkspace(db, { ownerId: userA.id, slug: "bf-ws-a" });
+    const wsB = await createWorkspace(db, { ownerId: userB.id, slug: "bf-ws-b" });
+
+    await db.action.create({
+      data: {
+        name: "A action",
+        status: "COMPLETED",
+        createdById: userA.id,
+        workspaceId: wsA.id,
+        createdAt: new Date("2026-03-31T10:00:00Z"),
+        completedAt: new Date("2026-04-01T10:00:00Z"),
+      },
+    });
+    await db.action.create({
+      data: {
+        name: "B action",
+        status: "COMPLETED",
+        createdById: userB.id,
+        workspaceId: wsB.id,
+        createdAt: new Date("2026-04-01T10:00:00Z"),
+        completedAt: new Date("2026-04-02T10:00:00Z"),
+      },
+    });
+
+    const resultA = await backfillWorkspaceActivity(db, { workspaceId: wsA.id });
+    expect(resultA.counts.action).toBe(1);
+    expect(resultA.counts.actionCreated).toBe(1);
+
+    // wsA should only have its own action; nothing from wsB
+    const wsARows = await db.workspaceActivityEvent.findMany({
+      where: { workspaceId: wsA.id },
+    });
+    expect(wsARows).toHaveLength(2); // one `created` + one `completed`
+
+    const wsBRows = await db.workspaceActivityEvent.findMany({
+      where: { workspaceId: wsB.id },
+    });
+    expect(wsBRows).toHaveLength(0);
+  });
+
+  it("is idempotent — second run is a no-op without `force`", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id, slug: "bf-ws-idem" });
+    await db.action.create({
+      data: {
+        name: "Once",
+        status: "COMPLETED",
+        createdById: user.id,
+        workspaceId: ws.id,
+        createdAt: new Date("2026-01-30T10:00:00Z"),
+        completedAt: new Date("2026-02-01T10:00:00Z"),
+      },
+    });
+
+    const first = await backfillWorkspaceActivity(db, { workspaceId: ws.id });
+    expect(first.skipped).toBe(false);
+    expect(first.total).toBeGreaterThan(0);
+
+    const second = await backfillWorkspaceActivity(db, { workspaceId: ws.id });
+    expect(second.skipped).toBe(true);
+    expect(second.total).toBe(0);
+
+    const rows = await db.workspaceActivityEvent.findMany({
+      where: { workspaceId: ws.id },
+    });
+    // No duplicates from the second run
+    expect(rows).toHaveLength(first.total);
+  });
+
+  it("`force: true` re-emits events even when rows already exist", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id, slug: "bf-ws-force" });
+    await db.action.create({
+      data: {
+        name: "Replay me",
+        status: "COMPLETED",
+        createdById: user.id,
+        workspaceId: ws.id,
+        createdAt: new Date("2026-01-14T10:00:00Z"),
+        completedAt: new Date("2026-01-15T10:00:00Z"),
+      },
+    });
+
+    const first = await backfillWorkspaceActivity(db, { workspaceId: ws.id });
+    expect(first.total).toBe(2); // one created + one completed
+
+    const forced = await backfillWorkspaceActivity(db, {
+      workspaceId: ws.id,
+      force: true,
+    });
+    expect(forced.skipped).toBe(false);
+    expect(forced.total).toBe(2);
+
+    // Both runs inserted rows — 4 total (no dedup key)
+    const rows = await db.workspaceActivityEvent.findMany({
+      where: { workspaceId: ws.id },
+    });
+    expect(rows).toHaveLength(4);
+  });
+
+  it("returns zero counts for an empty workspace", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id, slug: "bf-ws-empty" });
+
+    const result = await backfillWorkspaceActivity(db, { workspaceId: ws.id });
+
+    expect(result.skipped).toBe(false);
+    expect(result.total).toBe(0);
+    expect(result.counts).toEqual({
+      action: 0,
+      actionCreated: 0,
+      ticket: 0,
+      actionComment: 0,
+      ticketComment: 0,
+    });
+  });
+});

--- a/src/server/services/activity/backfillActivity.ts
+++ b/src/server/services/activity/backfillActivity.ts
@@ -1,0 +1,229 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+/**
+ * Per-entity counts produced by a backfill run. Sources that produced zero
+ * rows still appear in the summary so callers can tell "no actions in this
+ * workspace yet" from "we forgot to walk the table."
+ */
+export interface BackfillCounts {
+  action: number;
+  actionCreated: number;
+  ticket: number;
+  actionComment: number;
+  ticketComment: number;
+}
+
+export interface BackfillResult {
+  /** Total rows inserted into WorkspaceActivityEvent across all sources. */
+  total: number;
+  counts: BackfillCounts;
+  /** True when the workspace already had events and `force` wasn't set. */
+  skipped: boolean;
+}
+
+/** Batch size when calling `createMany` — keeps any single round-trip bounded. */
+const BATCH_SIZE = 500;
+
+interface BackfillRow {
+  workspaceId: string;
+  userId: string | null;
+  entityType: string;
+  entityId: string;
+  action: string;
+  metadata: Prisma.InputJsonValue;
+  createdAt: Date;
+}
+
+/**
+ * Insert rows in fixed-size batches via `createMany` so we don't hammer
+ * Postgres with a single 50k-row write on large workspaces.
+ */
+async function insertBatched(
+  db: PrismaClient,
+  rows: BackfillRow[],
+): Promise<number> {
+  if (rows.length === 0) return 0;
+  let inserted = 0;
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    const slice = rows.slice(i, i + BATCH_SIZE);
+    const res = await db.workspaceActivityEvent.createMany({ data: slice });
+    inserted += res.count;
+  }
+  return inserted;
+}
+
+/**
+ * One-time, idempotent backfill that seeds `WorkspaceActivityEvent` from the
+ * `completedAt` / `updatedAt` / `createdAt` of existing entities so the
+ * heatmap and activity feed look alive on day one rather than empty for the
+ * preceding twelve months.
+ *
+ * Idempotency:
+ * - If the workspace already has any `WorkspaceActivityEvent` rows, this is a
+ *   no-op and returns `{ skipped: true, ... }` with zero counts.
+ * - Pass `force: true` to re-emit even when rows exist. This MAY produce
+ *   duplicate rows; the table has no natural unique key for backfill
+ *   deduplication, so callers asking for `force` accept that.
+ *
+ * Metadata is sparse on purpose — backfilled rows are best-effort and don't
+ * try to reconstruct full provenance. Every row carries `{ backfilled: true }`
+ * plus the entity's name / title / parent id if cheaply derivable.
+ */
+export async function backfillWorkspaceActivity(
+  db: PrismaClient,
+  args: { workspaceId: string; force?: boolean },
+): Promise<BackfillResult> {
+  const { workspaceId } = args;
+  const force = args.force === true;
+
+  const empty: BackfillCounts = {
+    action: 0,
+    actionCreated: 0,
+    ticket: 0,
+    actionComment: 0,
+    ticketComment: 0,
+  };
+
+  if (!force) {
+    const existing = await db.workspaceActivityEvent.findFirst({
+      where: { workspaceId },
+      select: { id: true },
+    });
+    if (existing) {
+      return { total: 0, counts: empty, skipped: true };
+    }
+  }
+
+  // ── Walk Action rows ───────────────────────────────────────────────
+  // Actions can be scoped to the workspace directly OR inherit via project.
+  // The Action model has no `updatedAt`, so we can't honestly emit an
+  // `updated` event during backfill. We emit:
+  //   * `created` for every action (at its `createdAt`)
+  //   * `completed` for actions with `completedAt` set
+  // …which gives the heatmap real, verifiable signal without fabricating
+  // update events we can't actually time.
+  const actionRows = await db.action.findMany({
+    where: {
+      OR: [
+        { workspaceId },
+        { project: { workspaceId } },
+      ],
+    },
+    select: {
+      id: true,
+      name: true,
+      createdById: true,
+      createdAt: true,
+      completedAt: true,
+    },
+  });
+
+  const completedRows: BackfillRow[] = [];
+  const createdRows: BackfillRow[] = [];
+  for (const action of actionRows) {
+    createdRows.push({
+      workspaceId,
+      userId: action.createdById,
+      entityType: "action",
+      entityId: action.id,
+      action: "created",
+      metadata: { backfilled: true, name: action.name },
+      createdAt: action.createdAt,
+    });
+    if (action.completedAt) {
+      completedRows.push({
+        workspaceId,
+        userId: action.createdById,
+        entityType: "action",
+        entityId: action.id,
+        action: "completed",
+        metadata: { backfilled: true, name: action.name },
+        createdAt: action.completedAt,
+      });
+    }
+  }
+
+  // ── Walk Ticket rows ───────────────────────────────────────────────
+  const ticketRows = await db.ticket.findMany({
+    where: { product: { workspaceId } },
+    select: {
+      id: true,
+      title: true,
+      createdById: true,
+      assigneeId: true,
+      updatedAt: true,
+    },
+  });
+  const ticketEvents: BackfillRow[] = ticketRows.map((ticket) => ({
+    workspaceId,
+    // Prefer the assignee for "who touched it most recently"; fall back to
+    // the creator so userId is rarely null even pre-T7.
+    userId: ticket.assigneeId ?? ticket.createdById,
+    entityType: "ticket",
+    entityId: ticket.id,
+    action: "updated",
+    metadata: { backfilled: true, title: ticket.title },
+    createdAt: ticket.updatedAt,
+  }));
+
+  // ── Walk ActionComment rows ────────────────────────────────────────
+  const actionCommentRows = await db.actionComment.findMany({
+    where: {
+      action: {
+        OR: [{ workspaceId }, { project: { workspaceId } }],
+      },
+    },
+    select: {
+      id: true,
+      actionId: true,
+      authorId: true,
+      createdAt: true,
+    },
+  });
+  const actionCommentEvents: BackfillRow[] = actionCommentRows.map((comment) => ({
+    workspaceId,
+    userId: comment.authorId,
+    entityType: "action_comment",
+    entityId: comment.id,
+    action: "created",
+    metadata: { backfilled: true, actionId: comment.actionId },
+    createdAt: comment.createdAt,
+  }));
+
+  // ── Walk TicketComment rows ────────────────────────────────────────
+  const ticketCommentRows = await db.ticketComment.findMany({
+    where: { ticket: { product: { workspaceId } } },
+    select: {
+      id: true,
+      ticketId: true,
+      authorId: true,
+      createdAt: true,
+    },
+  });
+  const ticketCommentEvents: BackfillRow[] = ticketCommentRows.map((comment) => ({
+    workspaceId,
+    userId: comment.authorId,
+    entityType: "ticket_comment",
+    entityId: comment.id,
+    action: "created",
+    metadata: { backfilled: true, ticketId: comment.ticketId },
+    createdAt: comment.createdAt,
+  }));
+
+  const counts: BackfillCounts = {
+    action: await insertBatched(db, completedRows),
+    actionCreated: await insertBatched(db, createdRows),
+    ticket: await insertBatched(db, ticketEvents),
+    actionComment: await insertBatched(db, actionCommentEvents),
+    ticketComment: await insertBatched(db, ticketCommentEvents),
+  };
+
+  const total =
+    counts.action +
+    counts.actionCreated +
+    counts.ticket +
+    counts.actionComment +
+    counts.ticketComment;
+
+  return { total, counts, skipped: false };
+}


### PR DESCRIPTION
## Summary

Slice 8 of 9. Adds a one-time, idempotent backfill so the heatmap (T4) and activity feed (T5) look alive on day one rather than empty for the preceding twelve months.

## What ships

- **Service**: \`src/server/services/activity/backfillActivity.ts\` exports \`backfillWorkspaceActivity(db, { workspaceId, force? })\`.
- **tRPC**: \`workspace.backfillActivity({ workspaceId, force? })\` — owner-only.

## Sources walked

| Source | Timestamp | \`entityType\` | \`action\` |
|---|---|---|---|
| \`Action\` (always) | \`createdAt\` | \`action\` | \`created\` |
| \`Action\` (when set) | \`completedAt\` | \`action\` | \`completed\` |
| \`Ticket\` | \`updatedAt\` | \`ticket\` | \`updated\` |
| \`ActionComment\` | \`createdAt\` | \`action_comment\` | \`created\` |
| \`TicketComment\` | \`createdAt\` | \`ticket_comment\` | \`created\` |

### Deviation from spec

The spec proposed walking \`Action.updatedAt\` as well, but the \`Action\` model in this codebase has no \`updatedAt\` column. Emitting a \`created\` event at \`Action.createdAt\` is more honest than fabricating a fake \`updated\` timestamp from data we don't have. The summary count is named \`actionCreated\` accordingly.

## Idempotency + force

- Default behaviour: if any \`WorkspaceActivityEvent\` rows exist for the workspace, the run is a no-op and returns \`{ skipped: true, total: 0 }\`.
- \`force: true\` re-emits regardless. The table has no natural unique key for backfill dedup, so this can produce duplicates — callers asking for \`force\` explicitly opt into that.

## Permissions

Owner-only. Admins are deliberately excluded to keep this a deliberate owner action — easy to widen later if we need to. Existing role-string check matches the pattern in \`workspace.update\`.

## Batching

\`createMany\` inserts run in **500-row batches** (\`BATCH_SIZE = 500\`) so workspaces with thousands of source rows don't produce a single giant write.

## Tests

- **\`backfillActivity.integration.test.ts\`** (testcontainer Postgres, 6 cases):
  - \`completed\` event for actions with \`completedAt\`
  - \`created\` event for every action (open + completed)
  - Workspace scoping — wsA rows don't leak into wsB
  - Idempotency — second run returns \`skipped: true\` with no new rows
  - \`force: true\` re-emits (verifying duplicates land)
  - Empty workspace returns zero counts
- **Three new cases in \`workspace.integration.test.ts\`** for the tRPC permission gate: owner can run, admin cannot, non-member cannot.

## Test plan

- [x] \`npm run check\` clean
- [x] Integration tests pass on the testcontainer
- [x] No hardcoded hex (pre-commit color hook clean)
- [ ] Reviewer: pull and call \`api.workspace.backfillActivity.useMutation\` from a dev console on a workspace with completed actions; verify rows land at the expected historical timestamps and a second call returns \`{ skipped: true }\`.

Closes Exponential ticket cmp33e9zm000fl504cmpa0i3q.

🤖 Generated with [Claude Code](https://claude.com/claude-code)