### PR TITLE
feat: Parking for Problems — park/unpark with reason

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/problems/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/problems/page.tsx
@@ -16,16 +16,20 @@ import {
   Select,
   Skeleton,
   Stack,
+  Switch,
   Table,
   Text,
   Textarea,
   TextInput,
+  Tooltip,
   UnstyledButton,
 } from "@mantine/core";
 import {
   IconAffiliate,
+  IconArchiveOff,
   IconDots,
   IconLayoutKanban,
+  IconPlayerPause,
   IconPlus,
   IconTable,
   IconTargetArrow,
@@ -444,31 +448,47 @@ export default function ProblemsPage() {
   const [stageFilter, setStageFilter] = useState<string | null>(null);
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
   const [view, setView] = useState<"table" | "board">("table");
+  const [showParked, setShowParked] = useState(false);
+  const [parkTarget, setParkTarget] = useState<string | null>(null);
 
   const { data: product } = api.product.product.getBySlug.useQuery(
     { workspaceId: workspaceId ?? "", slug: productSlug },
     { enabled: !!workspaceId && !!productSlug },
   );
 
+  // The board always needs parked items (for its Parked lane); the table only
+  // when "Show parked" is on. Parked-ness is independent of stage.
+  const includeParked = view === "board" || showParked;
+
   const { data: problems, isLoading } = api.product.problem.list.useQuery(
-    { productId: product?.id ?? "" },
+    { productId: product?.id ?? "", includeParked },
     { enabled: !!product?.id },
   );
 
   const utils = api.useUtils();
 
+  const invalidateList = async () => {
+    if (product?.id)
+      await utils.product.problem.list.invalidate({ productId: product.id });
+  };
+
   const update = api.product.problem.update.useMutation({
-    onSuccess: async () => {
-      if (product?.id)
-        await utils.product.problem.list.invalidate({ productId: product.id });
-    },
+    onSuccess: invalidateList,
   });
 
   const deleteProblem = api.product.problem.delete.useMutation({
+    onSuccess: invalidateList,
+  });
+
+  const park = api.product.problem.park.useMutation({
     onSuccess: async () => {
-      if (product?.id)
-        await utils.product.problem.list.invalidate({ productId: product.id });
+      setParkTarget(null);
+      await invalidateList();
     },
+  });
+
+  const unpark = api.product.problem.unpark.useMutation({
+    onSuccess: invalidateList,
   });
 
   // Distinct categories present in the data, for the category filter.
@@ -578,6 +598,15 @@ export default function ProblemsPage() {
 
         <div className="flex-1" />
 
+        {view === "table" && (
+          <Switch
+            size="xs"
+            label="Show parked"
+            checked={showParked}
+            onChange={(e) => setShowParked(e.currentTarget.checked)}
+          />
+        )}
+
         <Button
           size="xs"
           leftSection={<IconPlus size={14} />}
@@ -602,6 +631,8 @@ export default function ProblemsPage() {
           <ProblemKanbanBoard
             problems={boardProblems}
             productId={product.id}
+            onPark={(id) => setParkTarget(id)}
+            onUnpark={(id) => unpark.mutate({ id })}
           />
         ) : (
           <EmptyState
@@ -637,17 +668,32 @@ export default function ProblemsPage() {
             </Table.Thead>
             <Table.Tbody>
               {filtered.map((problem) => (
-                <Table.Tr key={problem.id}>
+                <Table.Tr
+                  key={problem.id}
+                  className={problem.parkedAt ? "opacity-60" : undefined}
+                >
                   <Table.Td>
-                    <EditableText
-                      value={problem.title}
-                      placeholder="Untitled"
-                      required
-                      onCommit={(next) =>
-                        next != null &&
-                        update.mutate({ id: problem.id, title: next })
-                      }
-                    />
+                    <Group gap="xs" wrap="nowrap" align="center">
+                      {problem.parkedAt && (
+                        <Tooltip
+                          label={problem.parkReason ?? "Parked"}
+                          withinPortal
+                        >
+                          <Badge size="xs" variant="light" color="yellow">
+                            Parked
+                          </Badge>
+                        </Tooltip>
+                      )}
+                      <EditableText
+                        value={problem.title}
+                        placeholder="Untitled"
+                        required
+                        onCommit={(next) =>
+                          next != null &&
+                          update.mutate({ id: problem.id, title: next })
+                        }
+                      />
+                    </Group>
                   </Table.Td>
                   <Table.Td>
                     <EditableMultiline
@@ -756,6 +802,22 @@ export default function ProblemsPage() {
                           </ActionIcon>
                         </Menu.Target>
                         <Menu.Dropdown>
+                          {problem.parkedAt ? (
+                            <Menu.Item
+                              leftSection={<IconArchiveOff size={14} />}
+                              onClick={() => unpark.mutate({ id: problem.id })}
+                            >
+                              Unpark
+                            </Menu.Item>
+                          ) : (
+                            <Menu.Item
+                              leftSection={<IconPlayerPause size={14} />}
+                              onClick={() => setParkTarget(problem.id)}
+                            >
+                              Park…
+                            </Menu.Item>
+                          )}
+                          <Menu.Divider />
                           <Menu.Item
                             color="red"
                             leftSection={<IconTrash size={14} />}
@@ -802,6 +864,77 @@ export default function ProblemsPage() {
           productId={product.id}
         />
       )}
+
+      <ParkReasonModal
+        key={parkTarget ?? "none"}
+        opened={parkTarget !== null}
+        onClose={() => setParkTarget(null)}
+        loading={park.isPending}
+        onConfirm={(reason) => {
+          if (parkTarget) park.mutate({ id: parkTarget, reason });
+        }}
+      />
     </Stack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Park reason modal
+// ---------------------------------------------------------------------------
+
+function ParkReasonModal({
+  opened,
+  onClose,
+  onConfirm,
+  loading,
+}: {
+  opened: boolean;
+  onClose: () => void;
+  onConfirm: (reason: string) => void;
+  loading: boolean;
+}) {
+  const [reason, setReason] = useState("");
+
+  // Reset when the modal closes so the next park starts blank.
+  const handleClose = () => {
+    setReason("");
+    onClose();
+  };
+
+  return (
+    <Modal opened={opened} onClose={handleClose} title="Park problem" size="md">
+      <Stack gap="md">
+        <Text size="sm" className="text-text-muted">
+          Set this problem aside with a reason — it keeps its stage and can be
+          un-parked later. Parked items are hidden by default.
+        </Text>
+        <Textarea
+          label="Reason"
+          placeholder="e.g. Insufficient evidence, out of scope, duplicate…"
+          value={reason}
+          onChange={(e) => setReason(e.currentTarget.value)}
+          autosize
+          minRows={2}
+          maxRows={5}
+          size="sm"
+          required
+          data-autofocus
+        />
+        <Group justify="flex-end">
+          <Button variant="subtle" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            color="yellow"
+            leftSection={<IconPlayerPause size={16} />}
+            onClick={() => onConfirm(reason.trim())}
+            loading={loading}
+            disabled={!reason.trim()}
+          >
+            Park
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
   );
 }

--- a/src/app/_components/product/ProblemKanbanBoard.tsx
+++ b/src/app/_components/product/ProblemKanbanBoard.tsx
@@ -13,7 +13,17 @@ import {
 } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Badge, Card, Group, Paper, Stack, Text } from "@mantine/core";
+import {
+  ActionIcon,
+  Badge,
+  Card,
+  Group,
+  Paper,
+  Stack,
+  Text,
+  Tooltip,
+} from "@mantine/core";
+import { IconArchiveOff, IconPlayerPause } from "@tabler/icons-react";
 import { api } from "~/trpc/react";
 
 // ---------------------------------------------------------------------------
@@ -30,7 +40,11 @@ export interface ProblemCardItem {
   impact: number | null;
   confidence: number | null;
   stage: ProblemStage;
+  parkedAt: Date | null;
+  parkReason: string | null;
 }
+
+const PARKED_LANE_ID = "PARKED";
 
 const STAGE_LANES: ReadonlyArray<{
   value: ProblemStage;
@@ -43,15 +57,48 @@ const STAGE_LANES: ReadonlyArray<{
 ];
 
 // ---------------------------------------------------------------------------
-// ProblemCard (draggable)
+// Card body (shared by draggable + parked variants)
+// ---------------------------------------------------------------------------
+
+function CardBody({ problem }: { problem: ProblemCardItem }) {
+  return (
+    <>
+      <Text size="sm" fw={500} className="text-text-primary" lineClamp={2}>
+        {problem.title}
+      </Text>
+      <Group gap="xs" mt="xs">
+        {problem.category && (
+          <Badge size="xs" variant="light" color="grape">
+            {problem.category}
+          </Badge>
+        )}
+        {problem.impact != null && (
+          <Badge size="xs" variant="outline" color="orange" title="Impact">
+            I{problem.impact}
+          </Badge>
+        )}
+        {problem.confidence != null && (
+          <Badge size="xs" variant="outline" color="teal" title="Confidence">
+            C{problem.confidence}
+          </Badge>
+        )}
+      </Group>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ProblemCard (draggable, active lanes) — with a Park affordance
 // ---------------------------------------------------------------------------
 
 function ProblemCard({
   problem,
   isDragOverlay,
+  onPark,
 }: {
   problem: ProblemCardItem;
   isDragOverlay?: boolean;
+  onPark?: (id: string) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: problem.id });
@@ -73,24 +120,27 @@ function ProblemCard({
       padding="sm"
       radius="sm"
     >
-      <Text size="sm" fw={500} className="text-text-primary" lineClamp={2}>
-        {problem.title}
-      </Text>
-      <Group gap="xs" mt="xs">
-        {problem.category && (
-          <Badge size="xs" variant="light" color="grape">
-            {problem.category}
-          </Badge>
-        )}
-        {problem.impact != null && (
-          <Badge size="xs" variant="outline" color="orange" title="Impact">
-            I{problem.impact}
-          </Badge>
-        )}
-        {problem.confidence != null && (
-          <Badge size="xs" variant="outline" color="teal" title="Confidence">
-            C{problem.confidence}
-          </Badge>
+      <Group justify="space-between" wrap="nowrap" align="flex-start" gap="xs">
+        <div className="min-w-0 flex-1">
+          <CardBody problem={problem} />
+        </div>
+        {!isDragOverlay && onPark && (
+          <Tooltip label="Park" withinPortal>
+            <ActionIcon
+              variant="subtle"
+              size="xs"
+              className="text-text-muted shrink-0"
+              // Pointer listeners on the card start a drag; stop them here so
+              // the click registers as a Park, not a drag.
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                onPark(problem.id);
+              }}
+            >
+              <IconPlayerPause size={14} />
+            </ActionIcon>
+          </Tooltip>
         )}
       </Group>
     </Card>
@@ -98,21 +148,64 @@ function ProblemCard({
 }
 
 // ---------------------------------------------------------------------------
-// Lane (droppable)
+// ParkedCard (static) — with an Unpark affordance + reason
+// ---------------------------------------------------------------------------
+
+function ParkedCard({
+  problem,
+  onUnpark,
+}: {
+  problem: ProblemCardItem;
+  onUnpark: (id: string) => void;
+}) {
+  return (
+    <Card
+      className="border border-border-primary bg-surface-secondary opacity-80"
+      padding="sm"
+      radius="sm"
+    >
+      <Group justify="space-between" wrap="nowrap" align="flex-start" gap="xs">
+        <div className="min-w-0 flex-1">
+          <CardBody problem={problem} />
+          {problem.parkReason && (
+            <Text size="xs" className="text-text-muted mt-1" lineClamp={2}>
+              {problem.parkReason}
+            </Text>
+          )}
+        </div>
+        <Tooltip label="Unpark" withinPortal>
+          <ActionIcon
+            variant="subtle"
+            size="xs"
+            className="text-text-muted shrink-0"
+            onClick={() => onUnpark(problem.id)}
+          >
+            <IconArchiveOff size={14} />
+          </ActionIcon>
+        </Tooltip>
+      </Group>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stage lane (droppable)
 // ---------------------------------------------------------------------------
 
 function BoardLane({
-  stage,
+  id,
   label,
   color,
-  problems,
+  count,
+  children,
 }: {
-  stage: ProblemStage;
+  id: string;
   label: string;
   color: string;
-  problems: ProblemCardItem[];
+  count: number;
+  children: React.ReactNode;
 }) {
-  const { setNodeRef, isOver } = useDroppable({ id: stage });
+  const { setNodeRef, isOver } = useDroppable({ id });
 
   return (
     <Paper
@@ -134,22 +227,21 @@ function BoardLane({
           {label}
         </Badge>
         <Text size="xs" fw={600} className="text-text-muted">
-          {problems.length}
+          {count}
         </Text>
       </Group>
-      <Stack gap="xs">
-        {problems.map((problem) => (
-          <ProblemCard key={problem.id} problem={problem} />
-        ))}
-        {problems.length === 0 && (
-          <div className="h-16 border-2 border-dashed border-border-secondary rounded-md flex items-center justify-center">
-            <Text size="xs" className="text-text-muted">
-              Drop here
-            </Text>
-          </div>
-        )}
-      </Stack>
+      <Stack gap="xs">{children}</Stack>
     </Paper>
+  );
+}
+
+function EmptyDropHint() {
+  return (
+    <div className="h-16 border-2 border-dashed border-border-secondary rounded-md flex items-center justify-center">
+      <Text size="xs" className="text-text-muted">
+        Drop here
+      </Text>
+    </div>
   );
 }
 
@@ -160,11 +252,16 @@ function BoardLane({
 interface ProblemKanbanBoardProps {
   problems: ProblemCardItem[];
   productId: string;
+  /** Open the reason prompt to park a Problem (the reason is captured upstream). */
+  onPark: (id: string) => void;
+  onUnpark: (id: string) => void;
 }
 
 export function ProblemKanbanBoard({
   problems,
   productId,
+  onPark,
+  onUnpark,
 }: ProblemKanbanBoardProps) {
   const utils = api.useUtils();
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -198,16 +295,20 @@ export function ProblemKanbanBoard({
     [problems, optimisticMoves],
   );
 
-  const laneProblems = useMemo(() => {
-    const map: Record<ProblemStage, ProblemCardItem[]> = {
+  // Parked items go to the Parked lane regardless of stage; active items group
+  // into their stage lane.
+  const { laneProblems, parked } = useMemo(() => {
+    const lanes: Record<ProblemStage, ProblemCardItem[]> = {
       IDEA: [],
       QUALIFIED: [],
       PRIORITISED: [],
     };
+    const parkedList: ProblemCardItem[] = [];
     for (const p of effectiveProblems) {
-      map[p.stage].push(p);
+      if (p.parkedAt) parkedList.push(p);
+      else lanes[p.stage].push(p);
     }
-    return map;
+    return { laneProblems: lanes, parked: parkedList };
   }, [effectiveProblems]);
 
   const activeProblem = activeId
@@ -225,19 +326,26 @@ export function ProblemKanbanBoard({
       if (!over) return;
 
       const problemId = active.id as string;
+      const problem = effectiveProblems.find((p) => p.id === problemId);
+      if (!problem || problem.parkedAt) return; // parked cards aren't draggable
+
       const overId = String(over.id);
+
+      // Dropped on the Parked lane → request a park (reason captured upstream).
+      if (overId === PARKED_LANE_ID) {
+        onPark(problemId);
+        return;
+      }
+
       const overLane = STAGE_LANES.find((l) => l.value === overId);
       const overProblem = effectiveProblems.find((p) => p.id === overId);
       const nextStage = overLane?.value ?? overProblem?.stage;
-      if (!nextStage) return;
-
-      const problem = effectiveProblems.find((p) => p.id === problemId);
-      if (!problem || problem.stage === nextStage) return;
+      if (!nextStage || problem.stage === nextStage) return;
 
       setOptimisticMoves((prev) => ({ ...prev, [problemId]: nextStage }));
       updateProblem.mutate({ id: problemId, stage: nextStage });
     },
-    [effectiveProblems, updateProblem],
+    [effectiveProblems, updateProblem, onPark],
   );
 
   return (
@@ -250,12 +358,29 @@ export function ProblemKanbanBoard({
         {STAGE_LANES.map((lane) => (
           <BoardLane
             key={lane.value}
-            stage={lane.value}
+            id={lane.value}
             label={lane.label}
             color={lane.color}
-            problems={laneProblems[lane.value]}
-          />
+            count={laneProblems[lane.value].length}
+          >
+            {laneProblems[lane.value].map((problem) => (
+              <ProblemCard key={problem.id} problem={problem} onPark={onPark} />
+            ))}
+            {laneProblems[lane.value].length === 0 && <EmptyDropHint />}
+          </BoardLane>
         ))}
+
+        <BoardLane
+          id={PARKED_LANE_ID}
+          label="Parked"
+          color="yellow"
+          count={parked.length}
+        >
+          {parked.map((problem) => (
+            <ParkedCard key={problem.id} problem={problem} onUnpark={onUnpark} />
+          ))}
+          {parked.length === 0 && <EmptyDropHint />}
+        </BoardLane>
       </div>
       <DragOverlay>
         {activeProblem && <ProblemCard problem={activeProblem} isDragOverlay />}

--- a/src/plugins/product/server/routers/__tests__/problem.test.ts
+++ b/src/plugins/product/server/routers/__tests__/problem.test.ts
@@ -194,10 +194,24 @@ describe("problem router (mocked)", () => {
       });
 
       expect(result).toHaveLength(1);
+      // Parked items are excluded by default (parkedAt: null).
       expect(dbMock.problem.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { productId, stage: "QUALIFIED" },
+          where: { productId, stage: "QUALIFIED", parkedAt: null },
         }),
+      );
+    });
+
+    it("includes parked items when includeParked is true", async () => {
+      stubProductLookup(dbMock);
+      stubMembership(dbMock, true);
+      dbMock.problem.findMany.mockResolvedValue([]);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.product.problem.list({ productId, includeParked: true });
+
+      expect(dbMock.problem.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { productId } }),
       );
     });
 
@@ -210,6 +224,62 @@ describe("problem router (mocked)", () => {
         caller.product.problem.list({ productId }),
       ).rejects.toThrow(TRPCError);
       expect(dbMock.problem.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("park / unpark", () => {
+    const problemId = "problem-1";
+
+    function stubProblemLookup() {
+      dbMock.problem.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: problemId, productId, product: { workspaceId } } as any,
+      );
+    }
+
+    it("park sets parkedAt + parkReason, leaving stage untouched", async () => {
+      stubProblemLookup();
+      stubMembership(dbMock, true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dbMock.problem.update.mockResolvedValue({ id: problemId } as any);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.product.problem.park({
+        id: problemId,
+        reason: "Out of scope",
+      });
+
+      const call = dbMock.problem.update.mock.calls[0]?.[0];
+      expect(call?.where).toEqual({ id: problemId });
+      expect(call?.data).toMatchObject({ parkReason: "Out of scope" });
+      expect(call?.data).toHaveProperty("parkedAt");
+      expect(call?.data).not.toHaveProperty("stage");
+    });
+
+    it("park rejects an empty reason", async () => {
+      stubProblemLookup();
+      stubMembership(dbMock, true);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await expect(
+        caller.product.problem.park({ id: problemId, reason: "" }),
+      ).rejects.toThrow();
+      expect(dbMock.problem.update).not.toHaveBeenCalled();
+    });
+
+    it("unpark clears parkedAt + parkReason", async () => {
+      stubProblemLookup();
+      stubMembership(dbMock, true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dbMock.problem.update.mockResolvedValue({ id: problemId } as any);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.product.problem.unpark({ id: problemId });
+
+      expect(dbMock.problem.update).toHaveBeenCalledWith({
+        where: { id: problemId },
+        data: { parkedAt: null, parkReason: null },
+      });
     });
   });
 

--- a/src/plugins/product/server/routers/problem.ts
+++ b/src/plugins/product/server/routers/problem.ts
@@ -41,6 +41,10 @@ export const problemRouter = createTRPCRouter({
         productId: z.string(),
         stage: problemStageEnum.optional(),
         category: z.string().optional(),
+        // Parked items are hidden by default — parked-ness is independent of
+        // stage (a Problem keeps its stage while parked). Pass true to include
+        // them (the table's "Show parked" toggle and the board's Parked lane).
+        includeParked: z.boolean().optional(),
       }),
     )
     .query(async ({ ctx, input }) => {
@@ -51,6 +55,7 @@ export const problemRouter = createTRPCRouter({
           productId: input.productId,
           ...(input.stage ? { stage: input.stage } : {}),
           ...(input.category ? { category: input.category } : {}),
+          ...(input.includeParked ? {} : { parkedAt: null }),
         },
         orderBy: [{ createdAt: "desc" }],
         include: {
@@ -167,6 +172,38 @@ export const problemRouter = createTRPCRouter({
       await loadProblemWithAccess(ctx.db, ctx.session.user.id, input.id);
       await ctx.db.problem.delete({ where: { id: input.id } });
       return { success: true };
+    }),
+
+  // ── Parking ───────────────────────────────────────────────────────────
+  // An item that didn't pass its gate is set aside WITH A REASON, never
+  // deleted — and can be revived later at the stage it left. Parked-ness is
+  // independent of `stage` (it is NOT a status value).
+
+  park: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        reason: boundedText("Reason", TEXT_LIMITS.MEDIUM, { min: 1 }),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await loadProblemWithAccess(ctx.db, ctx.session.user.id, input.id);
+      return ctx.db.problem.update({
+        where: { id: input.id },
+        data: { parkedAt: new Date(), parkReason: input.reason },
+      });
+    }),
+
+  unpark: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await loadProblemWithAccess(ctx.db, ctx.session.user.id, input.id);
+      // Clearing parkedAt/parkReason restores the item at its prior stage,
+      // which was never touched while parked.
+      return ctx.db.problem.update({
+        where: { id: input.id },
+        data: { parkedAt: null, parkReason: null },
+      });
     }),
 
   // ── Approaches (Problem ↔ Project links) ──────────────────────────────


### PR DESCRIPTION
## What

Implements **Parking** for Problems. Per the triage process, an item that doesn't pass its gate is set aside **with a reason** — never deleted — and can be revived later at the stage it left. The `parkedAt`/`parkReason` columns already exist (from the Problem-spine slice); this slice adds the behaviour + UI.

- `park` mutation (sets `parkedAt = now`, stores `parkReason`) and `unpark` (clears both — the Problem keeps its `stage`, so it reappears exactly where it was).
- `list` gains `includeParked` (default false): parked items are hidden unless explicitly requested.
- **Park** action on a Problem (table row menu + board card) that prompts for a reason via a modal.
- Parked-ness is **independent of `stage`**: parked items are hidden from the active table and board by default.
- Table: a **"Show parked"** toggle reveals parked rows (dimmed, with Unpark + reason tooltip). Board: a **Parked** lane reveals parked cards (with Unpark + reason); dragging an active card onto the Parked lane opens the reason prompt.

## Acceptance criteria

- [x] `park`/`unpark` mutations; `list` excludes parked items unless explicitly requested
- [x] Park action prompts for a reason; the reason is stored and shown on the parked item
- [x] Parked items disappear from the active table/board; "Show parked" reveals them; un-park restores the item at its prior stage
- [x] No hardcoded colors; typecheck + 628 unit tests pass

---

Ships: hasty.hen

🤖 Generated with [Claude Code](https://claude.com/claude-code)