### PR TITLE
feat: "Favourites" sidebar section (workspace-scoped, opens drawer)

### DIFF
--- a/src/app/_components/layout/FavouritesNav.tsx
+++ b/src/app/_components/layout/FavouritesNav.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React from "react";
+import { IconTarget, IconTrendingUp } from "@tabler/icons-react";
+import { NavLink } from "./NavLinks";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import { api } from "~/trpc/react";
+
+/**
+ * "Favourites" sidebar section. Lists the current user's favourited OKR items
+ * scoped to the active workspace (per-user dynamic data from a tRPC query, not
+ * the plugin manifest). Each row deep-links to the OKRs page and opens that
+ * item's drawer via the `?drawer=<type>:<id>` URL state. Renders nothing when
+ * there are no favourites for the workspace.
+ */
+export function FavouritesNav(): React.JSX.Element | null {
+  const { workspaceId, workspaceSlug } = useWorkspace();
+
+  const { data: favourites } = api.favorite.list.useQuery(
+    { workspaceId: workspaceId ?? undefined },
+    { enabled: !!workspaceId },
+  );
+
+  if (!workspaceSlug || !favourites || favourites.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="sb-divider" />
+      <div className="sb-section-label">Favourites</div>
+      <div className="sb-group sb-group--secondary">
+        {favourites.map((fav) => (
+          <NavLink
+            key={fav.id}
+            href={`/w/${workspaceSlug}/goals?tab=okrs&drawer=${fav.entityType}:${fav.entityId}`}
+            icon={fav.entityType === "objective" ? IconTarget : IconTrendingUp}
+          >
+            {fav.title}
+          </NavLink>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/app/_components/layout/Sidebar.tsx
+++ b/src/app/_components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { NavLinks } from "./NavLinks";
 import { SidebarContent } from "./SidebarContent";
+import { FavouritesNav } from "./FavouritesNav";
 import { IconMenu2 } from "@tabler/icons-react";
 import { useState, useEffect } from 'react';
 import { usePathname } from 'next/navigation';
@@ -87,6 +88,8 @@ export default function Sidebar({ session, domain = 'forceflow.com' }: { session
           <div className="sb-group sb-group--secondary">
             <SidebarContent />
           </div>
+
+          <FavouritesNav />
         </nav>
 
         <UserMenu session={session} onClose={() => setIsMenuOpen(false)} />

--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -1517,6 +1517,8 @@ export function OkrDetailDrawer({
     },
     onSettled: () => {
       void utils.favorite.isFavorite.invalidate(favoriteKey);
+      // Refresh the sidebar Favourites section (warm.wren).
+      void utils.favorite.list.invalidate();
     },
   });
   const handleToggleFavorite = () => {

--- a/src/server/api/routers/favorite.ts
+++ b/src/server/api/routers/favorite.ts
@@ -39,7 +39,75 @@ async function resolveEntityWorkspace(
   return kr.workspaceId ?? null;
 }
 
+interface FavoriteListItem {
+  id: string;
+  entityType: EntityType;
+  entityId: string;
+  title: string;
+  workspaceId: string | null;
+}
+
 export const favoriteRouter = createTRPCRouter({
+  // The current user's favourites, optionally scoped to a workspace (the
+  // sidebar passes the active workspace). Titles are resolved per entity type;
+  // favourites whose target no longer exists are skipped (stale rows).
+  list: protectedProcedure
+    .input(z.object({ workspaceId: z.string().nullish() }).optional())
+    .query(async ({ ctx, input }): Promise<FavoriteListItem[]> => {
+      const userId = ctx.session.user.id;
+      const favorites = await ctx.db.favorite.findMany({
+        where: {
+          userId,
+          ...(input?.workspaceId ? { workspaceId: input.workspaceId } : {}),
+        },
+        orderBy: { createdAt: "desc" },
+      });
+
+      const objectiveIds = favorites
+        .filter((f) => f.entityType === "objective")
+        .map((f) => Number(f.entityId))
+        .filter((n) => Number.isInteger(n));
+      const keyResultIds = favorites
+        .filter((f) => f.entityType === "keyResult")
+        .map((f) => f.entityId);
+
+      const [goals, keyResults] = await Promise.all([
+        objectiveIds.length
+          ? ctx.db.goal.findMany({
+              where: { id: { in: objectiveIds } },
+              select: { id: true, title: true },
+            })
+          : Promise.resolve([]),
+        keyResultIds.length
+          ? ctx.db.keyResult.findMany({
+              where: { id: { in: keyResultIds } },
+              select: { id: true, title: true },
+            })
+          : Promise.resolve([]),
+      ]);
+
+      const goalTitle = new Map(goals.map((g) => [String(g.id), g.title]));
+      const krTitle = new Map(keyResults.map((k) => [k.id, k.title]));
+
+      const items: FavoriteListItem[] = [];
+      for (const f of favorites) {
+        const entityType = f.entityType as EntityType;
+        const title =
+          entityType === "objective"
+            ? goalTitle.get(f.entityId)
+            : krTitle.get(f.entityId);
+        if (!title) continue; // target deleted — skip stale favourite
+        items.push({
+          id: f.id,
+          entityType,
+          entityId: f.entityId,
+          title,
+          workspaceId: f.workspaceId,
+        });
+      }
+      return items;
+    }),
+
   // Whether the current user has favourited a given entity.
   isFavorite: protectedProcedure
     .input(z.object({ entityType: entityTypeEnum, entityId: z.string() }))


### PR DESCRIPTION
## What

Add a "Favourites" section to the left nav, under the "Workspaces" label. It lists the current user's favourited OKR items scoped to the **active workspace** (only favourites whose `workspaceId` matches). Data comes from a new workspace-scoped `favorite.list` tRPC query (resolves titles per entity type; skips stale rows whose target was deleted) — not the plugin manifest.

- Each row shows the item title with an icon (objective → target, KR → trend) and deep-links to `/w/<slug>/goals?tab=okrs&drawer=<type>:<id>`, opening that item's drawer.
- The section is hidden entirely when there are no favourites for the workspace.
- The Star toggle now also invalidates `favorite.list`, so toggling a star adds/removes the row here.
- Reuses the existing `NavLink` + sidebar CSS classes (no hardcoded colors).

## Acceptance criteria

- [ ] A "Favourites" section renders under "Workspaces" in the sidebar
- [ ] It lists the current user's favourites scoped to the active workspace only
- [ ] Clicking a favourite opens the correct item's drawer via the deep link
- [ ] Section is hidden/empty when there are no favourites for the workspace
- [ ] Toggling a star (slice #6) adds/removes the item from this section (after refetch/invalidation)
- [ ] Styling uses existing sidebar CSS tokens (no hardcoded colors)

## Notes / dependencies

- **Stacked on #140 (bold.raven / favourites)** — hard compile dependency on the `Favorite` model + `api.favorite`. PR base is `bold-raven-favourite-model-star-toggle` (chain: #138 → #140 → this); auto-retargets to `main` as parents merge.
- **Runtime dependency on #135 (quiet.cliff / drawer URL state).** The rows deep-link with `?drawer=<type>:<id>`; the drawer opens from that param only once #135 is on `main` (it's in QA). Until then the link navigates to the OKRs tab without opening the drawer. The dependency graph sequences #135 ahead of this.
- `next lint` OOMs in the dev environment; lint validated on changed files directly (clean); typecheck + 499 unit tests pass.

---

Ships: warm.wren

🤖 Generated with [Claude Code](https://claude.com/claude-code)