### PR TITLE
feat: WorkspaceRepository model + GitHub connection-state read

### DIFF
--- a/prisma/migrations/20260615072546_add_workspace_repository/migration.sql
+++ b/prisma/migrations/20260615072546_add_workspace_repository/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "WorkspaceRepository" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "integrationId" TEXT NOT NULL,
+    "owner" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "fullName" TEXT NOT NULL,
+    "installationId" TEXT,
+    "addedById" TEXT,
+    "syncStatus" TEXT NOT NULL DEFAULT 'pending',
+    "lastSyncedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WorkspaceRepository_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WorkspaceRepository_workspaceId_idx" ON "WorkspaceRepository"("workspaceId");
+
+-- CreateIndex
+CREATE INDEX "WorkspaceRepository_integrationId_idx" ON "WorkspaceRepository"("integrationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WorkspaceRepository_workspaceId_fullName_key" ON "WorkspaceRepository"("workspaceId", "fullName");
+
+-- AddForeignKey
+ALTER TABLE "WorkspaceRepository" ADD CONSTRAINT "WorkspaceRepository_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkspaceRepository" ADD CONSTRAINT "WorkspaceRepository_integrationId_fkey" FOREIGN KEY ("integrationId") REFERENCES "Integration"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WorkspaceRepository" ADD CONSTRAINT "WorkspaceRepository_addedById_fkey" FOREIGN KEY ("addedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,7 @@ model User {
   feedback                    Feedback[]
   goals                       Goal[]
   integrations                Integration[]
+  workspaceRepositoriesAdded  WorkspaceRepository[]       @relation("WorkspaceRepositoryAddedBy")
   permissionsGrantedBy        IntegrationPermission[]     @relation("PermissionGrantedBy")
   permissionsGrantedTo        IntegrationPermission[]     @relation("PermissionGrantedTo")
   permissionsRevokedBy        IntegrationPermission[]     @relation("PermissionRevokedBy")
@@ -360,6 +361,8 @@ model Workspace {
   deals                   Deal[]
   // Integration relations
   integrations            Integration[]
+  // GitHub repo connection (ADR-0020): repos this workspace tracks
+  workspaceRepositories   WorkspaceRepository[]
   // Notification override relations
   notificationOverrides   WorkspaceNotificationOverride[]
   // Slack channel config relation
@@ -1255,6 +1258,8 @@ model Integration {
   workflows               Workflow[]
   // PM Agent GitHub tracking
   githubActivities        GitHubActivity[]
+  // GitHub repo connection (ADR-0020): repos a workspace tracks via this installation
+  workspaceRepositories   WorkspaceRepository[]
 
   @@index([userId])
   @@index([teamId])
@@ -4253,4 +4258,31 @@ model ActionParticipantAssignee {
   @@index([actionId])
   @@index([participantId])
   @@index([workspaceId])
+}
+
+/// A GitHub repo a workspace has declared interest in (ADR-0020). Source of
+/// truth for which repos a workspace tracks — independent of who installed the
+/// GitHub App. The same repo can be tracked by multiple workspaces (one row per
+/// workspace × repo pair). `integrationId` points at the workspace's single
+/// GitHub App installation Integration.
+model WorkspaceRepository {
+  id             String    @id @default(cuid())
+  workspaceId    String
+  integrationId  String
+  owner          String
+  name           String
+  fullName       String
+  installationId String?
+  addedById      String?
+  syncStatus     String    @default("pending")
+  lastSyncedAt   DateTime?
+  createdAt      DateTime  @default(now())
+
+  workspace   Workspace   @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  integration Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade)
+  addedBy     User?       @relation("WorkspaceRepositoryAddedBy", fields: [addedById], references: [id], onDelete: SetNull)
+
+  @@unique([workspaceId, fullName])
+  @@index([workspaceId])
+  @@index([integrationId])
 }

--- a/src/server/api/routers/github.ts
+++ b/src/server/api/routers/github.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "~/server/api/trpc";
 import * as githubService from "~/server/services/githubService";
+import { requireWorkspaceMembership } from "~/server/services/access";
+import {
+  GITHUB_INSTALLATION_PROVIDER,
+  GITHUB_INSTALLATION_TYPE,
+  isGithubAppConfigured,
+  resolveGithubConnectionState,
+} from "~/server/services/github/connectionState";
 
 export const githubRouter = createTRPCRouter({
   listCommits: publicProcedure
@@ -176,6 +183,59 @@ export const githubRouter = createTRPCRouter({
           
         throw new Error(`Failed to create GitHub epic: ${errorMessage}`);
       }
+    }),
+
+  /**
+   * Read a workspace's GitHub connection state and the repos it tracks
+   * (ADR-0020). Composes the three layers: L1 env check
+   * (`isGithubAppConfigured`) → L2 installation `Integration` lookup → L3
+   * `WorkspaceRepository` count, mapped by `resolveGithubConnectionState`.
+   *
+   * Read-only; any workspace member may call it. Degrades to `NOT_CONFIGURED`
+   * with an empty repo list (never 500s) when the GitHub App env is absent —
+   * no DB work happens in that case.
+   */
+  getGithubConnectionState: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
+    .query(async ({ ctx, input }) => {
+      const appConfigured = isGithubAppConfigured();
+
+      if (!appConfigured) {
+        return {
+          state: resolveGithubConnectionState({
+            appConfigured,
+            installation: null,
+            repoCount: 0,
+          }),
+          repos: [],
+        };
+      }
+
+      const [installation, repos] = await Promise.all([
+        ctx.db.integration.findFirst({
+          where: {
+            workspaceId: input.workspaceId,
+            provider: GITHUB_INSTALLATION_PROVIDER,
+            type: GITHUB_INSTALLATION_TYPE,
+            status: "ACTIVE",
+          },
+          select: { id: true },
+        }),
+        ctx.db.workspaceRepository.findMany({
+          where: { workspaceId: input.workspaceId },
+          orderBy: { createdAt: "asc" },
+        }),
+      ]);
+
+      return {
+        state: resolveGithubConnectionState({
+          appConfigured,
+          installation,
+          repoCount: repos.length,
+        }),
+        repos,
+      };
     }),
 
 //   createQFIntegrationProject: protectedProcedure

--- a/src/server/services/github/__tests__/connectionState.test.ts
+++ b/src/server/services/github/__tests__/connectionState.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  GITHUB_APP_ENV_KEYS,
+  isGithubAppConfigured,
+  resolveGithubConnectionState,
+} from "../connectionState";
+
+/** A complete, valid GitHub App env — every required key present and non-blank. */
+function fullEnv(): Record<string, string | undefined> {
+  return {
+    GITHUB_APP_ID: "123456",
+    GITHUB_PRIVATE_KEY: "-----BEGIN KEY-----\nabc\n-----END KEY-----",
+    GITHUB_APP_SLUG: "exponential-app",
+    GITHUB_WEBHOOK_SECRET: "whsec_abc",
+  };
+}
+
+describe("isGithubAppConfigured", () => {
+  it("returns true when all four env vars are present", () => {
+    expect(isGithubAppConfigured(fullEnv())).toBe(true);
+  });
+
+  it("returns false when any single env var is missing", () => {
+    for (const key of GITHUB_APP_ENV_KEYS) {
+      const env = fullEnv();
+      delete env[key];
+      expect(isGithubAppConfigured(env)).toBe(false);
+    }
+  });
+
+  it("treats empty or whitespace-only values as missing", () => {
+    for (const key of GITHUB_APP_ENV_KEYS) {
+      const blank = fullEnv();
+      blank[key] = "";
+      expect(isGithubAppConfigured(blank)).toBe(false);
+
+      const spaces = fullEnv();
+      spaces[key] = "   ";
+      expect(isGithubAppConfigured(spaces)).toBe(false);
+    }
+  });
+
+  it("returns false for an empty environment", () => {
+    expect(isGithubAppConfigured({})).toBe(false);
+  });
+});
+
+describe("resolveGithubConnectionState", () => {
+  const installation = { id: "int_1" };
+
+  it("short-circuits to NOT_CONFIGURED when the app is not configured, ignoring install/repos", () => {
+    expect(
+      resolveGithubConnectionState({
+        appConfigured: false,
+        installation,
+        repoCount: 5,
+      }),
+    ).toBe("NOT_CONFIGURED");
+
+    expect(
+      resolveGithubConnectionState({
+        appConfigured: false,
+        installation: null,
+        repoCount: 0,
+      }),
+    ).toBe("NOT_CONFIGURED");
+  });
+
+  it("returns NOT_INSTALLED when configured but no installation exists", () => {
+    expect(
+      resolveGithubConnectionState({
+        appConfigured: true,
+        installation: null,
+        repoCount: 0,
+      }),
+    ).toBe("NOT_INSTALLED");
+  });
+
+  it("returns NO_REPOS when installed but zero repos are tracked", () => {
+    expect(
+      resolveGithubConnectionState({
+        appConfigured: true,
+        installation,
+        repoCount: 0,
+      }),
+    ).toBe("NO_REPOS");
+  });
+
+  it("returns CONNECTED when installed and at least one repo is tracked", () => {
+    expect(
+      resolveGithubConnectionState({
+        appConfigured: true,
+        installation,
+        repoCount: 1,
+      }),
+    ).toBe("CONNECTED");
+
+    expect(
+      resolveGithubConnectionState({
+        appConfigured: true,
+        installation,
+        repoCount: 42,
+      }),
+    ).toBe("CONNECTED");
+  });
+
+  it("treats a negative repo count as NO_REPOS (defensive)", () => {
+    expect(
+      resolveGithubConnectionState({
+        appConfigured: true,
+        installation,
+        repoCount: -1,
+      }),
+    ).toBe("NO_REPOS");
+  });
+});

--- a/src/server/services/github/connectionState.ts
+++ b/src/server/services/github/connectionState.ts
@@ -1,0 +1,87 @@
+/**
+ * GitHub repo connection state — the pure, app-agnostic core (ADR-0020).
+ *
+ * Two deep modules live here:
+ *  - `isGithubAppConfigured()` (L1): is the GitHub App registered in this
+ *    environment? Pure read of env vars, no I/O.
+ *  - `resolveGithubConnectionState()`: the single mapping from
+ *    (app configured? installed? how many repos?) → a connection-state enum.
+ *
+ * Both are dependency-free so they unit-test trivially and can be reused by the
+ * homepage Connect CTA and the `/integrations` GitHub card without dragging in
+ * Prisma or tRPC.
+ */
+
+/** Env vars that must all be present for the GitHub App to be usable (L1). */
+export const GITHUB_APP_ENV_KEYS = [
+  "GITHUB_APP_ID",
+  "GITHUB_PRIVATE_KEY",
+  "GITHUB_APP_SLUG",
+  "GITHUB_WEBHOOK_SECRET",
+] as const;
+
+/**
+ * Provider/type identifying a workspace's single GitHub App installation
+ * `Integration` row. Slice #2 (connect flow) creates the row with exactly these
+ * values; slice #1 reads them to detect "installed". Centralised here so both
+ * slices share one contract.
+ */
+export const GITHUB_INSTALLATION_PROVIDER = "github";
+export const GITHUB_INSTALLATION_TYPE = "github_app_installation";
+
+/**
+ * How connected a workspace is to GitHub. Drives both the homepage CTA and the
+ * `/integrations` card.
+ *  - `NOT_CONFIGURED` — the GitHub App isn't registered in this environment (L1
+ *    missing). Short-circuits everything below.
+ *  - `NOT_INSTALLED` — App configured, but this workspace has no installation.
+ *  - `NO_REPOS` — installed, but no repos associated yet.
+ *  - `CONNECTED` — installed and tracking at least one repo.
+ */
+export type GithubConnectionState =
+  | "NOT_CONFIGURED"
+  | "NOT_INSTALLED"
+  | "NO_REPOS"
+  | "CONNECTED";
+
+/**
+ * True only when every required GitHub App env var is present and non-blank.
+ * Defaults to `process.env` but accepts an explicit source for testing.
+ */
+export function isGithubAppConfigured(
+  source: Record<string, string | undefined> = process.env,
+): boolean {
+  return GITHUB_APP_ENV_KEYS.every((key) => {
+    const value = source[key];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+}
+
+/** Minimal shape of an installation `Integration` — only presence matters here. */
+export interface InstallationRef {
+  id: string;
+}
+
+export interface ResolveGithubConnectionStateInput {
+  /** Result of `isGithubAppConfigured()` (L1). */
+  appConfigured: boolean;
+  /** The workspace's installation `Integration`, or `null` if none (L2). */
+  installation: InstallationRef | null;
+  /** Count of `WorkspaceRepository` rows for the workspace (L3). */
+  repoCount: number;
+}
+
+/**
+ * The single source-of-truth mapping. Layers short-circuit top-down: an
+ * unconfigured App never looks at installation or repo count.
+ */
+export function resolveGithubConnectionState({
+  appConfigured,
+  installation,
+  repoCount,
+}: ResolveGithubConnectionStateInput): GithubConnectionState {
+  if (!appConfigured) return "NOT_CONFIGURED";
+  if (installation == null) return "NOT_INSTALLED";
+  if (repoCount <= 0) return "NO_REPOS";
+  return "CONNECTED";
+}


### PR DESCRIPTION
## What

The foundation slice for **GitHub repo connection** (parent feature `cmqe1h0ai0005jl04w8ltmkdh`, design of record ADR-0020). This is **connect + associate scaffolding only** — the identity claim (`User.githubLogin`) and commit surfacing into the activity feed / Weekly work digest are an explicit later phase and are **not** built here.

It adds a new `WorkspaceRepository` model and a tRPC read that answers "how connected is this workspace to GitHub?" — demoable on its own, before any connect/associate UI exists.

### Changes
- **`WorkspaceRepository` model** (`prisma/schema.prisma` + migration `20260615072546_add_workspace_repository`): source of truth for which repos a workspace tracks. `@@unique([workspaceId, fullName])` (a repo may be tracked by multiple workspaces), indexes on `workspaceId` and `integrationId`, FK to the installation `Integration` (cascade) and to `User` for `addedById` (set null).
- **Two pure deep modules** (`src/server/services/github/connectionState.ts`, **9 unit tests**):
  - `isGithubAppConfigured()` (L1) — true only when all four GitHub App env vars are present and non-blank (`GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, `GITHUB_APP_SLUG`, `GITHUB_WEBHOOK_SECRET`).
  - `resolveGithubConnectionState({ appConfigured, installation, repoCount })` → `NOT_CONFIGURED | NOT_INSTALLED | NO_REPOS | CONNECTED`. Not-configured short-circuits before any install/repo checks.
- **`github.getGithubConnectionState` tRPC read**: workspace-member gated (`requireWorkspaceMembership("view")`). Composes L1 → L2 installation lookup → L3 `WorkspaceRepository` count. Degrades to `NOT_CONFIGURED` with an empty repo list and **no DB work** when the GitHub App env is absent (never 500s). The installation `Integration` won't exist until slice #2, so today this resolves to `NOT_INSTALLED`.

### Notes for reviewers
- **Migration base = `main`.** The repo convention prefers `develop` for migrations, but `develop` is currently 3 migrations behind `main` (stale/diverged) and the shared dev DB matches `main`. Basing on `develop` would have made `migrate dev` see drift and offer a reset. Migration was human-run and applied cleanly.
- L1 reads `process.env` directly (matching the existing github router's `GITHUB_TOKEN` pattern), so absent env vars degrade gracefully rather than failing T3 env validation. Registering the GitHub App + setting those env vars is a one-time admin prerequisite (separate runbook), intentionally not automated here.

## Acceptance criteria

- [x] `WorkspaceRepository` model with fields, `@@unique([workspaceId, fullName])`, `@@index([workspaceId])`, FK to installation `Integration`
- [x] Migration created by the human; Prisma client regenerated
- [x] `isGithubAppConfigured()` unit-tested (true iff all four env vars present)
- [x] `resolveGithubConnectionState()` unit-tested (every layer combination)
- [x] `getGithubConnectionState` returns state enum + tracked repos; degrades to `NOT_CONFIGURED` (never 500s)
- [x] `npm run check` passes (tsc exit 0, eslint clean, 731 unit tests green)

---

Ships: cosmic.anchor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace members can now view and track GitHub repositories within their workspace.
  * Added GitHub connection status reporting to display integration configuration and repository availability.

* **Tests**
  * Added GitHub connection state validation test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->