### PR TITLE
feat(goals): agent can set goal parentage + show hierarchy on detail page

### DIFF
--- a/src/app/_components/initiatives/GoalDetailContent.tsx
+++ b/src/app/_components/initiatives/GoalDetailContent.tsx
@@ -258,6 +258,14 @@ export function GoalDetailContent({ goalId, workspaceSlug }: GoalDetailContentPr
                 </div>
               </IconPicker>
               <div>
+                {goal.parentGoal && (
+                  <Link
+                    href={`/w/${workspaceSlug}/goals/${goal.parentGoal.id}`}
+                    className="text-text-muted text-xs hover:text-text-secondary transition-colors"
+                  >
+                    ↑ {goal.parentGoal.title}
+                  </Link>
+                )}
                 <Group gap="xs" align="center">
                   <Title order={3} className="text-text-primary">
                     {goal.title}
@@ -314,6 +322,35 @@ export function GoalDetailContent({ goalId, workspaceSlug }: GoalDetailContentPr
           {/* Overview Tab */}
           <Tabs.Panel value="overview" pt="lg">
             <Stack gap="xl">
+              {/* Sub-goals (children in the goal hierarchy) */}
+              {goal.childGoals && goal.childGoals.length > 0 && (
+                <div>
+                  <Text size="sm" className="text-text-muted mb-2">
+                    Sub-goals
+                  </Text>
+                  <Stack gap="xs">
+                    {goal.childGoals.map((child) => (
+                      <Link
+                        key={child.id}
+                        href={`/w/${workspaceSlug}/goals/${child.id}`}
+                        className="flex items-center gap-2 rounded-md border border-border-primary px-3 py-2 hover:bg-surface-hover transition-colors"
+                      >
+                        <Text size="sm" className="text-text-primary">
+                          {child.title}
+                        </Text>
+                        <Badge
+                          color={getStatusColor(child.status)}
+                          variant="dot"
+                          size="xs"
+                          className="ml-auto"
+                        >
+                          {formatStatus(child.status)}
+                        </Badge>
+                      </Link>
+                    ))}
+                  </Stack>
+                </div>
+              )}
               {/* Properties */}
               <Group gap="xl">
                 <Group gap="xs">

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -25,7 +25,7 @@ import { filterAgentInstructions } from "~/server/services/agent-routing/agentIn
 import { loadProductWithAccess } from "~/plugins/product/server/routers/product";
 import { generateFunId } from "~/lib/fun-ids";
 import { recordActivity } from "~/server/services/activity/recordActivity";
-import { createGoalComment, createGoalUpdate } from "~/server/services/goalService";
+import { createGoal, createGoalComment, createGoalUpdate, setGoalParent } from "~/server/services/goalService";
 
 // OpenAI client for embeddings
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
@@ -3143,25 +3143,25 @@ export const mastraRouter = createTRPCRouter({
       description: z.string().optional(),
       whyThisGoal: z.string().optional(),
       period: z.string().optional(),
-      lifeDomainId: z.number().optional(),
+      // Agent-facing numerics: coerce stringified scalars (see
+      // dev-docs/AGENT_TOOL_INPUT_VALIDATION.md).
+      lifeDomainId: z.coerce.number().optional(),
+      parentGoalId: z.coerce.number().optional(),
       workspaceId: z.string().optional(),
     }))
     .mutation(async ({ ctx, input }) => {
-      const userId = ctx.session.user.id;
-
-      const goal = await ctx.db.goal.create({
-        data: {
+      // Route through the shared service so the depth/cycle parent guard runs
+      // (do not inline ctx.db.goal.create — it bypasses validation). See ADR-0016.
+      const goal = await createGoal({
+        ctx,
+        input: {
           title: input.title,
           description: input.description,
           whyThisGoal: input.whyThisGoal,
-          period: input.period ?? null,
-          lifeDomainId: input.lifeDomainId ?? null,
-          userId,
-          driUserId: userId,
-          workspaceId: input.workspaceId ?? null,
-        },
-        include: {
-          lifeDomain: true,
+          period: input.period,
+          lifeDomainId: input.lifeDomainId,
+          parentGoalId: input.parentGoalId,
+          workspaceId: input.workspaceId,
         },
       });
 
@@ -3171,10 +3171,38 @@ export const mastraRouter = createTRPCRouter({
           title: goal.title,
           description: goal.description,
           period: goal.period,
+          parentGoalId: goal.parentGoalId,
           lifeDomain: goal.lifeDomain
             ? { id: goal.lifeDomain.id, title: goal.lifeDomain.title }
             : null,
           workspaceId: goal.workspaceId,
+        },
+      };
+    }),
+
+  // Agent-facing: nest an existing Objective under a parent (or detach with
+  // parentGoalId = null). Delegates to goalService.setGoalParent, which writes
+  // ONLY parentGoalId (never clobbers projects/period/workspace like updateGoal
+  // would) and enforces access + no-self/no-cycle/depth.
+  setObjectiveParent: protectedProcedure
+    .input(z.object({
+      goalId: z.coerce.number(),
+      parentGoalId: z.coerce.number().nullable(),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      const goal = await setGoalParent({
+        ctx,
+        goalId: input.goalId,
+        parentGoalId: input.parentGoalId,
+      });
+      return {
+        objective: {
+          id: goal.id,
+          title: goal.title,
+          parentGoalId: goal.parentGoalId,
+          parentGoal: goal.parentGoal
+            ? { id: goal.parentGoal.id, title: goal.parentGoal.title }
+            : null,
         },
       };
     }),
@@ -3598,9 +3626,14 @@ export const mastraRouter = createTRPCRouter({
   bulkCreateStructure: protectedProcedure
     .input(z.object({
       workspaceId: z.string(),
+      // Batch-level parent: nest every created goal under this Objective unless a
+      // goal supplies its own parentGoalId. Use the page-context goalId here when
+      // the user says "build this under this goal". Coerced per AGENT_TOOL doc.
+      parentGoalId: z.coerce.number().optional(),
       goals: z.array(z.object({
         title: z.string().min(1),
         description: z.string().optional(),
+        parentGoalId: z.coerce.number().optional(),
         projects: z.array(z.object({
           name: z.string().min(1),
           description: z.string().optional(),
@@ -3628,13 +3661,14 @@ export const mastraRouter = createTRPCRouter({
       for (const goalInput of input.goals) {
         let goalId: number | null = null;
         try {
-          const goal = await ctx.db.goal.create({
-            data: {
+          // Route through the shared service so parent depth/cycle validation runs.
+          const goal = await createGoal({
+            ctx,
+            input: {
               title: goalInput.title,
-              description: goalInput.description ?? null,
-              userId,
-              driUserId: userId,
+              description: goalInput.description,
               workspaceId: input.workspaceId,
+              parentGoalId: goalInput.parentGoalId ?? input.parentGoalId,
             },
           });
           goalId = goal.id;

--- a/src/server/services/__tests__/goalService.test.ts
+++ b/src/server/services/__tests__/goalService.test.ts
@@ -24,7 +24,7 @@ vi.hoisted(() => {
   process.env.GOOGLE_CLIENT_SECRET ??= "test";
 });
 
-import { createGoalComment, createGoalUpdate } from "../goalService";
+import { createGoalComment, createGoalUpdate, setGoalParent } from "../goalService";
 import type { Context } from "~/server/auth/types";
 
 const USER_ID = "user-1";
@@ -197,6 +197,73 @@ describe("goalService.createGoalUpdate", () => {
     ).rejects.toThrow(/access denied/i);
 
     expect(db.goalUpdate.create).not.toHaveBeenCalled();
+    expect(db.goal.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("goalService.setGoalParent", () => {
+  beforeEach(() => {
+    mockReset(db);
+  });
+
+  // Owner access for every findUnique, and a parent chain that terminates (no
+  // cycle, depth 2). One value serves the access checks AND the chain walk.
+  function grantAccessAndShallowChain() {
+    db.goal.findUnique.mockResolvedValue({
+      id: GOAL_ID,
+      userId: USER_ID,
+      driUserId: null,
+      workspaceId: null,
+      parentGoalId: null,
+    } as never);
+  }
+
+  it("writes ONLY parentGoalId — never clobbers projects/period/workspace (unlike updateGoal)", async () => {
+    grantAccessAndShallowChain();
+    db.goal.update.mockResolvedValue({ id: GOAL_ID, parentGoalId: 19, parentGoal: null } as never);
+
+    await setGoalParent({ ctx: makeCtx(), goalId: GOAL_ID, parentGoalId: 19 });
+
+    expect(db.goal.update).toHaveBeenCalledTimes(1);
+    const updateArg = db.goal.update.mock.calls[0]![0]!;
+    expect(updateArg.where).toEqual({ id: GOAL_ID });
+    // The whole point of setGoalParent: a minimal, non-destructive write.
+    expect(updateArg.data).toEqual({ parentGoalId: 19 });
+  });
+
+  it("detaches (parentGoalId = null) without validating or touching other fields", async () => {
+    grantAccessAndShallowChain();
+    db.goal.update.mockResolvedValue({ id: GOAL_ID, parentGoalId: null, parentGoal: null } as never);
+
+    await setGoalParent({ ctx: makeCtx(), goalId: GOAL_ID, parentGoalId: null });
+
+    const updateArg = db.goal.update.mock.calls[0]![0]!;
+    expect(updateArg.data).toEqual({ parentGoalId: null });
+  });
+
+  it("rejects making a goal its own parent, and writes nothing", async () => {
+    grantAccessAndShallowChain();
+
+    await expect(
+      setGoalParent({ ctx: makeCtx(), goalId: GOAL_ID, parentGoalId: GOAL_ID }),
+    ).rejects.toThrow(/own parent/i);
+
+    expect(db.goal.update).not.toHaveBeenCalled();
+  });
+
+  it("throws when the caller lacks access, and writes nothing", async () => {
+    db.goal.findUnique.mockResolvedValue({
+      id: GOAL_ID,
+      userId: "someone-else",
+      driUserId: null,
+      workspaceId: null,
+      parentGoalId: null,
+    } as never);
+
+    await expect(
+      setGoalParent({ ctx: makeCtx(), goalId: GOAL_ID, parentGoalId: 19 }),
+    ).rejects.toThrow(/access denied/i);
+
     expect(db.goal.update).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/goalService.test.ts
+++ b/src/server/services/__tests__/goalService.test.ts
@@ -24,7 +24,7 @@ vi.hoisted(() => {
   process.env.GOOGLE_CLIENT_SECRET ??= "test";
 });
 
-import { createGoalComment, createGoalUpdate, setGoalParent } from "../goalService";
+import { createGoal, createGoalComment, createGoalUpdate, setGoalParent } from "../goalService";
 import type { Context } from "~/server/auth/types";
 
 const USER_ID = "user-1";
@@ -265,5 +265,63 @@ describe("goalService.setGoalParent", () => {
     ).rejects.toThrow(/access denied/i);
 
     expect(db.goal.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects a cycle (parent is a descendant of the goal), and writes nothing", async () => {
+    // Goal 42 (GOAL_ID); proposed parent 70 whose parent is 42 → cycle.
+    db.goal.findUnique.mockImplementation((args: unknown) => {
+      const id = (args as { where: { id: number } }).where.id;
+      return Promise.resolve(
+        id === 70
+          ? { id: 70, userId: USER_ID, driUserId: null, workspaceId: null, parentGoalId: GOAL_ID }
+          : { id, userId: USER_ID, driUserId: null, workspaceId: null, parentGoalId: null },
+      ) as never;
+    });
+
+    await expect(
+      setGoalParent({ ctx: makeCtx(), goalId: GOAL_ID, parentGoalId: 70 }),
+    ).rejects.toThrow(/cycle/i);
+
+    expect(db.goal.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("goalService.createGoal — parent access (IDOR guard)", () => {
+  beforeEach(() => {
+    mockReset(db);
+  });
+
+  it("rejects a parentGoalId the caller cannot access, and creates nothing", async () => {
+    // Parent goal owned by someone else, no workspace → verifyGoalAccess denies.
+    db.goal.findUnique.mockResolvedValue({
+      id: 999,
+      userId: "someone-else",
+      driUserId: null,
+      workspaceId: null,
+      parentGoalId: null,
+    } as never);
+
+    await expect(
+      createGoal({ ctx: makeCtx(), input: { title: "Sneaky child", parentGoalId: 999 } }),
+    ).rejects.toThrow(/access denied/i);
+
+    expect(db.goal.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a sub-goal when the parent is accessible", async () => {
+    db.goal.findUnique.mockResolvedValue({
+      id: 19,
+      userId: USER_ID,
+      driUserId: null,
+      workspaceId: null,
+      parentGoalId: null,
+    } as never);
+    db.goal.create.mockResolvedValue({ id: 100, parentGoalId: 19 } as never);
+
+    await createGoal({ ctx: makeCtx(), input: { title: "Phase 0", parentGoalId: 19 } });
+
+    expect(db.goal.create).toHaveBeenCalledTimes(1);
+    const createArg = db.goal.create.mock.calls[0]![0]!;
+    expect(createArg.data.parentGoalId).toBe(19);
   });
 });

--- a/src/server/services/goalService.ts
+++ b/src/server/services/goalService.ts
@@ -176,22 +176,13 @@ export async function createGoal({ ctx, input }: { ctx: Context, input: GoalInpu
     throw new Error("User not authenticated");
   }
 
-  // Enforce max nesting depth of 5 levels for sub-goals
+  // A sub-goal's parent must be ACCESSIBLE to the caller — never nest under
+  // another user's goal (that would inject a child into their tree and pollute
+  // their health roll-up) — and the chain must stay within the depth cap.
+  // Shared validation with updateGoal/setGoalParent.
   if (input.parentGoalId) {
-    let depth = 1;
-    let currentParentId: number | null = input.parentGoalId;
-    while (currentParentId) {
-      const parentGoal: { parentGoalId: number | null } | null = await ctx.db.goal.findUnique({
-        where: { id: currentParentId },
-        select: { parentGoalId: true },
-      });
-      if (!parentGoal) break;
-      currentParentId = parentGoal.parentGoalId;
-      depth++;
-      if (depth > 5) {
-        throw new Error("Maximum nesting depth of 5 levels exceeded");
-      }
-    }
+    await verifyGoalAccess({ ctx, goalId: input.parentGoalId });
+    await validateParentAssignment({ ctx, parentGoalId: input.parentGoalId });
   }
 
   return await ctx.db.goal.create({

--- a/src/server/services/goalService.ts
+++ b/src/server/services/goalService.ts
@@ -225,6 +225,43 @@ export async function createGoal({ ctx, input }: { ctx: Context, input: GoalInpu
   });
 }
 
+/**
+ * Validate a proposed parentGoalId: no self-parent, no cycle, and the resulting
+ * chain stays within the 5-level nesting cap. Shared by updateGoal and
+ * setGoalParent. Pass `goalId` for an existing goal being re-parented; omit it for
+ * a brand-new goal (createGoal) where self/cycle checks don't apply.
+ */
+async function validateParentAssignment({
+  ctx,
+  goalId,
+  parentGoalId,
+}: {
+  ctx: Context;
+  goalId?: number;
+  parentGoalId: number;
+}) {
+  if (goalId !== undefined && parentGoalId === goalId) {
+    throw new Error("A goal cannot be its own parent");
+  }
+  let depth = 1;
+  let currentParentId: number | null = parentGoalId;
+  while (currentParentId) {
+    const parent: { parentGoalId: number | null } | null = await ctx.db.goal.findUnique({
+      where: { id: currentParentId },
+      select: { parentGoalId: true },
+    });
+    if (!parent) break;
+    if (goalId !== undefined && parent.parentGoalId === goalId) {
+      throw new Error("Cannot set a descendant goal as parent (would create a cycle)");
+    }
+    currentParentId = parent.parentGoalId;
+    depth++;
+    if (depth > 5) {
+      throw new Error("Maximum nesting depth of 5 levels exceeded");
+    }
+  }
+}
+
 interface UpdateGoalInput extends GoalInput {
   id: number;
   displayOrder?: number;
@@ -241,33 +278,13 @@ export async function updateGoal({ ctx, input }: { ctx: Context, input: UpdateGo
     where: { id: input.id },
   });
 
-  // Enforce max nesting depth of 5 levels when changing parent
-  if (input.parentGoalId !== undefined && input.parentGoalId !== existingGoal.parentGoalId) {
-    // Prevent setting self as parent
-    if (input.parentGoalId === input.id) {
-      throw new Error("A goal cannot be its own parent");
-    }
-
-    if (input.parentGoalId) {
-      // Check that the new parent isn't a descendant (would create a cycle)
-      let depth = 1;
-      let currentParentId: number | null = input.parentGoalId;
-      while (currentParentId) {
-        const parentGoal: { parentGoalId: number | null } | null = await ctx.db.goal.findUnique({
-          where: { id: currentParentId },
-          select: { parentGoalId: true },
-        });
-        if (!parentGoal) break;
-        if (parentGoal.parentGoalId === input.id) {
-          throw new Error("Cannot set a descendant goal as parent (would create a cycle)");
-        }
-        currentParentId = parentGoal.parentGoalId;
-        depth++;
-        if (depth > 5) {
-          throw new Error("Maximum nesting depth of 5 levels exceeded");
-        }
-      }
-    }
+  // Validate parent change (no self/cycle, within depth cap). Shared with setGoalParent.
+  if (
+    input.parentGoalId !== undefined &&
+    input.parentGoalId !== existingGoal.parentGoalId &&
+    input.parentGoalId
+  ) {
+    await validateParentAssignment({ ctx, goalId: input.id, parentGoalId: input.parentGoalId });
   }
 
   return await ctx.db.goal.update({
@@ -304,6 +321,37 @@ export async function updateGoal({ ctx, input }: { ctx: Context, input: UpdateGo
       projects: true,
       outcomes: true,
     },
+  });
+}
+
+/**
+ * Re-parent a goal (or detach it with parentGoalId = null) WITHOUT touching any
+ * of its other fields. Unlike updateGoal (a full overwrite that clears projects,
+ * period, workspace, etc.), this only writes parentGoalId — safe for nesting an
+ * existing goal under another. Validates access to both goal and parent, and the
+ * no-self/no-cycle/depth rules.
+ */
+export async function setGoalParent({
+  ctx,
+  goalId,
+  parentGoalId,
+}: {
+  ctx: Context;
+  goalId: number;
+  parentGoalId: number | null;
+}) {
+  if (!ctx.session?.user?.id) {
+    throw new Error("User not authenticated");
+  }
+  await verifyGoalAccess({ ctx, goalId });
+  if (parentGoalId !== null) {
+    await verifyGoalAccess({ ctx, goalId: parentGoalId });
+    await validateParentAssignment({ ctx, goalId, parentGoalId });
+  }
+  return await ctx.db.goal.update({
+    where: { id: goalId },
+    data: { parentGoalId },
+    include: { parentGoal: { select: { id: true, title: true } } },
   });
 }
 


### PR DESCRIPTION
## Problem

Zoe created orphaned top-level goals (70–74) instead of nesting them under the user's north-star Goal 19. The data model already supports hierarchy (`Goal.parentGoalId`, depth cap, cycle prevention, health roll-up, parent picker in the human modal) — the gaps were the agent paths and the absence of any hierarchy display.

## Changes

**Backend (`goalService` + mastra router)**
- Extract `validateParentAssignment` (no-self / no-cycle / 5-level depth), shared by `updateGoal`.
- New **`setGoalParent`** — a **non-destructive** re-parent that writes *only* `parentGoalId`. ⚠️ `updateGoal` is a full overwrite (`projects: { set: [] }`, `period/workspace ?? null`), so reusing it for nesting would disconnect a goal's projects and wipe its workspace — hence a dedicated function.
- `mastra.createOkrObjective` + `mastra.bulkCreateStructure` now accept `parentGoalId` and **route goal creation through `goalService.createGoal`** (they were inlining `db.goal.create`, bypassing the depth/cycle guard — fixed, per the ADR-0016 shared-service principle).
- New `mastra.setObjectiveParent` → `setGoalParent`. Agent-facing numerics coerced with `z.coerce.number()`.

**UI (`GoalDetailContent`)**
- Parent breadcrumb (↑ parent) + a **Sub-goals** section listing children, each linking to its detail page. Data was already returned by `getGoalById`; previously unused.
- Dashboard stays top-level-only (roots); sub-goals are reached by drilling into the parent. (Dashboard tree view deferred.)

## Pairs with

positonic/mastra#24 (the tools: `createOkrObjective`/`bulkCreate` parentGoalId + new `linkObjectiveToParentTool` + Zoe "under this goal" instruction).

## Test

`goalService.test.ts` — 10 passed, incl. new `setGoalParent` cases (writes only `parentGoalId`; detaches on null; rejects self-parent; denies on no access). `tsc` clean.

> Manual verification recommended before merge: on Goal 19 ask Zoe "create 4 phase goals under this goal" → goals created with `parentGoalId = 19`, shown in Goal 19's Sub-goals section; "nest 70–74 under 19" works via the link tool.