### PR TITLE
feat(meetings): redesign meeting detail page as two-column workspace view

### DIFF
--- a/src/app/(sidemenu)/recording/[id]/page.tsx
+++ b/src/app/(sidemenu)/recording/[id]/page.tsx
@@ -1,152 +1,30 @@
 'use client';
 
 import { api } from "~/trpc/react";
-// import { useRouter } from "next/navigation";
-import {
-  Paper,
-  Title,
-  Text,
-  Skeleton,
-  Group,
-  Image,
-  SimpleGrid,
-  Stack,
-  Tabs,
-  ActionIcon,
-  Textarea,
-  Button,
-  Select,
-} from "@mantine/core";
-import { DateTimePicker } from "@mantine/dates";
-import { IconPencil } from "@tabler/icons-react";
-import { use, useEffect, useMemo, useState } from "react";
-import { SmartContentRenderer } from "~/app/_components/SmartContentRenderer";
-import { TranscriptionContentEditor } from "~/app/_components/TranscriptionContentEditor";
-import { TranscriptionRenderer } from "~/app/_components/TranscriptionRenderer";
-import { FirefliesSummaryDisplay } from "~/app/_components/FirefliesSummaryRenderer";
-import { parseFirefliesSummary, isEmptyFirefliesSummary } from "~/lib/fireflies-summary";
+import { Skeleton, Paper, Text } from "@mantine/core";
+import { use, useMemo } from "react";
 import { notifications } from "@mantine/notifications";
 import { useAgentModal, type ChatMessage } from "~/providers/AgentModalProvider";
-import { ActionsList } from "~/app/_components/actions/ActionsList";
 import { useRegisterPageContext } from "~/hooks/useRegisterPageContext";
