### PR TITLE
feat(activity): /w/{slug}/activity full-feed page + CTA wiring (T9)

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/activity/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/activity/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { WorkspaceActivityFullFeed } from '~/app/_components/home/activity/WorkspaceActivityFullFeed';
+
+/**
+ * `/w/[workspaceSlug]/activity` — the full paginated `WorkspaceActivityEvent`
+ * history for the current workspace. Reached from the "All activity →" CTA
+ * and "View older activity" footer in the home Activity feed card.
+ */
+export default function WorkspaceActivityPage() {
+  return (
+    <div className="flex h-full flex-col text-text-primary">
+      <WorkspaceActivityFullFeed />
+    </div>
+  );
+}

--- a/src/app/_components/home/activity/ActivityFeed.tsx
+++ b/src/app/_components/home/activity/ActivityFeed.tsx
@@ -12,7 +12,6 @@ import {
   type Icon as TablerIcon,
 } from '@tabler/icons-react';
 import Link from 'next/link';
-import { useState } from 'react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { api } from '~/trpc/react';
 import type { IconKind } from '~/server/services/activity/feedRenderHints';
@@ -126,38 +125,20 @@ function Sentence({ template, actor, entityRef }: SentenceProps) {
  */
 export function ActivityFeed() {
   const { workspace, workspaceId, workspaceSlug } = useWorkspace();
-  const [cursor, setCursor] = useState<string | null>(null);
-  const [accumulated, setAccumulated] = useState<
-    Array<{
-      id: string;
-      createdAt: Date;
-      hint: { template: string; iconKind: IconKind };
-      entityRef: string;
-      actor: { id: string; name: string | null; image: string | null } | null;
-    }>
-  >([]);
 
+  // The home card always shows the first page only — the "All activity" CTA
+  // and "View older activity" footer both route to /w/{slug}/activity for
+  // the paginated view. Keeping this card scoped to one page avoids two
+  // overlapping pagination UIs and keeps the home page snappy.
   const { data, isLoading } = api.workspace.getActivityFeed.useQuery(
-    { workspaceId: workspaceId ?? '', cursor: cursor ?? undefined },
-    {
-      enabled: !!workspaceId,
-    },
+    { workspaceId: workspaceId ?? '' },
+    { enabled: !!workspaceId },
   );
 
-  // Accumulate pages locally as the user clicks "View older".
-  const events = (data?.events ?? []).map((e) => ({
+  const display = (data?.events ?? []).map((e) => ({
     ...e,
     createdAt: new Date(e.createdAt),
   }));
-  const merged = cursor === null ? events : [...accumulated, ...events];
-  // De-dupe across React re-renders when the query refires for the current cursor.
-  const seen = new Set<string>();
-  const display = merged.filter((event) => {
-    if (seen.has(event.id)) return false;
-    seen.add(event.id);
-    return true;
-  });
-
   const hasMore = data?.nextCursor != null;
 
   return (
@@ -243,21 +224,14 @@ export function ActivityFeed() {
               </div>
             );
           })}
-          {hasMore ? (
+          {hasMore && workspaceSlug ? (
             <div className="wsa-feed__footer">
-              <button
-                type="button"
+              <Link
+                href={`/w/${workspaceSlug}/activity`}
                 className="wsa-feed__footer-btn"
-                onClick={() => {
-                  if (data?.nextCursor) {
-                    setAccumulated(display);
-                    setCursor(data.nextCursor);
-                  }
-                }}
-                disabled={isLoading}
               >
-                View older activity
-              </button>
+                View older activity →
+              </Link>
             </div>
           ) : null}
         </>

--- a/src/app/_components/home/activity/WorkspaceActivityFullFeed.tsx
+++ b/src/app/_components/home/activity/WorkspaceActivityFullFeed.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import { Button, Container, Skeleton, Stack, Text, Title } from '@mantine/core';
+import {
+  IconCheck,
+  IconCirclePlus,
+  IconClipboardList,
+  IconEdit,
+  IconMessageCircle,
+  IconRefresh,
+  IconStatusChange,
+  type Icon as TablerIcon,
+} from '@tabler/icons-react';
+import { useState } from 'react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { api } from '~/trpc/react';
+import type { IconKind } from '~/server/services/activity/feedRenderHints';
+
+import './activity-home.css';
+
+const ICON_BY_KIND: Record<IconKind, TablerIcon> = {
+  created: IconCirclePlus,
+  updated: IconEdit,
+  status_changed: IconStatusChange,
+  completed: IconCheck,
+  commented: IconMessageCircle,
+  fallback: IconRefresh,
+};
+
+const PAGE_SIZE = 50;
+
+const RTF =
+  typeof Intl !== 'undefined' && 'RelativeTimeFormat' in Intl
+    ? new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+    : null;
+
+const TIME_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+  ['year', 60 * 60 * 24 * 365],
+  ['month', 60 * 60 * 24 * 30],
+  ['week', 60 * 60 * 24 * 7],
+  ['day', 60 * 60 * 24],
+  ['hour', 60 * 60],
+  ['minute', 60],
+];
+
+function relativeTime(date: Date, now: Date = new Date()): string {
+  const deltaSec = (date.getTime() - now.getTime()) / 1000;
+  const absSec = Math.abs(deltaSec);
+  if (absSec < 30) return 'just now';
+  if (!RTF) return date.toISOString().slice(0, 10);
+  for (const [unit, secs] of TIME_UNITS) {
+    if (absSec >= secs) {
+      const value = Math.round(deltaSec / secs);
+      return RTF.format(value, unit);
+    }
+  }
+  return RTF.format(Math.round(deltaSec / 60), 'minute');
+}
+
+function initialsOf(name: string | null): string {
+  if (!name) return '?';
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  return `${parts[0]![0] ?? ''}${parts[parts.length - 1]![0] ?? ''}`.toUpperCase();
+}
+
+interface SentenceProps {
+  template: string;
+  actor: string;
+  entityRef: string;
+}
+
+function Sentence({ template, actor, entityRef }: SentenceProps) {
+  const parts: Array<{ kind: 'text' | 'actor' | 'entity'; value: string }> = [];
+  const regex = /\{(actor|entityRef)\}/g;
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(template)) !== null) {
+    if (match.index > cursor) {
+      parts.push({ kind: 'text', value: template.slice(cursor, match.index) });
+    }
+    parts.push({
+      kind: match[1] === 'actor' ? 'actor' : 'entity',
+      value: match[1] === 'actor' ? actor : entityRef,
+    });
+    cursor = match.index + match[0].length;
+  }
+  if (cursor < template.length) {
+    parts.push({ kind: 'text', value: template.slice(cursor) });
+  }
+  return (
+    <span className="wsa-feed__sentence">
+      {parts.map((part, i) => {
+        if (part.kind === 'actor') {
+          return (
+            <span key={i} className="wsa-feed__actor">
+              {part.value}
+            </span>
+          );
+        }
+        if (part.kind === 'entity') {
+          return (
+            <span key={i} className="wsa-feed__entity">
+              {part.value}
+            </span>
+          );
+        }
+        return <span key={i}>{part.value}</span>;
+      })}
+    </span>
+  );
+}
+
+interface AccumulatedEvent {
+  id: string;
+  createdAt: Date;
+  hint: { template: string; iconKind: IconKind };
+  entityRef: string;
+  actor: { id: string; name: string | null; image: string | null } | null;
+}
+
+/**
+ * Full paginated activity feed at `/w/[slug]/activity`. Uses the same
+ * `workspace.getActivityFeed` reader as the home card but with a larger page
+ * size (50) and a Mantine container chrome. Pagination accumulates pages
+ * locally via the "Load more" button.
+ *
+ * Workspace scoping is enforced by the tRPC procedure — events from other
+ * workspaces never reach this surface.
+ */
+export function WorkspaceActivityFullFeed() {
+  const { workspace, workspaceId, isLoading: workspaceLoading } = useWorkspace();
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [accumulated, setAccumulated] = useState<AccumulatedEvent[]>([]);
+
+  const { data, isLoading } = api.workspace.getActivityFeed.useQuery(
+    {
+      workspaceId: workspaceId ?? '',
+      cursor: cursor ?? undefined,
+      limit: PAGE_SIZE,
+    },
+    { enabled: !!workspaceId },
+  );
+
+  if (workspaceLoading || !workspace) {
+    return (
+      <Container size="md" className="py-8">
+        <Stack gap="md">
+          <Skeleton height={48} width="40%" />
+          <Skeleton height={300} />
+        </Stack>
+      </Container>
+    );
+  }
+
+  const fresh = (data?.events ?? []).map((e) => ({
+    ...e,
+    createdAt: new Date(e.createdAt),
+  }));
+  const merged = cursor === null ? fresh : [...accumulated, ...fresh];
+  const seen = new Set<string>();
+  const display = merged.filter((event) => {
+    if (seen.has(event.id)) return false;
+    seen.add(event.id);
+    return true;
+  });
+
+  const hasMore = data?.nextCursor != null;
+  const isEmpty = !isLoading && display.length === 0;
+
+  return (
+    <Container size="md" className="py-8">
+      <Stack gap="lg">
+        <div>
+          <Text size="xs" tt="uppercase" className="text-text-muted" style={{ letterSpacing: '0.08em' }}>
+            {workspace.name}
+          </Text>
+          <Title order={1} className="text-text-primary" mt={4}>
+            Activity
+          </Title>
+          <Text size="sm" className="text-text-secondary" mt={6}>
+            Every event in this workspace, newest first. Click an event for more
+            once entity links land.
+          </Text>
+        </div>
+
+        <section className="wsa-card">
+          <div className="wsa-card__head">
+            <h2 className="wsa-card__title">
+              <IconClipboardList size={14} stroke={1.8} />
+              All workspace activity
+              {data ? (
+                <span className="wsa-card__count">
+                  {display.length}
+                  {hasMore ? '+' : ''}
+                </span>
+              ) : null}
+            </h2>
+          </div>
+
+          {isLoading && display.length === 0 ? (
+            <Stack gap="sm">
+              {[0, 1, 2, 3, 4].map((row) => (
+                <div
+                  key={row}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '30px minmax(0, 1fr)',
+                    gap: 12,
+                    alignItems: 'center',
+                    padding: '10px 0',
+                  }}
+                >
+                  <Skeleton circle height={30} width={30} />
+                  <div>
+                    <Skeleton height={14} width="68%" />
+                    <Skeleton height={12} mt={6} width="42%" />
+                  </div>
+                </div>
+              ))}
+            </Stack>
+          ) : isEmpty ? (
+            <p className="wsa-feed__empty">
+              No activity yet in <b>{workspace.name}</b>. Events show up here
+              when you create, update, complete, or comment on actions and
+              tickets. If you&apos;ve been here a while, ask an owner to run
+              the activity backfill from workspace settings.
+            </p>
+          ) : (
+            <>
+              {display.map((event) => {
+                const Icon = ICON_BY_KIND[event.hint.iconKind] ?? IconRefresh;
+                const actorName = event.actor?.name ?? 'Someone';
+                return (
+                  <div key={event.id} className="wsa-feed__row">
+                    <div
+                      className={`wsa-feed__avatar${event.actor ? '' : ' wsa-feed__avatar--anonymous'}`}
+                      aria-hidden="true"
+                    >
+                      {event.actor?.image ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={event.actor.image} alt="" />
+                      ) : (
+                        initialsOf(event.actor?.name ?? null)
+                      )}
+                    </div>
+                    <div className="wsa-feed__body">
+                      <Sentence
+                        template={event.hint.template}
+                        actor={actorName}
+                        entityRef={event.entityRef}
+                      />
+                      <span className="wsa-feed__time">
+                        {relativeTime(event.createdAt)}
+                      </span>
+                    </div>
+                    <span
+                      className="wsa-feed__icon"
+                      data-kind={event.hint.iconKind}
+                      aria-hidden="true"
+                    >
+                      <Icon size={14} stroke={1.8} />
+                    </span>
+                  </div>
+                );
+              })}
+
+              {hasMore ? (
+                <div className="wsa-feed__footer">
+                  <Button
+                    variant="default"
+                    size="sm"
+                    loading={isLoading}
+                    onClick={() => {
+                      if (data?.nextCursor) {
+                        setAccumulated(display);
+                        setCursor(data.nextCursor);
+                      }
+                    }}
+                  >
+                    Load more
+                  </Button>
+                </div>
+              ) : display.length > 0 ? (
+                <p className="wsa-feed__empty">
+                  That&apos;s all of it — {display.length}{' '}
+                  {display.length === 1 ? 'event' : 'events'} total.
+                </p>
+              ) : null}
+            </>
+          )}
+        </section>
+      </Stack>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary

**Final slice of the 9-slice Workspace Home Activity Dashboard plan.** Adds the dedicated \`/w/[workspaceSlug]/activity\` route and rewires both CTAs on the home Activity feed card to point at it.

## Branch state

**Stacked on PR #122 (T5)** because it reuses the \`getActivityFeed\` reader and render-hint helpers shipped there. Base is set to \`feat/activity-feed-t5\` so the GitHub diff stays clean. Once T5 lands on develop, this will rebase + retarget to \`develop\`.

## What ships

**New route**: \`src/app/(sidemenu)/w/[workspaceSlug]/activity/page.tsx\` — thin client route that renders \`WorkspaceActivityFullFeed\`.

**New component**: \`WorkspaceActivityFullFeed.tsx\` — page-scale feed:
- Reuses the same \`workspace.getActivityFeed\` reader as the home card.
- 50-event page size with a "Load more" button that paginates via the cursor-based reader from T5.
- Accumulates pages locally into a single scroll.
- Renders the workspace name as breadcrumb, an "Activity" title, and a card body styled with the existing \`wsa-feed__*\` CSS (already shipped in T5).
- Friendlier empty state: hints at where events come from and suggests asking an owner to run the T8 backfill if the workspace existed pre-T7.

**Home card rewires** in \`ActivityFeed.tsx\`:
- "All activity →" header already pointed at \`/w/{slug}/activity\` in T5 — kept as-is.
- "View older activity" footer was a local-pagination button in T5; **now it's a Link to the new page** per T9 spec.
- Drops the cursor + accumulated useState that drove the local "View older" pagination. The home card becomes a strict first-page snapshot — simpler state, no duplicate pagination UIs.

## Test plan

No new automated tests — T9 is route + UI wiring composing T5's reader. The reader itself is covered by T5's integration tests.

- [x] \`npm run check\` clean
- [x] All 379+ existing unit tests pass
- [x] No hardcoded hex
- [ ] Reviewer (manual): from a workspace on the Activity dashboard, click "All activity →" in the feed card header → lands at \`/w/{slug}/activity\`. Click "View older activity" footer when there are >10 events → lands at same page. Click "Load more" on the full page → scroll grows. Switch workspaces → only that workspace's events appear.

Closes Exponential ticket cmp33ebiu000hl504tw57u00y.

## 🎉 9-slice plan complete

The full feature trail:

- PR #113 → T1 (homeLayout column + picker + routing) — **shipped**
- PR #114 → T3 (WorkspaceActivityEvent + recordActivity) — **shipped**
- PR #115 → develop → main release with T1 + T3 — **shipped**
- PR #118 → T2 (Activity dashboard shell + Hero/Projects real data) — **shipped**
- PR #119 → T7 (instrument 8 write sites) — **shipped**
- PR #120 → T8 (backfill endpoint + script)
- PR #121 → T4 (heatmap reader + level calculator + component)
- PR #122 → T5 (activity feed reader + paginated component)
- PR #123 → T6 (Week-in-Review sparkline + multi-week stats)
- This PR → T9 (full-feed page + CTA wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)