### PR TITLE
feat: eval-prompt orchestrator — export cases, run candidate, judge, pass-rate diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "electron:build:win": "npm run electron:build -- --win",
     "electron:build:linux": "npm run electron:build -- --linux",
     "score-threads": "tsx scripts/score-threads.ts",
+    "eval-prompt": "tsx scripts/eval-prompt.ts",
     "okr": "npx tsx scripts/okr-cli.ts",
     "okr:list": "npx tsx scripts/okr-cli.ts list",
     "okr:stats": "npx tsx scripts/okr-cli.ts stats",

--- a/scripts/eval-prompt.ts
+++ b/scripts/eval-prompt.ts
@@ -1,0 +1,187 @@
+/**
+ * eval-prompt — score a candidate brain prompt against the EvalCase suite,
+ * offline (ADR-0013). The flywheel's verification step.
+ *
+ * Pipeline: export active EvalCases from the DB (read-only) → invoke
+ * ../mastra's eval-replay runner as a subprocess (the candidate prompt is
+ * whatever branch ../mastra has checked out; tools never execute) → judge
+ * each regenerated response against the case's stored expectation with the
+ * same contract judge as live scoring → print the pass-rate diff vs
+ * baseline as a PR-pasteable evidence block.
+ *
+ * Usage:
+ *   npm run eval-prompt                                  # judge candidate, no baseline
+ *   npm run eval-prompt -- --save baseline.json          # save judged run (e.g. ../mastra on main)
+ *   npm run eval-prompt -- --baseline baseline.json      # diff candidate vs saved baseline
+ *   npm run eval-prompt -- --lane agent_behaviour        # filter exported cases by lane
+ *   npm run eval-prompt -- --since 2026-06-01            # only cases created since date
+ *   npm run eval-prompt -- --cases cases.json            # skip DB export, use a cases file
+ *   npm run eval-prompt -- --mastra ../mastra            # runner working tree (default ../mastra)
+ *
+ * Typical baseline flow: check out main in ../mastra, run with --save
+ * baseline.json; check out the candidate branch, run with --baseline
+ * baseline.json. Requires ANTHROPIC_API_KEY (judge + replay model calls).
+ * Reads EvalCase from DATABASE_URL; never writes.
+ */
+import { execFileSync } from "child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+
+import Anthropic from "@anthropic-ai/sdk";
+import { PrismaClient } from "@prisma/client";
+
+import {
+  createAnthropicReplayJudge,
+  diffRuns,
+  formatEvidenceBlock,
+  judgeReplayResults,
+  type ExportedEvalCase,
+  type JudgedRun,
+  type ReplayOutput,
+} from "../src/server/services/evalPromptOrchestrator";
+import { type TranscriptTurn } from "../src/server/services/AgentEvalService";
+
+interface Args {
+  lane?: string;
+  since?: Date;
+  casesFile?: string;
+  mastraDir: string;
+  baselineFile?: string;
+  saveFile?: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { mastraDir: "../mastra" };
+  const value = (flag: string): string | undefined => {
+    const i = argv.indexOf(flag);
+    if (i === -1) return undefined;
+    const v = argv[i + 1];
+    if (v === undefined || v.startsWith("--")) {
+      console.error(`${flag} requires a value`);
+      process.exit(1);
+    }
+    return v;
+  };
+  args.lane = value("--lane");
+  const since = value("--since");
+  if (since !== undefined) {
+    const parsed = new Date(since);
+    if (Number.isNaN(parsed.getTime())) {
+      console.error(`--since requires a parseable date, got "${since}"`);
+      process.exit(1);
+    }
+    args.since = parsed;
+  }
+  args.casesFile = value("--cases");
+  args.mastraDir = value("--mastra") ?? args.mastraDir;
+  args.baselineFile = value("--baseline");
+  args.saveFile = value("--save");
+  return args;
+}
+
+async function exportCases(args: Args): Promise<ExportedEvalCase[]> {
+  if (args.casesFile) {
+    const parsed = JSON.parse(readFileSync(args.casesFile, "utf8")) as {
+      cases: ExportedEvalCase[];
+    };
+    return parsed.cases;
+  }
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL is not set (or pass --cases <file> to skip the export)");
+    process.exit(1);
+  }
+  try {
+    console.log(`Database host: ${new URL(databaseUrl).hostname} (read-only export)`);
+  } catch {
+    console.log("Database host: (unparseable DATABASE_URL)");
+  }
+
+  const db = new PrismaClient();
+  try {
+    const rows = await db.evalCase.findMany({
+      where: {
+        active: true, // retired cases excluded by default (ADR-0013 decision 5)
+        ...(args.lane ? { lane: args.lane } : {}),
+        ...(args.since ? { createdAt: { gte: args.since } } : {}),
+      },
+      orderBy: { createdAt: "asc" },
+    });
+    return rows.map((row) => ({
+      id: row.id,
+      conversationId: row.conversationId,
+      transcript: row.transcript as unknown as TranscriptTurn[],
+      violatingTurnIndex: row.violatingTurnIndex,
+      expectation: row.expectation,
+      lane: row.lane,
+    }));
+  } finally {
+    await db.$disconnect();
+  }
+}
+
+function runReplay(cases: ExportedEvalCase[], mastraDir: string): ReplayOutput {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "eval-prompt-"));
+  const casesPath = path.join(tempDir, "cases.json");
+  const resultsPath = path.join(tempDir, "results.json");
+  try {
+    writeFileSync(casesPath, JSON.stringify({ cases }, null, 2));
+    console.log(
+      `Replaying ${cases.length} case(s) against the ${mastraDir} working tree (no Mastra server)...`,
+    );
+    execFileSync(
+      "npm",
+      ["--prefix", mastraDir, "run", "eval-replay", "--", casesPath, "--out", resultsPath],
+      { stdio: ["ignore", "inherit", "inherit"] },
+    );
+    return JSON.parse(readFileSync(resultsPath, "utf8")) as ReplayOutput;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  const cases = await exportCases(args);
+  if (cases.length === 0) {
+    console.error("No active EvalCases matched the filters — nothing to replay.");
+    process.exit(1);
+  }
+
+  const replay = runReplay(cases, args.mastraDir);
+
+  console.log(`Judging ${cases.length} replayed case(s)...`);
+  const judge = createAnthropicReplayJudge(new Anthropic());
+  const candidate = await judgeReplayResults(cases, replay, judge);
+
+  let baseline: JudgedRun | null = null;
+  if (args.baselineFile) {
+    baseline = JSON.parse(readFileSync(args.baselineFile, "utf8")) as JudgedRun;
+    if (baseline.judgeVersion !== candidate.judgeVersion) {
+      console.warn(
+        `⚠️  Baseline was judged with prompt ${baseline.judgeVersion}, candidate with ` +
+          `${candidate.judgeVersion} — pass rates may not be comparable.`,
+      );
+    }
+  }
+
+  if (args.saveFile) {
+    writeFileSync(args.saveFile, JSON.stringify(candidate, null, 2));
+    console.log(`Saved judged run to ${args.saveFile}`);
+  }
+
+  const diff = diffRuns(candidate.verdicts, baseline?.verdicts ?? null);
+  console.log(`\n${formatEvidenceBlock({ diff, candidate, baseline })}\n`);
+
+  // Exit non-zero on regressions so CI/automation can gate on it (Level C:
+  // a patch PR is only opened when evals improve without regressions).
+  if (diff.regressions.length > 0) process.exit(2);
+}
+
+main().catch((error: unknown) => {
+  console.error("eval-prompt failed:", error);
+  process.exit(1);
+});

