### PR TITLE
feat: Workspace-scope the voice spine — lifted resolver + JWT claim + tool threading

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/voice-debug/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/voice-debug/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+/**
+ * Voice debug page (Voice — Web Client, ticket #12). Proves the browser-side
+ * auth-and-dispatch contract by TYPING — before any WebRTC/audio lands on top.
+ *
+ * Flow: mint a voice session via `voice.createSession` (NextAuth cookie auth,
+ * scoped to the current workspace) → pick one of the 5 tools from the catalog →
+ * type a phrase → POST to `voice.dispatch` via `brainDispatcher` → render the
+ * DispatchResult. complete_action exercises the confirmation handshake.
+ */
+import { useMemo, useState } from "react";
+import {
+  Alert,
+  Badge,
+  Button,
+  Code,
+  Container,
+  Group,
+  Paper,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  Title,
+} from "@mantine/core";
+
+import { api } from "~/trpc/react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import {
+  dispatch,
+  BrainDispatchError,
+  type BrainDispatchInput,
+} from "~/lib/voice/brainDispatcher";
+import { VOICE_TOOL_CATALOG } from "~/lib/voice/voiceToolCatalog";
+import type { DispatchResult } from "~/server/api/routers/voice";
+
+/** Narrow the `pendingCompletion.id` out of a complete_action gate result. */
+function pendingActionIdOf(structured: unknown): string | undefined {
+  if (typeof structured !== "object" || structured === null) return undefined;
+  const pending = (structured as Record<string, unknown>).pendingCompletion;
+  if (typeof pending !== "object" || pending === null) return undefined;
+  const id = (pending as Record<string, unknown>).id;
+  return typeof id === "string" ? id : undefined;
+}
+
+export default function VoiceDebugPage() {
+  const { workspace, workspaceId } = useWorkspace();
+
+  const [token, setToken] = useState<string | null>(null);
+  const [toolName, setToolName] = useState<string>(VOICE_TOOL_CATALOG[0]!.name);
+  const [phrase, setPhrase] = useState("");
+  const [result, setResult] = useState<DispatchResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [dispatching, setDispatching] = useState(false);
+
+  const createSession = api.voice.createSession.useMutation({
+    onSuccess: (data) => {
+      setToken(data.voiceSessionToken);
+      setError(null);
+      setResult(null);
+    },
+    onError: (e) => setError(e.message),
+  });
+
+  const toolOptions = useMemo(
+    () => VOICE_TOOL_CATALOG.map((t) => ({ value: t.name, label: t.name })),
+    [],
+  );
+
+  const pendingActionId = result?.needsConfirmation
+    ? pendingActionIdOf(result.structured)
+    : undefined;
+
+  async function runDispatch(confirm: boolean) {
+    if (!token) return;
+    setDispatching(true);
+    setError(null);
+    const input: BrainDispatchInput = {
+      toolName,
+      voiceSessionToken: token,
+      ...(phrase.trim() ? { args: { phrase: phrase.trim() } } : {}),
+      ...(confirm ? { confirm: true } : {}),
+      ...(confirm && pendingActionId ? { pendingActionId } : {}),
+    };
+    try {
+      const res = await dispatch(input);
+      setResult(res);
+    } catch (e) {
+      const msg =
+        e instanceof BrainDispatchError
+          ? `[${e.kind}${e.code ? `/${e.code}` : ""}] ${e.message}`
+          : e instanceof Error
+            ? e.message
+            : "Unknown error";
+      setError(msg);
+    } finally {
+      setDispatching(false);
+    }
+  }
+
+  return (
+    <Container size="sm" py="xl">
+      <Stack gap="lg">
+        <div>
+          <Title order={2}>Voice brain — debug console</Title>
+          <Text size="sm" c="dimmed">
+            Type to exercise <Code>voice.dispatch</Code> in workspace{" "}
+            <strong>{workspace?.name ?? "—"}</strong>. No audio; auth is your
+            signed-in session.
+          </Text>
+        </div>
+
+        <Paper withBorder p="md" radius="md">
+          <Group justify="space-between">
+            <div>
+              <Text fw={500}>Session</Text>
+              <Text size="xs" c="dimmed">
+                {token ? "Voice session minted." : "No session yet."}
+              </Text>
+            </div>
+            <Group gap="xs">
+              {token ? <Badge color="green">ready</Badge> : null}
+              <Button
+                onClick={() =>
+                  createSession.mutate(
+                    workspaceId ? { workspaceId } : undefined,
+                  )
+                }
+                loading={createSession.isPending}
+                variant="light"
+              >
+                {token ? "Re-mint session" : "Mint session"}
+              </Button>
+            </Group>
+          </Group>
+        </Paper>
+
+        <Paper withBorder p="md" radius="md">
+          <Stack gap="sm">
+            <Select
+              label="Tool"
+              data={toolOptions}
+              value={toolName}
+              onChange={(v) => v && setToolName(v)}
+              allowDeselect={false}
+            />
+            <Textarea
+              label="Phrase / args"
+              placeholder="e.g. draft the investor update by Friday"
+              value={phrase}
+              onChange={(e) => setPhrase(e.currentTarget.value)}
+              autosize
+              minRows={2}
+              description="get_todays_plan ignores this; the other tools pass it verbatim as `phrase`."
+            />
+            <Group>
+              <Button
+                onClick={() => void runDispatch(false)}
+                loading={dispatching}
+                disabled={!token}
+              >
+                Dispatch
+              </Button>
+              {result?.needsConfirmation ? (
+                <Button
+                  color="red"
+                  variant="light"
+                  onClick={() => void runDispatch(true)}
+                  loading={dispatching}
+                  disabled={!token}
+                >
+                  Confirm (yes)
+                </Button>
+              ) : null}
+            </Group>
+          </Stack>
+        </Paper>
+
+        {error ? (
+          <Alert color="red" title="Dispatch error">
+            {error}
+          </Alert>
+        ) : null}
+
+        {result ? (
+          <Paper withBorder p="md" radius="md">
+            <Stack gap="xs">
+              <Group gap="xs">
+                <Text fw={500}>Result</Text>
+                {result.needsConfirmation ? (
+                  <Badge color="orange">needs confirmation</Badge>
+                ) : (
+                  <Badge color="gray">final</Badge>
+                )}
+              </Group>
+              <Text>{result.speakable}</Text>
+              <Text size="xs" c="dimmed">
+                structured
+              </Text>
+              <Code block>{JSON.stringify(result.structured, null, 2)}</Code>
+            </Stack>
+          </Paper>
+        ) : null}
+      </Stack>
+    </Container>
+  );
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/voice-debug/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/voice-debug/page.tsx
@@ -33,6 +33,7 @@ import {
   type BrainDispatchInput,
 } from "~/lib/voice/brainDispatcher";
 import { VOICE_TOOL_CATALOG } from "~/lib/voice/voiceToolCatalog";
+import { useVoiceSession } from "~/lib/voice/useVoiceSession";
 import type { DispatchResult } from "~/server/api/routers/voice";
 
 /** Narrow the `pendingCompletion.id` out of a complete_action gate result. */
@@ -61,6 +62,14 @@ export default function VoiceDebugPage() {
       setResult(null);
     },
     onError: (e) => setError(e.message),
+  });
+
+  const createSessionAsync = api.voice.createSession.useMutation();
+
+  // Live WebRTC audio session (speak to zoe, hear the spoken reply, barge-in).
+  const voice = useVoiceSession({
+    createSession: () =>
+      createSessionAsync.mutateAsync(workspaceId ? { workspaceId } : undefined),
   });
 
   const toolOptions = useMemo(
@@ -134,6 +143,37 @@ export default function VoiceDebugPage() {
               </Button>
             </Group>
           </Group>
+        </Paper>
+
+        <Paper withBorder p="md" radius="md">
+          <Group justify="space-between">
+            <div>
+              <Text fw={500}>Live voice (WebRTC)</Text>
+              <Text size="xs" c="dimmed">
+                Open a Realtime session, speak into your mic, hear zoe reply.
+                Barge-in supported.
+              </Text>
+            </div>
+            <Group gap="xs">
+              <Badge color={voice.state === "idle" ? "gray" : "blue"}>
+                {voice.state}
+              </Badge>
+              {voice.state === "idle" ? (
+                <Button onClick={() => void voice.start()} variant="light">
+                  Open voice session
+                </Button>
+              ) : (
+                <Button onClick={() => voice.stop()} color="red" variant="light">
+                  End session
+                </Button>
+              )}
+            </Group>
+          </Group>
+          {voice.lastError ? (
+            <Text size="xs" c="red" mt="xs">
+              {voice.lastError}
+            </Text>
+          ) : null}
         </Paper>
 
         <Paper withBorder p="md" radius="md">

--- a/src/app/_components/Chat.tsx
+++ b/src/app/_components/Chat.tsx
@@ -1,27 +1,33 @@
 'use client';
 
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { api } from "~/trpc/react";
-import { 
-  Paper, 
-  TextInput, 
-  Button, 
-  Stack, 
-  ScrollArea, 
-  Avatar, 
-  Group, 
+import {
+  Paper,
+  TextInput,
+  Button,
+  Stack,
+  ScrollArea,
+  Avatar,
+  Group,
   Text,
   Box,
-  ActionIcon
+  ActionIcon,
+  Badge,
+  Anchor,
 } from '@mantine/core';
 import { IconSend, IconMicrophone, IconMicrophoneOff } from '@tabler/icons-react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { useVoiceSession } from '~/lib/voice/useVoiceSession';
 
 interface Message {
     type: 'system' | 'human' | 'ai' | 'tool';
     content: string;
     tool_call_id?: string;
     name?: string;
+    /** 'voice' when this turn was spoken (renders the 🎙 marker). */
+    marker?: 'voice';
 }
 
 interface ChatProps {
@@ -66,7 +72,45 @@ export default function Chat({ initialMessages, githubSettings, buttons }: ChatP
 
   const utils = api.useUtils();
   const transcribeAudio = api.tools.transcribe.useMutation();
-//const transcribeAudio = api.tools.transcribeFox.useMutation(); 
+//const transcribeAudio = api.tools.transcribeFox.useMutation();
+
+  // ── Voice mode (live WebRTC speech-to-speech) ──────────────────────
+  // Separate, deliberate mode alongside the dictation mic above — that
+  // record→transcribe→fill-textarea flow stays exactly as it is.
+  const { workspaceId } = useWorkspace();
+  const voiceTokenRef = useRef<string | null>(null);
+  const createVoiceSession = api.voice.createSession.useMutation();
+  const persistVoiceTurn = api.voice.persistTurn.useMutation();
+
+  // A committed voice turn: show it in the thread (marked 🎙) and persist it to
+  // the voice-scoped memory thread so the session stays continuous.
+  const recordVoiceTurn = useCallback(
+    (type: 'human' | 'ai', content: string) => {
+      setMessages((prev) => [...prev, { type, content, marker: 'voice' }]);
+      const token = voiceTokenRef.current;
+      if (token) {
+        persistVoiceTurn.mutate({
+          token,
+          role: type === 'human' ? 'user' : 'assistant',
+          text: content,
+        });
+      }
+    },
+    [persistVoiceTurn],
+  );
+
+  const voice = useVoiceSession({
+    createSession: async () => {
+      const res = await createVoiceSession.mutateAsync(
+        workspaceId ? { workspaceId } : undefined,
+      );
+      voiceTokenRef.current = res.voiceSessionToken;
+      return res;
+    },
+    onUserTranscript: (text) => recordVoiceTurn('human', text),
+    onAssistantTranscript: (text) => recordVoiceTurn('ai', text),
+  });
+  const voiceActive = voice.state !== 'idle';
   // Scroll to bottom when messages change
   useEffect(() => {
     if (viewport.current) {
@@ -302,6 +346,11 @@ export default function Chat({ initialMessages, githubSettings, buttons }: ChatP
                         whiteSpace: 'pre-wrap',
                       }}
                     >
+                      {message.marker === 'voice' && (
+                        <span title="Spoken via voice mode" aria-label="voice" style={{ marginRight: 4 }}>
+                          🎙
+                        </span>
+                      )}
                       {renderMessageContent(message.content)}
                     </Text>
                   </Paper>
@@ -320,6 +369,36 @@ export default function Chat({ initialMessages, githubSettings, buttons }: ChatP
               </Box>
             ))}
           </ScrollArea>
+
+          {(voiceActive || voice.permissionDenied || voice.lastError) && (
+            <Box px="md">
+              {voice.permissionDenied ? (
+                <Text size="xs" c="red">
+                  Microphone access is blocked.{' '}
+                  <Anchor
+                    href="https://support.google.com/chrome/answer/2693767"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    size="xs"
+                  >
+                    Fix browser permissions
+                  </Anchor>{' '}
+                  then click Voice mode again.
+                </Text>
+              ) : voiceActive ? (
+                <Group gap="xs">
+                  <Badge color="blue" variant="light">
+                    Voice: {voice.state}
+                  </Badge>
+                  <Button size="compact-xs" variant="subtle" color="red" onClick={() => voice.stop()}>
+                    End voice
+                  </Button>
+                </Group>
+              ) : voice.lastError ? (
+                <Text size="xs" c="red">{voice.lastError}</Text>
+              ) : null}
+            </Box>
+          )}
 
           <form onSubmit={handleSubmit} style={{ marginTop: 'auto' }}>
             <Group align="flex-end">
@@ -340,15 +419,27 @@ export default function Chat({ initialMessages, githubSettings, buttons }: ChatP
                     }
                   }
                 }}
-                rightSectionWidth={100}
+                rightSectionWidth={140}
                 rightSection={
                   <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                    <ActionIcon
+                      onClick={() => (voiceActive ? voice.stop() : void voice.start())}
+                      variant={voiceActive ? 'filled' : 'subtle'}
+                      color={voiceActive ? 'blue' : 'gray'}
+                      className={voice.state === 'listening' ? 'animate-pulse' : ''}
+                      size="sm"
+                      title="Voice mode — talk to zoe"
+                      aria-label="Toggle voice mode"
+                    >
+                      🎙
+                    </ActionIcon>
                     <ActionIcon
                       onClick={handleMicClick}
                       variant="subtle"
                       color={isRecording ? "red" : "gray"}
                       className={isRecording ? "animate-pulse" : ""}
                       size="sm"
+                      title="Dictate — fill the message box"
                     >
                       {isRecording ? (
                         <IconMicrophoneOff size={16} />

--- a/src/lib/voice/__tests__/brainDispatcher.test.ts
+++ b/src/lib/voice/__tests__/brainDispatcher.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  dispatch,
+  BrainDispatchError,
+} from "~/lib/voice/brainDispatcher";
+
+/** Build a fake fetch returning the given JSON body + status. */
+function fakeFetch(body: unknown, status = 200): typeof fetch {
+  return vi.fn(async () =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    }) as unknown as Response,
+  ) as unknown as typeof fetch;
+}
+
+const SUCCESS_BODY = {
+  result: { data: { json: { speakable: "Done.", structured: { ok: true }, needsConfirmation: false } } },
+};
+
+describe("brainDispatcher.dispatch", () => {
+  it("returns the parsed DispatchResult on HTTP 2xx", async () => {
+    const fetchImpl = fakeFetch(SUCCESS_BODY);
+    const res = await dispatch(
+      { toolName: "query", voiceSessionToken: "tok", args: { phrase: "what's overdue?" } },
+      { fetchImpl },
+    );
+
+    expect(res.speakable).toBe("Done.");
+    expect(res.needsConfirmation).toBe(false);
+    expect(res.structured).toEqual({ ok: true });
+  });
+
+  it("posts the input wrapped as the tRPC {json:...} body", async () => {
+    const fetchImpl = fakeFetch(SUCCESS_BODY);
+    await dispatch(
+      { toolName: "complete_action", voiceSessionToken: "tok", args: { phrase: "x" }, confirm: true, pendingActionId: "a1" },
+      { fetchImpl },
+    );
+
+    const call = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toContain("/api/trpc/voice.dispatch");
+    const sent = JSON.parse((call[1] as RequestInit).body as string) as {
+      json: Record<string, unknown>;
+    };
+    expect(sent.json).toMatchObject({
+      token: "tok",
+      toolName: "complete_action",
+      args: { phrase: "x" },
+      confirm: true,
+      pendingActionId: "a1",
+    });
+  });
+
+  it("maps a tRPC UNAUTHORIZED envelope to an `auth` error", async () => {
+    const fetchImpl = fakeFetch(
+      { error: { json: { message: "Invalid or missing voice-session token", data: { code: "UNAUTHORIZED" } } } },
+      401,
+    );
+
+    const err = await dispatch({ toolName: "query", voiceSessionToken: "bad" }, { fetchImpl }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(BrainDispatchError);
+    expect((err as BrainDispatchError).kind).toBe("auth");
+    expect((err as BrainDispatchError).code).toBe("UNAUTHORIZED");
+  });
+
+  it("maps a tRPC BAD_REQUEST envelope to a `validation` error", async () => {
+    const fetchImpl = fakeFetch(
+      { error: { json: { message: "Invalid input", data: { code: "BAD_REQUEST" } } } },
+      400,
+    );
+
+    const err = await dispatch({ toolName: "", voiceSessionToken: "tok" }, { fetchImpl }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(BrainDispatchError);
+    expect((err as BrainDispatchError).kind).toBe("validation");
+  });
+
+  it("surfaces a transport error when fetch rejects", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+
+    const err = await dispatch({ toolName: "query", voiceSessionToken: "tok" }, { fetchImpl }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(BrainDispatchError);
+    expect((err as BrainDispatchError).kind).toBe("transport");
+    expect((err as BrainDispatchError).message).toContain("ECONNREFUSED");
+  });
+
+  it("raises a decoding error when the body is not a valid tRPC envelope", async () => {
+    const fetchImpl = fakeFetch({ unexpected: "shape" }, 200);
+    const err = await dispatch({ toolName: "query", voiceSessionToken: "tok" }, { fetchImpl }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(BrainDispatchError);
+    expect((err as BrainDispatchError).kind).toBe("decoding");
+  });
+});

--- a/src/lib/voice/brainDispatcher.ts
+++ b/src/lib/voice/brainDispatcher.ts
@@ -1,0 +1,191 @@
+/**
+ * brainDispatcher — the browser-side RPC client for the voice brain endpoint
+ * (`voice.dispatch`). Symmetric to the iOS `BrainClient.swift` dispatch contract
+ * (Voice — Web Client, PRD §27): a plain async function (NOT a React hook) so it
+ * can fire from the Realtime SDK's tool-call callback, which runs outside React.
+ *
+ * Audio never flows through here — only the coarse-tool call + its result. Auth
+ * is the voice-session JWT carried in the request body (minted by
+ * `voice.createSession`), exactly as iOS does it.
+ *
+ * Wire format (standard tRPC `fetchRequestHandler` + superjson, single call):
+ *   POST /api/trpc/voice.dispatch
+ *   body:     {"json": <input>}
+ *   success:  {"result": {"data": {"json": <DispatchResult>}}}
+ *   error:    {"error":  {"json": {"message": "...", "data": {"code": "..."}}}}
+ */
+import type { DispatchResult } from "~/server/api/routers/voice";
+
+const DISPATCH_PATH = "/api/trpc/voice.dispatch";
+
+export interface BrainDispatchInput {
+  toolName: string;
+  voiceSessionToken: string;
+  args?: Record<string, unknown>;
+  confirm?: boolean;
+  /** Pins a confirm to the action the gate proposed (complete_action handshake). */
+  pendingActionId?: string;
+  mode?: "capture" | "daily-brief";
+}
+
+/**
+ * The distinguishable failure modes a dispatch can surface:
+ *   - `auth`       : the voice-session token was rejected (UNAUTHORIZED/FORBIDDEN).
+ *   - `validation` : the brain rejected the input shape (BAD_REQUEST/PARSE_ERROR).
+ *   - `trpc`       : any other server-side tRPC error (e.g. INTERNAL_SERVER_ERROR).
+ *   - `transport`  : the request never produced a usable HTTP response.
+ *   - `decoding`   : a 2xx/response body we couldn't parse as a tRPC envelope.
+ */
+export type BrainErrorKind =
+  | "auth"
+  | "validation"
+  | "trpc"
+  | "transport"
+  | "decoding";
+
+export class BrainDispatchError extends Error {
+  constructor(
+    public readonly kind: BrainErrorKind,
+    message: string,
+    /** The tRPC error code when one was present (e.g. "UNAUTHORIZED"). */
+    public readonly code?: string,
+    /** The HTTP status when a response was received. */
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = "BrainDispatchError";
+  }
+}
+
+export interface BrainDispatcherOptions {
+  /** Base URL for cross-origin callers; defaults to same-origin (relative). */
+  baseUrl?: string;
+  /** Injectable fetch (tests / non-browser environments); defaults to global. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Forward one coarse-tool call to the brain and return its `DispatchResult`.
+ * Throws a {@link BrainDispatchError} (typed by {@link BrainErrorKind}) on any
+ * failure so callers can branch on transport vs auth vs validation.
+ */
+export async function dispatch(
+  input: BrainDispatchInput,
+  options: BrainDispatcherOptions = {},
+): Promise<DispatchResult> {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const url = `${options.baseUrl ?? ""}${DISPATCH_PATH}`;
+
+  const body = JSON.stringify({
+    json: {
+      token: input.voiceSessionToken,
+      toolName: input.toolName,
+      ...(input.args ? { args: input.args } : {}),
+      ...(input.confirm !== undefined ? { confirm: input.confirm } : {}),
+      ...(input.pendingActionId ? { pendingActionId: input.pendingActionId } : {}),
+      ...(input.mode ? { mode: input.mode } : {}),
+    },
+  });
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+  } catch (err) {
+    throw new BrainDispatchError(
+      "transport",
+      err instanceof Error ? err.message : "Network request failed",
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new BrainDispatchError(
+      "decoding",
+      `Malformed response (HTTP ${response.status})`,
+      undefined,
+      response.status,
+    );
+  }
+
+  // tRPC returns a structured error envelope even on non-2xx; prefer it.
+  const trpcError = extractTrpcError(payload);
+  if (trpcError) {
+    throw new BrainDispatchError(
+      mapErrorKind(trpcError.code),
+      trpcError.message ?? "Request failed",
+      trpcError.code,
+      response.status,
+    );
+  }
+
+  if (!response.ok) {
+    throw new BrainDispatchError(
+      "transport",
+      `Request failed (HTTP ${response.status})`,
+      undefined,
+      response.status,
+    );
+  }
+
+  const result = extractTrpcSuccess(payload);
+  if (!result) {
+    throw new BrainDispatchError(
+      "decoding",
+      "Response did not contain a result payload",
+      undefined,
+      response.status,
+    );
+  }
+  return result;
+}
+
+function mapErrorKind(code: string | undefined): BrainErrorKind {
+  switch (code) {
+    case "UNAUTHORIZED":
+    case "FORBIDDEN":
+      return "auth";
+    case "BAD_REQUEST":
+    case "PARSE_ERROR":
+      return "validation";
+    default:
+      return "trpc";
+  }
+}
+
+/** Pull `{message, code}` out of a tRPC failure envelope, if present. */
+function extractTrpcError(
+  payload: unknown,
+): { message?: string; code?: string } | null {
+  if (!isRecord(payload)) return null;
+  const error = payload.error;
+  if (!isRecord(error)) return null;
+  const json = error.json;
+  if (!isRecord(json)) return null;
+  const message = typeof json.message === "string" ? json.message : undefined;
+  const data = isRecord(json.data) ? json.data : undefined;
+  const code = data && typeof data.code === "string" ? data.code : undefined;
+  return { message, code };
+}
+
+/** Pull the `DispatchResult` out of a tRPC success envelope, if present. */
+function extractTrpcSuccess(payload: unknown): DispatchResult | null {
+  if (!isRecord(payload)) return null;
+  const result = payload.result;
+  if (!isRecord(result)) return null;
+  const data = isRecord(result.data) ? result.data : undefined;
+  if (!data) return null;
+  const json = data.json;
+  if (!isRecord(json)) return null;
+  if (typeof json.speakable !== "string") return null;
+  return json as unknown as DispatchResult;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/lib/voice/useVoiceSession.ts
+++ b/src/lib/voice/useVoiceSession.ts
@@ -1,0 +1,349 @@
+"use client";
+
+/**
+ * useVoiceSession — the browser Realtime audio layer (Voice — Web Client,
+ * ticket #13). Hides the OpenAI Realtime WebRTC lifecycle behind a small
+ * `{ state, start, stop, lastError }` interface so the chat-panel UI (next
+ * ticket) never has to learn WebRTC.
+ *
+ * Transport: native browser WebRTC (no SDK dependency) — the standard OpenAI
+ * Realtime browser flow. `start()`:
+ *   1. mints a voice session (caller-supplied, cookie-authed createSession);
+ *   2. captures the mic via getUserMedia;
+ *   3. opens an RTCPeerConnection + an "oai-events" data channel;
+ *   4. exchanges SDP with OpenAI using the ephemeral client_secret as Bearer
+ *      (the durable OPENAI_API_KEY never reaches the browser — only the
+ *      short-lived ephemeral key does);
+ *   5. registers the 5 voiceToolCatalog tools + router persona via session.update;
+ *   6. forwards model tool calls through brainDispatcher and voices the result.
+ *
+ * Server VAD (the Realtime default) drives turn-taking and barge-in. Per the
+ * PRD this transport module is validated by dogfooding, not unit tests.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  dispatch as dispatchToBrain,
+  type BrainDispatchInput,
+} from "~/lib/voice/brainDispatcher";
+import {
+  VOICE_TOOL_CATALOG,
+  VOICE_ROUTER_INSTRUCTIONS,
+} from "~/lib/voice/voiceToolCatalog";
+
+/** OpenAI Realtime WebRTC SDP-exchange endpoint (GA). */
+const REALTIME_CALLS_URL = "https://api.openai.com/v1/realtime/calls";
+
+export type VoiceSessionState =
+  | "idle"
+  | "connecting"
+  | "listening"
+  | "speaking"
+  | "ending";
+
+/** What the caller's createSession must return (subset of voice.createSession). */
+export interface VoiceSessionMint {
+  openaiEphemeralKey: string;
+  voiceSessionToken: string;
+  realtime: { model: string };
+}
+
+export interface UseVoiceSessionOptions {
+  /** Mint a voice session (cookie-authed). Usually `api.voice.createSession.mutateAsync`. */
+  createSession: () => Promise<VoiceSessionMint>;
+  /** Base URL for brainDispatcher; defaults to same-origin. */
+  baseUrl?: string;
+  /** Optional tap on raw Realtime server events (used by the transcript bridge). */
+  onServerEvent?: (event: RealtimeServerEvent) => void;
+}
+
+export interface UseVoiceSession {
+  state: VoiceSessionState;
+  start: () => Promise<void>;
+  stop: () => void;
+  lastError: string | null;
+}
+
+/** A Realtime server event — a tagged JSON object over the data channel. */
+export interface RealtimeServerEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+export function useVoiceSession(
+  options: UseVoiceSessionOptions,
+): UseVoiceSession {
+  const [state, setState] = useState<VoiceSessionState>("idle");
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  const pcRef = useRef<RTCPeerConnection | null>(null);
+  const dcRef = useRef<RTCDataChannel | null>(null);
+  const micRef = useRef<MediaStream | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const tokenRef = useRef<string | null>(null);
+  // Track the most recent complete_action gate so a confirm pins to that action.
+  const pendingActionIdRef = useRef<string | undefined>(undefined);
+  // Latest options without forcing start/stop identities to change.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const teardown = useCallback(() => {
+    dcRef.current?.close();
+    dcRef.current = null;
+    pcRef.current?.getSenders().forEach((s) => s.track?.stop());
+    pcRef.current?.close();
+    pcRef.current = null;
+    micRef.current?.getTracks().forEach((t) => t.stop());
+    micRef.current = null;
+    if (audioRef.current) {
+      audioRef.current.srcObject = null;
+      audioRef.current = null;
+    }
+    tokenRef.current = null;
+    pendingActionIdRef.current = undefined;
+  }, []);
+
+  const stop = useCallback(() => {
+    if (pcRef.current || dcRef.current || micRef.current) {
+      setState("ending");
+      teardown();
+    }
+    setState("idle");
+  }, [teardown]);
+
+  // Always release the session if the component using the hook unmounts.
+  useEffect(() => () => teardown(), [teardown]);
+
+  /** Send a client event over the data channel (no-op if not open). */
+  const send = useCallback((event: Record<string, unknown>) => {
+    const dc = dcRef.current;
+    if (dc && dc.readyState === "open") dc.send(JSON.stringify(event));
+  }, []);
+
+  /** Register the tool catalog + router persona on the live session. */
+  const configureSession = useCallback(() => {
+    send({
+      type: "session.update",
+      session: {
+        type: "realtime",
+        instructions: VOICE_ROUTER_INSTRUCTIONS,
+        tools: VOICE_TOOL_CATALOG,
+        tool_choice: "auto",
+      },
+    });
+  }, [send]);
+
+  /** Forward a model tool call to the brain and feed the result back. */
+  const handleToolCall = useCallback(
+    async (callId: string, name: string, rawArgs: string) => {
+      const token = tokenRef.current;
+      if (!token) return;
+
+      const parsed = parseToolArgs(rawArgs);
+      const input: BrainDispatchInput = {
+        toolName: name,
+        voiceSessionToken: token,
+        ...(parsed.phrase ? { args: { phrase: parsed.phrase } } : {}),
+        ...(parsed.confirm ? { confirm: true } : {}),
+        ...(parsed.confirm && pendingActionIdRef.current
+          ? { pendingActionId: pendingActionIdRef.current }
+          : {}),
+      };
+
+      let output: unknown;
+      try {
+        const result = await dispatchToBrain(input, {
+          baseUrl: optionsRef.current.baseUrl,
+        });
+        output = result;
+        // Remember a pending completion so the next confirm pins to it.
+        pendingActionIdRef.current = result.needsConfirmation
+          ? pendingActionIdOf(result.structured)
+          : undefined;
+      } catch (err) {
+        output = {
+          speakable:
+            "Sorry, something went wrong reaching the assistant. Try again?",
+          error: err instanceof Error ? err.message : "dispatch_failed",
+        };
+      }
+
+      // Hand the result back to the model and let it voice the reply.
+      send({
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: callId,
+          output: JSON.stringify(output),
+        },
+      });
+      send({ type: "response.create" });
+    },
+    [send],
+  );
+
+  /** Route a single Realtime server event: state transitions + tool calls. */
+  const onServerEvent = useCallback(
+    (event: RealtimeServerEvent) => {
+      optionsRef.current.onServerEvent?.(event);
+
+      switch (event.type) {
+        case "input_audio_buffer.speech_started":
+          setState("listening");
+          break;
+        case "response.created":
+        case "response.output_audio.delta":
+        case "output_audio_buffer.started":
+          setState("speaking");
+          break;
+        case "response.done":
+        case "output_audio_buffer.stopped":
+          setState("listening");
+          break;
+        case "response.function_call_arguments.done": {
+          // GA carries name + call_id + arguments on this event.
+          const callId = asString(event.call_id);
+          const name = asString(event.name);
+          const args = asString(event.arguments) ?? "{}";
+          if (callId && name) void handleToolCall(callId, name, args);
+          break;
+        }
+        case "response.output_item.done": {
+          // Fallback path: a completed function_call output item.
+          const item = event.item;
+          if (isRecord(item) && item.type === "function_call") {
+            const callId = asString(item.call_id);
+            const name = asString(item.name);
+            const args = asString(item.arguments) ?? "{}";
+            if (callId && name) void handleToolCall(callId, name, args);
+          }
+          break;
+        }
+        case "error":
+          setLastError(describeServerError(event));
+          break;
+        default:
+          break;
+      }
+    },
+    [handleToolCall],
+  );
+
+  const start = useCallback(async () => {
+    if (pcRef.current) return; // already running
+    setLastError(null);
+    setState("connecting");
+
+    try {
+      const mint = await optionsRef.current.createSession();
+      tokenRef.current = mint.voiceSessionToken;
+
+      const mic = await navigator.mediaDevices.getUserMedia({ audio: true });
+      micRef.current = mic;
+
+      const pc = new RTCPeerConnection();
+      pcRef.current = pc;
+
+      // Play zoe's audio: route the remote track to a hidden <audio> element.
+      const audioEl = new Audio();
+      audioEl.autoplay = true;
+      audioRef.current = audioEl;
+      pc.ontrack = (e) => {
+        audioEl.srcObject = e.streams[0] ?? null;
+      };
+
+      mic.getTracks().forEach((track) => pc.addTrack(track, mic));
+
+      const dc = pc.createDataChannel("oai-events");
+      dcRef.current = dc;
+      dc.onopen = () => {
+        configureSession();
+        setState("listening");
+      };
+      dc.onmessage = (e) => {
+        const parsed = safeParse(e.data);
+        if (parsed) onServerEvent(parsed);
+      };
+
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+
+      const sdpRes = await fetch(
+        `${REALTIME_CALLS_URL}?model=${encodeURIComponent(mint.realtime.model)}`,
+        {
+          method: "POST",
+          body: offer.sdp,
+          headers: {
+            Authorization: `Bearer ${mint.openaiEphemeralKey}`,
+            "Content-Type": "application/sdp",
+          },
+        },
+      );
+      if (!sdpRes.ok) {
+        throw new Error(`Realtime SDP exchange failed (${sdpRes.status})`);
+      }
+      const answerSdp = await sdpRes.text();
+      await pc.setRemoteDescription({ type: "answer", sdp: answerSdp });
+    } catch (err) {
+      setLastError(err instanceof Error ? err.message : "Failed to start voice session");
+      teardown();
+      setState("idle");
+    }
+  }, [configureSession, onServerEvent, teardown]);
+
+  return { state, start, stop, lastError };
+}
+
+// ── pure helpers ─────────────────────────────────────────────────────
+
+interface ParsedToolArgs {
+  phrase: string;
+  confirm: boolean;
+}
+
+/** Tolerant parse of the model's tool-call arguments JSON. */
+export function parseToolArgs(json: string): ParsedToolArgs {
+  try {
+    const obj: unknown = JSON.parse(json);
+    if (!isRecord(obj)) return { phrase: "", confirm: false };
+    const phrase = typeof obj.phrase === "string" ? obj.phrase.trim() : "";
+    const confirm = obj.confirm === true;
+    return { phrase, confirm };
+  } catch {
+    return { phrase: "", confirm: false };
+  }
+}
+
+function pendingActionIdOf(structured: unknown): string | undefined {
+  if (!isRecord(structured)) return undefined;
+  const pending = structured.pendingCompletion;
+  if (!isRecord(pending)) return undefined;
+  return typeof pending.id === "string" ? pending.id : undefined;
+}
+
+function safeParse(data: unknown): RealtimeServerEvent | null {
+  if (typeof data !== "string") return null;
+  try {
+    const obj: unknown = JSON.parse(data);
+    if (isRecord(obj) && typeof obj.type === "string") {
+      return obj as RealtimeServerEvent;
+    }
+  } catch {
+    // ignore malformed frames
+  }
+  return null;
+}
+
+function describeServerError(event: RealtimeServerEvent): string {
+  const err = event.error;
+  if (isRecord(err) && typeof err.message === "string") return err.message;
+  return "Realtime session error";
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/lib/voice/useVoiceSession.ts
+++ b/src/lib/voice/useVoiceSession.ts
@@ -53,8 +53,18 @@ export interface UseVoiceSessionOptions {
   createSession: () => Promise<VoiceSessionMint>;
   /** Base URL for brainDispatcher; defaults to same-origin. */
   baseUrl?: string;
-  /** Optional tap on raw Realtime server events (used by the transcript bridge). */
+  /** Optional tap on raw Realtime server events. */
   onServerEvent?: (event: RealtimeServerEvent) => void;
+  /** A committed user utterance transcript (one per finished user turn). */
+  onUserTranscript?: (text: string) => void;
+  /** A committed assistant spoken transcript (one per finished zoe turn). */
+  onAssistantTranscript?: (text: string) => void;
+  /**
+   * Auto-close the session after this many ms of total silence (no speech, no
+   * response activity), to bound Realtime per-minute billing. Default ~25s.
+   * Set to 0 to disable.
+   */
+  endOnSilenceMs?: number;
 }
 
 export interface UseVoiceSession {
@@ -62,7 +72,11 @@ export interface UseVoiceSession {
   start: () => Promise<void>;
   stop: () => void;
   lastError: string | null;
+  /** True when start() failed because mic permission was denied/blocked. */
+  permissionDenied: boolean;
 }
+
+const DEFAULT_END_ON_SILENCE_MS = 25_000;
 
 /** A Realtime server event — a tagged JSON object over the data channel. */
 export interface RealtimeServerEvent {
@@ -75,12 +89,14 @@ export function useVoiceSession(
 ): UseVoiceSession {
   const [state, setState] = useState<VoiceSessionState>("idle");
   const [lastError, setLastError] = useState<string | null>(null);
+  const [permissionDenied, setPermissionDenied] = useState(false);
 
   const pcRef = useRef<RTCPeerConnection | null>(null);
   const dcRef = useRef<RTCDataChannel | null>(null);
   const micRef = useRef<MediaStream | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const tokenRef = useRef<string | null>(null);
+  const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Track the most recent complete_action gate so a confirm pins to that action.
   const pendingActionIdRef = useRef<string | undefined>(undefined);
   // Latest options without forcing start/stop identities to change.
@@ -88,6 +104,10 @@ export function useVoiceSession(
   optionsRef.current = options;
 
   const teardown = useCallback(() => {
+    if (silenceTimerRef.current) {
+      clearTimeout(silenceTimerRef.current);
+      silenceTimerRef.current = null;
+    }
     dcRef.current?.close();
     dcRef.current = null;
     pcRef.current?.getSenders().forEach((s) => s.track?.stop());
@@ -113,6 +133,17 @@ export function useVoiceSession(
 
   // Always release the session if the component using the hook unmounts.
   useEffect(() => () => teardown(), [teardown]);
+
+  /** (Re)start the end-on-silence countdown; any activity event resets it. */
+  const armSilenceTimer = useCallback(() => {
+    const ms = optionsRef.current.endOnSilenceMs ?? DEFAULT_END_ON_SILENCE_MS;
+    if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+    if (ms <= 0) return;
+    silenceTimerRef.current = setTimeout(() => {
+      // Only running sessions hold a peer connection; bounds idle billing.
+      if (pcRef.current) stop();
+    }, ms);
+  }, [stop]);
 
   /** Send a client event over the data channel (no-op if not open). */
   const send = useCallback((event: Record<string, unknown>) => {
@@ -186,6 +217,8 @@ export function useVoiceSession(
   const onServerEvent = useCallback(
     (event: RealtimeServerEvent) => {
       optionsRef.current.onServerEvent?.(event);
+      // Any server event is activity — reset the end-on-silence countdown.
+      armSilenceTimer();
 
       switch (event.type) {
         case "input_audio_buffer.speech_started":
@@ -200,6 +233,17 @@ export function useVoiceSession(
         case "output_audio_buffer.stopped":
           setState("listening");
           break;
+        case "conversation.item.input_audio_transcription.completed": {
+          const text = asString(event.transcript)?.trim();
+          if (text) optionsRef.current.onUserTranscript?.(text);
+          break;
+        }
+        case "response.output_audio_transcript.done":
+        case "response.audio_transcript.done": {
+          const text = asString(event.transcript)?.trim();
+          if (text) optionsRef.current.onAssistantTranscript?.(text);
+          break;
+        }
         case "response.function_call_arguments.done": {
           // GA carries name + call_id + arguments on this event.
           const callId = asString(event.call_id);
@@ -226,19 +270,38 @@ export function useVoiceSession(
           break;
       }
     },
-    [handleToolCall],
+    [handleToolCall, armSilenceTimer],
   );
 
   const start = useCallback(async () => {
     if (pcRef.current) return; // already running
     setLastError(null);
+    setPermissionDenied(false);
     setState("connecting");
+
+    let mic: MediaStream;
+    try {
+      mic = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (err) {
+      // Distinguish a blocked-permission denial so the UI can explain how to fix it.
+      const denied =
+        err instanceof DOMException &&
+        (err.name === "NotAllowedError" || err.name === "SecurityError");
+      setPermissionDenied(denied);
+      setLastError(
+        denied
+          ? "Microphone access is blocked. Allow microphone permission in your browser settings, then try again."
+          : err instanceof Error
+            ? err.message
+            : "Couldn't access the microphone.",
+      );
+      setState("idle");
+      return;
+    }
 
     try {
       const mint = await optionsRef.current.createSession();
       tokenRef.current = mint.voiceSessionToken;
-
-      const mic = await navigator.mediaDevices.getUserMedia({ audio: true });
       micRef.current = mic;
 
       const pc = new RTCPeerConnection();
@@ -259,6 +322,7 @@ export function useVoiceSession(
       dc.onopen = () => {
         configureSession();
         setState("listening");
+        armSilenceTimer();
       };
       dc.onmessage = (e) => {
         const parsed = safeParse(e.data);
@@ -289,9 +353,9 @@ export function useVoiceSession(
       teardown();
       setState("idle");
     }
-  }, [configureSession, onServerEvent, teardown]);
+  }, [configureSession, onServerEvent, teardown, armSilenceTimer]);
 
-  return { state, start, stop, lastError };
+  return { state, start, stop, lastError, permissionDenied };
 }
 
 // ── pure helpers ─────────────────────────────────────────────────────

--- a/src/lib/voice/voiceToolCatalog.ts
+++ b/src/lib/voice/voiceToolCatalog.ts
@@ -1,0 +1,151 @@
+/**
+ * voiceToolCatalog — pure-data descriptors of the 5 voice coarse tools in the
+ * shape the OpenAI Realtime SDK expects on its `tools` field, plus the router
+ * persona for `session.update`.
+ *
+ * Mirrors the iOS `RealtimeToolCatalog.swift` verbatim (Voice — Web Client, PRD
+ * §28) so the two clients describe one canonical voice surface that can be
+ * diffed. PURE — no WebRTC/SDK import — so it stays trivially testable and
+ * importable from anywhere.
+ *
+ * ADR 0001's hard rule: the Realtime model is **router + voice with ZERO user
+ * data**. It must ALWAYS call a tool for any fact or action and NEVER answer
+ * from memory. The five tools below are the only way it touches the user's data;
+ * each is a thin RPC the web client forwards to `voice.dispatch` via
+ * `brainDispatcher`.
+ */
+
+/** The 5 coarse tools. Same identifiers the brain's dispatch switch routes on. */
+export const VOICE_TOOL_NAMES = [
+  "capture_action",
+  "get_todays_plan",
+  "query",
+  "complete_action",
+  "ask_exponential",
+] as const;
+
+export type VoiceToolName = (typeof VOICE_TOOL_NAMES)[number];
+
+/**
+ * A Realtime-API function tool descriptor. The Realtime API uses the FLAT
+ * function shape (name/description/parameters at the top level), not the
+ * Chat-Completions nesting under `function`.
+ */
+export interface RealtimeToolDescriptor {
+  type: "function";
+  name: VoiceToolName;
+  description: string;
+  /** JSON Schema for the tool's arguments. */
+  parameters: Record<string, unknown>;
+}
+
+/** A `{ phrase: string }` argument schema with a tool-specific description. */
+function phraseSchema(phraseDescription: string): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: {
+      phrase: { type: "string", description: phraseDescription },
+    },
+    required: ["phrase"],
+    additionalProperties: false,
+  };
+}
+
+/**
+ * The 5 tool descriptors, in declaration order matching iOS. The model only
+ * picks an intent and passes the user's words verbatim as `phrase`; the brain
+ * does the parsing, resolution, and composition server-side.
+ */
+export const VOICE_TOOL_CATALOG: RealtimeToolDescriptor[] = [
+  {
+    type: "function",
+    name: "capture_action",
+    description:
+      "Capture a new action/task the user wants to add. Use whenever the user wants to remember, add, capture, or note something to do.",
+    parameters: phraseSchema(
+      "The user's request, verbatim — e.g. 'draft the investor update by Friday'.",
+    ),
+  },
+  {
+    type: "function",
+    name: "get_todays_plan",
+    description: "Get the user's plan / daily brief for today. No phrase needed.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    type: "function",
+    name: "query",
+    description:
+      "Answer a question about the user's existing actions or projects (what's due, what's overdue, status, what's on a project). Use for ANY question about the user's data — you have none yourself.",
+    parameters: phraseSchema("The user's question, verbatim — e.g. 'what's overdue?'."),
+  },
+  {
+    type: "function",
+    name: "complete_action",
+    description:
+      "Mark an existing action as done. DESTRUCTIVE — requires a spoken confirmation (see the confirmation handshake in your instructions).",
+    parameters: {
+      type: "object",
+      properties: {
+        phrase: {
+          type: "string",
+          description: "Which action to complete, verbatim — e.g. 'the JWT refactor'.",
+        },
+        confirm: {
+          type: "boolean",
+          description:
+            "Set true ONLY after the user has spoken a clear yes to the confirmation prompt. Omit/false on the first call.",
+        },
+      },
+      required: ["phrase"],
+      additionalProperties: false,
+    },
+  },
+  {
+    // Brain passthrough (ADR 0003): the catch-all for everything the four coarse
+    // tools don't cover. Runs zoe's full agent server-side.
+    type: "function",
+    name: "ask_exponential",
+    description:
+      "The catch-all assistant. Use for ANY request the other four tools don't cover — projects, goals/OKRs, calendar, email, Slack, meetings/transcripts, web lookups, or richer multi-step asks. Pass the user's request verbatim; the assistant handles it and may ask you to confirm destructive actions before doing them.",
+    parameters: phraseSchema(
+      "The user's full request, verbatim — e.g. 'what meetings did I have this week?' or 'message Lea on Slack that I'm running late'.",
+    ),
+  },
+];
+
+/**
+ * The router persona for `session.update`. Mirrors iOS `routerInstructions`:
+ * ADR 0001's hard rule (always defer, never fabricate), the perceived-latency
+ * filler, and the server-relayed confirmation handshake for the one destructive
+ * tool. Consumed by `useVoiceSession` in the next ticket.
+ */
+export const VOICE_ROUTER_INSTRUCTIONS = `You are Zoe, the voice of Exponential — an AI companion, not a corporate bot. Your vibe: warm when it matters, sharp when needed, a little witty, with real opinions and zero sycophancy. Skip the "Great question!" filler — just help. Use contractions, vary your rhythm, keep spoken replies short, and match the user's energy: quick question, quick answer.
+
+VOICE — speak English with a British accent (Received Pronunciation). Stay in English even if a name or word sounds foreign; only switch languages if the user clearly addresses you entirely in another language for a full sentence.
+
+STAY ON TASK — you do exactly four things: capture an action, give today's plan, answer questions about the user's actions/projects, and complete an action. Do NOT invent other features, do NOT start unrelated conversations, and do NOT offer to do things outside these four. If the user says something off-topic, briefly steer back to what you can help with.
+
+HARD RULE — you are a router and a voice, NOT a source of knowledge. You have ZERO knowledge of the user's data: their actions, tasks, projects, schedule, deadlines, or anything they've captured. You cannot see any of it.
+- For ANY question about the user's data, or ANY request to add, change, or complete something, you MUST call one of your tools. NEVER answer such a request from memory and NEVER invent or guess details — you have nothing to invent from.
+- If you ever feel tempted to state a fact about the user's actions or projects without a tool result in hand, stop and call a tool instead.
+- Pass the user's words to the tool verbatim as \`phrase\`. Do not pre-parse dates, projects, or names — the brain does that.
+- The tool result is the only truth. Speak its \`speakable\` text in your own warm voice; do not add facts it didn't contain.
+- Speak ONLY the specific items named in the tool result. If a result summarizes (e.g. "3 actions, including Call Lea and Call your mom"), those named ones are the ONLY items you have — NEVER invent, guess, or rename the unnamed ones to reach the count. If the user wants the rest, call the tool again to fetch them (e.g. ask for the full list); never fill the gap from memory.
+
+FILLER — the brain takes a moment. The instant you call a tool, say a brief, natural filler out loud ("one sec", "let me check", "on it") so the wait never feels broken. Then speak the result when it arrives.
+
+TOOLS — pick the most specific one. The first four are fast, focused tools; ask_exponential is the catch-all for everything else.
+- capture_action: the user wants to add/capture a task or action.
+- get_todays_plan: the user wants today's plan or daily brief (no phrase).
+- query: the user asks about their existing ACTIONS or PROJECTS (what's due, overdue, on a project).
+- complete_action: the user wants to mark something done. DESTRUCTIVE.
+- ask_exponential: ANYTHING ELSE — goals/OKRs, calendar, email, Slack, meetings or transcripts, web lookups, or any richer/multi-step request. When in doubt and it's not clearly one of the first four, use this. Pass the user's words verbatim; this assistant will itself ask you to confirm before any destructive action.
+
+CONFIRMATION HANDSHAKE — complete_action only:
+1. First call complete_action with just the \`phrase\` (no confirm).
+2. The result will come back needing confirmation; voice that confirmation prompt and WAIT for the user.
+3. ONLY after the user clearly says yes (or an equivalent), call complete_action AGAIN with the SAME \`phrase\` and \`confirm: true\`.
+4. If the user says no or hesitates, do not call it again — acknowledge and move on. Never set confirm: true without a spoken yes.
+
+SCOPE — never decline a request for being "out of scope." The first four tools cover actions and projects; for anything else (goals/OKRs, calendar, email, Slack, meetings, web, etc.) route it to ask_exponential rather than guessing or refusing.`;

--- a/src/server/api/middleware/__tests__/resolveVoiceCaller.test.ts
+++ b/src/server/api/middleware/__tests__/resolveVoiceCaller.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+
+import {
+  resolveVoiceCaller,
+  type VoiceCallerContext,
+} from "~/server/api/middleware/resolveVoiceCaller";
+
+const db: DeepMockProxy<PrismaClient> = mockDeep<PrismaClient>();
+
+function ctx(overrides: Partial<VoiceCallerContext>): VoiceCallerContext {
+  return {
+    session: null,
+    headers: new Headers(),
+    db,
+    ...overrides,
+  };
+}
+
+describe("resolveVoiceCaller — any-of voice auth gate", () => {
+  beforeEach(() => mockReset(db));
+
+  it("resolves a NextAuth session cookie to the session user id", async () => {
+    const result = await resolveVoiceCaller(
+      ctx({ session: { user: { id: "user-session" } } }),
+    );
+    expect(result).toEqual({ userId: "user-session" });
+    // Session short-circuits — no API-key DB lookup.
+    expect(db.verificationToken.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("cookie WINS over x-api-key when both are present (priority order)", async () => {
+    const headers = new Headers({ "x-api-key": "key-abc" });
+    const result = await resolveVoiceCaller(
+      ctx({ session: { user: { id: "user-session" } }, headers }),
+    );
+    expect(result).toEqual({ userId: "user-session" });
+    expect(db.verificationToken.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("resolves an x-api-key header to the owning user id (no session)", async () => {
+    db.verificationToken.findFirst.mockResolvedValueOnce({
+      userId: "user-key",
+    } as never);
+
+    const headers = new Headers({ "x-api-key": "key-abc" });
+    const result = await resolveVoiceCaller(ctx({ headers }));
+
+    expect(result).toEqual({ userId: "user-key" });
+  });
+
+  it("rejects with UNAUTHORIZED when no credential source matches", async () => {
+    await expect(resolveVoiceCaller(ctx({}))).rejects.toBeInstanceOf(TRPCError);
+    await expect(resolveVoiceCaller(ctx({}))).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  it("rejects an x-api-key that matches no valid token", async () => {
+    db.verificationToken.findFirst.mockResolvedValue(null);
+    const headers = new Headers({ "x-api-key": "bogus" });
+    await expect(resolveVoiceCaller(ctx({ headers }))).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  it("device-token slot is inert: a Bearer device token alone does not resolve", async () => {
+    // The Authorization Bearer slot is reserved for native OAuth and returns
+    // "not resolved" today, so a request carrying only it is rejected.
+    const headers = new Headers({ authorization: "Bearer device-token-xyz" });
+    await expect(resolveVoiceCaller(ctx({ headers }))).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+});

--- a/src/server/api/middleware/resolveVoiceCaller.ts
+++ b/src/server/api/middleware/resolveVoiceCaller.ts
@@ -1,0 +1,89 @@
+/**
+ * resolveVoiceCaller — the single auth-resolution point for the voice surface
+ * (Voice — Web Client, ticket #11; PRD §25).
+ *
+ * Collapses three credential sources into one `(ctx) → { userId }` helper, tried
+ * in priority order:
+ *   1. NextAuth session cookie (web client). `createTRPCContext` also normalizes
+ *      a valid `Authorization: Bearer <app-JWT>` into `ctx.session`, so legacy
+ *      Bearer callers resolve here too.
+ *   2. `x-api-key` header (legacy iOS; kept indefinitely as a dev fallback).
+ *   3. `Authorization: Bearer <device-token>` — RESERVED for the upcoming native
+ *      OAuth effort and intentionally INERT today (no exchanger exists yet).
+ *      Wired into the chain so that work slots in without re-touching this gate.
+ *
+ * Rejects with `UNAUTHORIZED` when no source resolves a caller.
+ */
+import { TRPCError } from "@trpc/server";
+import crypto from "crypto";
+import type { PrismaClient } from "@prisma/client";
+
+export interface VoiceCaller {
+  userId: string;
+}
+
+/** The minimal slice of the tRPC context this resolver reads. */
+export interface VoiceCallerContext {
+  session: { user?: { id?: string | null } | null } | null;
+  headers: Headers;
+  db: PrismaClient;
+}
+
+export async function resolveVoiceCaller(
+  ctx: VoiceCallerContext,
+): Promise<VoiceCaller> {
+  // 1. Signed-in session (NextAuth cookie, or a Bearer app-JWT normalized upstream).
+  if (ctx.session?.user?.id) {
+    return { userId: ctx.session.user.id };
+  }
+
+  // 2. x-api-key header (legacy iOS).
+  const apiKey = ctx.headers.get("x-api-key");
+  if (apiKey) {
+    const userId = await resolveApiKeyUserId(apiKey, ctx.db);
+    if (userId) return { userId };
+  }
+
+  // 3. Device-token slot — reserved, inert today.
+  const deviceCaller = await resolveDeviceToken(ctx);
+  if (deviceCaller) return deviceCaller;
+
+  throw new TRPCError({
+    code: "UNAUTHORIZED",
+    message:
+      "Voice session requires authentication: a signed-in session or an x-api-key.",
+  });
+}
+
+/**
+ * Resolve an `x-api-key` to its owner. Tries the hashed lookup first (current
+ * keys are stored as sha256 hashes), then a plaintext fallback for legacy keys —
+ * mirroring `apiKeyMiddleware`. Returns null when no valid, unexpired key matches.
+ */
+async function resolveApiKeyUserId(
+  apiKey: string,
+  db: PrismaClient,
+): Promise<string | null> {
+  const hashedKey = `sha256:${crypto.createHash("sha256").update(apiKey).digest("hex")}`;
+  let verificationToken = await db.verificationToken.findFirst({
+    where: { token: hashedKey, expires: { gt: new Date() } },
+  });
+  if (!verificationToken) {
+    verificationToken = await db.verificationToken.findFirst({
+      where: { token: apiKey, expires: { gt: new Date() } },
+    });
+  }
+  return verificationToken?.userId ?? null;
+}
+
+/**
+ * Reserved slot for native-OAuth device tokens
+ * (`Authorization: Bearer <device-token>`). INERT until the native OAuth feature
+ * lands — always returns null today. The future ticket implements the exchanger
+ * here without re-touching `resolveVoiceCaller` or `voice.createSession`.
+ */
+function resolveDeviceToken(
+  _ctx: VoiceCallerContext,
+): Promise<VoiceCaller | null> {
+  return Promise.resolve(null);
+}

--- a/src/server/api/routers/__tests__/voice.integration.test.ts
+++ b/src/server/api/routers/__tests__/voice.integration.test.ts
@@ -13,8 +13,8 @@ vi.mock("~/server/services/voice/openai-realtime", () => ({
 }));
 
 import { getTestDb } from "~/test/test-db";
-import { createUser, createApiKey } from "~/test/factories";
-import { createApiKeyCaller } from "~/test/trpc-helpers";
+import { createUser, createApiKey, createWorkspace } from "~/test/factories";
+import { createApiKeyCaller, createTestCaller } from "~/test/trpc-helpers";
 import { mintVoiceSessionToken } from "~/server/utils/voice-token";
 import { generateJWT } from "~/server/utils/jwt";
 
@@ -51,6 +51,49 @@ describe("voice router (integration)", () => {
       expect(decoded.sub).toBe(user.id);
       expect(decoded.exp - decoded.iat).toBe(30 * 60);
       expect(res.expiresInSeconds).toBe(1800);
+    });
+
+    it("mints a voice-session JWT from a NextAuth session cookie (no API key)", async () => {
+      const user = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: user.id, name: "Cookie WS" });
+
+      // createTestCaller authenticates via a session (the web client's path) —
+      // no x-api-key is ever set.
+      const res = await createTestCaller(user.id).voice.createSession();
+
+      const decoded = jwt.verify(res.voiceSessionToken, process.env.AUTH_SECRET!, {
+        audience: "voice-session",
+        issuer: "todo-app",
+      }) as { sub: string; tokenType: string; workspaceId?: string };
+
+      expect(decoded.tokenType).toBe("voice-session");
+      expect(decoded.sub).toBe(user.id);
+      // The workspace claim from the previous ticket is still stamped on the
+      // cookie path (resolves to the user's only membership).
+      expect(decoded.workspaceId).toBe(ws.id);
+    });
+
+    it("cookie and x-api-key resolve to the same user; both carry the workspace claim", async () => {
+      const user = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: user.id, name: "Shared WS" });
+      const { raw } = await createApiKey(db, user.id);
+
+      const viaCookie = await createTestCaller(user.id).voice.createSession();
+      const viaKey = await createApiKeyCaller(raw).voice.createSession();
+
+      const decode = (token: string) =>
+        jwt.verify(token, process.env.AUTH_SECRET!, {
+          audience: "voice-session",
+          issuer: "todo-app",
+        }) as { sub: string; workspaceId?: string };
+
+      const dc = decode(viaCookie.voiceSessionToken);
+      const dk = decode(viaKey.voiceSessionToken);
+
+      expect(dc.sub).toBe(user.id);
+      expect(dk.sub).toBe(user.id);
+      expect(dc.workspaceId).toBe(ws.id);
+      expect(dk.workspaceId).toBe(ws.id);
     });
 
     it("rejects an invalid API key", async () => {

--- a/src/server/api/routers/__tests__/voiceWorkspaceScope.integration.test.ts
+++ b/src/server/api/routers/__tests__/voiceWorkspaceScope.integration.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import jwt from "jsonwebtoken";
+
+// Mock the OpenAI Realtime minter so createSession never hits the network.
+vi.mock("~/server/services/voice/openai-realtime", () => ({
+  createRealtimeSession: vi.fn(async () => ({
+    ephemeralKey: "ek_test_ephemeral_123",
+    expiresAt: 1_900_000_000,
+    model: "gpt-4o-realtime-preview",
+    voice: "alloy",
+  })),
+}));
+
+import { getTestDb } from "~/test/test-db";
+import {
+  createUser,
+  createWorkspace,
+  createProject,
+  createAction,
+  createApiKey,
+} from "~/test/factories";
+import { createApiKeyCaller } from "~/test/trpc-helpers";
+
+type Db = ReturnType<typeof getTestDb>;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface QueryStructured {
+  declined: boolean;
+  actions: Array<{ id: string; name: string }>;
+}
+
+/** Decode the workspaceId claim baked into a minted voice-session token. */
+function workspaceClaim(token: string): string | undefined {
+  const decoded = jwt.verify(token, process.env.AUTH_SECRET!, {
+    audience: "voice-session",
+    issuer: "todo-app",
+  }) as { workspaceId?: string };
+  return decoded.workspaceId;
+}
+
+describe("voice workspace scoping (integration): createSession → JWT claim → dispatch", () => {
+  let db: Db;
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  /**
+   * One user, two workspaces (Alpha + Beta), each with one overdue action. The
+   * user owns both, so membership is valid for either. A third workspace is owned
+   * by someone else to exercise the privilege-escalation rejection.
+   */
+  async function seed() {
+    const user = await createUser(db);
+    const alpha = await createWorkspace(db, { ownerId: user.id, name: "Alpha" });
+    const beta = await createWorkspace(db, { ownerId: user.id, name: "Beta" });
+
+    await createAction(db, {
+      createdById: user.id,
+      workspaceId: alpha.id,
+      name: "alpha overdue",
+      dueDate: new Date(Date.now() - 10 * DAY_MS),
+    });
+    await createAction(db, {
+      createdById: user.id,
+      workspaceId: beta.id,
+      name: "beta overdue",
+      dueDate: new Date(Date.now() - 10 * DAY_MS),
+    });
+
+    const { raw } = await createApiKey(db, user.id);
+    return { user, alpha, beta, raw };
+  }
+
+  it("stamps the explicit (validated) workspaceId into the voice-session JWT", async () => {
+    const { alpha, raw } = await seed();
+
+    const session = await createApiKeyCaller(raw).voice.createSession({
+      workspaceId: alpha.id,
+    });
+
+    expect(workspaceClaim(session.voiceSessionToken)).toBe(alpha.id);
+  });
+
+  it("rejects createSession for a workspace the caller is not a member of", async () => {
+    const { raw } = await seed();
+    const stranger = await createUser(db);
+    const foreign = await createWorkspace(db, { ownerId: stranger.id, name: "Foreign" });
+
+    await expect(
+      createApiKeyCaller(raw).voice.createSession({ workspaceId: foreign.id }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("a token minted for workspace A only ever sees workspace A's data through dispatch", async () => {
+    const { alpha, beta, raw } = await seed();
+
+    const aSession = await createApiKeyCaller(raw).voice.createSession({
+      workspaceId: alpha.id,
+    });
+    const bSession = await createApiKeyCaller(raw).voice.createSession({
+      workspaceId: beta.id,
+    });
+
+    const aRes = await createApiKeyCaller(null).voice.dispatch({
+      token: aSession.voiceSessionToken,
+      toolName: "query",
+      args: { phrase: "what's overdue?" },
+    });
+    const bRes = await createApiKeyCaller(null).voice.dispatch({
+      token: bSession.voiceSessionToken,
+      toolName: "query",
+      args: { phrase: "what's overdue?" },
+    });
+
+    const aActions = (aRes.structured as QueryStructured).actions.map((x) => x.name);
+    const bActions = (bRes.structured as QueryStructured).actions.map((x) => x.name);
+
+    expect(aActions).toEqual(["alpha overdue"]);
+    expect(bActions).toEqual(["beta overdue"]);
+  });
+
+  it("captures into the session's workspace (the stamped claim reaches the mutating tool)", async () => {
+    const { user, alpha, raw } = await seed();
+
+    const session = await createApiKeyCaller(raw).voice.createSession({
+      workspaceId: alpha.id,
+    });
+
+    await createApiKeyCaller(null).voice.dispatch({
+      token: session.voiceSessionToken,
+      toolName: "capture_action",
+      args: { phrase: "buy milk" },
+    });
+
+    const created = await db.action.findFirst({
+      where: { createdById: user.id, name: { contains: "milk", mode: "insensitive" } },
+      select: { workspaceId: true },
+    });
+    expect(created?.workspaceId).toBe(alpha.id);
+  });
+});

--- a/src/server/api/routers/voice.ts
+++ b/src/server/api/routers/voice.ts
@@ -29,6 +29,10 @@ import { runQuery } from "~/server/services/voice/query";
 import { completeAction } from "~/server/services/voice/complete";
 import { askExponential } from "~/server/services/voice/brainPassthrough";
 import { speakableCaptureConfirmation } from "~/server/services/voice/speakable";
+import {
+  resolveWorkspaceId,
+  WorkspaceAccessError,
+} from "~/server/services/voice/workspaceResolver";
 
 /** The four coarse tools configured on the Realtime session (v1). */
 export const COARSE_TOOLS = [
@@ -54,10 +58,30 @@ export const voiceRouter = createTRPCRouter({
    * x-api-key middleware (ctx.userId is guaranteed non-null here).
    */
   createSession: apiKeyMiddleware
-    .input(z.object({ mode: modeSchema }).optional())
-    .mutation(async ({ ctx }) => {
+    .input(
+      z
+        .object({ mode: modeSchema, workspaceId: z.string().optional() })
+        .optional(),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Resolve (and validate) the session's workspace once, here — the result
+      // is baked into the voice-session JWT as a verified claim so the device
+      // cannot tamper with the workspace the brain operates in.
+      let workspaceId: string | undefined;
+      try {
+        workspaceId = await resolveWorkspaceId(ctx.userId, db, input?.workspaceId);
+      } catch (err) {
+        if (err instanceof WorkspaceAccessError) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "You are not a member of the requested workspace.",
+          });
+        }
+        throw err;
+      }
+
       const realtime = await createRealtimeSession();
-      const voiceSessionToken = mintVoiceSessionToken({ id: ctx.userId });
+      const voiceSessionToken = mintVoiceSessionToken({ id: ctx.userId }, workspaceId);
 
       return {
         openaiEphemeralKey: realtime.ephemeralKey,
@@ -91,8 +115,9 @@ export const voiceRouter = createTRPCRouter({
     )
     .mutation(async ({ input }): Promise<DispatchResult> => {
       let userId: string;
+      let workspaceId: string | undefined;
       try {
-        ({ userId } = verifyVoiceSessionToken(input.token));
+        ({ userId, workspaceId } = verifyVoiceSessionToken(input.token));
       } catch {
         throw new TRPCError({
           code: "UNAUTHORIZED",
@@ -111,7 +136,7 @@ export const voiceRouter = createTRPCRouter({
               needsConfirmation: false,
             };
           }
-          const { action, inbox } = await captureAction(phrase, userId, db);
+          const { action, inbox } = await captureAction(phrase, userId, db, workspaceId);
           return {
             speakable: speakableCaptureConfirmation({
               name: action.name,
@@ -124,12 +149,15 @@ export const voiceRouter = createTRPCRouter({
         }
 
         case "get_todays_plan": {
-          // Read-only briefing: never raises the confirmation gate.
+          // Read-only briefing: never raises the confirmation gate. The verified
+          // token claim is authoritative; args.workspaceId is honoured only as a
+          // back-compat fallback for one release (see ticket #10 / PRD §33).
+          const argWorkspaceId =
+            typeof input.args?.workspaceId === "string"
+              ? input.args.workspaceId
+              : undefined;
           const { speakable, data } = await getTodaysPlan(userId, db, {
-            workspaceId:
-              typeof input.args?.workspaceId === "string"
-                ? input.args.workspaceId
-                : undefined,
+            workspaceId: workspaceId ?? argWorkspaceId,
           });
           return {
             speakable,
@@ -149,13 +177,16 @@ export const voiceRouter = createTRPCRouter({
               needsConfirmation: false,
             };
           }
+          // Token claim is authoritative; args.workspaceId is back-compat only.
+          const argWorkspaceId =
+            typeof input.args?.workspaceId === "string"
+              ? input.args.workspaceId
+              : undefined;
           const { speakable, structured } = await runQuery(
             phrase,
             userId,
             db,
-            typeof input.args?.workspaceId === "string"
-              ? input.args.workspaceId
-              : undefined,
+            workspaceId ?? argWorkspaceId,
           );
           return { speakable, structured, needsConfirmation: false };
         }
@@ -176,6 +207,7 @@ export const voiceRouter = createTRPCRouter({
           return completeAction(phrase, userId, db, {
             confirm: input.confirm,
             pendingId: input.pendingActionId,
+            workspaceId,
           });
         }
 
@@ -193,7 +225,7 @@ export const voiceRouter = createTRPCRouter({
             };
           }
           try {
-            return await askExponential(phrase, userId, db);
+            return await askExponential(phrase, userId, db, workspaceId);
           } catch (error) {
             console.error("[voice.dispatch] ask_exponential failed:", error);
             return {

--- a/src/server/api/routers/voice.ts
+++ b/src/server/api/routers/voice.ts
@@ -33,6 +33,11 @@ import {
   resolveWorkspaceId,
   WorkspaceAccessError,
 } from "~/server/services/voice/workspaceResolver";
+import {
+  persistVoiceTurn,
+  voiceThreadKey,
+  EmptyVoiceTurnError,
+} from "~/server/services/voice/voiceTranscriptBridge";
 
 /** The four coarse tools configured on the Realtime session (v1). */
 export const COARSE_TOOLS = [
@@ -254,6 +259,46 @@ export const voiceRouter = createTRPCRouter({
             needsConfirmation: false,
           };
         }
+      }
+    }),
+
+  /**
+   * Persist one voice transcript turn into the voice-scoped memory thread, so a
+   * voice session has continuity across turns. Authed by the voice-session JWT
+   * (same as dispatch). Isolated from text-chat memory — see voiceTranscriptBridge.
+   */
+  persistTurn: publicProcedure
+    .input(
+      z.object({
+        token: z.string().min(1, "voice-session token required"),
+        role: z.enum(["user", "assistant"]),
+        text: z.string(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      let userId: string;
+      try {
+        ({ userId } = verifyVoiceSessionToken(input.token));
+      } catch {
+        throw new TRPCError({
+          code: "UNAUTHORIZED",
+          message: "Invalid or missing voice-session token",
+        });
+      }
+
+      try {
+        const turn = await persistVoiceTurn({
+          userId,
+          role: input.role,
+          text: input.text,
+          threadKey: voiceThreadKey(userId),
+        });
+        return { id: turn.id, marker: turn.marker };
+      } catch (err) {
+        if (err instanceof EmptyVoiceTurnError) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: err.message });
+        }
+        throw err;
       }
     }),
 });

--- a/src/server/api/routers/voice.ts
+++ b/src/server/api/routers/voice.ts
@@ -17,7 +17,6 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 
-import { db } from "~/server/db";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import { resolveVoiceCaller } from "~/server/api/middleware/resolveVoiceCaller";
 import { DEFAULT_EXPIRY } from "~/server/utils/jwt";
@@ -77,7 +76,7 @@ export const voiceRouter = createTRPCRouter({
       // cannot tamper with the workspace the brain operates in.
       let workspaceId: string | undefined;
       try {
-        workspaceId = await resolveWorkspaceId(userId, db, input?.workspaceId);
+        workspaceId = await resolveWorkspaceId(userId, ctx.db, input?.workspaceId);
       } catch (err) {
         if (err instanceof WorkspaceAccessError) {
           throw new TRPCError({
@@ -121,7 +120,7 @@ export const voiceRouter = createTRPCRouter({
         pendingActionId: z.string().optional(),
       }),
     )
-    .mutation(async ({ input }): Promise<DispatchResult> => {
+    .mutation(async ({ ctx, input }): Promise<DispatchResult> => {
       let userId: string;
       let workspaceId: string | undefined;
       try {
@@ -144,7 +143,7 @@ export const voiceRouter = createTRPCRouter({
               needsConfirmation: false,
             };
           }
-          const { action, inbox } = await captureAction(phrase, userId, db, workspaceId);
+          const { action, inbox } = await captureAction(phrase, userId, ctx.db, workspaceId);
           return {
             speakable: speakableCaptureConfirmation({
               name: action.name,
@@ -164,7 +163,7 @@ export const voiceRouter = createTRPCRouter({
             typeof input.args?.workspaceId === "string"
               ? input.args.workspaceId
               : undefined;
-          const { speakable, data } = await getTodaysPlan(userId, db, {
+          const { speakable, data } = await getTodaysPlan(userId, ctx.db, {
             workspaceId: workspaceId ?? argWorkspaceId,
           });
           return {
@@ -193,7 +192,7 @@ export const voiceRouter = createTRPCRouter({
           const { speakable, structured } = await runQuery(
             phrase,
             userId,
-            db,
+            ctx.db,
             workspaceId ?? argWorkspaceId,
           );
           return { speakable, structured, needsConfirmation: false };
@@ -212,7 +211,7 @@ export const voiceRouter = createTRPCRouter({
               needsConfirmation: false,
             };
           }
-          return completeAction(phrase, userId, db, {
+          return completeAction(phrase, userId, ctx.db, {
             confirm: input.confirm,
             pendingId: input.pendingActionId,
             workspaceId,
@@ -233,7 +232,7 @@ export const voiceRouter = createTRPCRouter({
             };
           }
           try {
-            return await askExponential(phrase, userId, db, workspaceId);
+            return await askExponential(phrase, userId, ctx.db, workspaceId);
           } catch (error) {
             console.error("[voice.dispatch] ask_exponential failed:", error);
             return {

--- a/src/server/api/routers/voice.ts
+++ b/src/server/api/routers/voice.ts
@@ -19,7 +19,7 @@ import { TRPCError } from "@trpc/server";
 
 import { db } from "~/server/db";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
-import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
+import { resolveVoiceCaller } from "~/server/api/middleware/resolveVoiceCaller";
 import { DEFAULT_EXPIRY } from "~/server/utils/jwt";
 import { mintVoiceSessionToken, verifyVoiceSessionToken } from "~/server/utils/voice-token";
 import { createRealtimeSession } from "~/server/services/voice/openai-realtime";
@@ -54,22 +54,25 @@ export interface DispatchResult {
 
 export const voiceRouter = createTRPCRouter({
   /**
-   * Mint a voice session. Authed by the durable Exponential API key via the
-   * x-api-key middleware (ctx.userId is guaranteed non-null here).
+   * Mint a voice session. Authed by the any-of voice gate (resolveVoiceCaller):
+   * a NextAuth session cookie (web), an x-api-key (legacy iOS), or — reserved,
+   * inert today — a device token. Browser users never paste an API key.
    */
-  createSession: apiKeyMiddleware
+  createSession: publicProcedure
     .input(
       z
         .object({ mode: modeSchema, workspaceId: z.string().optional() })
         .optional(),
     )
     .mutation(async ({ ctx, input }) => {
+      const { userId } = await resolveVoiceCaller(ctx);
+
       // Resolve (and validate) the session's workspace once, here — the result
       // is baked into the voice-session JWT as a verified claim so the device
       // cannot tamper with the workspace the brain operates in.
       let workspaceId: string | undefined;
       try {
-        workspaceId = await resolveWorkspaceId(ctx.userId, db, input?.workspaceId);
+        workspaceId = await resolveWorkspaceId(userId, db, input?.workspaceId);
       } catch (err) {
         if (err instanceof WorkspaceAccessError) {
           throw new TRPCError({
@@ -81,7 +84,7 @@ export const voiceRouter = createTRPCRouter({
       }
 
       const realtime = await createRealtimeSession();
-      const voiceSessionToken = mintVoiceSessionToken({ id: ctx.userId }, workspaceId);
+      const voiceSessionToken = mintVoiceSessionToken({ id: userId }, workspaceId);
 
       return {
         openaiEphemeralKey: realtime.ephemeralKey,

--- a/src/server/services/parsing/parseActionInput.ts
+++ b/src/server/services/parsing/parseActionInput.ts
@@ -21,6 +21,8 @@ export interface ParseActionInputOptions {
   projectId?: string;
   /** Whether to parse natural language (default: true) */
   parseNaturalLanguage?: boolean;
+  /** If provided, only match against projects in this workspace. */
+  workspaceId?: string;
 }
 
 /**
@@ -56,6 +58,7 @@ export async function parseActionInput(
     where: {
       createdById: userId,
       status: { not: "COMPLETED" },
+      ...(options?.workspaceId ? { workspaceId: options.workspaceId } : {}),
     },
     select: {
       id: true,

--- a/src/server/services/voice/__tests__/voiceTranscriptBridge.test.ts
+++ b/src/server/services/voice/__tests__/voiceTranscriptBridge.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+});
+
+import {
+  persistVoiceTurn,
+  voiceTurnId,
+  voiceThreadKey,
+  EmptyVoiceTurnError,
+  type VoiceMemoryClient,
+} from "~/server/services/voice/voiceTranscriptBridge";
+
+function mockClient() {
+  const saveMessageToMemory = vi.fn(async () => ({}));
+  const client: VoiceMemoryClient = { saveMessageToMemory };
+  return { client, saveMessageToMemory };
+}
+
+describe("voiceTranscriptBridge.persistVoiceTurn", () => {
+  it("persists to the given thread key with the correct role, resource, and marker", async () => {
+    const { client, saveMessageToMemory } = mockClient();
+
+    const result = await persistVoiceTurn(
+      { userId: "u1", role: "user", text: "what's overdue?", threadKey: voiceThreadKey("u1") },
+      { client },
+    );
+
+    expect(result.threadKey).toBe("voice-u1");
+    expect(result.role).toBe("user");
+    expect(result.marker).toBe("voice");
+
+    expect(saveMessageToMemory).toHaveBeenCalledTimes(1);
+    const arg = saveMessageToMemory.mock.calls[0]![0];
+    const msg = arg.messages[0]!;
+    expect(arg.agentId).toBe("zoeAgent");
+    expect(msg.threadId).toBe("voice-u1");
+    expect(msg.resourceId).toBe("u1");
+    expect(msg.role).toBe("user");
+    expect(msg.content).toBe("what's overdue?");
+  });
+
+  it("rejects an empty / whitespace-only turn without persisting", async () => {
+    const { client, saveMessageToMemory } = mockClient();
+
+    await expect(
+      persistVoiceTurn({ userId: "u1", role: "user", text: "   ", threadKey: "voice-u1" }, { client }),
+    ).rejects.toBeInstanceOf(EmptyVoiceTurnError);
+
+    expect(saveMessageToMemory).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent on retry: the same turn yields the same deterministic id", async () => {
+    const { client } = mockClient();
+
+    const first = await persistVoiceTurn(
+      { userId: "u1", role: "assistant", text: "You have 2 overdue.", threadKey: "voice-u1" },
+      { client },
+    );
+    const retry = await persistVoiceTurn(
+      { userId: "u1", role: "assistant", text: "You have 2 overdue.", threadKey: "voice-u1" },
+      { client },
+    );
+
+    expect(first.id).toBe(retry.id);
+    expect(first.id).toBe(voiceTurnId("voice-u1", "assistant", "You have 2 overdue."));
+  });
+
+  it("trims surrounding whitespace before persisting", async () => {
+    const { client, saveMessageToMemory } = mockClient();
+    await persistVoiceTurn(
+      { userId: "u1", role: "user", text: "  hello  ", threadKey: "voice-u1" },
+      { client },
+    );
+    expect(saveMessageToMemory.mock.calls[0]![0].messages[0]!.content).toBe("hello");
+  });
+});

--- a/src/server/services/voice/__tests__/workspaceResolver.test.ts
+++ b/src/server/services/voice/__tests__/workspaceResolver.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import {
+  resolveWorkspaceId,
+  WorkspaceAccessError,
+} from "~/server/services/voice/workspaceResolver";
+
+const db: DeepMockProxy<PrismaClient> = mockDeep<PrismaClient>();
+
+describe("resolveWorkspaceId — three-tier voice workspace resolution", () => {
+  beforeEach(() => mockReset(db));
+
+  it("explicit-valid: returns the explicit id when the user IS a member", async () => {
+    // Membership lookup for the explicit id succeeds.
+    db.workspaceUser.findFirst.mockResolvedValueOnce({ workspaceId: "ws-explicit" } as never);
+
+    const result = await resolveWorkspaceId("user-1", db, "ws-explicit");
+
+    expect(result).toBe("ws-explicit");
+    // It must verify membership for the explicit id before trusting it.
+    expect(db.workspaceUser.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user-1", workspaceId: "ws-explicit" },
+      }),
+    );
+    // Validation short-circuits the default/first-membership tiers.
+    expect(db.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("explicit-invalid: rejects when the user is NOT a member of the explicit id", async () => {
+    db.workspaceUser.findFirst.mockResolvedValueOnce(null);
+
+    await expect(
+      resolveWorkspaceId("user-1", db, "ws-not-mine"),
+    ).rejects.toBeInstanceOf(WorkspaceAccessError);
+
+    // Never falls through to default/first-membership on an invalid explicit id —
+    // that would be a privilege-escalation path.
+    expect(db.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("default fallback: returns User.defaultWorkspaceId when no explicit id is given", async () => {
+    db.user.findUnique.mockResolvedValueOnce({ defaultWorkspaceId: "ws-default" } as never);
+
+    const result = await resolveWorkspaceId("user-1", db);
+
+    expect(result).toBe("ws-default");
+    // Default wins before consulting the membership list.
+    expect(db.workspaceUser.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("first-membership fallback: returns the oldest membership when no explicit id and no default", async () => {
+    db.user.findUnique.mockResolvedValueOnce({ defaultWorkspaceId: null } as never);
+    db.workspaceUser.findFirst.mockResolvedValueOnce({ workspaceId: "ws-first" } as never);
+
+    const result = await resolveWorkspaceId("user-1", db);
+
+    expect(result).toBe("ws-first");
+    expect(db.workspaceUser.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user-1" },
+        orderBy: { joinedAt: "asc" },
+      }),
+    );
+  });
+
+  it("no workspace: returns undefined when the user belongs to no workspace", async () => {
+    db.user.findUnique.mockResolvedValueOnce({ defaultWorkspaceId: null } as never);
+    db.workspaceUser.findFirst.mockResolvedValueOnce(null);
+
+    const result = await resolveWorkspaceId("user-1", db);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/server/services/voice/__tests__/workspaceResolver.test.ts
+++ b/src/server/services/voice/__tests__/workspaceResolver.test.ts
@@ -41,14 +41,32 @@ describe("resolveWorkspaceId — three-tier voice workspace resolution", () => {
     expect(db.user.findUnique).not.toHaveBeenCalled();
   });
 
-  it("default fallback: returns User.defaultWorkspaceId when no explicit id is given", async () => {
+  it("default fallback: returns User.defaultWorkspaceId when the user is still a member", async () => {
     db.user.findUnique.mockResolvedValueOnce({ defaultWorkspaceId: "ws-default" } as never);
+    // Membership check for the default workspace succeeds.
+    db.workspaceUser.findFirst.mockResolvedValueOnce({ workspaceId: "ws-default" } as never);
 
     const result = await resolveWorkspaceId("user-1", db);
 
     expect(result).toBe("ws-default");
-    // Default wins before consulting the membership list.
-    expect(db.workspaceUser.findFirst).not.toHaveBeenCalled();
+    // Verified the default against current memberships before trusting it.
+    expect(db.workspaceUser.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user-1", workspaceId: "ws-default" },
+      }),
+    );
+  });
+
+  it("stale default: ignores defaultWorkspaceId when the user is no longer a member, falls to first membership", async () => {
+    db.user.findUnique.mockResolvedValueOnce({ defaultWorkspaceId: "ws-removed" } as never);
+    // First findFirst = default-membership check (not a member); second = first-membership fallback.
+    db.workspaceUser.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ workspaceId: "ws-first" } as never);
+
+    const result = await resolveWorkspaceId("user-1", db);
+
+    expect(result).toBe("ws-first");
   });
 
   it("first-membership fallback: returns the oldest membership when no explicit id and no default", async () => {

--- a/src/server/services/voice/actionResolver.ts
+++ b/src/server/services/voice/actionResolver.ts
@@ -38,6 +38,7 @@ export async function resolveActionByDescription(
   phrase: string,
   userId: string,
   db: PrismaClient,
+  workspaceId?: string,
 ): Promise<ResolveResult> {
   const normalized = normalizeDescription(phrase);
   if (!normalized) return { kind: "none" };
@@ -54,6 +55,9 @@ export async function resolveActionByDescription(
         buildActionAccessWhere(userId),
         { status: { notIn: NON_OPEN_STATUSES } },
         { OR: nameOr },
+        // Scope to the session's workspace so a voice "mark X done" can never
+        // resolve an action from a workspace the session isn't operating in.
+        ...(workspaceId ? [{ workspaceId }] : []),
       ],
     },
     select: {

--- a/src/server/services/voice/brainPassthrough.ts
+++ b/src/server/services/voice/brainPassthrough.ts
@@ -28,6 +28,7 @@ import { RequestContext } from "@mastra/core/di";
 
 import { generateAgentJWT } from "~/server/utils/jwt";
 import { boundLength } from "~/server/services/voice/speakable";
+import { resolveWorkspaceId } from "~/server/services/voice/workspaceResolver";
 
 const MASTRA_API_URL = process.env.MASTRA_API_URL ?? "http://localhost:4111";
 
@@ -50,40 +51,23 @@ export interface BrainPassthroughResult {
 }
 
 /**
- * Resolve the user's workspace so zoe's workspace-scoped tools (OKR/goals/etc.)
- * have a valid id — without it, OKR writes hit a FK violation and zoe falls back
- * to `getUserWorkspaces` (currently a 405). Prefer the user's default workspace,
- * else their first membership.
- */
-async function resolveWorkspaceId(
-  userId: string,
-  db: PrismaClient,
-): Promise<string | undefined> {
-  const user = await db.user.findUnique({
-    where: { id: userId },
-    select: { defaultWorkspaceId: true },
-  });
-  if (user?.defaultWorkspaceId) return user.defaultWorkspaceId;
-
-  const membership = await db.workspaceUser.findFirst({
-    where: { userId },
-    orderBy: { joinedAt: "asc" },
-    select: { workspaceId: true },
-  });
-  return membership?.workspaceId;
-}
-
-/**
  * Run zoe's full agent for a voice turn and return a spoken answer. Throws are
  * caught by the caller (voice.dispatch) which renders a graceful fallback.
+ *
+ * `workspaceId` is the session's verified workspace (from the voice-session JWT
+ * claim, threaded by voice.dispatch) so zoe's workspace-scoped tools (OKR/goals)
+ * have a valid id. Legacy tokens minted before the claim existed pass it as
+ * undefined; we then fall back to the shared `workspaceResolver` (the same
+ * three-tier resolution used at session-mint time).
  */
 export async function askExponential(
   phrase: string,
   userId: string,
   db: PrismaClient,
+  workspaceId?: string,
 ): Promise<BrainPassthroughResult> {
   const agentJWT = generateAgentJWT({ id: userId });
-  const workspaceId = await resolveWorkspaceId(userId, db);
+  const effectiveWorkspaceId = workspaceId ?? (await resolveWorkspaceId(userId, db));
 
   const client = new MastraClient({
     baseUrl: MASTRA_API_URL,
@@ -95,7 +79,7 @@ export async function askExponential(
     ["authToken", agentJWT],
     ["userId", userId],
   ];
-  if (workspaceId) entries.push(["workspaceId", workspaceId]);
+  if (effectiveWorkspaceId) entries.push(["workspaceId", effectiveWorkspaceId]);
   const requestContext = new RequestContext(entries);
 
   const messages: MessageListInput = [
@@ -111,7 +95,7 @@ export async function askExponential(
   const text = (res.text ?? "").trim();
   return {
     speakable: boundLength(text.length > 0 ? text : "I didn't get an answer for that."),
-    structured: { via: "zoe", workspaceId: workspaceId ?? null },
+    structured: { via: "zoe", workspaceId: effectiveWorkspaceId ?? null },
     needsConfirmation: false,
   };
 }

--- a/src/server/services/voice/capture.ts
+++ b/src/server/services/voice/capture.ts
@@ -38,13 +38,22 @@ export async function captureAction(
   phrase: string,
   userId: string,
   db: PrismaClient,
+  workspaceId?: string,
 ): Promise<CaptureResult> {
-  const parsed = await parseActionInput(phrase, userId, db);
+  const parsed = await parseActionInput(
+    phrase,
+    userId,
+    db,
+    workspaceId ? { workspaceId } : undefined,
+  );
 
-  // Inherit kanban order + workspace from the resolved project (matches the
-  // existing quick-create paths). Inbox actions get neither.
+  // Inherit kanban order from the resolved project (matches the existing
+  // quick-create paths). The action belongs to the session's workspace; a
+  // matched project's workspace (always the session's, since matching is now
+  // scoped above) refines it, and inbox actions still carry the session
+  // workspace so "what's in <workspace>?" sees them.
   let kanbanOrder: number | null = null;
-  let workspaceId: string | null = null;
+  let resolvedWorkspaceId: string | null = workspaceId ?? null;
   if (parsed.projectId) {
     const [highest, proj] = await Promise.all([
       db.action.findFirst({
@@ -58,7 +67,7 @@ export async function captureAction(
       }),
     ]);
     kanbanOrder = (highest?.kanbanOrder ?? 0) + 1;
-    workspaceId = proj?.workspaceId ?? null;
+    resolvedWorkspaceId = proj?.workspaceId ?? resolvedWorkspaceId;
   }
 
   const action = await db.action.create({
@@ -73,7 +82,7 @@ export async function captureAction(
       source: "voice",
       kanbanStatus: parsed.projectId ? "TODO" : null,
       kanbanOrder,
-      workspaceId,
+      workspaceId: resolvedWorkspaceId,
     },
     select: {
       id: true,

--- a/src/server/services/voice/complete.ts
+++ b/src/server/services/voice/complete.ts
@@ -32,7 +32,7 @@ export async function completeAction(
   phrase: string,
   userId: string,
   db: PrismaClient,
-  options?: { confirm?: boolean; pendingId?: string },
+  options?: { confirm?: boolean; pendingId?: string; workspaceId?: string },
 ): Promise<CompleteResult> {
   // Confirm pinned to the action the gate originally proposed: complete exactly
   // that id, never re-resolve the phrase. Re-resolving on confirm could land on
@@ -40,10 +40,15 @@ export async function completeAction(
   // — the confirmation the user gave was for the suggested action, not whatever
   // the phrase now matches.
   if (options?.confirm && options.pendingId) {
-    return completeById(options.pendingId, userId, db);
+    return completeById(options.pendingId, userId, db, options.workspaceId);
   }
 
-  const resolution = await resolveActionByDescription(phrase, userId, db);
+  const resolution = await resolveActionByDescription(
+    phrase,
+    userId,
+    db,
+    options?.workspaceId,
+  );
 
   if (resolution.kind === "none") {
     return {
@@ -89,7 +94,7 @@ export async function completeAction(
 
   // Confirmed without a pinned id (legacy confirm path): complete the resolved
   // single match. We already know its name, so pass it to avoid a re-fetch.
-  return completeById(action.id, userId, db, action.name);
+  return completeById(action.id, userId, db, options?.workspaceId, action.name);
 }
 
 /**
@@ -102,6 +107,7 @@ async function completeById(
   id: string,
   userId: string,
   db: PrismaClient,
+  workspaceId?: string,
   knownName?: string,
 ): Promise<CompleteResult> {
   const res = await db.action.updateMany({
@@ -110,6 +116,9 @@ async function completeById(
         { id },
         buildActionAccessWhere(userId),
         { status: { notIn: ["COMPLETED", "DELETED"] } },
+        // Defence in depth: a pinned confirm can only complete an action in the
+        // session's workspace, never one resolved from a different workspace.
+        ...(workspaceId ? [{ workspaceId }] : []),
       ],
     },
     data: { status: "COMPLETED", completedAt: new Date() },
@@ -120,7 +129,13 @@ async function completeById(
   let name = knownName;
   if (name === undefined) {
     const found = await db.action.findFirst({
-      where: { AND: [{ id }, buildActionAccessWhere(userId)] },
+      where: {
+        AND: [
+          { id },
+          buildActionAccessWhere(userId),
+          ...(workspaceId ? [{ workspaceId }] : []),
+        ],
+      },
       select: { name: true },
     });
     name = found?.name ?? "that action";

--- a/src/server/services/voice/voiceTranscriptBridge.ts
+++ b/src/server/services/voice/voiceTranscriptBridge.ts
@@ -1,0 +1,125 @@
+/**
+ * voiceTranscriptBridge (Voice — Web Client, ticket #14) — persists a voice turn
+ * (the user's spoken utterance, or zoe's spoken reply) into a Mastra memory
+ * thread so a voice session has conversational continuity across turns.
+ *
+ * MEMORY MODEL — ISOLATE (decided with the human owner; see the ticket comment):
+ * the gating iOS audit response on memory alignment never arrived, the web chat
+ * doesn't actually key memory per-(user × workspace) (it keys per-conversation),
+ * and there is no app-side chat message table to add a `marker` column to. So
+ * voice turns persist to a VOICE-SCOPED thread (the same `voice-${userId}` key
+ * brainPassthrough already uses), kept isolated from the text-chat memory, and
+ * the 🎙 `marker` is a UI/contract attribute (MastraMessageV1 has no metadata
+ * slot for it). brainPassthrough's thread key is left untouched, so iOS runtime
+ * behaviour is unchanged. Reversible to alignment once the audit lands.
+ *
+ * Idempotent: a turn's id is derived from (threadKey, role, text), so a retry of
+ * the same turn upserts rather than duplicating.
+ */
+import crypto from "crypto";
+
+import { MastraClient } from "@mastra/client-js";
+import { generateAgentJWT } from "~/server/utils/jwt";
+
+const MASTRA_API_URL = process.env.MASTRA_API_URL ?? "http://localhost:4111";
+/** Same agent brainPassthrough drives, so the voice thread is one conversation. */
+const VOICE_AGENT_ID = "zoeAgent";
+
+export type VoiceTurnRole = "user" | "assistant";
+
+export interface PersistVoiceTurnInput {
+  userId: string;
+  role: VoiceTurnRole;
+  text: string;
+  /** The voice-scoped Mastra thread key (e.g. `voice-${userId}`). */
+  threadKey: string;
+  /** Display marker; defaults to "voice" (drives the 🎙 chat icon). */
+  marker?: "voice";
+}
+
+export interface PersistedVoiceTurn {
+  id: string;
+  role: VoiceTurnRole;
+  threadKey: string;
+  marker: "voice";
+}
+
+/** Thrown when asked to persist an empty/whitespace-only turn. */
+export class EmptyVoiceTurnError extends Error {
+  constructor() {
+    super("Refusing to persist an empty voice turn");
+    this.name = "EmptyVoiceTurnError";
+  }
+}
+
+/** The slice of MastraClient the bridge needs (injectable for tests). */
+export interface VoiceMemoryClient {
+  saveMessageToMemory(params: {
+    agentId: string;
+    messages: Array<{
+      id: string;
+      role: VoiceTurnRole;
+      content: string;
+      createdAt: Date;
+      threadId: string;
+      resourceId: string;
+      type: "text";
+    }>;
+  }): Promise<unknown>;
+}
+
+function defaultClient(userId: string): VoiceMemoryClient {
+  const agentJWT = generateAgentJWT({ id: userId });
+  return new MastraClient({
+    baseUrl: MASTRA_API_URL,
+    headers: { Authorization: `Bearer ${agentJWT}` },
+  }) as unknown as VoiceMemoryClient;
+}
+
+/** Deterministic id so retrying the same turn upserts instead of duplicating. */
+export function voiceTurnId(threadKey: string, role: VoiceTurnRole, text: string): string {
+  const hash = crypto
+    .createHash("sha256")
+    .update(`${threadKey}:${role}:${text}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `voice-${hash}`;
+}
+
+/**
+ * Persist one voice turn into its voice-scoped memory thread. Rejects empty
+ * turns; idempotent on retry (deterministic id). Returns the persisted record
+ * (carrying the marker the chat UI renders as 🎙).
+ */
+export async function persistVoiceTurn(
+  input: PersistVoiceTurnInput,
+  deps: { client?: VoiceMemoryClient } = {},
+): Promise<PersistedVoiceTurn> {
+  const text = input.text.trim();
+  if (!text) throw new EmptyVoiceTurnError();
+
+  const id = voiceTurnId(input.threadKey, input.role, text);
+  const client = deps.client ?? defaultClient(input.userId);
+
+  await client.saveMessageToMemory({
+    agentId: VOICE_AGENT_ID,
+    messages: [
+      {
+        id,
+        role: input.role,
+        content: text,
+        createdAt: new Date(),
+        threadId: input.threadKey,
+        resourceId: input.userId,
+        type: "text",
+      },
+    ],
+  });
+
+  return { id, role: input.role, threadKey: input.threadKey, marker: input.marker ?? "voice" };
+}
+
+/** The voice-scoped memory thread key for a user (matches brainPassthrough). */
+export function voiceThreadKey(userId: string): string {
+  return `voice-${userId}`;
+}

--- a/src/server/services/voice/workspaceResolver.ts
+++ b/src/server/services/voice/workspaceResolver.ts
@@ -14,7 +14,8 @@
  *      A caller must never be able to mint a session into a workspace they can't
  *      access (that would be a privilege-escalation path), so an explicit id the
  *      user is not a member of throws rather than silently falling through.
- *   2. the user's `defaultWorkspaceId`.
+ *   2. the user's `defaultWorkspaceId` — only if they are still a member of it
+ *      (a stale default for a workspace they were removed from is ignored).
  *   3. the user's first `WorkspaceUser` membership (oldest by `joinedAt`).
  *
  * Returns `undefined` only when no explicit id was given and the user belongs to
@@ -53,12 +54,21 @@ export async function resolveWorkspaceId(
     return explicit;
   }
 
-  // (2) The user's default workspace.
+  // (2) The user's default workspace — but only if they are STILL a member.
+  //     defaultWorkspaceId can go stale (the user was removed from it without
+  //     the field being cleared); trusting it blindly would mint a session for a
+  //     workspace they no longer belong to. Verify membership, else fall through.
   const user = await db.user.findUnique({
     where: { id: userId },
     select: { defaultWorkspaceId: true },
   });
-  if (user?.defaultWorkspaceId) return user.defaultWorkspaceId;
+  if (user?.defaultWorkspaceId) {
+    const stillMember = await db.workspaceUser.findFirst({
+      where: { userId, workspaceId: user.defaultWorkspaceId },
+      select: { workspaceId: true },
+    });
+    if (stillMember) return user.defaultWorkspaceId;
+  }
 
   // (3) First membership (oldest), as a last resort.
   const membership = await db.workspaceUser.findFirst({

--- a/src/server/services/voice/workspaceResolver.ts
+++ b/src/server/services/voice/workspaceResolver.ts
@@ -1,0 +1,70 @@
+/**
+ * Workspace resolver (Voice — Web Client, ticket #10) — the single source of
+ * truth for "which workspace does this voice session operate in".
+ *
+ * Lifted out of brainPassthrough.ts so EVERY voice tool gets workspace context
+ * the same way. Previously the inline copy only fed `ask_exponential`, so the
+ * four coarse tools operated user-wide — a latent multi-workspace bug. This
+ * helper is now called once at session-mint time (`voice.createSession`); the
+ * result is stamped into the voice-session JWT as a verified `workspaceId`
+ * claim, then threaded into every coarse tool by `voice.dispatch`.
+ *
+ * Three-tier resolution:
+ *   1. explicit `workspaceId` — ONLY if the user is a member; otherwise rejected.
+ *      A caller must never be able to mint a session into a workspace they can't
+ *      access (that would be a privilege-escalation path), so an explicit id the
+ *      user is not a member of throws rather than silently falling through.
+ *   2. the user's `defaultWorkspaceId`.
+ *   3. the user's first `WorkspaceUser` membership (oldest by `joinedAt`).
+ *
+ * Returns `undefined` only when no explicit id was given and the user belongs to
+ * no workspace at all.
+ */
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * Thrown when an explicit `workspaceId` is supplied but the user is not a member
+ * of it. `voice.createSession` maps this to a `FORBIDDEN` tRPC error.
+ */
+export class WorkspaceAccessError extends Error {
+  constructor(public readonly workspaceId: string) {
+    super(`User is not a member of workspace ${workspaceId}`);
+    this.name = "WorkspaceAccessError";
+  }
+}
+
+/**
+ * Resolve the workspace for a voice session. See module docs for the three-tier
+ * order. Throws {@link WorkspaceAccessError} when `explicit` is provided but the
+ * user is not a member.
+ */
+export async function resolveWorkspaceId(
+  userId: string,
+  db: PrismaClient,
+  explicit?: string,
+): Promise<string | undefined> {
+  // (1) Explicit id — validate membership before trusting it.
+  if (explicit) {
+    const membership = await db.workspaceUser.findFirst({
+      where: { userId, workspaceId: explicit },
+      select: { workspaceId: true },
+    });
+    if (!membership) throw new WorkspaceAccessError(explicit);
+    return explicit;
+  }
+
+  // (2) The user's default workspace.
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: { defaultWorkspaceId: true },
+  });
+  if (user?.defaultWorkspaceId) return user.defaultWorkspaceId;
+
+  // (3) First membership (oldest), as a last resort.
+  const membership = await db.workspaceUser.findFirst({
+    where: { userId },
+    orderBy: { joinedAt: "asc" },
+    select: { workspaceId: true },
+  });
+  return membership?.workspaceId;
+}

--- a/src/server/utils/jwt.ts
+++ b/src/server/utils/jwt.ts
@@ -60,6 +60,12 @@ export interface GenerateJWTOptions {
   expiryMinutes?: number;
   /** Optional token name (for api-token type) */
   tokenName?: string;
+  /**
+   * Extra non-security claims merged into the token payload (e.g. the
+   * voice-session `workspaceId`). Spread BEFORE the fixed claims so it can never
+   * clobber a security-relevant field (`sub`, `aud`, `exp`, `nbf`, …).
+   */
+  extraClaims?: Record<string, unknown>;
 }
 
 /**
@@ -124,12 +130,15 @@ export function generateJWT(
     tokenType,
     expiryMinutes = DEFAULT_EXPIRY[tokenType],
     tokenName,
+    extraClaims,
   } = options;
 
   const now = Math.floor(Date.now() / 1000);
 
   return jwt.sign(
     {
+      // Spread first so the fixed security claims below always take precedence.
+      ...extraClaims,
       userId: user.id,
       sub: user.id,
       email: user.email,

--- a/src/server/utils/voice-token.ts
+++ b/src/server/utils/voice-token.ts
@@ -89,5 +89,14 @@ export function verifyVoiceSessionToken(token: string): VerifiedVoiceSession {
     throw new Error("Voice-session token missing user identifier");
   }
 
-  return { userId, workspaceId: decoded.workspaceId };
+  // workspaceId is OPTIONAL by design (legacy tokens minted before the claim,
+  // and users who belong to no workspace, carry none — callers fall back). We
+  // therefore don't reject a missing claim; we only guard the TYPE, ignoring a
+  // malformed non-string claim rather than propagating it as a workspaceId.
+  const workspaceId =
+    typeof decoded.workspaceId === "string" && decoded.workspaceId.length > 0
+      ? decoded.workspaceId
+      : undefined;
+
+  return { userId, workspaceId };
 }

--- a/src/server/utils/voice-token.ts
+++ b/src/server/utils/voice-token.ts
@@ -33,12 +33,23 @@ function getAuthSecret(): string {
  * Mint a voice-session JWT for the given user. ~30-min expiry (DEFAULT_EXPIRY),
  * audience scoped to the voice tool surface.
  */
-export function mintVoiceSessionToken(user: JWTUserPayload): string {
-  return generateJWT(user, { tokenType: "voice-session" });
+export function mintVoiceSessionToken(
+  user: JWTUserPayload,
+  workspaceId?: string,
+): string {
+  return generateJWT(user, {
+    tokenType: "voice-session",
+    ...(workspaceId ? { extraClaims: { workspaceId } } : {}),
+  });
 }
 
 export interface VerifiedVoiceSession {
   userId: string;
+  /**
+   * The workspace this session operates in (verified claim). Absent on legacy
+   * tokens minted before the claim existed — callers fall back accordingly.
+   */
+  workspaceId?: string;
 }
 
 /**
@@ -57,6 +68,7 @@ export function verifyVoiceSessionToken(token: string): VerifiedVoiceSession {
     tokenType?: string;
     nbf?: number;
     securityVersion?: number;
+    workspaceId?: string;
   };
 
   if (decoded.tokenType !== "voice-session") {
@@ -77,5 +89,5 @@ export function verifyVoiceSessionToken(token: string): VerifiedVoiceSession {
     throw new Error("Voice-session token missing user identifier");
   }
 
-  return { userId };
+  return { userId, workspaceId: decoded.workspaceId };
 }


### PR DESCRIPTION
## What

Server-side foundation for the **Voice — Web Client (v1)** feature (`cmpwodjf9000el104wd0o417i`), and a fix for a latent multi-workspace bug affecting iOS today. Workspace context is lifted from a per-tool argument into a first-class property of the voice session.

- New **`workspaceResolver`** module (deep, three-tier): explicit `workspaceId` *if the user is a member* → `User.defaultWorkspaceId` → first `WorkspaceUser` membership. Throws `WorkspaceAccessError` on an explicit id the user isn't a member of. The inline copy in `brainPassthrough.ts` is removed in favour of this helper.
- **`voice.createSession`** accepts an optional `workspaceId`, resolves+validates it via the helper (invalid → `FORBIDDEN`), and stamps the result into the minted voice-session JWT as a verified claim (new `extraClaims` support in `generateJWT`).
- **`voice.dispatch`** reads `workspaceId` from the *verified token* (never from `args`) and threads it into every tool: `captureAction`, `runQuery`, `completeAction`, `getTodaysPlan`, `askExponential`. Each tool now scopes its queries/mutations to that workspace.
- **`get_todays_plan`** and **`query`** prefer the token claim over `args.workspaceId` (back-compat path retained for one release per PRD §33).
- The `askExponential(phrase, userId, db)` call site is already 3-arg on `main`; `npm run check` passes clean.

## Acceptance criteria

- [x] `workspaceResolver` lives in its own file with the three-tier interface; the inline copy in `brainPassthrough.ts` is removed and replaced with a call to the helper.
- [x] `voice.createSession` calls the resolver, accepts an optional `workspaceId`, validates explicit IDs against memberships (rejects if not a member), stamps the result into the JWT as a verified claim.
- [x] `voice.dispatch` reads `workspaceId` from the verified token and passes it into every tool; tool queries/mutations are scoped accordingly.
- [x] `get_todays_plan` prefers the token claim over `args.workspaceId` when both are present (back-compat retained).
- [x] The stale `askExponential` call site is fixed so `npm run check` passes clean.
- [x] Unit tests for `workspaceResolver` covering all four branches (explicit-valid, explicit-invalid, default fallback, first-membership) + a no-workspace case.
- [x] Integration test asserts the stamped `workspaceId` reaches every tool through `voice.dispatch`, and that a token minted for workspace A cannot read workspace B's data.

## Tests

- `src/server/services/voice/__tests__/workspaceResolver.test.ts` — 5 unit tests (mocked Prisma).
- `src/server/api/routers/__tests__/voiceWorkspaceScope.integration.test.ts` — 4 integration tests (real DB): claim stamping, FORBIDDEN on non-member workspace, cross-workspace read isolation, capture lands in the session workspace.
- Full suite green: 568 unit + 30 voice integration tests; typecheck clean.

---

Ships: #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-scoped voice sessions and tools so voice actions are created and queried within the correct workspace.
  * In-app Voice mode: start/stop voice sessions in Chat with 🎙 markers, voice-status panel, and permission-denied guidance.
  * Voice debug console page for testing voice tools and confirmation flows.

* **Tests**
  * Expanded integration and unit tests covering voice workspace scoping, session minting, dispatch, and transcript persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Ships: #11

Ships: #12

Ships: #13

Ships: #14