### PR TITLE
feat: Deterministic request-aware ack in ThinkingStatus

### DIFF
--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -307,7 +307,14 @@ const MessageList = memo(function MessageList({ messages, conversationId, isStre
                   {isStreaming &&
                     index === visibleMessages.length - 1 &&
                     message.content === '' && (
-                      <ThinkingStatus toolCalls={message.toolCalls} />
+                      <ThinkingStatus
+                        toolCalls={message.toolCalls}
+                        requestText={
+                          [...visibleMessages]
+                            .reverse()
+                            .find((m) => m.type === 'human')?.content
+                        }
+                      />
                     )}
                   <div className="text-text-primary text-sm leading-relaxed">
                     {message.marker === 'voice' && (

--- a/src/app/_components/agent/ThinkingStatus.tsx
+++ b/src/app/_components/agent/ThinkingStatus.tsx
@@ -4,6 +4,7 @@ import { memo, useEffect, useState } from "react";
 
 import type { ToolCall } from "~/providers/AgentModalProvider";
 import {
+  buildRequestAck,
   COMPOSING_MESSAGE,
   narrateTool,
   THINKING_MESSAGES,
@@ -14,42 +15,66 @@ const ROTATE_MS = 2500;
 interface ThinkingStatusProps {
   /** The in-flight message's tool calls, if any have started. */
   toolCalls?: ToolCall[];
+  /**
+   * The user's just-submitted message. Used to render a deterministic,
+   * request-aware acknowledgement the instant they hit send (no model call).
+   */
+  requestText?: string;
 }
 
 /**
  * Immediate, on-brand "thinking" affordance for Zoe's bubble, shown while the
- * bubble has no prose yet. Three phases, all in Zoe's voice:
- *   1. before any tool fires  → rotating whimsical lines (fills the first ~5s)
+ * bubble has no prose yet. Phases, all in Zoe's voice:
+ *   0. the instant the message is sent → a request-aware acknowledgement
+ *      derived client-side from the user's text ("On it — capturing that
+ *      now…"), so the very first frame reads as Zoe acknowledging *this*
+ *      request rather than a generic spinner
+ *   1. before any tool fires  → rotating whimsical lines (fills the dead air)
  *   2. while a tool is running → narrates the actual activity ("Going through
  *      your projects…"), so the wait reads as her thinking out loud
  *   3. tools done, no text yet → "Putting it together…"
- * Client-only, zero added latency. The parent unmounts it once prose streams.
+ * Client-only, zero added latency. The parent unmounts it once prose streams,
+ * so the ack is ephemeral and never stacks above the final response.
  */
 export const ThinkingStatus = memo(function ThinkingStatus({
   toolCalls,
+  requestText,
 }: ThinkingStatusProps) {
   const hasTools = !!toolCalls && toolCalls.length > 0;
+  // Deterministic, instant ack from the request text (null when not echoable).
+  const ack = buildRequestAck(requestText);
 
   // Random start so consecutive turns don't always open with the same line.
   const [idx, setIdx] = useState(() =>
     Math.floor(Math.random() * THINKING_MESSAGES.length),
   );
+  // The ack opens the turn; after one interval we fall into the rotating
+  // thinking lines so a long pre-tool wait doesn't sit frozen on the ack.
+  const [ackElapsed, setAckElapsed] = useState(false);
 
   useEffect(() => {
     // Only the pre-tool phase needs a timer; the tool/compose phases are driven
     // by toolCalls updates.
     if (hasTools) return;
+    // While the ack is on screen, the first timer just retires it; the
+    // rotating lines only start once the ack has had its moment.
+    if (ack && !ackElapsed) {
+      const id = setTimeout(() => setAckElapsed(true), ROTATE_MS);
+      return () => clearTimeout(id);
+    }
     const id = setInterval(() => {
       setIdx((i) => (i + 1) % THINKING_MESSAGES.length);
     }, ROTATE_MS);
     return () => clearInterval(id);
-  }, [hasTools]);
+  }, [hasTools, ack, ackElapsed]);
 
   let message: string;
   if (hasTools) {
     // Narrate the most recent running tool; if all have settled, she's composing.
     const running = [...toolCalls].reverse().find((c) => c.status === "running");
     message = running ? narrateTool(running.name) : COMPOSING_MESSAGE;
+  } else if (ack && !ackElapsed) {
+    message = ack;
   } else {
     message = THINKING_MESSAGES[idx] ?? THINKING_MESSAGES[0];
   }

--- a/src/app/_components/agent/__tests__/thinkingMessages.test.ts
+++ b/src/app/_components/agent/__tests__/thinkingMessages.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildRequestAck, narrateTool } from '../thinkingMessages';
+
+describe('buildRequestAck', () => {
+  it('returns null for empty / whitespace-only text (falls back to thinking lines)', () => {
+    expect(buildRequestAck(undefined)).toBeNull();
+    expect(buildRequestAck('')).toBeNull();
+    expect(buildRequestAck('   \n\t ')).toBeNull();
+  });
+
+  it('acknowledges capture intent for create/add-style requests', () => {
+    expect(buildRequestAck('Add a task to call the dentist')).toBe(
+      'On it — capturing that now…',
+    );
+    expect(buildRequestAck('create an action for the launch')).toBe(
+      'On it — capturing that now…',
+    );
+    expect(buildRequestAck('remind me to pay rent')).toBe(
+      'On it — capturing that now…',
+    );
+  });
+
+  it('acknowledges look-up intent for questions', () => {
+    expect(buildRequestAck('What is on my calendar today?')).toBe(
+      'On it — looking into that…',
+    );
+    expect(buildRequestAck('how many projects do I have')).toBe(
+      'On it — looking into that…',
+    );
+    // Trailing "?" alone is enough even without a leading interrogative.
+    expect(buildRequestAck('My projects, sorted by priority?')).toBe(
+      'On it — looking into that…',
+    );
+  });
+
+  it('echoes a trimmed, single-line version of other requests', () => {
+    expect(buildRequestAck('Tell James the meeting moved to Friday')).toBe(
+      'On it — “Tell James the meeting moved to Friday”…',
+    );
+  });
+
+  it('collapses whitespace/newlines in the echo', () => {
+    expect(buildRequestAck('Tell   James\nthe meeting moved')).toBe(
+      'On it — “Tell James the meeting moved”…',
+    );
+  });
+
+  it('truncates a long echo to keep the status line short', () => {
+    const long =
+      'Tell the entire team that the quarterly planning session has been rescheduled to next Thursday afternoon';
+    const ack = buildRequestAck(long)!;
+    expect(ack.startsWith('On it — “')).toBe(true);
+    expect(ack.endsWith('”…')).toBe(true);
+    // The echoed slice is capped (60 chars) — the full sentence must not fit.
+    expect(ack.length).toBeLessThan(long.length);
+    expect(ack).not.toContain('Thursday');
+  });
+});
+
+describe('narrateTool', () => {
+  it('narrates write verbs as jotting, before entity matches', () => {
+    expect(narrateTool('create-project-action')).toBe('Jotting that down…');
+    expect(narrateTool('quick-create-action')).toBe('Jotting that down…');
+  });
+
+  it('narrates read tools by entity', () => {
+    expect(narrateTool('get-all-projects')).toBe('Going through your projects…');
+    expect(narrateTool('search-emails')).toBe('Skimming your inbox…');
+  });
+
+  it('falls back for unknown tools', () => {
+    expect(narrateTool('some-unmapped-tool')).toBe('Having a look…');
+  });
+});

--- a/src/app/_components/agent/thinkingMessages.ts
+++ b/src/app/_components/agent/thinkingMessages.ts
@@ -50,3 +50,36 @@ export function narrateTool(name: string): string {
   }
   return "Having a look…";
 }
+
+// Write/capture verbs → Zoe confirms she's recording the request.
+const ACK_CREATE = /\b(add|create|capture|note|remember|log|jot|schedule|remind|set\s?up|make|draft|new)\b/i;
+// Interrogatives → she's looking into it rather than capturing it.
+const ACK_QUESTION = /^(what|when|who|whom|how|why|where|which|do|does|did|is|are|am|can|could|should|would|will|may)\b/i;
+const ACK_ECHO_MAX = 60;
+
+/**
+ * Deterministic, client-side acknowledgement derived from the user's
+ * just-submitted message — shown the instant they hit send, before any
+ * network round-trip or model call. Returns `null` when the text isn't
+ * usefully echoable (empty / whitespace only), so the caller falls back to
+ * the generic rotating thinking lines.
+ *
+ * Intentionally NOT model-generated: a generated ack adds a pass and can
+ * promise an outcome the brain then contradicts (e.g. acking "adding to
+ * Finances" when the Action lands in no project). See ADR-0015 (decision 5).
+ */
+export function buildRequestAck(requestText?: string): string | null {
+  const raw = requestText?.trim();
+  if (!raw) return null;
+  // Collapse newlines/runs of whitespace so the echo is a clean single line.
+  const oneLine = raw.replace(/\s+/g, " ");
+  if (ACK_CREATE.test(oneLine)) return "On it — capturing that now…";
+  if (ACK_QUESTION.test(oneLine) || oneLine.endsWith("?")) {
+    return "On it — looking into that…";
+  }
+  const echo =
+    oneLine.length > ACK_ECHO_MAX
+      ? `${oneLine.slice(0, ACK_ECHO_MAX).trimEnd()}…`
+      : oneLine;
+  return `On it — “${echo}”…`;
+}


### PR DESCRIPTION
## What

`ThinkingStatus` opened every turn with a generic rotating spinner ("Sizing up your day…") — it fired instantly but didn't read as Zoe acknowledging *this specific* request.

Adds `buildRequestAck()`: a deterministic, client-side acknowledgement derived from the user's just-submitted message:
- **capture intent** (add/create/remind/…) → "On it — capturing that now…"
- **question intent** → "On it — looking into that…"
- **otherwise** → an echo of a trimmed, single-line version of their text

`ThinkingStatus` shows the ack the instant the message is sent (0ms, before any network round-trip), then falls into the existing rotating thinking lines after one interval. Falls back to those lines when the text isn't usefully echoable.

**No model call** — a generated ack adds a pass and can promise an outcome the brain then contradicts (e.g. acking "adding to Finances" when the Action lands in no project). See ADR-0015 (decision 5). It's ephemeral: the parent already unmounts `ThinkingStatus` once prose streams, so it never stacks above the final response.

## Acceptance criteria

- [x] On submit, an acknowledgement that reflects the user's request appears immediately (no waiting for the first server byte).
- [x] Ephemeral — replaced when real prose streams; never stacks above the final response.
- [x] No additional LLM/model call introduced.
- [x] Falls back gracefully to the existing thinking copy when the request text isn't usefully echoable.

## Tests

`buildRequestAck` / `narrateTool` unit tests (9 cases) — empty→null fallback, capture/question/echo branches, whitespace collapse, long-echo truncation.

---

Refs: quirky.salmon
Ships: quirky.salmon