### PR TITLE
fix: quick-create honours stated priority & project

### DIFF
--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -1116,11 +1116,14 @@ export const mastraRouter = createTRPCRouter({
     .input(z.object({
       text: z.string().min(1),
       projectId: z.string().optional(),
+      // Canonical priority enum. Optional and backward-compatible: when omitted,
+      // the action falls back to "Quick" (the historical hardcoded value).
+      priority: z.enum(PRIORITY_VALUES).optional(),
     }))
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
-      console.log(`🎯 [tRPC quickCreateAction] RECEIVED: text="${input.text}", projectId=${input.projectId || "none"}`);
+      console.log(`🎯 [tRPC quickCreateAction] RECEIVED: text="${input.text}", projectId=${input.projectId || "none"}, priority=${input.priority ?? "none"}`);
 
       // Use the same parsing logic as action.quickCreate
       const { parseActionInput } = await import("~/server/services/parsing/parseActionInput");
@@ -1128,10 +1131,16 @@ export const mastraRouter = createTRPCRouter({
 
       console.log(`🎯 [tRPC quickCreateAction] PARSED: name="${parsed.name}", parsedProjectId=${parsed.projectId ?? "none"}, scheduledStart=${String(parsed.scheduledStart ?? "none")}, dueDate=${String(parsed.dueDate ?? "none")}`);
 
-      // Use context projectId as fallback if text parsing didn't match a project
-      if (!parsed.projectId && input.projectId) {
+      // An explicitly-passed projectId is a deliberately-resolved target — the
+      // agent resolves the user-named project via get-all-projects and passes the
+      // intended id — so it takes precedence over any project the text parser
+      // inferred. When no explicit id is passed, the parsed match stands (so calls
+      // that pass neither are unchanged).
+      if (input.projectId) {
+        if (parsed.projectId && parsed.projectId !== input.projectId) {
+          console.log(`🎯 [tRPC quickCreateAction] PRECEDENCE: explicit projectId=${input.projectId} overrides parsed=${parsed.projectId}`);
+        }
         parsed.projectId = input.projectId;
-        console.log(`🎯 [tRPC quickCreateAction] FALLBACK: using context projectId=${input.projectId}`);
       }
 
       // Get kanban order if project specified
@@ -1159,7 +1168,7 @@ export const mastraRouter = createTRPCRouter({
         data: {
           name: parsed.name,
           projectId: parsed.projectId,
-          priority: "Quick",
+          priority: input.priority ?? "Quick",
           status: "ACTIVE",
           createdById: userId,
           scheduledStart: parsed.scheduledStart,

--- a/src/server/services/parsing/parseActionInput.ts
+++ b/src/server/services/parsing/parseActionInput.ts
@@ -2,6 +2,7 @@ import type { PrismaClient } from "@prisma/client";
 
 import { parseDictation } from "./DictationParser";
 import type { ProjectForMatching } from "./types";
+import { buildProjectAccessWhere } from "~/server/services/access";
 
 export interface ParseActionInputResult {
   name: string;
@@ -53,10 +54,13 @@ export async function parseActionInput(
     };
   }
 
-  // Fetch user's active projects for matching
+  // Fetch the user's active projects for matching. Use the centralized
+  // access-aware filter (not owner-only `createdById`) so the deterministic
+  // matcher can also resolve shared/team projects the user can access but did
+  // not personally create.
   const userProjects: ProjectForMatching[] = await db.project.findMany({
     where: {
-      createdById: userId,
+      ...buildProjectAccessWhere(userId),
       status: { not: "COMPLETED" },
       ...(options?.workspaceId ? { workspaceId: options.workspaceId } : {}),
     },


### PR DESCRIPTION
## What

Make the assistant's quick-create path honour an explicitly-stated **priority** and **project** instead of silently dropping them. Two-repo change — this PR is the `exponential` side; the `../mastra` side (tool schema + agent instructions) deploys independently via railway.

**Priority.** `quickCreateAction` accepts an optional canonical `priority` (11-value enum) and persists `priority ?? "Quick"` instead of the hardcoded `"Quick"`.

**Project.** An explicitly-passed `projectId` now takes **precedence** over the text-parsed match (was a fallback only when parsing found nothing) — safe because the agent resolves the intended project deliberately. `parseActionInput` broadens its candidate-project pool from owner-only (`createdById`) to **access-aware** (`buildProjectAccessWhere`), so the deterministic matcher can resolve shared/team projects too.

Backward-compatible: new optional input; precedence only changes when an explicit id is passed. No schema change.

### Companion mastra change (deploys separately)
`quick-create-action` tool gains optional `priority` + `projectId` (forwarded; explicit id wins over page context); assistant + Zoe instructions fix the wrong priority list (`Quick/Short/Long/Research` → real enum), add NL→enum mapping, and instruct resolving a named project to a real id via get-all-projects.

## Acceptance criteria

- [ ] "add X, highest priority" → Action created at `1st Priority`; an unspecified priority still defaults to `Quick`.
- [ ] Natural-language priority terms map to the correct enum values.
- [ ] Naming a project — including a shared/team project the user can access but didn't create — links the Action to it.
- [ ] An explicitly named project wins over the current page context.
- [ ] Existing quick-create calls that pass neither priority nor project still behave as before.

---

Ships: windy.dahlia