### PR TITLE
feat: GitHub repo picker — searchable multi-select, refresh, home panel

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx
@@ -7,6 +7,7 @@ import { WorkspaceHomeConceptD as WorkspaceHomeCommand } from '~/app/_components
 import { WorkspaceHomeActivity } from '~/app/_components/home/WorkspaceHomeActivity';
 import { WorkspaceHomeCoaching } from '~/app/_components/home/WorkspaceHomeCoaching';
 import { GithubConnectCta } from '~/app/_components/home/GithubConnectCta';
+import { GithubTrackedRepos } from '~/app/_components/home/GithubTrackedRepos';
 import { validateHomeLayout } from '~/app/_components/home/HomeLayoutPicker';
 
 function WorkspaceHomeContent() {
@@ -46,6 +47,7 @@ function WorkspaceHomeContent() {
   return (
     <>
       <GithubConnectCta />
+      <GithubTrackedRepos />
       {layoutContent}
     </>
   );

--- a/src/app/_components/home/GithubTrackedRepos.tsx
+++ b/src/app/_components/home/GithubTrackedRepos.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  Container,
+  Paper,
+  Title,
+  Stack,
+  Group,
+  Badge,
+  Anchor,
+} from "@mantine/core";
+import { IconBrandGithub } from "@tabler/icons-react";
+import Link from "next/link";
+import { api } from "~/trpc/react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+
+/**
+ * Workspace-home panel listing the repos this workspace tracks (ADR-0020).
+ * Read-only summary for everyone; self-hides when nothing is tracked (the
+ * Connect CTA covers the not-yet-connected case instead). Links to
+ * `/settings/integrations` to manage the selection.
+ */
+export function GithubTrackedRepos() {
+  const { workspaceId } = useWorkspace();
+
+  const { data } = api.github.getGithubConnectionState.useQuery(
+    { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId },
+  );
+
+  const repos = data?.repos ?? [];
+  if (repos.length === 0) return null;
+
+  return (
+    <Container size="lg" className="pt-8">
+      <Paper
+        p="md"
+        radius="md"
+        className="border border-border-primary bg-surface-secondary"
+      >
+        <Stack gap="sm">
+          <Group justify="space-between" wrap="nowrap">
+            <Group gap="sm" wrap="nowrap">
+              <IconBrandGithub size={20} className="text-text-primary" />
+              <Title order={5} className="text-text-primary">
+                GitHub Repositories
+              </Title>
+            </Group>
+            <Anchor
+              component={Link}
+              href="/settings/integrations"
+              size="xs"
+              className="text-text-secondary"
+            >
+              Manage
+            </Anchor>
+          </Group>
+          <Group gap="xs">
+            {repos.map((repo) => (
+              <Badge key={repo.id} variant="light" color="gray" size="sm">
+                {repo.fullName}
+              </Badge>
+            ))}
+          </Group>
+        </Stack>
+      </Paper>
+    </Container>
+  );
+}

--- a/src/app/_components/integrations/GithubRepositoriesCard.tsx
+++ b/src/app/_components/integrations/GithubRepositoriesCard.tsx
@@ -8,11 +8,12 @@ import {
   Stack,
   Group,
   Button,
-  Checkbox,
+  MultiSelect,
+  Anchor,
   Badge,
   Skeleton,
 } from "@mantine/core";
-import { IconBrandGithub } from "@tabler/icons-react";
+import { IconBrandGithub, IconRefresh } from "@tabler/icons-react";
 import { notifications } from "@mantine/notifications";
 import { api } from "~/trpc/react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
@@ -72,14 +73,23 @@ export function GithubRepositoriesCard() {
     },
   });
 
