### PR TITLE
feat: calibration gate — judge-vs-human agreement metric + autonomy threshold

### DIFF
--- a/src/app/(sidemenu)/admin/feedback/ThreadScoreAnalytics.tsx
+++ b/src/app/(sidemenu)/admin/feedback/ThreadScoreAnalytics.tsx
@@ -21,6 +21,7 @@ import {
   IconRoute,
   IconAlertTriangle,
   IconVersions,
+  IconScale,
 } from "@tabler/icons-react";
 import {
   CartesianGrid,
@@ -71,6 +72,135 @@ function AxisBadge({ label, passed }: { label: string; passed: boolean }) {
     <Badge color={passed ? "green" : "red"} size="xs" variant="outline">
       {passed ? "✓" : "✗"} {label}
     </Badge>
+  );
+}
+
+/**
+ * Judge-vs-human calibration (ADR-0012 decision 9): directional agreement
+ * on Threads that have BOTH a judge ThreadScore and a human Feedback
+ * rating. Level B/C autonomy stays locked until the gate opens. The
+ * overlap set's rating distribution is shown because human ratings are
+ * selection-biased (people rate when angry or delighted).
+ */
+function CalibrationCard() {
+  const { data: calibration, isLoading } = api.admin.getCalibration.useQuery();
+  const gate = calibration?.gate;
+  const currentStats = gate?.stats ?? null;
+  const distributionTotal =
+    currentStats?.ratingDistribution.reduce((sum, d) => sum + d.count, 0) ?? 0;
+
+  return (
+    <Card className="border border-border-primary bg-surface-secondary">
+      <Group gap="xs" className="mb-4" justify="space-between">
+        <Group gap="xs">
+          <IconScale size={20} className="text-text-muted" />
+          <Title order={4} className="text-text-primary">
+            Judge calibration (vs human ratings)
+          </Title>
+          <Text size="xs" className="text-text-muted">
+            gates Level B/C autonomy — ADR-0012 decision 9
+          </Text>
+        </Group>
+        {isLoading ? (
+          <Skeleton height={24} width={110} />
+        ) : (
+          <Badge color={gate?.calibrated ? "green" : "red"} size="lg" variant="light">
+            Gate {gate?.calibrated ? "open" : "closed"}
+          </Badge>
+        )}
+      </Group>
+
+      {isLoading ? (
+        <Skeleton height={100} />
+      ) : (
+        <Stack gap="md">
+          <Text size="sm" className="text-text-secondary">
+            {gate?.reason}
+          </Text>
+
+          <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
+            <div>
+              <Text size="sm" className="text-text-muted">
+                Overlap pairs (judge {calibration?.currentJudgeVersion})
+              </Text>
+              <Title order={4} className="text-text-primary">
+                {currentStats?.pairCount ?? 0}
+                <Text span size="sm" className="ml-1 text-text-muted">
+                  ({currentStats?.directionalPairs ?? 0} directional)
+                </Text>
+              </Title>
+            </div>
+            <div>
+              <Text size="sm" className="text-text-muted">
+                Directional agreement
+              </Text>
+              <Title order={4} className="text-text-primary">
+                {currentStats?.agreementRate != null
+                  ? `${(currentStats.agreementRate * 100).toFixed(1)}%`
+                  : "—"}
+                <Text span size="sm" className="ml-1 text-text-muted">
+                  (threshold {((gate?.threshold ?? 0.8) * 100).toFixed(0)}%)
+                </Text>
+              </Title>
+            </div>
+            <div>
+              <Text size="sm" className="text-text-muted">
+                Overlap rating distribution (selection-bias check)
+              </Text>
+              <Stack gap={4} mt={4}>
+                {currentStats?.ratingDistribution.map((d) => (
+                  <Group key={d.rating} gap="xs">
+                    <Text size="xs" className="w-6 text-text-muted">
+                      {d.rating}★
+                    </Text>
+                    <Progress
+                      value={distributionTotal > 0 ? (d.count / distributionTotal) * 100 : 0}
+                      size="xs"
+                      className="flex-1"
+                      color={d.rating >= 4 ? "green" : d.rating <= 2 ? "red" : "yellow"}
+                    />
+                    <Text size="xs" className="w-6 text-right text-text-muted">
+                      {d.count}
+                    </Text>
+                  </Group>
+                )) ?? <Text className="text-text-muted">No overlap yet</Text>}
+              </Stack>
+            </div>
+          </SimpleGrid>
+
+          {(calibration?.perVersion.length ?? 0) > 1 && (
+            <Table>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Judge version</Table.Th>
+                  <Table.Th>Pairs</Table.Th>
+                  <Table.Th>Directional</Table.Th>
+                  <Table.Th>Agreement</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {calibration?.perVersion.map((stats) => (
+                  <Table.Tr key={stats.judgeVersion}>
+                    <Table.Td>
+                      <Text size="sm" className="font-mono text-text-primary">
+                        {stats.judgeVersion}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>{stats.pairCount}</Table.Td>
+                    <Table.Td>{stats.directionalPairs}</Table.Td>
+                    <Table.Td>
+                      {stats.agreementRate != null
+                        ? `${(stats.agreementRate * 100).toFixed(1)}%`
+                        : "—"}
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          )}
+        </Stack>
+      )}
+    </Card>
   );
 }
 
@@ -263,6 +393,9 @@ export function ThreadScoreAnalytics() {
           )}
         </Card>
       </SimpleGrid>
+
+      {/* Judge calibration gate */}
+      <CalibrationCard />
 
       {/* Prompt-version breakdown */}
       <Card className="border border-border-primary bg-surface-secondary">

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -9,6 +9,9 @@ import {
   buildScoreTrend,
   lastPromptVersionByConversation,
 } from "~/server/services/threadScoreAnalytics";
+import { computeCalibration, isCalibrated } from "~/server/services/calibrationGate";
+import { buildCalibrationPairs } from "~/server/services/calibrationGateService";
+import { JUDGE_VERSION } from "~/server/services/AgentEvalService";
 
 // `tokenUsage` is written via `JSON.stringify(...)` in AiInteractionLogger,
 // so Prisma returns it as a string. Older rows (or rows written via Prisma
@@ -580,6 +583,22 @@ export const adminRouter = createTRPCRouter({
         };
       });
     }),
