### PR TITLE
feat(meetings): auto-summarize meetings via cron sweep + summarized event (royal.raven)

### DIFF
--- a/src/app/api/cron/auto-summarize-meetings/route.ts
+++ b/src/app/api/cron/auto-summarize-meetings/route.ts
@@ -1,0 +1,49 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { db } from "~/server/db";
+import { runMeetingSummarySweep } from "~/server/services/meetings/meetingSummarySweep";
+
+/**
+ * Cron endpoint: auto-summarizes meetings (ADR-0018, royal.raven).
+ *
+ * Selects meetings with a transcript but no summary, summarizes a bounded batch
+ * inline (all work within the request — NO post-response fire-and-forget, which
+ * a serverless function can't run reliably), persists each summary, and emits a
+ * `meeting`/`summarized` activity event when one lands. Idempotent: only
+ * summary-null rows are picked up, so it heals the corpus forward and is safe to
+ * re-run.
+ *
+ * Call via: GET /api/cron/auto-summarize-meetings
+ * Vercel cron (see vercel.json) or external scheduler, protected by CRON_SECRET.
+ */
+
+// Allow the inline LLM summarization batch headroom beyond the default budget.
+export const maxDuration = 300;
+
+export async function GET(_request: NextRequest) {
+  try {
+    const headersList = await headers();
+    const authHeader = headersList.get("authorization");
+    const cronSecret = process.env.CRON_SECRET;
+
+    if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const result = await runMeetingSummarySweep(db);
+
+    if (result.notConfigured) {
+      console.warn(
+        "[Cron] auto-summarize-meetings: summarization not configured (missing OPENAI_API_KEY)",
+      );
+    }
+
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    console.error("[Cron] auto-summarize-meetings failed:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -8,12 +8,12 @@ import { TRPCError } from "@trpc/server";
 //import { getSetups } from "~/server/services/videoService";
 import { uploadToBlob } from "~/lib/blob";
 import { FirefliesSyncService } from "~/server/services/FirefliesSyncService";
-import {
-  FirefliesService,
-  type FirefliesTranscript,
-} from "~/server/services/FirefliesService";
 import { TranscriptionProcessingService } from "~/server/services/TranscriptionProcessingService";
 import { weeklyMeetingStats } from "~/server/services/meetings/weeklyMeetingStats";
+import {
+  extractReadableTranscript,
+  MAX_SUMMARY_TRANSCRIPT_CHARS,
+} from "~/server/services/meetings/extractReadableTranscript";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import {
   TranscriptSummarizerService,
@@ -140,37 +140,6 @@ async function ensureTranscriptionAccess(
   });
 }
 
-/** Cap the transcript fed to the summarizer to bound LLM cost/latency. */
-const MAX_SUMMARY_TRANSCRIPT_CHARS = 200_000;
-
-/**
- * Normalize a stored `transcription` field into readable plain text for the
- * summarizer. Fireflies sessions store a JSON `{ sentences: [...] }` blob;
- * device sessions store plain text. Returns "" when there's nothing to summarize.
- */
-function extractReadableTranscript(raw: string | null): string {
-  if (!raw) return "";
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) return "";
-
-  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
-    try {
-      const parsed: unknown = JSON.parse(trimmed);
-      const sentences =
-        parsed && typeof parsed === "object" && "sentences" in parsed
-          ? (parsed as { sentences?: FirefliesTranscript["sentences"] })
-              .sentences
-          : undefined;
-      if (sentences?.length) {
-        return FirefliesService.formatTranscriptText(sentences);
-      }
-    } catch {
-      // Not JSON — fall through and treat the raw string as plain text.
-    }
-  }
-
-  return trimmed;
-}
 
 export const transcriptionRouter = createTRPCRouter({
   startSession: apiKeyMiddleware

--- a/src/server/services/activity/feedRenderHints.ts
+++ b/src/server/services/activity/feedRenderHints.ts
@@ -131,6 +131,14 @@ const HINTS: Record<string, FeedRenderHint> = {
     template: "{actor} had a meeting {entityRef}",
     iconKind: "created",
   },
+  // A meeting's transcript was auto-summarized by the cron sweep (ADR-0018,
+  // royal.raven). Emitted once when the summary lands; the meeting title rides
+  // in metadata so {entityRef} renders the title, not a CUID. Reuses the
+  // "updated" icon kind since summarizing enriches an existing meeting.
+  [key("meeting", "summarized")]: {
+    template: "{actor} summarized a meeting {entityRef}",
+    iconKind: "updated",
+  },
 };
 
 /** Default hint used when no entry exists for the (entityType, action) pair. */

--- a/src/server/services/activity/recordActivity.ts
+++ b/src/server/services/activity/recordActivity.ts
@@ -11,7 +11,8 @@ export type ActivityAction =
   | "updated"
   | "status_changed"
   | "completed"
-  | "commented";
+  | "commented"
+  | "summarized";
 
 /**
  * Entity types we currently log activity for. New writers append new values

--- a/src/server/services/meetings/__tests__/selectMeetingsToSummarize.test.ts
+++ b/src/server/services/meetings/__tests__/selectMeetingsToSummarize.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for `selectMeetingsToSummarize` — the pure gate the auto-summarize
+ * cron sweep (ADR-0018, royal.raven) uses to decide which meetings to summarize.
+ *
+ * Pure function, no DB or IO, so these run in microseconds and need no mocking
+ * (prior art: recordActivity.test.ts / heatmap.test.ts style).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  selectMeetingsToSummarize,
+  type SummarizableMeeting,
+} from "../selectMeetingsToSummarize";
+
+const meeting = (
+  id: string,
+  transcription: string | null,
+  summary: string | null,
+): SummarizableMeeting => ({ id, transcription, summary });
+
+describe("selectMeetingsToSummarize", () => {
+  it("selects meetings with a transcript and no summary", () => {
+    const result = selectMeetingsToSummarize([
+      meeting("a", "we discussed the roadmap", null),
+    ]);
+    expect(result.map((m) => m.id)).toEqual(["a"]);
+  });
+
+  it("excludes already-summarised meetings", () => {
+    const result = selectMeetingsToSummarize([
+      meeting("a", "transcript", '{"overview":"done"}'),
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("excludes transcript-less meetings", () => {
+    const result = selectMeetingsToSummarize([
+      meeting("null-transcript", null, null),
+      meeting("empty-transcript", "", null),
+      meeting("whitespace-transcript", "   \n  ", null),
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("treats an empty/whitespace summary as not summarised yet", () => {
+    const result = selectMeetingsToSummarize([
+      meeting("empty-summary", "transcript", ""),
+      meeting("whitespace-summary", "transcript", "  \n "),
+    ]);
+    expect(result.map((m) => m.id)).toEqual([
+      "empty-summary",
+      "whitespace-summary",
+    ]);
+  });
+
+  it("filters a mixed batch down to only the eligible rows, preserving order", () => {
+    const result = selectMeetingsToSummarize([
+      meeting("eligible-1", "t1", null),
+      meeting("already-done", "t2", '{"overview":"x"}'),
+      meeting("no-transcript", null, null),
+      meeting("eligible-2", "t3", null),
+    ]);
+    expect(result.map((m) => m.id)).toEqual(["eligible-1", "eligible-2"]);
+  });
+
+  it("returns an empty array for an empty batch", () => {
+    expect(selectMeetingsToSummarize([])).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [
+      meeting("a", "t", null),
+      meeting("b", "t", '{"overview":"x"}'),
+    ];
+    const snapshot = [...input];
+    selectMeetingsToSummarize(input);
+    expect(input).toEqual(snapshot);
+  });
+
+  it("preserves caller-extended row shape (structural subtype)", () => {
+    interface RichMeeting extends SummarizableMeeting {
+      title: string | null;
+    }
+    const rows: RichMeeting[] = [
+      { id: "a", transcription: "t", summary: null, title: "Standup" },
+    ];
+    const result = selectMeetingsToSummarize(rows);
+    expect(result[0]?.title).toBe("Standup");
+  });
+});

--- a/src/server/services/meetings/extractReadableTranscript.ts
+++ b/src/server/services/meetings/extractReadableTranscript.ts
@@ -1,0 +1,40 @@
+import {
+  FirefliesService,
+  type FirefliesTranscript,
+} from "~/server/services/FirefliesService";
+
+/**
+ * Normalize a stored `transcription` field into readable plain text for the
+ * summarizer. Fireflies sessions store a JSON `{ sentences: [...] }` blob;
+ * device sessions store plain text. Returns "" when there's nothing to
+ * summarize.
+ *
+ * Shared by the transcription router's `generateSummary` mutation and the
+ * auto-summarize cron sweep so both produce summaries from identical input.
+ */
+export function extractReadableTranscript(raw: string | null): string {
+  if (!raw) return "";
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return "";
+
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      const sentences =
+        parsed && typeof parsed === "object" && "sentences" in parsed
+          ? (parsed as { sentences?: FirefliesTranscript["sentences"] })
+              .sentences
+          : undefined;
+      if (sentences?.length) {
+        return FirefliesService.formatTranscriptText(sentences);
+      }
+    } catch {
+      // Not JSON — fall through and treat the raw string as plain text.
+    }
+  }
+
+  return trimmed;
+}
+
+/** Max transcript chars fed to the summarizer (cost/latency bound). */
+export const MAX_SUMMARY_TRANSCRIPT_CHARS = 200_000;

