### PR TITLE
feat(activity): real Week-in-Review sparkline + multi-week stats (T6)

### DIFF
--- a/src/app/_components/home/activity/WeekInReview.tsx
+++ b/src/app/_components/home/activity/WeekInReview.tsx
@@ -1,17 +1,101 @@
 'use client';
 
 import { Button, Group, Skeleton, Tooltip } from '@mantine/core';
-import { IconChartBar, IconSparkles } from '@tabler/icons-react';
+import {
+  IconChartBar,
+  IconSparkles,
+  IconTrendingDown,
+  IconTrendingUp,
+} from '@tabler/icons-react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { api } from '~/trpc/react';
+
+const FMT_DATE = (d: Date) =>
+  d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 
 /**
- * Skeleton placeholder for the Week-in-Review card. Real data wires in
- * slice 6 — for T2 we render layout chrome plus skeletons so the home page
- * shows the full shape immediately.
+ * Compute the Mon → Sun range string for the current ISO week. Mirrors the
+ * boundaries used by `getWorkspaceHomeStats.weeklySparkline`.
+ */
+function currentWeekRange(now: Date): string {
+  const day = now.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+  // Days to go back to reach Monday (ISO week start).
+  const diffToMon = day === 0 ? -6 : 1 - day;
+  const monday = new Date(now);
+  monday.setDate(now.getDate() + diffToMon);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  return `${FMT_DATE(monday)} – ${FMT_DATE(sunday)}`;
+}
+
+interface WeeklyHeadlineProps {
+  total: number;
+  delta: number;
+}
+
+function WeeklyDelta({ delta }: { delta: number }) {
+  if (delta > 0) {
+    return (
+      <span className="wsa-week__delta wsa-week__delta--up">
+        <IconTrendingUp size={11} stroke={1.8} />+{delta} vs last week
+      </span>
+    );
+  }
+  if (delta < 0) {
+    return (
+      <span className="wsa-week__delta wsa-week__delta--down">
+        <IconTrendingDown size={11} stroke={1.8} />
+        {delta} vs last week
+      </span>
+    );
+  }
+  return <span className="wsa-week__delta wsa-week__delta--flat">steady</span>;
+}
+
+function WeeklyHeadline({ total, delta }: WeeklyHeadlineProps) {
+  return (
+    <div className="wsa-week__headline">
+      <span className="wsa-week__num">{total}</span>
+      <span className="wsa-week__num-label">
+        {total === 1 ? 'event this week' : 'events this week'}
+      </span>
+      <WeeklyDelta delta={delta} />
+    </div>
+  );
+}
+
+/**
+ * Week-in-Review card: weekly headline + delta pill, 7-day sparkline, and
+ * compare-row (last week / 4-week avg / best week).
  *
- * The two CTAs are wrapped in `Tooltip` and disabled to telegraph that the
- * surface is still coming.
+ * Narrative paragraph + 3 highlight rows are intentionally still skeletons
+ * — AI narration is out of scope for slice T6 and ships as its own slice
+ * later. Disabled CTAs telegraph that the surface is half-built.
+ *
+ * Data: `workspace.getHomeStats.weeklySparkline` + multi-week totals.
+ * All values come from `WorkspaceActivityEvent` daily aggregation.
  */
 export function WeekInReview() {
+  const { workspaceId } = useWorkspace();
+  const { data, isLoading } = api.workspace.getHomeStats.useQuery(
+    { workspaceId: workspaceId ?? '' },
+    { enabled: !!workspaceId },
+  );
+
+  const showSkeleton = isLoading || !data;
+  const range = currentWeekRange(new Date());
+
+  const sparkline = data?.weeklySparkline ?? [];
+  const sparkMax =
+    sparkline.length === 0 ? 0 : Math.max(...sparkline.map((b) => b.count));
+  const peakDay = sparkline.find((b) => b.count > 0 && b.count === sparkMax);
+
+  // Total events this week = sum of the sparkline. We don't reuse
+  // thisWeek.completed (DailyScore) here because the eyebrow card is
+  // tracking workspace activity, not the user's planned/completed task split.
+  const thisWeekTotal = sparkline.reduce((acc, b) => acc + b.count, 0);
+  const delta = thisWeekTotal - (data?.lastWeekTotal ?? 0);
+
   return (
     <section className="wsa-card wsa-week">
       <div>
@@ -20,12 +104,28 @@ export function WeekInReview() {
             <IconChartBar size={14} stroke={1.8} />
             Week in review
           </h2>
-          <span className="wsa-card__caption">Coming soon</span>
+          <span className="wsa-week__eyebrow">
+            <span className="wsa-week__pulse" aria-hidden="true" />
+            {range}
+          </span>
         </div>
-        <Skeleton height={48} width="60%" />
-        <Skeleton height={60} mt="md" />
-        <Skeleton height={16} mt="md" width="80%" />
-        <Skeleton height={16} mt={6} width="72%" />
+
+        {showSkeleton ? (
+          <Skeleton height={36} width="60%" />
+        ) : (
+          <WeeklyHeadline total={thisWeekTotal} delta={delta} />
+        )}
+
+        {/* Narrative + highlights stay as skeletons this slice. */}
+        <Skeleton height={48} mt="md" width="92%" />
+        <Skeleton height={14} mt="md" width="82%" />
+        <Skeleton height={14} mt={6} width="74%" />
+        <span
+          className="wsa-card__caption"
+          style={{ display: 'block', marginTop: 10 }}
+        >
+          AI-written narrative + highlights wire in a later slice.
+        </span>
 
         <Group className="wsa-week__cta-row">
           <Tooltip label="Coming soon" withArrow>
@@ -54,10 +154,74 @@ export function WeekInReview() {
       </div>
 
       <div>
-        <Skeleton height={120} />
-        <span className="wsa-card__caption" style={{ display: 'block', marginTop: 10 }}>
-          Daily completion sparkline lands in slice 6.
-        </span>
+        {showSkeleton ? (
+          <Skeleton height={120} />
+        ) : (
+          <>
+            <div className="wsa-week__spark" role="img" aria-label="Daily activity for this week">
+              {sparkline.map((bar) => {
+                const heightPct =
+                  sparkMax === 0 ? 0 : (bar.count / sparkMax) * 100;
+                const isPeak = bar.count > 0 && bar.count === sparkMax;
+                return (
+                  <div key={bar.day} className="wsa-week__spark-col">
+                    {bar.count > 0 ? (
+                      <span className="wsa-week__spark-val">{bar.count}</span>
+                    ) : null}
+                    <div
+                      className={[
+                        'wsa-week__spark-bar',
+                        bar.isToday ? 'wsa-week__spark-bar--today' : '',
+                        isPeak ? 'wsa-week__spark-bar--peak' : '',
+                      ]
+                        .filter(Boolean)
+                        .join(' ')}
+                      style={{ height: `${Math.max(heightPct, 4)}%` }}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+            <div className="wsa-week__spark-labels">
+              {sparkline.map((bar) => (
+                <span
+                  key={bar.day}
+                  className={
+                    bar.isToday
+                      ? 'wsa-week__spark-label wsa-week__spark-label--today'
+                      : 'wsa-week__spark-label'
+                  }
+                >
+                  {bar.day}
+                </span>
+              ))}
+            </div>
+            {peakDay ? (
+              <span
+                className="wsa-card__caption"
+                style={{ display: 'block', marginTop: 10 }}
+              >
+                Peak: {peakDay.day} ({peakDay.count}{' '}
+                {peakDay.count === 1 ? 'event' : 'events'})
+              </span>
+            ) : null}
+
+            <div className="wsa-week__compare">
+              <span>
+                <b className="wsa-week__compare-num">{data.lastWeekTotal}</b>
+                last week
+              </span>
+              <span>
+                <b className="wsa-week__compare-num">{data.fourWeekAvg}</b>
+                4-week avg
+              </span>
+              <span>
+                <b className="wsa-week__compare-num">{data.bestWeekTotal}</b>
+                best week
+              </span>
+            </div>
+          </>
+        )}
       </div>
     </section>
   );

--- a/src/app/_components/home/activity/activity-home.css
+++ b/src/app/_components/home/activity/activity-home.css
@@ -471,6 +471,164 @@
 }
 
 /* --------------------------------------------------------------------------
+   WEEK-IN-REVIEW — sparkline + delta + headline
+   -------------------------------------------------------------------------- */
+.wsa-week__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin-bottom: 8px;
+}
+
+.wsa-week__pulse {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--activity-accent-crm);
+  animation: wsa-week-pulse 2s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+@keyframes wsa-week-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.4; }
+}
+
+.wsa-week__headline {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.wsa-week__num {
+  font-size: 28px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-primary);
+  line-height: 1.1;
+}
+
+.wsa-week__num-label {
+  font-size: 12.5px;
+  color: var(--color-text-muted);
+}
+
+.wsa-week__delta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.wsa-week__delta--up {
+  color: var(--activity-accent-crm);
+  background: var(--activity-accent-crm-soft);
+  border: 1px solid var(--activity-accent-crm-border);
+}
+
+.wsa-week__delta--down {
+  color: var(--activity-accent-due);
+  background: var(--activity-accent-due-soft);
+  border: 1px solid var(--activity-accent-due-border);
+}
+
+.wsa-week__delta--flat {
+  color: var(--color-text-muted);
+  background: var(--color-surface-muted);
+  border: 1px solid var(--color-border-primary);
+}
+
+.wsa-week__compare {
+  display: flex;
+  gap: 18px;
+  margin-top: 14px;
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  flex-wrap: wrap;
+}
+
+.wsa-week__compare-num {
+  color: var(--color-text-primary);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  margin-right: 4px;
+}
+
+.wsa-week__spark {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+  align-items: end;
+  height: 88px;
+  margin-top: 4px;
+}
+
+.wsa-week__spark-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  position: relative;
+}
+
+.wsa-week__spark-bar {
+  width: 100%;
+  max-width: 22px;
+  border-radius: 3px 3px 0 0;
+  background: var(--color-brand-primary);
+  position: relative;
+  margin-top: auto;
+  min-height: 2px;
+  transition: height 200ms ease-out;
+}
+
+.wsa-week__spark-bar--today {
+  background: linear-gradient(180deg, var(--color-text-inverse), var(--color-brand-primary));
+  box-shadow: 0 0 12px var(--color-brand-subtle);
+}
+
+.wsa-week__spark-bar--peak {
+  filter: brightness(1.08);
+}
+
+.wsa-week__spark-val {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  font-size: 10px;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.wsa-week__spark-labels {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+  margin-top: 8px;
+  font-size: 10.5px;
+  color: var(--color-text-muted);
+  font-family: var(--ch-font-mono);
+}
+
+.wsa-week__spark-label {
+  text-align: center;
+}
+
+.wsa-week__spark-label--today {
+  color: var(--color-brand-primary);
+  font-weight: 600;
+}
+
+/* --------------------------------------------------------------------------
    ACTIVITY FEED
    -------------------------------------------------------------------------- */
 .wsa-feed__row {

--- a/src/server/services/activity/__tests__/workspaceHomeStats.integration.test.ts
+++ b/src/server/services/activity/__tests__/workspaceHomeStats.integration.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Integration tests for the T6 extensions to getWorkspaceHomeStats:
+ * weeklySparkline, lastWeekTotal, fourWeekAvg, bestWeekTotal — all driven
+ * by `WorkspaceActivityEvent` daily counts.
+ *
+ * Real DB via testcontainer Postgres because the multi-week aggregation
+ * runs `date_trunc('day', ...) GROUP BY day` and we want to verify the
+ * bucketing against actual rows, not a mock.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { addWeeks, startOfISOWeek } from "date-fns";
+import { getTestDb } from "~/test/test-db";
+import { createUser, createWorkspace } from "~/test/factories";
+import { getWorkspaceHomeStats } from "../workspaceHomeStats";
+
+async function seedEvent(
+  db: ReturnType<typeof getTestDb>,
+  args: {
+    workspaceId: string;
+    userId: string;
+    createdAt: Date;
+  },
+) {
+  return db.workspaceActivityEvent.create({
+    data: {
+      workspaceId: args.workspaceId,
+      userId: args.userId,
+      entityType: "action",
+      entityId: `e-${Math.random().toString(36).slice(2, 10)}`,
+      action: "created",
+      createdAt: args.createdAt,
+    },
+  });
+}
+
+describe("getWorkspaceHomeStats — T6 weekly fields (integration)", () => {
+  let db: ReturnType<typeof getTestDb>;
+  // Anchor "now" to a fixed Wednesday so ISO weeks are deterministic.
+  const now = new Date("2026-05-13T12:00:00Z"); // Wed
+  const thisMon = startOfISOWeek(now);
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("populates the 7-day sparkline with correct day counts + today flag", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, {
+      ownerId: user.id,
+      slug: "homestats-spark",
+    });
+
+    // Seed: 2 events Monday, 1 event Wednesday (today), 3 events Friday.
+    const mon = new Date(thisMon);
+    const wed = new Date(thisMon);
+    wed.setDate(thisMon.getDate() + 2);
+    const fri = new Date(thisMon);
+    fri.setDate(thisMon.getDate() + 4);
+
+    await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: mon });
+    await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: mon });
+    await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: wed });
+    await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: fri });
+    await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: fri });
+    await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: fri });
+
+    const stats = await getWorkspaceHomeStats(db, {
+      workspaceId: ws.id,
+      userId: user.id,
+      now,
+    });
+
+    expect(stats.weeklySparkline).toHaveLength(7);
+    expect(stats.weeklySparkline.map((b) => b.day)).toEqual([
+      "Mon",
+      "Tue",
+      "Wed",
+      "Thu",
+      "Fri",
+      "Sat",
+      "Sun",
+    ]);
+    expect(stats.weeklySparkline[0]!.count).toBe(2); // Mon
+    expect(stats.weeklySparkline[2]!.count).toBe(1); // Wed (today)
+    expect(stats.weeklySparkline[4]!.count).toBe(3); // Fri
+    // Only Wed is today
+    expect(stats.weeklySparkline.map((b) => b.isToday)).toEqual([
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  it("computes lastWeekTotal from events in the previous ISO week", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, {
+      ownerId: user.id,
+      slug: "homestats-lastweek",
+    });
+
+    const lastWeekStart = startOfISOWeek(addWeeks(now, -1));
+    // 4 events last week, spread across days
+    for (let i = 0; i < 4; i++) {
+      const d = new Date(lastWeekStart);
+      d.setDate(lastWeekStart.getDate() + i);
+      await seedEvent(db, { workspaceId: ws.id, userId: user.id, createdAt: d });
+    }
+    // 1 event this week (should not pollute lastWeekTotal)
+    await seedEvent(db, {
+      workspaceId: ws.id,
+      userId: user.id,
+      createdAt: thisMon,
+    });
+
+    const stats = await getWorkspaceHomeStats(db, {
+      workspaceId: ws.id,
+      userId: user.id,
+      now,
+    });
+
+    expect(stats.lastWeekTotal).toBe(4);
+  });
+
+  it("computes fourWeekAvg as the mean of the last 4 completed weeks (excludes current)", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, {
+      ownerId: user.id,
+      slug: "homestats-4wkavg",
+    });
+
+    // weeks 1..4 ago: 2, 4, 6, 8 events respectively  → avg = 5
+    for (let w = 1; w <= 4; w++) {
+      const wkStart = startOfISOWeek(addWeeks(now, -w));
+      const count = w * 2; // 2, 4, 6, 8
+      for (let i = 0; i < count; i++) {
+        const d = new Date(wkStart);
+        d.setDate(wkStart.getDate() + (i % 7));
+        await seedEvent(db, {
+          workspaceId: ws.id,
+          userId: user.id,
+          createdAt: d,
+        });
+      }
+    }
+    // Current week — should NOT factor in
+    await seedEvent(db, {
+      workspaceId: ws.id,
+      userId: user.id,
+      createdAt: thisMon,
+    });
+
+    const stats = await getWorkspaceHomeStats(db, {
+      workspaceId: ws.id,
+      userId: user.id,
+      now,
+    });
+
+    expect(stats.fourWeekAvg).toBe(5); // (2 + 4 + 6 + 8) / 4
+  });
+
+  it("computes bestWeekTotal as the max across the 12-week window", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, {
+      ownerId: user.id,
+      slug: "homestats-best",
+    });
+
+    // Week -6 has 9 events (the best). Other weeks have fewer.
+    const sixWeeksAgo = startOfISOWeek(addWeeks(now, -6));
+    for (let i = 0; i < 9; i++) {
+      const d = new Date(sixWeeksAgo);
+      d.setDate(sixWeeksAgo.getDate() + (i % 7));
+      await seedEvent(db, {
+        workspaceId: ws.id,
+        userId: user.id,
+        createdAt: d,
+      });
+    }
+    // A weaker week 2 weeks ago
+    const twoWeeksAgo = startOfISOWeek(addWeeks(now, -2));
+    for (let i = 0; i < 3; i++) {
+      const d = new Date(twoWeeksAgo);
+      d.setDate(twoWeeksAgo.getDate() + i);
+      await seedEvent(db, {
+        workspaceId: ws.id,
+        userId: user.id,
+        createdAt: d,
+      });
+    }
+
+    const stats = await getWorkspaceHomeStats(db, {
+      workspaceId: ws.id,
+      userId: user.id,
+      now,
+    });
+
+    expect(stats.bestWeekTotal).toBe(9);
+  });
+
+  it("returns zeroed weekly fields for a workspace with no activity events", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, {
+      ownerId: user.id,
+      slug: "homestats-empty",
+    });
+
+    const stats = await getWorkspaceHomeStats(db, {
+      workspaceId: ws.id,
+      userId: user.id,
+      now,
+    });
+
+    expect(stats.weeklySparkline).toHaveLength(7);
+    expect(stats.weeklySparkline.every((b) => b.count === 0)).toBe(true);
+    expect(stats.lastWeekTotal).toBe(0);
+    expect(stats.fourWeekAvg).toBe(0);
+    expect(stats.bestWeekTotal).toBe(0);
+  });
+});

