### PR TITLE
feat: connect-flow refactor — one workspace installation Integration + accessible repos

### DIFF
--- a/src/app/api/auth/github/authorize/route.ts
+++ b/src/app/api/auth/github/authorize/route.ts
@@ -1,12 +1,16 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { auth } from "~/server/auth";
+import { isGithubAppConfigured } from "~/server/services/github/connectionState";
 import { z } from "zod";
 
 const authorizeSchema = z.object({
   projectId: z.string().optional(),
+  workspaceId: z.string().optional(),
   redirectUrl: z.string().url().optional(),
 });
+
+const BASE_URL = process.env.NEXTAUTH_URL || "http://localhost:3000";
 
 // GitHub App credentials (currently unused)
 // const GITHUB_APP_ID = process.env.GITHUB_APP_ID!;
@@ -21,32 +25,41 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    // L1 prerequisite: can't start an install without the GitHub App
+    // registered. Degrade gracefully instead of sending the user to a broken
+    // github.com/apps/your-app-name URL.
+    if (!isGithubAppConfigured()) {
+      return NextResponse.redirect(
+        `${BASE_URL}/integrations?error=github_not_configured`,
+      );
+    }
+
     const { searchParams } = new URL(request.url);
     const params = Object.fromEntries(searchParams);
 
-    const { projectId, redirectUrl } = authorizeSchema.parse(params);
+    const { projectId, workspaceId, redirectUrl } =
+      authorizeSchema.parse(params);
 
-    // Create state parameter to maintain context
+    // Create state parameter to maintain context. `workspaceId` is what makes
+    // the install round-trip back to the originating workspace (ADR-0020).
     const state = Buffer.from(
       JSON.stringify({
         userId: session.user.id,
         projectId,
+        workspaceId,
         redirectUrl,
         timestamp: Date.now(),
       }),
     ).toString("base64");
 
-    // For GitHub App, we need to determine if the user has already installed the app
-    // If not, redirect to installation. If yes, redirect to repository selection.
-    
-    // GitHub App installation URL - replace YOUR_APP_SLUG with your actual app slug
-    const appSlug = process.env.GITHUB_APP_SLUG || "your-app-name";
-    
-    // First, redirect to GitHub App installation with state
-    const installUrl = new URL(`https://github.com/apps/${appSlug}/installations/new`);
+    // Redirect to GitHub App installation, carrying state through the install.
+    const appSlug = process.env.GITHUB_APP_SLUG!;
+    const installUrl = new URL(
+      `https://github.com/apps/${appSlug}/installations/new`,
+    );
     installUrl.searchParams.set("state", state);
