### PR TITLE
feat(date-picker): standardize single-date pickers on UnifiedDatePicker

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/weekly-plan/_components/ProjectDateBadges.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/weekly-plan/_components/ProjectDateBadges.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Badge, Group, Tooltip } from "@mantine/core";
-import { DatePickerInput } from "@mantine/dates";
+import { Badge, Group } from "@mantine/core";
 import { IconCalendarEvent, IconCalendarDue } from "@tabler/icons-react";
 import { format, differenceInDays } from "date-fns";
-import { useState } from "react";
+import { UnifiedDatePicker } from "~/app/_components/UnifiedDatePicker";
 
 interface ProjectDateBadgesProps {
   projectId: string;
@@ -19,9 +18,6 @@ export function ProjectDateBadges({
   endDate,
   onUpdate,
 }: ProjectDateBadgesProps) {
-  const [isEditingStart, setIsEditingStart] = useState(false);
-  const [isEditingEnd, setIsEditingEnd] = useState(false);
-
   const getEndDateColor = (date: Date | null | undefined): string => {
     if (!date) return "gray";
 
@@ -43,6 +39,11 @@ export function ProjectDateBadges({
     return format(new Date(date), "MMM d, yyyy");
   };
 
+  const getStartDateTooltip = (date: Date | null | undefined): string => {
+    if (!date) return "Click to set start date";
+    return format(new Date(date), "EEEE, MMMM d, yyyy");
+  };
+
   const getEndDateTooltip = (date: Date | null | undefined): string => {
     if (!date) return "No due date set";
 
@@ -62,64 +63,48 @@ export function ProjectDateBadges({
   return (
     <Group gap="sm">
       {/* Start Date */}
-      {isEditingStart ? (
-        <DatePickerInput
-          placeholder="Select start date"
-          value={startDate ? new Date(startDate) : null}
-          onChange={(value) => {
-            onUpdate({ startDate: value });
-            setIsEditingStart(false);
-          }}
-          clearable
-          popoverProps={{ opened: true, onClose: () => setIsEditingStart(false) }}
-          size="xs"
-          w={180}
-          leftSection={<IconCalendarEvent size={14} />}
-        />
-      ) : (
-        <Tooltip label={startDate ? format(new Date(startDate), "EEEE, MMMM d, yyyy") : "Click to set start date"} withArrow>
+      <UnifiedDatePicker
+        value={startDate ? new Date(startDate) : null}
+        onChange={(date) => onUpdate({ startDate: date })}
+        notificationContext="project start date"
+        onClear={() => onUpdate({ startDate: null })}
+        leftSection={<IconCalendarEvent size={14} />}
+        renderTrigger={({ toggle }) => (
           <Badge
             size="lg"
             variant="light"
             color="gray"
             leftSection={<IconCalendarEvent size={14} />}
             className="cursor-pointer"
-            onClick={() => setIsEditingStart(true)}
+            onClick={toggle}
+            title={getStartDateTooltip(startDate)}
           >
             Start: {formatDateBadge(startDate)}
           </Badge>
-        </Tooltip>
-      )}
+        )}
+      />
 
       {/* End Date */}
-      {isEditingEnd ? (
-        <DatePickerInput
-          placeholder="Select due date"
-          value={endDate ? new Date(endDate) : null}
-          onChange={(value) => {
-            onUpdate({ endDate: value });
-            setIsEditingEnd(false);
-          }}
-          clearable
-          popoverProps={{ opened: true, onClose: () => setIsEditingEnd(false) }}
-          size="xs"
-          w={180}
-          leftSection={<IconCalendarDue size={14} />}
-        />
-      ) : (
-        <Tooltip label={getEndDateTooltip(endDate)} withArrow>
+      <UnifiedDatePicker
+        value={endDate ? new Date(endDate) : null}
+        onChange={(date) => onUpdate({ endDate: date })}
+        notificationContext="project due date"
+        onClear={() => onUpdate({ endDate: null })}
+        leftSection={<IconCalendarDue size={14} />}
+        renderTrigger={({ toggle }) => (
           <Badge
             size="lg"
             variant="light"
             color={getEndDateColor(endDate)}
             leftSection={<IconCalendarDue size={14} />}
             className="cursor-pointer"
-            onClick={() => setIsEditingEnd(true)}
+            onClick={toggle}
+            title={getEndDateTooltip(endDate)}
           >
             Due: {formatDateBadge(endDate)}
           </Badge>
-        </Tooltip>
-      )}
+        )}
+      />
     </Group>
   );
 }

--- a/src/app/_components/CreateDayModal.tsx
+++ b/src/app/_components/CreateDayModal.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Modal, Button, Group, Select } from '@mantine/core';
+import { Modal, Button, Group, Select, Input } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { useState } from "react";
 import { api } from "~/trpc/react";
-import { DateInput } from '@mantine/dates';
+import { UnifiedDatePicker } from '~/app/_components/UnifiedDatePicker';
 
 interface CreateDayModalProps {
   children: React.ReactNode;
@@ -83,24 +83,16 @@ export function CreateDayModal({ children }: CreateDayModalProps) {
           }}
           className="p-4"
         >
-          <DateInput
-            value={date}
-            onChange={setDate}
-            label="Select date"
-            placeholder="Pick a date"
-            required
-            mt="md"
-            styles={{
-              input: {
-                backgroundColor: 'var(--color-surface-secondary)',
-                color: 'var(--color-text-primary)',
-                borderColor: 'var(--color-border-primary)',
-              },
-              label: {
-                color: 'var(--color-text-primary)',
-              },
-            }}
-          />
+          <Input.Wrapper label="Select date" required mt="md">
+            <div>
+              <UnifiedDatePicker
+                value={date}
+                onChange={setDate}
+                placeholder="Pick a date"
+                notificationContext="day"
+              />
+            </div>
+          </Input.Wrapper>
           
           <Select
             label="Select week"

--- a/src/app/_components/CreateEpicModal.tsx
+++ b/src/app/_components/CreateEpicModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button, Group, Modal, Select, Stack, TextInput, Textarea } from '@mantine/core';
-import { DateInput } from '@mantine/dates';
+import { Button, Group, Modal, Select, Stack, TextInput, Textarea, Input } from '@mantine/core';
+import { UnifiedDatePicker } from '~/app/_components/UnifiedDatePicker';
 import { useState } from 'react';
 import { api } from '~/trpc/react';
 import { EPIC_PRIORITY_OPTIONS } from '~/types/epic';
@@ -121,22 +121,26 @@ export function CreateEpicModal({ opened, onClose, workspaceId, onCreated }: Cre
         />
 
         <Group grow>
-          <DateInput
-            label="Start Date"
-            value={startDate}
-            onChange={setStartDate}
-            placeholder="Optional"
-            clearable
-            styles={inputStyles}
-          />
-          <DateInput
-            label="Target Date"
-            value={targetDate}
-            onChange={setTargetDate}
-            placeholder="Optional"
-            clearable
-            styles={inputStyles}
-          />
+          <Input.Wrapper label="Start Date">
+            <div>
+              <UnifiedDatePicker
+                value={startDate}
+                onChange={setStartDate}
+                placeholder="Optional"
+                notificationContext="epic"
+              />
+            </div>
+          </Input.Wrapper>
+          <Input.Wrapper label="Target Date">
+            <div>
+              <UnifiedDatePicker
+                value={targetDate}
+                onChange={setTargetDate}
+                placeholder="Optional"
+                notificationContext="epic"
+              />
+            </div>
+          </Input.Wrapper>
         </Group>
 
         <Group justify="flex-end" mt="sm">

--- a/src/app/_components/CreateMeetingModal.tsx
+++ b/src/app/_components/CreateMeetingModal.tsx
@@ -11,8 +11,10 @@ import {
   NumberInput,
   Text,
   Alert,
+  Input,
 } from "@mantine/core";
-import { DateInput, TimeInput } from "@mantine/dates";
+import { TimeInput } from "@mantine/dates";
+import { UnifiedDatePicker } from "~/app/_components/UnifiedDatePicker";
 import { useDisclosure } from "@mantine/hooks";
 import { useState, useEffect } from "react";
 import { api } from "~/trpc/react";
@@ -223,14 +225,17 @@ export function CreateMeetingModal({
               />
 
               <Group grow>
-                <DateInput
-                  label="Date"
-                  placeholder="Select date"
-                  value={meetingDate}
-                  onChange={setMeetingDate}
-                  required
-                  minDate={new Date()}
-                />
+                <Input.Wrapper label="Date" required>
+                  <div>
+                    <UnifiedDatePicker
+                      value={meetingDate}
+                      onChange={setMeetingDate}
+                      placeholder="Select date"
+                      notificationContext="meeting"
+                      minDate={new Date()}
+                    />
+                  </div>
+                </Input.Wrapper>
                 <TimeInput
                   label="Start Time"
                   value={startTime}

--- a/src/app/_components/CreateOutcomeModal.tsx
+++ b/src/app/_components/CreateOutcomeModal.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { Modal, Button, Group, TextInput, Select, Textarea } from '@mantine/core';
+import { Modal, Button, Group, TextInput, Select, Textarea, Input } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import { useDisclosure } from '@mantine/hooks';
 import { useState, useEffect } from "react";
 import { api } from "~/trpc/react";
-import { DateInput } from '@mantine/dates';
+import { UnifiedDatePicker } from '~/app/_components/UnifiedDatePicker';
 import { CreateGoalModal } from './CreateGoalModal';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 
@@ -377,41 +377,16 @@ export function CreateOutcomeModal({ children, projectId, outcome, trigger, onSu
             }}
           />
           
-          <DateInput
-            value={dueDate}
-            onChange={setDueDate}
-            label="Due date (optional)"
-            placeholder="Pick a date"
-            mt="md"
-            highlightToday={true}
-            styles={{
-              input: {
-                backgroundColor: 'var(--color-surface-secondary)',
-                color: 'var(--color-text-primary)',
-                borderColor: 'var(--color-border-primary)',
-              },
-              label: {
-                color: 'var(--color-text-primary)',
-              },
-
-              calendarHeader: {
-                backgroundColor: 'var(--color-surface-secondary)',
-                color: 'var(--color-text-primary)',
-              },
-              monthCell: {
-                color: 'var(--color-text-primary)',
-              },
-              month: {
-                color: 'var(--color-text-primary)',
-              },
-              weekday: {
-                color: 'var(--color-text-muted)',
-              },
-              day: {
-                color: 'var(--color-text-primary)',
-              },
-            }}
-          />
+          <Input.Wrapper label="Due date (optional)" mt="md">
+            <div>
+              <UnifiedDatePicker
+                value={dueDate}
+                onChange={setDueDate}
+                placeholder="Pick a date"
+                notificationContext="outcome"
+              />
+            </div>
+          </Input.Wrapper>
 
           {outcome && workspaces && workspaces.length > 0 && (
             <Select

--- a/src/app/_components/CreateProjectModal.tsx
+++ b/src/app/_components/CreateProjectModal.tsx
@@ -1,5 +1,5 @@
-import { Modal, TextInput, Textarea, Button, Group, Select, MultiSelect, Tooltip, Stack, Title, Text, Alert, Loader, Switch } from '@mantine/core';
-import { DateInput } from '@mantine/dates';
+import { Modal, TextInput, Textarea, Button, Group, Select, MultiSelect, Tooltip, Stack, Title, Text, Alert, Loader, Switch, Input } from '@mantine/core';
+import { UnifiedDatePicker } from '~/app/_components/UnifiedDatePicker';
 import { IconAlertCircle, IconBrandNotion, IconCheck, IconPlus } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useDisclosure } from '@mantine/hooks';
@@ -425,34 +425,26 @@ export function CreateProjectModal({ children, project, prefillName, prefillNoti
           />
 
           <Group grow mt="md" align="flex-start">
-            <DateInput
-              label="Start date"
-              placeholder="Select start date"
-              value={startDate}
-              onChange={setStartDate}
-              clearable
-              styles={{
-                input: {
-                  backgroundColor: 'var(--color-surface-secondary)',
-                  color: 'var(--color-text-primary)',
-                  borderColor: 'var(--color-border-primary)',
-                },
-              }}
-            />
-            <DateInput
-              label="End date"
-              placeholder="Select end date"
-              value={endDate}
-              onChange={setEndDate}
-              clearable
-              styles={{
-                input: {
-                  backgroundColor: 'var(--color-surface-secondary)',
-                  color: 'var(--color-text-primary)',
-                  borderColor: 'var(--color-border-primary)',
-                },
-              }}
-            />
+            <Input.Wrapper label="Start date">
+              <div>
+                <UnifiedDatePicker
+                  value={startDate}
+                  onChange={setStartDate}
+                  placeholder="Select start date"
+                  notificationContext="project"
+                />
+              </div>
+            </Input.Wrapper>
+            <Input.Wrapper label="End date">
+              <div>
+                <UnifiedDatePicker
+                  value={endDate}
+                  onChange={setEndDate}
+                  placeholder="Select end date"
+                  notificationContext="project"
+                />
+              </div>
+            </Input.Wrapper>
           </Group>
 
           <Tooltip

--- a/src/app/_components/CreateTranscriptionModal.tsx
+++ b/src/app/_components/CreateTranscriptionModal.tsx
@@ -7,8 +7,9 @@ import {
   TextInput,
   Textarea,
   Stack,
+  Input,
 } from "@mantine/core";
-import { DateInput } from "@mantine/dates";
+import { UnifiedDatePicker } from "~/app/_components/UnifiedDatePicker";
 import { useDisclosure } from "@mantine/hooks";
 import { useState } from "react";
 import { api } from "~/trpc/react";
@@ -126,18 +127,16 @@ export function CreateTranscriptionModal({
               onChange={(e) => setDescription(e.target.value)}
             />
 
-            <DateInput
-              label="Meeting Date"
-              placeholder="When did the meeting occur?"
-              value={meetingDate}
-              onChange={setMeetingDate}
-              clearable
-              valueFormat="MMMM D, YYYY"
-              popoverProps={{
-                withinPortal: true,
-                zIndex: 1000,
-              }}
-            />
+            <Input.Wrapper label="Meeting Date">
+              <div>
+                <UnifiedDatePicker
+                  value={meetingDate}
+                  onChange={setMeetingDate}
+                  placeholder="When did the meeting occur?"
+                  notificationContext="meeting"
+                />
+              </div>
+            </Input.Wrapper>
 
             <Textarea
               label="Transcript"

--- a/src/app/_components/UnifiedDatePicker.tsx
+++ b/src/app/_components/UnifiedDatePicker.tsx
@@ -10,27 +10,42 @@ import { useMediaQuery } from "@mantine/hooks";
 import {
   IconCalendar,
   IconX,
-  IconClock,
 } from "@tabler/icons-react";
 import { notifications } from "@mantine/notifications";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
+
+interface RenderTriggerArgs {
+  opened: boolean;
+  toggle: () => void;
+  value: Date | null;
+}
 
 interface UnifiedDatePickerProps {
   // Core functionality
   value: Date | null;
   onChange: (date: Date | null) => void;
-  
+
   // Display modes
   mode?: 'single' | 'bulk';
-  
+
   // Bulk mode specific
   selectedCount?: number;
-  
+
   // Customization
   triggerText?: string; // For bulk: "Reschedule Selected", for single: auto-generate from date
+  placeholder?: string; // Text shown in the pill when no value is selected (default "Date")
+  leftSection?: ReactNode; // Override the trigger icon (e.g. IconCalendarEvent vs IconCalendarDue)
   disabled?: boolean;
   notificationContext?: string; // "task", "bulk actions", etc.
-  
+
+  // Constraints
+  minDate?: Date;
+  maxDate?: Date;
+
+  // Custom trigger — render your own Popover target (e.g. a coloured Badge) while reusing
+  // the standard calendar popover. Receives { opened, toggle, value }; wire toggle to onClick.
+  renderTrigger?: (args: RenderTriggerArgs) => ReactNode;
+
   // Legacy support
   onClear?: () => void; // For backwards compatibility
 }
@@ -69,40 +84,43 @@ const getQuickOptions = () => [
   { label: "No Date", date: null, icon: "⭕", color: "var(--color-text-muted)" },
 ];
 
-export function UnifiedDatePicker({ 
+export function UnifiedDatePicker({
   value,
   onChange,
   mode = 'single',
   selectedCount = 1,
   triggerText,
+  placeholder = "Date",
+  leftSection,
   disabled = false,
   notificationContext = 'task',
+  minDate,
+  maxDate,
+  renderTrigger,
   onClear
 }: UnifiedDatePickerProps) {
   const [opened, setOpened] = useState(false);
-  const [calendarDate, setCalendarDate] = useState<Date | null>(null);
   const isMobile = useMediaQuery('(max-width: 640px)');
 
   const isToday = value?.toDateString() === new Date().toDateString();
   const isBulkMode = mode === 'bulk';
 
+  // Keep a date-only copy outside [minDate, maxDate] from being offered as a quick option.
+  const isWithinRange = (date: Date): boolean => {
+    if (minDate && date < minDate) return false;
+    if (maxDate && date > maxDate) return false;
+    return true;
+  };
+
   const handleDateSelect = (date: Date | null) => {
-    // Add debugging for date selection to verify fresh dates are being used
-    console.log('🗓️ [DATE PICKER DEBUG] Date selected:', {
-      date: date?.toISOString() || null,
-      label: date ? (date.toDateString() === new Date().toDateString() ? 'Today' : date.toDateString()) : 'No Date',
-      isFreshToday: date ? date.toDateString() === new Date().toDateString() : false,
-      timestamp: new Date().toISOString()
-    });
-    
     onChange(date);
     setOpened(false);
-    
+
     // Call legacy onClear callback if provided and date is null
     if (!date && onClear) {
       onClear();
     }
-    
+
     // Show appropriate notifications based on mode
     if (isBulkMode) {
       if (date) {
@@ -148,11 +166,7 @@ export function UnifiedDatePicker({
     }
   };
 
-  const handleCalendarSelect = (date: Date | null) => {
-    if (date) {
-      handleDateSelect(date);
-    }
-  };
+  const triggerIcon = leftSection ?? <IconCalendar size={16} />;
 
   // Generate trigger button content based on mode
   const getTriggerContent = () => {
@@ -160,8 +174,8 @@ export function UnifiedDatePicker({
       // Bulk mode or custom text
       return (
         <Group gap="xs">
-          <IconCalendar size={16} />
-          <Text size="sm">{triggerText || "Reschedule Selected"}</Text>
+          {triggerIcon}
+          <Text size="sm">{triggerText ?? "Reschedule Selected"}</Text>
         </Group>
       );
     }
@@ -170,8 +184,8 @@ export function UnifiedDatePicker({
     if (!value) {
       return (
         <Group gap="xs">
-          <IconCalendar size={16} />
-          <Text size="sm">Date</Text>
+          {triggerIcon}
+          <Text size="sm">{placeholder}</Text>
         </Group>
       );
     }
@@ -190,7 +204,7 @@ export function UnifiedDatePicker({
 
     return (
       <Group gap="xs">
-        <IconCalendar size={16} />
+        {triggerIcon}
         <Text size="sm">
           {value.toLocaleDateString("en-US", {
             day: "numeric",
@@ -202,6 +216,8 @@ export function UnifiedDatePicker({
     );
   };
 
+  const toggle = () => setOpened((o) => !o);
+
   return (
     <Popover
       width={isMobile ? 'calc(100vw - 48px)' : 300}
@@ -212,60 +228,67 @@ export function UnifiedDatePicker({
       middlewares={{ flip: true, shift: true }}
     >
       <Popover.Target>
-        <UnstyledButton
-          onClick={() => setOpened((o) => !o)}
-          disabled={disabled}
-          className={`rounded px-3 py-1.5 ${
-            disabled 
-              ? 'bg-surface-tertiary cursor-not-allowed opacity-50' 
-              : isBulkMode 
-                ? 'bg-surface-secondary hover:bg-surface-hover'
-                : !value 
-                  ? "bg-surface-secondary hover:bg-surface-hover" 
-                  : "bg-surface-tertiary hover:bg-surface-hover"
-          } flex items-center transition-colors`}
-        >
-          {getTriggerContent()}
-        </UnstyledButton>
+        {renderTrigger ? (
+          renderTrigger({ opened, toggle, value })
+        ) : (
+          <UnstyledButton
+            onClick={toggle}
+            disabled={disabled}
+            className={`rounded px-3 py-1.5 ${
+              disabled
+                ? 'bg-surface-tertiary cursor-not-allowed opacity-50'
+                : isBulkMode
+                  ? 'bg-surface-secondary hover:bg-surface-hover'
+                  : !value
+                    ? "bg-surface-secondary hover:bg-surface-hover"
+                    : "bg-surface-tertiary hover:bg-surface-hover"
+            } flex items-center transition-colors`}
+          >
+            {getTriggerContent()}
+          </UnstyledButton>
+        )}
       </Popover.Target>
-      
+
       <Popover.Dropdown p={0}>
         <Stack gap="xs" p="md">
-          {getQuickOptions().map((option) => (
-            <UnstyledButton
-              key={option.label}
-              onClick={() => handleDateSelect(option.date)}
-              className="flex items-center justify-between rounded p-2 hover:bg-surface-hover"
-            >
-              <Group gap="sm">
-                <Text size="lg" style={{ color: option.color }}>
-                  {option.icon}
-                </Text>
-                <Text>{option.label}</Text>
-              </Group>
-              {option.date && (
-                <Text size="sm" c="dimmed">
-                  {option.date.toLocaleDateString("en-US", {
-                    weekday: "short",
-                    day: "numeric",
-                    month: "short",
-                  })}
-                </Text>
-              )}
-            </UnstyledButton>
-          ))}
+          {getQuickOptions()
+            .filter((option) => !option.date || isWithinRange(option.date))
+            .map((option) => (
+              <UnstyledButton
+                key={option.label}
+                onClick={() => handleDateSelect(option.date)}
+                className="flex items-center justify-between rounded p-2 hover:bg-surface-hover"
+              >
+                <Group gap="sm">
+                  <Text size="lg" style={{ color: option.color }}>
+                    {option.icon}
+                  </Text>
+                  <Text>{option.label}</Text>
+                </Group>
+                {option.date && (
+                  <Text size="sm" c="dimmed">
+                    {option.date.toLocaleDateString("en-US", {
+                      weekday: "short",
+                      day: "numeric",
+                      month: "short",
+                    })}
+                  </Text>
+                )}
+              </UnstyledButton>
+            ))}
 
           <div className="mt-2 border-t border-border-primary pt-2">
             <DatePicker
-              value={calendarDate}
+              value={value}
               onChange={(date) => {
-                setCalendarDate(date);
                 if (date) {
-                  handleCalendarSelect(date);
+                  handleDateSelect(date);
                 }
               }}
               size="sm"
               highlightToday={true}
+              minDate={minDate}
+              maxDate={maxDate}
               classNames={{
                 day: 'unified-datepicker-day'
               }}
@@ -278,11 +301,6 @@ export function UnifiedDatePicker({
                 }
               }}
             />
-
-            <UnstyledButton className="mt-2 flex w-full items-center justify-center gap-2 border-t border-border-primary p-3 hover:bg-surface-hover">
-              <IconClock size={16} />
-              <Text>Time</Text>
-            </UnstyledButton>
           </div>
         </Stack>
       </Popover.Dropdown>

--- a/src/app/_components/WeeklyOutcomeModal.tsx
+++ b/src/app/_components/WeeklyOutcomeModal.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { Modal, TextInput, Textarea, Select, MultiSelect, Button, Group, Text, Stack } from "@mantine/core";
-import { DatePickerInput } from "@mantine/dates";
+import { Modal, TextInput, Textarea, Select, MultiSelect, Button, Group, Text, Stack, Input } from "@mantine/core";
+import { UnifiedDatePicker } from "~/app/_components/UnifiedDatePicker";
 import { api } from "~/trpc/react";
 import { notifications } from "@mantine/notifications";
 
@@ -155,14 +155,18 @@ export function WeeklyOutcomeModal({
               required
             />
             
-            <DatePickerInput
-              label="Due Date (Optional)"
-              placeholder="Select due date"
-              value={dueDate}
-              onChange={setDueDate}
-              minDate={weekStartDate}
-              maxDate={new Date(weekStartDate.getTime() + 6 * 24 * 60 * 60 * 1000)} // End of week
-            />
+            <Input.Wrapper label="Due Date (Optional)">
+              <div>
+                <UnifiedDatePicker
+                  value={dueDate}
+                  onChange={setDueDate}
+                  placeholder="Select due date"
+                  notificationContext="outcome"
+                  minDate={weekStartDate}
+                  maxDate={new Date(weekStartDate.getTime() + 6 * 24 * 60 * 60 * 1000)} // End of week
+                />
+              </div>
+            </Input.Wrapper>
           </Group>
           
           <MultiSelect

--- a/src/app/_components/pipeline/CreateDealModal.tsx
+++ b/src/app/_components/pipeline/CreateDealModal.tsx
@@ -10,8 +10,9 @@ import {
   Button,
   Group,
   Stack,
+  Input,
 } from "@mantine/core";
-import { DateInput } from "@mantine/dates";
+import { UnifiedDatePicker } from "~/app/_components/UnifiedDatePicker";
 import { api } from "~/trpc/react";
 import { notifications } from "@mantine/notifications";
 
@@ -203,13 +204,16 @@ export function CreateDealModal({
           clearable
         />
 
-        <DateInput
-          label="Expected Close Date"
-          placeholder="Select date"
-          value={expectedCloseDate}
-          onChange={setExpectedCloseDate}
-          clearable
-        />
+        <Input.Wrapper label="Expected Close Date">
+          <div>
+            <UnifiedDatePicker
+              value={expectedCloseDate}
+              onChange={setExpectedCloseDate}
+              placeholder="Select date"
+              notificationContext="deal"
+            />
+          </div>
+        </Input.Wrapper>
 
         <Group justify="flex-end" mt="sm">
           <Button variant="subtle" onClick={onClose}>

--- a/src/app/_components/pipeline/DealDetailDrawer.tsx
+++ b/src/app/_components/pipeline/DealDetailDrawer.tsx
@@ -15,8 +15,9 @@ import {
   Loader,
   NumberInput,
   TextInput,
+  Input,
 } from "@mantine/core";
-import { DateInput } from "@mantine/dates";
+import { UnifiedDatePicker } from "~/app/_components/UnifiedDatePicker";
 import {
   IconArrowRight,
   IconCurrencyDollar,
@@ -216,12 +217,16 @@ export function DealDetailDrawer({
                   onChange={(val) => setEditProbability(typeof val === "number" ? val : undefined)}
                 />
               </Group>
-              <DateInput
-                label="Expected Close Date"
-                value={editExpectedCloseDate}
-                onChange={setEditExpectedCloseDate}
-                clearable
-              />
+              <Input.Wrapper label="Expected Close Date">
+                <div>
+                  <UnifiedDatePicker
+                    value={editExpectedCloseDate}
+                    onChange={setEditExpectedCloseDate}
+                    placeholder="Select date"
+                    notificationContext="deal"
+                  />
+                </div>
+              </Input.Wrapper>
             </Stack>
           ) : (
             <Stack gap="xs">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -632,7 +632,7 @@
   color: var(--color-text-disabled);
 }
 .mantine-DateInput-day[data-today] {
-  background-color: var(--color-brand-success);
+  background-color: var(--color-brand-primary);
   color: var(--color-text-inverse);
   font-weight: 600;
 }
@@ -653,7 +653,7 @@
   color: var(--color-text-disabled);
 }
 .mantine-DatePicker-day[data-today] {
-  background-color: var(--color-brand-error);
+  background-color: var(--color-brand-primary);
   color: var(--color-text-inverse);
   font-weight: 600;
 }


### PR DESCRIPTION
## Why

Date pickers were inconsistent on every page. The weekly-plan **Project Pass** calendar was the visible offender — a bare Mantine `DatePickerInput` forced open via `popoverProps={{ opened: true }}`, rendering Mantine's default inline calendar. Across the app, single-date pickers used a mix of bare `DateInput`/`DatePickerInput` with hand-rolled inline `styles`, different widths, and — critically — **three different "today" highlight colors** (green for `DateInput`, red for `DatePicker`, blue for the reference picker).

The CreateActionModal picker (`UnifiedDatePicker`) is the agreed-correct reference. This PR promotes it into the single standard single-date component and rolls it out.

## What

- **Converge calendar CSS** (`globals.css`): the `[data-today]` color is now `--color-brand-primary` across `DateInput`/`DatePicker`, so every calendar in the app — including the out-of-scope range pickers and read-only month views — highlights today identically.
- **Promote `UnifiedDatePicker`** as the standard: added `placeholder`, `leftSection` (start vs due icons), `minDate`/`maxDate` (out-of-range quick options filtered), and an optional `renderTrigger` for custom triggers. The inner calendar now reflects the current value. Removed a leftover `console.log` and the non-functional "Time" button. Toasts on change preserved.
- **Fix the weekly-plan screenshot** (`ProjectDateBadges`): dropped the force-open hack; the urgency-colored badge is kept as a custom trigger that opens the standard styled popover.
- **Migrate 9 form modals** to the pill trigger (label via `Input.Wrapper`), dropping inline `styles`: CreateProject, CreateEpic, CreateOutcome, CreateMeeting, CreateTranscription, CreateDay, CreateDeal, DealDetailDrawer, WeeklyOutcome (min/max preserved).

## Scope decisions (per request)

- **Single-date pickers only.** Range pickers, date+time pickers, and read-only month calendars keep their own components and just inherit the unified today-color CSS.
- **Button/pill trigger everywhere**, including inside forms.
- **Toasts kept everywhere.**
- `DeadlinePicker` (date+time for action deadlines) left as-is.

## Verification

- Typecheck: all changed files clean.
- ESLint: 0 errors/warnings on changed files.
- Pre-commit hook: 528 unit tests pass, migration check + hardcoded-color check pass.

> Note: `tsc` reports pre-existing errors in `src/server/api/routers/calendar.ts` (stale generated Prisma client — `accountId` on `CalendarPreference`). Unrelated to this PR; cleared by `npx prisma generate`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced date picker with support for custom triggers, date range constraints, and placeholder text across the application.

* **Refactor**
  * Standardized date picker implementation across all date selection fields (projects, epics, meetings, outcomes, deals, and more) for consistent behavior.

* **Style**
  * Updated calendar day highlighting colors for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->