### PR TITLE
feat: Approaches — link a Problem to the Projects that tackle it

### DIFF
--- a/prisma/migrations/20260605130000_add_problem_approach/migration.sql
+++ b/prisma/migrations/20260605130000_add_problem_approach/migration.sql
@@ -1,0 +1,21 @@
+-- Pipeline Triage: "Approaches" — the many-to-many link between a Problem and
+-- the Projects that tackle it. An Approach IS a Project (ADR-0008), so this is
+-- just a join table, not a new entity. Forward direction only in v1.
+
+-- CreateTable
+CREATE TABLE "ProblemApproach" (
+    "problemId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProblemApproach_pkey" PRIMARY KEY ("problemId","projectId")
+);
+
+-- CreateIndex
+CREATE INDEX "ProblemApproach_projectId_idx" ON "ProblemApproach"("projectId");
+
+-- AddForeignKey
+ALTER TABLE "ProblemApproach" ADD CONSTRAINT "ProblemApproach_problemId_fkey" FOREIGN KEY ("problemId") REFERENCES "Problem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProblemApproach" ADD CONSTRAINT "ProblemApproach_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -763,6 +763,8 @@ model Project {
   // Deal Pipeline relations (when type = "pipeline")
   pipelineStages        PipelineStage[]
   deals                 Deal[]
+  // Pipeline Triage: Problems this project is an Approach for (ADR-0008)
+  problemApproaches     ProblemApproach[]
 
   @@index([name])
   @@index([status])
@@ -3938,12 +3940,28 @@ model Problem {
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
 
-  product   Product @relation(fields: [productId], references: [id], onDelete: Cascade)
-  createdBy User    @relation("ProblemCreatedBy", fields: [createdById], references: [id])
+  product    Product           @relation(fields: [productId], references: [id], onDelete: Cascade)
+  createdBy  User              @relation("ProblemCreatedBy", fields: [createdById], references: [id])
+  approaches ProblemApproach[]
 
   @@index([productId])
   @@index([stage])
   @@index([createdById])
+}
+
+/// "Approaches" — the many-to-many link between a Problem and the Projects
+/// that tackle it (ADR-0008: an Approach IS a Project, not a new model). A
+/// Project can address several Problems; a Problem has several Approaches.
+model ProblemApproach {
+  problemId String
+  projectId String
+  createdAt DateTime @default(now())
+
+  problem Problem @relation(fields: [problemId], references: [id], onDelete: Cascade)
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@id([problemId, projectId])
+  @@index([projectId])
 }
 
 // ============================================

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/problems/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/problems/page.tsx
@@ -10,6 +10,8 @@ import {
   Group,
   Menu,
   Modal,
+  MultiSelect,
+  Popover,
   Select,
   Skeleton,
   Stack,
@@ -17,8 +19,10 @@ import {
   Text,
   Textarea,
   TextInput,
+  UnstyledButton,
 } from "@mantine/core";
 import {
+  IconAffiliate,
   IconDots,
   IconPlus,
   IconTargetArrow,
@@ -193,6 +197,98 @@ function ScoreCell({
         input: { height: 28, minHeight: 28, fontSize: "0.8rem" },
       }}
     />
+  );
+}
+
+/**
+ * Inline Approaches editor — the Projects (Approaches) linked to a Problem,
+ * rendered as chips with a Notion-relation-style multi-select picker. Options
+ * are scoped to the product's own Projects. Forward direction only (v1).
+ */
+function ApproachesEditor({
+  problemId,
+  productId,
+  currentApproaches,
+}: {
+  problemId: string;
+  productId: string;
+  currentApproaches: Array<{ project: { id: string; name: string } }>;
+}) {
+  const utils = api.useUtils();
+  const [opened, setOpened] = useState(false);
+  const [selected, setSelected] = useState<string[]>(
+    currentApproaches.map((a) => a.project.id),
+  );
+
+  const { data: projects } = api.product.problem.productProjects.useQuery(
+    { productId },
+    { enabled: opened },
+  );
+
+  const setProjects = api.product.problem.setProjects.useMutation({
+    onSuccess: async () => {
+      await utils.product.problem.list.invalidate({ productId });
+    },
+  });
+
+  const hasApproaches = currentApproaches.length > 0;
+
+  return (
+    <Popover
+      position="bottom-start"
+      withinPortal
+      shadow="md"
+      opened={opened}
+      onChange={(next) => {
+        setOpened(next);
+        if (next) setSelected(currentApproaches.map((a) => a.project.id));
+      }}
+    >
+      <Popover.Target>
+        <UnstyledButton
+          onClick={() => setOpened((o) => !o)}
+          className="inline-flex flex-wrap items-center gap-1 text-text-muted hover:text-text-primary transition-colors"
+        >
+          {hasApproaches ? (
+            currentApproaches.map((a) => (
+              <Badge key={a.project.id} size="xs" variant="light" color="indigo">
+                {a.project.name}
+              </Badge>
+            ))
+          ) : (
+            <span className="inline-flex items-center gap-1">
+              <IconAffiliate size={12} />
+              <Text size="xs">Add approach</Text>
+            </span>
+          )}
+        </UnstyledButton>
+      </Popover.Target>
+      <Popover.Dropdown
+        styles={{
+          dropdown: {
+            backgroundColor: "var(--color-bg-elevated)",
+            border: "1px solid var(--color-border-primary)",
+            minWidth: 260,
+          },
+        }}
+      >
+        <MultiSelect
+          autoFocus
+          value={selected}
+          onChange={(next) => {
+            setSelected(next);
+            setProjects.mutate({ problemId, projectIds: next });
+          }}
+          data={(projects ?? []).map((p) => ({ value: p.id, label: p.name }))}
+          searchable
+          clearable
+          size="xs"
+          placeholder="Search projects..."
+          comboboxProps={{ withinPortal: true }}
+          nothingFoundMessage="No projects in this product yet"
+        />
+      </Popover.Dropdown>
+    </Popover>
   );
 }
 
