### PR TITLE
fix(mastra): coerce goalId on Zoe objective comment/update proxies

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -87,6 +87,10 @@ _Avoid_: Weekly narrative / Week-in-Review (that's the team, single-workspace ar
 An AI-suggested content starting point — a hook or framing for a social post, derived from the **Weekly work digest** (e.g. "what I learned shipping a cross-workspace feed"). Raw material for the user's own writing, not a finished draft. Surfaced as a labelled sub-section of the digest.
 _Avoid_: Content idea, post draft (an angle is a prompt, not a written post), suggestion.
 
+**Commit activity**:
+Git commits **polled and persisted** per **Workspace repository** by a cron (PAT-based, no GitHub App required), upserted by `commitSha`. Stored **per-commit** but **rendered grouped** in feeds ("pushed 7 commits to `exponential`"), and summarised in prose by the **Weekly work digest**. "Mine" is resolved by matching `commitAuthor` to the viewer's **GitHub identity claim** (`User.githubLogin`). This persists commits for the **Aggregated activity feed** and the digest — an explicit amendment of [ADR-0001](docs/adr/0001-activity-feed-storage.md)'s "GitHub events are not persisted for the panel" stance (the change ADR-0001 anticipated "later if latency/rate-limits bite").
+_Avoid_: Commits feed, GitHub feed (use "commit activity"); conflating with the webhook-fed `GitHubActivity` analytics path.
+
 ## Relationships (activity)
 
 - A **Workspace** has many **Workspace repositories**.
@@ -94,6 +98,8 @@ _Avoid_: Content idea, post draft (an angle is a prompt, not a written post), su
 - The **Activity feed** is the read-side union of `WorkspaceActivityEvent` rows (internal) and GitHub commits + PRs fetched live from each `WorkspaceRepository` at query time.
 - GitHub events shown in the activity feed are **not persisted** for the panel's purposes. They are fetched on page load via a shared `GITHUB_API_TOKEN` PAT (impactful-events style), with a ~5min server-side cache per repo to absorb refreshes.
 - The existing webhook path (`/api/webhooks/github`) and `GitHubActivity` table remain — they continue to feed `SprintSnapshot` analytics, **independent** of the activity panel. The two paths can coexist for the same repo; the activity feed only uses live-fetch.
+- **Meetings** now emit `WorkspaceActivityEvent` rows via `recordActivity` (entityType `meeting`: `created`, then `summarized` once the auto-summary lands) — the internal-data write-path of ADR-0001, so a meeting appears in the workspace feed, the **Aggregated activity feed**, and the **Weekly work digest** from one write.
+- **Commit activity** is **polled and persisted** (cron, PAT-based) so commits reach the **Aggregated activity feed** and the digest — amending ADR-0001's not-persisted stance (to be formalised in a follow-up ADR). The per-workspace panel's live-fetch vs. persisted-read reconciliation is an open decision for that ADR.
 
 ### Weekly planning
 

--- a/docs/adr/0001-activity-feed-storage.md
+++ b/docs/adr/0001-activity-feed-storage.md
@@ -4,6 +4,12 @@
 
 Accepted — 2026-05-14
 
+Amended by [ADR-0019](0019-persist-polled-commits.md) (2026-06-14): decisions #3
+and #4 below — "GitHub events are not persisted for the panel" and "persist
+polled GitHub data on a cron — rejected for v1" — are superseded for **commits**,
+which are now cron-polled and persisted to serve the aggregated feed and the
+Weekly work digest. The live-fetch union still describes PRs.
+
 ## Context
 
 Two append-only event streams already exist:

--- a/docs/adr/0018-weekly-work-digest-personal-sibling.md
+++ b/docs/adr/0018-weekly-work-digest-personal-sibling.md
@@ -1,0 +1,85 @@
+# Weekly work digest: a personal, cross-workspace sibling of Week-in-Review
+
+## Status
+
+Accepted — 2026-06-14
+
+## Context
+
+A user wants to see "what I've been working on this week" and feed it into a
+social-media content pipeline. Two facts shaped the design:
+
+- The top-level `/activity` page (the **Aggregated activity feed**) is a raw,
+  un-summarised list of `WorkspaceActivityEvent` rows across every workspace the
+  user belongs to. It shows *all members'* events, reads dry (status changes on
+  raw ticket CUIDs), and is not scoped to the viewer's own work.
+- A **Week-in-Review** narrative already exists — `WorkspaceWeeklyNarrative`, an
+  AI-generated `narrative` + `highlights`, cached per `(workspaceId, isoYear,
+  isoWeek)`. It is **per-workspace and team-shared**: one narrative for the whole
+  workspace, the same for every member.
+
+What the user needs is neither of those: a synthesis of **their own** work,
+**across all their workspaces**, turned into prose plus content ideas. The
+obvious-but-wrong move is to extend `WorkspaceWeeklyNarrative` to be per-user —
+which would entangle a private, cross-workspace artifact with a shared,
+single-workspace one.
+
+## Decision
+
+1. **The Weekly work digest is a distinct artifact, a personal sibling of
+   Week-in-Review — not an extension of it.** New cached row keyed
+   `(userId, isoYear, isoWeek)`; `WorkspaceWeeklyNarrative` is left untouched.
+2. **Subject is Z-scoped and cross-workspace.** It covers events the user
+   *acted on* **and** items *assigned to / owned by* them that moved, unioned
+   across every workspace they are a member of (direct or team), for the ISO week.
+3. **Four sources, unioned at read** by a deterministic gatherer: enriched
+   activity events (joined to live entities for real titles), the user's
+   assigned/owned entities that changed, **meetings attended** (one-line blurb
+   from the meeting summary, title fallback), and **the user's commits**.
+4. **Deterministic gather → one LLM call → cached.** The gatherer assembles a
+   structured bundle in code; a single `gpt-4o-mini` call returns the digest
+   narrative **and** the **content angles** (≈3 post-idea hooks) in one
+   structured response. Generation is **lazy-on-read + cache + in-flight
+   coalescing** — the exact shape of `weeklyNarrativeService`, no job queue.
+5. **Private to the user.** A digest reads workspace data the user can already
+   see, but the digest itself is visible only to its owner.
+6. **Surfaced as a panel atop `/activity`.** The digest sits above the
+   Aggregated activity feed: "the story of your week" over "every event".
+7. **Meetings become an activity source via the internal write-path.** A meeting
+   emits `WorkspaceActivityEvent` rows (`created`, then `summarized`) through
+   `recordActivity` — ADR-0001's rule for internal data — so it appears in the
+   workspace feed, the aggregated feed, and the digest from one write. (Auto-
+   summarisation runs as a cron sweep; see Q5 / the meeting-summary work.)
+
+## Considered alternatives
+
+- **Extend `WorkspaceWeeklyNarrative` to be per-user.** Rejected: conflates a
+  private, cross-workspace artifact with a shared, single-workspace one; the
+  cache key, scope, visibility, and output (angles) all differ. Two clean
+  entities beat one overloaded one.
+- **Agentic builder (Zoe roams with tools).** Rejected: slow, non-deterministic,
+  hard to cache, risks hallucinated accomplishments. The deterministic-gather +
+  single-call pattern (ADR-0007 lineage) bounds cost and keeps the digest honest
+  — the LLM can only narrate what the gatherer surfaced.
+- **Job queue for generation.** Rejected: no queue infra exists, and the
+  lazy-on-read + cache + inFlight pattern already in `weeklyNarrativeService`
+  covers it. An optional Monday Vercel cron can pre-warm.
+- **Read-side union of meetings (GitHub-style) instead of write-path events.**
+  Rejected for meetings: they are *internal* data, so ADR-0001's write-path
+  applies; persisting once makes them appear everywhere with no per-surface
+  plumbing.
+
+## Consequences
+
+- A new cached table (`(userId, isoYear, isoWeek)` → narrative + highlights +
+  angles) and a `weeklyWorkDigest` read procedure that performs the four-source
+  gather. The digest and Week-in-Review now share gather/cache/regenerate
+  machinery but stay separate rows.
+- Digest quality is bounded by the gatherer's richness — correct behaviour (no
+  invented accomplishments), and the reason Q4–Q5 invested in real sources.
+- The meeting + commit enrichment pays off twice: it also enriches the
+  per-workspace activity surfaces, not only the digest.
+- "Meetings attended" needs a participant query in the gatherer, not just
+  actor=me events — being in a call is not an authored action.
+- Content angles are raw material, not posts; platform formatting and draft
+  generation are explicitly out of scope for v1.

