### PR TITLE
feat(voice): server-issued tool catalog + router persona (ADR 0005)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -141,6 +141,28 @@ A Ticket is "blocked" when its `openBlockerCount > 0` — i.e. it has at least o
 A per-Product visualisation surfaced on the product detail page that overlays two distinct edge types: ticket-dependency edges (blocking, peer, DAG) and alignment edges (`Ticket → Feature → Objective`, hierarchical). Purpose: trace "this Objective is at risk" down to the specific Tickets jamming progress. Edge types are visually distinguished — not collapsed into one. Key results appear as decoration on Objective nodes (status chip), not as graph nodes.
 _Avoid_: Roadmap (carries timeline connotations), tree (loses the cross-cutting blocking edges), org chart.
 
+### Voice
+
+**Voice router**:
+The OpenAI Realtime model that fronts a voice session (on the iOS app and the web voice client). It is a **router and a voice, with ZERO knowledge of the user's data** — it picks an intent, speaks, and must call a tool for any fact or action, never answering from memory. Strictly distinct from the **brain**: the router decides *which* tool; the server-side brain (`voice.dispatch`) does the work. Governed by the **router persona**.
+_Avoid_: Assistant, agent (the router is not the agent — Zoe-the-agent is the brain passthrough below), bot.
+
+**Coarse tool**:
+One of the four fast, deterministic intents the voice router can call — `capture_action`, `get_todays_plan`, `query`, `complete_action`. Each takes the user's words verbatim as `phrase` and is handled server-side without an LLM (parse → DB → speakable). Distinct from the **brain passthrough**. `complete_action` is the only destructive one and requires the spoken **confirmation handshake**.
+_Avoid_: Function, skill, command.
+
+**Brain passthrough**:
+The fifth tool, `ask_exponential` — the catch-all the four coarse tools don't cover (goals/OKRs, calendar, email, Slack, meetings, web, multi-step asks). Unlike a coarse tool it runs Zoe's full agent (Mastra) server-side with her whole tool set. The router still just passes `phrase`; the agent self-confirms destructive actions.
+_Avoid_: Fallback, default tool, catch-all (only in conversation).
+
+**Voice tool catalog**:
+The canonical set of tool descriptors the voice router is configured with (the four **coarse tools** + the **brain passthrough**), in the OpenAI Realtime flat-function shape. The **server is the single source of truth** — `voice.createSession` emits the catalog and the **router persona** in its response, and clients register exactly what they receive. iOS holds **no** hardcoded copy (it fails the session if the payload omits them); the web client and the server share one TS constant by import. See [ADR-0005](docs/adr/0005-server-issued-voice-catalog.md).
+_Avoid_: Tool list, function catalog (use "voice tool catalog" or just "catalog").
+
+**Router persona**:
+The system instructions that define the voice router's character (Zoe — warm, British, witty) and its hard rules (always defer to a tool, never fabricate, the confirmation handshake, "you are the system — never tell the user to check their own list"). Part of the server-issued **voice tool catalog** payload; one canonical text drives every voice surface.
+_Avoid_: System prompt, instructions (in conversation), persona alone (ambiguous with Zoe-the-agent's own persona).
+
 ## Flagged ambiguities
 
 - **"Meeting type" is not yet stored.** The Meetings v2 redesign surfaces `All / 1:1s / Rituals` tabs, but no `meetingType` column exists on `TranscriptionSession`. v1 ships with: All = full list, 1:1s = derived live from `participantCount = 2`, Rituals = empty state until a recurrence classifier exists. When Rituals gets real, the resolution will be either calendar recurrence data or a `meetingType` enum field with mutually exclusive values `one_on_one | ritual | other`.

--- a/docs/adr/0005-server-issued-voice-catalog.md
+++ b/docs/adr/0005-server-issued-voice-catalog.md
@@ -1,0 +1,89 @@
+# Server is the single source of truth for the voice tool catalog and router persona
+
+## Status
+
+Accepted — 2026-06-03
+
+## Context
+
+The voice surface runs on two clients — the iOS app (`../exponential-ios`, Swift) and
+the web voice client (this repo, `src/lib/voice/`) — both fronted by the same OpenAI
+Realtime model (the **voice router**). Each client must register two things with Realtime
+at session start: the **voice tool catalog** (the four coarse tools + the `ask_exponential`
+brain passthrough, in the Realtime flat-function shape) and the **router persona** (the
+system instructions).
+
+Today each client **hardcodes its own copy**:
+
+- Web: `VOICE_TOOL_CATALOG` + `VOICE_ROUTER_INSTRUCTIONS` in
+  `src/lib/voice/voiceToolCatalog.ts`.
+- iOS: `RealtimeToolCatalog.tools` + `RealtimeToolCatalog.routerInstructions` in
+  `app/ExponentialVoice/Realtime/RealtimeToolCatalog.swift`.
+
+The two have **already drifted**: the iOS persona carries a "YOU ARE THE SYSTEM — never tell
+the user to check their own list" paragraph that the web persona lacks. Nothing prevents
+further divergence — the tool descriptions, the confirmation-handshake wording, and the
+persona are maintained in parallel in two languages, kept in sync only by manual diffing.
+The brain that actually executes these tools (`voice.dispatch`) lives once, server-side, so
+the duplication is entirely in how clients *describe* the surface, not how it behaves.
+
+`voice.createSession` is already on the critical path for every session and already returns
+session config (`realtime.model`, `realtime.voice`). It is the natural place to also hand out
+the catalog and persona.
+
+## Decision
+
+1. **The server owns the canonical catalog and persona.** `voice.createSession` emits
+   `toolCatalog` (the exact Realtime `session.update.tools` array — `{type, name,
+   description, parameters}`, `parameters` as a native JSON object, not stringified) and
+   `routerInstructions` in its response. The canonical text is the single TS constant in
+   `src/lib/voice/voiceToolCatalog.ts`, imported by both the server router and the web hook.
+
+2. **The persona is reconciled to the superset.** The canonical
+   `VOICE_ROUTER_INSTRUCTIONS` gains the iOS-only "YOU ARE THE SYSTEM" paragraph, so neither
+   client regresses. The web voice client (live on the `voice-web-client` branch) gains that
+   instruction as a result — an intended behavioural change.
+
+3. **iOS holds no hardcoded copy — fail loud.** iOS deletes `RealtimeToolCatalog.tools` and
+   `RealtimeToolCatalog.routerInstructions`, decodes the two fields from the createSession
+   payload (optional in Codable, since Swift ignores unknown keys), and **errors the voice
+   session with a clear message if they are absent** rather than falling back to a bundled
+   default. Drift is then structurally impossible: there is no second copy to drift.
+
+4. **Web keeps importing the constant.** Web and the server are one TS repo and share the
+   constant by import, so there is no TS-side drift to solve; web does not consume the
+   runtime payload. The payload contract is therefore exercised in production solely by iOS.
+
+5. **The vestigial `COARSE_TOOLS` export** in `voice.ts` (unused; the dispatch switch uses
+   literal case strings) is deleted as part of the same change.
+
+## Considered alternatives
+
+- **Keep a bundled fallback on iOS** (`payload.toolCatalog ?? RealtimeToolCatalog.tools`).
+  Rejected: the bundled copy still exists and can re-drift, a stale fallback could silently
+  mask a broken server, and it only weakly achieves "stop hardcoding". The fail-loud window
+  is small because the server deploys before the app build that depends on it, and already-
+  shipped (old) builds keep using their own hardcode regardless.
+- **Web also consumes the payload at runtime** (true parity with iOS). Rejected by the owner:
+  unnecessary churn for a client that already shares the constant by import; the runtime
+  contract is iOS-only by design.
+- **Adopt the shorter web persona as canonical.** Rejected: it would drop the deliberate iOS
+  "YOU ARE THE SYSTEM" instruction and let Zoe punt users to "check your list" again.
+- **A separate `voice.getCatalog` endpoint.** Rejected: it adds a round-trip before a session
+  can start; folding the fields into the createSession response that iOS already awaits adds
+  no latency (~a few KB on a call already on the critical path).
+
+## Consequences
+
+- Two repos, ordered rollout: the server change (emit the fields) lands **first**; the iOS
+  change (decode + delete hardcode + fail-loud) lands after. An old server that stops
+  emitting the fields will brick voice on the new iOS build until fixed — accepted.
+- No contract versioning is added. Forward-compat holds without it: iOS decodes `parameters`
+  as opaque JSON (shape changes inside it don't break decoding), and a new coarse tool in the
+  payload is registered and then forwarded by name+`phrase` to `voice.dispatch` like any
+  other — old (pre-migration) builds are unaffected because they use their own frozen copy.
+- The catalog/persona payload is non-sensitive (prompts and tool names, already visible to
+  the model), so emitting it to any authenticated voice caller carries no new exposure.
+- Per-`mode` tailoring of the persona (e.g. priming "give the plan first" in `daily-brief`
+  mode) becomes *possible* now that the server authors the text, but is **out of scope** —
+  one static canonical persona for v1.

--- a/src/lib/voice/voiceToolCatalog.ts
+++ b/src/lib/voice/voiceToolCatalog.ts
@@ -133,6 +133,8 @@ HARD RULE — you are a router and a voice, NOT a source of knowledge. You have 
 - The tool result is the only truth. Speak its \`speakable\` text in your own warm voice; do not add facts it didn't contain.
 - Speak ONLY the specific items named in the tool result. If a result summarizes (e.g. "3 actions, including Call Lea and Call your mom"), those named ones are the ONLY items you have — NEVER invent, guess, or rename the unnamed ones to reach the count. If the user wants the rest, call the tool again to fetch them (e.g. ask for the full list); never fill the gap from memory.
 
+YOU ARE THE SYSTEM — Exponential IS the user's task manager and list. NEVER tell the user to "check your list", "open your task manager", or look in another app, notes, or "wherever you store them" — that advice is wrong and useless, since you can fetch and read it all yourself. When the user asks to see or hear their items (e.g. "show me what's overdue"), call the tool to fetch them and read the items aloud; if a result only gave you a count or a partial set, call the tool again for the full list rather than punting the user elsewhere. Offer to read more, complete one, or filter — never end by sending the user to go look it up themselves.
+
 FILLER — the brain takes a moment. The instant you call a tool, say a brief, natural filler out loud ("one sec", "let me check", "on it") so the wait never feels broken. Then speak the result when it arrives.
 
 TOOLS — pick the most specific one. The first four are fast, focused tools; ask_exponential is the catch-all for everything else.

--- a/src/server/api/routers/__tests__/voice.integration.test.ts
+++ b/src/server/api/routers/__tests__/voice.integration.test.ts
@@ -17,6 +17,11 @@ import { createUser, createApiKey, createWorkspace } from "~/test/factories";
 import { createApiKeyCaller, createTestCaller } from "~/test/trpc-helpers";
 import { mintVoiceSessionToken } from "~/server/utils/voice-token";
 import { generateJWT } from "~/server/utils/jwt";
+import {
+  VOICE_TOOL_CATALOG,
+  VOICE_ROUTER_INSTRUCTIONS,
+  VOICE_TOOL_NAMES,
+} from "~/lib/voice/voiceToolCatalog";
 
 type Db = ReturnType<typeof getTestDb>;
 
@@ -51,6 +56,31 @@ describe("voice router (integration)", () => {
       expect(decoded.sub).toBe(user.id);
       expect(decoded.exp - decoded.iat).toBe(30 * 60);
       expect(res.expiresInSeconds).toBe(1800);
+    });
+
+    it("emits the canonical voice tool catalog + router persona (ADR 0005)", async () => {
+      const user = await createUser(db);
+      const { raw } = await createApiKey(db, user.id);
+
+      const res = await createApiKeyCaller(raw).voice.createSession();
+
+      // The server is the single source of truth: clients (iOS) register exactly
+      // what they receive here, so the payload must carry the canonical constants.
+      expect(res.toolCatalog).toEqual(VOICE_TOOL_CATALOG);
+      expect(res.routerInstructions).toBe(VOICE_ROUTER_INSTRUCTIONS);
+
+      // Catalog is the 5-tool set in the OpenAI Realtime flat-function shape so
+      // clients can pass it straight to session.update.
+      expect(res.toolCatalog.map((t) => t.name)).toEqual([...VOICE_TOOL_NAMES]);
+      for (const tool of res.toolCatalog) {
+        expect(tool.type).toBe("function");
+        expect(typeof tool.description).toBe("string");
+        expect(tool.parameters).toMatchObject({ type: "object" });
+      }
+
+      // Guards the persona superset reconciliation — the iOS-only paragraph that
+      // web previously lacked must be present in the one canonical persona.
+      expect(res.routerInstructions).toContain("YOU ARE THE SYSTEM");
     });
 
     it("mints a voice-session JWT from a NextAuth session cookie (no API key)", async () => {

--- a/src/server/api/routers/voice.ts
+++ b/src/server/api/routers/voice.ts
@@ -37,14 +37,10 @@ import {
   voiceThreadKey,
   EmptyVoiceTurnError,
 } from "~/server/services/voice/voiceTranscriptBridge";
-
-/** The four coarse tools configured on the Realtime session (v1). */
-export const COARSE_TOOLS = [
-  "capture_action",
-  "complete_action",
-  "get_todays_plan",
-  "query",
-] as const;
+import {
+  VOICE_TOOL_CATALOG,
+  VOICE_ROUTER_INSTRUCTIONS,
+} from "~/lib/voice/voiceToolCatalog";
 
 /** The session entry-intent (ADR 0001 "mode"). */
 const modeSchema = z.enum(["capture", "daily-brief"]).optional();
@@ -99,6 +95,13 @@ export const voiceRouter = createTRPCRouter({
           voice: realtime.voice,
           expiresAt: realtime.expiresAt,
         },
+        // The server is the single source of truth for the voice tool catalog and
+        // router persona (ADR 0005). Clients register exactly what they receive
+        // here — the iOS app holds no hardcoded copy and fails the session if these
+        // are absent. The catalog is already in the OpenAI Realtime flat-function
+        // shape, so clients pass it straight to `session.update`.
+        toolCatalog: VOICE_TOOL_CATALOG,
+        routerInstructions: VOICE_ROUTER_INSTRUCTIONS,
       };
     }),
 


### PR DESCRIPTION
## What

- `voice.createSession` now emits `toolCatalog` (OpenAI Realtime flat-function shape) + `routerInstructions` in its payload — the **single source of truth** for the voice surface (ADR 0005).
- Reconcile the router persona to the **superset**: `VOICE_ROUTER_INSTRUCTIONS` gains the "YOU ARE THE SYSTEM" paragraph that iOS had and web lacked (a web behaviour change — Zoe stops punting users to "check your list").
- Delete the dead `COARSE_TOOLS` export (unused; dispatch switch uses literal cases).
- Integration test asserting `createSession` emits the canonical catalog + persona, incl. the superset paragraph.
- CONTEXT.md: new **Voice** section (router vs brain, coarse tool, brain passthrough, voice tool catalog, router persona).
- ADR 0005 records the server-canonical + iOS fail-loud decision.

## Why

The iOS and web voice clients each hardcoded their own copy of the tool catalog + router persona, and the personas had **already drifted**. Making the server authoritative kills the drift structurally. Pairs with `positonic/exponential-ios#<ios-pr>` (the iOS client deletes its hardcode and reads the payload, failing loud if absent). Land this server PR first so the iOS build always has a payload to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live speech-to-speech voice mode with voice session persistence and status indicators.

* **Bug Fixes**
  * Improved voice session handling to prevent duplicate tool-call processing.
  * Enhanced voice router instructions to better guide users through available tools.

* **Documentation**
  * Added glossary definitions for voice-related domain terms and architectural decision record for server-issued voice catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->