@@ -465,6 +561,7 @@ export default function ProblemsPage() {
                 <Table.Th style={{ minWidth: 200 }}>Description</Table.Th>
                 <Table.Th style={{ minWidth: 200 }}>Evidence</Table.Th>
                 <Table.Th style={{ minWidth: 120 }}>Category</Table.Th>
+                <Table.Th style={{ minWidth: 160 }}>Approaches</Table.Th>
                 <Table.Th>Impact</Table.Th>
                 <Table.Th>Conf.</Table.Th>
                 <Table.Th style={{ minWidth: 130 }}>Stage</Table.Th>
@@ -511,6 +608,15 @@ export default function ProblemsPage() {
                         update.mutate({ id: problem.id, category: next })
                       }
                     />
+                  </Table.Td>
+                  <Table.Td>
+                    {product && (
+                      <ApproachesEditor
+                        problemId={problem.id}
+                        productId={product.id}
+                        currentApproaches={problem.approaches}
+                      />
+                    )}
                   </Table.Td>
                   <Table.Td>
                     <ScoreCell

--- a/src/plugins/product/server/routers/__tests__/problem.test.ts
+++ b/src/plugins/product/server/routers/__tests__/problem.test.ts
@@ -212,4 +212,55 @@ describe("problem router (mocked)", () => {
       expect(dbMock.problem.findMany).not.toHaveBeenCalled();
     });
   });