-    
-    // The installation process will redirect back to our setup-url configured in the GitHub App
+
+    // The install round-trips back to our setup-url (the callback route).
     return NextResponse.redirect(installUrl.toString());
   } catch (error) {
     console.error("GitHub OAuth authorization error:", error);

--- a/src/app/api/auth/github/callback/route.ts
+++ b/src/app/api/auth/github/callback/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { auth } from "~/server/auth";
+import { db } from "~/server/db";
 import { githubIntegrationService } from "~/server/services/github-integration";
+import { isGithubAppConfigured } from "~/server/services/github/connectionState";
 import { App } from "octokit";
 import { z } from "zod";
 
@@ -55,6 +57,14 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    // L1 prerequisite: without the GitHub App env the SDK can't mint an
+    // installation token. Degrade gracefully instead of throwing a 500.
+    if (!isGithubAppConfigured()) {
+      return NextResponse.redirect(
+        `${BASE_URL}/integrations?error=github_not_configured`,
+      );
+    }
+
     const { searchParams } = new URL(request.url);
     const params = Object.fromEntries(searchParams);
 
@@ -103,13 +113,15 @@ export async function GET(request: NextRequest) {
     // Mark this installation as being processed
     processedInstallations.add(installation_id);
 
-    // Parse state to get project ID if provided
+    // Parse state to get project / workspace context if provided
     let projectId: string | undefined = undefined;
+    let workspaceId: string | undefined = undefined;
     let userId: string | null = null;
     if (state) {
       try {
         const stateData = JSON.parse(Buffer.from(state, "base64").toString());
-        projectId = stateData.projectId || null;
+        projectId = stateData.projectId || undefined;
+        workspaceId = stateData.workspaceId || undefined;
         userId = stateData.userId || null;
       } catch (error) {
         console.error("Failed to parse state:", error);
@@ -153,6 +165,48 @@ export async function GET(request: NextRequest) {
 
     const { token: access_token } = tokenResponse.data;
 
+    const scopes = installationData.permissions
+      ? Object.keys(installationData.permissions)
+      : [];
+
+    // ── New workspace connect flow (ADR-0020) ──────────────────────────────
+    // When the install was started from a workspace, upsert the ONE
+    // workspace-scoped installation Integration and round-trip back to the
+    // workspace so repos can be associated (slice #3). This replaces the
+    // legacy one-Integration-per-repo shape for the workspace flow.
+    if (workspaceId) {
+      const membership = await db.workspaceUser.findFirst({
+        where: { workspaceId, userId: session.user.id },
+        select: { id: true },
+      });
+      if (!membership) {
+        return NextResponse.redirect(
+          `${BASE_URL}/integrations?error=${encodeURIComponent(
+            "Not a member of the target workspace",
+          )}`,
+        );
+      }
+
+      await githubIntegrationService.upsertWorkspaceInstallation({
+        workspaceId,
+        addedById: session.user.id,
+        installationId: parseInt(installation_id),
+        accessToken: access_token,
+        scopes,
+        githubUser,
+        accessibleRepos: reposResponse.data,
+      });
+
+      setTimeout(() => {
+        processedInstallations.delete(installation_id);
+      }, 60000);
+
+      return NextResponse.redirect(
+        `${BASE_URL}/integrations?github_connected=true`,
+      );
+    }
+
+    // ── Legacy project connect flow (unchanged) ────────────────────────────
     // Create GitHub integration using the service
     const integration = await githubIntegrationService.createGitHubIntegration(
       session.user.id,

--- a/src/server/api/routers/github.ts
+++ b/src/server/api/routers/github.ts
@@ -8,6 +8,7 @@ import {
   isGithubAppConfigured,
   resolveGithubConnectionState,
 } from "~/server/services/github/connectionState";
+import { normalizeAccessibleRepos } from "~/server/services/github/accessibleRepos";
 
 export const githubRouter = createTRPCRouter({
   listCommits: publicProcedure
@@ -236,6 +237,35 @@ export const githubRouter = createTRPCRouter({
         }),
         repos,
       };
+    }),
+
+  /**
+   * List the GitHub repos accessible to a workspace's installation (ADR-0020,
+   * slice #2), normalized to `RepoOption[]` for the associate UI. Reads the
+   * accessible-repo payload stashed on the installation `Integration` at install
+   * time, so it needs no live GitHub call and works when L1 env is absent.
+   * Returns `[]` when the workspace has no installation.
+   */
+  listAccessibleRepos: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
+    .query(async ({ ctx, input }) => {
+      const installation = await ctx.db.integration.findFirst({
+        where: {
+          workspaceId: input.workspaceId,
+          provider: GITHUB_INSTALLATION_PROVIDER,
+          type: GITHUB_INSTALLATION_TYPE,
+          status: "ACTIVE",
+        },
+        select: { providerConfig: true },
+      });
+
+      if (!installation) return [];
+
+      const config = installation.providerConfig as {
+        accessibleRepos?: unknown;
+      } | null;
+      return normalizeAccessibleRepos(config?.accessibleRepos);
     }),
 
 //   createQFIntegrationProject: protectedProcedure

--- a/src/server/services/github-integration.ts
+++ b/src/server/services/github-integration.ts
@@ -2,9 +2,38 @@ import { db } from "~/server/db";
 import type {
   Integration,
   IntegrationCredential,
+  Prisma,
   Workflow,
 } from "@prisma/client";
 import { encryptCredential } from "~/server/utils/credentialHelper";
+import {
+  GITHUB_INSTALLATION_PROVIDER,
+  GITHUB_INSTALLATION_TYPE,
+} from "~/server/services/github/connectionState";
+
+/** Minimal GitHub account shape captured at install time (account = user or org). */
+interface GitHubAccount {
+  id?: number;
+  login?: string;
+  avatar_url?: string;
+  html_url?: string;
+}
+
+interface UpsertWorkspaceInstallationParams {
+  workspaceId: string;
+  /** User who performed the install — recorded as the Integration's `userId`. */
+  addedById: string;
+  installationId: number;
+  accessToken: string;
+  scopes: string[];
+  githubUser: GitHubAccount | null;
+  /**
+   * Raw `apps.listReposAccessibleToInstallation` payload, stashed on the
+   * Integration's `providerConfig` so `listAccessibleRepos` can offer repos for
+   * selection without a live GitHub call (and works when L1 env is absent).
+   */
+  accessibleRepos: unknown;
+}
 
 interface GitHubIssue {
   id: number;
@@ -69,6 +98,96 @@ class GitHubIntegrationService {
     }
 
     return response.json();
+  }
+
+  /**
+   * Upsert the ONE workspace-scoped GitHub App installation `Integration`
+   * (ADR-0020, L2). Replaces the legacy one-Integration-per-repo shape for the
+   * workspace connect flow: a workspace has at most one installation row
+   * (`provider=github`, `type=github_app_installation`, `status=ACTIVE`), which
+   * is the FK target for `WorkspaceRepository`. Idempotent — re-installing
+   * refreshes the token, accessible-repo list, and metadata in place.
+   */
+  async upsertWorkspaceInstallation(
+    params: UpsertWorkspaceInstallationParams,
+  ): Promise<Integration> {
+    const {
+      workspaceId,
+      addedById,
+      installationId,
+      accessToken,
+      scopes,
+      githubUser,
+      accessibleRepos,
+    } = params;
+
+    const existing = await db.integration.findFirst({
+      where: {
+        workspaceId,
+        provider: GITHUB_INSTALLATION_PROVIDER,
+        type: GITHUB_INSTALLATION_TYPE,
+      },
+      select: { id: true },
+    });
+
+    const providerConfig: Prisma.InputJsonValue = {
+      installationId,
+      // Retained for the later identity-claim phase; never used to attribute
+      // commits in this slice.
+      githubLogin: githubUser?.login ?? null,
+      // Raw GitHub payload (JSON-serializable); normalized on read.
+      accessibleRepos: (accessibleRepos ?? null) as Prisma.InputJsonValue,
+    };
+
+    const data = {
+      name: "GitHub",
+      type: GITHUB_INSTALLATION_TYPE,
+      provider: GITHUB_INSTALLATION_PROVIDER,
+      status: "ACTIVE",
+      description: "GitHub App installation for this workspace",
+      workspaceId,
+      userId: addedById,
+      lastSyncAt: new Date(),
+      providerConfig,
+    };
+
+    const integration = existing
+      ? await db.integration.update({ where: { id: existing.id }, data })
+      : await db.integration.create({ data });
+
+    // Refresh the credentials we own for this installation. Replace-in-place so
+    // re-installs don't accumulate stale token/metadata rows.
+    const encryptedToken = encryptCredential(accessToken);
+    await db.integrationCredential.deleteMany({
+      where: {
+        integrationId: integration.id,
+        keyType: { in: ["access_token", "github_metadata"] },
+      },
+    });
+    await db.integrationCredential.createMany({
+      data: [
+        {
+          integrationId: integration.id,
+          key: encryptedToken.key,
+          keyType: "access_token",
+          isEncrypted: encryptedToken.isEncrypted,
+        },
+        {
+          integrationId: integration.id,
+          key: JSON.stringify({
+            githubUserId: githubUser?.id,
+            githubUsername: githubUser?.login,
+            avatarUrl: githubUser?.avatar_url,
+            scopes,
+            installationId,
+          }),
+          keyType: "github_metadata",
+          isEncrypted: false,
+        },
+      ],
+    });
+
+    return integration;
   }
 
   async createGitHubIntegration(

--- a/src/server/services/github/__tests__/accessibleRepos.test.ts
+++ b/src/server/services/github/__tests__/accessibleRepos.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAccessibleRepos } from "../accessibleRepos";
+
+/** A well-formed slice of GitHub's listReposAccessibleToInstallation payload. */
+function githubPayload() {
+  return {
+    total_count: 2,
+    repositories: [
+      {
+        id: 1,
+        name: "exponential",
+        full_name: "positonic/exponential",
+        private: false,
+        owner: { login: "positonic", id: 10 },
+      },
+      {
+        id: 2,
+        name: "secret-app",
+        full_name: "acme/secret-app",
+        private: true,
+        owner: { login: "acme", id: 20 },
+      },
+    ],
+  };
+}
+
+describe("normalizeAccessibleRepos", () => {
+  it("maps a well-formed installation payload to RepoOption[]", () => {
+    expect(normalizeAccessibleRepos(githubPayload())).toEqual([
+      {
+        owner: "positonic",
+        name: "exponential",
+        fullName: "positonic/exponential",
+        private: false,
+      },
+      {
+        owner: "acme",
+        name: "secret-app",
+        fullName: "acme/secret-app",
+        private: true,
+      },
+    ]);
+  });
+
+  it("accepts a bare array as well as the { repositories } envelope", () => {
+    const arr = githubPayload().repositories;
+    expect(normalizeAccessibleRepos(arr)).toHaveLength(2);
+  });
+
+  it("maps the private flag correctly (only strict true is private)", () => {
+    const result = normalizeAccessibleRepos({
+      repositories: [
+        { name: "a", full_name: "o/a", owner: { login: "o" }, private: true },
+        { name: "b", full_name: "o/b", owner: { login: "o" }, private: false },
+        { name: "c", full_name: "o/c", owner: { login: "o" } }, // missing → false
+      ],
+    });
+    expect(result.map((r) => r.private)).toEqual([true, false, false]);
+  });
+
+  it("falls back to the full_name prefix when owner.login is absent", () => {
+    const result = normalizeAccessibleRepos({
+      repositories: [{ name: "repo", full_name: "owner-x/repo", private: false }],
+    });
+    expect(result[0]?.owner).toBe("owner-x");
+  });
+
+  it("derives full_name from owner + name when full_name is missing", () => {
+    const result = normalizeAccessibleRepos({
+      repositories: [{ name: "repo", owner: { login: "owner-y" }, private: false }],
+    });
+    expect(result[0]?.fullName).toBe("owner-y/repo");
+  });
+
+  it("drops malformed entries without throwing", () => {
+    const result = normalizeAccessibleRepos({
+      repositories: [
+        null,
+        "not-an-object",
+        42,
+        {}, // no name/owner
+        { name: "ok", owner: { login: "o" }, private: false },
+      ],
+    });
+    expect(result).toEqual([
+      { owner: "o", name: "ok", fullName: "o/ok", private: false },
+    ]);
+  });
+
+  it("tolerates empty and non-object inputs", () => {
+    expect(normalizeAccessibleRepos({ repositories: [] })).toEqual([]);
+    expect(normalizeAccessibleRepos([])).toEqual([]);
+    expect(normalizeAccessibleRepos(null)).toEqual([]);
+    expect(normalizeAccessibleRepos(undefined)).toEqual([]);
+    expect(normalizeAccessibleRepos("garbage")).toEqual([]);
+    expect(normalizeAccessibleRepos({})).toEqual([]);
+  });
+});

--- a/src/server/services/github/accessibleRepos.ts
+++ b/src/server/services/github/accessibleRepos.ts
@@ -1,0 +1,69 @@
+/**
+ * Normalize the GitHub "repos accessible to an installation" payload into the
+ * minimal `RepoOption` shape the connect/associate UI offers for selection
+ * (ADR-0020, slice #2).
+ *
+ * Pure and defensive: the input is whatever GitHub's
+ * `apps.listReposAccessibleToInstallation` returned (or a stored copy of it),
+ * so it tolerates the `{ repositories: [...] }` envelope, a bare array, and
+ * malformed/empty input without throwing. Entries missing the fields we need
+ * are dropped rather than surfaced as half-populated options.
+ */
+
+export interface RepoOption {
+  owner: string;
+  name: string;
+  fullName: string;
+  private: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** Extract the repository array from either `{ repositories: [...] }` or `[...]`. */
+function extractRepoList(apiResponse: unknown): unknown[] {
+  if (Array.isArray(apiResponse)) return apiResponse;
+  if (isRecord(apiResponse) && Array.isArray(apiResponse.repositories)) {
+    return apiResponse.repositories;
+  }
+  return [];
+}
+
+/** Owner login, preferring `owner.login`, falling back to the `full_name` prefix. */
+function resolveOwner(repo: Record<string, unknown>): string | null {
+  if (isRecord(repo.owner) && typeof repo.owner.login === "string") {
+    return repo.owner.login;
+  }
+  if (typeof repo.full_name === "string" && repo.full_name.includes("/")) {
+    return repo.full_name.split("/")[0] ?? null;
+  }
+  return null;
+}
+
+export function normalizeAccessibleRepos(apiResponse: unknown): RepoOption[] {
+  const list = extractRepoList(apiResponse);
+  const options: RepoOption[] = [];
+
+  for (const entry of list) {
+    if (!isRecord(entry)) continue;
+
+    const name = typeof entry.name === "string" ? entry.name : null;
+    const owner = resolveOwner(entry);
+    if (!name || !owner) continue;
+
+    const fullName =
+      typeof entry.full_name === "string" && entry.full_name.length > 0
+        ? entry.full_name
+        : `${owner}/${name}`;
+
+    options.push({
+      owner,
+      name,
+      fullName,
+      private: entry.private === true,
+    });
+  }
+
+  return options;
+}


### PR DESCRIPTION
## What

The **L2 slice** of GitHub repo connection (parent `cmqe1h0ai0005jl04w8ltmkdh`, design of record ADR-0020). Makes installing the GitHub App actually connect a *workspace*, and exposes the installation's accessible repos for the next slice to offer for selection. Builds on #207 (cosmic.anchor).

Still **connect + associate only** — no identity claim, no commit surfacing.

### Changes
- **`upsertWorkspaceInstallation`** (`github-integration.ts`): installing the App now upserts exactly **ONE** workspace-scoped installation `Integration` (`provider=github`, `type=github_app_installation`, `workspaceId`, `addedById`, `installationId`, encrypted token) — replacing the legacy one-Integration-per-repo shape for the workspace flow. Idempotent: re-installing refreshes token/repos/metadata in place. `githubUser.login` is retained on `providerConfig` for the later identity-claim phase. The accessible-repo payload is stashed on `providerConfig` so selection needs no live GitHub call.
- **`authorize` handshake completed**: the route now carries `workspaceId` through `state`; the **callback** verifies workspace membership, upserts the installation, and round-trips back to the workspace.
- **`normalizeAccessibleRepos`** pure module (`accessibleRepos.ts`, **7 unit tests**): tolerant mapping of the installation repos payload → `RepoOption[]` (`owner`, `name`, `fullName`, `private`); malformed/empty tolerated without throwing.
- **`github.listAccessibleRepos`** tRPC: workspace-member gated; reads the stashed payload and normalizes it; returns `[]` when the workspace isn't installed. L1-independent.
- Both routes **degrade gracefully** (redirect, never 500) when the GitHub App env is absent.

### Design notes for reviewers
- **Legacy project connect flow left untouched.** `ProjectWorkflowsTab` → `authorize?projectId=` still creates its per-repo Integration + issue-sync workflow. Criterion "no more one-Integration-per-repo" is implemented for the **workspace** connect flow (the new path); removing the project path would regress project issue-sync, which is out of scope here. The new homepage CTA / integrations flow always supplies `workspaceId` and takes the new path.
- **`listAccessibleRepos` reads the stored payload** (stashed at install time) rather than live-fetching, so it's graceful and testable without L1.
- **L1** (GitHub App registration + `GITHUB_APP_ID`/`GITHUB_PRIVATE_KEY`/`GITHUB_APP_SLUG`/`GITHUB_WEBHOOK_SECRET`) is a one-time admin prerequisite (separate runbook). The callback/handshake is thin glue verified manually once L1 exists; the pure module + tRPC are unit-tested.

## Acceptance criteria

- [x] Install callback upserts exactly ONE workspace-scoped installation `Integration` per workspace; no more one-Integration-per-repo (workspace flow)
- [x] `authorize` handshake completed; install round-trips back to the originating workspace via `state`
- [x] `githubUser.login` from OAuth is still captured/retained
- [x] `normalizeAccessibleRepos()` unit-tested (well-formed → RepoOption[], malformed/empty tolerated, private flag mapped)
- [x] `listAccessibleRepos` returns normalized accessible repos for an installed workspace; graceful when not installed
- [x] After install, `getGithubConnectionState` (slice #1) reports `NO_REPOS` for that workspace
- [x] `npm run check` passes (tsc 0, eslint clean, 738 unit tests green)

---

Ships: cold.maple