+
+  /**
+   * Judge-vs-human calibration state (ADR-0012 decision 9): overlap pairs,
+   * directional agreement per judge version, and whether the Level B/C
+   * autonomy gate is open for the CURRENT judge version. The overlap set's
+   * rating distribution is included so selection bias (humans rate when
+   * angry or delighted) is visible rather than silently trusted.
+   */
+  getCalibration: adminProcedure.query(async ({ ctx }) => {
+    const pairs = await buildCalibrationPairs(ctx.db);
+    return {
+      currentJudgeVersion: JUDGE_VERSION,
+      gate: isCalibrated(pairs, JUDGE_VERSION),
+      perVersion: computeCalibration(pairs),
+    };
+  }),
 
   /**
    * Generate and preview the weekly Thread-score digest (without sending)

--- a/src/server/services/__tests__/calibrationGate.test.ts
+++ b/src/server/services/__tests__/calibrationGate.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CALIBRATION_AGREEMENT_THRESHOLD,
+  CALIBRATION_MIN_DIRECTIONAL_PAIRS,
+  computeCalibration,
+  humanDirection,
+  isCalibrated,
+  type CalibrationPair,
+} from "~/server/services/calibrationGate";
+
+const pair = (overrides: Partial<CalibrationPair>): CalibrationPair => ({
+  conversationId: "c1",
+  judgePassed: true,
+  failureLane: null,
+  judgeVersion: "v1",
+  humanRating: 5,
+  ...overrides,
+});
+
+/** n agreeing directional pairs: judge pass + human 5. */
+const agreeing = (n: number, judgeVersion = "v1"): CalibrationPair[] =>
+  Array.from({ length: n }, (_, i) =>
+    pair({ conversationId: `agree-${i}`, judgeVersion }),
+  );
+
+describe("humanDirection", () => {
+  it("maps 4-5 positive, 1-2 negative, 3 neutral", () => {
+    expect(humanDirection(5)).toBe("positive");
+    expect(humanDirection(4)).toBe("positive");
+    expect(humanDirection(3)).toBe("neutral");
+    expect(humanDirection(2)).toBe("negative");
+    expect(humanDirection(1)).toBe("negative");
+  });
+});
+
+describe("computeCalibration", () => {
+  it("counts agreements and disagreements directionally", () => {
+    const stats = computeCalibration([
+      pair({ conversationId: "a", judgePassed: true, humanRating: 5 }), // agree
+      pair({
+        conversationId: "b",
+        judgePassed: false,
+        failureLane: "agent_behaviour",
+        humanRating: 1,
+      }), // agree
+      pair({ conversationId: "c", judgePassed: true, humanRating: 1 }), // disagree
+      pair({ conversationId: "d", judgePassed: false, failureLane: "code_bug", humanRating: 3 }), // neutral
+    ]);
+    expect(stats).toHaveLength(1);
+    expect(stats[0]).toMatchObject({
+      judgeVersion: "v1",
+      pairCount: 4,
+      directionalPairs: 3,
+      agreements: 2,
+    });
+    expect(stats[0]!.agreementRate).toBeCloseTo(2 / 3);
+  });
+
+  it("partitions per judge version — a judge change resets the evidence", () => {
+    const stats = computeCalibration([
+      ...agreeing(2, "v1"),
+      pair({ conversationId: "x", judgeVersion: "v2", judgePassed: true, humanRating: 1 }),
+    ]);
+    expect(stats.map((s) => s.judgeVersion)).toEqual(["v1", "v2"]);
+    expect(stats.find((s) => s.judgeVersion === "v1")?.agreementRate).toBe(1);
+    expect(stats.find((s) => s.judgeVersion === "v2")?.agreementRate).toBe(0);
+  });
+
+  it("splits agreement per failure lane", () => {
+    const stats = computeCalibration([
+      pair({ conversationId: "a", judgePassed: false, failureLane: "code_bug", humanRating: 1 }),
+      pair({ conversationId: "b", judgePassed: false, failureLane: "code_bug", humanRating: 5 }),
+      pair({ conversationId: "c", judgePassed: true, humanRating: 5 }),
+    ]);
+    expect(stats[0]!.perLane).toEqual([
+      { lane: "code_bug", directionalPairs: 2, agreements: 1 },
+      { lane: "passing", directionalPairs: 1, agreements: 1 },
+    ]);
+  });
+
+  it("reports the overlap rating distribution (selection-bias visibility)", () => {
+    const stats = computeCalibration([
+      pair({ conversationId: "a", humanRating: 5 }),
+      pair({ conversationId: "b", humanRating: 4.6 }), // rounds to 5
+      pair({ conversationId: "c", humanRating: 1 }),
+    ]);
+    expect(stats[0]!.ratingDistribution).toEqual([
+      { rating: 1, count: 1 },
+      { rating: 2, count: 0 },
+      { rating: 3, count: 0 },
+      { rating: 4, count: 0 },
+      { rating: 5, count: 2 },
+    ]);
+  });
+});
+
+describe("isCalibrated", () => {
+  it("zero overlap pairs ⇒ gate closed, never vacuously open", () => {
+    const gate = isCalibrated([], "v1");
+    expect(gate.calibrated).toBe(false);
+    expect(gate.reason).toContain("No judge/human overlap pairs");
+  });
+
+  it("pairs for another judge version do not open this version's gate", () => {
+    const gate = isCalibrated(agreeing(20, "v0"), "v1");
+    expect(gate.calibrated).toBe(false);
+  });
+
+  it("stays closed below the minimum directional-pair volume even at 100% agreement", () => {
+    const gate = isCalibrated(agreeing(CALIBRATION_MIN_DIRECTIONAL_PAIRS - 1), "v1");
+    expect(gate.calibrated).toBe(false);
+    expect(gate.reason).toContain("volume");
+  });
+
+  it("opens exactly at the threshold (>= semantics)", () => {
+    // 8/10 = exactly 80%
+    const pairs = [
+      ...agreeing(8),
+      pair({ conversationId: "d1", judgePassed: true, humanRating: 1 }),
+      pair({ conversationId: "d2", judgePassed: true, humanRating: 1 }),
+    ];
+    expect(CALIBRATION_AGREEMENT_THRESHOLD).toBe(0.8);
+    const gate = isCalibrated(pairs, "v1");
+    expect(gate.stats?.agreementRate).toBeCloseTo(0.8);
+    expect(gate.calibrated).toBe(true);
+  });
+
+  it("closes just below the threshold", () => {
+    // 8/11 ≈ 72.7%
+    const pairs = [
+      ...agreeing(8),
+      pair({ conversationId: "d1", judgePassed: true, humanRating: 1 }),
+      pair({ conversationId: "d2", judgePassed: true, humanRating: 1 }),
+      pair({ conversationId: "d3", judgePassed: true, humanRating: 1 }),
+    ];
+    const gate = isCalibrated(pairs, "v1");
+    expect(gate.calibrated).toBe(false);
+    expect(gate.reason).toContain("below");
+  });
+
+  it("neutral ratings cannot open the gate (excluded from the denominator)", () => {
+    const pairs = Array.from({ length: 20 }, (_, i) =>
+      pair({ conversationId: `n-${i}`, humanRating: 3 }),
+    );
+    const gate = isCalibrated(pairs, "v1");
+    expect(gate.calibrated).toBe(false);
+    expect(gate.stats?.directionalPairs).toBe(0);
+  });
+
+  it("honours threshold and min-pairs overrides", () => {
+    const pairs = [...agreeing(3), pair({ conversationId: "d", judgePassed: true, humanRating: 1 })];
+    expect(
+      isCalibrated(pairs, "v1", { threshold: 0.7, minDirectionalPairs: 4 }).calibrated,
+    ).toBe(true);
+    expect(
+      isCalibrated(pairs, "v1", { threshold: 0.9, minDirectionalPairs: 4 }).calibrated,
+    ).toBe(false);
+  });
+});