--- a/src/server/services/activity/workspaceHomeStats.ts
+++ b/src/server/services/activity/workspaceHomeStats.ts
@@ -2,14 +2,29 @@ import type { PrismaClient } from "@prisma/client";
 import { addWeeks, endOfISOWeek, startOfISOWeek } from "date-fns";
 
 /**
- * Aggregated metrics that power the Activity dashboard Hero strip. Composed
- * from `DailyScore` (this week / last week task totals), `ProductivityStreak`
- * (longest active streak for the user), and `Project` (count of active
- * projects in the workspace).
+ * One bar of the Week-in-Review sparkline. `day` is the ISO weekday label
+ * (Mon..Sun) emitted in the user's locale-free short form so the component
+ * can render it directly without re-formatting.
+ */
+export interface WeeklySparklineBar {
+  /** "Mon" … "Sun". */
+  day: string;
+  /** Number of `WorkspaceActivityEvent` rows on that day. */
+  count: number;
+  /** True for the bar representing "today". */
+  isToday: boolean;
+}
+
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+/**
+ * Aggregated metrics that power the Activity dashboard Hero strip and
+ * Week-in-Review card. Composed from `DailyScore` (this week / last week
+ * task totals), `ProductivityStreak` (current streak), `Project` (active
+ * count), and `WorkspaceActivityEvent` (daily activity rollups for the
+ * sparkline + multi-week stats).
  *
- * The hero week-over-week delta is `thisWeekTotal - lastWeekTotal`. The
- * sparkline payload is intentionally left as `null` for this slice — the
- * 7-day breakdown is wired in slice 6 (Week-in-Review with real data).
+ * The hero week-over-week delta is `thisWeek.completed - lastWeek.completed`.
  */
 export interface WorkspaceHomeStats {
   thisWeek: {
@@ -26,8 +41,27 @@ export interface WorkspaceHomeStats {
   streakDays: number;
   /** Projects with `status = "ACTIVE"` in the workspace. */
   activeProjectCount: number;
-  /** 7-day per-day completion totals. Always `null` in this slice — wired in slice 6. */
-  weekDaily: null;
+  /**
+   * 7-day sparkline for the **current** ISO week (Mon → Sun) showing event
+   * counts per day. Wired in slice T6; reads from `WorkspaceActivityEvent`.
+   */
+  weeklySparkline: WeeklySparklineBar[];
+  /** Total events for last ISO week (Mon → Sun). */
+  lastWeekTotal: number;
+  /** Mean events per ISO week across the last 4 completed weeks. */
+  fourWeekAvg: number;
+  /** Highest single-ISO-week event total in the trailing 12 ISO weeks. */
+  bestWeekTotal: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getUTCFullYear() === b.getUTCFullYear() &&
+    a.getUTCMonth() === b.getUTCMonth() &&
+    a.getUTCDate() === b.getUTCDate()
+  );
 }
 
 export async function getWorkspaceHomeStats(
@@ -40,7 +74,18 @@ export async function getWorkspaceHomeStats(
   const lastWeekStart = startOfISOWeek(addWeeks(now, -1));
   const lastWeekEnd = endOfISOWeek(addWeeks(now, -1));
 
-  const [thisWeekRows, lastWeekRows, streak, activeProjectCount] = await Promise.all([
+  // For multi-week stats: query the last 12 ISO weeks of activity events so
+  // we can compute lastWeekTotal, fourWeekAvg, and bestWeekTotal from one
+  // round-trip rather than 12 separate findMany calls.
+  const twelveWeeksAgoStart = startOfISOWeek(addWeeks(now, -11));
+
+  const [
+    thisWeekRows,
+    lastWeekRows,
+    streak,
+    activeProjectCount,
+    activityRows,
+  ] = await Promise.all([
     db.dailyScore.findMany({
       where: {
         userId: args.userId,
@@ -65,6 +110,15 @@ export async function getWorkspaceHomeStats(
     db.project.count({
       where: { workspaceId: args.workspaceId, status: "ACTIVE" },
     }),
+    db.$queryRaw<Array<{ day: Date; count: bigint }>>`
+      SELECT date_trunc('day', "createdAt") AS day,
+             COUNT(*)::bigint AS count
+      FROM "WorkspaceActivityEvent"
+      WHERE "workspaceId" = ${args.workspaceId}
+        AND "createdAt" >= ${twelveWeeksAgoStart}
+        AND "createdAt" <= ${thisWeekEnd}
+      GROUP BY day
+    `,
   ]);
 
   const sumCompleted = (rows: Array<{ completedTasks: number }>) =>
@@ -74,6 +128,51 @@ export async function getWorkspaceHomeStats(
 
   const thisWeekCompleted = sumCompleted(thisWeekRows);
   const lastWeekCompleted = sumCompleted(lastWeekRows);
+
+  // ── Bucket activity rows by day ────────────────────────────────────
+  const countsByDay = new Map<string, number>();
+  for (const row of activityRows) {
+    const key = row.day.toISOString().slice(0, 10);
+    countsByDay.set(key, Number(row.count));
+  }
+
+  // ── This-week sparkline (Mon → Sun) ────────────────────────────────
+  const sparkline: WeeklySparklineBar[] = [];
+  for (let i = 0; i < 7; i++) {
+    const day = new Date(thisWeekStart.getTime() + i * MS_PER_DAY);
+    const key = day.toISOString().slice(0, 10);
+    sparkline.push({
+      day: DAY_LABELS[i] ?? "?",
+      count: countsByDay.get(key) ?? 0,
+      isToday: isSameDay(day, now),
+    });
+  }
+
+  // ── Multi-week aggregates ──────────────────────────────────────────
+  // Walk back 12 weeks; sum per-week totals; take last 4 for the average
+  // and the max across all 12 for the best-week.
+  const weekTotals: number[] = [];
+  for (let w = 0; w < 12; w++) {
+    const weekStart = startOfISOWeek(addWeeks(now, -w));
+    let total = 0;
+    for (let d = 0; d < 7; d++) {
+      const day = new Date(weekStart.getTime() + d * MS_PER_DAY);
+      total += countsByDay.get(day.toISOString().slice(0, 10)) ?? 0;
+    }
+    weekTotals.push(total);
+  }
+  // weekTotals[0] is current week, [1] is last week, …, [11] is 11 weeks ago.
+  const lastWeekTotal = weekTotals[1] ?? 0;
+  // 4-week average uses the last 4 completed weeks (index 1..4).
+  const fourWeekWindow = weekTotals.slice(1, 5);
+  const fourWeekAvg =
+    fourWeekWindow.length === 0
+      ? 0
+      : Math.round(
+          fourWeekWindow.reduce((acc, n) => acc + n, 0) /
+            fourWeekWindow.length,
+        );
+  const bestWeekTotal = weekTotals.length === 0 ? 0 : Math.max(...weekTotals);
 
   return {
     thisWeek: {
@@ -87,6 +186,9 @@ export async function getWorkspaceHomeStats(
     deltaCompleted: thisWeekCompleted - lastWeekCompleted,
     streakDays: streak?.currentStreak ?? 0,
     activeProjectCount,
-    weekDaily: null,
+    weeklySparkline: sparkline,
+    lastWeekTotal,
+    fourWeekAvg,
+    bestWeekTotal,
   };
 }


### PR DESCRIPTION
## Summary

Slice 6 of 9. Replaces the WeekInReview skeleton from T2 with real data — headline event count, delta pill, 7-day sparkline, and compare-row showing last-week / 4-week-avg / best-week totals.

## Branch state

**Stacked on PR #121 (T4)** because it shares the WorkspaceActivityEvent daily-count aggregation pattern. Base is set to \`feat/activity-heatmap-t4\` so the GitHub diff stays clean. Once T4 merges to develop, I'll rebase + retarget to \`develop\` (same flow we used for T3 stacked on T1).

## What ships

Backend — extends \`getWorkspaceHomeStats\` with four new fields, all sourced from \`WorkspaceActivityEvent\` daily aggregation:

- \`weeklySparkline\` — array of \`{ day, count, isToday }\` for current ISO week. Mon–Sun in fixed order.
- \`lastWeekTotal\` — sum of events in the previous ISO week.
- \`fourWeekAvg\` — rounded mean of the last 4 **completed** weeks (excludes the current week so the in-progress week doesn't drag down the average mid-week).
- \`bestWeekTotal\` — max single-week event total in the trailing 12 ISO weeks.

All four come from a single \`$queryRaw\` call that pulls 12 weeks of daily counts and walks the buckets in TS — one DB round-trip, not 12.

Component:
- Headline number + Mantine delta pill (green up / red down / muted flat) using \`--activity-accent-{crm,due}\` tokens.
- 7-bar sparkline, today rendered with white→brand gradient and brand glow shadow. Peak day highlighted with brightness filter, called out as caption below.
- Compare row: 3 labelled values (last week / 4-week avg / best week).
- Two CTAs ("Start weekly review", "Ask agent to summarize") still in disabled Mantine Tooltips — those wire later.
- Live-pulse dot in the eyebrow next to the date range.
- All animations suppressed by the existing \`prefers-reduced-motion\` rule.

## Design note: hero vs. week-in-review semantics

The hero stats card still uses \`DailyScore.completedTasks\` (user-level planned/completed split). The WeekInReview card uses \`WorkspaceActivityEvent\` (workspace-wide event count). Different semantics — kept them separate:

- **Hero** answers: "How am I doing this week?"
- **Week-in-Review** answers: "How alive is this workspace this week?"

## Cleanup

Removed the placeholder \`weekDaily: null\` field added in T2 — no consumer ever read it.

## Tests

\`workspaceHomeStats.integration.test.ts\` (testcontainer, 5 cases):

- Sparkline counts + isToday flag for events on specific weekdays
- \`lastWeekTotal\` scoped to the previous ISO week only
- \`fourWeekAvg\` = mean of last 4 completed weeks (current week excluded)
- \`bestWeekTotal\` = max across the 12-week window
- Empty workspace returns zeroed weekly fields

## Test plan

- [x] \`npm run check\` clean
- [x] Integration tests pass
- [x] No hardcoded hex
- [ ] Reviewer (manual): on the Activity dashboard, verify the WeekInReview headline number matches what you can count on the heatmap for the current week. Resize narrow to confirm collapse to single column at ≤920px.

Closes Exponential ticket cmp33e6yj000bl5047kyp2iz4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)