-  function toggle(fullName: string) {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(fullName)) next.delete(fullName);
-      else next.add(fullName);
-      return next;
-    });
-  }
+  const refreshRepos = api.github.refreshAccessibleRepos.useMutation({
+    onSuccess: async (repos) => {
+      notifications.show({
+        title: "Refreshed",
+        message: `Found ${repos.length} accessible ${repos.length === 1 ? "repository" : "repositories"}.`,
+        color: "green",
+      });
+      await utils.github.listAccessibleRepos.invalidate();
+    },
+    onError: (error) => {
+      notifications.show({
+        title: "Couldn't refresh",
+        message: error.message,
+        color: "red",
+      });
+    },
+  });
 
   const header = (
     <Group gap="sm">
@@ -157,36 +167,74 @@ export function GithubRepositoriesCard() {
     }
 
     const repos = accessibleRepos ?? [];
+    const repoByFullName = new Map(repos.map((r) => [r.fullName, r]));
+
     return (
       <Stack gap="md">
-        <Text size="sm" className="text-text-secondary">
-          Select the repositories this workspace should track.
-        </Text>
-        {repos.length === 0 ? (
+        <Group justify="space-between" align="flex-start" wrap="nowrap">
           <Text size="sm" className="text-text-secondary">
-            No accessible repositories found for this installation.
+            Search and select the repositories this workspace should track.
           </Text>
-        ) : (
-          <Stack gap="xs">
-            {repos.map((repo) => (
-              <Checkbox
-                key={repo.fullName}
-                checked={selected.has(repo.fullName)}
-                onChange={() => toggle(repo.fullName)}
-                label={
-                  <Group gap="xs" wrap="nowrap">
-                    <Text size="sm" className="text-text-primary">
-                      {repo.fullName}
-                    </Text>
-                    <Badge size="xs" variant="light" color={repo.private ? "gray" : "brand"}>
-                      {repo.private ? "Private" : "Public"}
-                    </Badge>
-                  </Group>
-                }
-              />
-            ))}
-          </Stack>
-        )}
+          <Button
+            variant="subtle"
+            color="gray"
+            size="compact-sm"
+            leftSection={<IconRefresh size={14} />}
+            loading={refreshRepos.isPending}
+            disabled={!workspaceId}
+            onClick={() =>
+              refreshRepos.mutate({ workspaceId: workspaceId ?? "" })
+            }
+          >
+            Refresh
+          </Button>
+        </Group>
+
+        <MultiSelect
+          data={repos.map((repo) => ({
+            value: repo.fullName,
+            label: repo.fullName,
+          }))}
+          value={[...selected]}
+          onChange={(values) => setSelected(new Set(values))}
+          searchable
+          clearable
+          hidePickedOptions
+          placeholder={selected.size > 0 ? undefined : "Search repositories…"}
+          nothingFoundMessage="No matching repositories"
+          maxDropdownHeight={280}
+          renderOption={({ option }) => {
+            const repo = repoByFullName.get(option.value);
+            return (
+              <Group gap="xs" justify="space-between" wrap="nowrap" w="100%">
+                <Text size="sm" className="text-text-primary">
+                  {option.label}
+                </Text>
+                {repo ? (
+                  <Badge
+                    size="xs"
+                    variant="light"
+                    color={repo.private ? "gray" : "brand"}
+                  >
+                    {repo.private ? "Private" : "Public"}
+                  </Badge>
+                ) : null}
+              </Group>
+            );
+          }}
+        />
+
+        <Text size="xs" className="text-text-muted">
+          Don&apos;t see a repository? Grant the GitHub App access to it, then{" "}
+          <Anchor
+            href={`/api/auth/github/authorize?workspaceId=${workspaceId ?? ""}`}
+            className="text-text-secondary"
+          >
+            manage repository access on GitHub
+          </Anchor>{" "}
+          or hit Refresh.
+        </Text>
+
         <Group>
           <Button
             variant="filled"

--- a/src/server/api/routers/__tests__/github.test.ts
+++ b/src/server/api/routers/__tests__/github.test.ts
@@ -238,3 +238,34 @@ describe("github.setWorkspaceRepositories (mocked)", () => {
     });
   });
 });