--- a/docs/adr/0019-persist-polled-commits.md
+++ b/docs/adr/0019-persist-polled-commits.md
@@ -1,0 +1,84 @@
+# Persist polled commits for the aggregated feed and digest
+
+## Status
+
+Accepted — 2026-06-14
+
+Amends [ADR-0001](0001-activity-feed-storage.md) decision #3 ("GitHub events for
+the panel are not persisted") and #4 ("persist polled GitHub data on a cron —
+rejected for v1").
+
+## Context
+
+ADR-0001 deliberately kept GitHub out of storage for the activity panel:
+commits + PRs are **live-fetched** per `WorkspaceRepository` on page load (shared
+PAT, ~5min cache), unioned in app code, never persisted. It explicitly rejected
+cron-polling-into-storage *for v1*, noting it "can be added later if rate limits
+or latency become problems."
+
+Two new requirements make live-fetch insufficient:
+
+- **Commits in the global feed.** The **Aggregated activity feed** (`/activity`)
+  reads only `WorkspaceActivityEvent`. Live-fetched commits never reach it, and
+  live-fetching across *every* workspace × repo on one page is an unbounded
+  fan-out.
+- **Weekly commit summarisation for the Weekly work digest** ([ADR-0018](0018-weekly-work-digest-personal-sibling.md)).
+  Summarising "what you shipped this week" from live-fetch means an N-repo API
+  fan-out per digest — slow and rate-limit-prone — with no author/time index.
+
+Most of the user's real work lives in Git, so commits are the highest-signal
+source for "what I'm working on". The `GitHubActivity` table already persists
+commit fields (`commitSha`, `commitMessage`, `commitAuthor`, `branchName`,
+`workspaceId`) — but only for repos with the **GitHub App webhook** installed,
+and it is consumed by Sprint Analytics, not the feed.
+
+## Decision
+
+1. **Cron-poll commits per `WorkspaceRepository` and persist them.** A Vercel
+   cron fetches each declared repo's recent commits via the existing PAT path and
+   **upserts by `commitSha`**. No GitHub App install required — it works for any
+   repo a workspace has declared.
+2. **Store per-commit, render grouped.** Rows are per-commit (needed for accurate
+   author/time and as a digest source), but feeds render a grouped roll-up
+   ("pushed 7 commits to `exponential`"), not one row per commit.
+3. **"Mine" is the GitHub identity claim.** A commit is attributed to a user by
+   matching `commitAuthor` to `User.githubLogin` (the OAuth-verified claim) —
+   never free-text.
+4. **All feeds read the persisted commits — one source of truth.** The
+   per-workspace panel **switches from live-fetch to reading persisted commits**,
+   the same rows the aggregated feed and digest read. Commit live-fetch for the
+   panel is retired.
+5. **The webhook `GitHubActivity` / Sprint Analytics path is untouched.** It
+   keeps serving analytics independently; this decision is about the
+   feed/digest read model.
+
+## Considered alternatives
+
+- **Keep live-fetch, extend the union to the global feed + digest.** Rejected:
+  doesn't scale to "global" (fan-out across all workspaces × repos per request),
+  no author/time index for weekly queries, and the aggregated feed can't union
+  live data cheaply.
+- **Per-workspace panel keeps live-fetch; only global/digest read persisted.**
+  Rejected (this is the "reconciliation" sub-decision): two commit code paths
+  that can disagree, for the sake of seconds-vs-minutes freshness. One source of
+  truth wins; the cron lag (minutes) is acceptable for an activity feed.
+- **Require the GitHub App webhook (reuse `GitHubActivity` as-is).** Rejected:
+  forces every workspace to install + authorise the App, the exact friction
+  ADR-0001 avoided with the PAT path. Cron-poll keeps the low-friction
+  declaration model.
+- **Daily commit roll-up rows instead of per-commit.** Rejected for storage:
+  loses the author/time granularity the digest needs. Roll-up is a *render*
+  concern (decision #2), not a storage one.
+
+## Consequences
+
+- A persisted commit store (extend `GitHubActivity` or a thin commits table) +
+  a cron poller keyed for idempotent upsert by `commitSha`.
+- Commit freshness in all feeds is now bounded by the cron interval (~15 min),
+  not real time — an accepted trade for consistency and a single code path.
+- The shared-PAT rate-limit and leak risks ADR-0001 flagged still apply to the
+  poller; per-workspace tokens remain a future slice.
+- A repo may appear in both this poll path and the webhook `GitHubActivity` path;
+  they stay independent (feed/digest vs. analytics), no dedupe between them.
+- ADR-0001's commit live-fetch for the panel is removed; PR live-fetch behaviour
+  outside this scope is unchanged until a follow-up addresses PRs.

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -3470,7 +3470,9 @@ export const mastraRouter = createTRPCRouter({
   // creator-only check or duplicate logic. See ADR-0016.
   addGoalComment: protectedProcedure
     .input(z.object({
-      goalId: z.number(),
+      // Agent-facing: the model often passes goalId as a string lifted from the
+      // prompt's page context, so coerce. The tool coerces too (defense in depth).
+      goalId: z.coerce.number(),
       content: z.string().min(1).max(10000),
     }))
     .mutation(async ({ ctx, input }) => {
@@ -3489,7 +3491,9 @@ export const mastraRouter = createTRPCRouter({
   // NOT copy the legacy OKR endpoints' inline creator-only check. See ADR-0016.
   addGoalUpdate: protectedProcedure
     .input(z.object({
-      goalId: z.number(),
+      // Agent-facing: the model often passes goalId as a string lifted from the
+      // prompt's page context, so coerce. The tool coerces too (defense in depth).
+      goalId: z.coerce.number(),
       content: z.string().min(1).max(10000),
       health: z.enum(["on-track", "at-risk", "off-track"]),
     }))


### PR DESCRIPTION
## Problem

Zoe fails to post Objective comments/updates from chat — she loops on "goalId needs to be a number" / "expecting the goalId in a different format" and tells the user to add it by hand.

**Root cause:** the model lifts `goalId` from the page-context text in the system prompt (`Goal: … (ID: 19)`) and emits it as a **string**. The agent tools' `inputSchema` used `z.number()` and rejected it before the call; this PR hardens the matching server proxies too.

## Fix

`z.number()` → `z.coerce.number()` for `goalId` on `mastra.addGoalComment` and `mastra.addGoalUpdate` (agent-facing only). The actual rejection happens in the Mastra tool's `inputSchema`, fixed in positonic/mastra#23 — this is defense-in-depth so the proxy accepts a string `goalId` regardless of client.

Human routers (`goalUpdate.addUpdate`, `goalComment.addComment`) and `goalService` keep strict `z.number()` — React sends real numbers. Access logic and the superjson wire format are unchanged.

## Test

Typecheck clean. Behavioural regression test lives with the tool in positonic/mastra#23 (asserts the `inputSchema` coerces a string `goalId`).

Paired with: positonic/mastra#23