### PR TITLE
fix: address CodeRabbit review (ConnectedAccount release)

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -11,9 +11,13 @@ export const dynamic = "force-dynamic";
  * confirm *what* is live without guessing. On Vercel, `VERCEL_GIT_COMMIT_SHA`
  * is injected at build + runtime; locally it's usually unset.
  *
- * GET /api/health  →  { status, commit, branch, builtAt? }
+ * GET /api/health  →  { status, commit, shortCommit, branch, env }
+ *   - commit:      full SHA (or "unknown" locally)
+ *   - shortCommit: first 8 chars of the SHA (or "unknown")
+ *   - branch:      VERCEL_GIT_COMMIT_REF, or null
+ *   - env:         VERCEL_ENV / NODE_ENV, or null
  */
-export function GET() {
+export function GET(): NextResponse {
   const commit =
     process.env.VERCEL_GIT_COMMIT_SHA ??
     process.env.GIT_COMMIT_SHA ??

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -609,20 +609,21 @@ export const keyResultRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       // Authorize the KR by ownership OR workspace membership — the weekly-plan
       // KR pool (getByObjective) is workspace-scoped, so a member must be able
-      // to link a KR owned by another member of the same workspace. Matches the
-      // authorization model used by getByIds.
+      // to link a KR owned by another member of the same workspace. Uses the
+      // centralized resolver so team-derived workspace access is honored (the
+      // inline members.some check missed team membership).
       const userId = ctx.session.user.id;
       const keyResult = await ctx.db.keyResult.findFirst({
-        where: {
-          id: input.keyResultId,
-          OR: [
-            { userId },
-            { workspace: { members: { some: { userId } } } },
-          ],
-        },
+        where: { id: input.keyResultId },
+        select: { id: true, userId: true, workspaceId: true },
       });
 
-      if (!keyResult) {
+      if (
+        !keyResult ||
+        (keyResult.userId !== userId &&
+          !(keyResult.workspaceId &&
+            (await getWorkspaceMembership(ctx.db, userId, keyResult.workspaceId))))
+      ) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Key result not found",
@@ -666,19 +667,20 @@ export const keyResultRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       // Authorize the KR by ownership OR workspace membership (mirrors
-      // linkProject / getByIds) so members can unlink workspace-shared KRs.
+      // linkProject) via the centralized resolver, so team-derived workspace
+      // access is honored when unlinking workspace-shared KRs.
       const userId = ctx.session.user.id;
       const keyResult = await ctx.db.keyResult.findFirst({
-        where: {
-          id: input.keyResultId,
-          OR: [
-            { userId },
-            { workspace: { members: { some: { userId } } } },
-          ],
-        },
+        where: { id: input.keyResultId },
+        select: { id: true, userId: true, workspaceId: true },
       });
 
-      if (!keyResult) {
+      if (
+        !keyResult ||
+        (keyResult.userId !== userId &&
+          !(keyResult.workspaceId &&
+            (await getWorkspaceMembership(ctx.db, userId, keyResult.workspaceId))))
+      ) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Key result not found",

--- a/src/server/api/routers/__tests__/calendar.test.ts
+++ b/src/server/api/routers/__tests__/calendar.test.ts
@@ -29,8 +29,7 @@ vi.hoisted(() => {
 
 vi.mock("openai", () => ({
   default: class MockOpenAI {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    constructor(_opts?: any) {
+    constructor(_opts?: unknown) {
       // intentionally empty
     }
   },

--- a/src/server/api/routers/calendar.ts
+++ b/src/server/api/routers/calendar.ts
@@ -178,7 +178,10 @@ export const calendarRouter = createTRPCRouter({
       const provider = input?.provider ?? "google";
       const accountProvider = getAccountProvider(provider);
 
-      const account = await ctx.db.connectedAccount.findFirst({
+      // Aggregate across ALL of the user's connected accounts for this
+      // provider — a user can connect several, so a single findFirst could
+      // report the wrong one as (dis)connected.
+      const accounts = await ctx.db.connectedAccount.findMany({
         where: {
           userId: ctx.session.user.id,
           provider: accountProvider,
@@ -188,25 +191,22 @@ export const calendarRouter = createTRPCRouter({
           refresh_token: true,
           scope: true,
           expires_at: true,
+          provider: true,
         },
       });
 
-      if (!account?.access_token) {
-        return { isConnected: false, hasCalendarScope: false };
-      }
-
-      const hasCalendarScope = provider === "google"
-        ? (account.scope?.includes("https://www.googleapis.com/auth/calendar.events") ?? false)
-        : (account.scope?.includes("Calendars.Read") ?? false);
-
-      const tokenNotExpired = !account.expires_at || account.expires_at > Math.floor(Date.now() / 1000) + 300;
-      const canRefresh = !!account.refresh_token;
-      const isTokenValid = tokenNotExpired || canRefresh;
+      const calendarScope = calendarScopeFor(accountProvider);
+      const hasCalendarScope = accounts.some((a) => a.scope?.includes(calendarScope) ?? false);
+      const anyTokenNotExpired = accounts.some(
+        (a) => !a.expires_at || a.expires_at > Math.floor(Date.now() / 1000) + 300,
+      );
+      const canRefresh = accounts.some((a) => !!a.refresh_token);
+      const isConnected = accounts.some((a) => isCalendarConnected(a));
 
       return {
-        isConnected: hasCalendarScope && isTokenValid,
+        isConnected,
         hasCalendarScope,
-        tokenExpired: !tokenNotExpired,
+        tokenExpired: hasCalendarScope && !anyTokenNotExpired,
         canRefresh,
       };
     }),


### PR DESCRIPTION
Addresses the CodeRabbit findings on the `develop → main` release (#164). Verified each against current code; fixed the valid ones, kept changes minimal.

**Fixed**
- **`getConnectionStatus` aggregation** (`calendar.ts`) — was a single `findFirst`, could report the wrong account's state when a user has several. Now `findMany` + `isCalendarConnected`/`calendarScopeFor` across all of the provider's connected accounts.
- **keyResult link/unlink auth** (`okr/keyResult.ts`) — inline `workspace.members.some` missed **team-derived** workspace access. Both procedures now use the centralized `getWorkspaceMembership` resolver (already used elsewhere in the file).
- **health route** — JSDoc corrected to the actual shape `{ status, commit, shortCommit, branch, env }`; `GET` gains an explicit `NextResponse` return type.
- **calendar.test** — `MockOpenAI` constructor param `any` → `unknown`, dropping the `no-explicit-any` disable.

**Skipped (with reason)**
- `getByIds` (`keyResult.ts:363`) uses the same inline `members.some` pattern, but the finding scoped explicitly to link/unlink — left out to keep this minimal. Flagging as a follow-up if you want team-membership parity there too.

Validation: typecheck 0 errors, 3 source files lint clean (`--no-ignore`), calendar unit tests 4/4.