### PR TITLE
fix: log toolsUsed on chat/stream interactions (judge saw zero tool calls everywhere)

### DIFF
--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -803,6 +803,10 @@ export async function POST(req: Request) {
               conversationId: threadId,
               userMessage: lastUserMsg.slice(0, 2000),
               aiResponse: fullText.slice(0, 5000),
+              // Without this the Thread judge sees "TOOLS INVOKED: (none)" on
+              // every turn and reads grounded responses as fabrication
+              // (ADR-0012 GROUNDED axis). Kept in call order, repeats included.
+              toolsUsed: toolCallNames,
               tokenUsage: finishUsage
                 ? {
                     prompt: finishUsage.inputTokens,


### PR DESCRIPTION
## What

Found by the first production `score-threads` run (beads: exponential-4dqy): 28/28 Threads failed, dominated by GROUNDED/"fabrication" verdicts — because the judge's input was wrong, not (necessarily) Zoe.

`/api/chat/stream` tracks `toolCallNames` for console logging but never passed them to `AiInteractionLogger.logInteraction` (which supports `toolsUsed` and defaults it to `[]`). Every web/manychat `AiInteractionHistory` row therefore has `toolsUsed: []`, the judge transcript renders `TOOLS INVOKED: (none)` on every turn, and grounded responses get read as fabrication.

One-line fix: pass `toolsUsed: toolCallNames` (call order, repeats included — repeats are themselves signal). `toolCallNames` is only reset on the empty-Haiku tier-retry path, so at log time it holds the final attempt's complete list.

Consequence worth knowing: Threads logged **before** this deploys are permanently unjudgeable on the GROUNDED axis (the data was never captured). The 81 existing ThreadScores were judged on that missing input — see follow-up discussion about retiring their distilled EvalCases.

No schema changes — fast-track to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced AI interaction logging system to track and record tools utilized by the AI during chat streaming sessions in the order they are invoked
  * Improved system monitoring and debugging capabilities by capturing sequential tool usage data in metadata logs for comprehensive insights into AI interaction patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->