### PR TITLE
docs: re-land defer-commits + unbuilt-GitHub honesty fixes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,18 +80,27 @@ The cross-workspace activity list at the top-level `/activity` route — every `
 _Avoid_: My activity, personal feed (it is not filtered to the viewer's own events — that's the **Weekly work digest**).
 
 **Weekly work digest**:
-A **personal, cross-workspace, per-ISO-week** synthesis of what *you* worked on — the AI-summarised story of your week, rendered as a panel at the top of the `/activity` page above the **Aggregated activity feed**. Subject is **Z-scoped**: events you acted on **and** items assigned to / owned by you that moved, unioned at read across four sources — enriched activity events, your assigned/owned entities, **Meetings** you attended (one-line blurb from the meeting summary, or title fallback), and your GitHub commits/PRs. Cached per `(userId, isoYear, isoWeek)`, regenerable, TTL on the active week — the personal sibling of the workspace **Week-in-Review** (`WorkspaceWeeklyNarrative`). Strictly distinct: Week-in-Review is one workspace, team-shared, a `narrative`; the work digest is all your workspaces, private to you, and additionally emits **Content angles**.
+A **personal, cross-workspace, per-ISO-week** synthesis of what *you* worked on — the AI-summarised story of your week, rendered as a panel at the top of the `/activity` page above the **Aggregated activity feed**. Subject is **Z-scoped**: events you acted on **and** items assigned to / owned by you that moved, unioned at read across **three** sources in v1 — enriched activity events, your assigned/owned entities, and **Meetings** you attended (one-line blurb from the meeting summary, or title fallback). (A fourth source, your commits, is **deferred** — see **Commit activity**.) Cached per `(userId, isoYear, isoWeek)`, regenerable, TTL on the active week — the personal sibling of the workspace **Week-in-Review** (`WorkspaceWeeklyNarrative`). Strictly distinct: Week-in-Review is one workspace, team-shared, a `narrative`; the work digest is all your workspaces, private to you, and additionally emits **Content angles**.
 _Avoid_: Weekly narrative / Week-in-Review (that's the team, single-workspace artifact), My Week, weekly summary.
 
 **Content angle**:
 An AI-suggested content starting point — a hook or framing for a social post, derived from the **Weekly work digest** (e.g. "what I learned shipping a cross-workspace feed"). Raw material for the user's own writing, not a finished draft. Surfaced as a labelled sub-section of the digest.
 _Avoid_: Content idea, post draft (an angle is a prompt, not a written post), suggestion.
 
-**Commit activity**:
-Git commits **polled and persisted** per **Workspace repository** by a cron (PAT-based, no GitHub App required), upserted by `commitSha`. Stored **per-commit** but **rendered grouped** in feeds ("pushed 7 commits to `exponential`"), and summarised in prose by the **Weekly work digest**. "Mine" is resolved by matching `commitAuthor` to the viewer's **GitHub identity claim** (`User.githubLogin`). This persists commits for the **Aggregated activity feed** and the digest — an explicit amendment of [ADR-0001](docs/adr/0001-activity-feed-storage.md)'s "GitHub events are not persisted for the panel" stance (the change ADR-0001 anticipated "later if latency/rate-limits bite").
+**Commit activity** _(Planned — NOT built; [ADR-0019](docs/adr/0019-persist-polled-commits.md) is **Deferred**)_:
+The intended design — git commits **polled and persisted** per **Workspace repository** by a cron (PAT-based, no GitHub App required), upserted by `commitSha`. Stored **per-commit** but **rendered grouped** in feeds ("pushed 7 commits to `exponential`"), and summarised in prose by the **Weekly work digest**. "Mine" is resolved by matching `commitAuthor` to the viewer's **GitHub identity claim** (`User.githubLogin`). This persists commits for the **Aggregated activity feed** and the digest — an explicit amendment of [ADR-0001](docs/adr/0001-activity-feed-storage.md)'s "GitHub events are not persisted for the panel" stance (the change ADR-0001 anticipated "later if latency/rate-limits bite").
 _Avoid_: Commits feed, GitHub feed (use "commit activity"); conflating with the webhook-fed `GitHubActivity` analytics path.
 
 ## Relationships (activity)
+
+> ⚠️ **Accuracy caveat (2026-06-14):** the GitHub-source items below (Workspace
+> repositories, the live-fetch union, activity sources / source switcher) are
+> **aspirational — never implemented**. A code audit found no `WorkspaceRepository`,
+> no `User.githubLogin`, no GitHub OAuth provider, and no GitHub handling in
+> `feed.ts` (the feed reads only `WorkspaceActivityEvent`). `GitHubActivity` is
+> webhook-fed and read only by Sprint Analytics. See [ADR-0001](docs/adr/0001-activity-feed-storage.md)'s
+> accuracy caveat. The terms are retained as the design's vocabulary, not as a
+> description of shipped behaviour.
 
 - A **Workspace** has many **Workspace repositories**.
 - A **Workspace** has many **Activity events** from zero or more **Activity sources**.
@@ -99,7 +108,7 @@ _Avoid_: Commits feed, GitHub feed (use "commit activity"); conflating with the 
 - GitHub events shown in the activity feed are **not persisted** for the panel's purposes. They are fetched on page load via a shared `GITHUB_API_TOKEN` PAT (impactful-events style), with a ~5min server-side cache per repo to absorb refreshes.
 - The existing webhook path (`/api/webhooks/github`) and `GitHubActivity` table remain — they continue to feed `SprintSnapshot` analytics, **independent** of the activity panel. The two paths can coexist for the same repo; the activity feed only uses live-fetch.
 - **Meetings** now emit `WorkspaceActivityEvent` rows via `recordActivity` (entityType `meeting`: `created`, then `summarized` once the auto-summary lands) — the internal-data write-path of ADR-0001, so a meeting appears in the workspace feed, the **Aggregated activity feed**, and the **Weekly work digest** from one write.
-- **Commit activity** is **polled and persisted** (cron, PAT-based) so commits reach the **Aggregated activity feed** and the digest — amending ADR-0001's not-persisted stance (to be formalised in a follow-up ADR). The per-workspace panel's live-fetch vs. persisted-read reconciliation is an open decision for that ADR.
+- **Commit activity** _(planned, not built — [ADR-0019](docs/adr/0019-persist-polled-commits.md) Deferred)_ would be **polled and persisted** (cron, PAT-based) so commits reach the **Aggregated activity feed** and the digest. Blocked on the missing repo-declaration + identity-claim primitives; commits are deferred from **Weekly work digest** v1.
 
 ### Weekly planning
 

--- a/docs/adr/0001-activity-feed-storage.md
+++ b/docs/adr/0001-activity-feed-storage.md
@@ -2,13 +2,15 @@
 
 ## Status
 
-Accepted — 2026-05-14
+Accepted — 2026-05-14.
 
-Amended by [ADR-0019](0019-persist-polled-commits.md) (2026-06-14): decisions #3
-and #4 below — "GitHub events are not persisted for the panel" and "persist
-polled GitHub data on a cron — rejected for v1" — are superseded for **commits**,
-which are now cron-polled and persisted to serve the aggregated feed and the
-Weekly work digest. The live-fetch union still describes PRs.
+⚠️ **Accuracy caveat (2026-06-14):** the GitHub half of this ADR (decisions #3–#5
+— live-fetch union, `WorkspaceRepository` as source of truth, the PAT path) was
+**never implemented**. A code audit found no `WorkspaceRepository`, no GitHub
+union in `feed.ts`, and no source switcher; `GitHubActivity` is webhook-fed and
+read only by Sprint Analytics, never by the activity feed. Treat those decisions
+as **proposed, not shipped**. [ADR-0019](0019-persist-polled-commits.md) would
+have amended #3/#4 but is itself **Deferred** pending the missing primitives.
 
 ## Context
 

--- a/docs/adr/0018-weekly-work-digest-personal-sibling.md
+++ b/docs/adr/0018-weekly-work-digest-personal-sibling.md
@@ -32,10 +32,14 @@ single-workspace one.
 2. **Subject is Z-scoped and cross-workspace.** It covers events the user
    *acted on* **and** items *assigned to / owned by* them that moved, unioned
    across every workspace they are a member of (direct or team), for the ISO week.
-3. **Four sources, unioned at read** by a deterministic gatherer: enriched
+3. **Sources, unioned at read** by a deterministic gatherer: enriched
    activity events (joined to live entities for real titles), the user's
-   assigned/owned entities that changed, **meetings attended** (one-line blurb
-   from the meeting summary, title fallback), and **the user's commits**.
+   assigned/owned entities that changed, and **meetings attended** (one-line
+   blurb from the meeting summary, title fallback). **A fourth source — the
+   user's commits — was planned but is deferred from v1** ([ADR-0019](0019-persist-polled-commits.md)
+   is Deferred: the repo-list / identity-claim primitives it needs don't exist
+   yet). So v1 ships **three sources**; commits slot in later behind the same
+   gatherer interface.
 4. **Deterministic gather → one LLM call → cached.** The gatherer assembles a
    structured bundle in code; a single `gpt-4o-mini` call returns the digest
    narrative **and** the **content angles** (≈3 post-idea hooks) in one
@@ -72,9 +76,9 @@ single-workspace one.
 ## Consequences
 
 - A new cached table (`(userId, isoYear, isoWeek)` → narrative + highlights +
-  angles) and a `weeklyWorkDigest` read procedure that performs the four-source
-  gather. The digest and Week-in-Review now share gather/cache/regenerate
-  machinery but stay separate rows.
+  angles) and a `weeklyWorkDigest` read procedure that performs the (v1)
+  three-source gather. The digest and Week-in-Review now share
+  gather/cache/regenerate machinery but stay separate rows.
 - Digest quality is bounded by the gatherer's richness — correct behaviour (no
   invented accomplishments), and the reason Q4–Q5 invested in real sources.
 - The meeting + commit enrichment pays off twice: it also enriches the

--- a/docs/adr/0019-persist-polled-commits.md
+++ b/docs/adr/0019-persist-polled-commits.md
@@ -2,11 +2,21 @@
 
 ## Status
 
-Accepted — 2026-06-14
+**Deferred — 2026-06-14.** Records the intended design, but **not implemented**:
+it rests on primitives that turned out not to exist. A code audit (schema,
+`develop`, all of `src/`) found **no `WorkspaceRepository` model, no
+`User.githubLogin`, no GitHub OAuth provider, and no GitHub union in the
+activity feed** — i.e. ADR-0001's GitHub half (decisions #3–#5) was written
+"Accepted" but never built. So there is no repo list to poll, no identity to
+attribute commits by, and no live-fetch to retire. Commits are therefore
+**dropped from the Weekly work digest v1** ([ADR-0018](0018-weekly-work-digest-personal-sibling.md)).
+Delivering this needs a prerequisite mini-epic first: a repo-declaration model
+(+ settings UI), a GitHub identity claim (+ a verified way to set it), then the
+ingest/persist, then the feed union + grouped render. Revisit then.
 
-Amends [ADR-0001](0001-activity-feed-storage.md) decision #3 ("GitHub events for
-the panel are not persisted") and #4 ("persist polled GitHub data on a cron —
-rejected for v1").
+When eventually built, this would amend [ADR-0001](0001-activity-feed-storage.md)
+decisions #3 ("GitHub events for the panel are not persisted") and #4 ("persist
+polled GitHub data on a cron — rejected for v1").
 
 ## Context
 


### PR DESCRIPTION
Re-lands the ADR/CONTEXT honesty fixes that were lost when PR #199's squash landed an unrelated branch's content instead (branch-stacking mishap).

- **ADR-0019** → Deferred (GitHub commit primitives — WorkspaceRepository, User.githubLogin, GitHub OAuth — don't exist).
- **ADR-0018** → digest v1 = 3 sources (commits deferred).
- **ADR-0001** → accuracy caveat (GitHub half #3–#5 never built).
- **CONTEXT.md** → digest 3 sources; Commit activity marked planned; caveat on aspirational GitHub-source relationships.

Docs-only, no migration → main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Clarified weekly work digest v1 composition (activity events, assigned/owned entities, and meeting attendance)
* Deferred commit activity contribution to a planned future release
* Updated feature status documentation distinguishing planned versus currently implemented capabilities, particularly for GitHub integration features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->