### PR TITLE
docs(adr): renumber agent-quality ADR 0010 → 0012

### DIFF
--- a/docs/adr/0012-agent-quality-thread-scoring.md
+++ b/docs/adr/0012-agent-quality-thread-scoring.md
@@ -4,9 +4,8 @@
 
 Accepted — 2026-06-04. Amended 2026-06-11: decisions 7–9 (prompt versioning,
 eval-set distillation, calibration gate) close the verify/attribute stages of
-the loop. Originally drafted as ADR-0008; renumbered to 0010 on landing because
-main had since taken 0008 (pipeline triage model) and 0009 (connected
-accounts).
+the loop. Originally drafted as ADR-0008; renumbered to 0012 on landing because
+main had since taken 0008–0011.
 
 ## Context
 


### PR DESCRIPTION
PR #173 landed the agent-quality ADR as 0010, but main had concurrently taken 0010 (weekly-plan digest) and 0011 (weekly-plan session), leaving two 0010 files. Renames to 0012. Docs-only.