--- a/src/server/services/__tests__/evalPromptOrchestrator.test.ts
+++ b/src/server/services/__tests__/evalPromptOrchestrator.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildReplayJudgeUserMessage,
+  diffRuns,
+  formatEvidenceBlock,
+  formatPrefixForJudge,
+  judgeReplayResults,
+  type CaseVerdict,
+  type ExportedEvalCase,
+  type JudgedRun,
+  type ReplayOutput,
+} from "~/server/services/evalPromptOrchestrator";
+import { JUDGE_MODEL, JUDGE_VERSION } from "~/server/services/AgentEvalService";
+
+const turn = (userMessage: string, aiResponse: string) => ({
+  userMessage,
+  aiResponse,
+  toolsUsed: [],
+  hadError: false,
+  responseTime: null,
+  createdAt: "2026-06-01T10:00:00.000Z",
+});
+
+const makeCase = (overrides: Partial<ExportedEvalCase> = {}): ExportedEvalCase => ({
+  id: "case-1",
+  conversationId: "conv-1",
+  transcript: [
+    turn("add milk to my list", "Done — created the Action."),
+    turn("what's on my list?", "Go check your own list."),
+  ],
+  violatingTurnIndex: 1,
+  expectation: "must not deflect; should call get-project-actions",
+  lane: "agent_behaviour",
+  ...overrides,
+});
+
+const verdict = (caseId: string, passed: boolean): CaseVerdict => ({
+  caseId,
+  lane: "agent_behaviour",
+  passed,
+  reasoning: passed ? "satisfies expectation" : "violates expectation",
+});
+
+describe("diffRuns", () => {
+  it("computes pass counts and finds regressions and fixes", () => {
+    const candidate = [verdict("a", true), verdict("b", false), verdict("c", true)];
+    const baseline = [verdict("a", true), verdict("b", true), verdict("c", false)];
+    expect(diffRuns(candidate, baseline)).toEqual({
+      total: 3,
+      candidatePasses: 2,
+      baselinePasses: 2,
+      regressions: ["b"],
+      fixes: ["c"],
+    });
+  });
+
+  it("handles a missing baseline (no diff, no regressions)", () => {
+    expect(diffRuns([verdict("a", true), verdict("b", false)], null)).toEqual({
+      total: 2,
+      candidatePasses: 1,
+      baselinePasses: null,
+      regressions: [],
+      fixes: [],
+    });
+  });
+
+  it("ignores cases the baseline never saw (suite grew since baseline ran)", () => {
+    const candidate = [verdict("a", false), verdict("new-case", false)];
+    const baseline = [verdict("a", true)];
+    const diff = diffRuns(candidate, baseline);
+    expect(diff.regressions).toEqual(["a"]);
+    expect(diff.baselinePasses).toBe(1); // counted over the shared case set
+  });
+});
+
+describe("judgeReplayResults", () => {
+  const replayFor = (results: ReplayOutput["results"]): ReplayOutput => ({
+    brainVersion: "brain@abc123def456",
+    results,
+  });
+
+  it("judges each result with the injected judge and stamps judge identity", async () => {
+    const judge = vi.fn().mockResolvedValue({ passed: true, reasoning: "called the tool" });
+    const evalCase = makeCase();
+    const run = await judgeReplayResults(
+      [evalCase],
+      replayFor([
+        {
+          caseId: "case-1",
+          response: "",
+          toolIntents: [{ toolName: "get-project-actions", args: { status: "ACTIVE" } }],
+        },
+      ]),
+      judge,
+    );
+    expect(judge).toHaveBeenCalledWith({
+      evalCase,
+      response: "",
+      toolIntents: [{ toolName: "get-project-actions", args: { status: "ACTIVE" } }],
+    });
+    expect(run).toEqual({
+      brainVersion: "brain@abc123def456",
+      judgeModel: JUDGE_MODEL,
+      judgeVersion: JUDGE_VERSION,
+      verdicts: [
+        {
+          caseId: "case-1",
+          lane: "agent_behaviour",
+          passed: true,
+          reasoning: "called the tool",
+        },
+      ],
+    });
+  });
+
+  it("auto-fails runner errors and missing results without calling the judge", async () => {
+    const judge = vi.fn();
+    const run = await judgeReplayResults(
+      [makeCase({ id: "errored" }), makeCase({ id: "missing" })],
+      replayFor([
+        { caseId: "errored", response: "", toolIntents: [], error: "model timeout" },
+        null,
+      ]),
+      judge,
+    );
+    expect(judge).not.toHaveBeenCalled();
+    expect(run.verdicts.map((v) => ({ id: v.caseId, passed: v.passed, error: v.error }))).toEqual([
+      { id: "errored", passed: false, error: "model timeout" },
+      { id: "missing", passed: false, error: "missing-result" },
+    ]);
+  });
+});
+
+describe("formatPrefixForJudge / buildReplayJudgeUserMessage", () => {
+  it("renders the frozen prefix ending at the violating user message", () => {
+    const rendered = formatPrefixForJudge(makeCase());
+    expect(rendered).toContain("USER: add milk to my list");
+    expect(rendered).toContain("ZOE: Done — created the Action.");
+    expect(rendered.trim().endsWith("USER: what's on my list?")).toBe(true);
+    // the original violating response is what gets regenerated — never shown
+    expect(rendered).not.toContain("Go check your own list.");
+  });
+
+  it("includes expectation, response placeholder, and tool intents", () => {
+    const message = buildReplayJudgeUserMessage({
+      evalCase: makeCase(),
+      response: "",
+      toolIntents: [{ toolName: "get-project-actions", args: { status: "ACTIVE" } }],
+    });
+    expect(message).toContain("must not deflect; should call get-project-actions");
+    expect(message).toContain("(no text — see tool intents)");
+    expect(message).toContain('get-project-actions({"status":"ACTIVE"})');
+  });
+});
+
+describe("formatEvidenceBlock", () => {
+  const run = (verdicts: CaseVerdict[], brainVersion: string): JudgedRun => ({
+    brainVersion,
+    judgeModel: JUDGE_MODEL,
+    judgeVersion: JUDGE_VERSION,
+    verdicts,
+  });
+
+  it("prints the N/M vs K/M headline, regressions, and a per-case table", () => {
+    const candidate = run([verdict("a", true), verdict("b", false)], "brain@cand");
+    const baseline = run([verdict("a", true), verdict("b", true)], "brain@base");
+    const block = formatEvidenceBlock({
+      diff: diffRuns(candidate.verdicts, baseline.verdicts),
+      candidate,
+      baseline,
+    });
+    expect(block).toContain("Candidate passes **1/2** vs baseline **2/2**");
+    expect(block).toContain("**Regressions (1)**: b");
+    expect(block).toContain("`brain@cand`");
+    expect(block).toContain("`brain@base`");
+    expect(block).toContain(`\`${JUDGE_MODEL}\``);
+    expect(block).toContain("| a | agent_behaviour | ✅ pass |");
+    expect(block).toContain("| b | agent_behaviour | ❌ fail |");
+  });
+
+  it("omits the baseline comparison when none was supplied", () => {
+    const candidate = run([verdict("a", true)], "brain@cand");
+    const block = formatEvidenceBlock({
+      diff: diffRuns(candidate.verdicts, null),
+      candidate,
+      baseline: null,
+    });
+    expect(block).toContain("Candidate passes **1/1** (no baseline supplied)");
+    expect(block).not.toContain("Regressions");
+  });
+});

