### PR TITLE
feat: replace redundant projects rail widget with GitHub repos

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx
@@ -45,7 +45,9 @@ function WorkspaceHomeContent() {
 
   return (
     <>
-      <GithubConnectCta />
+      {/* Activity layout shows GitHub in the rail widget; other layouts have no
+          rail, so they keep the top Connect banner. */}
+      {layout !== 'activity' && <GithubConnectCta />}
       {layoutContent}
     </>
   );

--- a/src/app/_components/home/activity/GithubReposPanel.tsx
+++ b/src/app/_components/home/activity/GithubReposPanel.tsx
@@ -1,26 +1,55 @@
 'use client';
 
-import { Skeleton } from '@mantine/core';
-import { IconBrandGithub } from '@tabler/icons-react';
+import { Button, Skeleton, TextInput } from '@mantine/core';
+import { IconBrandGithub, IconSearch } from '@tabler/icons-react';
 import Link from 'next/link';
+import { useMemo, useState } from 'react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { api } from '~/trpc/react';
 
 /**
- * Activity-rail panel listing the repos this workspace tracks (ADR-0020).
- * Styled as a `wsa-card` to sit alongside the projects panel in the right rail.
- * Self-hides when nothing is tracked (the Connect CTA covers that case).
+ * GitHub repositories rail widget (ADR-0020). Replaces the redundant projects
+ * panel in the activity-home rail (Active Projects above already lists
+ * projects). One `wsa-card` that adapts to connection state:
+ *  - tracks ≥1 repo → searchable list of repos (with a Manage link)
+ *  - not connected yet (owner/admin) → a compact Connect prompt
+ *  - otherwise (members, or not configured) → hidden
  */
 export function GithubReposPanel() {
-  const { workspaceId } = useWorkspace();
+  const { workspaceId, userRole } = useWorkspace();
+  const isOwnerOrAdmin = userRole === 'owner' || userRole === 'admin';
+  const [query, setQuery] = useState('');
 
   const { data, isLoading } = api.github.getGithubConnectionState.useQuery(
     { workspaceId: workspaceId ?? '' },
     { enabled: !!workspaceId },
   );
 
-  const repos = data?.repos ?? [];
-  if (!isLoading && repos.length === 0) return null;
+  const repos = useMemo(() => data?.repos ?? [], [data?.repos]);
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return repos;
+    return repos.filter((repo) => repo.fullName.toLowerCase().includes(needle));
+  }, [repos, query]);
+
+  if (isLoading) {
+    return (
+      <section className="wsa-card">
+        <Skeleton height={18} width={150} />
+        <Skeleton height={30} mt={10} />
+        <Skeleton height={24} mt={8} />
+      </section>
+    );
+  }
+  if (!data) return null;
+
+  const showConnectPrompt =
+    repos.length === 0 &&
+    isOwnerOrAdmin &&
+    (data.state === 'NOT_INSTALLED' || data.state === 'NO_REPOS');
+
+  // Nothing tracked and no actionable prompt → hide entirely.
+  if (repos.length === 0 && !showConnectPrompt) return null;
 
   return (
     <section className="wsa-card">
@@ -43,46 +72,80 @@ export function GithubReposPanel() {
             GitHub Repositories
           </span>
         </div>
-        <span className="wsa-card__count">{repos.length}</span>
+        {repos.length > 0 ? (
+          <span className="wsa-card__count">{filtered.length}</span>
+        ) : null}
       </div>
 
-      {isLoading ? (
-        <div>
-          {[0, 1, 2].map((i) => (
-            <Skeleton key={i} height={28} mt={i === 0 ? 0 : 6} />
-          ))}
-        </div>
+      {showConnectPrompt ? (
+        <>
+          <p
+            className="wsa-card__caption"
+            style={{ marginTop: 0, marginBottom: 10 }}
+          >
+            Link your repositories to bring GitHub activity into this workspace.
+          </p>
+          <Button
+            component={Link}
+            href="/settings/integrations"
+            variant="filled"
+            color="brand"
+            size="xs"
+            fullWidth
+          >
+            Connect GitHub
+          </Button>
+        </>
       ) : (
-        <div>
-          {repos.map((repo) => (
-            <div key={repo.id} className="wsa-projects__row">
-              <IconBrandGithub
-                size={14}
-                stroke={1.8}
-                style={{ color: 'var(--color-text-muted)' }}
-              />
-              <span
-                style={{
-                  minWidth: 0,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                <em>{repo.owner}/</em>
-                {repo.name}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
+        <>
+          {repos.length > 5 ? (
+            <TextInput
+              size="xs"
+              placeholder="Search repositories"
+              value={query}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+              leftSection={<IconSearch size={14} stroke={1.8} />}
+              mb={8}
+            />
+          ) : null}
 
-      <Link
-        href="/settings/integrations"
-        className="wsa-card__caption"
-        style={{ marginTop: 10, display: 'inline-block' }}
-      >
-        Manage repositories
-      </Link>
+          {filtered.length === 0 ? (
+            <p className="wsa-card__caption" style={{ marginTop: 4 }}>
+              No repositories match &ldquo;{query.trim()}&rdquo;.
+            </p>
+          ) : (
+            <div>
+              {filtered.map((repo) => (
+                <div key={repo.id} className="wsa-projects__row">
+                  <IconBrandGithub
+                    size={14}
+                    stroke={1.8}
+                    style={{ color: 'var(--color-text-muted)' }}
+                  />
+                  <span
+                    style={{
+                      minWidth: 0,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                  >
+                    <em>{repo.owner}/</em>
+                    {repo.name}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <Link
+            href="/settings/integrations"
+            className="wsa-card__caption"
+            style={{ marginTop: 10, display: 'inline-block' }}
+          >
+            Manage repositories
+          </Link>
+        </>
+      )}
     </section>
   );
 }

--- a/src/app/_components/home/activity/index.tsx
+++ b/src/app/_components/home/activity/index.tsx
@@ -5,7 +5,6 @@ import { ActivityFeed } from './ActivityFeed';
 import { GithubReposPanel } from './GithubReposPanel';
 import { Heatmap } from './Heatmap';
 import { Hero } from './Hero';
-import { ProjectsPanel } from './ProjectsPanel';
 import { WeekInReview } from './WeekInReview';
 import './activity-home.css';
 
@@ -16,7 +15,7 @@ import './activity-home.css';
  *   `hero` — `Hero` (this-week / streak / active projects)
  *   `week` — `WeekInReview` (sparkline + multi-week stats)
  *   `main` — `Heatmap` + `ActivityFeed`
- *   `rail` — `ActiveProjects` + `ProjectsPanel`
+ *   `rail` — `ActiveProjects` + `GithubReposPanel`
  */
 export function WorkspaceHomeActivityLayout() {
   return (
@@ -34,7 +33,6 @@ export function WorkspaceHomeActivityLayout() {
         </div>
         <div className="wsa__rail">
           <ActiveProjects />
-          <ProjectsPanel />
           <GithubReposPanel />
         </div>
       </div>


### PR DESCRIPTION
## What

Per feedback: the activity-home rail's **projects panel duplicated the Active Projects panel** right above it, so it was redundant. This **replaces** that widget with the **GitHub repositories** widget.

- `GithubReposPanel` is now the rail's repo widget: a `wsa-card` with a **searchable tracked-repo list** (search appears when >5 repos), a compact **Connect GitHub** prompt for owners/admins when not yet connected, and a **Manage repositories** link. Adapts to connection state; hidden for members on unconnected workspaces.
- Removed `ProjectsPanel` from the activity rail (Active Projects already covers projects). The component file is left in place, just no longer mounted.
- The top **Connect** banner (`GithubConnectCta`) now renders **only on the command/coaching layouts**, which have no rail. The **activity layout** shows GitHub entirely in the rail — no top banner.

Design tokens / CSS variables only; no hardcoded colors. `npm run check` passes.

> Follows the earlier connect/associate work (ADR-0020). Pure UI/placement change — no API or schema changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added in-card search functionality to filter GitHub repositories in the activity view (displays when workspace has 5+ repositories).
  * Implemented role-based GitHub repository management with connection state awareness and guided setup prompts.

* **Chores**
  * Reorganized GitHub connection prompts based on workspace layout selection to reduce redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->