+
+  describe("linkProject (Approaches)", () => {
+    const problemId = "problem-1";
+
+    /** Stub the problem lookup that `loadProblemWithAccess` runs. */
+    function stubProblemLookup() {
+      dbMock.problem.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: problemId, productId, product: { workspaceId } } as any,
+      );
+    }
+
+    it("links a Project that belongs to the same product", async () => {
+      stubProblemLookup();
+      stubMembership(dbMock, true);
+      dbMock.project.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: "proj-1", productId } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.product.problem.linkProject({
+        problemId,
+        projectId: "proj-1",
+      });
+
+      expect(dbMock.problemApproach.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: { problemId, projectId: "proj-1" },
+        }),
+      );
+    });
+
+    it("rejects linking a Project from a different product", async () => {
+      stubProblemLookup();
+      stubMembership(dbMock, true);
+      dbMock.project.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: "proj-2", productId: "other-product" } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await expect(
+        caller.product.problem.linkProject({
+          problemId,
+          projectId: "proj-2",
+        }),
+      ).rejects.toThrow(/does not belong/);
+      expect(dbMock.problemApproach.upsert).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/plugins/product/server/routers/problem.ts
+++ b/src/plugins/product/server/routers/problem.ts
@@ -55,7 +55,27 @@ export const problemRouter = createTRPCRouter({
         orderBy: [{ createdAt: "desc" }],
         include: {
           createdBy: { select: { id: true, name: true, image: true } },
+          approaches: {
+            include: {
+              project: { select: { id: true, name: true, slug: true } },
+            },
+          },
         },
+      });
+    }),
+
+  /**
+   * The product's own Projects, used to populate the Approach picker. Scoped to
+   * the product (and therefore its workspace, ADR-0003) — a bounded list.
+   */
+  productProjects: protectedProcedure
+    .input(z.object({ productId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      await loadProductWithAccess(ctx.db, ctx.session.user.id, input.productId);
+      return ctx.db.project.findMany({
+        where: { productId: input.productId },
+        select: { id: true, name: true, slug: true },
+        orderBy: [{ name: "asc" }],
       });
     }),
 
@@ -146,6 +166,92 @@ export const problemRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       await loadProblemWithAccess(ctx.db, ctx.session.user.id, input.id);
       await ctx.db.problem.delete({ where: { id: input.id } });
+      return { success: true };
+    }),
+
+  // ── Approaches (Problem ↔ Project links) ──────────────────────────────
+  // Forward direction only in v1: on a Problem, pick the Projects (Approaches)
+  // that tackle it. Links existing Projects only — never creates a Project.
+
+  linkProject: protectedProcedure
+    .input(z.object({ problemId: z.string(), projectId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const problem = await loadProblemWithAccess(
+        ctx.db,
+        ctx.session.user.id,
+        input.problemId,
+      );
+      const project = await ctx.db.project.findUnique({
+        where: { id: input.projectId },
+        select: { id: true, productId: true },
+      });
+      if (!project) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Project not found" });
+      }
+      if (project.productId !== problem.productId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Project does not belong to this problem's product",
+        });
+      }
+      await ctx.db.problemApproach.upsert({
+        where: {
+          problemId_projectId: {
+            problemId: input.problemId,
+            projectId: input.projectId,
+          },
+        },
+        create: { problemId: input.problemId, projectId: input.projectId },
+        update: {},
+      });
+      return { success: true };
+    }),
+
+  unlinkProject: protectedProcedure
+    .input(z.object({ problemId: z.string(), projectId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await loadProblemWithAccess(ctx.db, ctx.session.user.id, input.problemId);
+      await ctx.db.problemApproach.deleteMany({
+        where: { problemId: input.problemId, projectId: input.projectId },
+      });
+      return { success: true };
+    }),
+
+  /** Replace the full set of Projects (Approaches) linked to a Problem. */
+  setProjects: protectedProcedure
+    .input(z.object({ problemId: z.string(), projectIds: z.array(z.string()) }))
+    .mutation(async ({ ctx, input }) => {
+      const problem = await loadProblemWithAccess(
+        ctx.db,
+        ctx.session.user.id,
+        input.problemId,
+      );
+      const uniqueProjectIds = [...new Set(input.projectIds)];
+      await ctx.db.$transaction(async (tx) => {
+        if (uniqueProjectIds.length > 0) {
+          const validProjects = await tx.project.findMany({
+            where: { id: { in: uniqueProjectIds }, productId: problem.productId },
+            select: { id: true },
+          });
+          if (validProjects.length !== uniqueProjectIds.length) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "One or more projects do not belong to this problem's product",
+            });
+          }
+        }
+        await tx.problemApproach.deleteMany({
+          where: { problemId: input.problemId },
+        });
+        await tx.problemApproach.createMany({
+          data: uniqueProjectIds.map((projectId) => ({
+            problemId: input.problemId,
+            projectId,
+          })),
+          skipDuplicates: true,
+        });
+      });
       return { success: true };
     }),
 });


### PR DESCRIPTION
## What

Adds **Approaches**: the many-to-many link between a `Problem` and the **Projects** that tackle it. An Approach is *not* a new model — a pursued approach **is** a `Project` (ADR-0008). This slice lets you attach existing Projects to a Problem and see them as "Approaches". **Forward direction only** in v1.

- `ProblemApproach` join table + migration.
- `problem` router: `list` includes each Problem's linked Projects; new `productProjects` query (options scoped to the product's own Projects, ADR-0003); `linkProject` / `unlinkProject` / `setProjects` mutations — all product-scoped, link existing Projects only (never create one).
- Inline **multi-select project-picker** (chip cell, Notion-relation style) on the Problem table; options bounded to the product's Projects; selecting/deselecting updates the links live.
- **"Approaches"** column rendering linked Projects as chips.
- Unit tests for `linkProject` same-product scoping.

> ⚠️ **Migration not applied.** Per the DB-safety rule, `20260605130000_add_problem_approach` is committed but **not run**. Apply it with `npx prisma migrate dev`. It stacks on top of #1's `add_problem_model` migration.

> **Note:** branches off `main` in parallel with #2 (kanban board). Both touch `problems/page.tsx`; if #2 merges first, expect a small merge resolution here.

## Acceptance criteria

- [x] `Problem ↔ Project` M2M join added; migration created (not run)
- [x] link/unlink mutations; linking creates nothing new (links existing Projects only)
- [x] Inline picker lists only the current product's Projects; selecting/deselecting updates the links live
- [x] "Approaches" column shows linked Projects as chips
- [x] No hardcoded colors; typecheck + 624 unit tests pass

---

Ships: flat.shard

🤖 Generated with [Claude Code](https://claude.com/claude-code)