+
+describe("github.refreshAccessibleRepos (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  it.each(["member", "viewer"] as const)("forbids %s", async (role) => {
+    mockRole(dbMock, role);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.github.refreshAccessibleRepos({ workspaceId: WORKSPACE_ID }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    // Gate fails before any installation lookup.
+    expect(dbMock.integration.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("allows admin and returns [] gracefully when not installed", async () => {
+    mockRole(dbMock, "admin");
+    dbMock.integration.findFirst.mockResolvedValue(null as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.github.refreshAccessibleRepos({ workspaceId: WORKSPACE_ID }),
+    ).resolves.toEqual([]);
+  });
+});

--- a/src/server/api/routers/github.ts
+++ b/src/server/api/routers/github.ts
@@ -15,6 +15,7 @@ import {
 } from "~/server/services/github/connectionState";
 import { normalizeAccessibleRepos } from "~/server/services/github/accessibleRepos";
 import { reconcileWorkspaceRepositories } from "~/server/services/github/reconcileRepositories";
+import { githubIntegrationService } from "~/server/services/github-integration";
 
 export const githubRouter = createTRPCRouter({
   listCommits: publicProcedure
@@ -272,6 +273,33 @@ export const githubRouter = createTRPCRouter({
         accessibleRepos?: unknown;
       } | null;
       return normalizeAccessibleRepos(config?.accessibleRepos);
+    }),
+
+  /**
+   * Re-sync a workspace's accessible repos from GitHub and return the refreshed
+   * list (ADR-0020, slice #3 follow-up). Owner/admin only. Use after granting
+   * the GitHub App access to more repos so they appear in the picker without a
+   * re-install. Paginates past 100 repos. No-ops gracefully when L1 is absent.
+   */
+  refreshAccessibleRepos: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const membership = await getWorkspaceMembership(
+        ctx.db,
+        ctx.session.user.id,
+        input.workspaceId,
+      );
+      if (!membership || !hasMinimumWorkspaceRole(membership.role, "admin")) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Only workspace owners and admins can refresh GitHub repositories",
+        });
+      }
+
+      return githubIntegrationService.refreshWorkspaceAccessibleRepos(
+        input.workspaceId,
+      );
     }),
 
   /**

--- a/src/server/services/github-integration.ts
+++ b/src/server/services/github-integration.ts
@@ -201,8 +201,9 @@ class GitHubIntegrationService {
    * GitHub and refresh the cached `providerConfig.accessibleRepos` (ADR-0020,
    * slice #3 follow-up). Paginates so installations with >100 repos are fully
    * listed. Lets a user who just granted the App access to more repos on GitHub
-   * see them without re-installing. Returns `[]` (and writes nothing) when L1
-   * is absent or the workspace isn't installed, so it never throws on config.
+   * see them without re-installing. Never throws on config: returns `[]` when
+   * the workspace isn't installed, and falls back to the cached list (writing
+   * nothing) when L1 env is absent or the installation id is unusable.
    */
   async refreshWorkspaceAccessibleRepos(
     workspaceId: string,

--- a/src/server/services/github-integration.ts
+++ b/src/server/services/github-integration.ts
@@ -1,4 +1,5 @@
 import { db } from "~/server/db";
+import { App } from "octokit";
 import type {
   Integration,
   IntegrationCredential,
@@ -9,7 +10,12 @@ import { encryptCredential } from "~/server/utils/credentialHelper";
 import {
   GITHUB_INSTALLATION_PROVIDER,
   GITHUB_INSTALLATION_TYPE,
+  isGithubAppConfigured,
 } from "~/server/services/github/connectionState";
+import {
+  normalizeAccessibleRepos,
+  type RepoOption,
+} from "~/server/services/github/accessibleRepos";
 
 /** Minimal GitHub account shape captured at install time (account = user or org). */
 interface GitHubAccount {
@@ -188,6 +194,58 @@ class GitHubIntegrationService {
     });
 
     return integration;
+  }
+
+  /**
+   * Re-fetch the repos accessible to a workspace's installation directly from
+   * GitHub and refresh the cached `providerConfig.accessibleRepos` (ADR-0020,
+   * slice #3 follow-up). Paginates so installations with >100 repos are fully
+   * listed. Lets a user who just granted the App access to more repos on GitHub
+   * see them without re-installing. Returns `[]` (and writes nothing) when L1
+   * is absent or the workspace isn't installed, so it never throws on config.
+   */
+  async refreshWorkspaceAccessibleRepos(
+    workspaceId: string,
+  ): Promise<RepoOption[]> {
+    const installation = await db.integration.findFirst({
+      where: {
+        workspaceId,
+        provider: GITHUB_INSTALLATION_PROVIDER,
+        type: GITHUB_INSTALLATION_TYPE,
+        status: "ACTIVE",
+      },
+      select: { id: true, providerConfig: true },
+    });
+    if (!installation) return [];
+
+    const cfg = (installation.providerConfig ?? {}) as Record<string, unknown>;
+    const installationId = Number(cfg.installationId);
+    if (!isGithubAppConfigured() || !Number.isFinite(installationId)) {
+      return normalizeAccessibleRepos(cfg.accessibleRepos);
+    }
+
+    const app = new App({
+      appId: process.env.GITHUB_APP_ID!,
+      privateKey: process.env.GITHUB_PRIVATE_KEY!,
+    });
+    const octokit = await app.getInstallationOctokit(installationId);
+    const repositories = await octokit.paginate(
+      octokit.rest.apps.listReposAccessibleToInstallation,
+      { per_page: 100 },
+    );
+
+    const accessibleRepos = { repositories };
+    await db.integration.update({
+      where: { id: installation.id },
+      data: {
+        providerConfig: {
+          ...cfg,
+          accessibleRepos,
+        } as Prisma.InputJsonValue,
+      },
+    });
+
+    return normalizeAccessibleRepos(accessibleRepos);
   }
 
   async createGitHubIntegration(


### PR DESCRIPTION
## What

Follow-ups to the GitHub repo connection flow (ADR-0020) from live testing on `/settings/integrations`.

### Changes
1. **Searchable multi-select** — the `/integrations` GitHub card now uses a searchable Mantine `MultiSelect` (still multi-select) instead of a checkbox list, with a Private/Public badge per option. Scales to many repos.
2. **Refresh + pagination (fixes "my repo isn't in the list")** — new `refreshAccessibleRepos` tRPC (owner/admin) + `refreshWorkspaceAccessibleRepos` service method re-fetch the installation's accessible repos directly from GitHub, **paginated** (the install-time capture stopped at 100 with no pagination). A **"Refresh"** button and a **"manage repository access on GitHub"** link let you pick up a repo after granting the App access to it on GitHub — no re-install needed.
3. **Home panel** — `GithubTrackedRepos` on `/w/<slug>/home` lists the repos the workspace tracks (read-only, with a Manage link), shown once ≥1 repo is associated. Complements the Connect CTA (which covers the not-yet-connected case).

### Why the repo was missing
The accessible-repo list reflects what the GitHub App installation was granted, captured at install time and capped at 100 with no pagination. If you installed with "Only select repositories" (or the repo lives under a different account) it won't appear. After this PR: grant the App access on GitHub → **Refresh** → it shows up.

### Notes
- The refresh's octokit/pagination is thin glue (verified once L1 env exists); it degrades to the cached list when L1 is absent. Gate + graceful-no-install paths are unit-tested.
- Design tokens only; no hardcoded colors.

## Tests
- +3 mocked-Prisma gate tests for `refreshAccessibleRepos` (member/viewer FORBIDDEN; admin allowed, returns `[]` when not installed).
- `npm run check` passes — tsc 0, eslint clean, **757 unit tests green**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tracked GitHub repositories now display on the home page with quick access to manage settings
  * Added refresh button to synchronize accessible repositories from GitHub
  * Improved repository selection UI with enhanced multi-select interface and repository status badges

<!-- end of auto-generated comment: release notes by coderabbit.ai -->