### PR TITLE
feat(activity): real heatmap reader + 53x7 component (T4)

### DIFF
--- a/src/app/_components/home/activity/Heatmap.tsx
+++ b/src/app/_components/home/activity/Heatmap.tsx
@@ -2,6 +2,9 @@
 
 import { Skeleton, Tooltip } from '@mantine/core';
 import { IconActivity } from '@tabler/icons-react';
+import { useMemo, useRef, useState } from 'react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { api } from '~/trpc/react';
 
 const RANGES = [
   { key: 'week', label: 'Week' },
@@ -9,13 +12,51 @@ const RANGES = [
   { key: 'year', label: 'Year' },
 ] as const;
 
+interface TooltipState {
+  count: number;
+  date: string;
+  /** Pixel x in the scroll container. */
+  x: number;
+  /** Pixel y in the scroll container. */
+  y: number;
+}
+
+function formatDateForTip(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
 /**
- * Heatmap card placeholder. Renders the card chrome, the disabled
- * Week/Month/Year filter pills, and a single Skeleton bar where the
- * GitHub-style contribution graph will land.
+ * 12-month workspace activity heatmap. 53 columns × 7 rows.
+ *
+ * Data comes from `workspace.getActivityHeatmap` which counts every
+ * `WorkspaceActivityEvent` row in the window and buckets by day. The
+ * server emits a `HeatmapCell[]` with `level` (0–4) and `isToday`
+ * already computed; this component only handles rendering + tooltip
+ * state.
  */
 export function Heatmap() {
+  const { workspaceId } = useWorkspace();
   const activeRange: (typeof RANGES)[number]['key'] = 'year';
+
+  const { data, isLoading } = api.workspace.getActivityHeatmap.useQuery(
+    { workspaceId: workspaceId ?? '' },
+    { enabled: !!workspaceId },
+  );
+
+  const [tip, setTip] = useState<TooltipState | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const cells = data?.cells;
+  const total = data?.total ?? 0;
+
+  const headerCount = useMemo(() => {
+    if (!data) return null;
+    return total.toLocaleString();
+  }, [data, total]);
 
   return (
     <section className="wsa-card">
@@ -42,10 +83,81 @@ export function Heatmap() {
           </div>
         </Tooltip>
       </div>
-      <Skeleton height={140} />
-      <p className="wsa-card__caption" style={{ marginTop: 12 }}>
-        Coming soon — heatmap of your workspace activity over the last 12 months.
-      </p>
+
+      {isLoading || !cells ? (
+        <Skeleton height={140} />
+      ) : (
+        <div className="wsa-heatmap__scroll" ref={scrollRef}>
+          <div className="wsa-heatmap__grid">
+            {cells.map((c, i) => (
+              <button
+                type="button"
+                key={i}
+                className="wsa-heatmap__cell"
+                data-l={c.level}
+                data-today={c.isToday || undefined}
+                aria-label={`${c.count} ${c.count === 1 ? 'event' : 'events'} on ${formatDateForTip(c.date)}`}
+                onMouseEnter={(e) => {
+                  const cell = e.currentTarget;
+                  const container = scrollRef.current;
+                  if (!container) return;
+                  const cellRect = cell.getBoundingClientRect();
+                  const parentRect = container.getBoundingClientRect();
+                  setTip({
+                    count: c.count,
+                    date: formatDateForTip(c.date),
+                    x: cellRect.left - parentRect.left + cellRect.width / 2,
+                    y: cellRect.top - parentRect.top,
+                  });
+                }}
+                onMouseLeave={() => setTip(null)}
+                onFocus={(e) => {
+                  // Mirror mouseenter for keyboard users so the tooltip stays
+                  // accessible.
+                  e.currentTarget.dispatchEvent(
+                    new MouseEvent('mouseenter', { bubbles: false }),
+                  );
+                }}
+                onBlur={() => setTip(null)}
+              />
+            ))}
+          </div>
+          {tip ? (
+            <div
+              className="wsa-heatmap__tip"
+              style={{ left: tip.x, top: tip.y }}
+              role="status"
+            >
+              <strong>{tip.count}</strong>{' '}
+              {tip.count === 1 ? 'event' : 'events'} · {tip.date}
+            </div>
+          ) : null}
+        </div>
+      )}
+
+      <div className="wsa-heatmap__foot">
+        <div className="wsa-heatmap__total">
+          {data ? (
+            <>
+              <b>{headerCount}</b>{' '}
+              {total === 1 ? 'event' : 'events'} in the last 12 months
+            </>
+          ) : (
+            <span className="text-text-muted">—</span>
+          )}
+        </div>
+        <div className="wsa-heatmap__legend">
+          Less
+          <div className="wsa-heatmap__legend-cells">
+            <div className="wsa-heatmap__legend-cell" />
+            <div className="wsa-heatmap__legend-cell" data-l="1" />
+            <div className="wsa-heatmap__legend-cell" data-l="2" />
+            <div className="wsa-heatmap__legend-cell" data-l="3" />
+            <div className="wsa-heatmap__legend-cell" data-l="4" />
+          </div>
+          More
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/app/_components/home/activity/activity-home.css
+++ b/src/app/_components/home/activity/activity-home.css
@@ -367,6 +367,110 @@
 }
 
 /* --------------------------------------------------------------------------
+   HEATMAP
+   -------------------------------------------------------------------------- */
+.wsa-heatmap__scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  margin: 0 -2px;
+  padding: 0 2px;
+  position: relative;
+}
+
+.wsa-heatmap__grid {
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(7, 12px);
+  gap: 3px;
+  min-width: 825px;
+  position: relative;
+}
+
+.wsa-heatmap__cell {
+  width: 12px;
+  height: 12px;
+  border-radius: 2.5px;
+  background: var(--color-surface-muted);
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+}
+.wsa-heatmap__cell:hover {
+  outline: 1px solid var(--color-text-secondary);
+  outline-offset: 1px;
+}
+.wsa-heatmap__cell[data-l='1'] { background: var(--activity-heatmap-l1); }
+.wsa-heatmap__cell[data-l='2'] { background: var(--activity-heatmap-l2); }
+.wsa-heatmap__cell[data-l='3'] { background: var(--activity-heatmap-l3); }
+.wsa-heatmap__cell[data-l='4'] { background: var(--activity-heatmap-l4); }
+
+.wsa-heatmap__cell[data-today='true'] {
+  box-shadow: inset 0 0 0 1.5px var(--color-brand-primary);
+  animation: wsa-heatmap-pulse 2.8s ease-in-out infinite;
+}
+
+@keyframes wsa-heatmap-pulse {
+  0%, 100% { box-shadow: inset 0 0 0 1.5px var(--color-brand-primary), 0 0 0 0 var(--color-brand-subtle); }
+  50%      { box-shadow: inset 0 0 0 1.5px var(--color-brand-primary), 0 0 0 4px transparent; }
+}
+
+.wsa-heatmap__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 14px;
+  font-size: 11.5px;
+  color: var(--color-text-secondary);
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.wsa-heatmap__total b {
+  color: var(--color-text-primary);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.wsa-heatmap__legend {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-text-muted);
+  font-size: 11px;
+}
+
+.wsa-heatmap__legend-cells { display: flex; gap: 3px; }
+
+.wsa-heatmap__legend-cell {
+  width: 11px;
+  height: 11px;
+  border-radius: 2.5px;
+  background: var(--color-surface-muted);
+}
+.wsa-heatmap__legend-cell[data-l='1'] { background: var(--activity-heatmap-l1); }
+.wsa-heatmap__legend-cell[data-l='2'] { background: var(--activity-heatmap-l2); }
+.wsa-heatmap__legend-cell[data-l='3'] { background: var(--activity-heatmap-l3); }
+.wsa-heatmap__legend-cell[data-l='4'] { background: var(--activity-heatmap-l4); }
+
+.wsa-heatmap__tip {
+  position: absolute;
+  pointer-events: none;
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-primary);
+  padding: 6px 9px;
+  border-radius: 5px;
+  font-size: 11.5px;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  z-index: 30;
+  transform: translate(-50%, calc(-100% - 8px));
+}
+.wsa-heatmap__tip strong {
+  color: var(--color-brand-primary);
+  font-weight: 600;
+}
+
+/* --------------------------------------------------------------------------
    Reduced motion
    -------------------------------------------------------------------------- */
 @media (prefers-reduced-motion: reduce) {

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -11,6 +11,7 @@ import { sendTeamInvitationEmail } from "~/server/services/EmailService";
 import { uploadToBlob, deleteFromBlob } from "~/lib/blob";
 import { getWorkspaceHomeStats } from "~/server/services/activity/workspaceHomeStats";
 import { backfillWorkspaceActivity } from "~/server/services/activity/backfillActivity";
+import { getActivityHeatmap } from "~/server/services/activity/heatmap";
 
 export const workspaceRouter = createTRPCRouter({
   // API endpoint for browser extension - uses API key authentication
@@ -1399,5 +1400,38 @@ export const workspaceRouter = createTRPCRouter({
         workspaceId: input.workspaceId,
         force: input.force,
       });
+    }),
+
+  // 12-month activity heatmap for the Activity-layout workspace home.
+  // Returns 371 cells (53 weeks × 7 days) ending at "today", with each
+  // cell's level computed from quartiles of non-zero days in the window.
+  getActivityHeatmap: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const member = await ctx.db.workspaceUser.findUnique({
+        where: {
+          userId_workspaceId: {
+            userId: ctx.session.user.id,
+            workspaceId: input.workspaceId,
+          },
+        },
+        select: { role: true },
+      });
+
+      if (!member) {
+        const teamBased = await getWorkspaceMembership(
+          ctx.db,
+          ctx.session.user.id,
+          input.workspaceId,
+        );
+        if (!teamBased) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "You are not a member of this workspace",
+          });
+        }
+      }
+
+      return getActivityHeatmap(ctx.db, { workspaceId: input.workspaceId });
     }),
 });