--- a/src/server/services/meetings/meetingSummarySweep.ts
+++ b/src/server/services/meetings/meetingSummarySweep.ts
@@ -1,0 +1,170 @@
+import type { PrismaClient } from "@prisma/client";
+import {
+  TranscriptSummarizerService,
+  SummarizationNotConfiguredError,
+} from "~/server/services/TranscriptSummarizerService";
+import { recordActivity } from "~/server/services/activity/recordActivity";
+import {
+  extractReadableTranscript,
+  MAX_SUMMARY_TRANSCRIPT_CHARS,
+} from "~/server/services/meetings/extractReadableTranscript";
+import {
+  selectMeetingsToSummarize,
+  type SummarizableMeeting,
+} from "~/server/services/meetings/selectMeetingsToSummarize";
+
+/**
+ * Auto-summarize cron sweep (ADR-0018, royal.raven).
+ *
+ * Runs serverless-safe inside a Vercel cron request — all work happens within
+ * the request, never as post-response fire-and-forget. The sweep:
+ *   1. selects meetings with a transcript but no summary (heals forward; no
+ *      mass backfill of historical meetings),
+ *   2. summarizes each via the existing `TranscriptSummarizerService` and
+ *      persists the result to `summary` in the same shape as the manual
+ *      `generateSummary` mutation,
+ *   3. emits one `meeting`/`summarized` activity event per summary that lands.
+ *
+ * Idempotent: it only ever picks up `summary IS NULL` rows, so re-running is
+ * safe and never double-emits the `summarized` event for an already-summarised
+ * meeting. Meetings still lacking a summary (no transcript, or a failed/skipped
+ * summarize) are simply left for the next sweep — downstream consumers fall back
+ * to title.
+ */
+
+/** Default number of meetings summarized per sweep (bounds LLM cost/runtime). */
+const DEFAULT_SWEEP_LIMIT = 10;
+
+/** The columns the sweep needs from a `TranscriptionSession` row. */
+interface SweepMeeting extends SummarizableMeeting {
+  title: string | null;
+  workspaceId: string | null;
+  userId: string | null;
+}
+
+export interface MeetingSummarySweepOptions {
+  /** Max meetings to summarize in one sweep. Defaults to {@link DEFAULT_SWEEP_LIMIT}. */
+  limit?: number;
+}
+
+export interface MeetingSummarySweepResult {
+  /** Eligible meetings the selector returned for this sweep. */
+  candidates: number;
+  /** Meetings whose summary was generated and persisted. */
+  summarized: number;
+  /** Meetings that yielded no usable summary (empty transcript, LLM error). */
+  skipped: number;
+  /** `meeting`/`summarized` activity events successfully written. */
+  eventsEmitted: number;
+  /** True when summarization is not configured (missing OPENAI_API_KEY). */
+  notConfigured: boolean;
+}
+
+/**
+ * Run one auto-summarize sweep. Resolves with a per-run tally; never throws for
+ * per-meeting failures (those are logged and counted as skipped) so a single bad
+ * transcript can't sink the whole sweep. A missing OPENAI_API_KEY short-circuits
+ * the run cleanly via `notConfigured`.
+ */
+export async function runMeetingSummarySweep(
+  db: PrismaClient,
+  options: MeetingSummarySweepOptions = {},
+): Promise<MeetingSummarySweepResult> {
+  const limit = options.limit ?? DEFAULT_SWEEP_LIMIT;
+
+  const result: MeetingSummarySweepResult = {
+    candidates: 0,
+    summarized: 0,
+    skipped: 0,
+    eventsEmitted: 0,
+    notConfigured: false,
+  };
+
+  // DB-level prefilter mirrors the selector predicate (summary-null +
+  // transcript-present) so we only pull rows that could be eligible. Archived
+  // meetings are excluded — they're out of the active corpus.
+  const rows: SweepMeeting[] = await db.transcriptionSession.findMany({
+    where: {
+      summary: null,
+      transcription: { not: null },
+      archivedAt: null,
+    },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    select: {
+      id: true,
+      title: true,
+      transcription: true,
+      summary: true,
+      workspaceId: true,
+      userId: true,
+    },
+  });
+
+  // Pure selector is the authoritative gate (also drops empty-string/whitespace
+  // transcripts that the SQL `not null` check lets through).
+  const eligible = selectMeetingsToSummarize(rows);
+  result.candidates = eligible.length;
+
+  for (const meeting of eligible) {
+    const transcriptText = extractReadableTranscript(meeting.transcription);
+    if (transcriptText.trim().length === 0) {
+      result.skipped += 1;
+      continue;
+    }
+
+    let summaryJson: string;
+    try {
+      const summary =
+        await TranscriptSummarizerService.summarizeToFirefliesSummary(
+          transcriptText.slice(0, MAX_SUMMARY_TRANSCRIPT_CHARS),
+        );
+      summaryJson = JSON.stringify(summary, null, 2);
+    } catch (error) {
+      if (error instanceof SummarizationNotConfiguredError) {
+        // No key configured — abort the whole sweep cleanly; nothing here will
+        // succeed and the next sweep heals once it's configured.
+        result.notConfigured = true;
+        break;
+      }
+      console.error(
+        "[meetingSummarySweep] failed to summarize meeting",
+        meeting.id,
+        error instanceof Error ? error.message : String(error),
+      );
+      result.skipped += 1;
+      continue;
+    }
+
+    // Conditional persist guards against a concurrent writer (e.g. the manual
+    // generateSummary mutation) having filled `summary` since we read the row —
+    // `updateMany` with `summary: null` makes the write a no-op in that case, so
+    // we never overwrite a summary or double-emit the activity event.
+    const { count } = await db.transcriptionSession.updateMany({
+      where: { id: meeting.id, summary: null },
+      data: { summary: summaryJson, updatedAt: new Date() },
+    });
+    if (count === 0) {
+      result.skipped += 1;
+      continue;
+    }
+    result.summarized += 1;
+
+    // Emit one activity event per summary that lands. Skipped for personal
+    // (no-workspace) meetings since recordActivity requires a workspaceId; the
+    // title rides in metadata so the feed renders the title, not a CUID.
+    if (meeting.workspaceId && meeting.userId) {
+      const wrote = await recordActivity(db, {
+        workspaceId: meeting.workspaceId,
+        userId: meeting.userId,
+        entityType: "meeting",
+        entityId: meeting.id,
+        action: "summarized",
+        metadata: { title: meeting.title ?? undefined },
+      });
+      if (wrote) result.eventsEmitted += 1;
+    }
+  }
+
+  return result;
+}

