### PR TITLE
feat(chat): auto-refresh goal activity when Zoe posts a comment/update

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,18 +80,27 @@ The cross-workspace activity list at the top-level `/activity` route — every `
 _Avoid_: My activity, personal feed (it is not filtered to the viewer's own events — that's the **Weekly work digest**).
 
 **Weekly work digest**:
-A **personal, cross-workspace, per-ISO-week** synthesis of what *you* worked on — the AI-summarised story of your week, rendered as a panel at the top of the `/activity` page above the **Aggregated activity feed**. Subject is **Z-scoped**: events you acted on **and** items assigned to / owned by you that moved, unioned at read across four sources — enriched activity events, your assigned/owned entities, **Meetings** you attended (one-line blurb from the meeting summary, or title fallback), and your GitHub commits/PRs. Cached per `(userId, isoYear, isoWeek)`, regenerable, TTL on the active week — the personal sibling of the workspace **Week-in-Review** (`WorkspaceWeeklyNarrative`). Strictly distinct: Week-in-Review is one workspace, team-shared, a `narrative`; the work digest is all your workspaces, private to you, and additionally emits **Content angles**.
+A **personal, cross-workspace, per-ISO-week** synthesis of what *you* worked on — the AI-summarised story of your week, rendered as a panel at the top of the `/activity` page above the **Aggregated activity feed**. Subject is **Z-scoped**: events you acted on **and** items assigned to / owned by you that moved, unioned at read across **three** sources in v1 — enriched activity events, your assigned/owned entities, and **Meetings** you attended (one-line blurb from the meeting summary, or title fallback). (A fourth source, your commits, is **deferred** — see **Commit activity**.) Cached per `(userId, isoYear, isoWeek)`, regenerable, TTL on the active week — the personal sibling of the workspace **Week-in-Review** (`WorkspaceWeeklyNarrative`). Strictly distinct: Week-in-Review is one workspace, team-shared, a `narrative`; the work digest is all your workspaces, private to you, and additionally emits **Content angles**.
 _Avoid_: Weekly narrative / Week-in-Review (that's the team, single-workspace artifact), My Week, weekly summary.
 
 **Content angle**:
 An AI-suggested content starting point — a hook or framing for a social post, derived from the **Weekly work digest** (e.g. "what I learned shipping a cross-workspace feed"). Raw material for the user's own writing, not a finished draft. Surfaced as a labelled sub-section of the digest.
 _Avoid_: Content idea, post draft (an angle is a prompt, not a written post), suggestion.
 
-**Commit activity**:
-Git commits **polled and persisted** per **Workspace repository** by a cron (PAT-based, no GitHub App required), upserted by `commitSha`. Stored **per-commit** but **rendered grouped** in feeds ("pushed 7 commits to `exponential`"), and summarised in prose by the **Weekly work digest**. "Mine" is resolved by matching `commitAuthor` to the viewer's **GitHub identity claim** (`User.githubLogin`). This persists commits for the **Aggregated activity feed** and the digest — an explicit amendment of [ADR-0001](docs/adr/0001-activity-feed-storage.md)'s "GitHub events are not persisted for the panel" stance (the change ADR-0001 anticipated "later if latency/rate-limits bite").
+**Commit activity** _(Planned — NOT built; [ADR-0019](docs/adr/0019-persist-polled-commits.md) is **Deferred**)_:
+The intended design — git commits **polled and persisted** per **Workspace repository** by a cron (PAT-based, no GitHub App required), upserted by `commitSha`. Stored **per-commit** but **rendered grouped** in feeds ("pushed 7 commits to `exponential`"), and summarised in prose by the **Weekly work digest**. "Mine" is resolved by matching `commitAuthor` to the viewer's **GitHub identity claim** (`User.githubLogin`). This persists commits for the **Aggregated activity feed** and the digest — an explicit amendment of [ADR-0001](docs/adr/0001-activity-feed-storage.md)'s "GitHub events are not persisted for the panel" stance (the change ADR-0001 anticipated "later if latency/rate-limits bite").
 _Avoid_: Commits feed, GitHub feed (use "commit activity"); conflating with the webhook-fed `GitHubActivity` analytics path.
 
 ## Relationships (activity)
+
+> ⚠️ **Accuracy caveat (2026-06-14):** the GitHub-source items below (Workspace
+> repositories, the live-fetch union, activity sources / source switcher) are
+> **aspirational — never implemented**. A code audit found no `WorkspaceRepository`,
+> no `User.githubLogin`, no GitHub OAuth provider, and no GitHub handling in
+> `feed.ts` (the feed reads only `WorkspaceActivityEvent`). `GitHubActivity` is
+> webhook-fed and read only by Sprint Analytics. See [ADR-0001](docs/adr/0001-activity-feed-storage.md)'s
+> accuracy caveat. The terms are retained as the design's vocabulary, not as a
+> description of shipped behaviour.
 
 - A **Workspace** has many **Workspace repositories**.
 - A **Workspace** has many **Activity events** from zero or more **Activity sources**.
@@ -99,7 +108,7 @@ _Avoid_: Commits feed, GitHub feed (use "commit activity"); conflating with the 
 - GitHub events shown in the activity feed are **not persisted** for the panel's purposes. They are fetched on page load via a shared `GITHUB_API_TOKEN` PAT (impactful-events style), with a ~5min server-side cache per repo to absorb refreshes.
 - The existing webhook path (`/api/webhooks/github`) and `GitHubActivity` table remain — they continue to feed `SprintSnapshot` analytics, **independent** of the activity panel. The two paths can coexist for the same repo; the activity feed only uses live-fetch.
 - **Meetings** now emit `WorkspaceActivityEvent` rows via `recordActivity` (entityType `meeting`: `created`, then `summarized` once the auto-summary lands) — the internal-data write-path of ADR-0001, so a meeting appears in the workspace feed, the **Aggregated activity feed**, and the **Weekly work digest** from one write.
-- **Commit activity** is **polled and persisted** (cron, PAT-based) so commits reach the **Aggregated activity feed** and the digest — amending ADR-0001's not-persisted stance (to be formalised in a follow-up ADR). The per-workspace panel's live-fetch vs. persisted-read reconciliation is an open decision for that ADR.
+- **Commit activity** _(planned, not built — [ADR-0019](docs/adr/0019-persist-polled-commits.md) Deferred)_ would be **polled and persisted** (cron, PAT-based) so commits reach the **Aggregated activity feed** and the digest. Blocked on the missing repo-declaration + identity-claim primitives; commits are deferred from **Weekly work digest** v1.
 
 ### Weekly planning
 

--- a/dev-docs/AGENT_CHAT_UI_REFRESH.md
+++ b/dev-docs/AGENT_CHAT_UI_REFRESH.md
@@ -1,0 +1,78 @@
+# Agent chat → UI refresh: invalidating page data after Zoe writes
+
+When Zoe (the in-app agent / `ManyChat`) performs a **write** via a tool, the
+write happens server-side (chat stream → mastra → tRPC). Any page data showing
+that entity lives in a **separate** component with its own React Query cache, so
+it stays stale until a manual reload. This note records the approach so the next
+person hitting it doesn't rediscover it.
+
+## Why not an ADR
+
+By this repo's ADR test (all three must hold: hard to reverse, surprising without
+context, real trade-off with rejected alternatives), this **doesn't qualify** —
+it's a small, easily-reversed client convention. So it lives here as a how-to with
+a short decision note, not in `docs/adr/`. If this ever grows into a generic
+server-driven invalidation layer (Option B below), *that* would warrant an ADR.
+
+## The mechanism (works across the component tree)
+
+tRPC/React Query invalidation is **not** component-scoped: the cache is one
+app-wide `QueryClient` (`src/trpc/react.tsx`). Invalidating a query key from
+`ManyChat` (right pane) refetches every mounted subscriber of that key —
+including a feed rendered in a sibling component (left pane). No parent/child
+relationship needed. This is the same `invalidate()` the composer already calls
+on its own mutations (`src/hooks/useGoalActivity.ts` → `invalidate`).
+
+## How it's wired today (the goal-activity case)
+
+First (and currently only) case: Zoe posting an **Objective comment/update**.
+
+- `ManyChat` parses `__exp_tool__` tool frames during streaming into a
+  `toolCallsById` Map (entries typed `ToolCall` — `name` + `status` —
+  `src/providers/AgentModalProvider.tsx`).
+- After the stream completes (just after `setIsStreaming(false)` in
+  `src/app/_components/ManyChat.tsx`), it checks the **succeeded** tool calls and,
+  if the user is on a goal page (`pageContext?.pageType === 'goal'`) and a tool
+  matched, invalidates the goal-activity queries.
+- The brittle bit — the tool name reaches the client as the registration key
+  (`addObjectiveUpdateTool`), the createTool id (`add-objective-update`), or a
+  humanized label ("Add objective update") — is isolated in a pure, unit-tested
+  helper: `src/app/_components/manyChatToolRefresh.ts`
+  (+ `manyChatToolRefresh.test.ts`). Test the matcher, not the React glue.
+- It invalidates the **same key set** as `useGoalActivity.invalidate()`:
+  `goalActivity.getFeed`, `goalActivity.getCount`, `goal.getById`
+  (feed + count badge + health badge), procedure-wide (no args) to dodge
+  goalId-source fragility. Fires **only** on the success path.
+
+## Adding a new case (the narrow way we use now)
+
+1. Add/extend a matcher (mirror `toolTriggersGoalActivityRefresh`) for the new
+   tool name(s), with a unit test across the name forms.
+2. In `ManyChat`'s post-stream block, add a branch: if a matching tool succeeded
+   (and, if page-specific, the right `pageContext.pageType`), call
+   `utils.<router>.<procedure>.invalidate()` for the queries that page reads —
+   reuse the page's existing hook invalidation set, don't invent keys.
+
+## If this grows: two generalizations (decision: stay narrow for now)
+
+We deliberately kept it narrow (two tools). If many write-tools appear:
+
+- **Option A — client refresh registry.** Replace the `if` with a declarative
+  table of `{ when(toolName), pageType?, invalidate(utils) }` rows; after the
+  stream, run matching rows for each succeeded tool. Generic engine, but
+  registration is still manual (forget a row → silent staleness).
+- **Option B — server-tagged invalidation.** `/api/chat/stream` (same repo as the
+  tRPC routers) attaches an `invalidate: [...]` list to the tool/meta frame from a
+  server-side tool→queries map; `ManyChat` blindly applies it via a name→`utils`
+  resolver. The coupling lives next to the routers; the client needs zero per-tool
+  knowledge. More plumbing — worth it only at scale, and would get an ADR.
+
+We did **not** add realtime infra (websockets/SSE-for-data/polling) — the app has
+none, and client invalidation after the chat stream is the right-sized fix.
+
+## Pointers / grep anchors
+
+- `manyChatToolRefresh` — the matcher + test
+- `ManyChat.tsx` post-stream block (after `setIsStreaming(false)`)
+- `useGoalActivity.ts` → `invalidate` — the canonical key set to mirror
+- `src/trpc/react.tsx` — the single app-wide `QueryClient`

--- a/docs/adr/0001-activity-feed-storage.md
+++ b/docs/adr/0001-activity-feed-storage.md
@@ -2,13 +2,15 @@
 
 ## Status
 
-Accepted — 2026-05-14
+Accepted — 2026-05-14.
 
-Amended by [ADR-0019](0019-persist-polled-commits.md) (2026-06-14): decisions #3
-and #4 below — "GitHub events are not persisted for the panel" and "persist
-polled GitHub data on a cron — rejected for v1" — are superseded for **commits**,
-which are now cron-polled and persisted to serve the aggregated feed and the
-Weekly work digest. The live-fetch union still describes PRs.
+⚠️ **Accuracy caveat (2026-06-14):** the GitHub half of this ADR (decisions #3–#5
+— live-fetch union, `WorkspaceRepository` as source of truth, the PAT path) was
+**never implemented**. A code audit found no `WorkspaceRepository`, no GitHub
+union in `feed.ts`, and no source switcher; `GitHubActivity` is webhook-fed and
+read only by Sprint Analytics, never by the activity feed. Treat those decisions
+as **proposed, not shipped**. [ADR-0019](0019-persist-polled-commits.md) would
+have amended #3/#4 but is itself **Deferred** pending the missing primitives.
 
 ## Context
 

--- a/docs/adr/0018-weekly-work-digest-personal-sibling.md
+++ b/docs/adr/0018-weekly-work-digest-personal-sibling.md
@@ -32,10 +32,14 @@ single-workspace one.
 2. **Subject is Z-scoped and cross-workspace.** It covers events the user
    *acted on* **and** items *assigned to / owned by* them that moved, unioned
    across every workspace they are a member of (direct or team), for the ISO week.
-3. **Four sources, unioned at read** by a deterministic gatherer: enriched
+3. **Sources, unioned at read** by a deterministic gatherer: enriched
    activity events (joined to live entities for real titles), the user's
-   assigned/owned entities that changed, **meetings attended** (one-line blurb
-   from the meeting summary, title fallback), and **the user's commits**.
+   assigned/owned entities that changed, and **meetings attended** (one-line
+   blurb from the meeting summary, title fallback). **A fourth source — the
+   user's commits — was planned but is deferred from v1** ([ADR-0019](0019-persist-polled-commits.md)
+   is Deferred: the repo-list / identity-claim primitives it needs don't exist
+   yet). So v1 ships **three sources**; commits slot in later behind the same
+   gatherer interface.
 4. **Deterministic gather → one LLM call → cached.** The gatherer assembles a
    structured bundle in code; a single `gpt-4o-mini` call returns the digest
    narrative **and** the **content angles** (≈3 post-idea hooks) in one
@@ -72,9 +76,9 @@ single-workspace one.
 ## Consequences
 
 - A new cached table (`(userId, isoYear, isoWeek)` → narrative + highlights +
-  angles) and a `weeklyWorkDigest` read procedure that performs the four-source
-  gather. The digest and Week-in-Review now share gather/cache/regenerate
-  machinery but stay separate rows.
+  angles) and a `weeklyWorkDigest` read procedure that performs the (v1)
+  three-source gather. The digest and Week-in-Review now share
+  gather/cache/regenerate machinery but stay separate rows.
 - Digest quality is bounded by the gatherer's richness — correct behaviour (no
   invented accomplishments), and the reason Q4–Q5 invested in real sources.
 - The meeting + commit enrichment pays off twice: it also enriches the

--- a/docs/adr/0019-persist-polled-commits.md
+++ b/docs/adr/0019-persist-polled-commits.md
@@ -2,11 +2,21 @@
 
 ## Status
 
-Accepted — 2026-06-14
+**Deferred — 2026-06-14.** Records the intended design, but **not implemented**:
+it rests on primitives that turned out not to exist. A code audit (schema,
+`develop`, all of `src/`) found **no `WorkspaceRepository` model, no
+`User.githubLogin`, no GitHub OAuth provider, and no GitHub union in the
+activity feed** — i.e. ADR-0001's GitHub half (decisions #3–#5) was written
+"Accepted" but never built. So there is no repo list to poll, no identity to
+attribute commits by, and no live-fetch to retire. Commits are therefore
+**dropped from the Weekly work digest v1** ([ADR-0018](0018-weekly-work-digest-personal-sibling.md)).
+Delivering this needs a prerequisite mini-epic first: a repo-declaration model
+(+ settings UI), a GitHub identity claim (+ a verified way to set it), then the
+ingest/persist, then the feed union + grouped render. Revisit then.
 
-Amends [ADR-0001](0001-activity-feed-storage.md) decision #3 ("GitHub events for
-the panel are not persisted") and #4 ("persist polled GitHub data on a cron —
-rejected for v1").
+When eventually built, this would amend [ADR-0001](0001-activity-feed-storage.md)
+decisions #3 ("GitHub events for the panel are not persisted") and #4 ("persist
+polled GitHub data on a cron — rejected for v1").
 
 ## Context
 

--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
 import { api } from "~/trpc/react";
+import { toolTriggersGoalActivityRefresh } from "./manyChatToolRefresh";
 import DOMPurify from 'dompurify';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -374,6 +375,7 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
   const { messages, setMessages, conversationId, setConversationId, pageContext, isOpen, pendingPrompt, pendingContext, consumePendingPrompt } = useAgentModal();
   const { workspaceId: urlWorkspaceId } = useWorkspace();
   const workspaceId = workspaceIdProp ?? urlWorkspaceId;
+  const utils = api.useUtils();
 
   // Fetch the user's custom assistant (if configured)
   const { data: customAssistant } = api.assistant.getDefault.useQuery(
@@ -1329,6 +1331,24 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
 
       clearIdleTimer();
       setIsStreaming(false);
+
+      // When Zoe posts to a goal's activity feed from chat (objective comment /
+      // update), that feed renders in a sibling component with its own React
+      // Query cache, so it stays stale until reload. Invalidate the same key set
+      // useGoalActivity.invalidate() uses (feed + count + the goal for the health
+      // badge). Procedure-wide (no args) avoids goalId source/coercion fragility;
+      // only one goal feed is mounted, so the cost is one refetch.
+      if (pageContext?.pageType === 'goal') {
+        const postedToGoalActivity = Array.from(toolCallsById.values()).some(
+          (tc) => tc.status === 'success' && toolTriggersGoalActivityRefresh(tc.name),
+        );
+        if (postedToGoalActivity) {
+          void utils.goalActivity.getFeed.invalidate();
+          void utils.goalActivity.getCount.invalidate();
+          void utils.goal.getById.invalidate();
+        }
+      }
+
       const responseTime = Date.now() - startTime;
       // A turn that did tool work but produced no prose is NOT empty —
       // the user sees those calls in the ToolActivity row.

--- a/src/app/_components/manyChatToolRefresh.test.ts
+++ b/src/app/_components/manyChatToolRefresh.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { toolTriggersGoalActivityRefresh } from "./manyChatToolRefresh";
+
+describe("toolTriggersGoalActivityRefresh", () => {
+  it("matches the objective comment/update tools across name forms", () => {
+    // Registration key (what the chat stream emits today)
+    expect(toolTriggersGoalActivityRefresh("addObjectiveUpdateTool")).toBe(true);
+    expect(toolTriggersGoalActivityRefresh("addObjectiveCommentTool")).toBe(true);
+    // createTool id
+    expect(toolTriggersGoalActivityRefresh("add-objective-update")).toBe(true);
+    expect(toolTriggersGoalActivityRefresh("add-objective-comment")).toBe(true);
+    // Humanized label
+    expect(toolTriggersGoalActivityRefresh("Add objective comment")).toBe(true);
+    expect(toolTriggersGoalActivityRefresh("Add objective update")).toBe(true);
+  });
+
+  it("does not match unrelated tools", () => {
+    expect(toolTriggersGoalActivityRefresh("createProjectTool")).toBe(false);
+    expect(toolTriggersGoalActivityRefresh("getAllProjectsTool")).toBe(false);
+    expect(toolTriggersGoalActivityRefresh("checkInOkrKeyResultTool")).toBe(false);
+    expect(toolTriggersGoalActivityRefresh("")).toBe(false);
+  });
+});

--- a/src/app/_components/manyChatToolRefresh.ts
+++ b/src/app/_components/manyChatToolRefresh.ts
@@ -1,0 +1,21 @@
+/**
+ * Maps an agent tool name to whether it should trigger a refresh of the goal
+ * (Objective) activity feed.
+ *
+ * Why this exists as a tiny pure function: the tool name that reaches the client
+ * is brittle — the chat stream emits the registered key (`addObjectiveUpdateTool`),
+ * the tool's createTool id is `add-objective-update`, and the UI humanizes it to
+ * "Add objective update". The string we match on can drift, so the matching is the
+ * part most likely to be wrong. Keeping it pure makes it directly unit-testable
+ * (test the layer that can actually break, not the React glue around it).
+ *
+ * Normalizing to lowercase letters only makes the match hold across all three
+ * forms above.
+ */
+export function toolTriggersGoalActivityRefresh(toolName: string): boolean {
+  const normalized = toolName.toLowerCase().replace(/[^a-z]/g, "");
+  return (
+    normalized.includes("objectivecomment") ||
+    normalized.includes("objectiveupdate")
+  );
+}


### PR DESCRIPTION
## Problem

When Zoe posts an Objective comment/update from chat, the write happens server-side (chat stream → mastra → tRPC). The goal page's activity feed renders in a **sibling** component (`GoalActivityTab` via `useGoalActivity`) with its own React Query cache, which has no idea a write occurred through a different channel — so the new entry only appears after a manual F5.

## Fix

After the chat stream completes, ManyChat invalidates the goal activity queries when a **successful** tool call this turn was an objective comment/update tool **and** the user is on a goal page. This works across the component tree because the cache lives in one app-wide `QueryClient` — invalidating a key refetches every mounted subscriber, including the left-pane feed. It reuses the exact key set already in `useGoalActivity.invalidate()`:

- `goalActivity.getFeed` (the feed)
- `goalActivity.getCount` (the count badge)
- `goal.getById` (the health badge)

Invalidation is procedure-wide (no args) to avoid goalId source/coercion fragility; only one goal feed is mounted, so the cost is one refetch. Only the success path fires — a failed post does not refetch.

## Tool-name matching

The brittle part — the tool name that reaches the client can be the registration key (`addObjectiveUpdateTool`), the createTool id (`add-objective-update`), or the humanized label ("Add objective update") — is extracted into a **pure helper** `manyChatToolRefresh.ts` and unit-tested across all three forms (applying the lesson from the goalId incident: test the layer that can actually break).

## Test

- `manyChatToolRefresh.test.ts` — matcher passes for all name forms, rejects unrelated tools. ✅
- Typecheck clean.
- No backend changes.

> Manual verification (open goal 19, ask Zoe to post an update, confirm the feed + health badge refresh without F5) is the real proof and is recommended before merge — I have not run the live app in this environment.