-
-function isMarkdownContent(content: string) {
-  const markdownPatterns = [
-    /^#{1,6}\s/m,
-    /\*\*[^*]+\*\*/,
-    /(?<!\*)\*[^*]+\*(?!\*)/,
-    /\[[^\]]+\]\([^)]+\)/,
-    /^[-*+]\s/m,
-    /^\d+\.\s/m,
-    /```[\s\S]*?```/,
-    /`[^`]+`/,
-    /^>\s/m,
-  ];
-  return markdownPatterns.some((pattern) => pattern.test(content));
-}
-
-function isFirefliesFormat(content: string): boolean {
-  try {
-    const parsed: unknown = JSON.parse(content);
-    return (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      "sentences" in parsed &&
-      Array.isArray((parsed as { sentences: unknown }).sentences) &&
-      (parsed as { sentences: unknown[] }).sentences.length > 0
-    );
-  } catch {
-    return false;
-  }
-}
-
-function TranscriptionTabContent({
-  session,
-}: {
-  session: {
-    id: string;
-    transcription: string | null;
-    sourceIntegration?: { provider: string } | null;
-  };
-}) {
-  const [showRaw, setShowRaw] = useState(false);
-
-  if (!session.transcription) {
-    return <Text c="dimmed">No transcription available yet</Text>;
-  }
-
-  const provider = session.sourceIntegration?.provider;
-  const isFireflies =
-    provider === "fireflies" ||
-    (!provider && isFirefliesFormat(session.transcription));
-
-  if (isFireflies && !showRaw) {
-    return (
-      <Stack gap="md">
-        <Group justify="flex-end">
-          <Button variant="subtle" size="xs" onClick={() => setShowRaw(true)}>
-            View Raw / Edit
-          </Button>
-        </Group>
-        <TranscriptionRenderer
-          transcription={session.transcription}
-          provider="fireflies"
-          isPreview={false}
-          showCopyButton={true}
-        />
-      </Stack>
-    );
-  }
-
-  return (
-    <Stack gap="md">
-      {isFireflies && (
-        <Group justify="flex-end">
-          <Button
-            variant="subtle"
-            size="xs"
-            onClick={() => setShowRaw(false)}
-          >
-            View Formatted
-          </Button>
-        </Group>
-      )}
-      <TranscriptionContentEditor
-        transcriptionId={session.id}
-        initialContent={session.transcription}
-      />
-    </Stack>
-  );
-}
+import { MeetingDetail } from "~/app/_components/meeting/MeetingDetail";
 
 export default function SessionPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  
-  const { data: session, isLoading } = api.transcription.getById.useQuery({ 
-    id: id 
-  });
+
+  const { data: session, isLoading } = api.transcription.getById.useQuery({ id });
   const { data: transcriptActions = [], isLoading: isActionsLoading } =
     api.action.getByTranscription.useQuery(
       { transcriptionId: id },
-      { enabled: Boolean(id) }
+      { enabled: Boolean(id) },
     );
   const { data: workspaces } = api.workspace.list.useQuery();
   const utils = api.useUtils();
   const updateDetailsMutation = api.transcription.updateDetails.useMutation();
   const { openModal, setMessages } = useAgentModal();
-  const [isEditingDescription, setIsEditingDescription] = useState(false);
-  const [editedDescription, setEditedDescription] = useState("");
-  const [isEditingNotes, setIsEditingNotes] = useState(false);
-  const [editedNotes, setEditedNotes] = useState("");
-  const [isEditingSummary, setIsEditingSummary] = useState(false);
-  const [editedSummary, setEditedSummary] = useState("");
-  const [activeTab, setActiveTab] = useState<string>("overview");
-  const [pendingMeetingDate, setPendingMeetingDate] = useState<
-    Date | null | undefined
-  >(undefined);
 
-  // Deterministic extraction: Create Actions runs generateDraftActions (not the LLM),
-  // then appends an interactive review card to the active drawer thread (ADR-0007).
+  // Deterministic extraction: Create Actions runs generateDraftActions (not the
+  // LLM), then appends an interactive review card to the active drawer thread
+  // (ADR-0007).
   const generateDraftsMutation =
     api.transcription.generateDraftActions.useMutation({
       onSuccess: (result) => {
@@ -168,13 +46,12 @@ export default function SessionPage({ params }: { params: Promise<{ id: string }
           return;
         }
         void utils.transcription.getById.invalidate({ id });
-        // Append to the active continuous thread (no clearChat) and open the drawer.
-        // Dedup: if a review card for this meeting already exists in the thread,
-        // just re-open the drawer rather than stacking another identical card.
         const transcriptionId = session.id;
         setMessages((prev) => {
           const alreadyHasCard = prev.some(
-            (m) => m.card?.kind === "draft-actions" && m.card.transcriptionId === transcriptionId
+            (m) =>
+              m.card?.kind === "draft-actions" &&
+              m.card.transcriptionId === transcriptionId,
           );
           if (alreadyHasCard) return prev;
           const cardMessage: ChatMessage = {
@@ -202,107 +79,11 @@ export default function SessionPage({ params }: { params: Promise<{ id: string }
     generateDraftsMutation.mutate({ transcriptionId: session.id });
   }
 
-  // Register page context so the agent chat knows what recording the user is viewing
-  const recordingPageContext = useMemo(() => {
-    if (!session) return null;
-    return {
-      pageType: 'recording' as const,
-      pageTitle: session.title ?? 'Meeting',
-      pagePath: `/recording/${id}`,
-      data: {
-        transcriptionId: session.id,
-        title: session.title ?? 'Untitled',
-        summary: session.summary ?? null,
-        description: session.description ?? null,
-        actionsCount: transcriptActions.length,
-        hasTranscription: Boolean(session.transcription),
-        meetingDate: session.meetingDate ? String(session.meetingDate) : null,
-        workspaceName: session.workspace?.name ?? null,
-      },
-    };
-  }, [session, transcriptActions.length, id]);
-
-  useRegisterPageContext(recordingPageContext);
-
-  // const router = useRouter();
-
-  function handleStartEditDescription() {
-    if (!session) return;
-    setEditedDescription(session.description ?? "");
-    setIsEditingDescription(true);
-  }
-
-  function handleStartEditNotes() {
-    if (!session) return;
-    setEditedNotes(session.notes ?? "");
-    setIsEditingNotes(true);
-  }
-
-  function handleStartEditSummary() {
-    if (!session) return;
-    setEditedSummary(session.summary ?? "");
-    setIsEditingSummary(true);
-  }
-
-  async function handleSaveDescription() {
+  async function handleSaveSummary(value: string) {
     if (!session) return;
     try {
-      await updateDetailsMutation.mutateAsync({
-        id: session.id,
-        description: editedDescription,
-      });
-      notifications.show({
-        title: "Saved",
-        message: "Description updated successfully",
-        color: "green",
-      });
-      setIsEditingDescription(false);
-      void utils.transcription.getById.invalidate({ id });
-    } catch (error) {
-      notifications.show({
-        title: "Error",
-        message: error instanceof Error ? error.message : "Failed to update description",
-        color: "red",
-      });
-    }
-  }
-
-  async function handleSaveNotes() {
-    if (!session) return;
-    try {
-      await updateDetailsMutation.mutateAsync({
-        id: session.id,
-        notes: editedNotes,
-      });
-      notifications.show({
-        title: "Saved",
-        message: "Notes updated successfully",
-        color: "green",
-      });
-      setIsEditingNotes(false);
-      void utils.transcription.getById.invalidate({ id });
-    } catch (error) {
-      notifications.show({
-        title: "Error",
-        message: error instanceof Error ? error.message : "Failed to update notes",
-        color: "red",
-      });
-    }
-  }
-
-  async function handleSaveSummary() {
-    if (!session) return;
-    try {
-      await updateDetailsMutation.mutateAsync({
-        id: session.id,
-        summary: editedSummary,
-      });
-      notifications.show({
-        title: "Saved",
-        message: "Summary updated successfully",
-        color: "green",
-      });
-      setIsEditingSummary(false);
+      await updateDetailsMutation.mutateAsync({ id: session.id, summary: value });
+      notifications.show({ title: "Saved", message: "Summary updated", color: "green" });
       void utils.transcription.getById.invalidate({ id });
     } catch (error) {
       notifications.show({
@@ -313,18 +94,32 @@ export default function SessionPage({ params }: { params: Promise<{ id: string }
     }
   }
 
+  async function handleMeetingDateChange(value: Date | null) {
+    if (!session) return;
+    try {
+      await updateDetailsMutation.mutateAsync({ id: session.id, meetingDate: value });
+      notifications.show({
+        title: "Saved",
+        message: value ? "Meeting date updated" : "Meeting date cleared",
+        color: "green",
+      });
+      void utils.transcription.getById.invalidate({ id });
+    } catch (error) {
+      notifications.show({
+        title: "Error",
+        message: error instanceof Error ? error.message : "Failed to update meeting date",
+        color: "red",
+      });
+    }
+  }
+
   async function handleWorkspaceChange(workspaceId: string | null) {
     if (!session) return;
     try {
-      await updateDetailsMutation.mutateAsync({
-        id: session.id,
-        workspaceId,
-      });
+      await updateDetailsMutation.mutateAsync({ id: session.id, workspaceId });
       notifications.show({
         title: "Saved",
-        message: workspaceId
-          ? "Meeting moved to workspace"
-          : "Meeting removed from workspace",
+        message: workspaceId ? "Meeting moved to workspace" : "Meeting removed from workspace",
         color: "green",
       });
       void utils.transcription.getById.invalidate({ id });
@@ -337,41 +132,27 @@ export default function SessionPage({ params }: { params: Promise<{ id: string }
     }
   }
 
-  async function handleMeetingDateChange(value: Date | null) {
-    if (!session) return;
-    try {
-      await updateDetailsMutation.mutateAsync({
-        id: session.id,
-        meetingDate: value,
-      });
-      notifications.show({
-        title: "Saved",
-        message: value
-          ? "Meeting date updated"
-          : "Meeting date cleared",
-        color: "green",
-      });
-      void utils.transcription.getById.invalidate({ id });
-    } catch (error) {
-      notifications.show({
-        title: "Error",
-        message:
-          error instanceof Error ? error.message : "Failed to update meeting date",
-        color: "red",
-      });
-    }
-  }
+  // Register page context so the agent chat knows what recording is in view.
+  const recordingPageContext = useMemo(() => {
+    if (!session) return null;
+    return {
+      pageType: "recording" as const,
+      pageTitle: session.title ?? "Meeting",
+      pagePath: `/recording/${id}`,
+      data: {
+        transcriptionId: session.id,
+        title: session.title ?? "Untitled",
+        summary: session.summary ?? null,
+        description: session.description ?? null,
+        actionsCount: transcriptActions.length,
+        hasTranscription: Boolean(session.transcription),
+        meetingDate: session.meetingDate ? String(session.meetingDate) : null,
+        workspaceName: session.workspace?.name ?? null,
+      },
+    };
+  }, [session, transcriptActions.length, id]);
 
-  useEffect(() => {
-    if (pendingMeetingDate === undefined) return;
-    const valueToSave = pendingMeetingDate;
-    const handle = setTimeout(() => {
-      void handleMeetingDateChange(valueToSave);
-      setPendingMeetingDate(undefined);
-    }, 600);
-    return () => clearTimeout(handle);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingMeetingDate]);
+  useRegisterPageContext(recordingPageContext);
 
   if (isLoading) {
     return <Skeleton height={400} />;
@@ -386,301 +167,16 @@ export default function SessionPage({ params }: { params: Promise<{ id: string }
   }
 
   return (
-    <>
-      <Paper p="md">
-        <Group justify="space-between" mb="lg">
-          <Title order={2}>{session.title ?? "Meeting"}</Title>
-        </Group>
-
-      <Tabs
-        value={activeTab}
-        onChange={(value) => setActiveTab(value ?? "overview")}
-        keepMounted={false}
-      >
-        <Tabs.List>
-          <Tabs.Tab value="overview">Overview</Tabs.Tab>
-          <Tabs.Tab value="transcription">Transcription</Tabs.Tab>
-          <Tabs.Tab value="screenshots">Screenshots</Tabs.Tab>
-        </Tabs.List>
-
-        <Tabs.Panel value="overview" pt="md">
-          <Stack gap="sm">
-            <Stack gap={4}>
-              <Group justify="space-between">
-                <Text fw={500}>Description</Text>
-                {!isEditingDescription && (
-                  <ActionIcon
-                    variant="subtle"
-                    size="sm"
-                    onClick={handleStartEditDescription}
-                  >
-                    <IconPencil size={16} />
-                  </ActionIcon>
-                )}
-              </Group>
-              {isEditingDescription ? (
-                <Stack gap="sm">
-                  <Textarea
-                    value={editedDescription}
-                    onChange={(event) => setEditedDescription(event.currentTarget.value)}
-                    minRows={6}
-                    autosize
-                    maxRows={16}
-                    placeholder="Enter description..."
-                    styles={{
-                      input: {
-                        fontFamily: isMarkdownContent(editedDescription) ? "monospace" : undefined,
-                      },
-                    }}
-                  />
-                  {isMarkdownContent(editedDescription) && (
-                    <Text size="xs" c="dimmed">
-                      Markdown supported.
-                    </Text>
-                  )}
-                  <Group justify="flex-end">
-                    <Button
-                      size="xs"
-                      variant="default"
-                      onClick={() => setIsEditingDescription(false)}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      size="xs"
-                      onClick={() => void handleSaveDescription()}
-                      loading={updateDetailsMutation.isPending}
-                    >
-                      Save
-                    </Button>
-                  </Group>
-                </Stack>
-              ) : session.description ? (
-                <SmartContentRenderer content={session.description} />
-              ) : (
-                <Text c="dimmed">No description available</Text>
-              )}
-            </Stack>
-            <Stack gap={4}>
-              <Group justify="space-between">
-                <Text fw={500}>Notes</Text>
-                {!isEditingNotes && (
-                  <ActionIcon
-                    variant="subtle"
-                    size="sm"
-                    onClick={handleStartEditNotes}
-                  >
-                    <IconPencil size={16} />
-                  </ActionIcon>
-                )}
-              </Group>
-              {isEditingNotes ? (
-                <Stack gap="sm">
-                  <Textarea
-                    value={editedNotes}
-                    onChange={(event) => setEditedNotes(event.currentTarget.value)}
-                    minRows={6}
-                    autosize
-                    maxRows={16}
-                    placeholder="Enter notes..."
-                    styles={{
-                      input: {
-                        fontFamily: isMarkdownContent(editedNotes) ? "monospace" : undefined,
-                      },
-                    }}
-                  />
-                  {isMarkdownContent(editedNotes) && (
-                    <Text size="xs" c="dimmed">
-                      Markdown supported.
-                    </Text>
-                  )}
-                  <Group justify="flex-end">
-                    <Button
-                      size="xs"
-                      variant="default"
-                      onClick={() => setIsEditingNotes(false)}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      size="xs"
-                      onClick={() => void handleSaveNotes()}
-                      loading={updateDetailsMutation.isPending}
-                    >
-                      Save
-                    </Button>
-                  </Group>
-                </Stack>
-              ) : session.notes ? (
-                <SmartContentRenderer content={session.notes} />
-              ) : (
-                <Text c="dimmed">No notes available</Text>
-              )}
-            </Stack>
-            <Stack gap={4}>
-              <Group justify="space-between">
-                <Text fw={500}>Summary</Text>
-                {!isEditingSummary && (
-                  <ActionIcon
-                    variant="subtle"
-                    size="sm"
-                    onClick={handleStartEditSummary}
-                  >
-                    <IconPencil size={16} />
-                  </ActionIcon>
-                )}
-              </Group>
-              {isEditingSummary ? (
-                <Stack gap="sm">
-                  <Textarea
-                    value={editedSummary}
-                    onChange={(event) => setEditedSummary(event.currentTarget.value)}
-                    minRows={6}
-                    autosize
-                    maxRows={16}
-                    placeholder="Enter summary..."
-                    styles={{
-                      input: {
-                        fontFamily: isMarkdownContent(editedSummary) ? "monospace" : undefined,
-                      },
-                    }}
-                  />
-                  {isMarkdownContent(editedSummary) && (
-                    <Text size="xs" c="dimmed">
-                      Markdown supported.
-                    </Text>
-                  )}
-                  <Group justify="flex-end">
-                    <Button
-                      size="xs"
-                      variant="default"
-                      onClick={() => setIsEditingSummary(false)}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      size="xs"
-                      onClick={() => void handleSaveSummary()}
-                      loading={updateDetailsMutation.isPending}
-                    >
-                      Save
-                    </Button>
-                  </Group>
-                </Stack>
-              ) : session.summary ? (
-                (() => {
-                  const firefliesSummary = parseFirefliesSummary(session.summary);
-                  if (firefliesSummary) {
-                    return isEmptyFirefliesSummary(firefliesSummary)
-                      ? <Text c="dimmed">No summary available</Text>
-                      : <FirefliesSummaryDisplay summary={firefliesSummary} />;
-                  }
-                  return <SmartContentRenderer content={session.summary} />;
-                })()
-              ) : (
-                <Text c="dimmed">No summary available</Text>
-              )}
-            </Stack>
-          </Stack>
-          <Stack gap="xs" mt="lg">
-            <Text><strong>Session ID:</strong> {session.sessionId}</Text>
-            <Text><strong>Created:</strong> {new Date(session.createdAt).toLocaleString()}</Text>
-            <Text><strong>Updated:</strong> {new Date(session.updatedAt).toLocaleString()}</Text>
-            <DateTimePicker
-              label="Meeting Date"
-              description="When the meeting actually happened"
-              value={
-                pendingMeetingDate !== undefined
-                  ? pendingMeetingDate
-                  : session.meetingDate
-                    ? new Date(session.meetingDate)
-                    : null
-              }
-              onChange={(value) => {
-                setPendingMeetingDate(value);
-              }}
-              clearable
-              valueFormat="MMMM D, YYYY h:mm A"
-              popoverProps={{ withinPortal: true }}
-            />
-          </Stack>
-          {workspaces && workspaces.length > 0 && (
-            <Select
-              label="Workspace"
-              description="Move this meeting to a different workspace"
-              data={[
-                { value: '', label: 'No Workspace' },
-                ...workspaces.map(ws => ({ value: ws.id, label: ws.name }))
-              ]}
-              value={session.workspaceId ?? ''}
-              onChange={(value) => {
-                void handleWorkspaceChange(value === '' ? null : value);
-              }}
-              mt="md"
-            />
-          )}
-
-          <Stack gap="sm" mt="xl">
-            <Text fw={600}>
-              Actions
-              {transcriptActions.length > 0 ? ` (${transcriptActions.length})` : ""}
-            </Text>
-            {isActionsLoading ? (
-              <Skeleton height={120} />
-            ) : transcriptActions.length > 0 ? (
-              <ActionsList
-                viewName="transcription-actions"
-                actions={transcriptActions}
-                showCheckboxes={false}
-                showProject
-              />
-            ) : session.transcription ? (
-              <Stack gap="sm" align="flex-start">
-                <Text c="dimmed">No actions created from this meeting yet.</Text>
-                <Button
-                  onClick={handleCreateActions}
-                  loading={generateDraftsMutation.isPending}
-                >
-                  Create Actions
-                </Button>
-              </Stack>
-            ) : (
-              <Text c="dimmed">
-                No transcript available to create actions from.
-              </Text>
-            )}
-          </Stack>
-        </Tabs.Panel>
-
-        <Tabs.Panel value="transcription" pt="md">
-          <TranscriptionTabContent session={session} />
-        </Tabs.Panel>
-
-        <Tabs.Panel value="screenshots" pt="md">
-          {session.screenshots && session.screenshots.length > 0 ? (
-            <SimpleGrid cols={3} spacing="md">
-              {session.screenshots.map((screenshot: any) => (
-                <div key={screenshot.id}>
-                  <Text size="sm" c="dimmed" mb="xs">
-                    {screenshot.timestamp}
-                  </Text>
-                  <Image
-                    src={screenshot.url}
-                    alt={`Screenshot from ${screenshot.timestamp}`}
-                    radius="md"
-                    onClick={() => window.open(screenshot.url, "_blank")}
-                    style={{ cursor: "pointer" }}
-                  />
-                </div>
-              ))}
-            </SimpleGrid>
-          ) : (
-            <Text c="dimmed">No screenshots for this session</Text>
-          )}
-        </Tabs.Panel>
-
-      </Tabs>
-      </Paper>
-    </>
+    <MeetingDetail
+      session={session}
+      actions={transcriptActions}
+      isActionsLoading={isActionsLoading}
+      workspaces={(workspaces ?? []).map((ws) => ({ id: ws.id, name: ws.name }))}
+      isCreatingActions={generateDraftsMutation.isPending}
+      onSaveSummary={handleSaveSummary}
+      onMeetingDateChange={handleMeetingDateChange}
+      onWorkspaceChange={handleWorkspaceChange}
+      onCreateActions={handleCreateActions}
+    />
   );
 }

--- a/src/app/_components/meeting/ContextRail.tsx
+++ b/src/app/_components/meeting/ContextRail.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import Link from "next/link";
+import { Select } from "@mantine/core";
+import { DateTimePicker } from "@mantine/dates";
+import {
+  IconPlayerPlay,
+  IconArrowRight,
+  IconShare,
+  IconFileExport,
+  IconExternalLink,
+} from "@tabler/icons-react";
+import { MpAvatar } from "./MpAvatar";
+import type { MeetingParticipant } from "~/lib/meeting-view-model";
+
+interface ContextRailProps {
+  participants: MeetingParticipant[];
+  project: { name: string } | null;
+  projectHref: string | null;
+  hasVideo: boolean;
+  videoUrl: string | null;
+  sourceLabel: string | null;
+  sourceSub: string | null;
+  sessionId: string;
+  createdLabel: string;
+  updatedLabel: string;
+  meetingDate: Date | null;
+  onMeetingDateChange: (value: Date | null) => void;
+  workspaceId: string | null;
+  workspaces: { id: string; name: string }[];
+  onWorkspaceChange: (value: string | null) => void;
+  onShare: () => void;
+  onExportTranscript: () => void;
+  canExport: boolean;
+}
+
+export function ContextRail({
+  participants,
+  project,
+  projectHref,
+  hasVideo,
+  videoUrl,
+  sourceLabel,
+  sourceSub,
+  sessionId,
+  createdLabel,
+  updatedLabel,
+  meetingDate,
+  onMeetingDateChange,
+  workspaceId,
+  workspaces,
+  onWorkspaceChange,
+  onShare,
+  onExportTranscript,
+  canExport,
+}: ContextRailProps) {
+  return (
+    <aside className="mp-rail">
+      {participants.length > 0 && (
+        <div className="mp-rail__section">
+          <div className="mp-rail__label">Participants</div>
+          <div className="mp-people">
+            {participants.map((p) => (
+              <div key={p.id} className="mp-person">
+                <MpAvatar initial={p.initial} flavor={p.flavor} />
+                <div style={{ minWidth: 0 }}>
+                  <div className="mp-person__name">{p.name}</div>
+                  {p.role && <div className="mp-person__role">{p.role}</div>}
+                </div>
+                {p.talk && <span className="mp-person__talk" title="Talk-time">{p.talk}</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {project && (
+        <div className="mp-rail__section">
+          <div className="mp-rail__label">Linked</div>
+          {projectHref ? (
+            <Link href={projectHref} className="mp-linkrow">
+              <span className="mp-linkrow__glyph mp-linkrow__glyph--ritual">
+                {project.name.charAt(0).toUpperCase()}
+              </span>
+              <div style={{ minWidth: 0 }}>
+                <div className="mp-linkrow__title">{project.name}</div>
+                <div className="mp-linkrow__sub">Project</div>
+              </div>
+              <IconArrowRight size={13} className="mp-linkrow__arrow" />
+            </Link>
+          ) : (
+            <div className="mp-linkrow">
+              <span className="mp-linkrow__glyph mp-linkrow__glyph--ritual">
+                {project.name.charAt(0).toUpperCase()}
+              </span>
+              <div style={{ minWidth: 0 }}>
+                <div className="mp-linkrow__title">{project.name}</div>
+                <div className="mp-linkrow__sub">Project</div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {(hasVideo || sourceLabel) && (
+        <div className="mp-rail__section">
+          <div className="mp-rail__label">Source</div>
+          <div className="mp-source">
+            <span className="mp-source__icon">
+              <IconPlayerPlay size={14} />
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div className="mp-source__title">{sourceLabel ?? "Recording"}</div>
+              {sourceSub && <div className="mp-source__sub">{sourceSub}</div>}
+            </div>
+            {videoUrl && (
+              <a href={videoUrl} target="_blank" rel="noopener noreferrer" aria-label="Open recording">
+                <IconExternalLink size={14} className="mp-linkrow__arrow" />
+              </a>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Demoted plumbing — editable, but out of the main flow */}
+      <div className="mp-rail__section">
+        <div className="mp-rail__label">Details</div>
+        <div className="mp-railkv">
+          <div className="mp-railkv__row">
+            <span className="mp-railkv__k">Created</span>
+            <span className="mp-railkv__v">{createdLabel}</span>
+          </div>
+          <div className="mp-railkv__row">
+            <span className="mp-railkv__k">Updated</span>
+            <span className="mp-railkv__v">{updatedLabel}</span>
+          </div>
+          <div className="mp-railkv__row">
+            <span className="mp-railkv__k">Session</span>
+            <span className="mp-railkv__v mp-railkv__v--mono" title={sessionId}>
+              {sessionId}
+            </span>
+          </div>
+        </div>
+        <div className="mp-rail__field">
+          <DateTimePicker
+            label="Meeting date"
+            value={meetingDate}
+            onChange={(value) => onMeetingDateChange(value ? new Date(value) : null)}
+            clearable
+            size="xs"
+            valueFormat="MMM D, YYYY h:mm A"
+            popoverProps={{ withinPortal: true }}
+          />
+        </div>
+        {workspaces.length > 0 && (
+          <div className="mp-rail__field">
+            <Select
+              label="Workspace"
+              size="xs"
+              data={[
+                { value: "", label: "No workspace" },
+                ...workspaces.map((ws) => ({ value: ws.id, label: ws.name })),
+              ]}
+              value={workspaceId ?? ""}
+              onChange={(value) => onWorkspaceChange(value === "" ? null : value)}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="mp-rail__section">
+        <div className="mp-rail__label">Actions</div>
+        <div className="mp-quick">
+          <button className="mp-quick__btn" onClick={onShare}>
+            <IconShare size={13} /> Share with team
+          </button>
+          <button className="mp-quick__btn" onClick={onExportTranscript} disabled={!canExport}>
+            <IconFileExport size={13} /> Export transcript
+          </button>
+          {videoUrl && (
+            <a
+              className="mp-quick__btn"
+              href={videoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <IconExternalLink size={13} /> Open recording
+            </a>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/_components/meeting/MeetingDetail.tsx
+++ b/src/app/_components/meeting/MeetingDetail.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { notifications } from "@mantine/notifications";
+import { IconSparkles, IconFileText, IconPhoto } from "@tabler/icons-react";
+import "./meeting-detail.css";
+import { MeetingHeader } from "./MeetingHeader";
+import { SummaryTab } from "./SummaryTab";
+import { TranscriptTab } from "./TranscriptTab";
+import { ScreenshotsTab } from "./ScreenshotsTab";
+import { ContextRail } from "./ContextRail";
+import { buildMeetingViewModel } from "~/lib/meeting-view-model";
+import type { MeetingSession } from "~/lib/meeting-view-model";
+import type { RouterOutputs } from "~/trpc/react";
+
+type TranscriptAction = RouterOutputs["action"]["getByTranscription"][number];
+type Tab = "summary" | "transcript" | "screenshots";
+
+interface MeetingDetailProps {
+  session: MeetingSession;
+  actions: TranscriptAction[];
+  isActionsLoading: boolean;
+  workspaces: { id: string; name: string }[];
+  isCreatingActions: boolean;
+  onSaveSummary: (value: string) => Promise<void>;
+  onMeetingDateChange: (value: Date | null) => void;
+  onWorkspaceChange: (value: string | null) => void;
+  onCreateActions: () => void;
+}
+
+const dateFmt: Intl.DateTimeFormatOptions = {
+  weekday: "short",
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+};
+
+export function MeetingDetail({
+  session,
+  actions,
+  isActionsLoading,
+  workspaces,
+  isCreatingActions,
+  onSaveSummary,
+  onMeetingDateChange,
+  onWorkspaceChange,
+  onCreateActions,
+}: MeetingDetailProps) {
+  const [tab, setTab] = useState<Tab>("summary");
+  const vm = useMemo(() => buildMeetingViewModel(session), [session]);
+
+  const meetingDateObj = session.meetingDate ? new Date(session.meetingDate) : null;
+  const displayDate = meetingDateObj ?? new Date(session.createdAt);
+  const dateLabel = displayDate.toLocaleDateString(undefined, dateFmt);
+  const timeLabel = meetingDateObj
+    ? meetingDateObj.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })
+    : null;
+
+  const sourceLabel =
+    session.sourceIntegration?.name ?? (vm.hasVideo ? "Screen recording" : null);
+  const sourceSub = [vm.durationLabel, vm.captureCount > 0 ? `${vm.captureCount} captures` : null]
+    .filter(Boolean)
+    .join(" · ");
+
+  const workspaceSlug = session.workspace?.slug ?? null;
+  const backHref = workspaceSlug ? `/w/${workspaceSlug}/meetings` : "/";
+  const projectHref =
+    workspaceSlug && session.project?.slug
+      ? `/w/${workspaceSlug}/projects/${session.project.slug}`
+      : null;
+
+  const generatedStamp = session.processedAt
+    ? new Date(session.processedAt).toLocaleString(undefined, {
+        day: "numeric",
+        month: "short",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : null;
+
+  function handleShare() {
+    if (typeof window === "undefined") return;
+    void navigator.clipboard.writeText(window.location.href);
+    notifications.show({ message: "Link copied to clipboard", color: "green" });
+  }
+
+  function handleExportTranscript() {
+    if (!session.transcription || typeof window === "undefined") return;
+    const blob = new Blob([session.transcription], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${session.title ?? "transcript"}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="-m-4 -mt-16 sm:-mt-4 lg:-m-8 -mb-20 sm:-mb-4 lg:-mb-8">
+      <div className="meeting-detail">
+        <MeetingHeader
+          title={session.title ?? "Meeting"}
+          meetingType={vm.meetingType}
+          dateLabel={dateLabel}
+          timeLabel={timeLabel}
+          durationLabel={vm.durationLabel}
+          participants={vm.participants}
+          sourceLabel={sourceLabel}
+          workspaceName={session.workspace?.name ?? null}
+          backHref={backHref}
+          onShare={handleShare}
+        />
+
+        <nav className="mp-tabs" role="tablist" aria-label="Meeting sections">
+          <button
+            role="tab"
+            aria-selected={tab === "summary"}
+            className={`mp-tab ${tab === "summary" ? "on" : ""}`}
+            onClick={() => setTab("summary")}
+          >
+            <IconSparkles size={14} /> Summary
+          </button>
+          <button
+            role="tab"
+            aria-selected={tab === "transcript"}
+            className={`mp-tab ${tab === "transcript" ? "on" : ""}`}
+            onClick={() => setTab("transcript")}
+          >
+            <IconFileText size={14} /> Transcript
+          </button>
+          <button
+            role="tab"
+            aria-selected={tab === "screenshots"}
+            className={`mp-tab ${tab === "screenshots" ? "on" : ""}`}
+            onClick={() => setTab("screenshots")}
+          >
+            <IconPhoto size={14} /> Screenshots
+            {vm.captureCount > 0 && <span className="mp-tab__count">{vm.captureCount}</span>}
+          </button>
+        </nav>
+
+        <div className="mp-body">
+          <main className="mp-main" role="tabpanel">
+            {tab === "summary" && (
+              <SummaryTab
+                vm={vm}
+                rawSummary={session.summary ?? null}
+                generatedStamp={generatedStamp}
+                actions={actions}
+                isActionsLoading={isActionsLoading}
+                hasTranscript={Boolean(session.transcription)}
+                isCreatingActions={isCreatingActions}
+                onSaveSummary={onSaveSummary}
+                onCreateActions={onCreateActions}
+              />
+            )}
+            {tab === "transcript" && (
+              <TranscriptTab
+                transcription={session.transcription}
+                sentencesJson={session.sentencesJson}
+                chapters={vm.chapters}
+                participants={vm.participants}
+              />
+            )}
+            {tab === "screenshots" && (
+              <ScreenshotsTab
+                screenshots={session.screenshots.map((s) => ({
+                  id: s.id,
+                  url: s.url,
+                  timestamp: s.timestamp,
+                }))}
+                videoUrl={session.videoUrl}
+              />
+            )}
+          </main>
+
+          <ContextRail
+            participants={vm.participants}
+            project={session.project ? { name: session.project.name } : null}
+            projectHref={projectHref}
+            hasVideo={vm.hasVideo}
+            videoUrl={session.videoUrl}
+            sourceLabel={sourceLabel}
+            sourceSub={sourceSub || null}
+            sessionId={session.sessionId}
+            createdLabel={new Date(session.createdAt).toLocaleString()}
+            updatedLabel={new Date(session.updatedAt).toLocaleString()}
+            meetingDate={meetingDateObj}
+            onMeetingDateChange={onMeetingDateChange}
+            workspaceId={session.workspaceId ?? null}
+            workspaces={workspaces}
+            onWorkspaceChange={onWorkspaceChange}
+            onShare={handleShare}
+            onExportTranscript={handleExportTranscript}
+            canExport={Boolean(session.transcription)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/meeting/MeetingHeader.tsx
+++ b/src/app/_components/meeting/MeetingHeader.tsx
@@ -1,0 +1,106 @@
+import Link from "next/link";
+import {
+  IconArrowLeft,
+  IconCalendar,
+  IconClock,
+  IconPlayerPlay,
+  IconShare,
+} from "@tabler/icons-react";
+import { MpAvatar } from "./MpAvatar";
+import type { MeetingParticipant } from "~/lib/meeting-view-model";
+
+interface MeetingHeaderProps {
+  title: string;
+  meetingType: string | null;
+  dateLabel: string | null;
+  timeLabel: string | null;
+  durationLabel: string | null;
+  participants: MeetingParticipant[];
+  sourceLabel: string | null;
+  workspaceName: string | null;
+  backHref: string;
+  onShare: () => void;
+}
+
+export function MeetingHeader({
+  title,
+  meetingType,
+  dateLabel,
+  timeLabel,
+  durationLabel,
+  participants,
+  sourceLabel,
+  workspaceName,
+  backHref,
+  onShare,
+}: MeetingHeaderProps) {
+  return (
+    <header className="mp-head">
+      <div className="mp-crumb">
+        <Link href={backHref} className="mp-crumb__back">
+          <IconArrowLeft size={13} /> Meetings
+        </Link>
+        {workspaceName && (
+          <>
+            <span className="mp-crumb__sep">/</span>
+            <span>{workspaceName}</span>
+          </>
+        )}
+        {dateLabel && (
+          <>
+            <span className="mp-crumb__sep">/</span>
+            <span className="mp-crumb__cur">{dateLabel}</span>
+          </>
+        )}
+      </div>
+
+      <div className="mp-titlebar">
+        <div className="mp-titlebar__main">
+          {meetingType && (
+            <span className="mp-type">
+              <span className="mp-type__dot" />
+              {meetingType}
+            </span>
+          )}
+          <h1 className="mp-title">
+            <span className="mp-title__text">{title}</span>
+          </h1>
+          <div className="mp-meta">
+            {dateLabel && (
+              <span className="mp-meta__item">
+                <IconCalendar size={14} />
+                <b>{dateLabel}</b>
+                {timeLabel ? ` · ${timeLabel}` : null}
+              </span>
+            )}
+            {durationLabel && (
+              <span className="mp-meta__item">
+                <IconClock size={14} /> {durationLabel}
+              </span>
+            )}
+            {participants.length > 0 && (
+              <span className="mp-meta__item">
+                <span className="mp-meta__avs">
+                  {participants.slice(0, 5).map((p) => (
+                    <MpAvatar key={p.id} initial={p.initial} flavor={p.flavor} title={p.name} />
+                  ))}
+                </span>
+                {participants.length} {participants.length === 1 ? "person" : "people"}
+              </span>
+            )}
+            {sourceLabel && (
+              <span className="mp-meta__item">
+                <IconPlayerPlay size={13} /> {sourceLabel}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="mp-head-actions">
+          <button className="mp-btn" onClick={onShare}>
+            <IconShare size={14} /> Share
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/app/_components/meeting/MpAvatar.tsx
+++ b/src/app/_components/meeting/MpAvatar.tsx
@@ -1,0 +1,18 @@
+import type { ParticipantFlavor } from "~/lib/meeting-view-model";
+
+interface MpAvatarProps {
+  initial: string;
+  flavor: ParticipantFlavor;
+  className?: string;
+  title?: string;
+}
+
+/** Identity-coloured initials avatar for the meeting detail page. Blue (`me`)
+ *  is the host/you; other participants rotate through the identity palette. */
+export function MpAvatar({ initial, flavor, className, title }: MpAvatarProps) {
+  return (
+    <span className={`mp-av mp-av--${flavor}${className ? ` ${className}` : ""}`} title={title}>
+      {initial}
+    </span>
+  );
+}

--- a/src/app/_components/meeting/ScreenshotsTab.tsx
+++ b/src/app/_components/meeting/ScreenshotsTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Image } from "@mantine/core";
 import { IconExternalLink } from "@tabler/icons-react";
 
 interface ScreenshotItem {
@@ -42,10 +43,10 @@ export function ScreenshotsTab({ screenshots, videoUrl }: ScreenshotsTabProps) {
           <figure key={shot.id} className="mp-shot" style={{ margin: 0 }}>
             <div className="mp-shot__frame">
               {shot.timestamp && <span className="mp-shot__time">{shot.timestamp}</span>}
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
+              <Image
                 className="mp-shot__img"
                 src={shot.url}
+                fit="cover"
                 alt={`Screen capture${shot.timestamp ? ` at ${shot.timestamp}` : ""}`}
                 onClick={() => window.open(shot.url, "_blank")}
               />

--- a/src/app/_components/meeting/ScreenshotsTab.tsx
+++ b/src/app/_components/meeting/ScreenshotsTab.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { IconExternalLink } from "@tabler/icons-react";
+
+interface ScreenshotItem {
+  id: string;
+  url: string;
+  timestamp: string | null;
+}
+
+interface ScreenshotsTabProps {
+  screenshots: ScreenshotItem[];
+  videoUrl: string | null;
+}
+
+export function ScreenshotsTab({ screenshots, videoUrl }: ScreenshotsTabProps) {
+  if (screenshots.length === 0) {
+    return <div className="mp-empty">No screenshots captured for this meeting.</div>;
+  }
+
+  return (
+    <div>
+      <div className="mp-shots-head">
+        <div className="mp-sec" style={{ margin: 0, flex: 1 }}>
+          <h3>Auto-captured frames</h3>
+          <span className="mp-sec__count">{screenshots.length}</span>
+          <span className="mp-sec__rule" />
+        </div>
+        {videoUrl && (
+          <a
+            className="mp-chipbtn"
+            href={videoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <IconExternalLink size={11} /> Open recording
+          </a>
+        )}
+      </div>
+      <div className="mp-shots">
+        {screenshots.map((shot) => (
+          <figure key={shot.id} className="mp-shot" style={{ margin: 0 }}>
+            <div className="mp-shot__frame">
+              {shot.timestamp && <span className="mp-shot__time">{shot.timestamp}</span>}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                className="mp-shot__img"
+                src={shot.url}
+                alt={`Screen capture${shot.timestamp ? ` at ${shot.timestamp}` : ""}`}
+                onClick={() => window.open(shot.url, "_blank")}
+              />
+            </div>
+            {shot.timestamp && <figcaption className="mp-shot__cap">{shot.timestamp}</figcaption>}
+          </figure>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/meeting/SummaryTab.tsx
+++ b/src/app/_components/meeting/SummaryTab.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState } from "react";
+import { Textarea, Button } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import {
+  IconSparkles,
+  IconCopy,
+  IconPencil,
+  IconCheck,
+  IconAlertCircle,
+  IconPlus,
+} from "@tabler/icons-react";
+import { SmartContentRenderer } from "~/app/_components/SmartContentRenderer";
+import { FirefliesSummaryDisplay } from "~/app/_components/FirefliesSummaryRenderer";
+import { ActionsList } from "~/app/_components/actions/ActionsList";
+import type { MeetingViewModel } from "~/lib/meeting-view-model";
+import type { RouterOutputs } from "~/trpc/react";
+
+type TranscriptAction = RouterOutputs["action"]["getByTranscription"][number];
+
+interface SummaryTabProps {
+  vm: MeetingViewModel;
+  rawSummary: string | null;
+  generatedStamp: string | null;
+  actions: TranscriptAction[];
+  isActionsLoading: boolean;
+  hasTranscript: boolean;
+  isCreatingActions: boolean;
+  onSaveSummary: (value: string) => Promise<void>;
+  onCreateActions: () => void;
+}
+
+export function SummaryTab({
+  vm,
+  rawSummary,
+  generatedStamp,
+  actions,
+  isActionsLoading,
+  hasTranscript,
+  isCreatingActions,
+  onSaveSummary,
+  onCreateActions,
+}: SummaryTabProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const hasSummary = Boolean(vm.firefliesSummary ?? vm.plainSummary);
+
+  function startEdit() {
+    setDraft(rawSummary ?? "");
+    setIsEditing(true);
+  }
+
+  async function save() {
+    setIsSaving(true);
+    try {
+      await onSaveSummary(draft);
+      setIsEditing(false);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function copySummary() {
+    const text = vm.plainSummary ?? rawSummary ?? "";
+    void navigator.clipboard.writeText(text);
+    notifications.show({ message: "Summary copied", color: "green" });
+  }
+
+  return (
+    <>
+      {/* ===== AI summary ===== */}
+      <section className="mp-tldr">
+        <div className="mp-tldr__head">
+          <IconSparkles size={12} /> AI summary
+          <span className="mp-spacer" />
+          {generatedStamp && <span className="mp-tldr__stamp">generated {generatedStamp}</span>}
+        </div>
+
+        {isEditing ? (
+          <>
+            <Textarea
+              value={draft}
+              onChange={(e) => setDraft(e.currentTarget.value)}
+              autosize
+              minRows={6}
+              maxRows={20}
+              placeholder="Enter a summary…"
+            />
+            <div className="mp-tldr__foot">
+              <Button size="xs" loading={isSaving} onClick={() => void save()}>
+                Save
+              </Button>
+              <Button size="xs" variant="subtle" onClick={() => setIsEditing(false)}>
+                Cancel
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            {vm.firefliesSummary ? (
+              <FirefliesSummaryDisplay summary={vm.firefliesSummary} />
+            ) : vm.plainSummary ? (
+              <div className="mp-tldr__text">
+                <SmartContentRenderer content={vm.plainSummary} />
+              </div>
+            ) : (
+              <p className="mp-tldr__text">No summary yet for this meeting.</p>
+            )}
+            <div className="mp-tldr__foot">
+              {hasSummary && (
+                <button className="mp-chipbtn" onClick={copySummary}>
+                  <IconCopy size={11} /> Copy
+                </button>
+              )}
+              <button className="mp-chipbtn" onClick={startEdit}>
+                <IconPencil size={11} /> Edit
+              </button>
+            </div>
+          </>
+        )}
+      </section>
+
+      {/* ===== Key moments (dormant until AI extraction lands) ===== */}
+      {vm.keyMoments.length > 0 && (
+        <section>
+          <div className="mp-sec">
+            <h3>Key moments</h3>
+            <span className="mp-sec__count">{vm.keyMoments.length}</span>
+            <span className="mp-sec__rule" />
+          </div>
+        </section>
+      )}
+
+      {/* ===== Decisions / Open questions (dormant until AI extraction lands) ===== */}
+      {(vm.decisions.length > 0 || vm.questions.length > 0) && (
+        <div className="mp-twocard">
+          <div className="mp-card">
+            <div className="mp-card__label mp-card__label--decision">
+              <IconCheck size={11} /> Decisions
+            </div>
+          </div>
+          <div className="mp-card">
+            <div className="mp-card__label mp-card__label--question">
+              <IconAlertCircle size={11} /> Open questions
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ===== Actions ===== */}
+      <section>
+        <div className="mp-sec">
+          <h3>Actions</h3>
+          {actions.length > 0 && <span className="mp-sec__count">{actions.length}</span>}
+          <span className="mp-sec__rule" />
+        </div>
+
+        {isActionsLoading ? (
+          <div className="mp-empty">Loading actions…</div>
+        ) : actions.length > 0 ? (
+          <ActionsList
+            viewName="transcription-actions"
+            actions={actions}
+            showCheckboxes={false}
+            showProject
+          />
+        ) : hasTranscript ? (
+          <div className="mp-actbar">
+            <div className="mp-actbar__txt">
+              <b>AI-drafted actions</b> can be pulled from this meeting. Review and confirm the
+              ones you want — they’re added to your projects.
+            </div>
+            <button
+              className="mp-btn mp-btn--primary"
+              onClick={onCreateActions}
+              disabled={isCreatingActions}
+            >
+              <IconPlus size={13} /> Create Actions
+            </button>
+          </div>
+        ) : (
+          <div className="mp-empty">No transcript available to create actions from.</div>
+        )}
+      </section>
+    </>
+  );
+}

--- a/src/app/_components/meeting/SummaryTab.tsx
+++ b/src/app/_components/meeting/SummaryTab.tsx
@@ -58,6 +58,8 @@ export function SummaryTab({
     try {
       await onSaveSummary(draft);
       setIsEditing(false);
+    } catch {
+      // onSaveSummary surfaces its own error notification; stay in edit mode.
     } finally {
       setIsSaving(false);
     }

--- a/src/app/_components/meeting/TranscriptTab.tsx
+++ b/src/app/_components/meeting/TranscriptTab.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { IconSearch, IconUsers } from "@tabler/icons-react";
+import { MpAvatar } from "./MpAvatar";
+import { getInitial } from "~/utils/avatarColors";
+import type {
+  MeetingChapter,
+  MeetingParticipant,
+  ParticipantFlavor,
+} from "~/lib/meeting-view-model";
+
+interface Sentence {
+  text: string;
+  speakerName: string | null;
+  startTime: number;
+}
+
+interface TranscriptTabProps {
+  transcription: string | null;
+  sentencesJson: unknown;
+  chapters: MeetingChapter[];
+  participants: MeetingParticipant[];
+}
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+/** Parse the best available diarized transcript. Prefers `sentencesJson`,
+ *  falls back to a Fireflies-shaped `transcription` string, else null. */
+function parseSentences(transcription: string | null, sentencesJson: unknown): Sentence[] | null {
+  const fromArray = (arr: unknown[]): Sentence[] | null => {
+    const rows = arr
+      .map((s) => {
+        if (!s || typeof s !== "object") return null;
+        const obj = s as Record<string, unknown>;
+        const text = typeof obj.text === "string" ? obj.text : null;
+        if (text === null) return null;
+        const speakerName =
+          typeof obj.speaker_name === "string" ? obj.speaker_name : null;
+        const startTime = typeof obj.start_time === "number" ? obj.start_time : 0;
+        return { text, speakerName, startTime };
+      })
+      .filter((r): r is Sentence => r !== null);
+    return rows.length > 0 ? rows : null;
+  };
+
+  if (Array.isArray(sentencesJson)) {
+    const parsed = fromArray(sentencesJson);
+    if (parsed) return parsed;
+  }
+  if (transcription) {
+    try {
+      const obj: unknown = JSON.parse(transcription);
+      if (obj && typeof obj === "object" && Array.isArray((obj as { sentences?: unknown }).sentences)) {
+        return fromArray((obj as { sentences: unknown[] }).sentences);
+      }
+    } catch {
+      /* not JSON — plain text */
+    }
+  }
+  return null;
+}
+
+function withHighlight(text: string, query: string) {
+  if (!query) return text;
+  const lower = text.toLowerCase();
+  const q = query.toLowerCase();
+  const parts: React.ReactNode[] = [];
+  let i = 0;
+  let key = 0;
+  while (i < text.length) {
+    const idx = lower.indexOf(q, i);
+    if (idx === -1) {
+      parts.push(text.slice(i));
+      break;
+    }
+    if (idx > i) parts.push(text.slice(i, idx));
+    parts.push(<mark key={key++}>{text.slice(idx, idx + q.length)}</mark>);
+    i = idx + q.length;
+  }
+  return parts;
+}
+
+export function TranscriptTab({
+  transcription,
+  sentencesJson,
+  chapters,
+  participants,
+}: TranscriptTabProps) {
+  const [query, setQuery] = useState("");
+  const [onlyMe, setOnlyMe] = useState(false);
+
+  const sentences = useMemo(
+    () => parseSentences(transcription, sentencesJson),
+    [transcription, sentencesJson],
+  );
+
+  // speaker name → identity flavor (match participants first, then rotate)
+  const flavorBySpeaker = useMemo(() => {
+    const map = new Map<string, ParticipantFlavor>();
+    for (const p of participants) map.set(p.name, p.flavor);
+    if (sentences) {
+      let rotation = 0;
+      const rotated: ParticipantFlavor[] = ["them", "alt"];
+      for (const s of sentences) {
+        const name = s.speakerName ?? "";
+        if (!name || map.has(name)) continue;
+        map.set(name, rotated[rotation % rotated.length]!);
+        rotation += 1;
+      }
+    }
+    return map;
+  }, [participants, sentences]);
+
+  const hostNames = useMemo(
+    () => new Set(participants.filter((p) => p.flavor === "me").map((p) => p.name)),
+    [participants],
+  );
+
+  // Plain-text fallback: no diarization data.
+  if (!sentences) {
+    if (!transcription) {
+      return <div className="mp-empty">No transcript available yet.</div>;
+    }
+    return (
+      <div>
+        <div className="mp-tr__toolbar">
+          <div className="mp-tr__search">
+            <IconSearch size={14} />
+            <input
+              placeholder="Search the transcript"
+              value={query}
+              onChange={(e) => setQuery(e.currentTarget.value)}
+            />
+          </div>
+        </div>
+        <p className="mp-turn__text" style={{ whiteSpace: "pre-wrap" }}>
+          {withHighlight(transcription, query)}
+        </p>
+      </div>
+    );
+  }
+
+  const filtered = sentences.filter((s) => {
+    if (onlyMe && !(s.speakerName && hostNames.has(s.speakerName))) return false;
+    if (query && !s.text.toLowerCase().includes(query.toLowerCase())) return false;
+    return true;
+  });
+
+  // interleave chapter markers by start time (only when not filtering)
+  const sortedChapters = [...chapters].sort((a, b) => a.startTime - b.startTime);
+  const showChapters = !query && !onlyMe && sortedChapters.length > 0;
+  let nextChapter = 0;
+
+  return (
+    <div>
+      <div className="mp-tr__toolbar">
+        <div className="mp-tr__search">
+          <IconSearch size={14} />
+          <input
+            placeholder="Search the transcript"
+            value={query}
+            onChange={(e) => setQuery(e.currentTarget.value)}
+          />
+        </div>
+        {hostNames.size > 0 && (
+          <button
+            className={`mp-tr__filter ${onlyMe ? "on" : ""}`}
+            onClick={() => setOnlyMe((v) => !v)}
+          >
+            <IconUsers size={12} /> Only me
+          </button>
+        )}
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="mp-empty">No matching transcript lines.</div>
+      ) : (
+        filtered.map((s, i) => {
+          const chapterMarkers: React.ReactNode[] = [];
+          if (showChapters) {
+            while (
+              nextChapter < sortedChapters.length &&
+              s.startTime >= sortedChapters[nextChapter]!.startTime
+            ) {
+              const ch = sortedChapters[nextChapter]!;
+              chapterMarkers.push(
+                <div key={`ch-${nextChapter}`} className="mp-chapter">
+                  <span className="mp-chapter__label">{ch.title}</span>
+                  <span className="mp-chapter__line" />
+                  <span className="mp-chapter__time">{formatTime(ch.startTime)}</span>
+                </div>,
+              );
+              nextChapter += 1;
+            }
+          }
+
+          const name = s.speakerName ?? "";
+          const flavor = flavorBySpeaker.get(name) ?? "them";
+          return (
+            <div key={`row-${i}`}>
+              {chapterMarkers}
+              <div className="mp-turn">
+                <div className="mp-turn__gutter">
+                  <span className="mp-turn__time">{formatTime(s.startTime)}</span>
+                  {name && (
+                    <MpAvatar
+                      initial={getInitial(name)}
+                      flavor={flavor}
+                      className="mp-turn__avatar"
+                    />
+                  )}
+                </div>
+                <div>
+                  {name && <div className={`mp-turn__name mp-turn__name--${flavor}`}>{name}</div>}
+                  <p className="mp-turn__text">{withHighlight(s.text, query)}</p>
+                </div>
+              </div>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/src/app/_components/meeting/meeting-detail.css
+++ b/src/app/_components/meeting/meeting-detail.css
@@ -1,0 +1,260 @@
+/* ============================================================
+   Meeting detail — redesigned "workspace" layout (Direction B).
+   All raw color values live in globals.css under .meeting-detail;
+   this file uses only var(). Recreated from the design handoff,
+   mapped onto the app's existing semantic tokens so it themes in
+   both light and dark.
+   ============================================================ */
+
+.meeting-detail {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  width: 100%;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-family: var(--font-sans);
+  overflow: hidden;
+}
+.meeting-detail * { box-sizing: border-box; }
+.meeting-detail button { background: none; border: 0; cursor: pointer; font: inherit; color: inherit; padding: 0; }
+
+/* avatar identity gradients */
+.mp-av { border-radius: 50%; display: grid; place-items: center; color: var(--mp-on-accent); font-weight: 700; letter-spacing: 0.02em; flex-shrink: 0; }
+.mp-av--me   { background: var(--mp-identity-me); }
+.mp-av--them { background: var(--mp-identity-them); }
+.mp-av--alt  { background: var(--mp-identity-alt); }
+
+/* ============ HEADER ============ */
+.mp-head { padding: 26px 34px 0; flex-shrink: 0; }
+.mp-crumb { display: flex; align-items: center; gap: 7px; font-size: 12.5px; color: var(--color-text-muted); margin-bottom: 16px; }
+.mp-crumb__sep { color: var(--color-text-faint); }
+.mp-crumb__cur { color: var(--color-text-secondary); }
+.mp-crumb__back {
+  display: inline-flex; align-items: center; gap: 6px; color: var(--color-text-secondary);
+  padding: 3px 8px 3px 5px; margin-left: -5px; border-radius: var(--radius-sm);
+  transition: background 120ms, color 120ms;
+}
+.mp-crumb__back:hover { background: var(--color-bg-hover); color: var(--color-text-primary); }
+
+.mp-titlebar { display: flex; align-items: flex-start; gap: 18px; }
+.mp-titlebar__main { min-width: 0; flex: 1; }
+.mp-type {
+  display: inline-flex; align-items: center; gap: 6px; height: 22px; padding: 0 9px; border-radius: var(--radius-sm);
+  background: var(--mp-brand-10); border: 1px solid var(--mp-brand-22); color: var(--brand-400);
+  font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; margin-bottom: 12px;
+}
+.mp-type__dot { width: 5px; height: 5px; border-radius: 50%; background: var(--brand-400); }
+.mp-title {
+  font-size: 28px; font-weight: 600; letter-spacing: -0.02em; margin: 0; color: var(--color-text-primary);
+  line-height: 1.15; display: flex; align-items: center; gap: 10px;
+}
+.mp-title__text { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+.mp-title__edit {
+  width: 26px; height: 26px; border-radius: 5px; color: var(--color-text-faint);
+  display: grid; place-items: center; flex-shrink: 0; transition: background 120ms, color 120ms;
+}
+.mp-title__edit:hover { color: var(--color-text-secondary); background: var(--color-bg-hover); }
+.mp-meta { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; margin-top: 12px; font-size: 13px; color: var(--color-text-secondary); }
+.mp-meta__item { display: inline-flex; align-items: center; gap: 7px; }
+.mp-meta__item svg { color: var(--color-text-muted); }
+.mp-meta__item b { color: var(--color-text-primary); font-weight: 500; }
+.mp-meta__avs { display: flex; }
+.mp-meta__avs .mp-av { width: 22px; height: 22px; font-size: 8.5px; border: 2px solid var(--color-bg-primary); margin-left: -7px; }
+.mp-meta__avs .mp-av:first-child { margin-left: 0; }
+
+.mp-head-actions { display: flex; align-items: center; gap: 8px; }
+.mp-iconbtn {
+  width: 32px; height: 32px; border-radius: var(--radius-sm); display: grid; place-items: center;
+  border: 1px solid transparent; color: var(--color-text-secondary); transition: background 120ms, color 120ms, border-color 120ms;
+}
+.mp-iconbtn:hover { background: var(--color-bg-hover); color: var(--color-text-primary); }
+.mp-btn {
+  height: 32px; padding: 0 14px; border-radius: var(--radius-sm); font-size: 13px; font-weight: 500;
+  border: 1px solid var(--color-border-primary); background: var(--color-surface-muted); color: var(--color-text-primary);
+  display: inline-flex; align-items: center; gap: 7px; transition: background 120ms, border-color 120ms;
+}
+.mp-btn:hover { background: var(--color-bg-hover); border-color: var(--color-border-strong); }
+.mp-btn--primary { background: var(--brand-500); border-color: var(--brand-500); color: var(--mp-on-accent); }
+.mp-btn--primary:hover { background: var(--brand-600); border-color: var(--brand-600); }
+.mp-btn:disabled { opacity: 0.6; cursor: default; }
+
+/* ============ TABS ============ */
+.mp-tabs {
+  display: flex; align-items: center; gap: 2px; margin-top: 22px; padding: 0 34px;
+  border-bottom: 1px solid var(--color-border-subtle); flex-shrink: 0;
+}
+.mp-tab {
+  height: 40px; padding: 0 13px; font-size: 13.5px; font-weight: 500; color: var(--color-text-secondary);
+  display: inline-flex; align-items: center; gap: 8px; position: relative; transition: color 120ms;
+}
+.mp-tab:hover { color: var(--color-text-primary); }
+.mp-tab.on { color: var(--color-text-primary); }
+.mp-tab.on::after { content: ""; position: absolute; left: 6px; right: 6px; bottom: -1px; height: 2px; background: var(--brand-400); border-radius: 2px 2px 0 0; }
+.mp-tab__count { font-size: 10.5px; font-weight: 600; padding: 1px 6px; border-radius: 10px; background: var(--color-surface-muted); color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
+.mp-tab.on .mp-tab__count { background: var(--mp-brand-14); color: var(--brand-400); }
+
+/* ============ BODY (two-column grid, independent scroll) ============ */
+.mp-body { flex: 1; display: grid; grid-template-columns: minmax(0, 1fr) 312px; min-height: 0; overflow: hidden; }
+.mp-main { overflow-y: auto; overflow-x: hidden; min-width: 0; padding: 28px 30px 40px; border-right: 1px solid var(--color-border-subtle); display: flex; flex-direction: column; gap: 28px; }
+.mp-rail { overflow-y: auto; overflow-x: hidden; background: var(--color-bg-secondary); display: flex; flex-direction: column; }
+
+@media (max-width: 1100px) {
+  .mp-body { grid-template-columns: 1fr; }
+  .mp-rail { display: none; }
+}
+
+.meeting-detail ::-webkit-scrollbar { width: 8px; height: 8px; }
+.meeting-detail ::-webkit-scrollbar-thumb { background: var(--color-border-primary); border-radius: 4px; }
+.meeting-detail ::-webkit-scrollbar-track { background: transparent; }
+
+/* ============ SECTION HEAD ============ */
+.mp-sec { display: flex; align-items: baseline; gap: 11px; margin: 0 0 14px; }
+.mp-sec h3 { font-size: 12px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--color-text-muted); margin: 0; }
+.mp-sec__count { color: var(--color-text-faint); font-size: 11.5px; font-variant-numeric: tabular-nums; }
+.mp-sec__rule { flex: 1; height: 1px; background: var(--color-border-subtle); }
+
+/* ============ AI SUMMARY ============ */
+.mp-tldr {
+  background: linear-gradient(180deg, var(--mp-brand-05), transparent 72%), var(--color-bg-elevated);
+  border: 1px solid var(--color-border-subtle); border-radius: var(--radius-lg); padding: 20px 22px;
+}
+.mp-tldr__head { display: flex; align-items: center; gap: 8px; font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--brand-400); margin-bottom: 12px; }
+.mp-tldr__head .mp-spacer { flex: 1; }
+.mp-tldr__stamp { font-size: 10.5px; color: var(--color-text-faint); letter-spacing: 0; text-transform: none; font-weight: 400; }
+.mp-tldr__text { font-size: 15px; line-height: 1.7; color: var(--color-text-primary); margin: 0; }
+.mp-tldr__foot { display: flex; align-items: center; gap: 8px; margin-top: 14px; }
+.mp-chipbtn { display: inline-flex; align-items: center; gap: 6px; height: 26px; padding: 0 10px; border-radius: var(--radius-sm); border: 1px solid var(--color-border-subtle); color: var(--color-text-muted); font-size: 11.5px; font-weight: 500; transition: color 120ms, border-color 120ms; }
+.mp-chipbtn:hover { color: var(--color-text-primary); border-color: var(--color-border-strong); }
+
+/* ============ KEY MOMENTS ============ */
+.mp-moments { display: flex; flex-direction: column; gap: 8px; }
+.mp-moment { display: grid; grid-template-columns: 52px 1fr 16px; align-items: start; gap: 14px; padding: 13px 15px; text-align: left; width: 100%; background: var(--color-bg-secondary); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); transition: border-color 120ms, background 120ms; }
+.mp-moment:hover { border-color: var(--color-border-strong); background: var(--color-bg-elevated); }
+.mp-moment__time { font-family: var(--font-mono); font-size: 11.5px; color: var(--brand-400); font-variant-numeric: tabular-nums; padding-top: 2px; }
+.mp-moment__title { font-size: 14px; font-weight: 500; color: var(--color-text-primary); margin-bottom: 5px; }
+.mp-moment__quote { font-size: 13px; color: var(--color-text-secondary); line-height: 1.55; border-left: 2px solid var(--color-border-primary); padding-left: 11px; margin: 0; }
+.mp-moment__quote b { color: var(--color-text-primary); font-weight: 500; }
+.mp-moment__jump { color: var(--color-text-faint); align-self: center; }
+.mp-moment:hover .mp-moment__jump { color: var(--color-text-secondary); }
+
+/* ============ DECISIONS / QUESTIONS ============ */
+.mp-twocard { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.mp-card { background: var(--color-bg-secondary); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); padding: 16px 18px; }
+.mp-card__label { display: inline-flex; align-items: center; gap: 7px; font-size: 10.5px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; margin-bottom: 12px; }
+.mp-card__label--decision { color: var(--accent-crm); }
+.mp-card__label--question { color: var(--accent-okr); }
+.mp-card__list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
+.mp-card__list li { display: grid; grid-template-columns: 15px 1fr; gap: 9px; font-size: 13.5px; color: var(--color-text-primary); line-height: 1.5; }
+.mp-card__list li svg { margin-top: 3px; }
+.mp-card__list--decision li svg { color: var(--accent-crm); }
+.mp-card__list--question li svg { color: var(--accent-okr); }
+
+/* ============ ACTIONS ============ */
+.mp-actbar {
+  display: flex; align-items: center; gap: 12px; padding: 14px 16px; margin-bottom: 12px;
+  background: linear-gradient(180deg, var(--mp-brand-05), transparent 80%), var(--color-bg-elevated);
+  border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md);
+}
+.mp-actbar__txt { flex: 1; font-size: 13px; color: var(--color-text-secondary); line-height: 1.5; }
+.mp-actbar__txt b { color: var(--color-text-primary); font-weight: 600; }
+.mp-actions { display: flex; flex-direction: column; gap: 8px; }
+.mp-action { display: grid; grid-template-columns: 18px 1fr auto; gap: 14px; align-items: start; padding: 14px 16px; background: var(--color-bg-secondary); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); transition: border-color 120ms, background 120ms; }
+.mp-action:hover { border-color: var(--color-border-strong); background: var(--color-bg-elevated); }
+.mp-action__check { width: 17px; height: 17px; border: 1.5px solid var(--color-border-strong); border-radius: 5px; margin-top: 1px; display: grid; place-items: center; color: transparent; transition: background 120ms, border-color 120ms, color 120ms; }
+.mp-action:hover .mp-action__check { border-color: var(--brand-400); }
+.mp-action.done .mp-action__check { background: var(--brand-500); border-color: var(--brand-500); color: var(--mp-on-accent); }
+.mp-action.done .mp-action__title { text-decoration: line-through; color: var(--color-text-muted); }
+.mp-action__body { min-width: 0; }
+.mp-action__title { font-size: 14px; font-weight: 500; color: var(--color-text-primary); line-height: 1.4; margin-bottom: 7px; }
+.mp-action__quote { font-size: 12.5px; color: var(--color-text-secondary); line-height: 1.5; border-left: 2px solid var(--color-border-primary); padding-left: 10px; margin: 0 0 9px; }
+.mp-action__meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 11.5px; }
+.mp-pill { display: inline-flex; align-items: center; gap: 5px; height: 22px; padding: 0 8px; border-radius: var(--radius-sm); background: var(--color-surface-muted); border: 1px solid var(--color-border-subtle); color: var(--color-text-secondary); font-weight: 500; }
+.mp-pill--draft { background: var(--mp-amber-08); border-color: var(--mp-amber-22); color: var(--accent-okr); }
+.mp-pill--quick { background: var(--mp-brand-08); border-color: var(--mp-brand-22); color: var(--brand-400); }
+.mp-pill--project { color: var(--color-text-primary); }
+.mp-pill__glyph { width: 13px; height: 13px; border-radius: 3px; background: var(--accent-ritual); color: var(--mp-on-accent); font-size: 8px; font-weight: 700; display: grid; place-items: center; }
+.mp-action__owner { display: inline-flex; align-items: center; gap: 7px; height: 27px; padding: 0 10px 0 7px; background: var(--color-surface-muted); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-sm); font-size: 11.5px; color: var(--color-text-secondary); font-weight: 500; }
+.mp-action__owner .mp-av { width: 17px; height: 17px; font-size: 8px; }
+
+/* ============ TRANSCRIPT ============ */
+.mp-tr__toolbar { display: flex; align-items: center; gap: 10px; margin-bottom: 18px; }
+.mp-tr__search { flex: 1; display: flex; align-items: center; gap: 9px; height: 34px; padding: 0 12px; background: var(--color-bg-secondary); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); color: var(--color-text-muted); }
+.mp-tr__search input { flex: 1; background: transparent; border: 0; outline: 0; color: var(--color-text-primary); font: inherit; font-size: 13px; min-width: 0; }
+.mp-tr__search input::placeholder { color: var(--color-text-muted); }
+.mp-tr__search kbd { font-family: var(--font-mono); font-size: 10.5px; color: var(--color-text-faint); }
+.mp-tr__filter { display: inline-flex; align-items: center; gap: 6px; height: 34px; padding: 0 11px; background: var(--color-bg-secondary); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); font-size: 12.5px; color: var(--color-text-secondary); transition: color 120ms, border-color 120ms, background 120ms; }
+.mp-tr__filter:hover { color: var(--color-text-primary); border-color: var(--color-border-strong); }
+.mp-tr__filter.on { background: var(--mp-brand-10); border-color: var(--mp-brand-25); color: var(--brand-400); }
+
+.mp-chapter { margin: 22px 0 12px; display: flex; align-items: center; gap: 11px; }
+.mp-chapter:first-child { margin-top: 0; }
+.mp-chapter__label { font-size: 10.5px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; white-space: nowrap; color: var(--brand-400); padding: 3px 8px; background: var(--mp-brand-10); border: 1px solid var(--mp-brand-22); border-radius: var(--radius-sm); }
+.mp-chapter__line { flex: 1; height: 1px; background: var(--color-border-subtle); }
+.mp-chapter__time { font-family: var(--font-mono); font-size: 11px; color: var(--color-text-muted); }
+
+.mp-turn { display: grid; grid-template-columns: 58px 1fr; gap: 16px; padding: 11px 0; align-items: start; }
+.mp-turn + .mp-turn { border-top: 1px solid var(--color-border-subtle); }
+.mp-turn__gutter { display: flex; flex-direction: column; align-items: flex-start; gap: 6px; padding-top: 1px; }
+.mp-turn__time { font-family: var(--font-mono); font-size: 11px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
+.mp-turn__avatar { width: 24px; height: 24px; font-size: 9px; }
+.mp-turn__name { font-size: 12.5px; font-weight: 600; margin-bottom: 3px; }
+.mp-turn__name--me { color: var(--brand-400); }
+.mp-turn__name--them { color: var(--accent-meetings); }
+.mp-turn__name--alt { color: var(--accent-crm); }
+.mp-turn__text { font-size: 14px; line-height: 1.65; color: var(--color-text-primary); margin: 0; }
+.mp-turn__text mark { background: var(--mp-amber-18); color: var(--color-text-primary); border-radius: 2px; padding: 0 3px; }
+
+/* ============ SCREENSHOTS ============ */
+.mp-shots-head { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
+.mp-shots { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
+.mp-shot { border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); overflow: hidden; background: var(--color-bg-secondary); transition: border-color 120ms; }
+.mp-shot:hover { border-color: var(--color-border-strong); }
+.mp-shot__frame { aspect-ratio: 16 / 10; position: relative; display: grid; place-items: center; background: var(--color-surface-muted); }
+.mp-shot__img { width: 100%; height: 100%; object-fit: cover; display: block; cursor: pointer; }
+.mp-shot__time { position: absolute; top: 8px; left: 8px; font-family: var(--font-mono); font-size: 10px; color: var(--mp-on-accent); background: var(--mp-shot-overlay); border: 1px solid var(--color-border-subtle); padding: 2px 6px; border-radius: 3px; font-variant-numeric: tabular-nums; }
+.mp-shot__flag { position: absolute; top: 8px; right: 8px; font-size: 9.5px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--accent-okr); background: var(--mp-amber-12); border: 1px solid var(--mp-amber-25); padding: 2px 6px; border-radius: 3px; }
+.mp-shot__cap { padding: 10px 12px; font-size: 12.5px; color: var(--color-text-secondary); line-height: 1.4; }
+
+/* ============ EMPTY STATES ============ */
+.mp-empty { display: flex; flex-direction: column; align-items: flex-start; gap: 10px; padding: 24px 0; color: var(--color-text-muted); font-size: 13.5px; }
+
+/* ============ RIGHT RAIL ============ */
+.mp-rail__section { padding: 18px 22px; border-bottom: 1px solid var(--color-border-subtle); }
+.mp-rail__section:last-child { border-bottom: 0; }
+.mp-rail__label { font-size: 10.5px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--color-text-muted); margin-bottom: 14px; display: flex; align-items: center; justify-content: space-between; }
+.mp-people { display: flex; flex-direction: column; gap: 12px; }
+.mp-person { display: grid; grid-template-columns: 30px 1fr auto; align-items: center; gap: 11px; }
+.mp-person .mp-av { width: 30px; height: 30px; font-size: 10px; }
+.mp-person__name { font-size: 13px; font-weight: 500; color: var(--color-text-primary); line-height: 1.2; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mp-person__role { font-size: 11.5px; color: var(--color-text-muted); line-height: 1.2; margin-top: 1px; }
+.mp-person__talk { font-family: var(--font-mono); font-size: 10.5px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; padding: 3px 7px; border-radius: 3px; background: var(--color-surface-muted); }
+.mp-linkrow { display: grid; grid-template-columns: 22px 1fr 14px; gap: 11px; align-items: center; padding: 9px 10px; margin: 0 -10px; border-radius: var(--radius-md); transition: background 120ms; }
+.mp-linkrow:hover { background: var(--color-bg-hover); }
+.mp-linkrow__glyph { width: 22px; height: 22px; border-radius: 5px; display: grid; place-items: center; font-size: 10px; font-weight: 700; color: var(--mp-on-accent); }
+.mp-linkrow__glyph--ritual { background: var(--mp-glyph-ritual); }
+.mp-linkrow__glyph--okr { background: var(--mp-glyph-okr); }
+.mp-linkrow__title { font-size: 12.5px; color: var(--color-text-primary); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mp-linkrow__sub { font-size: 11px; color: var(--color-text-muted); margin-top: 1px; }
+.mp-linkrow__arrow { color: var(--color-text-faint); }
+.mp-linkrow:hover .mp-linkrow__arrow { color: var(--color-text-secondary); }
+.mp-source { display: flex; align-items: center; gap: 11px; padding: 11px 12px; background: var(--color-bg-secondary); border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); }
+.mp-source__icon { width: 30px; height: 30px; border-radius: 7px; display: grid; place-items: center; background: var(--mp-brand-10); color: var(--brand-400); flex-shrink: 0; }
+.mp-source__title { font-size: 12.5px; font-weight: 500; color: var(--color-text-primary); }
+.mp-source__sub { font-size: 11px; color: var(--color-text-muted); margin-top: 1px; }
+.mp-quick { display: flex; flex-direction: column; gap: 6px; }
+.mp-quick__btn { display: flex; align-items: center; gap: 11px; width: 100%; padding: 9px 11px; border: 1px solid var(--color-border-subtle); border-radius: var(--radius-md); color: var(--color-text-secondary); font-size: 12.5px; text-align: left; transition: background 120ms, color 120ms, border-color 120ms; }
+.mp-quick__btn:hover { color: var(--color-text-primary); border-color: var(--color-border-strong); background: var(--color-bg-hover); }
+.mp-quick__btn svg { color: var(--color-text-muted); }
+.mp-quick__btn:hover svg { color: var(--color-text-secondary); }
+
+/* details rows in rail (editable plumbing lives here) */
+.mp-railkv { display: flex; flex-direction: column; gap: 12px; }
+.mp-railkv__row { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; font-size: 12.5px; }
+.mp-railkv__k { color: var(--color-text-muted); flex-shrink: 0; }
+.mp-railkv__v { color: var(--color-text-primary); font-weight: 500; text-align: right; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mp-railkv__v--mono { font-family: var(--font-mono); font-size: 11px; color: var(--color-text-secondary); }
+.mp-rail__field { margin-top: 4px; }
+
+/* loading / not-found */
+.mp-centered { display: grid; place-items: center; height: 60vh; color: var(--color-text-muted); }

--- a/src/lib/meeting-view-model.ts
+++ b/src/lib/meeting-view-model.ts
@@ -1,0 +1,152 @@
+import type { RouterOutputs } from "~/trpc/react";
+import { getInitial } from "~/utils/avatarColors";
+import { parseFirefliesSummary, isEmptyFirefliesSummary } from "~/lib/fireflies-summary";
+import type { FirefliesSummary } from "~/server/services/FirefliesService";
+
+/**
+ * The meeting-detail redesign expects a richer record than we store today
+ * (key moments, decisions, open questions, talk-time, linked goal). This
+ * module maps a real `TranscriptionSession` into the view the UI consumes,
+ * deriving what we can from Fireflies summary/analytics and leaving the rest
+ * empty so the corresponding sections self-hide (graceful degradation).
+ */
+
+export type MeetingSession = NonNullable<RouterOutputs["transcription"]["getById"]>;
+
+/** Avatar/name identity tones. Blue (`me`) for the host/you, others rotate
+ *  through the identity palette — never the blue page chrome. */
+export type ParticipantFlavor = "me" | "them" | "alt";
+
+export interface MeetingParticipant {
+  id: string;
+  name: string;
+  initial: string;
+  /** e.g. "Host", "Product" — best-effort; empty when unknown. */
+  role: string;
+  /** "41%" — only when derivable from analytics, else null. */
+  talk: string | null;
+  flavor: ParticipantFlavor;
+  isHost: boolean;
+}
+
+export interface MeetingChapter {
+  title: string;
+  startTime: number;
+  endTime: number;
+}
+
+export interface MeetingViewModel {
+  /** Fireflies meeting_type, capitalised; null → no type pill shown. */
+  meetingType: string | null;
+  /** Parsed Fireflies summary object when present (rich renderer), else null. */
+  firefliesSummary: FirefliesSummary | null;
+  /** Plain summary text fallback (markdown/plain) when not Fireflies JSON. */
+  plainSummary: string | null;
+  durationLabel: string | null;
+  participants: MeetingParticipant[];
+  chapters: MeetingChapter[];
+  /** Derived AI sections we have no source for yet → empty until extraction
+   *  lands. Kept on the model so the UI shape is stable. */
+  keyMoments: never[];
+  decisions: never[];
+  questions: never[];
+  hasVideo: boolean;
+  captureCount: number;
+}
+
+function capitalise(value: string): string {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function formatDuration(seconds: number | null | undefined): string | null {
+  if (!seconds || seconds <= 0) return null;
+  const mins = Math.round(seconds / 60);
+  if (mins < 60) return `${mins} min`;
+  const hours = Math.floor(mins / 60);
+  const rem = mins % 60;
+  return rem === 0 ? `${hours} hr` : `${hours} hr ${rem} min`;
+}
+
+/** Tolerant extraction of per-speaker talk-time from Fireflies analyticsJson.
+ *  Fireflies stores `{ speakers: [{ name, duration }] }`; we sum durations to a
+ *  percentage. Returns a name→"NN%" map, empty when the shape isn't present. */
+function extractTalkTime(analyticsJson: unknown): Map<string, string> {
+  const result = new Map<string, string>();
+  if (!analyticsJson || typeof analyticsJson !== "object") return result;
+  const speakers = (analyticsJson as { speakers?: unknown }).speakers;
+  if (!Array.isArray(speakers)) return result;
+
+  const rows = speakers
+    .map((s) => {
+      if (!s || typeof s !== "object") return null;
+      const obj = s as Record<string, unknown>;
+      const name = typeof obj.name === "string" ? obj.name : null;
+      const durationRaw =
+        typeof obj.duration === "number"
+          ? obj.duration
+          : typeof obj.duration_pct === "number"
+            ? obj.duration_pct
+            : null;
+      if (!name || durationRaw === null) return null;
+      return { name, duration: durationRaw };
+    })
+    .filter((r): r is { name: string; duration: number } => r !== null);
+
+  const total = rows.reduce((sum, r) => sum + r.duration, 0);
+  if (total <= 0) return result;
+  for (const row of rows) {
+    result.set(row.name, `${Math.round((row.duration / total) * 100)}%`);
+  }
+  return result;
+}
+
+export function buildMeetingViewModel(session: MeetingSession): MeetingViewModel {
+  const firefliesSummary = parseFirefliesSummary(session.summary);
+  const hasRichSummary =
+    firefliesSummary !== null && !isEmptyFirefliesSummary(firefliesSummary);
+
+  const meetingType = firefliesSummary?.meeting_type
+    ? capitalise(firefliesSummary.meeting_type)
+    : null;
+
+  const talkTime = extractTalkTime(session.analyticsJson);
+
+  const participants: MeetingParticipant[] = session.participants.map((p, index) => {
+    const name = p.name ?? p.email ?? "Unknown";
+    const isHost = Boolean(p.isHost);
+    const flavor: ParticipantFlavor = isHost
+      ? "me"
+      : index % 2 === 0
+        ? "them"
+        : "alt";
+    const speakerKey = p.speakerLabel ?? p.name ?? "";
+    return {
+      id: p.id,
+      name,
+      initial: getInitial(p.name, p.email),
+      role: isHost ? "Host" : "",
+      talk: talkTime.get(speakerKey) ?? talkTime.get(name) ?? null,
+      flavor,
+      isHost,
+    };
+  });
+
+  const chapters: MeetingChapter[] = (firefliesSummary?.transcript_chapters ?? []).map(
+    (c) => ({ title: c.title, startTime: c.start_time, endTime: c.end_time }),
+  );
+
+  return {
+    meetingType,
+    firefliesSummary: hasRichSummary ? firefliesSummary : null,
+    plainSummary: hasRichSummary ? null : (session.summary ?? null),
+    durationLabel: formatDuration(session.durationSeconds),
+    participants,
+    chapters,
+    keyMoments: [],
+    decisions: [],
+    questions: [],
+    hasVideo: Boolean(session.videoUrl),
+    captureCount: session.screenshots.length,
+  };
+}

--- a/src/lib/meeting-view-model.ts
+++ b/src/lib/meeting-view-model.ts
@@ -59,6 +59,11 @@ function capitalise(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
+/**
+ * Format a duration in seconds into a short human-readable label.
+ * @param seconds Duration in seconds; null/undefined/≤0 yields null.
+ * @returns e.g. "44 min", "1 hr", "1 hr 30 min", or null when unavailable.
+ */
 export function formatDuration(seconds: number | null | undefined): string | null {
   if (!seconds || seconds <= 0) return null;
   const mins = Math.round(seconds / 60);
@@ -101,6 +106,15 @@ function extractTalkTime(analyticsJson: unknown): Map<string, string> {
   return result;
 }
 
+/**
+ * Map a `TranscriptionSession` (+ parsed Fireflies summary/analytics) into the
+ * view model the meeting-detail UI consumes. Derives meeting type, summary
+ * (rich Fireflies object or plain text), duration, participants with talk-time,
+ * and transcript chapters. Sections we have no source for yet (key moments,
+ * decisions, open questions) are returned empty so the UI self-hides them.
+ * @param session The transcription session record from `transcription.getById`.
+ * @returns The derived {@link MeetingViewModel}.
+ */
 export function buildMeetingViewModel(session: MeetingSession): MeetingViewModel {
   const firefliesSummary = parseFirefliesSummary(session.summary);
   const hasRichSummary =

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -912,6 +912,47 @@
 }
 
 /* ==========================================================================
+   Meeting detail surface (/recording/[id], redesigned "workspace" layout) —
+   scoped design tokens. Consumed by
+   src/app/_components/meeting/meeting-detail.css. Mirrors today-surface: all
+   raw color values live here (this file is allow-listed by the pre-commit
+   hook); the feature CSS uses only var(). Tints reference the global rgb
+   triplets so they track the active theme; identity gradients are fixed
+   (participant identity, never page chrome).
+   ========================================================================== */
+.meeting-detail {
+  /* Blue chrome tints (type pill, AI card glow, active tab, key-moment chips) */
+  --mp-brand-05: rgb(var(--brand-400-rgb) / 0.05);
+  --mp-brand-08: rgb(var(--brand-400-rgb) / 0.08);
+  --mp-brand-10: rgb(var(--brand-400-rgb) / 0.10);
+  --mp-brand-14: rgb(var(--brand-400-rgb) / 0.14);
+  --mp-brand-22: rgb(var(--brand-400-rgb) / 0.22);
+  --mp-brand-25: rgb(var(--brand-400-rgb) / 0.25);
+
+  /* Amber accents (draft pills, transcript highlights, flag chips) */
+  --mp-amber-08: rgb(var(--accent-okr-rgb) / 0.08);
+  --mp-amber-12: rgb(var(--accent-okr-rgb) / 0.12);
+  --mp-amber-18: rgb(var(--accent-okr-rgb) / 0.18);
+  --mp-amber-22: rgb(var(--accent-okr-rgb) / 0.22);
+  --mp-amber-25: rgb(var(--accent-okr-rgb) / 0.25);
+
+  /* Participant identity gradients (avatars) — reserved for identity only */
+  --mp-identity-me: linear-gradient(135deg, var(--brand-400), var(--brand-500));
+  --mp-identity-them: linear-gradient(135deg, #A78BFA, #7C5BFF);
+  --mp-identity-alt: linear-gradient(135deg, #4ADE8C, #18A86B);
+
+  /* Linked-row glyph gradients */
+  --mp-glyph-ritual: linear-gradient(135deg, #6B8CFF, #3D5BE0);
+  --mp-glyph-okr: linear-gradient(135deg, #F5B94A, #D89019);
+
+  /* Screenshot timestamp/flag overlay scrim */
+  --mp-shot-overlay: rgb(5 8 13 / 0.7);
+
+  /* Foreground on filled accent surfaces (avatars, primary buttons, glyphs) */
+  --mp-on-accent: #ffffff;
+}
+
+/* ==========================================================================
    Today desktop surface (/today, redesigned shell) — scoped design tokens.
    Consumed by src/app/_components/today-redesign/today-desktop.css.
    Mirrors auth-surface / portfolio-review-surface: all hex lives here, the


### PR DESCRIPTION
## What

- Replaces the plumbing-first `/recording/[id]` page with a two-column "workspace" layout: a scrolling main column (AI summary, actions) plus a fixed **312px context rail** (participants, linked project, source, demoted/editable details, quick actions).
- Three tabs: **Summary** / **Transcript** / **Screenshots** (underline-active).
- **Transcript**: diarized turns from `sentencesJson`/Fireflies with search, "Only me" filter, and chapter markers; degrades to plain text when there's no speaker data.
- **Summary**: AI-summary card (reuses `FirefliesSummaryDisplay`/`SmartContentRenderer`) with summary editing preserved; Actions wired to the existing ADR-0007 draft-actions review flow.
- New `meeting-view-model` maps `TranscriptionSession` + Fireflies summary/analytics into the UI shape, with **graceful degradation** — sections with no backing data (key moments, decisions, open questions, talk-time, linked goal) self-hide until AI extraction lands.
- Editing preserved but relocated: meeting-date + workspace now live in the rail's Details block.
- Styling recreated on the app's existing semantic tokens (no hardcoded hex); new tints scoped under `.meeting-detail` in `globals.css`, feature CSS uses `var()` only.

## Why

Lead with the AI summary and actions instead of database plumbing; keep transcript and screenshots one click away. Implements the Meeting Detail "Direction B" design handoff.

## Notes / follow-ups (out of scope)
- Empty/"still processing" states, <1100px responsive (rail hides under 1100px), deeper light-mode tuning.
- Key moments / decisions / open questions and talk-time need AI extraction + a goal relation before they render.
- Title rename omitted (no `title` field on `updateDetails`; no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)