### PR TITLE
feat: Roll KR comments + check-ins into the Objective Activity tab

### DIFF
--- a/src/plugins/okr/client/components/OkrDashboard.tsx
+++ b/src/plugins/okr/client/components/OkrDashboard.tsx
@@ -411,16 +411,16 @@ export function OkrDashboard({
       handleViewKeyResult(kr);
       return;
     }
+    // Not in the current period's data — set a minimal item and push the
+    // deep-link param so the URL-driven drawer (ticket 1) opens and fetches it.
     setDrawerItem({
       type: "keyResult",
       id: krId,
-      title: krTitle ?? "",
-      description: null,
+      title: krTitle,
       progress: 0,
       status: "on-track",
-      lifeDomainName: null,
     });
-    openDrawer();
+    openDrawerUrl("keyResult", krId);
   };
 
   // Summary for the header subtitle

--- a/src/plugins/okr/client/components/OkrDashboard.tsx
+++ b/src/plugins/okr/client/components/OkrDashboard.tsx
@@ -400,6 +400,29 @@ export function OkrDashboard({
     openDrawerUrl("keyResult", kr.id);
   };
 
+  // Open a KR drawer by id — used by the objective Activity tab's rolled-up KR
+  // source chips. Reuses the loaded KR when available (correct progress/status)
+  // and otherwise opens by id so the drawer can fetch it.
+  const handleOpenKeyResultById = (krId: string, krTitle?: string) => {
+    const kr = visibleObjectives
+      .flatMap((o) => o.keyResults)
+      .find((k) => k.id === krId);
+    if (kr) {
+      handleViewKeyResult(kr);
+      return;
+    }
+    setDrawerItem({
+      type: "keyResult",
+      id: krId,
+      title: krTitle ?? "",
+      description: null,
+      progress: 0,
+      status: "on-track",
+      lifeDomainName: null,
+    });
+    openDrawer();
+  };
+
   // Summary for the header subtitle
   const summary = useMemo(() => {
     const allKrs = visibleObjectives.flatMap((o) => o.keyResults);
@@ -853,6 +876,7 @@ export function OkrDashboard({
         progress={drawerItem?.progress}
         status={drawerItem?.status}
         lifeDomainName={drawerItem?.lifeDomainName}
+        onOpenKeyResult={handleOpenKeyResultById}
       />
     </Container>
   );

--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Drawer, Tooltip, ActionIcon, Skeleton, Textarea } from "@mantine/core";
 import {
   IconTarget,
@@ -1179,6 +1179,13 @@ export function OkrDetailDrawer({
   const utils = api.useUtils();
   const [tab, setTab] = useState<string>("overview");
   const [size, setSize] = useState<TopBarSize>("m");
+
+  // The "krs" / "projects" tabs are entity-specific, so a tab that's valid for
+  // one entity renders a blank body for another. Reset to "overview" whenever
+  // the drawer switches to a different entity (e.g. objective → key result).
+  useEffect(() => {
+    setTab("overview");
+  }, [type, itemId]);
 
   const drawerSize =
     size === "s" ? 560 : size === "l" ? 960 : size === "max" ? "100%" : 720;

--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -20,7 +20,7 @@ import {
   IconLink,
 } from "@tabler/icons-react";
 import { formatDistanceToNow, format } from "date-fns";
-import { api } from "~/trpc/react";
+import { api, type RouterOutputs } from "~/trpc/react";
 import {
   clamp01,
   expectedProgress,
@@ -45,6 +45,8 @@ interface OkrDetailDrawerProps {
   progress?: number;
   status?: string;
   lifeDomainName?: string | null;
+  /** Open a key result's drawer — used by rolled-up KR activity source chips. */
+  onOpenKeyResult?: (keyResultId: string, keyResultTitle?: string) => void;
 }
 
 interface DrawerUser {
@@ -961,6 +963,148 @@ function ActivityFeed({
   );
 }
 
+type ObjectiveActivityItem =
+  RouterOutputs["okr"]["getObjectiveActivity"][number];
+
+const GOAL_HEALTH_CONFIDENCE: Record<string, Confidence> = {
+  "on-track": "ok",
+  "at-risk": "warn",
+  "off-track": "bad",
+};
+
+function KrSourceChip({
+  code,
+  title,
+  onOpen,
+}: {
+  code: string;
+  title: string;
+  onOpen?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      disabled={!onOpen}
+      className="inline-flex max-w-[220px] items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider transition-colors enabled:hover:bg-surface-hover disabled:cursor-default"
+      style={{
+        background: "var(--color-brand-glow)",
+        borderColor: "var(--color-brand-glow)",
+        color: "var(--brand-400)",
+      }}
+      title={`${code} · ${title}`}
+    >
+      <IconTrendingUp size={10} className="flex-shrink-0" />
+      <span className="flex-shrink-0">{code}</span>
+      <span className="truncate normal-case tracking-normal opacity-80">
+        {title}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Renders an objective's rolled-up activity timeline (the
+ * `okr.getObjectiveActivity` merge). KR-sourced items carry a clickable source
+ * chip that opens that KR's drawer; objective-native items show no chip.
+ */
+function ObjectiveActivityFeed({
+  items,
+  onOpenKeyResult,
+}: {
+  items: ObjectiveActivityItem[];
+  onOpenKeyResult?: (keyResultId: string, keyResultTitle?: string) => void;
+}) {
+  if (items.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-border-primary p-8 text-center text-sm text-text-muted">
+        No activity yet. Post an update or comment to get things started.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {items.map((it) => {
+        const isKr = it.kind === "krComment" || it.kind === "krCheckIn";
+        const verb =
+          it.kind === "goalUpdate"
+            ? "posted an update"
+            : it.kind === "krCheckIn"
+              ? "updated progress"
+              : "commented";
+        return (
+          <div
+            key={`${it.kind}-${it.id}`}
+            className="grid grid-cols-[28px_1fr] gap-3 border-b border-border-secondary py-3 last:border-b-0"
+          >
+            <Avatar user={it.author} size={26} />
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-baseline gap-2">
+                <span className="text-xs font-medium text-text-primary">
+                  {it.author?.name ?? "Unknown"}
+                </span>
+                <span className="text-xs text-text-secondary">{verb}</span>
+                {isKr && (
+                  <KrSourceChip
+                    code={it.keyResultCode}
+                    title={it.keyResultTitle}
+                    onOpen={
+                      onOpenKeyResult
+                        ? () => onOpenKeyResult(it.keyResultId, it.keyResultTitle)
+                        : undefined
+                    }
+                  />
+                )}
+                <div className="flex-1" />
+                <span className="text-[11px] text-text-muted">
+                  {formatDistanceToNow(new Date(it.createdAt), {
+                    addSuffix: true,
+                  })}
+                </span>
+              </div>
+              {it.kind === "krCheckIn" ? (
+                <div className="mt-2 inline-flex items-baseline gap-2 rounded-lg border border-border-secondary bg-surface-primary px-3 py-2 tabular-nums">
+                  <span className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+                    Progress
+                  </span>
+                  <span className="text-sm text-text-muted line-through">
+                    {it.previousValue}
+                  </span>
+                  <span className="text-xs text-text-muted">→</span>
+                  <span className="text-base font-semibold text-text-primary">
+                    {it.newValue}
+                  </span>
+                  {it.notes && (
+                    <span className="ml-2 text-xs text-text-secondary">
+                      {it.notes}
+                    </span>
+                  )}
+                </div>
+              ) : (
+                <>
+                  {it.kind === "goalUpdate" && (
+                    <div className="mt-2">
+                      <StatusPill
+                        confidence={
+                          GOAL_HEALTH_CONFIDENCE[it.health] ?? "idle"
+                        }
+                      />
+                    </div>
+                  )}
+                  <div className="mt-2 whitespace-pre-wrap rounded-lg border border-border-secondary bg-surface-primary p-3 text-sm leading-relaxed text-text-secondary">
+                    {it.content}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 function ActivityComposer({
   onSubmit,
   isSubmitting,
@@ -1030,6 +1174,7 @@ export function OkrDetailDrawer({
   title: titleProp,
   status: statusProp = "on-track",
   lifeDomainName,
+  onOpenKeyResult,
 }: OkrDetailDrawerProps) {
   const utils = api.useUtils();
   const [tab, setTab] = useState<string>("overview");
@@ -1057,9 +1202,19 @@ export function OkrDetailDrawer({
     { enabled: opened && type === "keyResult" && typeof itemId === "string" },
   );
 
+  // Objective Activity tab: merged, time-sorted feed of the objective's own
+  // comments/updates rolled up with all child-KR comments + check-ins.
+  const objectiveActivityQuery = api.okr.getObjectiveActivity.useQuery(
+    { goalId: itemId as number },
+    { enabled: opened && type === "objective" && typeof itemId === "number" },
+  );
+
   const addGoalComment = api.okr.addGoalComment.useMutation({
     onSuccess: () => {
       void utils.okr.getGoalComments.invalidate({ goalId: itemId as number });
+      void utils.okr.getObjectiveActivity.invalidate({
+        goalId: itemId as number,
+      });
     },
   });
   const addKrComment = api.okr.addKeyResultComment.useMutation({
@@ -1285,13 +1440,17 @@ export function OkrDetailDrawer({
 
   const kind: "objective" | "keyResult" = type;
 
+  // For an objective the Activity tab reflects the merged rollup total; for a
+  // KR it's that KR's own comments + check-ins.
+  const objectiveActivity = objectiveActivityQuery.data ?? [];
+
   const tabs = useMemo(() => {
     if (!view) return [{ id: "overview", label: "Overview" }];
     if (view.kind === "objective") {
       return [
         { id: "overview", label: "Overview" },
         { id: "krs", label: "Key Results", count: view.krs.length },
-        { id: "activity", label: "Activity", count: comments.length },
+        { id: "activity", label: "Activity", count: objectiveActivity.length },
       ];
     }
     return [
@@ -1303,7 +1462,7 @@ export function OkrDetailDrawer({
         count: comments.length + (view.checkIns?.length ?? 0),
       },
     ];
-  }, [view, comments.length]);
+  }, [view, comments.length, objectiveActivity.length]);
 
   const heroCrumb = view
     ? view.kind === "objective"
@@ -1533,12 +1692,14 @@ export function OkrDetailDrawer({
                   }
                 />
                 <SectionHeader title="Activity" count={tabs.find((t) => t.id === "activity")?.count} />
-                <ActivityFeed
-                  comments={comments}
-                  checkIns={
-                    view.kind === "keyResult" ? view.checkIns : undefined
-                  }
-                />
+                {view.kind === "objective" ? (
+                  <ObjectiveActivityFeed
+                    items={objectiveActivity}
+                    onOpenKeyResult={onOpenKeyResult}
+                  />
+                ) : (
+                  <ActivityFeed comments={comments} checkIns={view.checkIns} />
+                )}
               </>
             )}
           </div>

--- a/src/plugins/okr/server/objectiveActivity.ts
+++ b/src/plugins/okr/server/objectiveActivity.ts
@@ -1,0 +1,156 @@
+/**
+ * Read-side rollup of an objective's activity timeline. Pure (no DB / tRPC /
+ * auth imports) so it can be unit-tested directly; the `okr.getObjectiveActivity`
+ * procedure fetches the rows and delegates the merge here.
+ */
+
+export interface ActivityAuthor {
+  id: string;
+  name: string | null;
+  image: string | null;
+}
+
+/**
+ * One entry in an objective's rolled-up activity timeline. Discriminated on
+ * `kind`: the objective's own comments/updates plus its child key results'
+ * comments and check-ins. KR-sourced kinds carry the KR id/title/code so the
+ * UI can render a clickable source chip.
+ */
+export type ObjectiveActivityItem =
+  | {
+      kind: "goalComment";
+      id: string;
+      createdAt: Date;
+      author: ActivityAuthor;
+      content: string;
+    }
+  | {
+      kind: "goalUpdate";
+      id: string;
+      createdAt: Date;
+      author: ActivityAuthor;
+      content: string;
+      health: string;
+    }
+  | {
+      kind: "krComment";
+      id: string;
+      createdAt: Date;
+      author: ActivityAuthor;
+      content: string;
+      keyResultId: string;
+      keyResultTitle: string;
+      keyResultCode: string;
+    }
+  | {
+      kind: "krCheckIn";
+      id: string;
+      createdAt: Date;
+      author: ActivityAuthor | null;
+      previousValue: number;
+      newValue: number;
+      notes: string | null;
+      keyResultId: string;
+      keyResultTitle: string;
+      keyResultCode: string;
+    };
+
+export interface MergeObjectiveActivityInput {
+  goalComments: Array<{
+    id: string;
+    createdAt: Date;
+    content: string;
+    author: ActivityAuthor;
+  }>;
+  goalUpdates: Array<{
+    id: string;
+    createdAt: Date;
+    content: string;
+    health: string;
+    author: ActivityAuthor;
+  }>;
+  // Assumed ordered (createdAt asc) so the per-objective KR code is stable.
+  keyResults: Array<{
+    id: string;
+    title: string;
+    comments: Array<{
+      id: string;
+      createdAt: Date;
+      content: string;
+      author: ActivityAuthor;
+    }>;
+    checkIns: Array<{
+      id: string;
+      createdAt: Date;
+      previousValue: number;
+      newValue: number;
+      notes: string | null;
+      createdBy: ActivityAuthor | null;
+    }>;
+  }>;
+}
+
+/**
+ * Merge an objective's own comments/updates with all its child key results'
+ * comments and check-ins into one newest-first timeline.
+ */
+export function mergeObjectiveActivity(
+  input: MergeObjectiveActivityInput,
+): ObjectiveActivityItem[] {
+  const items: ObjectiveActivityItem[] = [];
+
+  for (const c of input.goalComments) {
+    items.push({
+      kind: "goalComment",
+      id: c.id,
+      createdAt: c.createdAt,
+      author: c.author,
+      content: c.content,
+    });
+  }
+
+  for (const u of input.goalUpdates) {
+    items.push({
+      kind: "goalUpdate",
+      id: u.id,
+      createdAt: u.createdAt,
+      author: u.author,
+      content: u.content,
+      health: u.health,
+    });
+  }
+
+  input.keyResults.forEach((kr, index) => {
+    const keyResultCode = `KR${index + 1}`;
+    for (const c of kr.comments) {
+      items.push({
+        kind: "krComment",
+        id: c.id,
+        createdAt: c.createdAt,
+        author: c.author,
+        content: c.content,
+        keyResultId: kr.id,
+        keyResultTitle: kr.title,
+        keyResultCode,
+      });
+    }
+    for (const ci of kr.checkIns) {
+      items.push({
+        kind: "krCheckIn",
+        id: ci.id,
+        createdAt: ci.createdAt,
+        author: ci.createdBy ?? null,
+        previousValue: ci.previousValue,
+        newValue: ci.newValue,
+        notes: ci.notes,
+        keyResultId: kr.id,
+        keyResultTitle: kr.title,
+        keyResultCode,
+      });
+    }
+  });
+
+  // Newest first — matches how the drawer's activity feed already reads.
+  items.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  return items;
+}

--- a/src/plugins/okr/server/routers/__tests__/mergeObjectiveActivity.test.ts
+++ b/src/plugins/okr/server/routers/__tests__/mergeObjectiveActivity.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { mergeObjectiveActivity } from "../../objectiveActivity";
+
+const author = { id: "u1", name: "Ada", image: null };
+const other = { id: "u2", name: "Grace", image: null };
+
+const at = (iso: string) => new Date(iso);
+
+describe("mergeObjectiveActivity", () => {
+  it("returns an empty array when there is no activity", () => {
+    expect(
+      mergeObjectiveActivity({
+        goalComments: [],
+        goalUpdates: [],
+        keyResults: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it("merges all four kinds into one newest-first feed", () => {
+    const items = mergeObjectiveActivity({
+      goalComments: [
+        { id: "gc1", createdAt: at("2026-01-01"), content: "objective note", author },
+      ],
+      goalUpdates: [
+        {
+          id: "gu1",
+          createdAt: at("2026-01-05"),
+          content: "status update",
+          health: "at-risk",
+          author,
+        },
+      ],
+      keyResults: [
+        {
+          id: "kr-a",
+          title: "Ship v1",
+          comments: [
+            { id: "kc1", createdAt: at("2026-01-03"), content: "kr note", author: other },
+          ],
+          checkIns: [
+            {
+              id: "ci1",
+              createdAt: at("2026-01-04"),
+              previousValue: 10,
+              newValue: 20,
+              notes: "progress",
+              createdBy: other,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(items.map((i) => i.id)).toEqual(["gu1", "ci1", "kc1", "gc1"]);
+    expect(items.map((i) => i.kind)).toEqual([
+      "goalUpdate",
+      "krCheckIn",
+      "krComment",
+      "goalComment",
+    ]);
+  });
+
+  it("numbers KR codes per-objective in input order", () => {
+    const items = mergeObjectiveActivity({
+      goalComments: [],
+      goalUpdates: [],
+      keyResults: [
+        {
+          id: "kr-a",
+          title: "First KR",
+          comments: [
+            { id: "kc-a", createdAt: at("2026-01-01"), content: "a", author },
+          ],
+          checkIns: [],
+        },
+        {
+          id: "kr-b",
+          title: "Second KR",
+          comments: [],
+          checkIns: [
+            {
+              id: "ci-b",
+              createdAt: at("2026-01-02"),
+              previousValue: 0,
+              newValue: 5,
+              notes: null,
+              createdBy: null,
+            },
+          ],
+        },
+      ],
+    });
+
+    const byId = Object.fromEntries(items.map((i) => [i.id, i]));
+    expect(byId["kc-a"]).toMatchObject({
+      kind: "krComment",
+      keyResultId: "kr-a",
+      keyResultCode: "KR1",
+      keyResultTitle: "First KR",
+    });
+    expect(byId["ci-b"]).toMatchObject({
+      kind: "krCheckIn",
+      keyResultId: "kr-b",
+      keyResultCode: "KR2",
+      author: null,
+    });
+  });
+
+  it("does not attach a KR chip to objective-native items", () => {
+    const items = mergeObjectiveActivity({
+      goalComments: [
+        { id: "gc1", createdAt: at("2026-01-01"), content: "note", author },
+      ],
+      goalUpdates: [],
+      keyResults: [],
+    });
+    expect(items[0]).not.toHaveProperty("keyResultId");
+    expect(items[0]).not.toHaveProperty("keyResultCode");
+  });
+});

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -905,9 +905,11 @@ export const keyResultRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      // Verify user owns this goal
-      const goal = await ctx.db.goal.findFirst({
-        where: { id: input.goalId, userId: ctx.session.user.id },
+      // Access mirrors getObjectiveActivity: owner, or any member of the goal's
+      // workspace. Shared-workspace OKRs are commentable by members.
+      const goal = await ctx.db.goal.findUnique({
+        where: { id: input.goalId },
+        select: { id: true, userId: true, workspaceId: true },
       });
 
       if (!goal) {
@@ -915,6 +917,19 @@ export const keyResultRouter = createTRPCRouter({
           code: "NOT_FOUND",
           message: "Objective not found",
         });
+      }
+
+      if (goal.workspaceId) {
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          ctx.session.user.id,
+          goal.workspaceId,
+        );
+        if (!membership && goal.userId !== ctx.session.user.id) {
+          throw new TRPCError({ code: "FORBIDDEN", message: "Access denied" });
+        }
+      } else if (goal.userId !== ctx.session.user.id) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Access denied" });
       }
 
       const comment = await ctx.db.goalComment.create({
@@ -941,9 +956,11 @@ export const keyResultRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
-      // Verify user owns this goal
-      const goal = await ctx.db.goal.findFirst({
-        where: { id: input.goalId, userId: ctx.session.user.id },
+      // Access mirrors getObjectiveActivity: owner, or any member of the goal's
+      // workspace. Shared-workspace OKRs are readable by members.
+      const goal = await ctx.db.goal.findUnique({
+        where: { id: input.goalId },
+        select: { id: true, userId: true, workspaceId: true },
       });
 
       if (!goal) {
@@ -951,6 +968,19 @@ export const keyResultRouter = createTRPCRouter({
           code: "NOT_FOUND",
           message: "Objective not found",
         });
+      }
+
+      if (goal.workspaceId) {
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          ctx.session.user.id,
+          goal.workspaceId,
+        );
+        if (!membership && goal.userId !== ctx.session.user.id) {
+          throw new TRPCError({ code: "FORBIDDEN", message: "Access denied" });
+        }
+      } else if (goal.userId !== ctx.session.user.id) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Access denied" });
       }
 
       return ctx.db.goalComment.findMany({
@@ -1101,11 +1131,12 @@ export const keyResultRouter = createTRPCRouter({
           where: { goalId: input.goalId },
           include: { author: authorSelect },
         }),
-        // Order by createdAt asc so the per-objective KR code (KR1, KR2, …) is
-        // stable and matches the KRs tab's listing order.
+        // Order by createdAt asc, then id asc as a deterministic tiebreaker so
+        // the per-objective KR code (KR1, KR2, …) is stable even when two KRs
+        // share a createdAt timestamp, and matches the KRs tab's listing order.
         ctx.db.keyResult.findMany({
           where: { goalId: input.goalId },
-          orderBy: { createdAt: "asc" },
+          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
           select: {
             id: true,
             title: true,

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -3,6 +3,10 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
 import { computeGoalHealth } from "~/server/services/goalService";
+import {
+  mergeObjectiveActivity,
+  type ObjectiveActivityItem,
+} from "../objectiveActivity";
 
 // Input validation schemas
 const createKeyResultInput = z.object({
@@ -45,6 +49,7 @@ const checkInInput = z.object({
   newValue: z.number(),
   notes: z.string().optional(),
 });
+
 
 /**
  * Get the parent annual period for a quarterly or half-year period.
@@ -1047,6 +1052,77 @@ export const keyResultRouter = createTRPCRouter({
           },
         },
         orderBy: { createdAt: "asc" },
+      });
+    }),
+
+  // Merged, time-sorted activity timeline for an objective: the objective's
+  // own comments/updates rolled up with the comments and check-ins of ALL its
+  // child key results. Read-side union over existing tables (no schema change,
+  // same pattern as ADR-0001). The merge happens here so the client never
+  // fans out per-KR (no N+1). KR-sourced items carry the KR id/title/code so
+  // the UI can render a clickable source chip.
+  getObjectiveActivity: protectedProcedure
+    .input(z.object({ goalId: z.number() }))
+    .query(async ({ ctx, input }): Promise<ObjectiveActivityItem[]> => {
+      // Access check mirrors goal.getById: owner, or any member of the goal's
+      // workspace. Shared workspace OKRs stay readable here.
+      const goal = await ctx.db.goal.findUnique({
+        where: { id: input.goalId },
+        select: { id: true, userId: true, workspaceId: true },
+      });
+
+      if (!goal) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Objective not found" });
+      }
+
+      if (goal.workspaceId) {
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          ctx.session.user.id,
+          goal.workspaceId,
+        );
+        if (!membership && goal.userId !== ctx.session.user.id) {
+          throw new TRPCError({ code: "FORBIDDEN", message: "Access denied" });
+        }
+      } else if (goal.userId !== ctx.session.user.id) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Access denied" });
+      }
+
+      const authorSelect = {
+        select: { id: true, name: true, image: true },
+      } as const;
+
+      const [goalCommentRows, goalUpdateRows, keyResultRows] = await Promise.all([
+        ctx.db.goalComment.findMany({
+          where: { goalId: input.goalId },
+          include: { author: authorSelect },
+        }),
+        ctx.db.goalUpdate.findMany({
+          where: { goalId: input.goalId },
+          include: { author: authorSelect },
+        }),
+        // Order by createdAt asc so the per-objective KR code (KR1, KR2, …) is
+        // stable and matches the KRs tab's listing order.
+        ctx.db.keyResult.findMany({
+          where: { goalId: input.goalId },
+          orderBy: { createdAt: "asc" },
+          select: {
+            id: true,
+            title: true,
+            comments: { include: { author: authorSelect } },
+            checkIns: {
+              include: {
+                createdBy: { select: { id: true, name: true, image: true } },
+              },
+            },
+          },
+        }),
+      ]);
+
+      return mergeObjectiveActivity({
+        goalComments: goalCommentRows,
+        goalUpdates: goalUpdateRows,
+        keyResults: keyResultRows,
       });
     }),
 


### PR DESCRIPTION
## What

In the Objective detail drawer's Activity tab, show a single time-sorted timeline that merges the objective's own comments/updates with the comments and check-ins of **all** its child Key results. Previously the objective Activity tab showed `GoalComment`s only and never reached into child KRs.

Adds one server-side tRPC procedure `okr.getObjectiveActivity({ goalId })` that fans out and merges server-side, returning a discriminated-union array (`goalComment | goalUpdate | krComment | krCheckIn`) sorted newest-first. KR-sourced items carry `{ keyResultId, keyResultTitle, keyResultCode }`. Read-side union over existing tables — no schema change (ADR-0001 pattern). The pure merge is extracted to `objectiveActivity.ts` and unit-tested.

UI: rolled-up KR items render a clickable source chip (`KR1 · <title>`) that opens that KR's drawer; objective-native items show no chip. The composer still posts an objective-level `GoalComment`; the hero "Latest update" card stays objective-level only.

## Acceptance criteria

- [ ] `okr.getObjectiveActivity` returns a single time-sorted, typed feed of goal comments/updates + all child-KR comments + check-ins
- [ ] Objective Activity tab renders the merged timeline; KR items carry a clickable source chip that opens the KR drawer
- [ ] Activity tab count badge reflects the merged total
- [ ] Hero "Latest update" remains objective-level only (unchanged by KR activity)
- [ ] Composer posts an objective-level GoalComment; KR items are read-only in this feed
- [ ] No N+1 on the client (merge happens server-side)

## Notes

- `next lint` OOMs in the dev environment; lint validated on the changed files directly (clean), typecheck + 495 unit tests pass (incl. new `mergeObjectiveActivity` tests).

---

Ships: warm.oak

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Objective Activity tab now displays a unified timeline of objective and key result updates.
  * Key result items in the activity feed are clickable, allowing quick navigation to individual key result details.
  * Key Result drawers can now be opened directly by ID.
  * Activity timeline automatically syncs when posting new comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->