### PR TITLE
feat(activity): record project completions in workspace feed

### DIFF
--- a/src/app/_components/home/activity/ActivityFeed.tsx
+++ b/src/app/_components/home/activity/ActivityFeed.tsx
@@ -9,6 +9,7 @@ import {
   IconMessageCircle,
   IconRefresh,
   IconStatusChange,
+  IconTrophy,
   type Icon as TablerIcon,
 } from '@tabler/icons-react';
 import Link from 'next/link';
@@ -22,6 +23,7 @@ const ICON_BY_KIND: Record<IconKind, TablerIcon> = {
   status_changed: IconStatusChange,
   completed: IconCheck,
   commented: IconMessageCircle,
+  milestone: IconTrophy,
   fallback: IconRefresh,
 };
 
@@ -192,7 +194,11 @@ export function ActivityFeed() {
             const Icon = ICON_BY_KIND[event.hint.iconKind] ?? IconRefresh;
             const actorName = event.actor?.name ?? 'Someone';
             return (
-              <div key={event.id} className="wsa-feed__row">
+              <div
+                key={event.id}
+                className="wsa-feed__row"
+                data-kind={event.hint.iconKind}
+              >
                 <div
                   className={`wsa-feed__avatar${event.actor ? '' : ' wsa-feed__avatar--anonymous'}`}
                   aria-hidden="true"

--- a/src/app/_components/home/activity/WorkspaceActivityFullFeed.tsx
+++ b/src/app/_components/home/activity/WorkspaceActivityFullFeed.tsx
@@ -9,6 +9,7 @@ import {
   IconMessageCircle,
   IconRefresh,
   IconStatusChange,
+  IconTrophy,
   type Icon as TablerIcon,
 } from '@tabler/icons-react';
 import { useState } from 'react';
@@ -24,6 +25,7 @@ const ICON_BY_KIND: Record<IconKind, TablerIcon> = {
   status_changed: IconStatusChange,
   completed: IconCheck,
   commented: IconMessageCircle,
+  milestone: IconTrophy,
   fallback: IconRefresh,
 };
 
@@ -232,7 +234,11 @@ export function WorkspaceActivityFullFeed() {
                 const Icon = ICON_BY_KIND[event.hint.iconKind] ?? IconRefresh;
                 const actorName = event.actor?.name ?? 'Someone';
                 return (
-                  <div key={event.id} className="wsa-feed__row">
+                  <div
+                    key={event.id}
+                    className="wsa-feed__row"
+                    data-kind={event.hint.iconKind}
+                  >
                     <div
                       className={`wsa-feed__avatar${event.actor ? '' : ' wsa-feed__avatar--anonymous'}`}
                       aria-hidden="true"

--- a/src/app/_components/home/activity/activity-home.css
+++ b/src/app/_components/home/activity/activity-home.css
@@ -990,6 +990,28 @@
 .wsa-feed__icon[data-kind='completed']      { color: var(--activity-accent-crm); }
 .wsa-feed__icon[data-kind='commented']      { color: var(--activity-accent-knowledge); }
 
+/* Milestone (completed project) — a filled gold chip instead of a tinted glyph,
+   so it reads as a celebration rather than another status change. */
+.wsa-feed__icon[data-kind='milestone'] {
+  color: var(--activity-accent-milestone-contrast);
+  background: var(--activity-accent-milestone);
+}
+
+/* Emphasized milestone row: soft gold wash, a gold left rail, and a touch more
+   breathing room so a completed project visibly punctuates the feed. */
+.wsa-feed__row[data-kind='milestone'] {
+  background: var(--activity-accent-milestone-soft);
+  border: 1px solid var(--activity-accent-milestone-border);
+  border-left-width: 3px;
+  border-radius: 8px;
+  padding-left: 10px;
+  padding-right: 10px;
+  margin: 4px 0;
+}
+.wsa-feed__row[data-kind='milestone'] .wsa-feed__entity {
+  color: var(--activity-accent-milestone);
+}
+
 .wsa-feed__footer {
   margin-top: 12px;
   padding-top: 10px;

--- a/src/server/api/routers/project.ts
+++ b/src/server/api/routers/project.ts
@@ -14,6 +14,7 @@ import {
   AccessControlService,
 } from "~/server/services/access";
 import { completeOnboardingStep } from "~/server/services/onboarding/syncOnboardingProgress";
+import { recordActivity } from "~/server/services/activity/recordActivity";
 import type { PrismaClient } from "@prisma/client";
 
 /**
@@ -397,6 +398,14 @@ export const projectRouter = createTRPCRouter({
         });
       }
 
+      // Snapshot the prior status so we only emit a "completed" activity event
+      // on the actual transition into COMPLETED (not on every re-save of an
+      // already-completed project).
+      const priorProject = await ctx.db.project.findUnique({
+        where: { id },
+        select: { status: true },
+      });
+
       // A product can only be linked to a project in the same workspace.
       if (productId) {
         let effectiveWorkspaceId: string | null;
@@ -465,6 +474,26 @@ export const projectRouter = createTRPCRouter({
           ...(enableBounties !== undefined ? { enableBounties } : {}),
         },
       });
+
+      // Record a milestone activity event when a project is newly completed.
+      // Fire-and-forget: recordActivity never throws, and a null workspaceId is
+      // skipped (personal projects with no workspace produce no feed entry).
+      if (
+        input.status === "COMPLETED" &&
+        priorProject?.status !== "COMPLETED" &&
+        updated.workspaceId
+      ) {
+        await recordActivity(ctx.db, {
+          workspaceId: updated.workspaceId,
+          userId: ctx.session.user.id,
+          entityType: "project",
+          entityId: updated.id,
+          action: "completed",
+          metadata: { name: updated.name },
+        }).catch(() => {
+          /* instrumentation failure is non-fatal */
+        });
+      }
 
       // Replace key result links when keyResultIds is provided
       if (keyResultIds !== undefined) {

--- a/src/server/services/activity/feedRenderHints.ts
+++ b/src/server/services/activity/feedRenderHints.ts
@@ -19,6 +19,7 @@ export type IconKind =
   | "status_changed"
   | "completed"
   | "commented"
+  | "milestone"
   | "fallback";
 
 export interface FeedRenderHint {
@@ -80,6 +81,13 @@ const HINTS: Record<string, FeedRenderHint> = {
   [key("ticket_comment", "created")]: {
     template: "{actor} commented on ticket {entityRef}",
     iconKind: "commented",
+  },
+
+  // Projects — completing a project is a milestone, so it gets the emphasized
+  // "milestone" icon kind (trophy + filled chip) to stand out from task churn.
+  [key("project", "completed")]: {
+    template: "{actor} completed project {entityRef}",
+    iconKind: "milestone",
   },
 };
 

--- a/src/server/services/activity/recordActivity.ts
+++ b/src/server/services/activity/recordActivity.ts
@@ -21,7 +21,8 @@ export type ActivityEntityType =
   | "action"
   | "action_comment"
   | "ticket"
-  | "ticket_comment";
+  | "ticket_comment"
+  | "project";
 
 export interface RecordActivityInput {
   workspaceId: string;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1269,6 +1269,13 @@
   --activity-accent-crm-border: rgba(74, 222, 140, 0.22);
   --activity-accent-due-soft: rgba(248, 113, 113, 0.10);
   --activity-accent-due-border: rgba(248, 113, 113, 0.22);
+
+  /* Milestone (project-completed) accent — celebratory gold. Filled chip plus a
+     soft wash so completed-project rows stand out from routine task churn. */
+  --activity-accent-milestone: #F5B94A;
+  --activity-accent-milestone-contrast: #1A1300;
+  --activity-accent-milestone-soft: rgba(245, 185, 74, 0.12);
+  --activity-accent-milestone-border: rgba(245, 185, 74, 0.34);
 }
 
 /* Pulsing dot used by active-timer indicators (sidebar widget, action surfaces,


### PR DESCRIPTION
## Record project completions in the workspace activity feed

Adds a `project_completed` activity event so finishing a project shows up in the workspace feed.

### Changes
- `recordActivity` / `feedRenderHints` — new `project_completed` activity kind + render hints.
- `project` router — record the completion activity when a project transitions to completed.
- `ActivityFeed` / `WorkspaceActivityFullFeed` — render the new event (icon + copy).
- Feed styling for the new event row.

Separated from the Weekly Plan redesign (PR #160) so each ships independently.
