### PR TITLE
feat(transcription): saveTranscription accepts optional notes

### DIFF
--- a/src/server/api/routers/__tests__/transcription.test.ts
+++ b/src/server/api/routers/__tests__/transcription.test.ts
@@ -518,3 +518,77 @@ describe("transcription router (mocked) — findRelated", () => {
     expect(result.byTitle).toHaveLength(3);
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────
+// saveTranscription — optional `notes` (exponential-ios ADR 0006 amendment).
+// The transcript always appends; notes REPLACE when provided and are left
+// untouched (field omitted from the update) when absent.
+// ──────────────────────────────────────────────────────────────────────
+describe("transcription router (mocked) — saveTranscription notes", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+  const callerId = "caller-1";
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    // An existing session owned by the caller, with prior transcript text.
+    dbMock.transcriptionSession.findUnique.mockResolvedValue({
+      id: "sess1",
+      userId: callerId,
+      transcription: "earlier text",
+      notes: "old notes",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    dbMock.transcriptionSession.update.mockResolvedValue({} as any);
+  });
+
+  function updateData() {
+    const call = dbMock.transcriptionSession.update.mock.calls[0]?.[0] as
+      | { data: { transcription: string; notes?: string } }
+      | undefined;
+    return call?.data;
+  }
+
+  it("replaces notes and appends the transcript when notes are provided", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+    await caller.transcription.saveTranscription({
+      id: "sess1",
+      transcription: "new line",
+      notes: "ask Sam about pricing",
+    });
+
+    const data = updateData();
+    expect(data?.transcription).toBe("earlier text new line");
+    expect(data?.notes).toBe("ask Sam about pricing");
+  });
+
+  it("leaves notes untouched (field omitted) when notes are absent", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+    await caller.transcription.saveTranscription({
+      id: "sess1",
+      transcription: "new line",
+    });
+
+    const data = updateData();
+    expect(data?.transcription).toBe("earlier text new line");
+    // No `notes` key at all — the server must not overwrite existing notes.
+    expect(data).not.toHaveProperty("notes");
+  });
+
+  it("re-submitting replaces (does not duplicate) the notes", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+    await caller.transcription.saveTranscription({
+      id: "sess1",
+      transcription: "more",
+      notes: "edited notes",
+    });
+
+    // Replace semantics: the update sets notes to exactly the new value, never
+    // appending to "old notes".
+    expect(updateData()?.notes).toBe("edited notes");
+  });
+});

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -193,6 +193,11 @@ export const transcriptionRouter = createTRPCRouter({
       z.object({
         id: z.string(),
         transcription: z.string(),
+        // Optional human-authored Notes from the device (exponential-ios, ADR 0006
+        // amendment). Additive + backward-compatible: existing callers omit it and
+        // behave exactly as before. When present it REPLACES the session's notes;
+        // the transcript continues to append regardless.
+        notes: z.string().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -222,12 +227,17 @@ export const transcriptionRouter = createTRPCRouter({
           ? `${existingSession.transcription} ${input.transcription}`
           : input.transcription;
 
-      // Update with the combined transcription
+      // Update with the combined transcription, and replace notes only when the
+      // caller provided them (absent → leave existing notes untouched).
+      const updateData: { transcription: string; notes?: string } = {
+        transcription: updatedTranscription,
+      };
+      if (input.notes !== undefined) {
+        updateData.notes = input.notes;
+      }
       await ctx.db.transcriptionSession.update({
         where: { id: input.id },
-        data: {
-          transcription: updatedTranscription,
-        },
+        data: updateData,
       });
       return {
         success: true,


### PR DESCRIPTION
## What

Additive, backward-compatible extension of the in-production `transcription.saveTranscription` procedure: it gains an optional `notes` field. When provided, it **replaces** the session's `notes`; when absent, the field is omitted from the update so existing notes are left untouched. The transcript continues to **append** as before, so existing no-notes callers are byte-for-byte unchanged.

This is the **server half** of the macOS ExponentialVoice feature *Granola-style Notes* (exponential-ios feature `cmpyhyjvh0001l804i53tpz8f`, ticket #43). It lets the device Submit a Recording's human-authored Notes into the Meeting's `notes` field in the same `saveTranscription` call — no new endpoint, not bidirectional sync (ADR 0006 amendment).

The client (exponential-ios) only sends `notes` when the Recording has non-empty Notes, so this change is inert until that ships.

## Acceptance criteria

- [x] `saveTranscription` accepts an optional `notes` field; present → replaces the Meeting's notes; absent → notes untouched and transcript still appends.
- [x] Re-submitting an edited Recording replaces (does not duplicate) the server notes.
- [x] Server-side tests: saveTranscription with and without `notes` (3 new in `transcription.test.ts`).

Tests: 14 transcription unit tests pass (3 new); full unit suite green (605); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transcription saving now supports an optional notes field. Notes are updated when provided and preserved when omitted during save operations.

* **Tests**
  * Added comprehensive test suite covering transcription notes behavior, including updates, preservation, and replacement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->