--- a/src/server/services/calibrationGate.ts
+++ b/src/server/services/calibrationGate.ts
@@ -1,0 +1,200 @@
+/**
+ * calibrationGate — judge-vs-human directional agreement (ADR-0012 decision 9).
+ *
+ * Wherever a Thread has BOTH a ThreadScore (the judge's apparent-quality
+ * verdict) and a human Feedback rating (ground truth), the two are compared
+ * directionally. Level B/C autonomy (auto-filing, auto prompt-patch PRs)
+ * stays locked until the judge clears an agreement threshold on that
+ * overlap set — an uncalibrated judge driving automated prompt changes
+ * optimises for the wrong thing, confidently.
+ *
+ * Pure functions only: overlap pairs in → stats out. No DB, no network —
+ * calibrationGateService.ts assembles pairs from Prisma and is what Level
+ * B/C code consults.
+ *
+ * Direction mapping: the judge's verdict is binary (failureLane null =
+ * pass). A human rating ≥ 4 is positive, ≤ 2 negative; 3 is neutral and
+ * excluded from directional agreement (but still counted and reported).
+ * Human ratings are sparse and selection-biased — people rate when angry
+ * or delighted — so the overlap set's rating distribution is reported
+ * alongside agreement rather than silently trusted.
+ *
+ * Agreement is partitioned per judgeVersion: a judge-prompt change resets
+ * the evidence rather than inheriting the old version's track record.
+ */
+
+export interface CalibrationPair {
+  conversationId: string;
+  /** ThreadScore verdict: failureLane === null. */
+  judgePassed: boolean;
+  failureLane: string | null;
+  judgeVersion: string;
+  /** Mean human Feedback rating (1–5) across the Thread's rated turns. */
+  humanRating: number;
+}
+
+export type HumanDirection = "positive" | "negative" | "neutral";
+
+export function humanDirection(rating: number): HumanDirection {
+  if (rating >= 4) return "positive";
+  if (rating <= 2) return "negative";
+  return "neutral";
+}
+
+export interface LaneAgreement {
+  /** Failure lane of the judge verdict, or "passing". */
+  lane: string;
+  directionalPairs: number;
+  agreements: number;
+}
+
+export interface CalibrationStats {
+  judgeVersion: string;
+  /** All overlap pairs for this judge version, neutrals included. */
+  pairCount: number;
+  /** Pairs with a non-neutral human direction — the agreement denominator. */
+  directionalPairs: number;
+  agreements: number;
+  /** agreements / directionalPairs; null when there are no directional pairs. */
+  agreementRate: number | null;
+  perLane: LaneAgreement[];
+  /** Rating histogram of the overlap set (selection-bias visibility). */
+  ratingDistribution: Array<{ rating: 1 | 2 | 3 | 4 | 5; count: number }>;
+}
+
+function pairAgrees(pair: CalibrationPair): boolean | null {
+  const direction = humanDirection(pair.humanRating);
+  if (direction === "neutral") return null;
+  return (direction === "positive") === pair.judgePassed;
+}
+
+/** Compute agreement stats, partitioned per judge version. */
+export function computeCalibration(pairs: CalibrationPair[]): CalibrationStats[] {
+  const byVersion = new Map<string, CalibrationPair[]>();
+  for (const pair of pairs) {
+    const bucket = byVersion.get(pair.judgeVersion) ?? [];
+    bucket.push(pair);
+    byVersion.set(pair.judgeVersion, bucket);
+  }
+
+  return [...byVersion.entries()]
+    .map(([judgeVersion, versionPairs]) => {
+      let directionalPairs = 0;
+      let agreements = 0;
+      const byLane = new Map<string, { directional: number; agreements: number }>();
+      const histogram = new Map<number, number>();
+
+      for (const pair of versionPairs) {
+        const rounded = Math.min(5, Math.max(1, Math.round(pair.humanRating)));
+        histogram.set(rounded, (histogram.get(rounded) ?? 0) + 1);
+
+        const agrees = pairAgrees(pair);
+        if (agrees === null) continue;
+        directionalPairs += 1;
+        if (agrees) agreements += 1;
+
+        const lane = pair.failureLane ?? "passing";
+        const laneBucket = byLane.get(lane) ?? { directional: 0, agreements: 0 };
+        laneBucket.directional += 1;
+        if (agrees) laneBucket.agreements += 1;
+        byLane.set(lane, laneBucket);
+      }
+
+      return {
+        judgeVersion,
+        pairCount: versionPairs.length,
+        directionalPairs,
+        agreements,
+        agreementRate: directionalPairs > 0 ? agreements / directionalPairs : null,
+        perLane: [...byLane.entries()]
+          .map(([lane, b]) => ({
+            lane,
+            directionalPairs: b.directional,
+            agreements: b.agreements,
+          }))
+          .sort((a, b) => b.directionalPairs - a.directionalPairs),
+        ratingDistribution: ([1, 2, 3, 4, 5] as const).map((rating) => ({
+          rating,
+          count: histogram.get(rating) ?? 0,
+        })),
+      };
+    })
+    .sort((a, b) => a.judgeVersion.localeCompare(b.judgeVersion));
+}
+
+/** Default gate: ≥80% directional agreement (ADR-0012 decision 9). */
+export const CALIBRATION_AGREEMENT_THRESHOLD = 0.8;
+
+/**
+ * Minimum directional pairs before the gate can open. One lucky pair must
+ * not unlock autonomy; the PRD is explicit that the overlap set needs
+ * volume — until it has it, the loop runs at Level A regardless of tooling.
+ */
+export const CALIBRATION_MIN_DIRECTIONAL_PAIRS = 10;
+
+export interface CalibrationGateOptions {
+  threshold?: number;
+  minDirectionalPairs?: number;
+}
+
+export interface CalibrationGateResult {
+  calibrated: boolean;
+  reason: string;
+  judgeVersion: string;
+  stats: CalibrationStats | null;
+  threshold: number;
+  minDirectionalPairs: number;
+}
+
+/**
+ * The explicit check Level B/C features must consult before doing anything
+ * autonomous. Zero overlap pairs ⇒ closed — never vacuously open.
+ */
+export function isCalibrated(
+  pairs: CalibrationPair[],
+  judgeVersion: string,
+  options: CalibrationGateOptions = {},
+): CalibrationGateResult {
+  const threshold = options.threshold ?? CALIBRATION_AGREEMENT_THRESHOLD;
+  const minDirectionalPairs =
+    options.minDirectionalPairs ?? CALIBRATION_MIN_DIRECTIONAL_PAIRS;
+
+  const stats =
+    computeCalibration(pairs).find((s) => s.judgeVersion === judgeVersion) ?? null;
+  const base = { judgeVersion, stats, threshold, minDirectionalPairs };
+
+  if (!stats || stats.pairCount === 0) {
+    return {
+      ...base,
+      calibrated: false,
+      reason: `No judge/human overlap pairs for judge ${judgeVersion} — gate closed.`,
+    };
+  }
+  if (stats.directionalPairs < minDirectionalPairs) {
+    return {
+      ...base,
+      calibrated: false,
+      reason:
+        `Only ${stats.directionalPairs} directional pair(s) for judge ${judgeVersion} ` +
+        `(minimum ${minDirectionalPairs}) — gate closed until the overlap set has volume.`,
+    };
+  }
+  const rate = stats.agreementRate ?? 0;
+  if (rate < threshold) {
+    return {
+      ...base,
+      calibrated: false,
+      reason:
+        `Directional agreement ${(rate * 100).toFixed(1)}% is below the ` +
+        `${(threshold * 100).toFixed(0)}% threshold (${stats.agreements}/${stats.directionalPairs}) — gate closed.`,
+    };
+  }
+  return {
+    ...base,
+    calibrated: true,
+    reason:
+      `Directional agreement ${(rate * 100).toFixed(1)}% ` +
+      `(${stats.agreements}/${stats.directionalPairs}) clears the ` +
+      `${(threshold * 100).toFixed(0)}% threshold — gate open.`,
+  };
+}

