### PR TITLE
feat: WhatsApp groups settings card (link groups to a workspace)

### DIFF
--- a/src/app/_components/home/activity/WhatsAppGroupsPanel.tsx
+++ b/src/app/_components/home/activity/WhatsAppGroupsPanel.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { ActionIcon, Select, Skeleton, Tooltip } from '@mantine/core';
+import { IconBrandWhatsapp, IconX } from '@tabler/icons-react';
+import { useMemo } from 'react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { api } from '~/trpc/react';
+
+const PROVIDER = 'whatsapp';
+
+/**
+ * WhatsApp groups rail widget (ADR-0023 settings UI). Sits below the GitHub
+ * repositories panel in the activity-home rail. Lets a workspace member link a
+ * watched WhatsApp group to this workspace so its periodic summaries land on the
+ * activity feed.
+ *
+ * Adapts to state, mirroring `GithubReposPanel`:
+ *  - linked groups → a list, each with an unlink control
+ *  - connected gateway → a searchable picker of the account's groups (minus
+ *    already-linked ones)
+ *  - gateway unconfigured AND nothing linked → hidden
+ *  - WhatsApp not connected → a connect hint (but still shows existing links)
+ */
+export function WhatsAppGroupsPanel() {
+  const { workspaceId } = useWorkspace();
+  const utils = api.useUtils();
+
+  const { data: links, isLoading: linksLoading } =
+    api.channelLink.list.useQuery(
+      { workspaceId: workspaceId ?? '' },
+      { enabled: !!workspaceId },
+    );
+
+  const { data: gateway, isLoading: groupsLoading } =
+    api.whatsappGateway.getGroups.useQuery(undefined, {
+      enabled: !!workspaceId,
+    });
+
+  const linkMutation = api.channelLink.link.useMutation({
+    onSuccess: () => {
+      if (workspaceId) void utils.channelLink.list.invalidate({ workspaceId });
+    },
+  });
+  const unlinkMutation = api.channelLink.unlink.useMutation({
+    onSuccess: () => {
+      if (workspaceId) void utils.channelLink.list.invalidate({ workspaceId });
+    },
+  });
+
+  const linkedWhatsApp = useMemo(
+    () => (links ?? []).filter((l) => l.provider === PROVIDER),
+    [links],
+  );
+  const linkedJids = useMemo(
+    () => new Set(linkedWhatsApp.map((l) => l.externalId)),
+    [linkedWhatsApp],
+  );
+
+  // Groups from the gateway that aren't linked yet → the picker options.
+  const options = useMemo(
+    () =>
+      (gateway?.groups ?? [])
+        .filter((g) => !linkedJids.has(g.jid))
+        .map((g) => ({ value: g.jid, label: g.subject })),
+    [gateway?.groups, linkedJids],
+  );
+
+  if (linksLoading) {
+    return (
+      <section className="wsa-card">
+        <Skeleton height={18} width={150} />
+        <Skeleton height={30} mt={10} />
+      </section>
+    );
+  }
+
+  // Nothing configured and nothing linked → don't show an empty card.
+  if (gateway && !gateway.configured && linkedWhatsApp.length === 0) {
+    return null;
+  }
+
+  function handleSelect(jid: string | null) {
+    if (!jid || !workspaceId) return;
+    const group = gateway?.groups.find((g) => g.jid === jid);
+    linkMutation.mutate({
+      provider: PROVIDER,
+      externalId: jid,
+      workspaceId,
+      displayName: group?.subject,
+    });
+  }
+
+  const connected = gateway?.connected ?? false;
+
+  return (
+    <section className="wsa-card">
+      <div className="wsa-card__head" style={{ marginBottom: 8 }}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <IconBrandWhatsapp
+            size={16}
+            stroke={1.8}
+            style={{ color: 'var(--color-text-muted)' }}
+          />
+          <span
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              letterSpacing: '0.04em',
+              textTransform: 'uppercase',
+              color: 'var(--color-text-primary)',
+            }}
+          >
+            WhatsApp Groups
+          </span>
+        </div>
+        {linkedWhatsApp.length > 0 ? (
+          <span className="wsa-card__count">{linkedWhatsApp.length}</span>
+        ) : null}
+      </div>
+
+      {linkedWhatsApp.length > 0 ? (
+        <div style={{ marginBottom: 8 }}>
+          {linkedWhatsApp.map((link) => (
+            <div
+              key={link.id}
+              className="wsa-projects__row"
+              style={{ justifyContent: 'space-between' }}
+            >
+              <span
+                style={{
+                  display: 'flex',
+                  gap: 8,
+                  alignItems: 'center',
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                <IconBrandWhatsapp
+                  size={14}
+                  stroke={1.8}
+                  style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
+                />
+                {link.displayName ?? link.externalId}
+              </span>
+              <Tooltip label="Unlink group" withinPortal>
+                <ActionIcon
+                  size="sm"
+                  variant="subtle"
+                  color="gray"
+                  aria-label="Unlink group"
+                  loading={
+                    unlinkMutation.isPending &&
+                    unlinkMutation.variables?.id === link.id
+                  }
+                  onClick={() => unlinkMutation.mutate({ id: link.id })}
+                >
+                  <IconX size={14} stroke={1.8} />
+                </ActionIcon>
+              </Tooltip>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {connected ? (
+        <Select
+          size="xs"
+          placeholder="Search WhatsApp groups…"
+          searchable
+          clearable
+          value={null}
+          data={options}
+          onChange={handleSelect}
+          disabled={groupsLoading || linkMutation.isPending}
+          comboboxProps={{ withinPortal: true }}
+          nothingFoundMessage={
+            groupsLoading ? 'Loading groups…' : 'No more groups to link'
+          }
+        />
+      ) : (
+        <p className="wsa-card__caption" style={{ marginTop: 4 }}>
+          {groupsLoading
+            ? 'Checking WhatsApp connection…'
+            : 'Connect WhatsApp to link groups to this workspace.'}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/app/_components/home/activity/index.tsx
+++ b/src/app/_components/home/activity/index.tsx
@@ -6,6 +6,7 @@ import { GithubReposPanel } from './GithubReposPanel';
 import { Heatmap } from './Heatmap';
 import { Hero } from './Hero';
 import { WeekInReview } from './WeekInReview';
+import { WhatsAppGroupsPanel } from './WhatsAppGroupsPanel';
 import './activity-home.css';
 
 /**
@@ -15,7 +16,7 @@ import './activity-home.css';
  *   `hero` — `Hero` (this-week / streak / active projects)
  *   `week` — `WeekInReview` (sparkline + multi-week stats)
  *   `main` — `Heatmap` + `ActivityFeed`
- *   `rail` — `ActiveProjects` + `GithubReposPanel`
+ *   `rail` — `ActiveProjects` + `GithubReposPanel` + `WhatsAppGroupsPanel`
  */
 export function WorkspaceHomeActivityLayout() {
   return (
@@ -34,6 +35,7 @@ export function WorkspaceHomeActivityLayout() {
         <div className="wsa__rail">
           <ActiveProjects />
           <GithubReposPanel />
+          <WhatsAppGroupsPanel />
         </div>
       </div>
     </div>

--- a/src/server/api/routers/whatsappGateway.ts
+++ b/src/server/api/routers/whatsappGateway.ts
@@ -6,6 +6,14 @@ import { generateJWT } from "~/server/utils/jwt";
 // Environment variable for gateway URL
 const WHATSAPP_GATEWAY_URL = process.env.WHATSAPP_GATEWAY_URL;
 
+// One WhatsApp group as returned by the gateway's
+// `GET /sessions/{sessionId}/groups` endpoint.
+interface WhatsAppGroup {
+  jid: string;
+  subject: string;
+  participants: number;
+}
+
 export const whatsappGatewayRouter = createTRPCRouter({
   // Check if gateway is configured
   isConfigured: protectedProcedure.query(() => {
@@ -217,6 +225,54 @@ export const whatsappGatewayRouter = createTRPCRouter({
         status: data.connected ? "CONNECTED" : "PENDING",
       };
     }),
+
+  // List the WhatsApp groups the caller's connected session belongs to, for the
+  // workspace "WhatsApp Groups" settings card (ADR-0023). Resolves the user's
+  // connected gateway session, then proxies the gateway's
+  // `GET /sessions/{sessionId}/groups`. Degrades gracefully: returns an empty
+  // list (never throws) when the gateway is unconfigured, no session is
+  // connected, or the gateway call fails — the card renders a connect hint.
+  getGroups: protectedProcedure.query(async ({ ctx }) => {
+    if (!WHATSAPP_GATEWAY_URL) {
+      return { configured: false, connected: false, groups: [] as WhatsAppGroup[] };
+    }
+
+    const session = await ctx.db.whatsAppGatewaySession.findFirst({
+      where: { userId: ctx.session.user.id, status: "CONNECTED" },
+      orderBy: { connectedAt: "desc" },
+    });
+
+    if (!session) {
+      return { configured: true, connected: false, groups: [] as WhatsAppGroup[] };
+    }
+
+    const authToken = generateJWT(ctx.session.user, {
+      tokenType: "whatsapp-gateway",
+    });
+
+    try {
+      const response = await fetch(
+        `${WHATSAPP_GATEWAY_URL}/sessions/${session.sessionId}/groups`,
+        { headers: { Authorization: `Bearer ${authToken}` } },
+      );
+
+      if (!response.ok) {
+        // 503 = session not connected to WhatsApp; treat as "not connected".
+        console.error("[whatsappGateway] getGroups failed:", response.status);
+        return { configured: true, connected: false, groups: [] as WhatsAppGroup[] };
+      }
+
+      const data = (await response.json()) as { groups?: WhatsAppGroup[] };
+      return {
+        configured: true,
+        connected: true,
+        groups: data.groups ?? [],
+      };
+    } catch (error) {
+      console.error("[whatsappGateway] getGroups error:", error);
+      return { configured: true, connected: false, groups: [] as WhatsAppGroup[] };
+    }
+  }),
 
   // List user's sessions
   listSessions: protectedProcedure.query(async ({ ctx }) => {


### PR DESCRIPTION
## What

The ADR-0023 settings UI that was deferred from v1 — a **WhatsApp Groups** card on the workspace activity-home rail, directly below **GitHub Repositories**. Lets a workspace member pick which WhatsApp groups feed this workspace's activity summaries, instead of seeding a `ChannelLink` by hand.

- **`whatsappGateway.getGroups`** (new tRPC query) — resolves the caller's connected `WhatsAppGatewaySession` and proxies the gateway's **existing** `GET /sessions/{sessionId}/groups` (returns `{ jid, subject, participants }`). Degrades gracefully — gateway unconfigured / no connected session / gateway error all return `{ connected: false, groups: [] }`, never throws.
- **`WhatsAppGroupsPanel`** (new card, mirrors `GithubReposPanel`):
  - Lists currently-linked groups (from `channelLink.list`, filtered to `provider: "whatsapp"`), each with an unlink (✕) control (`channelLink.unlink`).
  - A searchable Mantine `Select` of the account's groups (minus already-linked) → selecting one links it via `channelLink.link({ provider: "whatsapp", externalId: jid, workspaceId, displayName: subject })` and invalidates the list.
  - Hidden when the gateway is unconfigured and nothing is linked; shows a "Connect WhatsApp" hint when no session is connected (still lets you unlink existing links).

This is **exponential-only** — the gateway's groups endpoint and the `channelLink` link/list/unlink router already exist (shipped in #223). Pure app-side glue + UI.

## Acceptance criteria

- [x] Card renders under GitHub Repositories on `/w/[slug]/home` (activity layout).
- [x] Searchable dropdown lists the gateway's WhatsApp groups; already-linked groups are excluded.
- [x] Selecting a group links it to the workspace; it moves to the linked list.
- [x] Unlinking removes the `ChannelLink`; the group reappears in the dropdown.
- [x] No connected WhatsApp session → a clear connect hint, no crash.
- [x] No hardcoded colors; reuses `wsa-card` classes + Mantine.

## Notes

- Requires the `ChannelLink` migration (#223) applied to the target DB, and the workspace on the `activity` home layout (where this rail lives).
- This supersedes the hand-seeded approach in go-live ticket **coral.mist** — once merged, linking the HSS group (or any group) is just picking it in this card.

Refs: thick.salmon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WhatsApp Groups panel now available in the activity dashboard showing linked groups.
  * View all currently linked WhatsApp groups in one consolidated location.
  * Link additional WhatsApp groups from the gateway when the connection is active.
  * Unlink groups individually with responsive per-item loading state indicators.
  * Panel visibility automatically adjusts based on gateway configuration and existing link status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->