### PR TITLE
feat: Drawer open-state in the URL (deep-link open/close)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,6 +63,10 @@ _Avoid_: Connected repo, tracked repo, linked repo (use "workspace repository" o
 The chronological list shown in the activity panel on `/w/[slug]/home`. A union over the workspace's activity events from all enabled sources, paginated by cursor on `createdAt`. The feed is a **read-side projection** — it merges the two underlying tables (`WorkspaceActivityEvent` and `GitHubActivity`) in app code; the tables are kept separate at rest because they have genuinely different shapes and serve other consumers (Sprint Analytics queries `GitHubActivity` columns directly).
 _Avoid_: Activity log, event log, stream.
 
+**OKR activity**:
+Distinct from the workspace **Activity feed** above — this is the per-item timeline inside the OKR detail drawer's "Activity" tab. For a Key result it merges that KR's comments (`KeyResultComment`) and check-ins (`KeyResultCheckIn`). For an Objective it is a **roll-up**: the objective's own comments/updates (`GoalComment`, `GoalUpdate`) merged with the comments and check-ins of *all its child Key results*, time-sorted into one feed, each rolled-up item tagged with a source chip naming its KR. Built read-side by a single `okr.getObjectiveActivity` procedure (same merge-in-app-code pattern as [ADR-0001](docs/adr/0001-activity-feed-storage.md)), never stored. The objective composer always writes an objective-level `GoalComment`; rolled-up KR items are read-only context.
+_Avoid_: Comments (the tab is a mixed feed of comments **and** check-ins, not comments alone), Discussion.
+
 ## Relationships (activity)
 
 - A **Workspace** has many **Workspace repositories**.
@@ -98,6 +102,14 @@ The measurable arm of an Objective, stored as `KeyResult`. Has `currentValue`, `
 **OKR**:
 Shorthand for the *pair* (Objective + its Key results). Never use "OKR" to mean a single Objective or a single Key result on its own — be specific.
 _Avoid_: Using "OKR" as a singular noun for one of the parts.
+
+**Effective status**:
+What an Objective's or Key result's status badge actually shows. Each entity stores **two separate values**: an **auto** value — `Goal.health` (the "computed health cache aggregated from KRs", rewritten by `recomputeHealth`) / `KeyResult.status` (rewritten by check-ins) — and a nullable **manual override** — `Goal.healthOverride` / `KeyResult.statusOverride`. The effective status displayed everywhere is `override ?? auto`. Setting status via the drawer writes the *override* column only; choosing "Auto" sets the override back to `null` and the derived value reappears. The auto column is never overwritten by the manual path. See [ADR-0004](docs/adr/0004-okr-manual-status-override.md).
+_Avoid_: Conflating "health" (Objective) with "status" (Key result) — same idea, different column per entity; "status" as a single stored value (it is two columns reconciled at read).
+
+**Favourite**:
+A per-user pin of any entity, surfaced in a "Favourites" section in the left nav under "Workspaces". Stored polymorphically in `Favorite { userId, workspaceId, entityType, entityId, createdAt }` — one row per user × entity. v1 wires `entityType` `objective` and `keyResult` only (table is deliberately extensible to projects/meetings later). The Favourites section is **workspace-scoped** — it shows only favourites whose `workspaceId` matches the current workspace. Clicking a favourite opens that item's OKR drawer via its deep link. Toggled by the star CTA in the OKR detail drawer.
+_Avoid_: Star, bookmark, pin (use "favourite"; "star" only for the CTA icon itself).
 
 ### Product alignment chain
 

--- a/docs/adr/0004-okr-manual-status-override.md
+++ b/docs/adr/0004-okr-manual-status-override.md
@@ -1,0 +1,60 @@
+# OKR status: manual override stored beside the auto-derived value
+
+## Status
+
+Accepted — 2026-06-01
+
+## Context
+
+An Objective's and a Key result's status badge ("AT RISK", "On track", …) is today
+**derived**, and derived inconsistently:
+
+- `Goal.health` is a "computed health cache aggregated from KRs", written by
+  `recomputeHealth`. But the OKR card badge ignores it and computes a **worst-KR roll-up**
+  (`objectiveRollupStatus`), while the drawer derives the badge from **progress %**
+  (`statusFromProgress`). Three sources, one badge.
+- `KeyResult.status` is auto-rewritten on every check-in based on progress-vs-expected.
+
+The OKR detail drawer's "Set status" CTA needs somewhere coherent to write a human's
+explicit judgement ("I know the number looks fine, but this is at risk"). There was no
+column for that — writing it into `Goal.health` / `KeyResult.status` would be clobbered the
+next time `recomputeHealth` or a check-in ran.
+
+## Decision
+
+1. **Two columns per entity, never merged at rest.** Keep the existing auto column
+   (`Goal.health`, `KeyResult.status`) exactly as is — `recomputeHealth` and `checkIn`
+   keep writing it. Add a nullable **manual override** column alongside:
+   `Goal.healthOverride` (+ `healthOverrideAt`, `healthOverrideById`) and
+   `KeyResult.statusOverride` (+ `statusOverrideAt`, `statusOverrideById`).
+2. **Effective status = `override ?? auto`**, reconciled at read, applied consistently in
+   the card and the drawer (this also retires the three-way derivation inconsistency —
+   both surfaces compute effective status the same way).
+3. **"Set status" writes the override only.** An **"Auto"** option sets the override back
+   to `null`, at which point the derived value reappears. The manual path never touches
+   the auto column, so a later recompute/check-in cannot silently erase a human decision,
+   and clearing the override never loses the derived value.
+
+## Considered alternatives
+
+- **Single column, manual writes overwrite the auto value.** Rejected: the next
+  `recomputeHealth`/`checkIn` clobbers the human's decision, and there is no way to tell
+  "a person set this" from "the system computed this", nor to revert to auto.
+- **Objective "Set status" sets lifecycle status** (`active`/`completed`/`archived`) and
+  leave health fully auto. Rejected: the badge users point at is *health*, not lifecycle;
+  the button would visibly not move the thing it appears to control.
+- **A `manualOverride: boolean` flag plus one value column.** Rejected: you still lose the
+  derived value while the override is active, so "Auto" can't restore it without a
+  recompute round-trip, and history (`overrideAt`/`overrideById`) has nowhere to live.
+
+## Consequences
+
+- A migration adds six nullable columns; no backfill needed (null = "no override" = today's
+  behaviour). Per repo rules the migration is authored but **run manually by the owner**.
+- Every read site that shows a status badge must use the shared `override ?? auto` helper,
+  not the raw column — including `objectiveRollupStatus` and the drawer's `statusFromProgress`,
+  which are replaced by it.
+- Auto-derivation keeps running underneath an override. When the override is cleared, the
+  current derived value (not a stale one) is what shows — desirable.
+- Audit columns (`*OverrideAt`, `*OverrideById`) let the Activity timeline attribute a
+  manual status change later if we choose to surface it; not wired in v1.

--- a/src/plugins/okr/client/components/OkrDashboard.tsx
+++ b/src/plugins/okr/client/components/OkrDashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { useSearchParams } from "next/navigation";
 import {
   Container,
   Text,
@@ -64,14 +65,75 @@ const unitOptions = [
   { value: "custom", label: "Custom" },
 ];
 
+interface DrawerItem {
+  type: "objective" | "keyResult";
+  id: number | string;
+  title?: string;
+  description?: string | null;
+  progress: number;
+  status: string;
+  lifeDomainName?: string | null;
+}
+
+function statusFromObjectiveProgress(progress: number): string {
+  return progress >= 100
+    ? "achieved"
+    : progress >= 70
+      ? "on-track"
+      : progress >= 40
+        ? "at-risk"
+        : "off-track";
+}
+
+function buildObjectiveDrawerItem(obj: ObjectiveCardObjective): DrawerItem {
+  return {
+    type: "objective",
+    id: obj.id,
+    title: obj.title,
+    description: obj.description,
+    progress: obj.progress,
+    status: statusFromObjectiveProgress(obj.progress),
+    lifeDomainName: obj.lifeDomain?.name ?? null,
+  };
+}
+
+function buildKeyResultDrawerItem(kr: ObjectiveCardKeyResult): DrawerItem {
+  const range = kr.targetValue - kr.startValue;
+  const progress = range > 0 ? ((kr.currentValue - kr.startValue) / range) * 100 : 0;
+  return {
+    type: "keyResult",
+    id: kr.id,
+    title: kr.title,
+    description: kr.description ?? null,
+    progress: Math.min(100, Math.max(0, progress)),
+    status: kr.status,
+    lifeDomainName: null,
+  };
+}
+
 export function OkrDashboard({
   scope = "workspace",
 }: { scope?: "workspace" | "mine" } = {}) {
   const { workspaceId, workspaceSlug } = useWorkspace();
-  const { year: selectedYear, period: selectedPeriod, setYear, setPeriod } =
-    useOkrSearchParams();
+  const {
+    year: selectedYear,
+    period: selectedPeriod,
+    setYear,
+    setPeriod,
+    drawerParam,
+    openDrawer: openDrawerUrl,
+    closeDrawer: closeDrawerUrl,
+  } = useOkrSearchParams();
+  const searchParams = useSearchParams();
 
   const onlyMine = scope === "mine";
+
+  // Both the OKRs and My Goals tabs mount an OkrDashboard simultaneously
+  // (Mantine keeps inactive Tabs.Panels mounted). Gate URL-driven drawer
+  // opening to the active panel so a `drawer=` param opens only one drawer.
+  const activeTab = searchParams.get("tab") ?? "goals";
+  const isActivePanel =
+    scope === "mine" ? activeTab === "my-goals" : activeTab === "okrs";
 
   const [createModalOpened, { open: openCreateModal, close: closeCreateModal }] =
     useDisclosure(false);
@@ -80,17 +142,17 @@ export function OkrDashboard({
   const [editingKeyResult, setEditingKeyResult] =
     useState<ObjectiveCardKeyResult | null>(null);
 
-  const [drawerOpened, { open: openDrawer, close: closeDrawer }] =
-    useDisclosure(false);
-  const [drawerItem, setDrawerItem] = useState<{
-    type: "objective" | "keyResult";
-    id: number | string;
-    title: string;
-    description?: string | null;
-    progress: number;
-    status: string;
-    lifeDomainName?: string | null;
-  } | null>(null);
+  const [drawerItem, setDrawerItem] = useState<DrawerItem | null>(null);
+
+  // The drawer is open when this panel is active and the URL `drawer=` param
+  // resolves to an item we've materialised. Requiring the materialised item to
+  // match the param keeps invalid/stale ids from opening an empty drawer.
+  const drawerOpened =
+    isActivePanel &&
+    drawerParam !== null &&
+    drawerItem !== null &&
+    drawerItem.type === drawerParam.type &&
+    String(drawerItem.id) === drawerParam.id;
 
   const [expandedObjectives, setExpandedObjectives] = useState<Set<number>>(
     new Set(),
@@ -201,6 +263,52 @@ export function OkrDashboard({
     }
   }, [visibleObjectives, expandedObjectives.size]);
 
+  // Materialise the drawer item from the URL `drawer=` param. Handles deep
+  // links, refresh, and browser back/forward where there's no in-memory item
+  // from a click. When the item isn't in the current period's data we open it
+  // by id so the drawer can fetch it; a malformed objective id stays closed.
+  useEffect(() => {
+    if (!isActivePanel || !drawerParam) return;
+    if (
+      drawerItem &&
+      drawerItem.type === drawerParam.type &&
+      String(drawerItem.id) === drawerParam.id
+    ) {
+      return;
+    }
+    if (drawerParam.type === "objective") {
+      const obj = visibleObjectives.find(
+        (o) => String(o.id) === drawerParam.id,
+      );
+      if (obj) {
+        setDrawerItem(buildObjectiveDrawerItem(obj));
+        return;
+      }
+      const numericId = Number(drawerParam.id);
+      if (!Number.isInteger(numericId)) return;
+      setDrawerItem({
+        type: "objective",
+        id: numericId,
+        progress: 0,
+        status: "on-track",
+      });
+    } else {
+      const kr = visibleObjectives
+        .flatMap((o) => o.keyResults)
+        .find((k) => String(k.id) === drawerParam.id);
+      if (kr) {
+        setDrawerItem(buildKeyResultDrawerItem(kr));
+        return;
+      }
+      setDrawerItem({
+        type: "keyResult",
+        id: drawerParam.id,
+        progress: 0,
+        status: "on-track",
+      });
+    }
+  }, [isActivePanel, drawerParam, visibleObjectives, drawerItem]);
+
   const toggleExpand = (objectiveId: number) => {
     setExpandedObjectives((prev) => {
       const next = new Set(prev);
@@ -281,39 +389,15 @@ export function OkrDashboard({
   };
 
   const handleViewObjective = (obj: ObjectiveCardObjective) => {
-    const statusFromProgress =
-      obj.progress >= 100
-        ? "achieved"
-        : obj.progress >= 70
-          ? "on-track"
-          : obj.progress >= 40
-            ? "at-risk"
-            : "off-track";
-    setDrawerItem({
-      type: "objective",
-      id: obj.id,
-      title: obj.title,
-      description: obj.description,
-      progress: obj.progress,
-      status: statusFromProgress,
-      lifeDomainName: obj.lifeDomain?.name ?? null,
-    });
-    openDrawer();
+    // Set the item synchronously to avoid a flash before the effect resolves
+    // it, then push the deep-link param.
+    setDrawerItem(buildObjectiveDrawerItem(obj));
+    openDrawerUrl("objective", obj.id);
   };
 
   const handleViewKeyResult = (kr: ObjectiveCardKeyResult) => {
-    const range = kr.targetValue - kr.startValue;
-    const progress = range > 0 ? ((kr.currentValue - kr.startValue) / range) * 100 : 0;
-    setDrawerItem({
-      type: "keyResult",
-      id: kr.id,
-      title: kr.title,
-      description: kr.description ?? null,
-      progress: Math.min(100, Math.max(0, progress)),
-      status: kr.status,
-      lifeDomainName: null,
-    });
-    openDrawer();
+    setDrawerItem(buildKeyResultDrawerItem(kr));
+    openDrawerUrl("keyResult", kr.id);
   };
 
   // Summary for the header subtitle
@@ -761,7 +845,7 @@ export function OkrDashboard({
 
       <OkrDetailDrawer
         opened={drawerOpened}
-        onClose={closeDrawer}
+        onClose={closeDrawerUrl}
         type={drawerItem?.type ?? "objective"}
         itemId={drawerItem?.id ?? null}
         title={drawerItem?.title}

--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -1073,6 +1073,7 @@ export function OkrDetailDrawer({
   const isObjective = type === "objective";
   const data = isObjective ? objectiveQuery.data : krQuery.data;
   const isLoading = isObjective ? objectiveQuery.isLoading : krQuery.isLoading;
+  const isError = isObjective ? objectiveQuery.isError : krQuery.isError;
 
   // Compute all display fields once we have data
   const view = useMemo(() => {
@@ -1338,7 +1339,12 @@ export function OkrDetailDrawer({
         onClose={onClose}
       />
 
-      {isLoading || !view ? (
+      {isError ? (
+        <div className="grid flex-1 place-items-center p-6 text-center text-sm text-text-muted">
+          This item couldn’t be found. It may have been deleted, or you don’t
+          have access to it.
+        </div>
+      ) : isLoading || !view ? (
         <div className="flex-1 p-6">
           <Skeleton height={28} width={160} mb="md" />
           <Skeleton height={32} width="80%" mb="lg" />

--- a/src/plugins/okr/client/hooks/__tests__/useOkrSearchParams.test.ts
+++ b/src/plugins/okr/client/hooks/__tests__/useOkrSearchParams.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { parseDrawerParam } from "../useOkrSearchParams";
+
+describe("parseDrawerParam", () => {
+  it("returns null for missing param", () => {
+    expect(parseDrawerParam(null)).toBeNull();
+    expect(parseDrawerParam("")).toBeNull();
+  });
+
+  it("parses an objective deep-link", () => {
+    expect(parseDrawerParam("objective:42")).toEqual({
+      type: "objective",
+      id: "42",
+    });
+  });
+
+  it("parses a key result deep-link with a cuid id", () => {
+    expect(parseDrawerParam("keyResult:cml123abc")).toEqual({
+      type: "keyResult",
+      id: "cml123abc",
+    });
+  });
+
+  it("preserves colons inside the id", () => {
+    expect(parseDrawerParam("keyResult:a:b")).toEqual({
+      type: "keyResult",
+      id: "a:b",
+    });
+  });
+
+  it("returns null for an unknown entity type", () => {
+    expect(parseDrawerParam("project:1")).toBeNull();
+    expect(parseDrawerParam("objective")).toBeNull();
+  });
+
+  it("returns null when the id is empty", () => {
+    expect(parseDrawerParam("objective:")).toBeNull();
+  });
+
+  it("returns null when there is no separator", () => {
+    expect(parseDrawerParam("objective42")).toBeNull();
+  });
+});

--- a/src/plugins/okr/client/hooks/useOkrSearchParams.ts
+++ b/src/plugins/okr/client/hooks/useOkrSearchParams.ts
@@ -1,8 +1,33 @@
 "use client";
 
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
-import { useCallback, useTransition } from "react";
+import { useCallback, useMemo, useTransition } from "react";
 import { getCurrentYear, getCurrentQuarterType } from "../utils/periodUtils";
+
+export type DrawerEntity = "objective" | "keyResult";
+
+export interface DrawerParam {
+  type: DrawerEntity;
+  /** Raw id from the URL. Objective ids are numeric; key result ids are cuids. */
+  id: string;
+}
+
+/**
+ * Parse the `drawer` query param. Encoded as `objective:<goalId>` or
+ * `keyResult:<keyResultId>`. Returns null for missing or malformed values so
+ * stale/invalid deep links fail gracefully (drawer stays closed).
+ */
+export function parseDrawerParam(raw: string | null): DrawerParam | null {
+  if (!raw) return null;
+  const sep = raw.indexOf(":");
+  if (sep <= 0) return null;
+  const type = raw.slice(0, sep);
+  const id = raw.slice(sep + 1);
+  if ((type === "objective" || type === "keyResult") && id) {
+    return { type, id };
+  }
+  return null;
+}
 
 export function useOkrSearchParams() {
   const searchParams = useSearchParams();
@@ -13,6 +38,33 @@ export function useOkrSearchParams() {
   const year = searchParams.get("year") ?? getCurrentYear();
   const period = (searchParams.get("period") as "Annual" | "Q1" | "Q2" | "Q3" | "Q4" | "Timeline") ??
     getCurrentQuarterType().replace(/-(Annual)?/, '') as "Q1" | "Q2" | "Q3" | "Q4";
+
+  const drawerParam = useMemo(
+    () => parseDrawerParam(searchParams.get("drawer")),
+    [searchParams],
+  );
+
+  // Opening pushes a history entry so the browser back button restores the
+  // prior drawer state; closing removes the param the same way.
+  const openDrawer = useCallback(
+    (type: DrawerEntity, id: string | number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("drawer", `${type}:${id}`);
+      startTransition(() => {
+        router.push(`${pathname}?${params.toString()}`, { scroll: false });
+      });
+    },
+    [searchParams, router, pathname, startTransition],
+  );
+
+  const closeDrawer = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("drawer");
+    const qs = params.toString();
+    startTransition(() => {
+      router.push(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    });
+  }, [searchParams, router, pathname, startTransition]);
 
   const setParams = useCallback(
     (newYear: string, newPeriod: "Annual" | "Q1" | "Q2" | "Q3" | "Q4" | "Timeline") => {
@@ -47,5 +99,8 @@ export function useOkrSearchParams() {
     setYear,
     setPeriod,
     setParams,
+    drawerParam,
+    openDrawer,
+    closeDrawer,
   };
 }


### PR DESCRIPTION
## What

Make the OKR detail drawer openable and closeable via the URL so an open item can be deep-linked, survives refresh, and works with the browser back button. Previously the drawer's open-state was local React state in `OkrDashboard` only.

The open item is encoded as a query param on the OKRs page: `?drawer=objective:<goalId>` or `?drawer=keyResult:<keyResultId>`. Opening pushes a history entry (so back restores prior state); closing removes the param. On load/refresh/back the item is reconstructed from the URL. URL-driven opening is gated to the active tab (Mantine keeps both OKRs + My Goals panels mounted) so only one drawer opens.

Foundational plumbing reused by Share (copy deep link, still.grape) and the Favourites sidebar (click to open, warm.wren).

## Acceptance criteria

- [ ] Opening an objective or KR drawer reflects the item in the URL query string
- [ ] Loading the page with a `drawer=` param opens the correct drawer for that item
- [ ] Closing the drawer removes the param; back-button restores prior drawer state
- [ ] Refresh with the param present re-opens the same drawer
- [ ] Works in both card and timeline views; invalid/stale ids fail gracefully (no crash, drawer stays closed)

## Notes

- This branch also carries the shared feature docs commit (CONTEXT.md glossary + ADR-0004) that was pre-filed alongside the ticket batch.
- `next lint` OOMs in the dev environment; lint was validated on the changed files directly (clean) and typecheck + unit tests pass.

---

Ships: quiet.cliff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OKR drawer now supports URL-based navigation, enabling users to share and deep-link to specific objectives and key results.

* **Bug Fixes**
  * Added error handling with user-friendly messaging when accessing OKR items that no longer exist or are inaccessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->