### PR TITLE
feat: Wire "Update progress" CTA (KR check-in; objective KR-picker)

### DIFF
--- a/src/plugins/okr/client/components/OkrDashboard.tsx
+++ b/src/plugins/okr/client/components/OkrDashboard.tsx
@@ -389,6 +389,28 @@ export function OkrDashboard({
     openEditKrModal();
   };
 
+  // "Update progress" CTA in the drawer opens the KR's check-in modal. Reuse
+  // the loaded KR when available; otherwise (e.g. an objective's KR from a
+  // different period) open an id stub — the modal fetches fresh data by id.
+  const handleUpdateProgressForKr = (krId: string) => {
+    const kr = visibleObjectives
+      .flatMap((o) => o.keyResults)
+      .find((k) => k.id === krId);
+    if (kr) {
+      handleEditKeyResult(kr);
+      return;
+    }
+    setEditingKeyResult({
+      id: krId,
+      title: "",
+      currentValue: 0,
+      targetValue: 0,
+      startValue: 0,
+      status: "on-track",
+    });
+    openEditKrModal();
+  };
+
   const handleViewObjective = (obj: ObjectiveCardObjective) => {
     // Set the item synchronously to avoid a flash before the effect resolves
     // it, then push the deep-link param.
@@ -864,6 +886,9 @@ export function OkrDashboard({
           void utils.okr.getByObjective.invalidate();
           void utils.okr.getStats.invalidate();
           void utils.okr.getCountsByYear.invalidate();
+          // Refresh the objective drawer (goal.getById) so a KR check-in made
+          // via its "Update progress" picker reflects immediately.
+          void utils.goal.getById.invalidate();
         }}
       />
 
@@ -878,6 +903,7 @@ export function OkrDashboard({
         status={drawerItem?.status}
         lifeDomainName={drawerItem?.lifeDomainName}
         onOpenKeyResult={handleOpenKeyResultById}
+        onUpdateProgress={handleUpdateProgressForKr}
       />
     </Container>
   );

--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -51,6 +51,8 @@ interface OkrDetailDrawerProps {
   lifeDomainName?: string | null;
   /** Open a key result's drawer — used by rolled-up KR activity source chips. */
   onOpenKeyResult?: (keyResultId: string, keyResultTitle?: string) => void;
+  /** Open a key result's check-in modal — wires the "Update progress" CTA. */
+  onUpdateProgress?: (keyResultId: string) => void;
 }
 
 interface DrawerUser {
@@ -450,10 +452,125 @@ function SetStatusMenu({
   );
 }
 
+interface UpdateProgressKr {
+  id: string;
+  code: string;
+  title: string;
+}
+
+const UPDATE_PROGRESS_CLASS =
+  "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium text-text-inverse disabled:opacity-60";
+
+/**
+ * "Update progress" hero CTA (ADR-free; reuses the existing check-in modal).
+ * On a KR it opens that KR's modal directly. On an objective it routes to a
+ * KR's modal: a picker when there are several KRs, straight through for one,
+ * and a disabled+tooltip state for none (an objective has no value of its own).
+ */
+function UpdateProgressButton({
+  kind,
+  keyResultId,
+  objectiveKrs,
+  onUpdateProgress,
+}: {
+  kind: "objective" | "keyResult";
+  keyResultId?: string;
+  objectiveKrs?: UpdateProgressKr[];
+  onUpdateProgress?: (keyResultId: string) => void;
+}) {
+  const label = (
+    <>
+      <IconEdit size={13} /> Update progress
+      <span
+        className="ml-1 rounded px-1 py-px text-[10px]"
+        style={{ background: "var(--color-cta-overlay-light)" }}
+      >
+        U
+      </span>
+    </>
+  );
+
+  // Key result: open its check-in modal directly.
+  if (kind === "keyResult") {
+    return (
+      <button
+        type="button"
+        onClick={() => keyResultId && onUpdateProgress?.(keyResultId)}
+        className={UPDATE_PROGRESS_CLASS}
+        style={{ background: "var(--color-brand-primary)" }}
+      >
+        {label}
+      </button>
+    );
+  }
+
+  const krs = objectiveKrs ?? [];
+
+  // No KRs: an objective has no value of its own — nudge to add one.
+  if (krs.length === 0) {
+    return (
+      <Tooltip label="Add a key result first">
+        <span className="inline-flex">
+          <button
+            type="button"
+            disabled
+            className={UPDATE_PROGRESS_CLASS}
+            style={{ background: "var(--color-brand-primary)" }}
+          >
+            {label}
+          </button>
+        </span>
+      </Tooltip>
+    );
+  }
+
+  // Exactly one KR: skip the picker.
+  if (krs.length === 1) {
+    return (
+      <button
+        type="button"
+        onClick={() => onUpdateProgress?.(krs[0]!.id)}
+        className={UPDATE_PROGRESS_CLASS}
+        style={{ background: "var(--color-brand-primary)" }}
+      >
+        {label}
+      </button>
+    );
+  }
+
+  // Several KRs: pick which one to check in.
+  return (
+    <Menu position="bottom-start" width={260}>
+      <Menu.Target>
+        <button
+          type="button"
+          className={UPDATE_PROGRESS_CLASS}
+          style={{ background: "var(--color-brand-primary)" }}
+        >
+          {label}
+        </button>
+      </Menu.Target>
+      <Menu.Dropdown>
+        <Menu.Label>Which key result?</Menu.Label>
+        {krs.map((kr) => (
+          <Menu.Item key={kr.id} onClick={() => onUpdateProgress?.(kr.id)}>
+            <span className="font-mono text-[11px] text-text-muted">
+              {kr.code}
+            </span>{" "}
+            {kr.title}
+          </Menu.Item>
+        ))}
+      </Menu.Dropdown>
+    </Menu>
+  );
+}
+
 function HeroCtas({
   kind,
   currentOverride,
   isSettingStatus,
+  keyResultId,
+  objectiveKrs,
   onUpdateProgress,
   onPostUpdate,
   onSetStatus,
@@ -463,7 +580,9 @@ function HeroCtas({
   kind: "objective" | "keyResult";
   currentOverride: string | null | undefined;
   isSettingStatus?: boolean;
-  onUpdateProgress?: () => void;
+  keyResultId?: string;
+  objectiveKrs?: UpdateProgressKr[];
+  onUpdateProgress?: (keyResultId: string) => void;
   onPostUpdate?: () => void;
   onSetStatus?: (status: string | null) => void;
   onStar?: () => void;
@@ -471,20 +590,12 @@ function HeroCtas({
 }) {
   return (
     <div className="mt-4 flex flex-wrap items-center gap-2">
-      <button
-        type="button"
-        onClick={onUpdateProgress}
-        className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium text-text-inverse"
-        style={{ background: "var(--color-brand-primary)" }}
-      >
-        <IconEdit size={13} /> Update progress
-        <span
-          className="ml-1 rounded px-1 py-px text-[10px]"
-          style={{ background: "var(--color-cta-overlay-light)" }}
-        >
-          U
-        </span>
-      </button>
+      <UpdateProgressButton
+        kind={kind}
+        keyResultId={keyResultId}
+        objectiveKrs={objectiveKrs}
+        onUpdateProgress={onUpdateProgress}
+      />
       <button
         type="button"
         onClick={onPostUpdate}
@@ -1259,6 +1370,7 @@ export function OkrDetailDrawer({
   title: titleProp,
   lifeDomainName,
   onOpenKeyResult,
+  onUpdateProgress,
 }: OkrDetailDrawerProps) {
   const utils = api.useUtils();
   const [tab, setTab] = useState<string>("overview");
@@ -1732,8 +1844,21 @@ export function OkrDetailDrawer({
               kind={kind}
               currentOverride={view.statusOverride}
               isSettingStatus={isSettingStatus}
+              keyResultId={
+                view.kind === "keyResult" ? String(view.id) : undefined
+              }
+              objectiveKrs={
+                view.kind === "objective"
+                  ? view.krs.map((k) => ({
+                      id: k.id,
+                      code: k.code,
+                      title: k.title,
+                    }))
+                  : undefined
+              }
               onPostUpdate={handlePostUpdate}
               onSetStatus={handleSetStatus}
+              onUpdateProgress={onUpdateProgress}
             />
           </div>
 


### PR DESCRIPTION
## What

Wire the previously-dead **Update progress** hero CTA in the OKR detail drawer, reusing the existing check-in modal (`EditKeyResultModal` / `okr.update`) — no new backend.

- **On a Key result**: opens its check-in modal directly.
- **On an Objective**: an objective has no direct value (progress is the average of its KRs), so route to a KR's modal — a "which key result?" picker when there are several KRs, straight through when there's exactly one, and a **disabled** button with a tooltip ("Add a key result first") when there are none.
- The dashboard handler reuses the loaded KR when available; otherwise (e.g. an objective's KR from a different period than the active tab) it opens an id stub and the modal fetches fresh data by id. Added a `goal.getById` invalidation so the objective drawer reflects a check-in made via its picker.

## Acceptance criteria

- [ ] "Update progress" on a KR opens its check-in modal directly
- [ ] "Update progress" on an objective with >1 KR shows a KR picker, then opens the chosen KR's check-in modal
- [ ] Objective with exactly 1 KR skips the picker
- [ ] Objective with 0 KRs disables the button with an explanatory tooltip
- [ ] After a check-in, drawer/progress reflect the update (existing invalidation)

## Notes

- `next lint` OOMs in the dev environment; lint validated on the changed files directly (clean); typecheck + 491 unit tests pass.

---

Ships: zippy.parrot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Update progress" button in the objective drawer for quick access to Key Result editing.
  * Dropdown menu to select a key result when an objective has multiple options.

* **Improvements**
  * Objective drawer now refreshes automatically after Key Result edits.
  * Button intelligently handles single key results and disables when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->