### PR TITLE
fix: coerce judge numerics; one bad judgement no longer aborts the score-threads drain

### DIFF
--- a/scripts/score-threads.ts
+++ b/scripts/score-threads.ts
@@ -91,7 +91,7 @@ async function main(): Promise<void> {
         `Settled unscored Threads: ${settled.length}; judging ${planned} this run.\n`,
     );
 
-    const results = await service.scoreBacklog({
+    const { results, errors } = await service.scoreBacklog({
       limit,
       onProgress: (done, total, result) => {
         const verdict =
@@ -102,12 +102,19 @@ async function main(): Promise<void> {
           `[${done}/${total}] ${result.conversationId} — ${verdict} (${result.turnCount} turns)`,
         );
       },
+      onThreadError: (conversationId, error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(
+          `[skip] ${conversationId} — judging failed, left unscored for the next run: ${oneLine(message)}`,
+        );
+      },
     });
 
     const failures = results.filter((result) => result.failureLane !== null);
     console.log(
       `\nDone. Judged ${results.length} Thread(s): ` +
-        `${results.length - failures.length} passed, ${failures.length} failed.`,
+        `${results.length - failures.length} passed, ${failures.length} failed` +
+        (errors.length > 0 ? `; ${errors.length} errored (will retry next run).` : "."),
     );
 
     const report = buildLaneReport(results);

--- a/src/server/services/AgentEvalService.ts
+++ b/src/server/services/AgentEvalService.ts
@@ -120,16 +120,20 @@ export interface TranscriptTurn {
   createdAt: string; // ISO 8601 — kept JSON-serializable for EvalCase.transcript
 }
 
+// Numeric fields are coerced: the judge model occasionally returns numbers
+// as JSON strings ("2" instead of 2) despite the tool schema, and a strict
+// parse would reject an otherwise-sound judgement. null short-circuits
+// .nullable() before coercion, so nullables stay nullable.
 const judgementSchema = z.object({
   resolved: z.boolean(),
   grounded: z.boolean(),
   toolSuccess: z.boolean(),
   noDeflection: z.boolean(),
-  overallScore: z.number().int().min(0).max(100),
+  overallScore: z.coerce.number().int().min(0).max(100),
   failureLane: z.enum(FAILURE_LANES).nullable(),
   reasoning: z.string(),
   expectation: z.string().nullable(),
-  violatingTurn: z.number().int().min(1).nullable(),
+  violatingTurn: z.coerce.number().int().min(1).nullable(),
 });
 
 export type Judgement = z.infer<typeof judgementSchema>;
@@ -253,7 +257,15 @@ export interface ScoreBacklogOptions {
   limit?: number;
   /** Called after each Thread is judged (for CLI progress logging). */
   onProgress?: (done: number, total: number, result: ScoreThreadResult) => void;
+  /** Called when one Thread fails to judge/persist; the drain continues. */
+  onThreadError?: (conversationId: string, error: unknown) => void;
   now?: Date;
+}
+
+export interface ScoreBacklogSummary {
+  results: ScoreThreadResult[];
+  /** Threads that errored this run — left unscored, retried on the next run. */
+  errors: Array<{ conversationId: string; error: unknown }>;
 }
 
 export class AgentEvalService {
@@ -457,23 +469,31 @@ export class AgentEvalService {
 
   /**
    * Drain the settled-Thread backlog sequentially. Idempotent — re-running
-   * skips everything already in ThreadScore.
+   * skips everything already in ThreadScore. A Thread that fails to judge
+   * (e.g. a malformed judgement) is reported and skipped rather than
+   * aborting the drain: it stays unscored and is retried on the next run.
    */
   async scoreBacklog(
     options: ScoreBacklogOptions = {},
-  ): Promise<ScoreThreadResult[]> {
+  ): Promise<ScoreBacklogSummary> {
     const ids = await this.findSettledThreadIds(options.now ?? new Date());
     const queue =
       options.limit !== undefined ? ids.slice(0, options.limit) : ids;
 
     const results: ScoreThreadResult[] = [];
+    const errors: ScoreBacklogSummary["errors"] = [];
     for (const conversationId of queue) {
-      const result = await this.scoreThread(conversationId);
-      if (result) {
-        results.push(result);
-        options.onProgress?.(results.length, queue.length, result);
+      try {
+        const result = await this.scoreThread(conversationId);
+        if (result) {
+          results.push(result);
+          options.onProgress?.(results.length, queue.length, result);
+        }
+      } catch (error) {
+        errors.push({ conversationId, error });
+        options.onThreadError?.(conversationId, error);
       }
     }
-    return results;
+    return { results, errors };
   }
 }

--- a/src/server/services/__tests__/AgentEvalService.test.ts
+++ b/src/server/services/__tests__/AgentEvalService.test.ts
@@ -4,6 +4,7 @@
  * (Anthropic) is never called here.
  */
 import { describe, expect, it } from "vitest";
+import type Anthropic from "@anthropic-ai/sdk";
 import { mockDeep } from "vitest-mock-extended";
 import type { PrismaClient } from "@prisma/client";
 
@@ -205,5 +206,148 @@ describe("findSettledThreadIds (mocked Prisma)", () => {
     ]);
     await expect(service.findSettledThreadIds(NOW)).resolves.toEqual([]);
     expect(db.threadScore.findMany).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Judgement parsing + backlog resilience (exponential-3jpn)
+// ---------------------------------------------------------------------------
+
+const settledAt2 = new Date(NOW.getTime() - 2 * SETTLED_AFTER_MS);
+
+function turnRow(conversationId: string) {
+  return {
+    userMessage: "what's on my list?",
+    aiResponse: "Here is your list.",
+    toolsUsed: ["get-project-actions"],
+    hadError: false,
+    responseTime: 1200,
+    createdAt: settledAt2,
+    systemUserId: "user-1",
+    agentId: "zoeAgent",
+  };
+}
+
+function judgementInput(overrides: Record<string, unknown> = {}) {
+  return {
+    resolved: true,
+    grounded: true,
+    toolSuccess: true,
+    noDeflection: true,
+    overallScore: 90,
+    failureLane: null,
+    reasoning: "fine",
+    expectation: null,
+    violatingTurn: null,
+    ...overrides,
+  };
+}
+
+function fakeAnthropic(
+  responses: Array<Record<string, unknown> | Error>,
+): Anthropic {
+  let call = 0;
+  return {
+    messages: {
+      create: async () => {
+        const next = responses[Math.min(call++, responses.length - 1)]!;
+        if (next instanceof Error) throw next;
+        return {
+          stop_reason: "tool_use",
+          content: [{ type: "tool_use", name: "record_judgement", input: next }],
+        };
+      },
+    },
+  } as unknown as Anthropic;
+}
+
+describe("judgeTranscript coercion", () => {
+  it("accepts numeric judge fields returned as JSON strings", async () => {
+    const db = mockDeep<PrismaClient>();
+    const service = new AgentEvalService(
+      db,
+      fakeAnthropic([
+        judgementInput({
+          overallScore: "35",
+          failureLane: "agent_behaviour",
+          violatingTurn: "2",
+        }),
+      ]),
+    );
+    const judgement = await service.judgeTranscript([]);
+    expect(judgement.overallScore).toBe(35);
+    expect(judgement.violatingTurn).toBe(2);
+  });
+
+  it("still rejects garbage numerics", async () => {
+    const db = mockDeep<PrismaClient>();
+    const service = new AgentEvalService(
+      db,
+      fakeAnthropic([judgementInput({ violatingTurn: "second turn" })]),
+    );
+    await expect(service.judgeTranscript([])).rejects.toThrow();
+  });
+});
+
+describe("scoreBacklog resilience", () => {
+  function makeBacklogDb(ids: string[]) {
+    const db = mockDeep<PrismaClient>();
+    db.aiInteractionHistory.groupBy.mockResolvedValue(
+      ids.map((conversationId) => ({
+        conversationId,
+        _max: { createdAt: settledAt2 },
+      })) as never,
+    );
+    db.threadScore.findMany.mockResolvedValue([] as never);
+    db.threadScore.findUnique.mockResolvedValue(null as never);
+    db.aiInteractionHistory.findMany.mockImplementation(((args: {
+      where: { conversationId: string };
+    }) => Promise.resolve([turnRow(args.where.conversationId)])) as never);
+    db.threadScore.create.mockResolvedValue({} as never);
+    return db;
+  }
+
+  it("skips a Thread whose judgement fails and keeps draining", async () => {
+    const db = makeBacklogDb(["bad-1", "good-1"]);
+    const service = new AgentEvalService(
+      db,
+      fakeAnthropic([new Error("model returned garbage"), judgementInput()]),
+    );
+    const errored: string[] = [];
+    const { results, errors } = await service.scoreBacklog({
+      now: NOW,
+      onThreadError: (conversationId) => errored.push(conversationId),
+    });
+
+    expect(results.map((r) => r.conversationId)).toEqual(["good-1"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.conversationId).toBe("bad-1");
+    expect(errored).toEqual(["bad-1"]);
+    // the failed Thread was never persisted — it stays unscored for retry
+    expect(db.threadScore.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists a coerced string violatingTurn as a 0-based index on the EvalCase", async () => {
+    const db = makeBacklogDb(["fail-1"]);
+    const service = new AgentEvalService(
+      db,
+      fakeAnthropic([
+        judgementInput({
+          resolved: false,
+          overallScore: "20",
+          failureLane: "agent_behaviour",
+          expectation: "must not deflect",
+          violatingTurn: "1",
+        }),
+      ]),
+    );
+    const { results, errors } = await service.scoreBacklog({ now: NOW });
+    expect(errors).toEqual([]);
+    expect(results).toHaveLength(1);
+    const createArgs = db.threadScore.create.mock.calls[0]?.[0] as {
+      data: { overallScore: number; evalCase: { create: { violatingTurnIndex: number } } };
+    };
+    expect(createArgs.data.overallScore).toBe(20);
+    expect(createArgs.data.evalCase.create.violatingTurnIndex).toBe(0);
   });
 });


### PR DESCRIPTION
## What

Two findings from the first production `score-threads` run (beads: exponential-3jpn):

1. **Judge schema too strict for model output.** Haiku occasionally returns numeric judgement fields as JSON strings (`"violatingTurn": "2"`) despite the tool schema. The strict zod parse threw and killed the run. `overallScore` and `violatingTurn` now use `z.coerce.number()` — null still short-circuits `.nullable()`, and genuine garbage (`"second turn"`) is still rejected.
2. **One bad judgement aborted the whole drain.** `scoreBacklog` now catches per-Thread errors, reports them (`onThreadError` callback + `[skip]` line and summary count in the CLI), and leaves the Thread unscored so the next idempotent run retries it. 28 healthy Threads no longer hostage to 1 weird one.

No schema/DB changes — fast-track to main. 4 new regression tests (string-numeric coercion end-to-end into the EvalCase `violatingTurnIndex`, garbage rejection, drain-continues-past-error, failed Thread never persisted).

Unblocks the remaining 29-Thread scoring backlog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of numeric fields returned as JSON strings by external judging services

* **Improvements**
  * Batch scoring operations now continue processing when individual threads encounter errors, instead of stopping the entire run
  * Enhanced error tracking with detailed reporting showing which conversations failed and can be retried in subsequent runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->