### PR TITLE
feat: Wire "Share" CTA → copy deep link (re-ship of #142)

### DIFF
--- a/src/plugins/okr/client/components/OkrDashboard.tsx
+++ b/src/plugins/okr/client/components/OkrDashboard.tsx
@@ -18,6 +18,7 @@ import {
   ActionIcon,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { notifications } from "@mantine/notifications";
 import {
   IconTargetArrow,
   IconPlus,
@@ -444,6 +445,31 @@ export function OkrDashboard({
       status: "on-track",
     });
     openDrawerUrl("keyResult", krId);
+  };
+
+  // Copy an absolute deep link that reopens this exact drawer (?drawer=type:id)
+  // on the panel that matches this dashboard's scope. Used by the Share CTA.
+  const handleShare = (type: "objective" | "keyResult", id: number | string) => {
+    const tab = scope === "mine" ? "my-goals" : "okrs";
+    const path = workspaceSlug ? `/w/${workspaceSlug}/goals` : "/goals";
+    const url = `${window.location.origin}${path}?tab=${tab}&drawer=${type}:${id}`;
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      void navigator.clipboard.writeText(url).then(
+        () => notifications.show({ message: "Link copied", color: "green" }),
+        () =>
+          notifications.show({
+            title: "Couldn't copy link",
+            message: url,
+            color: "red",
+          }),
+      );
+    } else {
+      notifications.show({
+        title: "Clipboard unavailable — copy this link",
+        message: url,
+        color: "yellow",
+      });
+    }
   };
 
   // Summary for the header subtitle
@@ -904,6 +930,11 @@ export function OkrDashboard({
         lifeDomainName={drawerItem?.lifeDomainName}
         onOpenKeyResult={handleOpenKeyResultById}
         onUpdateProgress={handleUpdateProgressForKr}
+        onShare={
+          drawerItem
+            ? () => handleShare(drawerItem.type, drawerItem.id)
+            : undefined
+        }
       />
     </Container>
   );

--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -54,6 +54,8 @@ interface OkrDetailDrawerProps {
   onOpenKeyResult?: (keyResultId: string, keyResultTitle?: string) => void;
   /** Open a key result's check-in modal — wires the "Update progress" CTA. */
   onUpdateProgress?: (keyResultId: string) => void;
+  /** Copy a deep link to this item — wires the "Share" CTA. */
+  onShare?: () => void;
 }
 
 interface DrawerUser {
@@ -1379,6 +1381,7 @@ export function OkrDetailDrawer({
   lifeDomainName,
   onOpenKeyResult,
   onUpdateProgress,
+  onShare,
 }: OkrDetailDrawerProps) {
   const utils = api.useUtils();
   const [tab, setTab] = useState<string>("overview");
@@ -1905,6 +1908,7 @@ export function OkrDetailDrawer({
               onSetStatus={handleSetStatus}
               onStar={handleToggleFavorite}
               onUpdateProgress={onUpdateProgress}
+              onShare={onShare}
             />
           </div>
 


### PR DESCRIPTION
Re-ships **still.grape** properly into `main`. The original #142 was accidentally merged into its stacked base (`quiet-cliff`, the #135 branch) instead of `main`, so its code never reached `main`. This is the same Share-CTA commit cherry-picked cleanly onto `main` (which already contains its dependency, ticket 1 / #135).

## What

Wire the Share hero CTA in the OKR detail drawer to copy an absolute deep link (`?drawer=<type>:<id>`) that reopens the exact drawer; toast on copy, graceful fallback when the clipboard API is unavailable.

## Acceptance criteria

- [ ] "Share" copies an absolute deep-link URL for the current objective/KR
- [ ] Opening that URL reopens the same drawer for the same item
- [ ] Confirmation toast on copy
- [ ] Graceful handling if clipboard API is unavailable

---

Ships: still.grape (supersedes #142)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now share objectives and key results. A shareable deep link is automatically copied to the clipboard with success/failure notifications. If clipboard is unavailable, the link is displayed instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->