### PR TITLE
feat: recordChannelSummary ingest endpoint + ingestChannelSummary service

### DIFF
--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -25,6 +25,7 @@ import { filterAgentInstructions } from "~/server/services/agent-routing/agentIn
 import { loadProductWithAccess } from "~/plugins/product/server/routers/product";
 import { generateFunId } from "~/lib/fun-ids";
 import { recordActivity } from "~/server/services/activity/recordActivity";
+import { ingestChannelSummary } from "~/server/services/activity/ingestChannelSummary";
 import { createGoal, createGoalComment, createGoalUpdate, setGoalParent } from "~/server/services/goalService";
 import { NotionAgentService } from "~/server/services/notionAgentService";
 
@@ -3112,6 +3113,26 @@ export const mastraRouter = createTRPCRouter({
         pageId: input.pageId,
         properties: input.properties,
       });
+    }),
+
+  // ADR-0023: the gateway pushes ONE finished channel summary tagged only with
+  // (provider, externalId). Authenticated by the agent JWT (resolves to a user
+  // in the tRPC context) so only the trusted gateway can write summaries. The
+  // routing (workspace/project), drop-if-unlinked, and dedup-by-window logic
+  // all live in ingestChannelSummary — this endpoint is a thin shell. The
+  // event's owner is the link's creator, not the JWT user.
+  recordChannelSummary: protectedProcedure
+    .input(z.object({
+      provider: z.string().min(1),
+      externalId: z.string().min(1),
+      summary: z.string().min(1),
+      displayName: z.string().optional(),
+      windowStart: z.string().datetime(),
+      windowEnd: z.string().datetime(),
+      messageCount: z.number().int().nonnegative(),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      return ingestChannelSummary(ctx.db, input);
     }),
 
   getOkrObjectives: protectedProcedure

--- a/src/server/services/activity/__tests__/ingestChannelSummary.test.ts
+++ b/src/server/services/activity/__tests__/ingestChannelSummary.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for `ingestChannelSummary` (ADR-0023) — the routing + idempotency
+ * logic behind the `recordChannelSummary` endpoint.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety"). Asserts external behavior: a routed
+ * event, a dropped summary, a deduped (updated) row — never internal call order.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import { ingestChannelSummary } from "../ingestChannelSummary";
+
+const PROVIDER = "whatsapp";
+const EXTERNAL_ID = "12345@g.us";
+const WORKSPACE_ID = "ws-1";
+const PROJECT_ID = "proj-1";
+const CREATOR_ID = "user-1";
+const WINDOW_START = "2026-06-16T00:00:00.000Z";
+const WINDOW_END = "2026-06-17T00:00:00.000Z";
+const ENTITY_ID = `${PROVIDER}:${EXTERNAL_ID}:${WINDOW_START}`;
+
+function baseInput() {
+  return {
+    provider: PROVIDER,
+    externalId: EXTERNAL_ID,
+    summary: "3 messages about the Friday release; Alice is blocked on the API key.",
+    displayName: "Finance Team",
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+    messageCount: 3,
+  };
+}
+
+function mockLink(
+  db: DeepMockProxy<PrismaClient>,
+  overrides: Partial<{
+    isActive: boolean;
+    workspaceId: string;
+    projectId: string | null;
+    createdById: string | null;
+  }> = {},
+) {
+  db.channelLink.findUnique.mockResolvedValue({
+    id: "cl-1",
+    provider: PROVIDER,
+    externalId: EXTERNAL_ID,
+    displayName: "Finance Team",
+    workspaceId: overrides.workspaceId ?? WORKSPACE_ID,
+    projectId: "projectId" in overrides ? overrides.projectId : PROJECT_ID,
+    isActive: overrides.isActive ?? true,
+    createdById: "createdById" in overrides ? overrides.createdById : CREATOR_ID,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as never);
+}
+
+describe("ingestChannelSummary", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = mockDeep<PrismaClient>();
+    mockReset(db);
+  });
+
+  describe("drop-if-unlinked", () => {
+    it("drops when no link exists, writing nothing", async () => {
+      db.channelLink.findUnique.mockResolvedValue(null as never);
+
+      const result = await ingestChannelSummary(db, baseInput());
+
+      expect(result).toEqual({ status: "dropped" });
+      expect(db.workspaceActivityEvent.findFirst).not.toHaveBeenCalled();
+      expect(db.workspaceActivityEvent.create).not.toHaveBeenCalled();
+      expect(db.workspaceActivityEvent.update).not.toHaveBeenCalled();
+    });
+
+    it("drops when the link is inactive", async () => {
+      mockLink(db, { isActive: false });
+
+      const result = await ingestChannelSummary(db, baseInput());
+
+      expect(result).toEqual({ status: "dropped" });
+      expect(db.workspaceActivityEvent.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("record (new window)", () => {
+    it("routes to the link's workspace and maps metadata, with userId = createdById", async () => {
+      mockLink(db);
+      db.workspaceActivityEvent.findFirst.mockResolvedValue(null as never);
+
+      const result = await ingestChannelSummary(db, baseInput());
+
+      expect(result).toMatchObject({ status: "recorded", deduped: false });
+      expect(db.workspaceActivityEvent.create).toHaveBeenCalledWith({
+        data: {
+          workspaceId: WORKSPACE_ID,
+          userId: CREATOR_ID, // userId = ChannelLink.createdById
+          entityType: "channel_summary",
+          entityId: ENTITY_ID,
+          action: "summarized",
+          metadata: {
+            provider: PROVIDER,
+            externalId: EXTERNAL_ID,
+            displayName: "Finance Team",
+            projectId: PROJECT_ID,
+            messageCount: 3,
+            windowStart: WINDOW_START,
+            windowEnd: WINDOW_END,
+            summary: baseInput().summary,
+          },
+        },
+      });
+      expect(db.workspaceActivityEvent.update).not.toHaveBeenCalled();
+    });
+
+    it("carries a null projectId for a workspace-only link", async () => {
+      mockLink(db, { projectId: null });
+      db.workspaceActivityEvent.findFirst.mockResolvedValue(null as never);
+
+      await ingestChannelSummary(db, baseInput());
+
+      expect(db.workspaceActivityEvent.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            metadata: expect.objectContaining({ projectId: null }),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("dedup (re-delivery)", () => {
+    it("updates the existing event for the same window instead of inserting", async () => {
+      mockLink(db);
+      db.workspaceActivityEvent.findFirst.mockResolvedValue({
+        id: "evt-existing",
+      } as never);
+
+      const result = await ingestChannelSummary(db, baseInput());
+
+      expect(result).toEqual({
+        status: "recorded",
+        eventId: "evt-existing",
+        deduped: true,
+      });
+      expect(db.workspaceActivityEvent.update).toHaveBeenCalledWith({
+        where: { id: "evt-existing" },
+        data: expect.objectContaining({
+          userId: CREATOR_ID,
+          action: "summarized",
+        }),
+      });
+      expect(db.workspaceActivityEvent.create).not.toHaveBeenCalled();
+    });
+
+    it("looks up the dedup row by (workspace, channel_summary, window entityId)", async () => {
+      mockLink(db);
+      db.workspaceActivityEvent.findFirst.mockResolvedValue(null as never);
+
+      await ingestChannelSummary(db, baseInput());
+
+      expect(db.workspaceActivityEvent.findFirst).toHaveBeenCalledWith({
+        where: {
+          workspaceId: WORKSPACE_ID,
+          entityType: "channel_summary",
+          entityId: ENTITY_ID,
+        },
+        select: { id: true },
+      });
+    });
+  });
+});

--- a/src/server/services/activity/ingestChannelSummary.ts
+++ b/src/server/services/activity/ingestChannelSummary.ts
@@ -1,0 +1,112 @@
+/**
+ * ingestChannelSummary — the routing + idempotency logic behind the
+ * `recordChannelSummary` endpoint (ADR-0023).
+ *
+ * Given a finished summary tagged only with `(provider, externalId)` (the
+ * gateway knows nothing about workspaces/projects), this:
+ *   1. **Resolves** the `ChannelLink` by `(provider, externalId)`.
+ *   2. **Drops** silently if there is no active link (orphan/unconfigured
+ *      channel → nothing written).
+ *   3. **Dedups** by `(provider, externalId, windowStart)` — an at-least-once
+ *      re-delivery updates the existing event rather than inserting a second
+ *      feed row.
+ *   4. **Records** one `channel_summary` `WorkspaceActivityEvent` (reusing the
+ *      `recordActivity` primitive for the insert path), routed to the link's
+ *      workspace, with `userId = ChannelLink.createdById`.
+ *
+ * Takes an explicit `db` handle so it is callable from the endpoint and
+ * unit-testable with a mocked Prisma client.
+ */
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+import { resolveChannelLink } from "~/server/services/channelLinkService";
+import { recordActivity } from "./recordActivity";
+
+export interface IngestChannelSummaryInput {
+  provider: string;
+  externalId: string;
+  summary: string;
+  displayName?: string | null;
+  windowStart: string;
+  windowEnd: string;
+  messageCount: number;
+}
+
+export type IngestChannelSummaryResult =
+  | { status: "dropped" }
+  | { status: "recorded"; eventId: string; deduped: boolean };
+
+/**
+ * Stable per-window identity used to dedup re-deliveries. Encodes the ADR's
+ * `(provider, externalId, windowStart)` dedup key into the `entityId` column so
+ * no JSON-path query (or new unique index) is required.
+ */
+function summaryEntityId(
+  provider: string,
+  externalId: string,
+  windowStartIso: string,
+): string {
+  return `${provider}:${externalId}:${windowStartIso}`;
+}
+
+export async function ingestChannelSummary(
+  db: PrismaClient,
+  input: IngestChannelSummaryInput,
+): Promise<IngestChannelSummaryResult> {
+  const link = await resolveChannelLink(db, input.provider, input.externalId);
+  if (!link) {
+    // Orphan / unconfigured channel — drop silently (ADR-0023).
+    return { status: "dropped" };
+  }
+
+  // Normalize the window bounds so the dedup key is canonical regardless of the
+  // exact string the gateway sent.
+  const windowStartIso = new Date(input.windowStart).toISOString();
+  const windowEndIso = new Date(input.windowEnd).toISOString();
+  const entityId = summaryEntityId(input.provider, input.externalId, windowStartIso);
+
+  const metadata: Prisma.InputJsonObject = {
+    provider: input.provider,
+    externalId: input.externalId,
+    displayName: input.displayName ?? null,
+    projectId: link.projectId ?? null,
+    messageCount: input.messageCount,
+    windowStart: windowStartIso,
+    windowEnd: windowEndIso,
+    summary: input.summary,
+  };
+
+  // Dedup by (provider, externalId, windowStart): upsert, not insert. A second
+  // delivery for the same window updates the existing feed row in place.
+  const existing = await db.workspaceActivityEvent.findFirst({
+    where: {
+      workspaceId: link.workspaceId,
+      entityType: "channel_summary",
+      entityId,
+    },
+    select: { id: true },
+  });
+
+  if (existing) {
+    await db.workspaceActivityEvent.update({
+      where: { id: existing.id },
+      data: {
+        userId: link.createdById,
+        action: "summarized",
+        metadata,
+      },
+    });
+    return { status: "recorded", eventId: existing.id, deduped: true };
+  }
+
+  await recordActivity(db, {
+    workspaceId: link.workspaceId,
+    userId: link.createdById,
+    entityType: "channel_summary",
+    entityId,
+    action: "summarized",
+    metadata,
+  });
+
+  return { status: "recorded", eventId: entityId, deduped: false };
+}

--- a/src/server/services/activity/recordActivity.ts
+++ b/src/server/services/activity/recordActivity.ts
@@ -29,11 +29,17 @@ export type ActivityEntityType =
   | "workspace_member"
   | "deal"
   | "meeting"
-  | "time_entry";
+  | "time_entry"
+  | "channel_summary";
 
 export interface RecordActivityInput {
   workspaceId: string;
-  userId: string;
+  /**
+   * Acting user. Normally a real user id; `null` is permitted for system-actor
+   * events whose `ChannelLink.createdById` was cleared (the column is nullable,
+   * SET NULL on user delete). See ADR-0023 channel summaries.
+   */
+  userId: string | null;
   entityType: ActivityEntityType;
   entityId: string;
   action: ActivityAction;


### PR DESCRIPTION
## What

The heart of the channel-summary feature (ADR-0023): the agent-JWT-authenticated `mastra.recordChannelSummary` endpoint and the `ingestChannelSummary` deep module behind it. This is the cross-repo contract the `../mastra` gateway pushes to.

Input: `{ provider, externalId, summary, displayName?, windowStart, windowEnd, messageCount }`. Behavior:
1. **Resolve** the `ChannelLink` by `(provider, externalId)`.
2. **Drop** silently if no (active) link exists — orphan/unconfigured channel writes nothing.
3. **Dedup** by `(provider, externalId, windowStart)` — encoded into the event's `entityId` so an at-least-once re-delivery **updates** the existing event rather than inserting a second feed row (no new unique index / migration).
4. **Record** one `WorkspaceActivityEvent` via the existing `recordActivity` primitive: `entityType: "channel_summary"`, `action: "summarized"`, `userId = ChannelLink.createdById`, with `provider` / `externalId` / `displayName` / `projectId` / `messageCount` / `windowStart` / `windowEnd` / `summary` in `metadata`.

`ActivityEntityType` gains `"channel_summary"`; `recordActivity`'s `userId` is widened to `string | null` (the column is already nullable, SET NULL on user delete) so a channel summary can attribute to the link's creator. No new table — reuses `WorkspaceActivityEvent` per ADR-0001.

The endpoint is a `protectedProcedure`; the agent JWT resolves to a user in the tRPC context (ADR-0016/0020 callback pattern), so only the trusted gateway can write. The event's owner is the link's creator, not the JWT user.

## Acceptance criteria

- [x] `recordChannelSummary` endpoint exists, authenticated by an agent JWT (resolves to a user).
- [x] `ingestChannelSummary` implements resolve → drop-if-unlinked → dedup-upsert → record.
- [x] A summary for a linked channel produces exactly one `channel_summary` event routed to the link's workspace (projectId in metadata when present).
- [x] A summary for an unlinked `(provider, externalId)` writes nothing.
- [x] A second delivery with the same `windowStart` updates the existing event — no duplicate row.
- [x] `ActivityEntityType` includes `"channel_summary"`.
- [x] Unit tests (mocked Prisma) cover routing to workspace/project, drop-when-unlinked, dedup, metadata mapping, `userId = createdById`.

## Tests

`src/server/services/activity/__tests__/ingestChannelSummary.test.ts` — 6 tests (mocked Prisma). Full suite green.

> Demoable once the ChannelLink migration (PR #223) is applied: a manual `mastra.recordChannelSummary` call for a linked channel produces a queryable `WorkspaceActivityEvent`.

---

Ships: onyx.moon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new protected API endpoint to record channel message summaries with provider and external ID parameters
  * Implemented automatic deduplication to prevent duplicate recordings of identical summaries
  * Enhanced activity logging to support system-level events

* **Tests**
  * Added comprehensive test suite for channel summary ingestion and deduplication workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->