### PR TITLE
feat: Wire "Share" CTA → copy deep link

### DIFF
--- a/src/plugins/okr/client/components/OkrDashboard.tsx
+++ b/src/plugins/okr/client/components/OkrDashboard.tsx
@@ -18,6 +18,7 @@ import {
   ActionIcon,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { notifications } from "@mantine/notifications";
 import {
   IconTargetArrow,
   IconPlus,
@@ -398,6 +399,31 @@ export function OkrDashboard({
   const handleViewKeyResult = (kr: ObjectiveCardKeyResult) => {
     setDrawerItem(buildKeyResultDrawerItem(kr));
     openDrawerUrl("keyResult", kr.id);
+  };
+
+  // Copy an absolute deep link that reopens this exact drawer (?drawer=type:id)
+  // on the panel that matches this dashboard's scope. Used by the Share CTA.
+  const handleShare = (type: "objective" | "keyResult", id: number | string) => {
+    const tab = scope === "mine" ? "my-goals" : "okrs";
+    const path = workspaceSlug ? `/w/${workspaceSlug}/goals` : "/goals";
+    const url = `${window.location.origin}${path}?tab=${tab}&drawer=${type}:${id}`;
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      void navigator.clipboard.writeText(url).then(
+        () => notifications.show({ message: "Link copied", color: "green" }),
+        () =>
+          notifications.show({
+            title: "Couldn't copy link",
+            message: url,
+            color: "red",
+          }),
+      );
+    } else {
+      notifications.show({
+        title: "Clipboard unavailable — copy this link",
+        message: url,
+        color: "yellow",
+      });
+    }
   };
 
   // Summary for the header subtitle
@@ -853,6 +879,11 @@ export function OkrDashboard({
         progress={drawerItem?.progress}
         status={drawerItem?.status}
         lifeDomainName={drawerItem?.lifeDomainName}
+        onShare={
+          drawerItem
+            ? () => handleShare(drawerItem.type, drawerItem.id)
+            : undefined
+        }
       />
     </Container>
   );

--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -45,6 +45,8 @@ interface OkrDetailDrawerProps {
   progress?: number;
   status?: string;
   lifeDomainName?: string | null;
+  /** Copy a deep link to this item — wires the "Share" CTA. */
+  onShare?: () => void;
 }
 
 interface DrawerUser {
@@ -1030,6 +1032,7 @@ export function OkrDetailDrawer({
   title: titleProp,
   status: statusProp = "on-track",
   lifeDomainName,
+  onShare,
 }: OkrDetailDrawerProps) {
   const utils = api.useUtils();
   const [tab, setTab] = useState<string>("overview");
@@ -1416,7 +1419,7 @@ export function OkrDetailDrawer({
               )}
             </div>
 
-            <HeroCtas />
+            <HeroCtas onShare={onShare} />
           </div>
 
           <PeopleStrip

--- a/src/test/factories/index.ts
+++ b/src/test/factories/index.ts
@@ -1,5 +1,5 @@
 import { Factory } from "fishery";
-import { randomUUID } from "crypto";
+import { randomUUID, createHash } from "crypto";
 import type { PrismaClient, $Enums } from "@prisma/client";
 
 // Use randomUUID to avoid collisions when test files run in parallel
@@ -20,6 +20,32 @@ export const userFactory = Factory.define<UserAttrs>(({ sequence }) => ({
 export async function createUser(db: PrismaClient, overrides: Partial<UserAttrs> = {}) {
   const attrs = userFactory.build(overrides);
   return db.user.create({ data: attrs });
+}
+
+// ── Durable API key ──────────────────────────────────────────────────
+// Mirrors how the app stores durable Exponential API keys: a VerificationToken
+// row whose `token` is the sha256 hash of the raw key (the same hashing
+// `apiKeyMiddleware` applies to the incoming `x-api-key` header). Returns the
+// raw (unhashed) key for the caller to present.
+
+export async function createApiKey(
+  db: PrismaClient,
+  userId: string,
+  opts: { expiresAt?: Date } = {},
+) {
+  const raw = `exp_${randomUUID()}${randomUUID()}`.replace(/-/g, "");
+  const token = `sha256:${createHash("sha256").update(raw).digest("hex")}`;
+  const expires =
+    opts.expiresAt ?? new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+  await db.verificationToken.create({
+    data: {
+      identifier: `api-key:${userId}:${uid()}`,
+      token,
+      userId,
+      expires,
+    },
+  });
+  return { raw };
 }
 
 // ── Workspace Factory ────────────────────────────────────────────────

--- a/src/test/trpc-helpers.ts
+++ b/src/test/trpc-helpers.ts
@@ -78,6 +78,24 @@ export function createUnauthenticatedCaller() {
   });
 }
 
+/**
+ * Create a tRPC caller authenticated by a durable API key (no session),
+ * presented via the `x-api-key` header — the path `apiKeyMiddleware` takes.
+ * Pass `null` to omit the header (for missing/invalid-key guard tests, and for
+ * endpoints like `voice.dispatch` that authenticate via a token argument).
+ */
+export function createApiKeyCaller(apiKey: string | null) {
+  const db = getTestDb();
+  const headers = new Headers();
+  if (apiKey) headers.set("x-api-key", apiKey);
+
+  return createCaller({
+    db,
+    session: null,
+    headers,
+  });
+}
+
 // ── Query Counter ────────────────────────────────────────────────────
 
 interface QueryLog {


### PR DESCRIPTION
## What

Wire the previously-dead **Share** hero CTA in the OKR detail drawer to copy a deep link to the clipboard — a full absolute URL that, when opened by any workspace member, reopens this exact drawer via the `?drawer=objective:<id>` / `?drawer=keyResult:<id>` URL state. The link targets the panel matching the dashboard scope (`tab=okrs` / `tab=my-goals`). Shows a "Link copied" toast; falls back to a toast containing the URL when the clipboard API is unavailable. No backend, no public share page (deferred).

## Acceptance criteria

- [ ] "Share" copies an absolute deep-link URL for the current objective/KR to the clipboard
- [ ] Opening that URL reopens the same drawer for the same item
- [ ] A confirmation toast/notification is shown on copy
- [ ] Graceful handling if the clipboard API is unavailable

## Notes / dependencies

- **Stacked on #135 (quiet.cliff / drawer URL state)** — the deep link relies on the `?drawer=` param that #135 reads to open the drawer. PR base is `quiet-cliff-drawer-open-state-in-url`; auto-retargets to `main` when #135 merges.
- `next lint` OOMs in the dev environment; lint validated on changed files directly (clean); typecheck + 498 unit tests pass.

---

Ships: still.grape

🤖 Generated with [Claude Code](https://claude.com/claude-code)