### PR TITLE
test(goals): lock in reduction-KR progress semantics

### DIFF
--- a/src/server/services/__tests__/goalProgress.test.ts
+++ b/src/server/services/__tests__/goalProgress.test.ts
@@ -35,6 +35,16 @@ describe("keyResultProgress", () => {
     // overshoot clamps to 100, regression clamps to 0 -> mean 50
     expect(keyResultProgress([kr(0, 200, 100), kr(0, -50, 100)])).toBe(50);
   });
+
+  it("measures reduction KRs where target < start", () => {
+    // "Cut cost 100 -> 80": at 90 the goal is half done. The negative range is
+    // not zero, so it is measured (unlike the old OKR calc, which gated on
+    // range > 0 and reported 0% for every reduction KR). This matches the
+    // canonical goalProgress() helper in workspaceFocusSummary.ts.
+    expect(keyResultProgress([kr(100, 90, 80)])).toBe(50);
+    expect(keyResultProgress([kr(100, 80, 80)])).toBe(100);
+    expect(keyResultProgress([kr(100, 100, 80)])).toBe(0);
+  });
 });
 
 describe("resolveGoalProgress", () => {


### PR DESCRIPTION
## What

Adds one regression test to `goalProgress.test.ts` covering **reduction key results** (`target < start`, e.g. "cut cost 100 → 80").

## Why

Follow-up to the goal-progress resolver (merged via #168). During PR review I noticed the unified `resolveGoalProgress`/`keyResultProgress` helper changed two behaviors versus the old OKR-dashboard calc — both intentionally, to match the canonical `goalProgress()` helper in `workspaceFocusSummary.ts`:

- **Reduction KRs** (`target < start`) now report real progress instead of a hard-coded 0% (the old calc gated on `range > 0`).
- **Zero-range KRs** (`target == start`) are excluded from the average rather than dragging it toward 0.

The behavior already shipped in #168; this test just makes the reduction-KR semantics explicit so a future refactor can't silently revert them. Test-only change — no runtime behavior change, no migration.

## Test

`keyResultProgress([kr(100, 90, 80)]) === 50`, `(100,80,80) === 100`, `(100,100,80) === 0`. 12/12 pass.