--- a/src/server/services/calibrationGateService.ts
+++ b/src/server/services/calibrationGateService.ts
@@ -1,0 +1,75 @@
+import { type PrismaClient } from "@prisma/client";
+
+import { JUDGE_VERSION } from "./AgentEvalService";
+import {
+  isCalibrated,
+  type CalibrationGateOptions,
+  type CalibrationGateResult,
+  type CalibrationPair,
+} from "./calibrationGate";
+
+/**
+ * Assemble judge/human overlap pairs from the DB and run the pure gate
+ * (ADR-0012 decision 9). This is THE check Level B/C code must call before
+ * auto-filing issues or proposing prompt patches:
+ *
+ *   const gate = await getCalibrationGate(db);
+ *   if (!gate.calibrated) { stay at Level A; surface gate.reason }
+ *
+ * A pair = one Thread with a ThreadScore (judge verdict) AND at least one
+ * human Feedback rating on its turns; multiple ratings average.
+ */
+export async function buildCalibrationPairs(
+  db: PrismaClient,
+): Promise<CalibrationPair[]> {
+  const scores = await db.threadScore.findMany({
+    select: {
+      conversationId: true,
+      failureLane: true,
+      judgeVersion: true,
+    },
+  });
+  if (scores.length === 0) return [];
+
+  const ratedTurns = await db.aiInteractionHistory.findMany({
+    where: {
+      conversationId: { in: scores.map((s) => s.conversationId) },
+      feedback: { some: {} },
+    },
+    select: {
+      conversationId: true,
+      feedback: { select: { rating: true } },
+    },
+  });
+
+  const ratingsByConversation = new Map<string, number[]>();
+  for (const turn of ratedTurns) {
+    if (turn.conversationId === null) continue;
+    const bucket = ratingsByConversation.get(turn.conversationId) ?? [];
+    bucket.push(...turn.feedback.map((f) => f.rating));
+    ratingsByConversation.set(turn.conversationId, bucket);
+  }
+
+  return scores.flatMap((score) => {
+    const ratings = ratingsByConversation.get(score.conversationId);
+    if (!ratings || ratings.length === 0) return [];
+    return [
+      {
+        conversationId: score.conversationId,
+        judgePassed: score.failureLane === null,
+        failureLane: score.failureLane,
+        judgeVersion: score.judgeVersion,
+        humanRating: ratings.reduce((a, b) => a + b, 0) / ratings.length,
+      },
+    ];
+  });
+}
+
+/** Current-judge-version gate state. Options override threshold/min-pairs. */
+export async function getCalibrationGate(
+  db: PrismaClient,
+  options: CalibrationGateOptions = {},
+): Promise<CalibrationGateResult> {
+  const pairs = await buildCalibrationPairs(db);
+  return isCalibrated(pairs, JUDGE_VERSION, options);
+}