--- a/src/server/services/activity/__tests__/heatmap.integration.test.ts
+++ b/src/server/services/activity/__tests__/heatmap.integration.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Integration test for getActivityHeatmap. Uses the testcontainer Postgres
+ * because the reader runs `SELECT date_trunc('day', ...) GROUP BY day` and
+ * we want to assert the per-day bucketing against real DB rows.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestDb } from "~/test/test-db";
+import { createUser, createWorkspace } from "~/test/factories";
+import { getActivityHeatmap } from "../heatmap";
+
+async function seedEvent(
+  db: ReturnType<typeof getTestDb>,
+  args: {
+    workspaceId: string;
+    userId: string;
+    createdAt: Date;
+    entityType?: string;
+    action?: string;
+  },
+) {
+  return db.workspaceActivityEvent.create({
+    data: {
+      workspaceId: args.workspaceId,
+      userId: args.userId,
+      entityType: args.entityType ?? "action",
+      entityId: `e-${Math.random().toString(36).slice(2, 10)}`,
+      action: args.action ?? "created",
+      createdAt: args.createdAt,
+    },
+  });
+}
+
+describe("getActivityHeatmap (integration)", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("buckets events by day inside the 12-month window", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id, slug: "hm-bucket" });
+    // Fix "now" to anchor the window deterministically.
+    const now = new Date("2026-05-13T12:00:00Z");
+
+    // Three events on the same day, two on another day, one outside the window.
+    const dayA = new Date("2026-05-10T10:00:00Z");
+    const dayB = new Date("2026-04-01T09:00:00Z");
+    const wayOld = new Date("2025-01-01T09:00:00Z"); // ~16 months ago, outside
+
+    await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: dayA });
+    await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: dayA });
+    await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: dayA });
+    await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: dayB });
+    await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: dayB });
+    await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: wayOld });
+
+    const { cells, total } = await getActivityHeatmap(db, {
+      workspaceId: ws.id,
+      now,
+    });
+
+    // The window holds exactly 371 days (53 weeks × 7).
+    expect(cells).toHaveLength(371);
+    // Total counts only events inside the window — the ~16-month-old event is excluded.
+    expect(total).toBe(5);
+
+    // Specific day buckets land on the right cells.
+    const dayACell = cells.find(
+      (c) => c.date.toISOString().slice(0, 10) === "2026-05-10",
+    );
+    const dayBCell = cells.find(
+      (c) => c.date.toISOString().slice(0, 10) === "2026-04-01",
+    );
+    expect(dayACell?.count).toBe(3);
+    expect(dayBCell?.count).toBe(2);
+    expect(dayACell?.level).toBe(4); // bigger than dayB → top bucket
+    expect(dayBCell?.level).toBeGreaterThan(0);
+  });
+
+  it("scopes counts to the right workspace (no leakage)", async () => {
+    const user = await createUser(db);
+    const wsA = await createWorkspace(db, { ownerId: user.id, slug: "hm-a" });
+    const wsB = await createWorkspace(db, { ownerId: user.id, slug: "hm-b" });
+    const now = new Date("2026-05-13T12:00:00Z");
+
+    await seedEvent(db, {
+      workspaceId: wsA.id,
+      userId: user.id,
+      createdAt: new Date("2026-05-10T10:00:00Z"),
+    });
+    await seedEvent(db, {
+      workspaceId: wsB.id,
+      userId: user.id,
+      createdAt: new Date("2026-05-10T10:00:00Z"),
+    });
+    await seedEvent(db, {
+      workspaceId: wsB.id,
+      userId: user.id,
+      createdAt: new Date("2026-05-11T10:00:00Z"),
+    });
+
+    const resultA = await getActivityHeatmap(db, {
+      workspaceId: wsA.id,
+      now,
+    });
+    expect(resultA.total).toBe(1);
+
+    const resultB = await getActivityHeatmap(db, {
+      workspaceId: wsB.id,
+      now,
+    });
+    expect(resultB.total).toBe(2);
+  });
+
+  it("returns 371 empty cells for a workspace with no events", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id, slug: "hm-empty" });
+
+    const result = await getActivityHeatmap(db, {
+      workspaceId: ws.id,
+      now: new Date("2026-05-13T12:00:00Z"),
+    });
+
+    expect(result.cells).toHaveLength(371);
+    expect(result.total).toBe(0);
+    expect(result.cells.every((c) => c.level === 0)).toBe(true);
+  });
+
+  it("counts events from any entityType/action combination", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id, slug: "hm-mixed" });
+    const now = new Date("2026-05-13T12:00:00Z");
+    const dayInWindow = new Date("2026-05-10T10:00:00Z");
+
+    // One of each known entity/action pair, all on the same day.
+    await seedEvent(db, {
+      workspaceId: ws.id,
+      userId: user.id,
+      createdAt: dayInWindow,
+      entityType: "action",
+      action: "completed",
+    });
+    await seedEvent(db, {
+      workspaceId: ws.id,
+      userId: user.id,
+      createdAt: dayInWindow,
+      entityType: "ticket",
+      action: "status_changed",
+    });
+    await seedEvent(db, {
+      workspaceId: ws.id,
+      userId: user.id,
+      createdAt: dayInWindow,
+      entityType: "action_comment",
+      action: "created",
+    });
+
+    const { total } = await getActivityHeatmap(db, {
+      workspaceId: ws.id,
+      now,
+    });
+    expect(total).toBe(3);
+  });
+});

