### PR TITLE
feat(activity): weekly work digest panel on /activity (shiny.torch)

### DIFF
--- a/src/app/_components/home/activity/AggregatedActivityFeed.tsx
+++ b/src/app/_components/home/activity/AggregatedActivityFeed.tsx
@@ -16,6 +16,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { api } from '~/trpc/react';
 import type { IconKind } from '~/server/services/activity/feedRenderHints';
+import { WeeklyWorkDigestPanel } from './WeeklyWorkDigestPanel';
 
 import './activity-home.css';
 
@@ -167,6 +168,8 @@ export function AggregatedActivityFeed() {
             Every event across the workspaces you belong to, newest first.
           </Text>
         </div>
+
+        <WeeklyWorkDigestPanel />
 
         <section className="wsa-card">
           <div className="wsa-card__head">

--- a/src/app/_components/home/activity/WeeklyWorkDigestPanel.tsx
+++ b/src/app/_components/home/activity/WeeklyWorkDigestPanel.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { ActionIcon, Button, Loader, Skeleton, Tooltip } from '@mantine/core';
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconRefresh,
+  IconSparkles,
+  IconUserStar,
+} from '@tabler/icons-react';
+import {
+  addWeeks,
+  getISOWeek,
+  getISOWeekYear,
+  setISOWeek,
+  setISOWeekYear,
+  startOfISOWeek,
+  endOfISOWeek,
+  subWeeks,
+} from 'date-fns';
+import { useMemo, useState } from 'react';
+import { MarkdownRenderer } from '~/app/_components/shared/MarkdownRenderer';
+import { api } from '~/trpc/react';
+
+import './activity-home.css';
+
+interface IsoWeek {
+  isoYear: number;
+  isoWeek: number;
+}
+
+function isoWeekOf(date: Date): IsoWeek {
+  return { isoYear: getISOWeekYear(date), isoWeek: getISOWeek(date) };
+}
+
+/** Reconstruct a Date that lands inside the given ISO week (its Monday). */
+function dateForIsoWeek({ isoYear, isoWeek }: IsoWeek): Date {
+  // Order matters: set the ISO-week-year first, then the week within it.
+  return startOfISOWeek(setISOWeek(setISOWeekYear(new Date(), isoYear), isoWeek));
+}
+
+function sameIsoWeek(a: IsoWeek, b: IsoWeek): boolean {
+  return a.isoYear === b.isoYear && a.isoWeek === b.isoWeek;
+}
+
+const FMT_DATE = (d: Date) =>
+  d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+
+/**
+ * Weekly work digest — a personal, cross-workspace panel that sits atop the
+ * `/activity` feed ("the story of your week" over "every event"). Reads
+ * `workspace.getMyWeeklyWorkDigest` for the selected ISO week and renders the
+ * narrative, highlights, and AI-suggested content angles. A week pager moves
+ * back through prior ISO weeks (never into the future); a regenerate action
+ * re-runs synthesis with `force` and degrades gracefully when the server's
+ * cooldown trips (`TOO_MANY_REQUESTS`).
+ *
+ * Deliberately visually distinct from the team Week-in-Review (.wsa-week):
+ * a violet accent + left rail mark this as a private artifact. See ADR-0018.
+ */
+export function WeeklyWorkDigestPanel() {
+  const utils = api.useUtils();
+  const currentWeek = useMemo(() => isoWeekOf(new Date()), []);
+  const [selected, setSelected] = useState<IsoWeek>(currentWeek);
+
+  const isCurrentWeek = sameIsoWeek(selected, currentWeek);
+
+  // Omit isoYear/isoWeek for the current week so the server resolves "now".
+  const queryInput = isCurrentWeek
+    ? {}
+    : { isoYear: selected.isoYear, isoWeek: selected.isoWeek };
+
+  const digestQ = api.workspace.getMyWeeklyWorkDigest.useQuery(queryInput, {
+    // Cache hits render instantly; this just dampens dev-mode refetch churn.
+    staleTime: 30 * 60 * 1000,
+    retry: false,
+  });
+
+  // getMyWeeklyWorkDigest is a query, not a mutation. Force-regenerate by
+  // fetching with force:true via the utils client, then seeding the cache.
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  const [regenError, setRegenError] = useState<string | null>(null);
+
+  const handleRegenerate = async () => {
+    setRegenError(null);
+    setIsRegenerating(true);
+    try {
+      const fresh = await utils.workspace.getMyWeeklyWorkDigest.fetch({
+        ...queryInput,
+        force: true,
+      });
+      utils.workspace.getMyWeeklyWorkDigest.setData(queryInput, fresh);
+    } catch (err) {
+      const code =
+        err != null &&
+        typeof err === 'object' &&
+        'data' in err &&
+        err.data != null &&
+        typeof err.data === 'object' &&
+        'code' in err.data
+          ? (err.data as { code?: unknown }).code
+          : undefined;
+      setRegenError(
+        code === 'TOO_MANY_REQUESTS'
+          ? 'Regenerated recently — try again shortly.'
+          : "Couldn't regenerate the digest. Try again in a moment.",
+      );
+    } finally {
+      setIsRegenerating(false);
+    }
+  };
+
+  const goPrevWeek = () => {
+    setRegenError(null);
+    setSelected(isoWeekOf(subWeeks(dateForIsoWeek(selected), 1)));
+  };
+
+  const goNextWeek = () => {
+    if (isCurrentWeek) return;
+    setRegenError(null);
+    const next = isoWeekOf(addWeeks(dateForIsoWeek(selected), 1));
+    // Clamp to the current week — never page into the future.
+    setSelected(sameIsoWeek(next, currentWeek) || isFuture(next) ? currentWeek : next);
+  };
+
+  function isFuture(week: IsoWeek): boolean {
+    return dateForIsoWeek(week).getTime() > dateForIsoWeek(currentWeek).getTime();
+  }
+
+  const weekRef = dateForIsoWeek(selected);
+  const rangeLabel = `${FMT_DATE(startOfISOWeek(weekRef))} – ${FMT_DATE(endOfISOWeek(weekRef))}`;
+  const pagerLabel = isCurrentWeek ? 'This week' : rangeLabel;
+
+  const data = digestQ.data;
+  const busy = digestQ.isLoading || isRegenerating;
+  const angles = data?.angles ?? [];
+
+  return (
+    <section className="wsa-card wsa-digest" aria-label="Weekly work digest">
+      <div className="wsa-digest__head">
+        <span className="wsa-digest__eyebrow">
+          <IconUserStar size={14} stroke={1.8} />
+          Your week in work
+        </span>
+        {data?.cached && !busy ? (
+          <span className="wsa-digest__cached">cached</span>
+        ) : null}
+
+        <div className="wsa-digest__pager">
+          <Tooltip label="Previous week" withArrow position="top">
+            <ActionIcon
+              size="sm"
+              variant="subtle"
+              color="gray"
+              aria-label="Previous week"
+              disabled={busy}
+              onClick={goPrevWeek}
+            >
+              <IconChevronLeft size={15} stroke={1.8} />
+            </ActionIcon>
+          </Tooltip>
+          <span className="wsa-digest__pager-label">{pagerLabel}</span>
+          <Tooltip
+            label={isCurrentWeek ? 'No future weeks' : 'Next week'}
+            withArrow
+            position="top"
+          >
+            <ActionIcon
+              size="sm"
+              variant="subtle"
+              color="gray"
+              aria-label="Next week"
+              disabled={busy || isCurrentWeek}
+              onClick={goNextWeek}
+            >
+              <IconChevronRight size={15} stroke={1.8} />
+            </ActionIcon>
+          </Tooltip>
+          <Tooltip label="Regenerate digest" withArrow position="top">
+            <ActionIcon
+              size="sm"
+              variant="subtle"
+              color="gray"
+              aria-label="Regenerate digest"
+              disabled={busy}
+              loading={isRegenerating}
+              onClick={() => void handleRegenerate()}
+            >
+              <IconRefresh size={14} stroke={1.8} />
+            </ActionIcon>
+          </Tooltip>
+        </div>
+      </div>
+
+      {digestQ.isLoading ? (
+        <DigestSkeleton />
+      ) : digestQ.isError ? (
+        <p className="wsa-digest__error">
+          Couldn&apos;t load your weekly digest. Try the refresh button, or check
+          back shortly.
+        </p>
+      ) : data ? (
+        <>
+          {isRegenerating ? (
+            <div className="wsa-digest__loading">
+              <Loader size="xs" />
+              <span className="wsa-card__caption">Regenerating your digest…</span>
+            </div>
+          ) : null}
+
+          <MarkdownRenderer
+            content={data.narrative}
+            variant="prose"
+            className="wsa-digest__narrative"
+          />
+
+          {data.highlights.length > 0 ? (
+            <ul className="wsa-digest__highlights">
+              {data.highlights.map((h, i) => (
+                <li className="wsa-digest__highlight" key={i}>
+                  <span className="wsa-digest__highlight-dot" aria-hidden="true" />
+                  <span>{h}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+
+          <div className="wsa-digest__angles">
+            <p className="wsa-digest__section-label wsa-digest__angles-label">
+              <IconSparkles size={13} stroke={1.8} />
+              Content angles
+            </p>
+            {angles.length > 0 ? (
+              <ul className="wsa-digest__angle-list">
+                {angles.map((angle, i) => (
+                  <li className="wsa-digest__angle" key={i}>
+                    <span className="wsa-digest__angle-idx">{i + 1}</span>
+                    <span>{angle}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="wsa-digest__angles-empty">
+                No content angles for this week yet — a quieter week leaves less to
+                turn into posts. Come back after a busier stretch.
+              </p>
+            )}
+          </div>
+
+          {regenError ? (
+            <p className="wsa-digest__error" style={{ marginTop: 16 }}>
+              {regenError}
+            </p>
+          ) : null}
+
+          {!isCurrentWeek ? (
+            <div style={{ marginTop: 18 }}>
+              <Button
+                size="xs"
+                variant="subtle"
+                color="gray"
+                onClick={() => {
+                  setRegenError(null);
+                  setSelected(currentWeek);
+                }}
+              >
+                Back to this week
+              </Button>
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+function DigestSkeleton() {
+  return (
+    <div>
+      <Skeleton height={14} width="92%" />
+      <Skeleton height={14} width="84%" mt={8} />
+      <Skeleton height={14} width="60%" mt={8} />
+      <Skeleton height={11} width={90} mt={22} />
+      <Skeleton height={13} width="70%" mt={12} />
+      <Skeleton height={13} width="66%" mt={10} />
+      <Skeleton height={13} width="72%" mt={10} />
+      <Skeleton height={11} width={120} mt={24} />
+      <Skeleton height={44} mt={12} radius="md" />
+      <Skeleton height={44} mt={9} radius="md" />
+    </div>
+  );
+}

--- a/src/app/_components/home/activity/activity-home.css
+++ b/src/app/_components/home/activity/activity-home.css
@@ -1072,6 +1072,207 @@
 }
 
 /* --------------------------------------------------------------------------
+   WEEKLY WORK DIGEST — personal, cross-workspace panel atop /activity
+
+   Deliberately distinct from the team Week-in-Review (.wsa-week, brand-blue):
+   this is the viewer's *own* story of the week, so it leans on a violet accent
+   and a left rail to read as a private artifact, not the shared workspace card.
+   All colors via var(); the violet accent is self-scoped here so the panel is
+   correct even outside the .activity-layout token scope.
+   -------------------------------------------------------------------------- */
+.wsa-digest {
+  --wsa-digest-accent: var(--accent-meetings);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--color-border-primary);
+  border-left: 3px solid var(--wsa-digest-accent);
+  background:
+    radial-gradient(140% 200% at -6% -30%, var(--color-brand-subtle), transparent 50%),
+    var(--color-surface-secondary);
+  border-radius: 14px;
+  padding: 24px 26px;
+}
+
+.wsa-digest__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.wsa-digest__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--wsa-digest-accent);
+}
+
+.wsa-digest__sub {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+/* ---- week pager ---- */
+.wsa-digest__pager {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wsa-digest__pager-label {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+  min-width: 92px;
+  text-align: center;
+}
+
+.wsa-digest__cached {
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-faint);
+}
+
+/* ---- narrative ---- */
+.wsa-digest__narrative {
+  color: var(--color-text-secondary);
+  font-size: 14px;
+  line-height: 1.62;
+  text-wrap: pretty;
+  margin: 0 0 18px;
+}
+
+.wsa-digest__narrative b,
+.wsa-digest__narrative strong {
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+/* ---- highlights ---- */
+.wsa-digest__section-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0 0 10px;
+}
+
+.wsa-digest__highlights {
+  list-style: none;
+  margin: 0 0 22px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.wsa-digest__highlight {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  padding: 10px 2px;
+  font-size: 13.5px;
+  color: var(--color-text-secondary);
+  line-height: 1.45;
+}
+
+.wsa-digest__highlight + .wsa-digest__highlight {
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.wsa-digest__highlight-dot {
+  width: 7px;
+  height: 7px;
+  margin-top: 5px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--wsa-digest-accent);
+  box-shadow: 0 0 0 3px var(--color-brand-glow);
+}
+
+/* ---- content angles ---- */
+.wsa-digest__angles {
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: 18px;
+}
+
+.wsa-digest__angles-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.wsa-digest__angle-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.wsa-digest__angle {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 11px 13px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 9px;
+  background: var(--color-surface-muted);
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+
+.wsa-digest__angle-idx {
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--wsa-digest-accent);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.wsa-digest__angles-empty {
+  font-size: 12.5px;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* ---- states ---- */
+.wsa-digest__error {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.wsa-digest__loading {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 6px 0 18px;
+  font-style: italic;
+}
+
+@media (max-width: 720px) {
+  .wsa-digest__pager {
+    margin-left: 0;
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+/* --------------------------------------------------------------------------
    Reduced motion
    -------------------------------------------------------------------------- */
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Ticket

shiny.torch (`cmqdr47dr000nju04zuybygsi`) — "Weekly work digest panel on /activity (narrative + angles + week pager)"
Feature: `cmqdr2gsn000fih046xriyd1f` (Weekly work digest). See ADR-0018.

## What this does

Adds a **personal, cross-workspace weekly work digest panel** at the top of the `/activity` page, above the aggregated activity feed — "the story of your week" over "every event".

New component `WeeklyWorkDigestPanel.tsx` (rendered by `AggregatedActivityFeed` above the `<section className="wsa-card">` feed) reads `workspace.getMyWeeklyWorkDigest` for the selected ISO week and renders:

- **Narrative** prose (via `MarkdownRenderer`)
- **Highlights** list
- A clearly-labelled **"Content angles"** sub-section listing the AI-suggested post hooks, with a sensible empty-state when a quiet week yields no angles

## Behaviour

- **Week pager** (prev/next) using `date-fns` ISO-week math. Pages back through prior weeks; "next" is disabled on the current week and the forward step is clamped — no future weeks. Past weeks pass `isoYear`/`isoWeek` to the query; the current week omits them so the server resolves "now". A "Back to this week" shortcut appears when viewing a past week.
- **Regenerate** action force-refetches (`force: true`) via the tRPC utils client and seeds the displayed query's cache. The server's `TOO_MANY_REQUESTS` cooldown is caught and shown as a friendly "Regenerated recently — try again shortly." message rather than crashing.
- **States**: loading skeleton (first generation can take seconds), error, and quiet/empty-week (renders the backend's canned narrative + empty-angles state). Cache hits render instantly and show a small "cached" marker.

## Visual distinction

Reuses the `activity-home.css` vocabulary with a new `.wsa-digest` block. A violet (`--accent-meetings`) left-rail accent and eyebrow mark it as a private artifact, distinct from the brand-blue team Week-in-Review (`.wsa-week`). **Tokens only — no hex/rgb** (pre-commit color check passed).

## Scope

UI only. No backend, schema, or migration changes. The existing aggregated feed behaviour is untouched — the panel is simply rendered above it.

## Checks

- `npx tsc --noEmit` — clean
- `eslint` on changed files — 0 problems
- `npm run test` (unit) — 705 passed
- Pre-commit hook: tests pass, Prisma migration check passed, no hardcoded colors
