### PR TITLE
feat: Favourite model + Star CTA toggle

### DIFF
--- a/prisma/migrations/20260601130000_add_favorites/migration.sql
+++ b/prisma/migrations/20260601130000_add_favorites/migration.sql
@@ -1,0 +1,26 @@
+-- Per-user favourites (polymorphic pins). v1 wires entityType
+-- "objective" and "keyResult"; the table is extensible to other entities.
+
+-- CreateTable
+CREATE TABLE "Favorite" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "workspaceId" TEXT,
+    "entityType" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Favorite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Favorite_userId_entityType_entityId_key" ON "Favorite"("userId", "entityType", "entityId");
+
+-- CreateIndex
+CREATE INDEX "Favorite_userId_workspaceId_idx" ON "Favorite"("userId", "workspaceId");
+
+-- AddForeignKey
+ALTER TABLE "Favorite" ADD CONSTRAINT "Favorite_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Favorite" ADD CONSTRAINT "Favorite_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -160,6 +160,8 @@ model User {
   projectActivitiesAuthored   ProjectActivity[]           @relation("ProjectActivityAuthor")
   // Workspace home activity feed
   workspaceActivityEvents     WorkspaceActivityEvent[]
+  // Per-user favourites (polymorphic pins)
+  favorites                   Favorite[]
 
   // Onboarding: Attribution
   attributionSource String? // "google", "twitter", "linkedin", "friend", "youtube", "podcast", "other"
