### PR TITLE
test(goals): lock in reduction-KR progress semantics

### DIFF
--- a/src/server/services/__tests__/goalProgress.test.ts
+++ b/src/server/services/__tests__/goalProgress.test.ts
@@ -35,6 +35,16 @@ describe("keyResultProgress", () => {
     // overshoot clamps to 100, regression clamps to 0 -> mean 50
     expect(keyResultProgress([kr(0, 200, 100), kr(0, -50, 100)])).toBe(50);
   });
+
+  it("measures reduction KRs where target < start", () => {
+    // "Cut cost 100 -> 80": at 90 the goal is half done. The negative range is
+    // not zero, so it is measured (unlike the old OKR calc, which gated on
+    // range > 0 and reported 0% for every reduction KR). This matches the
+    // canonical goalProgress() helper in workspaceFocusSummary.ts.
+    expect(keyResultProgress([kr(100, 90, 80)])).toBe(50);
+    expect(keyResultProgress([kr(100, 80, 80)])).toBe(100);
+    expect(keyResultProgress([kr(100, 100, 80)])).toBe(0);
+  });
 });
 
 describe("resolveGoalProgress", () => {


### PR DESCRIPTION
## What
Cherry-picks the one commit stranded on `develop` after the #186 promotion — a 10-line regression test for reduction key results (`target < start`) in `goalProgress.test.ts`.

## Why
Part of retiring the stale `develop` branch (moving to trunk-based on `main`). Verified that every other `develop`-only commit is already on `main` (via #186 "access fixes / tool-call logging / docs" or superseded), or is a throwaway beads file. This test was the **only** genuine gap. Landing it here makes `main` content-complete with `develop` so `develop` can be safely reset/retired with zero loss.

Test-only; no runtime change, no migration.

## Test
`keyResultProgress([kr(100,90,80)]) === 50`, `(100,80,80) === 100`, `(100,100,80) === 0`. Already green on #171.