--- a/src/server/services/evalPromptOrchestrator.ts
+++ b/src/server/services/evalPromptOrchestrator.ts
@@ -1,0 +1,348 @@
+/**
+ * evalPromptOrchestrator — the flywheel's verification step (ADR-0013).
+ *
+ * Scores a candidate brain prompt (whatever branch ../mastra has checked
+ * out) against the stored EvalCase suite, offline:
+ *
+ *   export active EvalCases → ../mastra eval-replay subprocess (frozen
+ *   prefix, one model call per case, tools captured as intent, never
+ *   executed) → judge each regenerated response against the case's stored
+ *   expectation → pass-rate diff vs baseline.
+ *
+ * The replay judge is the same versioned contract judge as live scoring
+ * (JUDGE_MODEL / JUDGE_VERSION from AgentEvalService), so eval and live
+ * numbers are comparable (ADR-0013 decision 2). This module keeps the
+ * maths and judging pure/injectable; scripts/eval-prompt.ts does the I/O.
+ */
+import type Anthropic from "@anthropic-ai/sdk";
+
+import {
+  JUDGE_MODEL,
+  JUDGE_VERSION,
+  type TranscriptTurn,
+} from "./AgentEvalService";
+
+// ---------------------------------------------------------------------------
+// Case export / replay result shapes (the contract with ../mastra's runner)
+// ---------------------------------------------------------------------------
+
+export interface ExportedEvalCase {
+  id: string;
+  conversationId: string;
+  /** Full stored transcript; the runner derives the frozen prefix from it. */
+  transcript: TranscriptTurn[];
+  violatingTurnIndex: number;
+  expectation: string;
+  lane: string;
+}
+
+export interface ToolIntent {
+  toolName: string;
+  args: unknown;
+}
+
+/** One entry of the runner's results JSON. */
+export interface ReplayCaseResult {
+  caseId: string;
+  expectation?: string;
+  response: string;
+  toolIntents: ToolIntent[];
+  error?: string;
+}
+
+export interface ReplayOutput {
+  brainVersion?: string;
+  results: Array<ReplayCaseResult | null | undefined>;
+}
+
+// ---------------------------------------------------------------------------
+// Per-case judging
+// ---------------------------------------------------------------------------
+
+export interface CaseVerdict {
+  caseId: string;
+  lane: string;
+  passed: boolean;
+  reasoning: string;
+  /** Set when the runner errored on this case (auto-fail, judge not called). */
+  error?: string;
+}
+
+/** A judged run, comparable across candidate/baseline. */
+export interface JudgedRun {
+  brainVersion: string | null;
+  judgeModel: string;
+  judgeVersion: string;
+  verdicts: CaseVerdict[];
+}
+
+export type ReplayJudge = (params: {
+  evalCase: ExportedEvalCase;
+  response: string;
+  toolIntents: ToolIntent[];
+}) => Promise<{ passed: boolean; reasoning: string }>;
+
+/** Render the frozen prefix the candidate saw, for the judge. */
+export function formatPrefixForJudge(evalCase: ExportedEvalCase): string {
+  const lines: string[] = [];
+  for (let i = 0; i < evalCase.violatingTurnIndex; i++) {
+    const turn = evalCase.transcript[i];
+    if (!turn) continue;
+    lines.push(`USER: ${turn.userMessage}`);
+    lines.push(`ZOE: ${turn.aiResponse}`);
+  }
+  const violating = evalCase.transcript[evalCase.violatingTurnIndex];
+  if (violating) lines.push(`USER: ${violating.userMessage}`);
+  return lines.join("\n");
+}
+
+export const REPLAY_JUDGE_SYSTEM_PROMPT = `You are a quality judge for "Zoe", the AI assistant of Exponential (a task/project management product). This is an OFFLINE EVAL REPLAY: a failed conversation was frozen just before the turn that violated Zoe's contract, and a CANDIDATE version of Zoe has regenerated only that one response.
+
+You are given:
+- the frozen conversation prefix (ending with the user message being answered),
+- the contract expectation the ORIGINAL response violated,
+- the candidate's regenerated response text,
+- the tool calls the candidate ATTEMPTED (captured as intent — they were never executed, so there are no tool results; attempting the right tool counts as taking the action).
+
+Decide whether the candidate's response SATISFIES the stored expectation. Judge strictly against the expectation, not generic helpfulness. A response that calls the right tool but produces little or no text is a PASS when the expectation is about tool use. A response that fabricates data, deflects ("check your own list"), or ignores the expectation is a FAIL.`;
+
+export const REPLAY_VERDICT_TOOL = {
+  name: "record_replay_verdict",
+  description: "Record the pass/fail verdict for one replayed eval case.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      passed: {
+        type: "boolean" as const,
+        description: "Whether the candidate response satisfies the stored expectation.",
+      },
+      reasoning: {
+        type: "string" as const,
+        description: "One short paragraph explaining the verdict.",
+      },
+    },
+    required: ["passed", "reasoning"],
+  },
+};
+
+export function buildReplayJudgeUserMessage(params: {
+  evalCase: ExportedEvalCase;
+  response: string;
+  toolIntents: ToolIntent[];
+}): string {
+  const { evalCase, response, toolIntents } = params;
+  const intents =
+    toolIntents.length > 0
+      ? toolIntents
+          .map((intent) => `- ${intent.toolName}(${JSON.stringify(intent.args ?? {})})`)
+          .join("\n")
+      : "(none)";
+  return [
+    `=== Frozen conversation prefix ===`,
+    formatPrefixForJudge(evalCase),
+    ``,
+    `=== Violated contract expectation ===`,
+    evalCase.expectation,
+    ``,
+    `=== Candidate's regenerated response ===`,
+    response.trim().length > 0 ? response : "(no text — see tool intents)",
+    ``,
+    `=== Tool calls attempted by the candidate (intent only, never executed) ===`,
+    intents,
+  ].join("\n");
+}
+
+/** The real judge: Haiku via forced tool use — same model/version as live scoring. */
+export function createAnthropicReplayJudge(client: Anthropic): ReplayJudge {
+  return async ({ evalCase, response, toolIntents }) => {
+    const apiResponse = await client.messages.create({
+      model: JUDGE_MODEL,
+      max_tokens: 512,
+      system: REPLAY_JUDGE_SYSTEM_PROMPT,
+      tools: [REPLAY_VERDICT_TOOL],
+      tool_choice: { type: "tool", name: "record_replay_verdict" },
+      messages: [
+        {
+          role: "user",
+          content: buildReplayJudgeUserMessage({ evalCase, response, toolIntents }),
+        },
+      ],
+    });
+    const toolUse = apiResponse.content.find(
+      (block): block is Anthropic.ToolUseBlock => block.type === "tool_use",
+    );
+    if (!toolUse) {
+      throw new Error(
+        `Replay judge returned no tool_use block (stop_reason: ${apiResponse.stop_reason})`,
+      );
+    }
+    const input = toolUse.input as { passed?: unknown; reasoning?: unknown };
+    if (typeof input.passed !== "boolean" || typeof input.reasoning !== "string") {
+      throw new Error(`Replay judge returned malformed verdict: ${JSON.stringify(input)}`);
+    }
+    return { passed: input.passed, reasoning: input.reasoning };
+  };
+}
+
+/**
+ * Judge every replayed case. Runner errors auto-fail without calling the
+ * judge (a candidate that crashes the replay cannot pass); cases missing
+ * from the results also auto-fail, loudly.
+ */
+export async function judgeReplayResults(
+  cases: ExportedEvalCase[],
+  replay: ReplayOutput,
+  judge: ReplayJudge,
+): Promise<JudgedRun> {
+  const resultsByCase = new Map(
+    replay.results
+      .filter((result): result is ReplayCaseResult => Boolean(result))
+      .map((result) => [result.caseId, result]),
+  );
+
+  const verdicts: CaseVerdict[] = [];
+  for (const evalCase of cases) {
+    const result = resultsByCase.get(evalCase.id);
+    if (!result) {
+      verdicts.push({
+        caseId: evalCase.id,
+        lane: evalCase.lane,
+        passed: false,
+        reasoning: "No replay result produced for this case.",
+        error: "missing-result",
+      });
+      continue;
+    }
+    if (result.error) {
+      verdicts.push({
+        caseId: evalCase.id,
+        lane: evalCase.lane,
+        passed: false,
+        reasoning: `Replay errored: ${result.error}`,
+        error: result.error,
+      });
+      continue;
+    }
+    const verdict = await judge({
+      evalCase,
+      response: result.response,
+      toolIntents: result.toolIntents,
+    });
+    verdicts.push({
+      caseId: evalCase.id,
+      lane: evalCase.lane,
+      passed: verdict.passed,
+      reasoning: verdict.reasoning,
+    });
+  }
+
+  return {
+    brainVersion: replay.brainVersion ?? null,
+    judgeModel: JUDGE_MODEL,
+    judgeVersion: JUDGE_VERSION,
+    verdicts,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pass-rate diff (pure)
+// ---------------------------------------------------------------------------
+
+export interface PassRateDiff {
+  total: number;
+  candidatePasses: number;
+  /** Null when no baseline run was supplied. */
+  baselinePasses: number | null;
+  /** Cases that passed on baseline but fail on candidate. */
+  regressions: string[];
+  /** Cases that failed on baseline but pass on candidate. */
+  fixes: string[];
+}
+
+export function diffRuns(
+  candidate: CaseVerdict[],
+  baseline: CaseVerdict[] | null,
+): PassRateDiff {
+  const candidatePasses = candidate.filter((v) => v.passed).length;
+  if (!baseline) {
+    return {
+      total: candidate.length,
+      candidatePasses,
+      baselinePasses: null,
+      regressions: [],
+      fixes: [],
+    };
+  }
+  const baselineByCase = new Map(baseline.map((v) => [v.caseId, v]));
+  const regressions: string[] = [];
+  const fixes: string[] = [];
+  for (const verdict of candidate) {
+    const base = baselineByCase.get(verdict.caseId);
+    if (!base) continue; // case unseen by baseline — neither regression nor fix
+    if (base.passed && !verdict.passed) regressions.push(verdict.caseId);
+    if (!base.passed && verdict.passed) fixes.push(verdict.caseId);
+  }
+  // Baseline pass count over the candidate's case set, so N/M and K/M share M.
+  const baselinePasses = candidate.filter(
+    (v) => baselineByCase.get(v.caseId)?.passed,
+  ).length;
+  return {
+    total: candidate.length,
+    candidatePasses,
+    baselinePasses,
+    regressions,
+    fixes,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Evidence block (PR-pasteable)
+// ---------------------------------------------------------------------------
+
+export function formatEvidenceBlock(params: {
+  diff: PassRateDiff;
+  candidate: JudgedRun;
+  baseline: JudgedRun | null;
+}): string {
+  const { diff, candidate, baseline } = params;
+  const lines: string[] = [];
+
+  lines.push(`## Eval evidence (ADR-0013)`);
+  lines.push(``);
+  const headline =
+    diff.baselinePasses === null
+      ? `Candidate passes **${diff.candidatePasses}/${diff.total}** (no baseline supplied)`
+      : `Candidate passes **${diff.candidatePasses}/${diff.total}** vs baseline **${diff.baselinePasses}/${diff.total}**`;
+  lines.push(headline);
+  lines.push(``);
+  lines.push(`- Candidate prompt: \`${candidate.brainVersion ?? "unknown"}\``);
+  if (baseline) {
+    lines.push(`- Baseline prompt: \`${baseline.brainVersion ?? "unknown"}\``);
+  }
+  lines.push(`- Judge: \`${candidate.judgeModel}\` (prompt \`${candidate.judgeVersion}\`)`);
+  lines.push(``);
+
+  if (diff.baselinePasses !== null) {
+    lines.push(
+      diff.regressions.length === 0
+        ? `**Regressions: none**`
+        : `**Regressions (${diff.regressions.length})**: ${diff.regressions.join(", ")}`,
+    );
+    if (diff.fixes.length > 0) {
+      lines.push(`**Newly passing (${diff.fixes.length})**: ${diff.fixes.join(", ")}`);
+    }
+    lines.push(``);
+  }
+
+  lines.push(`| Case | Lane | Verdict | Reasoning |`);
+  lines.push(`|------|------|---------|-----------|`);
+  for (const verdict of candidate.verdicts) {
+    const flat = verdict.reasoning.replace(/\s+/g, " ").trim();
+    const clipped = flat.length > 140 ? `${flat.slice(0, 139)}…` : flat;
+    lines.push(
+      `| ${verdict.caseId} | ${verdict.lane} | ${verdict.passed ? "✅ pass" : "❌ fail"} | ${clipped.replace(/\|/g, "\\|")} |`,
+    );
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## What

Per ADR-0013 (epic cmq9s4x0l0001jp05n2qmgc5v): the flywheel's verification step. `npm run eval-prompt`:

1. **Export** active EvalCases (filterable by `--lane` / `--since`; retired `active: false` cases excluded by default; `--cases <file>` skips the DB) — read-only against DATABASE_URL.
2. **Replay** via `../mastra`'s eval-replay runner as a subprocess (`npm --prefix ../mastra run eval-replay`): the candidate prompt is whatever branch is checked out there; frozen prefix, one model call per case, tools captured as intent, never executed. No Mastra server anywhere in the path.
3. **Judge** each regenerated response + tool intents against the case's stored expectation, with the same contract judge (`JUDGE_MODEL`) and `JUDGE_VERSION` as live scoring, so eval and live numbers are comparable. Forced tool use; runner errors and missing results auto-fail without burning judge calls.
4. **Evidence block** (markdown, PR-pasteable): `candidate passes N/M vs baseline K/M`, regression list (passed on baseline, fails on candidate), newly-passing list, per-case verdict table with reasoning. Exits 2 on regressions so Level C can gate patch PRs mechanically.

Baseline = the production prompt's judged run over the same cases: `--save baseline.json` with `../mastra` on main, then `--baseline baseline.json` against the candidate branch. Baseline pass count is computed over the candidate's case set so N/M and K/M share M; the script warns when judge versions differ.

Judging + diff maths live in `evalPromptOrchestrator.ts`, pure with an injectable judge; the script does the I/O (mirrors `score-threads` conventions).

**Verified end-to-end**: baseline run against `../mastra` main (`brain@9294a20a92db`, judge failed the smoke case with sound reasoning), then a throwaway candidate branch with an instruction edit (`brain@721e6e00f242`) diffed against it — headline, regression section, and per-case table all rendered; exit 0 with no regressions.

## Acceptance criteria

- [x] eval-prompt runs end-to-end against a candidate ../mastra branch and prints pass-rate diff vs baseline
- [x] Regression list names each case that passed on baseline but fails on candidate
- [x] Inactive (retired) EvalCases excluded by default
- [x] Unit tests: pass-rate diff math, regression detection, per-case judging with a mocked judge (9 tests)
- [x] Output block is copy-pasteable as PR evidence

---

Ships: onyx.penguin