--- a/src/server/services/activity/__tests__/heatmap.test.ts
+++ b/src/server/services/activity/__tests__/heatmap.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the heatmap level calculator. Pure function — no DB,
+ * no mocked Prisma. Verifies the level-bucketing rules in isolation
+ * before the reader service composes them with real counts.
+ */
+
+import { describe, it, expect } from "vitest";
+import { calculateLevels } from "../heatmap";
+
+const day = (iso: string): Date => new Date(`${iso}T00:00:00Z`);
+
+describe("calculateLevels", () => {
+  it("returns all level 0 when every cell has count 0", () => {
+    const cells = [
+      { date: day("2026-01-01"), count: 0 },
+      { date: day("2026-01-02"), count: 0 },
+      { date: day("2026-01-03"), count: 0 },
+    ];
+    const result = calculateLevels(cells, { now: day("2026-01-03") });
+    expect(result.map((c) => c.level)).toEqual([0, 0, 0]);
+  });
+
+  it("buckets uniform non-zero counts into L4 (saturated)", () => {
+    const cells = [
+      { date: day("2026-01-01"), count: 5 },
+      { date: day("2026-01-02"), count: 5 },
+      { date: day("2026-01-03"), count: 5 },
+    ];
+    const result = calculateLevels(cells, { now: day("2026-01-03") });
+    expect(result.map((c) => c.level)).toEqual([4, 4, 4]);
+  });
+
+  it("never buckets a zero-count day into a non-zero level", () => {
+    const cells = [
+      { date: day("2026-01-01"), count: 0 },
+      { date: day("2026-01-02"), count: 100 },
+      { date: day("2026-01-03"), count: 0 },
+    ];
+    const result = calculateLevels(cells, { now: day("2026-01-03") });
+    expect(result[0]!.level).toBe(0);
+    expect(result[2]!.level).toBe(0);
+    // Only one non-zero day → uniform → L4
+    expect(result[1]!.level).toBe(4);
+  });
+
+  it("distributes a 1-to-4 spread across L1–L4", () => {
+    const cells = [
+      { date: day("2026-01-01"), count: 1 }, // min → L1
+      { date: day("2026-01-02"), count: 2 },
+      { date: day("2026-01-03"), count: 3 },
+      { date: day("2026-01-04"), count: 4 }, // max → L4
+    ];
+    const result = calculateLevels(cells, { now: day("2026-01-04") });
+    const levels = result.map((c) => c.level);
+    expect(levels[0]).toBe(1);
+    expect(levels[3]).toBe(4);
+    // L1 ≤ rest ≤ L4 monotonically
+    expect(levels[1]).toBeGreaterThanOrEqual(levels[0]!);
+    expect(levels[2]).toBeGreaterThanOrEqual(levels[1]!);
+    expect(levels[3]).toBeGreaterThanOrEqual(levels[2]!);
+  });
+
+  it("buckets the top of the range into L4 even with outliers", () => {
+    const cells = [
+      { date: day("2026-01-01"), count: 1 },
+      { date: day("2026-01-02"), count: 1 },
+      { date: day("2026-01-03"), count: 100 }, // outlier → still L4
+    ];
+    const result = calculateLevels(cells, { now: day("2026-01-03") });
+    expect(result[2]!.level).toBe(4);
+  });
+
+  it("flags today's cell with isToday=true and only that cell", () => {
+    const today = day("2026-05-13");
+    const cells = [
+      { date: day("2026-05-12"), count: 2 },
+      { date: day("2026-05-13"), count: 3 },
+      { date: day("2026-05-14"), count: 1 },
+    ];
+    const result = calculateLevels(cells, { now: today });
+    const flags = result.map((c) => c.isToday);
+    expect(flags).toEqual([false, true, false]);
+  });
+
+  it("preserves input ordering and count values", () => {
+    const cells = [
+      { date: day("2026-01-01"), count: 7 },
+      { date: day("2026-01-02"), count: 0 },
+      { date: day("2026-01-03"), count: 3 },
+    ];
+    const result = calculateLevels(cells, { now: day("2026-01-03") });
+    expect(result.map((c) => c.count)).toEqual([7, 0, 3]);
+    expect(result.map((c) => c.date.toISOString())).toEqual([
+      cells[0]!.date.toISOString(),
+      cells[1]!.date.toISOString(),
+      cells[2]!.date.toISOString(),
+    ]);
+  });
+});

