### PR TITLE
feat: workspace homepage Connect GitHub CTA

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx
@@ -6,6 +6,7 @@ import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { WorkspaceHomeConceptD as WorkspaceHomeCommand } from '~/app/_components/home/WorkspaceHomeConceptD';
 import { WorkspaceHomeActivity } from '~/app/_components/home/WorkspaceHomeActivity';
 import { WorkspaceHomeCoaching } from '~/app/_components/home/WorkspaceHomeCoaching';
+import { GithubConnectCta } from '~/app/_components/home/GithubConnectCta';
 import { validateHomeLayout } from '~/app/_components/home/HomeLayoutPicker';
 
 function WorkspaceHomeContent() {
@@ -33,9 +34,21 @@ function WorkspaceHomeContent() {
 
   const layout = validateHomeLayout(workspace.homeLayout);
 
-  if (layout === 'activity') return <WorkspaceHomeActivity />;
-  if (layout === 'coaching') return <WorkspaceHomeCoaching />;
-  return <WorkspaceHomeCommand />;
+  const layoutContent =
+    layout === 'activity' ? (
+      <WorkspaceHomeActivity />
+    ) : layout === 'coaching' ? (
+      <WorkspaceHomeCoaching />
+    ) : (
+      <WorkspaceHomeCommand />
+    );
+
+  return (
+    <>
+      <GithubConnectCta />
+      {layoutContent}
+    </>
+  );
 }
 
 export default function WorkspaceHomePage() {

--- a/src/app/_components/home/GithubConnectCta.tsx
+++ b/src/app/_components/home/GithubConnectCta.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Container, Paper, Group, Text, Button } from "@mantine/core";
+import { IconBrandGithub } from "@tabler/icons-react";
+import Link from "next/link";
+import { api } from "~/trpc/react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+
+/**
+ * "Connect GitHub" call-to-action on the workspace homepage (ADR-0020, slice #4).
+ *
+ * Visibility keys off `getGithubConnectionState` (slice #1):
+ *  - Shown when state is `NOT_INSTALLED` or `NO_REPOS` — and only for
+ *    owners/admins, who have the controls to act on it.
+ *  - Hidden once `CONNECTED` (the workspace tracks at least one repo).
+ *  - Hidden when `NOT_CONFIGURED` — don't nag with a CTA that leads nowhere;
+ *    `/integrations` shows the graceful state instead.
+ *  - Hidden for plain members.
+ */
+export function GithubConnectCta() {
+  const { workspaceId, userRole } = useWorkspace();
+  const isOwnerOrAdmin = userRole === "owner" || userRole === "admin";
+
+  const { data } = api.github.getGithubConnectionState.useQuery(
+    { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId && isOwnerOrAdmin },
+  );
+
+  if (!isOwnerOrAdmin) return null;
+  if (!data) return null;
+  if (data.state !== "NOT_INSTALLED" && data.state !== "NO_REPOS") return null;
+
+  return (
+    <Container size="lg" className="pt-8">
+      <Paper
+        p="md"
+        radius="md"
+        className="border border-border-primary bg-surface-secondary"
+      >
+        <Group justify="space-between" wrap="nowrap" gap="md">
+          <Group gap="md" wrap="nowrap">
+            <IconBrandGithub size={24} className="text-text-primary" />
+            <div>
+              <Text fw={600} size="sm" className="text-text-primary">
+                Connect GitHub
+              </Text>
+              <Text size="xs" className="text-text-secondary">
+                Link your repositories to bring GitHub activity into this
+                workspace.
+              </Text>
+            </div>
+          </Group>
+          <Button
+            component={Link}
+            href="/integrations"
+            variant="filled"
+            color="brand"
+            size="sm"
+            className="flex-shrink-0"
+          >
+            Connect
+          </Button>
+        </Group>
+      </Paper>
+    </Container>
+  );
+}


### PR DESCRIPTION
## What

Slice #4 of GitHub repo connection (parent `cmqe1h0ai0005jl04w8ltmkdh`, ADR-0020). A "Connect GitHub" CTA on the workspace homepage giving owners/admins an obvious entry point, which disappears once the workspace tracks a repo. Builds on #207 (the `getGithubConnectionState` read).

### Behavior (keys off `getGithubConnectionState`)
- **Shown** for owners/admins when state is `NOT_INSTALLED` or `NO_REPOS`.
- **Hidden** once `CONNECTED` (≥1 `WorkspaceRepository` row).
- **Hidden** for plain members (no controls they can use).
- **Hidden** when `NOT_CONFIGURED` — no broken CTA; `/integrations` shows the graceful state.
- Clicking navigates to `/integrations` via Mantine `Button component={Link}`.

### Notes
- `GithubConnectCta` is self-hiding (returns `null` when not applicable) and carries its own `Container`, so it adds no empty space and renders cleanly above whichever home layout (command/activity/coaching) is active. The query is `enabled` only for owners/admins, so members never fetch it.
- Design tokens only (`border-border-primary`, `bg-surface-secondary`, `text-text-*`); no hardcoded colors.
- Presentational component wired to existing hooks — no pure module to unit-test in this slice. The full "disappears once connected" path is observable end-to-end once slice #3 (associate repos) lands.

## Acceptance criteria

- [x] CTA renders on the homepage when state is `NO_REPOS`/`NOT_INSTALLED` for an owner/admin
- [x] CTA hidden once state is `CONNECTED`
- [x] CTA hidden for non-owner/admin members
- [x] Clicking the CTA navigates to `/integrations`
- [x] No hardcoded colors; `npm run check` passes

---

Ships: stormy.clover