### PR TITLE
feat(prd): persist & render PRD body as a rich document (read path)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,8 @@
         "@tiptap/extension-placeholder": "^2.11.5",
         "@tiptap/extension-subscript": "^2.11.5",
         "@tiptap/extension-superscript": "^2.11.5",
+        "@tiptap/extension-task-item": "^2.27.2",
+        "@tiptap/extension-task-list": "^2.27.2",
         "@tiptap/extension-text-align": "^2.11.5",
         "@tiptap/extension-underline": "^2.11.5",
         "@tiptap/react": "^2.11.5",
@@ -90,6 +92,7 @@
         "server-only": "^0.0.1",
         "simli-client": "^1.2.8",
         "superjson": "^2.2.1",
+        "tiptap-markdown": "^0.9.0",
         "web-push": "^3.6.7",
         "zod": "^3.23.3"
       },
@@ -8216,6 +8219,33 @@
     },
     "node_modules/@tiptap/extension-superscript": {
       "version": "2.26.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-task-item": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-item/-/extension-task-item-2.27.2.tgz",
+      "integrity": "sha512-ZBSqj/dygB/Rp5K9qOxRVwASTZCmKVoTq8C59KvMgD/aFjJxhq/w2dZaWkCUEXEep+NmvJqo0kfeAEMY5UDnGg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-task-list": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-list/-/extension-task-list-2.27.2.tgz",
+      "integrity": "sha512-5nupAewdzZ9F3599oAcaK0WkDH04wdACAVBPM4zG7InlIpkbho3txB7zWmm64OxfhCMIMGKiXY1q0bw9i0QBGQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -16866,6 +16896,12 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==",
+      "license": "ISC"
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "license": "MIT",
@@ -21990,6 +22026,46 @@
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }
+    },
+    "node_modules/tiptap-markdown": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/tiptap-markdown/-/tiptap-markdown-0.9.0.tgz",
+      "integrity": "sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "dependencies": {
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.1.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "prosemirror-markdown": "^1.11.1"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.0.1"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+      "license": "MIT"
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/markdown-it": {
+      "version": "13.0.9",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.9.tgz",
+      "integrity": "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^3",
+        "@types/mdurl": "^1"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/mdurl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
+      "license": "MIT"
     },
     "node_modules/tlds": {
       "version": "1.261.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "@tiptap/extension-placeholder": "^2.11.5",
     "@tiptap/extension-subscript": "^2.11.5",
     "@tiptap/extension-superscript": "^2.11.5",
+    "@tiptap/extension-task-item": "^2.27.2",
+    "@tiptap/extension-task-list": "^2.27.2",
     "@tiptap/extension-text-align": "^2.11.5",
     "@tiptap/extension-underline": "^2.11.5",
     "@tiptap/react": "^2.11.5",
@@ -123,6 +125,7 @@
     "server-only": "^0.0.1",
     "simli-client": "^1.2.8",
     "superjson": "^2.2.1",
+    "tiptap-markdown": "^0.9.0",
     "web-push": "^3.6.7",
     "zod": "^3.23.3"
   },