--- a/src/server/services/activity/heatmap.ts
+++ b/src/server/services/activity/heatmap.ts
@@ -1,0 +1,182 @@
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * One day of the activity heatmap. `level` 0 = no events, 1–4 = quartile
+ * bucket of non-zero days within the queried window.
+ */
+export interface HeatmapCell {
+  /** Calendar date the cell represents (midnight UTC). */
+  date: Date;
+  /** Number of events on this day. */
+  count: number;
+  /** Visual intensity bucket. 0 = empty. */
+  level: 0 | 1 | 2 | 3 | 4;
+  /** True for the cell representing "today" in the caller's local timezone. */
+  isToday: boolean;
+}
+
+interface RawCell {
+  date: Date;
+  count: number;
+}
+
+/**
+ * Convert a raw per-day count array into a level-bucketed array suitable for
+ * heatmap rendering. Pure function — no DB, no timezone tricks. Designed to
+ * be re-used by callers that have their own count data (CSV import,
+ * mocks, etc).
+ *
+ * Algorithm:
+ * - count === 0 → level 0
+ * - count > 0 → quartile bucket of non-zero counts (1, 2, 3, or 4)
+ *
+ * Quartile boundaries use linear interpolation between min and max of the
+ * non-zero set so the heatmap "feels right" regardless of absolute scale:
+ * a workspace logging 1–4 events/day uses the full L1–L4 palette just like
+ * one logging 100–400. Uniform non-zero counts all bucket to L4 (saturated).
+ */
+export function calculateLevels(
+  cells: RawCell[],
+  options?: { now?: Date },
+): HeatmapCell[] {
+  const now = options?.now ?? new Date();
+  const todayKey = isoDayKey(now);
+
+  const nonZeroCounts = cells
+    .map((c) => c.count)
+    .filter((n): n is number => n > 0);
+
+  if (nonZeroCounts.length === 0) {
+    return cells.map((c) => ({
+      date: c.date,
+      count: c.count,
+      level: 0,
+      isToday: isoDayKey(c.date) === todayKey,
+    }));
+  }
+
+  const min = Math.min(...nonZeroCounts);
+  const max = Math.max(...nonZeroCounts);
+
+  // Uniform counts (min === max) → every non-zero day is L4 (the max bucket).
+  if (min === max) {
+    return cells.map((c) => ({
+      date: c.date,
+      count: c.count,
+      level: c.count === 0 ? 0 : 4,
+      isToday: isoDayKey(c.date) === todayKey,
+    }));
+  }
+
+  // Bucket size: split (max - min) into four equal slices. Edge case: when
+  // counts are very tightly clustered we still want every bucket reachable,
+  // so we use ceil so the top of the range always lands in L4.
+  const span = max - min;
+  const sliceSize = span / 4;
+
+  return cells.map((c) => {
+    let level: 0 | 1 | 2 | 3 | 4 = 0;
+    if (c.count > 0) {
+      const normalised = c.count - min;
+      // Linear interpolation: place each non-zero count into one of 4
+      // contiguous buckets [min, min+slice), [min+slice, min+2*slice), …
+      const bucket = Math.min(3, Math.floor(normalised / sliceSize));
+      level = (bucket + 1) as 1 | 2 | 3 | 4;
+    }
+    return {
+      date: c.date,
+      count: c.count,
+      level,
+      isToday: isoDayKey(c.date) === todayKey,
+    };
+  });
+}
+
+/** YYYY-MM-DD in UTC. Used purely as a same-day equality key. */
+function isoDayKey(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = `${d.getUTCMonth() + 1}`.padStart(2, "0");
+  const day = `${d.getUTCDate()}`.padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Build the 53-week × 7-day window anchored at "today's local midnight",
+ * filling unseen days with count 0. Returned in row-major (week-by-week)
+ * order so the renderer can flow it column-by-column.
+ */
+function buildWindow(
+  countsByDay: Map<string, number>,
+  now: Date,
+): RawCell[] {
+  const today = new Date(now);
+  today.setUTCHours(0, 0, 0, 0);
+
+  // 371 = 53 * 7. We render an exact GitHub-style grid.
+  const totalDays = 371;
+  const start = new Date(today.getTime() - (totalDays - 1) * (WEEK_MS / 7));
+
+  const cells: RawCell[] = [];
+  for (let i = 0; i < totalDays; i++) {
+    const date = new Date(start.getTime() + i * (WEEK_MS / 7));
+    const key = isoDayKey(date);
+    cells.push({ date, count: countsByDay.get(key) ?? 0 });
+  }
+  return cells;
+}
+
+export interface HeatmapData {
+  cells: HeatmapCell[];
+  /** Sum of `count` across every cell in the window. */
+  total: number;
+  /** Inclusive window boundaries — useful for the card subtitle. */
+  range: { start: Date; end: Date };
+}
+
+/**
+ * Reader service for the 12-month heatmap card. Counts every
+ * `WorkspaceActivityEvent` in the window — regardless of `entityType` /
+ * `action` — and buckets them into 53 × 7 cells via `calculateLevels`.
+ *
+ * Workspace scoping is enforced by the prisma query: events from other
+ * workspaces never enter the count.
+ */
+export async function getActivityHeatmap(
+  db: PrismaClient,
+  args: { workspaceId: string; now?: Date },
+): Promise<HeatmapData> {
+  const now = args.now ?? new Date();
+  const end = new Date(now);
+  end.setUTCHours(0, 0, 0, 0);
+
+  const start = new Date(end.getTime() - 370 * (WEEK_MS / 7));
+
+  // Raw SQL is necessary because Prisma doesn't expose `date_trunc` and we
+  // want server-side day-bucketing rather than fetching every row.
+  // Workspace scope is parameterised — no string interpolation.
+  const rows = await db.$queryRaw<Array<{ day: Date; count: bigint }>>`
+    SELECT date_trunc('day', "createdAt") AS day,
+           COUNT(*)::bigint AS count
+    FROM "WorkspaceActivityEvent"
+    WHERE "workspaceId" = ${args.workspaceId}
+      AND "createdAt" >= ${start}
+      AND "createdAt" < ${new Date(end.getTime() + WEEK_MS / 7)}
+    GROUP BY day
+  `;
+
+  const countsByDay = new Map<string, number>();
+  for (const row of rows) {
+    countsByDay.set(isoDayKey(row.day), Number(row.count));
+  }
+
+  const cells = calculateLevels(buildWindow(countsByDay, now), { now });
+  const total = cells.reduce((acc, c) => acc + c.count, 0);
+
+  return {
+    cells,
+    total,
+    range: { start, end },
+  };
+}


### PR DESCRIPTION
## Summary

Slice 4 of 9. Replaces the heatmap skeleton from T2 with a real 12-month activity heatmap that reads from \`WorkspaceActivityEvent\`. Three layers — pure calculator, reader service, component — each with their own tests.

## Layers

### 1. Pure level calculator — \`calculateLevels(cells)\`

In \`src/server/services/activity/heatmap.ts\`. Buckets per-day counts into levels 0–4 via quartile ranges of non-zero days:

- count === 0 → L0
- A single non-zero day → L4 (saturated)
- Spread inputs use linear interpolation across (max − min)
- Outliers pull the rest down but the max always lands in L4

Pure function, no DB, no timezone tricks — fully unit-testable.

### 2. Reader — \`getActivityHeatmap(db, { workspaceId, now? })\`

Runs \`SELECT date_trunc('day', "createdAt") GROUP BY day\` parameterised on \`workspaceId\` (raw SQL — Prisma doesn't expose \`date_trunc\`). Builds the 371-cell (53 weeks × 7 days) window ending at "today", fills unseen days with 0, runs the result through \`calculateLevels\`. Workspace scoping enforced at the SQL level.

### 3. tRPC — \`workspace.getActivityHeatmap\`

Member-gated query, falls back to team-based access for guest project members (same pattern as \`getHomeStats\`).

### 4. Heatmap component

Replaces the skeleton card with:

- 12×12 cells, 2.5px radius, 3px gap. Colours bound to \`--activity-heatmap-l1..l4\` tokens added in T2.
- Hover tooltip: \`<count> events · Month Day, Year\`, absolute-positioned via \`getBoundingClientRect\`.
- Today's cell has a pulsing inset border. Suppressed by the existing \`prefers-reduced-motion\` rule.
- Horizontal scroll on narrow viewports (min-width: 825px on the grid) so the contribution graph doesn't get squashed.
- Footer: total count on the left, Less–More legend on the right.

Heatmap counts events regardless of \`entityType\` — it's a general "how active was this workspace" signal, not a filter view. Week/Month/Year filter pills remain disabled in \`<Tooltip label="Coming soon">\` for now.

## Tests

### Unit (mocked Prisma, 7 cases) — \`heatmap.test.ts\`

- Empty input → all L0
- Uniform non-zero counts → all L4
- Zero days never bucket non-zero
- 1-to-4 spread → L1..L4 monotonically
- Outliers always reach L4
- Today flag unique to today's cell
- Input ordering + counts preserved

### Integration (testcontainer, 4 cases) — \`heatmap.integration.test.ts\`

- Events bucket by day; total counts only events in window
- Workspace scoping — wsA rows don't leak into wsB
- Empty workspaces return 371 cells all at L0
- Any \`entityType\`/\`action\` combination counts

## Test plan

- [x] \`npm run check\` clean
- [x] 13 activity unit tests pass (7 new + 6 existing)
- [x] Integration tests pass on testcontainer
- [x] No hardcoded hex
- [ ] Reviewer (manual): switch a workspace to "Activity dashboard", verify the heatmap renders with the right colours; hover cells to see tooltips; today's cell pulses; resize narrow to confirm horizontal scroll engages.

Closes Exponential ticket cmp33e3vn0007l504eeuu991r.

🤖 Generated with [Claude Code](https://claude.com/claude-code)