--- a/src/server/services/meetings/selectMeetingsToSummarize.ts
+++ b/src/server/services/meetings/selectMeetingsToSummarize.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure selector for the auto-summarize cron sweep (ADR-0018, royal.raven).
+ *
+ * Given a batch of meeting rows, decide which ones the sweep should summarize:
+ * a meeting is eligible iff it has a transcript to summarize but no summary yet.
+ * Everything else — already-summarised meetings and transcript-less ones — is
+ * skipped, which is what makes the sweep safe to re-run (idempotent) and lets it
+ * "heal forward" without mass-backfilling.
+ *
+ * This is intentionally a free function with no DB or IO so it can be unit
+ * tested in isolation (prior art: recordActivity.test.ts / heatmap.test.ts).
+ * The narrow input shape (`SummarizableMeeting`) is a structural subset of
+ * `TranscriptionSession`, so the sweep service can pass real rows directly.
+ */
+
+/** The minimal meeting shape the selector reasons about. */
+export interface SummarizableMeeting {
+  id: string;
+  /** Raw transcript blob (Fireflies JSON or device plain text), or null. */
+  transcription: string | null;
+  /** Persisted summary; null/empty means "not summarised yet". */
+  summary: string | null;
+}
+
+/** Returns true when the transcript field holds something worth summarizing. */
+function hasTranscript(transcription: string | null): boolean {
+  return typeof transcription === "string" && transcription.trim().length > 0;
+}
+
+/** Returns true when the meeting already has a non-empty summary. */
+function hasSummary(summary: string | null): boolean {
+  return typeof summary === "string" && summary.trim().length > 0;
+}
+
+/**
+ * Filter `meetings` down to the ones the sweep should summarize:
+ * transcript present AND summary absent. Order is preserved.
+ *
+ * Pure: no mutation, no IO. Safe to call on every sweep — already-summarised
+ * rows fall out here, so the sweep never double-summarizes or double-emits the
+ * `meeting`/`summarized` activity event.
+ */
+export function selectMeetingsToSummarize<T extends SummarizableMeeting>(
+  meetings: readonly T[],
+): T[] {
+  return meetings.filter(
+    (m) => hasTranscript(m.transcription) && !hasSummary(m.summary),
+  );
+}

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
     {
       "path": "/api/cron/weekly-thread-score-digest",
       "schedule": "0 9 * * 1"
+    },
+    {
+      "path": "/api/cron/auto-summarize-meetings",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Implements Exponential ticket **royal.raven** (`cmqdr3rpi000fju049jnwbna8`) — "Auto-summarize meetings (cron sweep + summarized event + graceful fallback)", under feature **Weekly work digest** (`cmqdr2gsn000fih046xriyd1f`). See ADR-0018.

## What this does

Makes meeting summarization automatic going forward, serverless-safely. A new Vercel cron runs an inline sweep that finds meetings with a transcript but no summary, summarizes a bounded batch, persists each summary, and emits a `meeting`/`summarized` activity event. The sweep heals the corpus forward — no mass backfill.

## How the cron is wired

- `vercel.json` gets a new hourly cron entry → `GET /api/cron/auto-summarize-meetings`.
- The route (`src/app/api/cron/auto-summarize-meetings/route.ts`) follows the existing cron pattern (CRON_SECRET bearer check, JSON result) and sets `maxDuration = 300` to give the inline LLM batch headroom. It calls `runMeetingSummarySweep(db)` and returns the per-run tally.

## How post-response work is avoided

All summarization happens **inside the cron request** — `runMeetingSummarySweep` awaits each summarize+persist+event before returning. There is no `void`/detached promise, no "after the response" work that a serverless function can't reliably finish. The batch is bounded (default 10/run) so the request stays within `maxDuration`.

## Files

- `src/server/services/meetings/selectMeetingsToSummarize.ts` — **pure, exported `select(meetings) -> toSummarize[]`** (transcript present AND summary absent; excludes already-summarised and transcript-less). Unit-tested.
- `src/server/services/meetings/__tests__/selectMeetingsToSummarize.test.ts` — 8 unit tests (recordActivity/heatmap style).
- `src/server/services/meetings/meetingSummarySweep.ts` — orchestrator: DB prefilter (`summary: null`, `transcription not null`, `archivedAt: null`) → pure selector gate → `TranscriptSummarizerService.summarizeToFirefliesSummary` → conditional `updateMany({ summary: null })` persist → one `meeting`/`summarized` event per summary.
- `src/server/services/meetings/extractReadableTranscript.ts` — extracted the transcript-normalizer (was a private copy in the transcription router) so the router and sweep summarize from identical input.
- `src/app/api/cron/auto-summarize-meetings/route.ts` — the cron route.
- `src/server/services/activity/recordActivity.ts` — `summarized` added to `ActivityAction`.
- `src/server/services/activity/feedRenderHints.ts` — `meeting`/`summarized` render hint ("{actor} summarized a meeting {entityRef}"); title in metadata so the feed shows the title, not a CUID.
- `src/server/api/routers/transcription.ts` — now imports the shared `extractReadableTranscript`/`MAX_SUMMARY_TRANSCRIPT_CHARS` (dead local copy + now-unused Fireflies imports removed).

## Idempotency & graceful fallback

- Only `summary IS NULL` rows are ever picked up → safe to re-run, never double-summarizes.
- Persist uses `updateMany({ where: { id, summary: null } })` so a concurrent `generateSummary` mutation can't be overwritten and the `summarized` event isn't double-emitted (no-op `count===0` → skipped).
- Per-meeting failures are logged and counted as skipped; a missing `OPENAI_API_KEY` short-circuits the run cleanly (`notConfigured`). Meetings still lacking a summary are left for the next sweep — downstream consumers fall back to title.

## No migration

`summary` already exists on `TranscriptionSession`; `prisma/schema.prisma` is untouched. PR targets `main`.

## Checks

- `npm run test` — 685/685 unit tests pass (incl. the 8 new selector tests and the existing transcription router test, which still passes after the refactor).
- `npx tsc --noEmit` — clean.
- `next lint --dir src` — no errors (only pre-existing warnings in untouched files).
- Pre-commit hook (tests + Prisma check + hardcoded-color check) all green.