--- a/prisma/migrations/20260618175127_add_feature_description_doc/migration.sql
+++ b/prisma/migrations/20260618175127_add_feature_description_doc/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Feature" ADD COLUMN     "descriptionDoc" JSONB,
+ADD COLUMN     "docVersion" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3707,7 +3707,14 @@ model Feature {
   id          String        @id @default(cuid())
   productId   String
   name        String
+  // PRD body — the scoped ADR-0017 exception (ADR-0024). `descriptionDoc` is the
+  // canonical ProseMirror document the editor reads/writes; `description` is a
+  // derived, write-only Markdown projection for off-island readers (CLI, agents,
+  // card previews) and never read back into the editor. `docVersion` powers the
+  // optimistic-concurrency stale-write guard for single-writer editing.
   description String?
+  descriptionDoc Json?
+  docVersion  Int           @default(0)
   vision      String?
   status      FeatureStatus @default(IDEA)
   effort      Float?

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
@@ -43,6 +43,8 @@ import {
 import { PriorityIcon } from "~/app/_components/product/PriorityIcon";
 import { TagBadge } from "~/app/_components/TagBadge";
 import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
+import { PrdDocument } from "~/app/_components/prd/PrdDocument";
+import type { JSONContent } from "@tiptap/core";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -214,12 +216,12 @@ export default function FeatureDetailPage() {
             </Group>
           </div>
 
-          {/* Description */}
-          {feature.description ? (
-            <MarkdownRenderer content={feature.description} />
-          ) : (
-            <Text size="sm" className="text-text-muted">No description provided.</Text>
-          )}
+          {/* PRD body — rich document (ADR-0024), replaces MarkdownRenderer here only */}
+          <PrdDocument
+            featureId={featureId}
+            descriptionDoc={(feature.descriptionDoc as JSONContent | null) ?? null}
+            description={feature.description ?? null}
+          />
 
           {/* Vision */}
           {feature.vision && (

--- a/src/app/_components/prd/PrdDocument.tsx
+++ b/src/app/_components/prd/PrdDocument.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { EditorContent, useEditor } from "@tiptap/react";
+import type { JSONContent } from "@tiptap/core";
+import { Text } from "@mantine/core";
+import { api } from "~/trpc/react";
+import { buildPrdExtensions } from "~/lib/prd/extensions";
+import { markdownToDoc, EMPTY_DOC, isDocEmpty } from "~/lib/prd/codec";
+
+interface PrdDocumentProps {
+  featureId: string;
+  /** Canonical ProseMirror document; null until the feature is first migrated. */
+  descriptionDoc: JSONContent | null;
+  /** Legacy/derived Markdown projection — source of the one-time migration. */
+  description: string | null;
+}
+
+/**
+ * Read-only renderer for the **PRD body** (ADR-0024). This is the single Tiptap
+ * component that replaces `MarkdownRenderer` on the Feature detail page; a later
+ * slice toggles `editable` on top of it for in-place WYSIWYG editing.
+ *
+ * Read path with lazy migration: if `descriptionDoc` already exists it is
+ * rendered directly. If not, the legacy `description` Markdown is converted to
+ * ProseMirror JSON on first load (client-side — the codec needs a DOM),
+ * rendered, and persisted via `initDescriptionDoc` so the JSON becomes
+ * canonical thereafter. The Markdown is never read back into the editor again.
+ */
+export function PrdDocument({
+  featureId,
+  descriptionDoc,
+  description,
+}: PrdDocumentProps) {
+  const [doc, setDoc] = useState<JSONContent | null>(descriptionDoc);
+  const migrationStarted = useRef(false);
+
+  const initDescriptionDoc = api.product.feature.initDescriptionDoc.useMutation();
+
+  // Resolve the document to render, migrating legacy Markdown once.
+  useEffect(() => {
+    if (descriptionDoc) {
+      setDoc(descriptionDoc);
+      return;
+    }
+    if (migrationStarted.current) return;
+    migrationStarted.current = true;
+
+    if (!description || description.trim() === "") {
+      setDoc(EMPTY_DOC);
+      return;
+    }
+    const converted = markdownToDoc(description);
+    setDoc(converted);
+    initDescriptionDoc.mutate({ id: featureId, doc: converted });
+    // initDescriptionDoc is stable; intentionally not a dep.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [descriptionDoc, description, featureId]);
+
+  const editor = useEditor({
+    editable: false,
+    extensions: buildPrdExtensions(),
+    content: doc ?? "",
+    immediatelyRender: false,
+    editorProps: {
+      attributes: {
+        class: "prose prose-invert max-w-none focus:outline-none",
+      },
+    },
+  });
+
+  // Push the resolved doc into the editor once both are ready.
+  useEffect(() => {
+    if (editor && doc) {
+      editor.commands.setContent(doc);
+    }
+  }, [editor, doc]);
+
+  if (doc && isDocEmpty(doc)) {
+    return (
+      <Text size="sm" className="text-text-muted">
+        No description provided.
+      </Text>
+    );
+  }
+
+  return <EditorContent editor={editor} className="prd-document" />;
+}

--- a/src/lib/prd/__tests__/codec.test.ts
+++ b/src/lib/prd/__tests__/codec.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import type { JSONContent } from "@tiptap/core";
+
+import { markdownToDoc, docToMarkdown, isDocEmpty, EMPTY_DOC } from "../codec";
+
+const roundTrip = (md: string) => docToMarkdown(markdownToDoc(md));
+
+describe("PRD document codec", () => {
+  describe("markdownToDoc", () => {
+    it("produces a ProseMirror doc node", () => {
+      const doc = markdownToDoc("Hello world");
+      expect(doc.type).toBe("doc");
+      expect(Array.isArray(doc.content)).toBe(true);
+    });
+
+    it("maps blank/empty input to the canonical empty doc", () => {
+      expect(markdownToDoc("")).toEqual(EMPTY_DOC);
+      expect(markdownToDoc("   ")).toEqual(EMPTY_DOC);
+      expect(markdownToDoc(null)).toEqual(EMPTY_DOC);
+    });
+  });
+
+  describe("round-trips representative content", () => {
+    it("paragraphs and inline marks", () => {
+      const md = "A **bold**, *italic*, `code` paragraph.";
+      expect(roundTrip(md)).toBe(md);
+    });
+
+    it("headings", () => {
+      const md = "# Heading 1\n\n## Heading 2\n\n### Heading 3";
+      expect(roundTrip(md)).toBe(md);
+    });
+
+    it("links", () => {
+      const md = "See [the docs](https://example.com/docs).";
+      expect(roundTrip(md)).toBe(md);
+    });
+
+    it("ordered lists", () => {
+      const md = "1. First\n2. Second\n3. Third";
+      expect(roundTrip(md)).toBe(md);
+    });
+
+    it("bullet lists", () => {
+      const md = "- Apple\n- Banana\n- Cherry";
+      expect(roundTrip(md)).toBe(md);
+    });
+
+    it("task lists", () => {
+      const md = "- [ ] todo\n- [x] done";
+      const out = roundTrip(md);
+      expect(out).toContain("[ ] todo");
+      expect(out).toContain("[x] done");
+      // Stable on a second pass.
+      expect(roundTrip(out)).toBe(out);
+    });
+
+    it("code blocks", () => {
+      const md = "```ts\nconst x = 1;\n```";
+      expect(roundTrip(md)).toBe(md);
+    });
+
+    it("nested lists survive and serialise stably", () => {
+      const md = ["- Parent", "  - Child", "  - Child 2", "- Sibling"].join("\n");
+      const out = roundTrip(md);
+      // ProseMirror represents nesting structurally; assert the structure
+      // survives and is idempotent rather than guessing exact indentation.
+      expect(out).toContain("Parent");
+      expect(out).toContain("Child");
+      expect(out).toContain("Sibling");
+      const doc = markdownToDoc(md);
+      const list = doc.content?.[0];
+      expect(list?.type).toBe("bulletList");
+      expect(roundTrip(out)).toBe(out);
+    });
+
+    it("a mixed document is idempotent across passes", () => {
+      const md = [
+        "# Title",
+        "",
+        "Intro with a [link](https://x.test) and **bold**.",
+        "",
+        "## Tasks",
+        "",
+        "- [ ] one",
+        "- [x] two",
+        "",
+        "```js",
+        "console.log('hi');",
+        "```",
+      ].join("\n");
+      const once = roundTrip(md);
+      expect(roundTrip(once)).toBe(once);
+    });
+  });
+
+  describe("comment marks drop from the Markdown projection", () => {
+    it("keeps the text but emits no comment mark/span/threadId", () => {
+      const doc: JSONContent = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", text: "Hello " },
+              {
+                type: "text",
+                text: "anchored",
+                marks: [{ type: "comment", attrs: { threadId: "thread-123" } }],
+              },
+              { type: "text", text: " world!" },
+            ],
+          },
+        ],
+      };
+      const md = docToMarkdown(doc);
+      expect(md).toBe("Hello anchored world!");
+      expect(md).not.toContain("thread-123");
+      expect(md).not.toContain("data-comment-thread");
+      expect(md.toLowerCase()).not.toContain("<span");
+    });
+
+    it("a comment mark combined with bold still drops the comment but keeps bold", () => {
+      const doc: JSONContent = {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "important",
+                marks: [
+                  { type: "bold" },
+                  { type: "comment", attrs: { threadId: "t9" } },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const md = docToMarkdown(doc);
+      expect(md).toBe("**important**");
+    });
+  });
+
+  describe("isDocEmpty", () => {
+    it("treats the empty doc and null as empty", () => {
+      expect(isDocEmpty(EMPTY_DOC)).toBe(true);
+      expect(isDocEmpty(null)).toBe(true);
+      expect(isDocEmpty(markdownToDoc(""))).toBe(true);
+    });
+
+    it("treats real content as non-empty", () => {
+      expect(isDocEmpty(markdownToDoc("Something"))).toBe(false);
+    });
+  });
+});

--- a/src/lib/prd/codec.ts
+++ b/src/lib/prd/codec.ts
@@ -1,0 +1,66 @@
+import { Editor, type JSONContent } from "@tiptap/core";
+import { PRD_EXTENSIONS } from "./extensions";
+
+/**
+ * PRD document codec — the pure boundary between the two representations of the
+ * PRD body (ADR-0024):
+ *
+ *  - `descriptionDoc` (ProseMirror JSON) is the **source of truth** the editor
+ *    reads and writes.
+ *  - `description` (Markdown) is a **derived, write-only projection** for
+ *    off-island readers (CLI, agents/SDK, card previews).
+ *
+ * The invariant: Markdown is written *from* the JSON, one way only, and never
+ * read back into the editor. The single exception is the lazy, one-time
+ * migration of a legacy `description` into `descriptionDoc` the first time a
+ * feature is opened ({@link markdownToDoc}); thereafter the JSON is canonical.
+ *
+ * Both functions spin up a throwaway headless Tiptap editor. That requires a
+ * DOM, so they run in the browser and in unit tests (happy-dom) — never during
+ * SSR. Callers must invoke them client-side (e.g. inside an effect).
+ */
+
+/** Canonical empty document. */
+export const EMPTY_DOC: JSONContent = {
+  type: "doc",
+  content: [{ type: "paragraph" }],
+};
+
+function withEditor<T>(content: string | JSONContent, fn: (editor: Editor) => T): T {
+  const editor = new Editor({
+    extensions: PRD_EXTENSIONS,
+    content,
+  });
+  try {
+    return fn(editor);
+  } finally {
+    editor.destroy();
+  }
+}
+
+/**
+ * Markdown → ProseMirror JSON. Used for the one-time lazy migration of a
+ * legacy `description` and anywhere we need to seed a doc from Markdown.
+ */
+export function markdownToDoc(markdown: string | null | undefined): JSONContent {
+  if (!markdown || markdown.trim() === "") return EMPTY_DOC;
+  return withEditor(markdown, (editor) => editor.getJSON());
+}
+
+/**
+ * ProseMirror JSON → Markdown. Produces the derived `description` projection.
+ * Comment marks (and any other view-only marks) drop cleanly because their
+ * markdown spec is empty.
+ */
+export function docToMarkdown(doc: JSONContent | null | undefined): string {
+  if (!doc) return "";
+  return withEditor(doc, (editor) =>
+    (editor.storage.markdown as { getMarkdown: () => string }).getMarkdown(),
+  );
+}
+
+/** True when the document has no meaningful content (empty or whitespace). */
+export function isDocEmpty(doc: JSONContent | null | undefined): boolean {
+  if (!doc) return true;
+  return docToMarkdown(doc).trim() === "";
+}

--- a/src/lib/prd/comment-mark.ts
+++ b/src/lib/prd/comment-mark.ts
@@ -1,0 +1,77 @@
+import { Mark, mergeAttributes } from "@tiptap/core";
+
+/**
+ * Inline mark that anchors a {@link FeatureComment} thread to a span of the PRD
+ * body. The mark carries only a `threadId`; the comment content lives in the
+ * `FeatureComment` table (ADR-0024). Because the mark is part of the
+ * ProseMirror document, ProseMirror position mapping keeps the highlight glued
+ * to the marked words as the document is edited.
+ *
+ * The visual highlight + click-to-open behaviour is layered on in later slices;
+ * here we only need the schema (so the codec can round-trip documents that
+ * contain comment marks) and the guarantee that the mark **drops cleanly from
+ * the Markdown projection** — comment marks are a view concern with no Markdown
+ * form (ADR-0024 §5).
+ */
+export interface CommentMarkOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+export const COMMENT_HIGHLIGHT_CLASS = "prd-comment-highlight";
+
+export const CommentMark = Mark.create<CommentMarkOptions>({
+  name: "comment",
+
+  // Multiple overlapping threads may cover the same text.
+  excludes: "",
+  inclusive: false,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      threadId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-comment-thread"),
+        renderHTML: (attributes) => {
+          const threadId = attributes.threadId as string | null;
+          if (!threadId) return {};
+          return { "data-comment-thread": threadId };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "span[data-comment-thread]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "span",
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        class: COMMENT_HIGHLIGHT_CLASS,
+      }),
+      0,
+    ];
+  },
+
+  /**
+   * tiptap-markdown reads `extension.storage.markdown`. Empty open/close means
+   * the mark contributes nothing to the Markdown output — the text passes
+   * through unwrapped, so comment marks vanish from the projection while the
+   * canonical JSON keeps them.
+   */
+  addStorage() {
+    return {
+      markdown: {
+        serialize: { open: "", close: "", mixable: true },
+        parse: {},
+      },
+    };
+  },
+});

--- a/src/lib/prd/extensions.ts
+++ b/src/lib/prd/extensions.ts
@@ -1,0 +1,67 @@
+import type { Extensions } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import Link from "@tiptap/extension-link";
+import Placeholder from "@tiptap/extension-placeholder";
+import TaskList from "@tiptap/extension-task-list";
+import TaskItem from "@tiptap/extension-task-item";
+import { Markdown } from "tiptap-markdown";
+import { CommentMark } from "./comment-mark";
+
+/**
+ * The schema for the **PRD body** — the single scoped exception to ADR-0017
+ * where prose is a node-addressable ProseMirror document rather than a Markdown
+ * string (ADR-0024). This same extension set is used in three places, so it
+ * lives in one shared module:
+ *
+ *  - the read-only renderer on the Feature detail page,
+ *  - the live "Tier B" editor (later slice), and
+ *  - the pure {@link ./codec} (Markdown ⇄ ProseMirror JSON).
+ *
+ * Keeping a single source of truth guarantees the editor and the codec agree on
+ * the schema, so a document the editor produces always round-trips through the
+ * projection.
+ *
+ * Capability is deliberately "Tier B / Linear-grade": headings, lists, task
+ * lists, code blocks, links, inline marks, and anchored comment marks. Every
+ * node/mark here is serialisable by tiptap-markdown except {@link CommentMark},
+ * which intentionally drops from the Markdown projection.
+ */
+export const PRD_DEFAULT_PLACEHOLDER =
+  "Write the PRD… select text to format or comment, or type / for blocks.";
+
+export function buildPrdExtensions(
+  options: { placeholder?: string } = {},
+): Extensions {
+  return [
+    StarterKit.configure({
+      // StarterKit ships a basic codeBlock; keep it (tiptap-markdown serialises
+      // it). Everything else in StarterKit is used as-is.
+    }),
+    Link.configure({
+      openOnClick: true,
+      autolink: true,
+      HTMLAttributes: {
+        class: "text-brand-primary underline cursor-pointer",
+        rel: "noopener noreferrer nofollow",
+      },
+    }),
+    TaskList,
+    TaskItem.configure({ nested: true }),
+    CommentMark,
+    Placeholder.configure({
+      placeholder: options.placeholder ?? PRD_DEFAULT_PLACEHOLDER,
+    }),
+    // Must come last so it can read the other extensions' markdown specs.
+    Markdown.configure({
+      html: true,
+      tightLists: true,
+      linkify: true,
+      breaks: false,
+      transformPastedText: true,
+      transformCopiedText: true,
+    }),
+  ];
+}
+
+/** Extension set used by the headless codec (placeholder is irrelevant there). */
+export const PRD_EXTENSIONS: Extensions = buildPrdExtensions();

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -2,8 +2,11 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { loadProductWithAccess, assertWorkspaceMember } from "./product";
-import type { PrismaClient } from "@prisma/client";
+import type { Prisma, PrismaClient } from "@prisma/client";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
+
+/** A ProseMirror document object (PRD body, ADR-0024). Validated structurally. */
+const prosemirrorDoc = z.record(z.string(), z.unknown());
 
 const featureStatusEnum = z.enum([
   "IDEA",
@@ -242,6 +245,37 @@ export const featureRouter = createTRPCRouter({
         where: { id },
         data,
       });
+    }),
+
+  /**
+   * Persist the one-time lazy migration of a legacy Markdown `description` into
+   * the canonical `descriptionDoc` (ADR-0024). The client converts Markdown →
+   * ProseMirror JSON via the codec on first open and calls this to store it.
+   *
+   * Idempotent and write-once: if `descriptionDoc` is already set, the existing
+   * doc wins and nothing is written — so a second tab (or a real edit that has
+   * already happened) is never clobbered by a migration. `description` is left
+   * untouched (it is the source of this migration), as is `docVersion`.
+   */
+  initDescriptionDoc: protectedProcedure
+    .input(z.object({ id: z.string(), doc: prosemirrorDoc }))
+    .mutation(async ({ ctx, input }) => {
+      await loadFeatureWithAccess(ctx.db, ctx.session.user.id, input.id);
+
+      const existing = await ctx.db.feature.findUnique({
+        where: { id: input.id },
+        select: { descriptionDoc: true },
+      });
+      if (existing?.descriptionDoc != null) {
+        return { migrated: false, descriptionDoc: existing.descriptionDoc };
+      }
+
+      const updated = await ctx.db.feature.update({
+        where: { id: input.id },
+        data: { descriptionDoc: input.doc as Prisma.InputJsonValue },
+        select: { descriptionDoc: true },
+      });
+      return { migrated: true, descriptionDoc: updated.descriptionDoc };
     }),
 
   delete: protectedProcedure


### PR DESCRIPTION
## What

Foundation slice of the PRD rich-document feature (ADR-0024, scoped exception to ADR-0017). Makes the **PRD body** (`Feature.description` on the Feature detail page) a node-addressable ProseMirror document persisted as JSON, while keeping a derived Markdown copy for machine readers. Read + storage path only — no editing or comments yet.

- **Schema**: `Feature.descriptionDoc Json?` (canonical doc) + `Feature.docVersion Int @default(0)` (for later optimistic concurrency). Migration `20260618175127_add_feature_description_doc`.
- **PRD document codec** (pure, `src/lib/prd/`): Markdown ⇄ ProseMirror JSON via `tiptap-markdown`. Comment marks have an empty markdown spec so they drop cleanly from the projection.
- **Read path**: `PrdDocument` replaces `MarkdownRenderer` for the body only, renders `descriptionDoc` read-only, and lazily converts a legacy `description` (Markdown→JSON) on first load — persisted via `feature.initDescriptionDoc` (idempotent, write-once; never clobbers an existing doc).
- **Invariant**: `descriptionDoc` is the source of truth; `description` Markdown is written *from* it, one way only, and never read back into the editor. CLI/agents/card previews keep reading `description`.

## Acceptance criteria

- [x] `Feature.descriptionDoc` and `Feature.docVersion` exist via a manual Prisma migration
- [x] Codec round-trips representative content (paragraphs, headings, ordered/nested lists, task lists, code blocks, links) and drops comment marks from the Markdown output
- [x] Opening an existing PRD renders its content intact via the read-only Tiptap path (lazy Markdown→JSON migration on first load)
- [x] `description` Markdown stays populated/derived so `exponential features get` and card previews still show readable text
- [x] Codec unit tests pass (15); `tsc --noEmit` clean; ESLint clean; full unit suite 850 passing

## Notes

New dependency: `tiptap-markdown` (+ `@tiptap/extension-task-list`/`task-item`). The Markdown projection is currently derived client-side from the canonical JSON (no server-side DOM); the editable write path (server-side derivation per ADR-0024 §API contracts) lands in the follow-up edit-path ticket and any deviation will be flagged there.

---

Ships: onyx.elk (Exponential ticket `cmqjs6saw0001lb0498qtbcxs`)