### PR TITLE
docs: ADRs + CONTEXT for the GitHub activity / merge-automation phase

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,12 +60,12 @@ The origin of an activity event. Two sources exist today: `internal` (things tha
 _Avoid_: Type, kind, channel.
 
 **GitHub identity claim**:
-An Exponential user's claim to a GitHub login, stored as `User.githubLogin: String?`. The column can only be set via an OAuth-verified flow on `/settings/profile` — never by free-text input — so that one user cannot claim another user's commits. The activity feed joins GitHub events to `User` via `User.githubLogin = githubEvent.author`; unmatched events render with the raw GitHub login and a generic icon. Separate from `IntegrationUserMapping`, which scopes external identities to specific integration installations and is meant for Slack-style "users discovered through this integration."
+An Exponential user's claim to a GitHub login, stored as `User.githubLogin: String?`. Set only via an **OAuth-verified flow** on `/settings/profile` — the **NextAuth GitHub provider** (user signs in with GitHub; we capture the verified login) — **never** free-text, so one user cannot claim another's commits. It **cannot** be derived from the installer login captured at connect (`Integration.providerConfig.githubLogin`) — that's the installing *account/org*, not each member's personal identity. The activity feed joins GitHub events to `User` via `User.githubLogin = githubEvent.author`; unmatched events render with the raw GitHub login and a generic icon. Separate from `IntegrationUserMapping`, which scopes external identities to specific integration installations and is meant for Slack-style "users discovered through this integration." **Deferred** (not built): only needed for "mine" attribution — it gates commits-in-the-**Weekly work digest**, nothing earlier (the feed and PR-merge promotion don't need it).
 _Avoid_: GitHub user mapping, GitHub link (use "GitHub identity claim" or just "claim" in conversation).
 
 **Workspace repository**:
-A GitHub repo a workspace has declared interest in, stored in `WorkspaceRepository { workspaceId, owner, name, friendlyName?, isPrimary?, syncStatus, lastSyncedAt }`. Added by pasting a `https://github.com/owner/repo` URL in the workspace settings → Integrations → GitHub Repositories card. The declaration is independent of whether anyone has installed the GitHub App on the repo — the source of truth for "which repos belong to this workspace's activity panel" is `WorkspaceRepository`, not `Integration`. A repo can be present in multiple workspaces (one row per workspace × repo pair).
-_Avoid_: Connected repo, tracked repo, linked repo (use "workspace repository" or just "repo" in conversation).
+A GitHub repo a workspace tracks, stored in `WorkspaceRepository { workspaceId, integrationId, owner, name, fullName, installationId?, addedById?, syncStatus, lastSyncedAt }` ([ADR-0020](docs/adr/0020-github-repo-association-via-app-installation.md)). **Selected from** the repos the workspace's **GitHub App installation** can access — not pasted as a free URL — and carries a required FK (`integrationId`) to that single installation `Integration`. So a repo can only be tracked if the App is installed on it with access granted: the `WorkspaceRepository` row is the source of truth for *which* repos a workspace tracks, but it is **not** independent of the install — it is created by selecting from the installation's accessible repos on the workspace settings → Integrations → GitHub Repositories card. A repo can be present in multiple workspaces (one row per workspace × repo pair; `@@unique([workspaceId, fullName])`). Activity for the repo is read via that installation's **per-install App token**, never a shared PAT.
+_Avoid_: Connected repo, linked repo (use "workspace repository", "tracked repo", or just "repo" in conversation). Don't say repos are "added by URL" or "independent of the App install" — that was the pre-ADR-0020 design.
 
 **Activity feed**:
 The chronological list shown in the activity panel on `/w/[slug]/home`. A union over the workspace's activity events from all enabled sources, paginated by cursor on `createdAt`. The feed is a **read-side projection** — it merges the two underlying tables (`WorkspaceActivityEvent` and `GitHubActivity`) in app code; the tables are kept separate at rest because they have genuinely different shapes and serve other consumers (Sprint Analytics queries `GitHubActivity` columns directly).
@@ -91,24 +91,38 @@ _Avoid_: Content idea, post draft (an angle is a prompt, not a written post), su
 The intended design — git commits **polled and persisted** per **Workspace repository** by a cron (PAT-based, no GitHub App required), upserted by `commitSha`. Stored **per-commit** but **rendered grouped** in feeds ("pushed 7 commits to `exponential`"), and summarised in prose by the **Weekly work digest**. "Mine" is resolved by matching `commitAuthor` to the viewer's **GitHub identity claim** (`User.githubLogin`). This persists commits for the **Aggregated activity feed** and the digest — an explicit amendment of [ADR-0001](docs/adr/0001-activity-feed-storage.md)'s "GitHub events are not persisted for the panel" stance (the change ADR-0001 anticipated "later if latency/rate-limits bite").
 _Avoid_: Commits feed, GitHub feed (use "commit activity"); conflating with the webhook-fed `GitHubActivity` analytics path.
 
+**Ticket promotion on merge** _([ADR-0021](docs/adr/0021-pr-merge-promotes-ticket-via-app-webhook.md))_:
+When a tracked repo's PR **merges**, the GitHub-App `pull_request` webhook
+(`closed` + `merged === true`) looks up the `Ticket` by **exact `prUrl`** and, if
+it is in `QA`, transitions it to `DONE` — the in-app, central replacement for the
+per-repo `/setup-merge-hook` Action. `QA`-only guard (never clobbers/​reopens);
+exact-PR-URL match (no base-branch gate); `DEPLOYED` is reserved for a later
+production-deploy signal. This is **write-back to Exponential** (GitHub → ticket
+state), distinct from surfacing GitHub activity in a feed.
+_Avoid_: Auto-close, auto-merge (it promotes a ticket on *someone else's* merge, it doesn't merge anything).
+
 ## Relationships (activity)
 
-> ⚠️ **Accuracy caveat (2026-06-14):** the GitHub-source items below (Workspace
-> repositories, the live-fetch union, activity sources / source switcher) are
-> **aspirational — never implemented**. A code audit found no `WorkspaceRepository`,
-> no `User.githubLogin`, no GitHub OAuth provider, and no GitHub handling in
-> `feed.ts` (the feed reads only `WorkspaceActivityEvent`). `GitHubActivity` is
-> webhook-fed and read only by Sprint Analytics. See [ADR-0001](docs/adr/0001-activity-feed-storage.md)'s
-> accuracy caveat. The terms are retained as the design's vocabulary, not as a
-> description of shipped behaviour.
+> ⚠️ **Status (2026-06-15):** **Connect + associate is now shipped** — the
+> `WorkspaceRepository` model, the GitHub-App connect flow, and the
+> `/integrations` + workspace-home repo-tracking UI all exist, built
+> **App-installation-based** per [ADR-0020](docs/adr/0020-github-repo-association-via-app-installation.md)
+> (which supersedes the earlier "paste-a-URL, App-independent, PAT-based" design
+> and ADR-0019's "no GitHub App required" framing). **Decided but not yet built:**
+> the ingestion mechanism — webhook + poll, persisted to `GitHubActivity` via the
+> per-install App token ([ADR-0022](docs/adr/0022-github-activity-ingestion-webhook-poll-persisted.md))
+> — and PR-merge → ticket promotion ([ADR-0021](docs/adr/0021-pr-merge-promotes-ticket-via-app-webhook.md)).
+> **Still undecided / not built:** the **GitHub identity claim** (`User.githubLogin`)
+> and the feed/digest render of the persisted rows. The bullets below reflect the
+> ADR-0022 ingestion model, not the retired live-fetch/shared-PAT one.
 
 - A **Workspace** has many **Workspace repositories**.
 - A **Workspace** has many **Activity events** from zero or more **Activity sources**.
-- The **Activity feed** is the read-side union of `WorkspaceActivityEvent` rows (internal) and GitHub commits + PRs fetched live from each `WorkspaceRepository` at query time.
-- GitHub events shown in the activity feed are **not persisted** for the panel's purposes. They are fetched on page load via a shared `GITHUB_API_TOKEN` PAT (impactful-events style), with a ~5min server-side cache per repo to absorb refreshes.
-- The existing webhook path (`/api/webhooks/github`) and `GitHubActivity` table remain — they continue to feed `SprintSnapshot` analytics, **independent** of the activity panel. The two paths can coexist for the same repo; the activity feed only uses live-fetch.
+- The **Activity feed** is the read-side union of `WorkspaceActivityEvent` rows (internal) and **persisted** `GitHubActivity` rows scoped to the workspace's tracked repos (`repoFullName ∈ WorkspaceRepository`) — [ADR-0022](docs/adr/0022-github-activity-ingestion-webhook-poll-persisted.md).
+- GitHub events **are persisted** (one store, `GitHubActivity`), ingested by **both** the App `pull_request`/`push` webhook (real-time) **and** a per-install App-token poll (backfill + reconciliation), upserted with dedup key `(workspaceId, externalId)`. This amends [ADR-0001](docs/adr/0001-activity-feed-storage.md) #3 ("not persisted for the panel") and retires the shared-`GITHUB_API_TOKEN` live-fetch path.
+- `GitHubActivity` now has **two read consumers** of the same rows: the activity feed/digest **and** `SprintSnapshot` analytics. (Pre-ADR-0022 these were independent — analytics-only, live-fetch panel.)
 - **Meetings** now emit `WorkspaceActivityEvent` rows via `recordActivity` (entityType `meeting`: `created`, then `summarized` once the auto-summary lands) — the internal-data write-path of ADR-0001, so a meeting appears in the workspace feed, the **Aggregated activity feed**, and the **Weekly work digest** from one write.
-- **Commit activity** _(planned, not built — [ADR-0019](docs/adr/0019-persist-polled-commits.md) Deferred)_ would be **polled and persisted** (cron, PAT-based) so commits reach the **Aggregated activity feed** and the digest. Blocked on the missing repo-declaration + identity-claim primitives; commits are deferred from **Weekly work digest** v1.
+- **Commit activity** _(decided, not yet built — [ADR-0022](docs/adr/0022-github-activity-ingestion-webhook-poll-persisted.md))_: commits are **persisted** to `GitHubActivity` via the webhook `push` event + the per-install App-token poll (not the retired PAT cron of ADR-0019), per-commit stored but **rendered grouped**, reaching the **Aggregated activity feed** and the digest. Attributing a commit to *you* still needs the **GitHub identity claim** (`User.githubLogin`), which remains unbuilt — so "mine" filtering is the gating dependency for commits in the **Weekly work digest**.
 
 ### Weekly planning
 

--- a/docs/adr/0019-persist-polled-commits.md
+++ b/docs/adr/0019-persist-polled-commits.md
@@ -2,7 +2,17 @@
 
 ## Status
 
-**Deferred — 2026-06-14.** Records the intended design, but **not implemented**:
+**Deferred — 2026-06-14.** **Declaration premise superseded by
+[ADR-0020](0020-github-repo-association-via-app-installation.md) (2026-06-15):**
+repos are now associated via a **GitHub App installation** (per-install token),
+not "paste-a-URL, no App required, shared PAT." The repo-declaration primitive it
+was blocked on now exists (`WorkspaceRepository` + connect/associate UI). The
+**ingestion** decision (cron-poll-via-PAT vs webhook-push vs App-token poll vs
+live-fetch) is re-opened by ADR-0020 and not yet settled — decision #1 (poll via
+PAT) and the "no App install" framing no longer hold; the persist-per-commit /
+render-grouped / attribute-by-claim intent (#2–#4) still stands.
+
+Records the intended design, but **not implemented**:
 it rests on primitives that turned out not to exist. A code audit (schema,
 `develop`, all of `src/`) found **no `WorkspaceRepository` model, no
 `User.githubLogin`, no GitHub OAuth provider, and no GitHub union in the

--- a/docs/adr/0020-github-repo-association-via-app-installation.md
+++ b/docs/adr/0020-github-repo-association-via-app-installation.md
@@ -1,0 +1,68 @@
+# GitHub repo association via App installation
+
+## Status
+
+Accepted — 2026-06-15. Supersedes the repo-**declaration** model assumed by
+[ADR-0001](0001-activity-feed-storage.md) and [ADR-0019](0019-persist-polled-commits.md)
+(paste-a-URL, App-independent, shared-PAT). The downstream **ingestion** decision
+(how commit/PR activity actually reaches the feed/digest) is deliberately left
+open here — see Consequences.
+
+## Context
+
+ADR-0001 and ADR-0019 assumed a workspace declares a repo by **pasting a
+`github.com/owner/repo` URL**, independent of any GitHub App install, with
+activity read via a **shared `GITHUB_API_TOKEN` PAT**. ADR-0019 explicitly
+*rejected* "require the GitHub App" as "the exact friction ADR-0001 avoided."
+
+When connect + associate was actually built (the `cosmic.anchor` → `cold.maple`
+→ `giddy.rune` → `stormy.clover` batch), that model was reversed. A workspace now
+connects GitHub by **installing a GitHub App**, and repos are picked from what
+the installation can access. The reversal was driven by capabilities the
+paste-URL/PAT model can't offer: per-install tokens (no shared-secret leak or
+single-account rate-limit ceiling), access to **private** repos, **granular**
+GitHub-App permissions, per-workspace isolation, and native **webhook** delivery.
+
+## Decision
+
+1. **A workspace connects GitHub by installing the GitHub App.** The install
+   upserts exactly **one** workspace-scoped installation `Integration`
+   (`provider=github`, `type=github_app_installation`) holding the encrypted
+   installation token and the installation's accessible-repo list.
+2. **`WorkspaceRepository` rows are *selected from* the installation's accessible
+   repos** (`apps.listReposAccessibleToInstallation`), not pasted as URLs.
+   `integrationId` is a **required FK** to that installation `Integration`.
+3. **Activity is read with the per-install App token**, never a shared PAT.
+4. **A repo can only be tracked if the App is installed on it** with access
+   granted. The tracked set is reconciled **idempotently** — save the desired
+   `fullName` set; create/delete rows to match.
+5. **`WorkspaceRepository` is the source of truth for *which* repos a workspace
+   tracks.** Removing a row stops tracking only — it leaves any `GitHubActivity`
+   intact.
+
+## Considered alternatives
+
+- **Paste-a-URL + shared PAT (the original ADR-0001/0019 model).** Rejected:
+  shared-PAT leak + single-account rate-limit risk, no private-repo access, no
+  per-workspace isolation, no native webhooks, and "public repos only, read via
+  one shared token" is too weak a foundation for surfacing real commit/PR work.
+- **Hybrid — App where installed, PAT fallback for URL-declared repos.** Rejected
+  for v1: two declaration paths and two security models that can disagree. Defer
+  until there's a concrete need to track a repo *without* an install.
+
+## Consequences
+
+- A workspace **must install the App (and grant repo access)** to track a repo —
+  higher friction than paste-a-URL. Accepted for the security/capability gain;
+  this is the exact friction ADR-0019 tried to avoid, now consciously accepted.
+- **The ingestion mechanism is re-opened.** With a per-install App token *and*
+  webhook delivery now available, ADR-0019's "cron-poll via PAT" is no longer the
+  only option — webhook-push, App-token polling, and live-fetch are all viable.
+  That choice is a separate decision (forthcoming), not settled by this ADR.
+- **ADR-0019 stays `Deferred`**, but its "no GitHub App required" / PAT
+  declaration premise is **superseded** here.
+- The App's **currently-granted permissions** (read: issues, metadata, repository
+  hooks) are **insufficient to read commits/PRs**. Surfacing those needs
+  `contents: read` + `pull_requests: read` plus `push`/`pull_request` event
+  subscriptions — a one-time App-settings change + re-consent (an admin
+  prerequisite, tracked separately).

--- a/docs/adr/0021-pr-merge-promotes-ticket-via-app-webhook.md
+++ b/docs/adr/0021-pr-merge-promotes-ticket-via-app-webhook.md
@@ -1,0 +1,60 @@
+# PR merge auto-promotes the linked ticket via the central App webhook
+
+## Status
+
+Accepted — 2026-06-15. Supersedes the per-repo GitHub Action approach
+(`/setup-merge-hook` → `exponential-promote.yml`) as the **default** way tickets
+are promoted on merge. Builds on [ADR-0020](0020-github-repo-association-via-app-installation.md)
+(App installation) and the forthcoming GitHub-activity **ingestion** ADR (the
+shared webhook handler).
+
+## Context
+
+`/ship-ticket` links a `Ticket` to its PR (`Ticket.prUrl`) and leaves it in
+`QA`. This repo has **no auto-promotion** today — shipped tickets sit in `QA`
+until moved by hand (observed directly: the connect+associate batch's tickets
+stayed in `QA` and were closed manually).
+
+The existing `/setup-merge-hook` skill scaffolds a **per-repo GitHub Action**
+that promotes `QA → DONE` on merge into the deploy trigger, via the **external**
+Exponential API (`EXPONENTIAL_TOKEN` secret). Per ADR-0020, every tracked repo
+now has a GitHub App installation that already delivers **signature-verified
+`pull_request` webhooks** to `/api/webhooks/github`. That makes a **central,
+in-app** promotion possible — no per-repo workflow files, no API tokens.
+
+## Decision
+
+1. On `pull_request` `action=closed` with **`merged === true`**, the webhook
+   handler looks up `Ticket where prUrl === pull_request.html_url`.
+2. If found **and currently `QA`**, transition to `DONE`. The `QA`-only guard
+   means we never clobber a hand-moved, already-`DONE`, or `ARCHIVED` ticket, and
+   never reopen anything — making the handler idempotent.
+3. Match is by **exact PR URL** — no base-branch gate. A ticket's stored PR URL
+   is unique to that PR, so a feature-branch merge can't accidentally match.
+4. `DEPLOYED` is reserved for a future **production-deploy** signal. A PR merge
+   is `DONE`, not `DEPLOYED`.
+5. This central webhook is the **default** and supersedes the per-repo
+   `exponential-promote.yml` Action; a repo using the App webhook should not also
+   run the Action.
+
+## Considered alternatives
+
+- **Per-repo GitHub Action (status-quo skill).** Rejected as default: per-repo
+  workflow + secret, an external API hop, only works on repos you control, and
+  doesn't scale to "every workspace repository."
+- **Base-branch-gated promotion (only merge into `main`/deploy-trigger).**
+  Rejected for v1: the exact-PR-URL match is already precise, and cross-repo we
+  don't know each repo's deploy branch. Revisit alongside `DEPLOYED`.
+- **Promote from any status.** Rejected: clobbers manual state. The `QA`-only
+  guard keeps it safe and idempotent.
+
+## Consequences
+
+- The auto-promote the repo lacked now exists, centrally: ship-ticket → `QA` →
+  (PR merges) → `DONE`, no hand-move.
+- Requires the App to subscribe to `pull_request` and hold `pull_requests: read`
+  (the ingestion prerequisite — admin one-time).
+- A ticket whose PR merges into `develop` (not prod) goes `DONE`, not
+  `DEPLOYED` — accepted for v1; `DEPLOYED` is a later refinement.
+- The per-repo Action and this webhook must not both run for one repo
+  (double-promote). The App webhook is the default; disable the Action there.

--- a/docs/adr/0022-github-activity-ingestion-webhook-poll-persisted.md
+++ b/docs/adr/0022-github-activity-ingestion-webhook-poll-persisted.md
@@ -1,0 +1,73 @@
+# GitHub activity ingestion: webhook + poll, persisted to GitHubActivity via the App token
+
+## Status
+
+Accepted — 2026-06-15. **Amends** [ADR-0001](0001-activity-feed-storage.md)
+decisions #3–#5 (GitHub not persisted for the panel; live-fetch). **Replaces the
+ingestion mechanism** of [ADR-0019](0019-persist-polled-commits.md) (cron-poll via
+shared PAT) — its persist-per-commit / render-grouped / attribute-by-claim intent
+(#2–#4) still holds. Builds on [ADR-0020](0020-github-repo-association-via-app-installation.md)
+(App installation + per-install token) and shares the webhook handler with
+[ADR-0021](0021-pr-merge-promotes-ticket-via-app-webhook.md).
+
+## Context
+
+ADR-0001 kept GitHub out of storage for the activity panel — live-fetched per
+`WorkspaceRepository` (shared PAT, ~5 min cache), never persisted — but
+anticipated cron-polling-into-storage "later if rate-limits or latency bite."
+ADR-0019 chose poll+persist (still PAT) but was `Deferred` for missing
+primitives. ADR-0020 shipped those primitives (`WorkspaceRepository` + per-install
+App token), and ADR-0021's merge-automation needs a webhook regardless. Two
+requirements push past live-fetch: commits/PRs in the cross-workspace
+**Aggregated activity feed**, and weekly summarisation in the **Weekly work
+digest** — both need an author/time index and can't fan out live per request.
+
+## Decision
+
+1. **Ingest via both a webhook and a poll**, into one persisted store:
+   - **Webhook** (App `pull_request`, and `push` for commits): real-time; drives
+     ADR-0021's merge-automation and real-time PR/commit rows.
+   - **Poll** (cron, per-install **App token**): backfill at connect time, commit
+     history, and **reconciliation** of missed webhook deliveries.
+2. **One store — `GitHubActivity`.** Both writers **upsert**; dedup by
+   `externalId` (commit SHA / PR node-id), `deliveryId` for webhook idempotency.
+   Rows are scoped **per tracking workspace** → dedup key `(workspaceId, externalId)`.
+3. **Read with the per-install App token, never a shared PAT** (ADR-0020). The
+   shared `GITHUB_API_TOKEN` panel path is retired.
+4. **Feeds read the persisted rows.** The per-workspace **Activity feed** unions
+   `WorkspaceActivityEvent` with `GitHubActivity` scoped to the workspace's tracked
+   repos (`repoFullName ∈ WorkspaceRepository`); the **Aggregated activity feed**
+   and **Weekly work digest** read the same rows. Per-commit stored, **rendered
+   grouped** (ADR-0019 #2).
+5. **Sprint Analytics keeps reading `GitHubActivity` unchanged** — one store, two
+   read consumers (feed/digest + analytics).
+
+## Considered alternatives
+
+- **Keep live-fetch (ADR-0001).** Rejected: doesn't scale to the Aggregated feed
+  (per-request fan-out across all workspaces × repos) or the weekly digest (no
+  author/time index).
+- **Webhook-only.** Rejected: no backfill (feed empty until the next push) and
+  needs reconciliation for missed deliveries — i.e. it needs a poll anyway.
+- **Poll-only.** Rejected: ADR-0021's merge-automation is an event-triggered
+  side-effect that wants real-time; ~15 min poll lag is wrong for closing a ticket.
+- **Two tables (separate feed store vs analytics store).** Rejected: `GitHubActivity`
+  already has the shape and workspace scope; one store with two read consumers is
+  simpler, no cross-table dedupe.
+- **Shared PAT (ADR-0019 #1).** Rejected: the per-install App token removes the
+  shared-secret leak + single-account rate-limit ceiling ADR-0019 flagged as a
+  "future slice."
+
+## Consequences
+
+- Freshness is **real-time** for subscribed webhook events and bounded by the
+  **cron interval (~15 min)** for poll-only gaps — accepted.
+- Requires App permissions `contents: read` + `pull_requests: read` and
+  `push` / `pull_request` event subscriptions (admin one-time; also ADR-0021's
+  prerequisite).
+- ADR-0001's panel live-fetch and the shared `GITHUB_API_TOKEN` path are retired
+  for the feed.
+- `GitHubActivity` now has feed/digest **and** analytics consumers — schema
+  changes must consider both.
+- "Mine" attribution in the digest still needs the **GitHub identity claim**
+  (`User.githubLogin`) — a separate, not-yet-built primitive (next decision).


### PR DESCRIPTION
## What

Documentation for the **next GitHub phase** (designed in a grilling session), plus a reconciliation of the docs with what the connect+associate batch (#207–#213) actually shipped. **Docs-only — no code.**

### New ADRs
- **[ADR-0020] GitHub repo association via App installation** — repos are *selected from* the installation's accessible repos (required FK to the installation `Integration`, read via the per-install App token). Supersedes the "paste-a-URL / shared-PAT / App-independent" model that ADR-0001 and ADR-0019 assumed. (This is the design the shipped batch followed; the ADR was referenced but never written.)
- **[ADR-0021] PR merge auto-promotes the linked ticket** — central App `pull_request` webhook: `closed`+`merged` → match `Ticket` by exact `prUrl` → `QA→DONE` (QA-only guard, no base-branch gate). Supersedes the per-repo `setup-merge-hook` Action as the default.
- **[ADR-0022] GitHub activity ingestion: webhook + poll, persisted** — one `GitHubActivity` store, webhook (real-time) + App-token poll (backfill/reconcile), deduped `(workspaceId, externalId)`; feeds read it scoped to the workspace's tracked repos. Amends ADR-0001 #3–#5 (live-fetch / not-persisted); replaces ADR-0019's PAT-cron mechanism.

### Updated
- **ADR-0019** — marked declaration-premise superseded by ADR-0020; ingestion re-opened by ADR-0022 (its persist-per-commit / grouped-render / attribute-by-claim intent still stands).
- **CONTEXT.md** — "Workspace repository" rewritten to match reality; the stale `2026-06-14` accuracy caveat corrected (there *is* a `WorkspaceRepository` now); "GitHub identity claim" sharpened (NextAuth GitHub verifier, deferred); new **"Ticket promotion on merge"** term; activity-relationship bullets moved off live-fetch/PAT onto the persisted webhook+poll model.

## Why
The connect+associate batch shipped an App-installation-based model that **contradicted** the documented (PAT / paste-URL) design, and `ADR-0020` was referenced but never written. This brings the design-of-record back in sync and records the forward plan (slices 0–4) before building.

Implementation slices will follow as Exponential tickets.