### PR TITLE
feat: associate repos — reconcile save + /integrations multi-select UI

### DIFF
--- a/src/app/(sidemenu)/settings/integrations/page.tsx
+++ b/src/app/(sidemenu)/settings/integrations/page.tsx
@@ -25,6 +25,7 @@ import { GoogleCalendarConnect } from '~/app/_components/GoogleCalendarConnect';
 import { CalendarMultiSelect } from '~/app/_components/calendar/CalendarMultiSelect';
 import { FirefliesIntegrationsList } from '~/app/_components/integrations/FirefliesIntegrationsList';
 import { FirefliesWizardModal } from '~/app/_components/integrations/FirefliesWizardModal';
+import { GithubRepositoriesCard } from '~/app/_components/integrations/GithubRepositoriesCard';
 import IntegrationsClient from '~/app/(sidemenu)/integrations/IntegrationsClient';
 import { WhatsAppGatewayModal } from '~/app/_components/WhatsAppGatewayModal';
 import { TelegramGatewayModal } from '~/app/_components/TelegramGatewayModal';
@@ -245,6 +246,11 @@ export default function IntegrationsSettingsPage() {
             </Button>
           </Group>
         </Paper>
+
+        <Divider />
+
+        {/* GitHub repositories (ADR-0020) */}
+        <GithubRepositoriesCard />
 
         <Divider />
 

--- a/src/app/_components/integrations/GithubRepositoriesCard.tsx
+++ b/src/app/_components/integrations/GithubRepositoriesCard.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Paper,
+  Title,
+  Text,
+  Stack,
+  Group,
+  Button,
+  Checkbox,
+  Badge,
+  Skeleton,
+} from "@mantine/core";
+import { IconBrandGithub } from "@tabler/icons-react";
+import { notifications } from "@mantine/notifications";
+import { api } from "~/trpc/react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+
+/**
+ * `/integrations` GitHub card (ADR-0020, slice #3). Renders by connection state
+ * (from `getGithubConnectionState`) and lets owners/admins pick which accessible
+ * repos the workspace tracks. Plain members see the tracked list read-only.
+ */
+export function GithubRepositoriesCard() {
+  const { workspaceId, userRole } = useWorkspace();
+  const isOwnerOrAdmin = userRole === "owner" || userRole === "admin";
+  const utils = api.useUtils();
+
+  const { data: connection, isLoading } =
+    api.github.getGithubConnectionState.useQuery(
+      { workspaceId: workspaceId ?? "" },
+      { enabled: !!workspaceId },
+    );
+
+  const state = connection?.state;
+  const showRepoPicker = state === "NO_REPOS" || state === "CONNECTED";
+
+  const { data: accessibleRepos } = api.github.listAccessibleRepos.useQuery(
+    { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId && isOwnerOrAdmin && showRepoPicker },
+  );
+
+  // Selection state, seeded once from the currently-tracked repos.
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const seeded = useRef(false);
+  useEffect(() => {
+    if (!seeded.current && connection?.repos) {
+      setSelected(new Set(connection.repos.map((r) => r.fullName)));
+      seeded.current = true;
+    }
+  }, [connection?.repos]);
+
+  const setRepos = api.github.setWorkspaceRepositories.useMutation({
+    onSuccess: async () => {
+      notifications.show({
+        title: "Saved",
+        message: "GitHub repositories updated.",
+        color: "green",
+      });
+      await Promise.all([
+        utils.github.getGithubConnectionState.invalidate(),
+        utils.github.listAccessibleRepos.invalidate(),
+      ]);
+    },
+    onError: (error) => {
+      notifications.show({
+        title: "Couldn't save",
+        message: error.message,
+        color: "red",
+      });
+    },
+  });
+
+  function toggle(fullName: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(fullName)) next.delete(fullName);
+      else next.add(fullName);
+      return next;
+    });
+  }
+
+  const header = (
+    <Group gap="sm">
+      <IconBrandGithub size={20} className="text-text-primary" />
+      <Title order={4} className="text-text-primary">
+        GitHub Repositories
+      </Title>
+    </Group>
+  );
+
+  function Body() {
+    if (isLoading || !state) {
+      return <Skeleton height={80} />;
+    }
+
+    if (state === "NOT_CONFIGURED") {
+      return (
+        <Text size="sm" className="text-text-secondary">
+          GitHub isn&apos;t set up on this deployment yet. Once an administrator
+          configures the GitHub App, you&apos;ll be able to connect repositories
+          here.
+        </Text>
+      );
+    }
+
+    if (state === "NOT_INSTALLED") {
+      if (!isOwnerOrAdmin) {
+        return (
+          <Text size="sm" className="text-text-secondary">
+            GitHub isn&apos;t connected for this workspace yet.
+          </Text>
+        );
+      }
+      return (
+        <Stack gap="sm" align="flex-start">
+          <Text size="sm" className="text-text-secondary">
+            Install the GitHub App to choose which repositories this workspace
+            tracks.
+          </Text>
+          <Button
+            component="a"
+            href={`/api/auth/github/authorize?workspaceId=${workspaceId ?? ""}`}
+            variant="filled"
+            color="brand"
+            size="sm"
+            leftSection={<IconBrandGithub size={16} />}
+          >
+            Install GitHub App
+          </Button>
+        </Stack>
+      );
+    }
+
+    // NO_REPOS or CONNECTED
+    if (!isOwnerOrAdmin) {
+      const tracked = connection?.repos ?? [];
+      if (tracked.length === 0) {
+        return (
+          <Text size="sm" className="text-text-secondary">
+            No repositories are being tracked yet.
+          </Text>
+        );
+      }
+      return (
+        <Stack gap="xs">
+          {tracked.map((repo) => (
+            <Group key={repo.id} gap="xs">
+              <Text size="sm" className="text-text-primary">
+                {repo.fullName}
+              </Text>
+            </Group>
+          ))}
+        </Stack>
+      );
+    }
+
+    const repos = accessibleRepos ?? [];
+    return (
+      <Stack gap="md">
+        <Text size="sm" className="text-text-secondary">
+          Select the repositories this workspace should track.
+        </Text>
+        {repos.length === 0 ? (
+          <Text size="sm" className="text-text-secondary">
+            No accessible repositories found for this installation.
+          </Text>
+        ) : (
+          <Stack gap="xs">
+            {repos.map((repo) => (
+              <Checkbox
+                key={repo.fullName}
+                checked={selected.has(repo.fullName)}
+                onChange={() => toggle(repo.fullName)}
+                label={
+                  <Group gap="xs" wrap="nowrap">
+                    <Text size="sm" className="text-text-primary">
+                      {repo.fullName}
+                    </Text>
+                    <Badge size="xs" variant="light" color={repo.private ? "gray" : "brand"}>
+                      {repo.private ? "Private" : "Public"}
+                    </Badge>
+                  </Group>
+                }
+              />
+            ))}
+          </Stack>
+        )}
+        <Group>
+          <Button
+            variant="filled"
+            color="brand"
+            size="sm"
+            loading={setRepos.isPending}
+            disabled={!workspaceId}
+            onClick={() =>
+              setRepos.mutate({
+                workspaceId: workspaceId ?? "",
+                fullNames: [...selected],
+              })
+            }
+          >
+            Save
+          </Button>
+        </Group>
+      </Stack>
+    );
+  }
+
+  return (
+    <Paper p="lg" withBorder className="bg-surface-secondary">
+      <Stack gap="md">
+        {header}
+        <Body />
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/server/api/routers/__tests__/github.test.ts
+++ b/src/server/api/routers/__tests__/github.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for `github.setWorkspaceRepositories` (ADR-0020, slice #3).
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety"). Asserts the owner/admin gate and the
+ * reconcile create/delete behaviour the associate flow depends on.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const WORKSPACE_ID = "ws-1";
+const USER_ID = "user-1";
+
+/** Make the installation lookup return an installation with two accessible repos. */
+function mockInstallationWithRepos(dbMock: DeepMockProxy<PrismaClient>) {
+  dbMock.integration.findFirst.mockResolvedValue({
+    id: "int-1",
+    providerConfig: {
+      installationId: 42,
+      accessibleRepos: {
+        repositories: [
+          { name: "alpha", full_name: "acme/alpha", owner: { login: "acme" }, private: false },
+          { name: "beta", full_name: "acme/beta", owner: { login: "acme" }, private: true },
+        ],
+      },
+    },
+  } as never);
+}
+
+function mockRole(
+  dbMock: DeepMockProxy<PrismaClient>,
+  role: "owner" | "admin" | "member" | "viewer" | null,
+) {
+  // getWorkspaceMembership → direct WorkspaceUser lookup
+  dbMock.workspaceUser.findUnique.mockResolvedValue(
+    role ? ({ role, workspaceId: WORKSPACE_ID } as never) : null,
+  );
+  // No team-based fallback membership
+  dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+}
+
+describe("github.setWorkspaceRepositories (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  describe("authorization", () => {
+    it.each(["owner", "admin"] as const)("allows %s", async (role) => {
+      mockRole(dbMock, role);
+      mockInstallationWithRepos(dbMock);
+      dbMock.workspaceRepository.findMany.mockResolvedValue([] as never);
+      dbMock.workspaceRepository.createMany.mockResolvedValue({ count: 1 } as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.github.setWorkspaceRepositories({
+          workspaceId: WORKSPACE_ID,
+          fullNames: ["acme/alpha"],
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it.each(["member", "viewer"] as const)("forbids %s", async (role) => {
+      mockRole(dbMock, role);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.github.setWorkspaceRepositories({
+          workspaceId: WORKSPACE_ID,
+          fullNames: ["acme/alpha"],
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" } satisfies Partial<TRPCError>);
+
+      // Gate fails before any write.
+      expect(dbMock.workspaceRepository.createMany).not.toHaveBeenCalled();
+      expect(dbMock.workspaceRepository.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it("forbids a non-member", async () => {
+      mockRole(dbMock, null);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.github.setWorkspaceRepositories({
+          workspaceId: WORKSPACE_ID,
+          fullNames: [],
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+  });
+
+  describe("reconcile", () => {
+    beforeEach(() => {
+      mockRole(dbMock, "admin");
+      mockInstallationWithRepos(dbMock);
+      dbMock.workspaceRepository.deleteMany.mockResolvedValue({ count: 0 } as never);
+      dbMock.workspaceRepository.createMany.mockResolvedValue({ count: 0 } as never);
+    });
+
+    it("creates only the added repos with correct row data", async () => {
+      // currently tracking alpha; desired = alpha + beta → create beta only
+      dbMock.workspaceRepository.findMany.mockResolvedValue([
+        { fullName: "acme/alpha" },
+      ] as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await caller.github.setWorkspaceRepositories({
+        workspaceId: WORKSPACE_ID,
+        fullNames: ["acme/alpha", "acme/beta"],
+      });
+
+      expect(dbMock.workspaceRepository.deleteMany).not.toHaveBeenCalled();
+      expect(dbMock.workspaceRepository.createMany).toHaveBeenCalledWith({
+        data: [
+          {
+            workspaceId: WORKSPACE_ID,
+            integrationId: "int-1",
+            owner: "acme",
+            name: "beta",
+            fullName: "acme/beta",
+            installationId: "42",
+            addedById: USER_ID,
+          },
+        ],
+        skipDuplicates: true,
+      });
+    });
+
+    it("deletes only the removed repos", async () => {
+      // currently tracking alpha + beta; desired = alpha → delete beta only
+      dbMock.workspaceRepository.findMany.mockResolvedValue([
+        { fullName: "acme/alpha" },
+        { fullName: "acme/beta" },
+      ] as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await caller.github.setWorkspaceRepositories({
+        workspaceId: WORKSPACE_ID,
+        fullNames: ["acme/alpha"],
+      });
+
+      expect(dbMock.workspaceRepository.deleteMany).toHaveBeenCalledWith({
+        where: { workspaceId: WORKSPACE_ID, fullName: { in: ["acme/beta"] } },
+      });
+      expect(dbMock.workspaceRepository.createMany).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when the selection is unchanged", async () => {
+      dbMock.workspaceRepository.findMany.mockResolvedValue([
+        { fullName: "acme/alpha" },
+      ] as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await caller.github.setWorkspaceRepositories({
+        workspaceId: WORKSPACE_ID,
+        fullNames: ["acme/alpha"],
+      });
+
+      expect(dbMock.workspaceRepository.createMany).not.toHaveBeenCalled();
+      expect(dbMock.workspaceRepository.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it("rejects repos not accessible to the installation", async () => {
+      dbMock.workspaceRepository.findMany.mockResolvedValue([] as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.github.setWorkspaceRepositories({
+          workspaceId: WORKSPACE_ID,
+          fullNames: ["acme/alpha", "evil/repo"],
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(dbMock.workspaceRepository.createMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/api/routers/github.ts
+++ b/src/server/api/routers/github.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "~/server/api/trpc";
 import * as githubService from "~/server/services/githubService";
-import { requireWorkspaceMembership } from "~/server/services/access";
+import { TRPCError } from "@trpc/server";
+import {
+  getWorkspaceMembership,
+  hasMinimumWorkspaceRole,
+  requireWorkspaceMembership,
+} from "~/server/services/access";
 import {
   GITHUB_INSTALLATION_PROVIDER,
   GITHUB_INSTALLATION_TYPE,
@@ -9,6 +14,7 @@ import {
   resolveGithubConnectionState,
 } from "~/server/services/github/connectionState";
 import { normalizeAccessibleRepos } from "~/server/services/github/accessibleRepos";
+import { reconcileWorkspaceRepositories } from "~/server/services/github/reconcileRepositories";
 
 export const githubRouter = createTRPCRouter({
   listCommits: publicProcedure
@@ -266,6 +272,132 @@ export const githubRouter = createTRPCRouter({
         accessibleRepos?: unknown;
       } | null;
       return normalizeAccessibleRepos(config?.accessibleRepos);
+    }),
+
+  /**
+   * Set which repos a workspace tracks (ADR-0020, slice #3, L3). Reconciles
+   * `WorkspaceRepository` rows against the desired selection idempotently —
+   * re-saving the same set is a no-op. **Owner/admin only**, enforced via the
+   * centralized workspace-access resolvers. Removing a repo deletes only its
+   * `WorkspaceRepository` row; any `GitHubActivity` is left untouched.
+   */
+  setWorkspaceRepositories: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        fullNames: z.array(z.string()),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      // Owner/admin gate via the centralized resolvers (not a duplicated check).
+      const membership = await getWorkspaceMembership(
+        ctx.db,
+        userId,
+        input.workspaceId,
+      );
+      if (!membership || !hasMinimumWorkspaceRole(membership.role, "admin")) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Only workspace owners and admins can manage GitHub repositories",
+        });
+      }
+
+      const installation = await ctx.db.integration.findFirst({
+        where: {
+          workspaceId: input.workspaceId,
+          provider: GITHUB_INSTALLATION_PROVIDER,
+          type: GITHUB_INSTALLATION_TYPE,
+          status: "ACTIVE",
+        },
+        select: { id: true, providerConfig: true },
+      });
+
+      const desired = [...new Set(input.fullNames)];
+
+      if (!installation) {
+        if (desired.length > 0) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "GitHub App is not installed for this workspace",
+          });
+        }
+        // Nothing installed and nothing desired — ensure no stale rows remain.
+        await ctx.db.workspaceRepository.deleteMany({
+          where: { workspaceId: input.workspaceId },
+        });
+        return { tracked: [] };
+      }
+
+      // Only repos actually accessible to the installation may be tracked.
+      const cfg = installation.providerConfig as {
+        accessibleRepos?: unknown;
+        installationId?: unknown;
+      } | null;
+      const accessibleByFullName = new Map(
+        normalizeAccessibleRepos(cfg?.accessibleRepos).map((r) => [
+          r.fullName,
+          r,
+        ]),
+      );
+      const unknownRepos = desired.filter(
+        (fullName) => !accessibleByFullName.has(fullName),
+      );
+      if (unknownRepos.length > 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Not accessible to this installation: ${unknownRepos.join(", ")}`,
+        });
+      }
+
+      const current = await ctx.db.workspaceRepository.findMany({
+        where: { workspaceId: input.workspaceId },
+        select: { fullName: true },
+      });
+      const { toCreate, toDelete } = reconcileWorkspaceRepositories(
+        current.map((r) => r.fullName),
+        desired,
+      );
+
+      const installationIdStr =
+        typeof cfg?.installationId === "number" ||
+        typeof cfg?.installationId === "string"
+          ? String(cfg.installationId)
+          : null;
+
+      if (toDelete.length > 0) {
+        await ctx.db.workspaceRepository.deleteMany({
+          where: {
+            workspaceId: input.workspaceId,
+            fullName: { in: toDelete },
+          },
+        });
+      }
+      if (toCreate.length > 0) {
+        await ctx.db.workspaceRepository.createMany({
+          data: toCreate.map((fullName) => {
+            const repo = accessibleByFullName.get(fullName)!;
+            return {
+              workspaceId: input.workspaceId,
+              integrationId: installation.id,
+              owner: repo.owner,
+              name: repo.name,
+              fullName,
+              installationId: installationIdStr,
+              addedById: userId,
+            };
+          }),
+          skipDuplicates: true,
+        });
+      }
+
+      const tracked = await ctx.db.workspaceRepository.findMany({
+        where: { workspaceId: input.workspaceId },
+        orderBy: { createdAt: "asc" },
+      });
+      return { tracked };
     }),
 
 //   createQFIntegrationProject: protectedProcedure

--- a/src/server/services/github/__tests__/reconcileRepositories.test.ts
+++ b/src/server/services/github/__tests__/reconcileRepositories.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { reconcileWorkspaceRepositories } from "../reconcileRepositories";
+
+describe("reconcileWorkspaceRepositories", () => {
+  it("creates additions not already tracked", () => {
+    const result = reconcileWorkspaceRepositories(
+      ["o/a"],
+      ["o/a", "o/b", "o/c"],
+    );
+    expect(result.toCreate.sort()).toEqual(["o/b", "o/c"]);
+    expect(result.toDelete).toEqual([]);
+  });
+
+  it("deletes removals no longer desired", () => {
+    const result = reconcileWorkspaceRepositories(
+      ["o/a", "o/b", "o/c"],
+      ["o/a"],
+    );
+    expect(result.toCreate).toEqual([]);
+    expect(result.toDelete.sort()).toEqual(["o/b", "o/c"]);
+  });
+
+  it("is a no-op when current and desired match (no spurious writes)", () => {
+    const result = reconcileWorkspaceRepositories(
+      ["o/a", "o/b"],
+      ["o/b", "o/a"], // same set, different order
+    );
+    expect(result.toCreate).toEqual([]);
+    expect(result.toDelete).toEqual([]);
+  });
+
+  it("removes all when desired is empty", () => {
+    const result = reconcileWorkspaceRepositories(["o/a", "o/b"], []);
+    expect(result.toCreate).toEqual([]);
+    expect(result.toDelete.sort()).toEqual(["o/a", "o/b"]);
+  });
+
+  it("adds all when current is empty", () => {
+    const result = reconcileWorkspaceRepositories([], ["o/a", "o/b"]);
+    expect(result.toCreate.sort()).toEqual(["o/a", "o/b"]);
+    expect(result.toDelete).toEqual([]);
+  });
+
+  it("handles simultaneous add and remove", () => {
+    const result = reconcileWorkspaceRepositories(
+      ["o/a", "o/b"],
+      ["o/b", "o/c"],
+    );
+    expect(result.toCreate).toEqual(["o/c"]);
+    expect(result.toDelete).toEqual(["o/a"]);
+  });
+
+  it("returns nothing for two empty sets", () => {
+    expect(reconcileWorkspaceRepositories([], [])).toEqual({
+      toCreate: [],
+      toDelete: [],
+    });
+  });
+});

--- a/src/server/services/github/reconcileRepositories.ts
+++ b/src/server/services/github/reconcileRepositories.ts
@@ -1,0 +1,26 @@
+/**
+ * Reconcile a workspace's tracked GitHub repos against a desired selection
+ * (ADR-0020, slice #3). Pure set-difference: returns which `fullName`s to
+ * create and which to delete so that re-saving the same selection is a no-op
+ * (idempotent — no spurious writes).
+ */
+
+export interface RepositoryReconciliation {
+  /** `fullName`s present in desired but not current — rows to create. */
+  toCreate: string[];
+  /** `fullName`s present in current but not desired — rows to delete. */
+  toDelete: string[];
+}
+
+export function reconcileWorkspaceRepositories(
+  currentFullNames: readonly string[],
+  desiredFullNames: readonly string[],
+): RepositoryReconciliation {
+  const current = new Set(currentFullNames);
+  const desired = new Set(desiredFullNames);
+
+  const toCreate = [...desired].filter((fullName) => !current.has(fullName));
+  const toDelete = [...current].filter((fullName) => !desired.has(fullName));
+
+  return { toCreate, toDelete };
+}


### PR DESCRIPTION
## What

The **L3 association** slice of GitHub repo connection (parent `cmqe1h0ai0005jl04w8ltmkdh`, ADR-0020). Lets a workspace owner/admin pick which accessible repos the workspace tracks, on `/integrations`, saved idempotently. Builds on #208 (installation Integration + `listAccessibleRepos`) and #207 (model + state read).

### Changes
- **`reconcileWorkspaceRepositories`** pure module (`reconcileRepositories.ts`, **7 unit tests**): set-difference of current vs desired `fullName`s → `{ toCreate, toDelete }`. Re-saving the same selection is a no-op.
- **`github.setWorkspaceRepositories`** tRPC: **owner/admin only** via the centralized resolvers (`getWorkspaceMembership` + `hasMinimumWorkspaceRole(role, "admin")`). Reconciles `WorkspaceRepository` rows idempotently against the desired set, restricted to repos actually accessible to the installation. **Removing a repo deletes only its `WorkspaceRepository` row** — `GitHubActivity` is never touched.
- **Mocked-Prisma router tests** (`github.test.ts`, **9 tests**): owner allowed, admin allowed, member/viewer/non-member FORBIDDEN; reconcile creates/deletes exactly the right rows (+ no-op and reject-inaccessible).
- **`/integrations` GitHub card** (`GithubRepositoriesCard`): renders by connection state —
  - `NOT_CONFIGURED` → graceful "GitHub isn't set up on this deployment yet" (no 500)
  - `NOT_INSTALLED` → "Install GitHub App" affordance (owner/admin) / informational text (members)
  - `NO_REPOS` / `CONNECTED` → accessible-repo multi-select (checkboxes, owner/name + private/public badge) with Save
  - Owners/admins manage; plain members see the tracked list read-only.
  - Design tokens only; no hardcoded colors.

### Notes for reviewers
- The mocked-Prisma test is a unit test (`github.test.ts`) per repo convention — `*.integration.test.ts` is reserved for real-DB testcontainer tests (CLAUDE.md "Test database safety"). It still covers the role matrix + reconcile rows the ticket asked for.
- `setWorkspaceRepositories` uses sequential `deleteMany`/`createMany` (guarded by length) rather than a transaction — the two sets are disjoint and the op is idempotent; this also keeps it cleanly assertable under mocked Prisma.

## Acceptance criteria

- [x] `reconcileWorkspaceRepositories()` unit-tested: add, remove, no-op re-save, empty desired (remove all), empty current (add all)
- [x] `setWorkspaceRepositories` reconciles rows idempotently; owner/admin only
- [x] Mocked-Prisma test: owner/admin allowed, member/viewer FORBIDDEN; reconcile creates/deletes correct rows
- [x] `/integrations` card renders all four connection states; multi-select with owner/name + private/public; Save persists
- [x] Removing a repo deletes only the `WorkspaceRepository` row (no `GitHubActivity` deletion)
- [x] Plain members see read-only tracked repos, no manage controls
- [x] No hardcoded colors; `npm run check` passes (tsc 0, eslint clean, 754 unit tests green)

---

Ships: giddy.rune