### PR TITLE
feat: Problem spine — model, CRUD, Problems tab + table

### DIFF
--- a/prisma/migrations/20260605120000_add_problem_model/migration.sql
+++ b/prisma/migrations/20260605120000_add_problem_model/migration.sql
@@ -1,0 +1,42 @@
+-- Pipeline Triage: Problem (Stage 1–2). See docs/adr/0008-pipeline-triage-model.md.
+-- A validated issue worth solving, scoped to a Product. `impact`/`confidence`
+-- are the two prioritisation axes; ease is deliberately omitted (lives on the
+-- Approach later). `parkedAt`/`parkReason` ship now to avoid a second migration.
+
+-- CreateEnum
+CREATE TYPE "ProblemStage" AS ENUM ('IDEA', 'QUALIFIED', 'PRIORITISED');
+
+-- CreateTable
+CREATE TABLE "Problem" (
+    "id" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "evidence" TEXT,
+    "category" TEXT,
+    "impact" INTEGER,
+    "confidence" INTEGER,
+    "stage" "ProblemStage" NOT NULL DEFAULT 'IDEA',
+    "parkedAt" TIMESTAMP(3),
+    "parkReason" TEXT,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Problem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Problem_productId_idx" ON "Problem"("productId");
+
+-- CreateIndex
+CREATE INDEX "Problem_stage_idx" ON "Problem"("stage");
+
+-- CreateIndex
+CREATE INDEX "Problem_createdById_idx" ON "Problem"("createdById");
+
+-- AddForeignKey
+ALTER TABLE "Problem" ADD CONSTRAINT "Problem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Problem" ADD CONSTRAINT "Problem_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -219,6 +219,7 @@ model User {
   ticketComments        TicketComment[]    @relation("TicketCommentAuthor")
   ticketDepsCreated     TicketDependency[] @relation("TicketDependencyCreatedBy")
   insightsCreated       Insight[]          @relation("InsightCreatedBy")
+  problemsCreated       Problem[]          @relation("ProblemCreatedBy")
 
   // One2b agent schema additions
   phone            Bytes?  @map("phone_encrypted") @db.ByteA
@@ -343,9 +344,9 @@ model Workspace {
   pendingDriveUploads              PendingDriveUpload[]
 
   // Workspace home activity feed
-  activityEvents    WorkspaceActivityEvent[]
+  activityEvents   WorkspaceActivityEvent[]
   // Cached AI-generated Week-in-Review narratives (one row per ISO week).
-  weeklyNarratives  WorkspaceWeeklyNarrative[]
+  weeklyNarratives WorkspaceWeeklyNarrative[]
 
   @@index([slug])
   @@index([ownerId])
@@ -2527,31 +2528,31 @@ model PluginConfig {
 // ============================================
 
 model KeyResult {
-  id           String    @id @default(cuid())
-  title        String
-  description  String?
-  targetValue  Float
-  currentValue Float     @default(0)
-  startValue   Float     @default(0)
-  unit         String    @default("percent") // "percent", "count", "currency", "hours", "custom"
-  unitLabel    String? // Custom label like "$" or "users"
-  period       String // "Q1-2025", "H1-2025", "Annual-2025"
-  periodStart  DateTime?
-  periodEnd    DateTime?
-  status       String    @default("on-track") // "on-track", "at-risk", "off-track", "achieved"
+  id                 String    @id @default(cuid())
+  title              String
+  description        String?
+  targetValue        Float
+  currentValue       Float     @default(0)
+  startValue         Float     @default(0)
+  unit               String    @default("percent") // "percent", "count", "currency", "hours", "custom"
+  unitLabel          String? // Custom label like "$" or "users"
+  period             String // "Q1-2025", "H1-2025", "Annual-2025"
+  periodStart        DateTime?
+  periodEnd          DateTime?
+  status             String    @default("on-track") // "on-track", "at-risk", "off-track", "achieved"
   // Manual status override stored BESIDE the auto `status` (ADR-0004).
   // Effective status = statusOverride ?? status. null = no override (use auto).
   // The auto `status` column is never written by the manual override path.
   statusOverride     String? // "on-track" | "at-risk" | "off-track" | "achieved"
   statusOverrideAt   DateTime? // when the override was last set
   statusOverrideById String? // user id who set it (audit; no FK)
-  confidence   Int? // 0-100 confidence score
-  goalId       Int
-  userId       String
-  driUserId    String?
-  workspaceId  String?
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
+  confidence         Int? // 0-100 confidence score
+  goalId             Int
+  userId             String
+  driUserId          String?
+  workspaceId        String?
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
 
   goal      Goal               @relation(fields: [goalId], references: [id], onDelete: Cascade)
   user      User               @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -3510,6 +3511,7 @@ model Product {
   retrospectives  Retrospective[]
   ticketTemplates TicketTemplate[]
   projects        Project[]
+  problems        Problem[]
 
   @@unique([workspaceId, slug])
   @@index([workspaceId])
@@ -3900,6 +3902,48 @@ model InsightTag {
 
   @@unique([insightId, tagId])
   @@index([tagId])
+}
+
+// ============================================
+// Pipeline Triage — Problem (see docs/adr/0008-pipeline-triage-model.md)
+// ============================================
+
+/// Lifecycle of a Problem as it moves through the triage pipeline.
+/// Independent of parked-ness (a Problem can be parked at any stage).
+enum ProblemStage {
+  IDEA
+  QUALIFIED
+  PRIORITISED
+}
+
+/// A validated issue worth solving — "who's hurt and how", scoped to a Product.
+/// Distinct from an Insight (raw research evidence); a Problem is the committed
+/// issue that enters the strategy pipeline. `impact`/`confidence` are the two
+/// prioritisation axes — ease is deliberately NOT scored here (it lives on the
+/// Approach later). `parkedAt`/`parkReason` are populated by a later slice but
+/// the columns exist now to avoid a second migration.
+model Problem {
+  id          String       @id @default(cuid())
+  productId   String
+  title       String
+  description String?
+  evidence    String?
+  category    String?
+  impact      Int?
+  confidence  Int?
+  stage       ProblemStage @default(IDEA)
+  parkedAt    DateTime?
+  parkReason  String?
+  createdById String
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+
+  product   Product @relation(fields: [productId], references: [id], onDelete: Cascade)
+  createdBy User    @relation("ProblemCreatedBy", fields: [createdById], references: [id])
+
+  @@index([productId])
+  @@index([stage])
+  @@index([createdById])
 }
 
 // ============================================

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
@@ -10,6 +10,7 @@ import {
   IconSettings,
   IconPlus,
   IconAffiliate,
+  IconTargetArrow,
 } from "@tabler/icons-react";
 import {
   ActionIcon,
@@ -25,6 +26,7 @@ import { api } from "~/trpc/react";
 
 const tabs = [
   { value: "overview", href: "", label: "Overview", icon: IconHome },
+  { value: "problems", href: "/problems", label: "Problems", icon: IconTargetArrow },
   { value: "backlog", href: "/tickets", label: "Backlog", icon: IconLayoutList },
   { value: "features", href: "/features", label: "Features", icon: IconBulb },
   { value: "graph", href: "/graph", label: "Graph", icon: IconAffiliate },

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/problems/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/problems/page.tsx
@@ -1,0 +1,634 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+  ActionIcon,
+  Avatar,
+  Badge,
+  Button,
+  Group,
+  Menu,
+  Modal,
+  Select,
+  Skeleton,
+  Stack,
+  Table,
+  Text,
+  Textarea,
+  TextInput,
+} from "@mantine/core";
+import {
+  IconDots,
+  IconPlus,
+  IconTargetArrow,
+  IconTrash,
+} from "@tabler/icons-react";
+import { modals } from "@mantine/modals";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import { api } from "~/trpc/react";
+import { EmptyState } from "~/app/_components/EmptyState";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+type ProblemStage = "IDEA" | "QUALIFIED" | "PRIORITISED";
+
+const STAGE_OPTIONS: ReadonlyArray<{ value: ProblemStage; label: string }> = [
+  { value: "IDEA", label: "Idea" },
+  { value: "QUALIFIED", label: "Qualified" },
+  { value: "PRIORITISED", label: "Prioritised" },
+];
+
+const STAGE_COLORS: Record<ProblemStage, string> = {
+  IDEA: "gray",
+  QUALIFIED: "blue",
+  PRIORITISED: "green",
+};
+
+// impact/confidence are scored 1–5 (the two prioritisation axes).
+const SCORE_OPTIONS = ["1", "2", "3", "4", "5"].map((v) => ({
+  value: v,
+  label: v,
+}));
+
+// ---------------------------------------------------------------------------
+// Inline-edit cells
+// ---------------------------------------------------------------------------
+
+/** Single-line text cell that becomes an input on click and commits on blur/Enter. */
+function EditableText({
+  value,
+  placeholder,
+  required,
+  onCommit,
+}: {
+  value: string | null;
+  placeholder: string;
+  required?: boolean;
+  onCommit: (next: string | null) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value ?? "");
+
+  const commit = () => {
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (required && trimmed.length === 0) return; // revert — title can't be empty
+    const next = trimmed.length === 0 ? null : trimmed;
+    if (next !== (value ?? null)) onCommit(next);
+  };
+
+  if (editing) {
+    return (
+      <TextInput
+        autoFocus
+        value={draft}
+        onChange={(e) => setDraft(e.currentTarget.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          if (e.key === "Escape") {
+            setDraft(value ?? "");
+            setEditing(false);
+          }
+        }}
+        size="xs"
+        styles={{ input: { height: 28, minHeight: 28, fontSize: "0.8rem" } }}
+      />
+    );
+  }
+
+  return (
+    <Text
+      size="sm"
+      className={`cursor-text ${value ? "text-text-primary" : "text-text-muted"}`}
+      onClick={() => {
+        setDraft(value ?? "");
+        setEditing(true);
+      }}
+    >
+      {value ?? placeholder}
+    </Text>
+  );
+}
+
+/** Multi-line text cell (description / evidence) editable in a small textarea. */
+function EditableMultiline({
+  value,
+  placeholder,
+  onCommit,
+}: {
+  value: string | null;
+  placeholder: string;
+  onCommit: (next: string | null) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value ?? "");
+
+  const commit = () => {
+    setEditing(false);
+    const trimmed = draft.trim();
+    const next = trimmed.length === 0 ? null : trimmed;
+    if (next !== (value ?? null)) onCommit(next);
+  };
+
+  if (editing) {
+    return (
+      <Textarea
+        autoFocus
+        value={draft}
+        onChange={(e) => setDraft(e.currentTarget.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            setDraft(value ?? "");
+            setEditing(false);
+          }
+        }}
+        autosize
+        minRows={1}
+        maxRows={5}
+        size="xs"
+        styles={{ input: { fontSize: "0.8rem" } }}
+      />
+    );
+  }
+
+  return (
+    <Text
+      size="xs"
+      lineClamp={2}
+      className={`cursor-text ${value ? "text-text-secondary" : "text-text-muted"}`}
+      onClick={() => {
+        setDraft(value ?? "");
+        setEditing(true);
+      }}
+    >
+      {value ?? placeholder}
+    </Text>
+  );
+}
+
+/** Score cell (1–5) backed by a clearable select. */
+function ScoreCell({
+  value,
+  onCommit,
+}: {
+  value: number | null;
+  onCommit: (next: number | null) => void;
+}) {
+  return (
+    <Select
+      value={value != null ? String(value) : null}
+      onChange={(v) => onCommit(v != null ? Number(v) : null)}
+      data={SCORE_OPTIONS}
+      placeholder="—"
+      clearable
+      size="xs"
+      comboboxProps={{ withinPortal: true }}
+      styles={{
+        root: { width: 64 },
+        input: { height: 28, minHeight: 28, fontSize: "0.8rem" },
+      }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Create modal
+// ---------------------------------------------------------------------------
+
+function CreateProblemModal({
+  opened,
+  onClose,
+  productId,
+}: {
+  opened: boolean;
+  onClose: () => void;
+  productId: string;
+}) {
+  const utils = api.useUtils();
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [evidence, setEvidence] = useState("");
+  const [category, setCategory] = useState("");
+  const [impact, setImpact] = useState<string | null>(null);
+  const [confidence, setConfidence] = useState<string | null>(null);
+  const [stage, setStage] = useState<ProblemStage>("IDEA");
+
+  const reset = () => {
+    setTitle("");
+    setDescription("");
+    setEvidence("");
+    setCategory("");
+    setImpact(null);
+    setConfidence(null);
+    setStage("IDEA");
+  };
+
+  const create = api.product.problem.create.useMutation({
+    onSuccess: async () => {
+      await utils.product.problem.list.invalidate({ productId });
+      reset();
+      onClose();
+    },
+  });
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="New problem" size="lg">
+      <Stack gap="md">
+        <TextInput
+          label="Problem statement"
+          placeholder="Who's hurt and how?"
+          value={title}
+          onChange={(e) => setTitle(e.currentTarget.value)}
+          size="sm"
+          required
+        />
+        <Textarea
+          label="Description"
+          placeholder="More detail on the problem..."
+          value={description}
+          onChange={(e) => setDescription(e.currentTarget.value)}
+          autosize
+          minRows={2}
+          maxRows={6}
+          size="sm"
+        />
+        <Textarea
+          label="Evidence"
+          placeholder="A count, a quote, an incident, a screenshot link..."
+          value={evidence}
+          onChange={(e) => setEvidence(e.currentTarget.value)}
+          autosize
+          minRows={2}
+          maxRows={6}
+          size="sm"
+        />
+        <TextInput
+          label="Category"
+          placeholder="e.g. Data Scarcity, Pipeline problems"
+          value={category}
+          onChange={(e) => setCategory(e.currentTarget.value)}
+          size="sm"
+        />
+        <Group grow>
+          <Select
+            label="Impact"
+            value={impact}
+            onChange={setImpact}
+            data={SCORE_OPTIONS}
+            placeholder="1–5"
+            clearable
+            size="sm"
+            comboboxProps={{ withinPortal: true }}
+          />
+          <Select
+            label="Confidence"
+            value={confidence}
+            onChange={setConfidence}
+            data={SCORE_OPTIONS}
+            placeholder="1–5"
+            clearable
+            size="sm"
+            comboboxProps={{ withinPortal: true }}
+          />
+          <Select
+            label="Stage"
+            value={stage}
+            onChange={(v) => v && setStage(v as ProblemStage)}
+            data={STAGE_OPTIONS.map((s) => ({ value: s.value, label: s.label }))}
+            size="sm"
+            comboboxProps={{ withinPortal: true }}
+          />
+        </Group>
+        <Group justify="flex-end">
+          <Button variant="subtle" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() =>
+              create.mutate({
+                productId,
+                title: title.trim(),
+                description: description.trim() || undefined,
+                evidence: evidence.trim() || undefined,
+                category: category.trim() || undefined,
+                impact: impact != null ? Number(impact) : undefined,
+                confidence: confidence != null ? Number(confidence) : undefined,
+                stage,
+              })
+            }
+            loading={create.isPending}
+            disabled={!title.trim()}
+          >
+            Create
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function ProblemsPage() {
+  const params = useParams();
+  const productSlug = params.productSlug as string;
+  const { workspace, workspaceId } = useWorkspace();
+  const [modalOpened, setModalOpened] = useState(false);
+  const [stageFilter, setStageFilter] = useState<string | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
+
+  const { data: product } = api.product.product.getBySlug.useQuery(
+    { workspaceId: workspaceId ?? "", slug: productSlug },
+    { enabled: !!workspaceId && !!productSlug },
+  );
+
+  const { data: problems, isLoading } = api.product.problem.list.useQuery(
+    { productId: product?.id ?? "" },
+    { enabled: !!product?.id },
+  );
+
+  const utils = api.useUtils();
+
+  const update = api.product.problem.update.useMutation({
+    onSuccess: async () => {
+      if (product?.id)
+        await utils.product.problem.list.invalidate({ productId: product.id });
+    },
+  });
+
+  const deleteProblem = api.product.problem.delete.useMutation({
+    onSuccess: async () => {
+      if (product?.id)
+        await utils.product.problem.list.invalidate({ productId: product.id });
+    },
+  });
+
+  // Distinct categories present in the data, for the category filter.
+  const categories = useMemo(() => {
+    const set = new Set<string>();
+    for (const p of problems ?? []) {
+      if (p.category) set.add(p.category);
+    }
+    return [...set].sort((a, b) => a.localeCompare(b));
+  }, [problems]);
+
+  const filtered = useMemo(() => {
+    if (!problems) return [];
+    let list = [...problems];
+    if (stageFilter) list = list.filter((p) => p.stage === stageFilter);
+    if (categoryFilter)
+      list = list.filter((p) => p.category === categoryFilter);
+    return list;
+  }, [problems, stageFilter, categoryFilter]);
+
+  const handleDelete = (id: string, title: string) => {
+    modals.openConfirmModal({
+      title: "Delete problem",
+      children: (
+        <Text size="sm">Delete &quot;{title}&quot;? This cannot be undone.</Text>
+      ),
+      labels: { confirm: "Delete", cancel: "Cancel" },
+      confirmProps: { color: "red" },
+      onConfirm: () => deleteProblem.mutate({ id }),
+    });
+  };
+
+  if (!workspace) return null;
+
+  return (
+    <Stack gap="sm">
+      {/* Action bar */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <Select
+          value={stageFilter}
+          onChange={setStageFilter}
+          data={STAGE_OPTIONS.map((s) => ({ value: s.value, label: s.label }))}
+          placeholder="Stage"
+          size="xs"
+          clearable
+          comboboxProps={{ withinPortal: true }}
+          styles={{
+            root: { width: 140 },
+            input: { height: 30, minHeight: 30, fontSize: "0.8rem" },
+          }}
+        />
+
+        <Select
+          value={categoryFilter}
+          onChange={setCategoryFilter}
+          data={categories.map((c) => ({ value: c, label: c }))}
+          placeholder="Category"
+          size="xs"
+          clearable
+          disabled={categories.length === 0}
+          comboboxProps={{ withinPortal: true }}
+          styles={{
+            root: { width: 160 },
+            input: { height: 30, minHeight: 30, fontSize: "0.8rem" },
+          }}
+        />
+
+        <div className="flex-1" />
+
+        <Button
+          size="xs"
+          leftSection={<IconPlus size={14} />}
+          onClick={() => setModalOpened(true)}
+          disabled={!product}
+          variant="light"
+          styles={{ root: { height: 30 } }}
+        >
+          New problem
+        </Button>
+      </div>
+
+      {/* Content */}
+      {isLoading ? (
+        <Stack gap="sm">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} height={48} />
+          ))}
+        </Stack>
+      ) : filtered.length > 0 ? (
+        <div className="border border-border-primary rounded-lg overflow-x-auto">
+          <Table verticalSpacing="xs" horizontalSpacing="md" highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th style={{ minWidth: 240 }}>Problem</Table.Th>
+                <Table.Th style={{ minWidth: 200 }}>Description</Table.Th>
+                <Table.Th style={{ minWidth: 200 }}>Evidence</Table.Th>
+                <Table.Th style={{ minWidth: 120 }}>Category</Table.Th>
+                <Table.Th>Impact</Table.Th>
+                <Table.Th>Conf.</Table.Th>
+                <Table.Th style={{ minWidth: 130 }}>Stage</Table.Th>
+                <Table.Th style={{ width: 80 }} />
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {filtered.map((problem) => (
+                <Table.Tr key={problem.id}>
+                  <Table.Td>
+                    <EditableText
+                      value={problem.title}
+                      placeholder="Untitled"
+                      required
+                      onCommit={(next) =>
+                        next != null &&
+                        update.mutate({ id: problem.id, title: next })
+                      }
+                    />
+                  </Table.Td>
+                  <Table.Td>
+                    <EditableMultiline
+                      value={problem.description}
+                      placeholder="Add description"
+                      onCommit={(next) =>
+                        update.mutate({ id: problem.id, description: next })
+                      }
+                    />
+                  </Table.Td>
+                  <Table.Td>
+                    <EditableMultiline
+                      value={problem.evidence}
+                      placeholder="Add evidence"
+                      onCommit={(next) =>
+                        update.mutate({ id: problem.id, evidence: next })
+                      }
+                    />
+                  </Table.Td>
+                  <Table.Td>
+                    <EditableText
+                      value={problem.category}
+                      placeholder="—"
+                      onCommit={(next) =>
+                        update.mutate({ id: problem.id, category: next })
+                      }
+                    />
+                  </Table.Td>
+                  <Table.Td>
+                    <ScoreCell
+                      value={problem.impact}
+                      onCommit={(next) =>
+                        update.mutate({ id: problem.id, impact: next })
+                      }
+                    />
+                  </Table.Td>
+                  <Table.Td>
+                    <ScoreCell
+                      value={problem.confidence}
+                      onCommit={(next) =>
+                        update.mutate({ id: problem.id, confidence: next })
+                      }
+                    />
+                  </Table.Td>
+                  <Table.Td>
+                    <Select
+                      value={problem.stage}
+                      onChange={(v) =>
+                        v &&
+                        update.mutate({
+                          id: problem.id,
+                          stage: v as ProblemStage,
+                        })
+                      }
+                      data={STAGE_OPTIONS.map((s) => ({
+                        value: s.value,
+                        label: s.label,
+                      }))}
+                      size="xs"
+                      comboboxProps={{ withinPortal: true }}
+                      renderOption={({ option }) => (
+                        <Badge
+                          size="sm"
+                          variant="light"
+                          color={STAGE_COLORS[option.value as ProblemStage]}
+                        >
+                          {option.label}
+                        </Badge>
+                      )}
+                      styles={{
+                        root: { width: 130 },
+                        input: {
+                          height: 28,
+                          minHeight: 28,
+                          fontSize: "0.8rem",
+                        },
+                      }}
+                    />
+                  </Table.Td>
+                  <Table.Td>
+                    <Group gap={4} wrap="nowrap" justify="flex-end">
+                      <Avatar
+                        size="xs"
+                        radius="xl"
+                        src={problem.createdBy?.image}
+                      >
+                        {(problem.createdBy?.name ?? "?")[0]?.toUpperCase()}
+                      </Avatar>
+                      <Menu position="bottom-end" withinPortal>
+                        <Menu.Target>
+                          <ActionIcon
+                            variant="subtle"
+                            size="xs"
+                            className="text-text-muted"
+                          >
+                            <IconDots size={14} />
+                          </ActionIcon>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                          <Menu.Item
+                            color="red"
+                            leftSection={<IconTrash size={14} />}
+                            onClick={() =>
+                              handleDelete(problem.id, problem.title)
+                            }
+                          >
+                            Delete
+                          </Menu.Item>
+                        </Menu.Dropdown>
+                      </Menu>
+                    </Group>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </div>
+      ) : problems && problems.length > 0 ? (
+        <Text size="sm" className="text-text-muted py-8 text-center">
+          No problems match your filters.
+        </Text>
+      ) : (
+        <EmptyState
+          icon={IconTargetArrow}
+          message="No problems yet. Capture validated issues worth solving — who's hurt and how, backed by evidence."
+          action={
+            <Button
+              onClick={() => setModalOpened(true)}
+              leftSection={<IconPlus size={16} />}
+              color="brand"
+              disabled={!product}
+            >
+              New problem
+            </Button>
+          }
+        />
+      )}
+
+      {product && (
+        <CreateProblemModal
+          opened={modalOpened}
+          onClose={() => setModalOpened(false)}
+          productId={product.id}
+        />
+      )}
+    </Stack>
+  );
+}

--- a/src/plugins/product/server/routers/__tests__/problem.test.ts
+++ b/src/plugins/product/server/routers/__tests__/problem.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for the `problem` router's product-scoped create/list access.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` instead of a real
+ * database, so they run in milliseconds and CANNOT touch any real DB. Mirrors
+ * the test layout from `action.test.ts` / `document.test.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+// Seed env vars before any module imports — `vi.hoisted` runs before regular
+// top-level statements. Mirrors action.test.ts.
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+// ── Stub heavy/IO modules pulled in by the wider router tree ─────────
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(_opts?: any) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({
+    auth: () => null,
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+// ── dbMock plumbing ─────────────────────────────────────────────────
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = {
+  current: null,
+};
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) {
+    dbHolder.current = mockDeep<PrismaClient>();
+  }
+  return dbHolder.current;
+}
+
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+// ── Stub side-effect-heavy modules used by sibling routers ───────────
+vi.mock("~/server/services/notifications/EmailNotificationService", () => ({
+  sendAssignmentNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/server/services/onboarding/syncOnboardingProgress", () => ({
+  completeOnboardingStep: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/lib/blob", () => ({
+  uploadToBlob: vi.fn().mockResolvedValue({ url: "blob://test" }),
+}));
+
+// ── Imports of code under test (must come AFTER vi.mock calls) ───────
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const callerId = "user-1";
+const workspaceId = "ws-1";
+const productId = "prod-1";
+
+/** Stub the workspace-membership probe that `assertWorkspaceMember` runs. */
+function stubMembership(dbMock: DeepMockProxy<PrismaClient>, isMember: boolean) {
+  dbMock.workspaceUser.findUnique.mockResolvedValue(
+    isMember
+      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ({ role: "member", workspaceId } as any)
+      : null,
+  );
+}
+
+/** Stub the product lookup that `loadProductWithAccess` runs. */
+function stubProductLookup(dbMock: DeepMockProxy<PrismaClient>) {
+  dbMock.product.findUnique.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { id: productId, workspaceId, slug: "p" } as any,
+  );
+}
+
+describe("problem router (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  describe("create", () => {
+    it("creates a Problem scoped to the product and caller", async () => {
+      stubProductLookup(dbMock);
+      stubMembership(dbMock, true);
+      dbMock.problem.create.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: "problem-1", productId, title: "Onboarding drops off" } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.product.problem.create({
+        productId,
+        title: "Onboarding drops off",
+        impact: 4,
+        confidence: 3,
+      });
+
+      expect(result.id).toBe("problem-1");
+      expect(dbMock.problem.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          productId,
+          title: "Onboarding drops off",
+          stage: "IDEA",
+          impact: 4,
+          confidence: 3,
+          createdById: callerId,
+        }),
+      });
+    });
+
+    it("rejects when the caller is not a workspace member", async () => {
+      stubProductLookup(dbMock);
+      stubMembership(dbMock, false);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await expect(
+        caller.product.problem.create({ productId, title: "x" }),
+      ).rejects.toThrow(TRPCError);
+      expect(dbMock.problem.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects when the product does not exist", async () => {
+      dbMock.product.findUnique.mockResolvedValue(null);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await expect(
+        caller.product.problem.create({ productId, title: "x" }),
+      ).rejects.toThrow(/Product not found/);
+      expect(dbMock.problem.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("list", () => {
+    it("lists Problems filtered by productId (and optional stage)", async () => {
+      stubProductLookup(dbMock);
+      stubMembership(dbMock, true);
+      dbMock.problem.findMany.mockResolvedValue([
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: "problem-1", productId, stage: "QUALIFIED" } as any,
+      ]);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.product.problem.list({
+        productId,
+        stage: "QUALIFIED",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(dbMock.problem.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { productId, stage: "QUALIFIED" },
+        }),
+      );
+    });
+
+    it("rejects listing when the caller is not a workspace member", async () => {
+      stubProductLookup(dbMock);
+      stubMembership(dbMock, false);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await expect(
+        caller.product.problem.list({ productId }),
+      ).rejects.toThrow(TRPCError);
+      expect(dbMock.problem.findMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/plugins/product/server/routers/index.ts
+++ b/src/plugins/product/server/routers/index.ts
@@ -6,6 +6,7 @@ import { researchRouter } from "./research";
 import { cycleRouter } from "./cycle";
 import { retrospectiveRouter } from "./retrospective";
 import { insightRouter } from "./insight";
+import { problemRouter } from "./problem";
 
 export const productPluginRouter = createTRPCRouter({
   product: productRouter,
@@ -13,6 +14,7 @@ export const productPluginRouter = createTRPCRouter({
   ticket: ticketRouter,
   research: researchRouter,
   insight: insightRouter,
+  problem: problemRouter,
   cycle: cycleRouter,
   retrospective: retrospectiveRouter,
 });

--- a/src/plugins/product/server/routers/problem.ts
+++ b/src/plugins/product/server/routers/problem.ts
@@ -1,0 +1,151 @@
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { TRPCError } from "@trpc/server";
+import { loadProductWithAccess, assertWorkspaceMember } from "./product";
+import type { PrismaClient } from "@prisma/client";
+import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
+
+const problemStageEnum = z.enum(["IDEA", "QUALIFIED", "PRIORITISED"]);
+
+// impact/confidence are the two prioritisation axes, scored 1–5.
+const scoreSchema = z.number().int().min(1).max(5);
+
+/**
+ * Load a problem and verify the caller is a member of its product's workspace.
+ * Mirrors `loadInsightWithAccess`.
+ */
+async function loadProblemWithAccess(
+  db: PrismaClient,
+  userId: string,
+  problemId: string,
+) {
+  const problem = await db.problem.findUnique({
+    where: { id: problemId },
+    select: {
+      id: true,
+      productId: true,
+      product: { select: { workspaceId: true } },
+    },
+  });
+  if (!problem) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Problem not found" });
+  }
+  await assertWorkspaceMember(db, userId, problem.product.workspaceId);
+  return problem;
+}
+
+export const problemRouter = createTRPCRouter({
+  list: protectedProcedure
+    .input(
+      z.object({
+        productId: z.string(),
+        stage: problemStageEnum.optional(),
+        category: z.string().optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      await loadProductWithAccess(ctx.db, ctx.session.user.id, input.productId);
+
+      return ctx.db.problem.findMany({
+        where: {
+          productId: input.productId,
+          ...(input.stage ? { stage: input.stage } : {}),
+          ...(input.category ? { category: input.category } : {}),
+        },
+        orderBy: [{ createdAt: "desc" }],
+        include: {
+          createdBy: { select: { id: true, name: true, image: true } },
+        },
+      });
+    }),
+
+  getById: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const problem = await ctx.db.problem.findUnique({
+        where: { id: input.id },
+        include: {
+          product: {
+            select: { id: true, slug: true, workspaceId: true, name: true },
+          },
+          createdBy: { select: { id: true, name: true, image: true } },
+        },
+      });
+      if (!problem) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Problem not found" });
+      }
+      await assertWorkspaceMember(
+        ctx.db,
+        ctx.session.user.id,
+        problem.product.workspaceId,
+      );
+      return problem;
+    }),
+
+  create: protectedProcedure
+    .input(
+      z.object({
+        productId: z.string(),
+        title: boundedText("Title", 500, { min: 1 }),
+        description: boundedText("Description", TEXT_LIMITS.LARGE).optional(),
+        evidence: boundedText("Evidence", TEXT_LIMITS.LARGE).optional(),
+        category: boundedText("Category", TEXT_LIMITS.LABEL).optional(),
+        impact: scoreSchema.optional(),
+        confidence: scoreSchema.optional(),
+        stage: problemStageEnum.optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await loadProductWithAccess(ctx.db, ctx.session.user.id, input.productId);
+
+      return ctx.db.problem.create({
+        data: {
+          productId: input.productId,
+          title: input.title,
+          description: input.description,
+          evidence: input.evidence,
+          category: input.category,
+          impact: input.impact,
+          confidence: input.confidence,
+          stage: input.stage ?? "IDEA",
+          createdById: ctx.session.user.id,
+        },
+      });
+    }),
+
+  update: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        title: boundedText("Title", 500, { min: 1 }).optional(),
+        description: boundedText("Description", TEXT_LIMITS.LARGE)
+          .nullable()
+          .optional(),
+        evidence: boundedText("Evidence", TEXT_LIMITS.LARGE)
+          .nullable()
+          .optional(),
+        category: boundedText("Category", TEXT_LIMITS.LABEL)
+          .nullable()
+          .optional(),
+        impact: scoreSchema.nullable().optional(),
+        confidence: scoreSchema.nullable().optional(),
+        stage: problemStageEnum.optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await loadProblemWithAccess(ctx.db, ctx.session.user.id, input.id);
+      const { id, ...data } = input;
+      return ctx.db.problem.update({
+        where: { id },
+        data,
+      });
+    }),
+
+  delete: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await loadProblemWithAccess(ctx.db, ctx.session.user.id, input.id);
+      await ctx.db.problem.delete({ where: { id: input.id } });
+      return { success: true };
+    }),
+});


### PR DESCRIPTION
## What

Foundational tracer bullet for **Problems** (Stage 1–2 of the Pipeline Triage feature). Adds a new `Problem` model and a "Problems" tab on the product surface where you can create, list, edit, and delete Problems end-to-end. See `docs/adr/0008-pipeline-triage-model.md` and the CONTEXT.md "Pipeline triage" section.

- **Schema**: `Problem` model (`title`, `description?`, `evidence?`, `category?`, `impact?`, `confidence?`, `stage`, `parkedAt?`, `parkReason?`) + `ProblemStage` enum (`IDEA → QUALIFIED → PRIORITISED`). `parkedAt`/`parkReason` ship now to avoid a second migration. Cascade on product delete; indexes on `productId`, `stage`, `createdById`.
- **API**: `problem` tRPC router (product-scoped `create`/`list`/`update`/`delete`), registered in the product router index, mirrors the `insight` router's auth/scoping.
- **UI**: "Problems" tab inserted right after Overview. Table of the product's Problems with a create-modal, inline cell edit (title/description/evidence/category/impact/confidence/stage), and filters by stage + category.
- **Tests**: unit tests for the router's create/list scoping (mocked Prisma).

> ⚠️ **Migration not applied.** Per the repo DB-safety rule, the migration `20260605120000_add_problem_model` is committed but **not run**. Apply it with `npx prisma migrate dev` before/at deploy.

## Acceptance criteria

- [x] `Problem` model + `ProblemStage` enum added; migration created (not run)
- [x] `problem` tRPC router with product-scoped create/list/update/delete, registered, fully typed (no `any`)
- [x] "Problems" tab appears after Overview and lists the current product's Problems
- [x] Create-modal adds a Problem; inline edit updates fields; delete removes it — no reload
- [x] Table can filter by category and by stage
- [x] No hardcoded colors; typecheck + unit tests pass
- [x] Unit test for the router's create/list scoping (mocked Prisma)

---

Ships: sunny.tulip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Problems section to product workspaces with a dedicated tab for viewing and managing problems.
  * Users can create, edit, and delete problems with details including title, description, evidence, category, impact, and confidence scores.
  * Problems support filtering by stage and category, with inline editing and a create modal for new problems.

* **Tests**
  * Added test coverage for problem creation and retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->