@@ -292,6 +294,7 @@ model Workspace {
   // Plugin and OKR relations
   pluginConfigs           PluginConfig[]
   keyResults              KeyResult[]
+  favorites               Favorite[]
   // Tag relations
   tags                    Tag[]
   weeklyReviewCompletions WeeklyReviewCompletion[]
@@ -2717,6 +2720,25 @@ model KeyResultComment {
   @@index([keyResultId])
   @@index([authorId])
   @@index([createdAt])
+}
+
+// Per-user favourite (polymorphic pin of any entity). v1 wires entityType
+// "objective" and "keyResult"; deliberately extensible to projects/meetings.
+// entityId is a stringified id (Goal id or KeyResult cuid) — no FK because the
+// target is polymorphic. workspaceId is captured for workspace-scoped surfaces.
+model Favorite {
+  id          String   @id @default(cuid())
+  userId      String
+  workspaceId String?
+  entityType  String // "objective" | "keyResult"
+  entityId    String // Goal id (as string) or KeyResult cuid
+  createdAt   DateTime @default(now())
+
+  user      User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  workspace Workspace? @relation(fields: [workspaceId], references: [id], onDelete: SetNull)
+
+  @@unique([userId, entityType, entityId])
+  @@index([userId, workspaceId])
 }
 
 // Action Discussion Comments

--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -19,6 +19,7 @@ import {
   IconPlus,
   IconLink,
   IconCheck,
+  IconStarFilled,
 } from "@tabler/icons-react";
 import { formatDistanceToNow, format } from "date-fns";
 import { api, type RouterOutputs } from "~/trpc/react";
@@ -571,6 +572,7 @@ function HeroCtas({
   isSettingStatus,
   keyResultId,
   objectiveKrs,
+  favorited,
   onUpdateProgress,
   onPostUpdate,
   onSetStatus,
@@ -582,6 +584,7 @@ function HeroCtas({
   isSettingStatus?: boolean;
   keyResultId?: string;
   objectiveKrs?: UpdateProgressKr[];
+  favorited?: boolean;
   onUpdateProgress?: (keyResultId: string) => void;
   onPostUpdate?: () => void;
   onSetStatus?: (status: string | null) => void;
@@ -615,10 +618,15 @@ function HeroCtas({
       <ActionIcon
         variant="subtle"
         size="md"
-        aria-label="Star"
+        aria-label={favorited ? "Remove from favourites" : "Add to favourites"}
+        aria-pressed={favorited}
         onClick={onStar}
       >
-        <IconStar size={14} />
+        {favorited ? (
+          <IconStarFilled size={14} style={{ color: "var(--accent-okr)" }} />
+        ) : (
+          <IconStar size={14} />
+        )}
       </ActionIcon>
       <ActionIcon
         variant="subtle"
@@ -1482,6 +1490,40 @@ export function OkrDetailDrawer({
   const isSettingStatus =
     setObjectiveOverride.isPending || setKrOverride.isPending;
 
+  // Favourite state for the Star CTA. entityId is stringified so objectives
+  // (numeric id) and key results (cuid) share one polymorphic key.
+  const favoriteKey = {
+    entityType: type,
+    entityId: String(itemId ?? ""),
+  };
+  const favoriteQuery = api.favorite.isFavorite.useQuery(favoriteKey, {
+    enabled: opened && itemId != null,
+  });
+  const favorited = favoriteQuery.data?.favorited ?? false;
+  const toggleFavorite = api.favorite.toggle.useMutation({
+    // Optimistic flip; reconcile on settle.
+    onMutate: async () => {
+      await utils.favorite.isFavorite.cancel(favoriteKey);
+      const prev = utils.favorite.isFavorite.getData(favoriteKey);
+      utils.favorite.isFavorite.setData(favoriteKey, (old) => ({
+        favorited: !(old?.favorited ?? false),
+      }));
+      return { prev };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.prev) {
+        utils.favorite.isFavorite.setData(favoriteKey, context.prev);
+      }
+    },
+    onSettled: () => {
+      void utils.favorite.isFavorite.invalidate(favoriteKey);
+    },
+  });
+  const handleToggleFavorite = () => {
+    if (itemId == null) return;
+    toggleFavorite.mutate({ entityType: type, entityId: String(itemId) });
+  };
+
   const isObjective = type === "objective";
   const data = isObjective ? objectiveQuery.data : krQuery.data;
   const isLoading = isObjective ? objectiveQuery.isLoading : krQuery.isLoading;
@@ -1856,8 +1898,10 @@ export function OkrDetailDrawer({
                     }))
                   : undefined
               }
+              favorited={favorited}
               onPostUpdate={handlePostUpdate}
               onSetStatus={handleSetStatus}
+              onStar={handleToggleFavorite}
               onUpdateProgress={onUpdateProgress}
             />
           </div>

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -73,6 +73,7 @@ import { crmApiRouter } from "./routers/crmApi";
 import { pluginConfigRouter } from "./routers/pluginConfig";
 import { keyResultRouter } from "~/plugins/okr/server/routers/keyResult";
 import { productPluginRouter } from "~/plugins/product/server/routers";
+import { favoriteRouter } from "~/server/api/routers/favorite";
 import { authRouter } from "./routers/auth";
 import { documentRouter } from "./routers/document";
 import { voiceRouter } from "./routers/voice";
@@ -159,6 +160,7 @@ export const appRouter = createTRPCRouter({
   pluginConfig: pluginConfigRouter,
   okr: keyResultRouter,
   product: productPluginRouter,
+  favorite: favoriteRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/favorite.ts
+++ b/src/server/api/routers/favorite.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import type { Context } from "~/server/auth/types";
+import { verifyGoalAccess } from "~/server/services/goalService";
+
+// Polymorphic favourites. v1 wires "objective" and "keyResult"; the model is
+// deliberately extensible to projects/meetings later.
+const entityTypeEnum = z.enum(["objective", "keyResult"]);
+type EntityType = z.infer<typeof entityTypeEnum>;
+
+/**
+ * Verify the user may favourite this entity and return the entity's
+ * workspaceId (captured on the Favorite row for workspace-scoped surfaces).
+ * Objectives use goal access (owner / DRI / workspace member); key results use
+ * ownership, matching how the KR drawer already gates reads.
+ */
+async function resolveEntityWorkspace(
+  ctx: Context,
+  entityType: EntityType,
+  entityId: string,
+): Promise<string | null> {
+  if (entityType === "objective") {
+    const goalId = Number(entityId);
+    if (!Number.isInteger(goalId)) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: "Invalid objective id" });
+    }
+    const goal = await verifyGoalAccess({ ctx, goalId });
+    return goal.workspaceId ?? null;
+  }
+
+  const kr = await ctx.db.keyResult.findFirst({
+    where: { id: entityId, userId: ctx.session!.user.id },
+    select: { workspaceId: true },
+  });
+  if (!kr) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Key result not found" });
+  }
+  return kr.workspaceId ?? null;
+}
+
+export const favoriteRouter = createTRPCRouter({
+  // Whether the current user has favourited a given entity.
+  isFavorite: protectedProcedure
+    .input(z.object({ entityType: entityTypeEnum, entityId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const fav = await ctx.db.favorite.findUnique({
+        where: {
+          userId_entityType_entityId: {
+            userId: ctx.session.user.id,
+            entityType: input.entityType,
+            entityId: input.entityId,
+          },
+        },
+        select: { id: true },
+      });
+      return { favorited: fav !== null };
+    }),
+
+  // Toggle a favourite for the current user + entity. Captures the entity's
+  // workspaceId on create so the sidebar can scope by workspace.
+  toggle: protectedProcedure
+    .input(z.object({ entityType: entityTypeEnum, entityId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const existing = await ctx.db.favorite.findUnique({
+        where: {
+          userId_entityType_entityId: {
+            userId,
+            entityType: input.entityType,
+            entityId: input.entityId,
+          },
+        },
+        select: { id: true },
+      });
+
+      if (existing) {
+        await ctx.db.favorite.delete({ where: { id: existing.id } });
+        return { favorited: false };
+      }
+
+      const workspaceId = await resolveEntityWorkspace(
+        ctx,
+        input.entityType,
+        input.entityId,
+      );
+      await ctx.db.favorite.create({
+        data: {
+          userId,
+          entityType: input.entityType,
+          entityId: input.entityId,
+          workspaceId,
+        },
+      });
+      return { favorited: true };
+    }),
+});


### PR DESCRIPTION
## What

Add per-user favourites, persisted, with the OKR detail drawer's Star CTA as the toggle (previously dead).

- **Migration** (`20260601130000_add_favorites`): polymorphic `Favorite { id, userId, workspaceId?, entityType, entityId, createdAt }`, unique on `(userId, entityType, entityId)`. v1 wires `entityType` `objective` and `keyResult`; extensible to other entities. **Run manually by the owner** (already applied on dev).
- **API** (`api.favorite`): `isFavorite` (check) and `toggle` (create/delete). `toggle` captures the entity's `workspaceId` server-side — via goal access for objectives, ownership for KRs — so the sidebar slice (warm.wren) can scope by workspace.
- **UI**: the Star hero CTA toggles the current item's favourite optimistically; the icon reflects favourited state (`IconStarFilled`) and persists across reopen/refresh. Works for both objective and KR drawers.

## Acceptance criteria

- [ ] Migration adds the `Favorite` table with the unique constraint; owner runs it manually
- [ ] Toggle mutation creates/removes a Favorite row for the current user + item
- [ ] Star CTA reflects favourited state, toggles optimistically, and persists on reopen
- [ ] Works for both objective and key result drawers
- [ ] `workspaceId` is captured on the row (used by the sidebar slice for scoping)

## Notes

- **Stacked on #138 (astral.trout / ADR-0004).** The dev DB shares one migration history; once #138's migration was applied, a fresh main-based branch looked "diverged". Basing this branch on #138 keeps the migration chain linear (`20260601120000` → `20260601130000`). PR base is `astral-trout-manual-status-override` and will auto-retarget to `main` when #138 merges.
- Migration applied on dev via owner-run `npx prisma migrate dev` (no `db push`).
- `next lint` OOMs in the dev environment; lint validated on changed files directly (clean); typecheck + 499 unit tests pass.

---

Ships: bold.raven

🤖 Generated with [Claude Code](https://claude.com/claude-code)