### PR DESCRIPTION
## What

ADR-0012 decision 9 (epic cmq9s4x0l0001jp05n2qmgc5v). Wherever a Thread has BOTH a ThreadScore (the judge's apparent-quality verdict) and a human Feedback rating (ground truth), directional agreement is tracked; Level B/C autonomy (auto-filing, auto prompt-patch PRs) stays locked until the judge clears the threshold.

- **Pure module** (`calibrationGate.ts`): overlap pairs in → agreement stats out — no DB, no network. Direction mapping: human rating 4–5 positive, 1–2 negative, 3 neutral (excluded from the agreement denominator but counted and reported). Stats are partitioned **per judgeVersion**, so a judge-prompt change resets the evidence rather than inheriting the old version's track record. The overlap set's rating distribution is reported alongside agreement, so selection bias (humans rate when angry or delighted) is visible rather than silently trusted.
- **`isCalibrated`**: ≥80% directional agreement (configurable) AND a minimum of 10 directional pairs (configurable — one lucky pair must not unlock autonomy; the PRD is explicit the overlap set needs volume). Zero overlap pairs ⇒ closed, never vacuously open.
- **`getCalibrationGate(db)`** (`calibrationGateService.ts`) is the explicit check later Level B/C code consults: pairs are assembled from ThreadScore × Feedback (ratings averaged per Thread) and run through the pure gate for the current `JUDGE_VERSION`.
- **Admin surfacing**: the Thread Scores section on `/admin/feedback` gains a calibration card — gate open/closed badge with the gate's reason, overlap pair counts, agreement % vs threshold, overlap rating distribution, and a per-judge-version table when more than one version has evidence.

## Acceptance criteria

- [x] Pure agreement module with unit tests (agreement math, threshold edges incl. exactly-80%, per-judge-version partitioning) — 12 tests
- [x] isCalibrated check consultable by later Level B/C code (`getCalibrationGate(db)`)
- [x] Admin view shows pairs count, agreement %, gate state, overlap rating distribution
- [x] Zero overlap pairs ⇒ gate closed (never vacuously open)

---

Ships: thin.blaze