### PR TITLE
feat(prd): edit PRD body inline (Tier B WYSIWYG + autosave + stale-write guard)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@tiptap/extension-underline": "^2.11.5",
         "@tiptap/react": "^2.11.5",
         "@tiptap/starter-kit": "^2.11.5",
+        "@tiptap/suggestion": "2.11.5",
         "@trpc/client": "^11.0.0-rc.446",
         "@trpc/react-query": "^11.0.0-rc.446",
         "@trpc/server": "^11.0.0-rc.446",
@@ -8377,6 +8378,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/suggestion": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-2.11.5.tgz",
+      "integrity": "sha512-uafwGgB5YuKX/xLRjnt2H5eA21I8HcNXpdbH4Du2gg3KM71RpUbkyjaV7KEMA/5qwCEo+sddlpuErj4wBycZ5Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@tiptap/extension-underline": "^2.11.5",
     "@tiptap/react": "^2.11.5",
     "@tiptap/starter-kit": "^2.11.5",
+    "@tiptap/suggestion": "2.11.5",
     "@trpc/client": "^11.0.0-rc.446",
     "@trpc/react-query": "^11.0.0-rc.446",
     "@trpc/server": "^11.0.0-rc.446",

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
@@ -216,11 +216,14 @@ export default function FeatureDetailPage() {
             </Group>
           </div>
 
-          {/* PRD body — rich document (ADR-0024), replaces MarkdownRenderer here only */}
+          {/* PRD body — rich document (ADR-0024), replaces MarkdownRenderer here only.
+              Editable for any workspace member (getById already gates membership). */}
           <PrdDocument
             featureId={featureId}
             descriptionDoc={(feature.descriptionDoc as JSONContent | null) ?? null}
             description={feature.description ?? null}
+            docVersion={feature.docVersion}
+            editable
           />
 
           {/* Vision */}

--- a/src/app/_components/prd/PrdDocument.tsx
+++ b/src/app/_components/prd/PrdDocument.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { EditorContent, useEditor } from "@tiptap/react";
-import type { JSONContent } from "@tiptap/core";
+import { EditorContent, BubbleMenu, useEditor } from "@tiptap/react";
+import { RichTextEditor } from "@mantine/tiptap";
+import type { Editor, JSONContent } from "@tiptap/core";
 import { Text } from "@mantine/core";
+import { modals } from "@mantine/modals";
 import { api } from "~/trpc/react";
 import { buildPrdExtensions } from "~/lib/prd/extensions";
+import { SlashCommand } from "~/lib/prd/slash-command";
 import { markdownToDoc, EMPTY_DOC, isDocEmpty } from "~/lib/prd/codec";
+import "@mantine/tiptap/styles.css";
 
 interface PrdDocumentProps {
   featureId: string;
@@ -14,28 +18,44 @@ interface PrdDocumentProps {
   descriptionDoc: JSONContent | null;
   /** Legacy/derived Markdown projection — source of the one-time migration. */
   description: string | null;
+  /** Stored doc version, the base for the optimistic-concurrency check. */
+  docVersion?: number;
+  /** Workspace members edit in place; everyone else gets a read-only render. */
+  editable?: boolean;
 }
 
 /**
- * Read-only renderer for the **PRD body** (ADR-0024). This is the single Tiptap
- * component that replaces `MarkdownRenderer` on the Feature detail page; a later
- * slice toggles `editable` on top of it for in-place WYSIWYG editing.
+ * The single Tiptap component for the **PRD body** (ADR-0024), with `editable`
+ * toggled by permission. Read mode renders `descriptionDoc` (lazily migrating a
+ * legacy Markdown `description` on first load). Edit mode adds the Tier B
+ * surface — selection bubble menu, `/` slash-command block menu, task lists,
+ * code blocks, placeholder — with debounced autosave and an
+ * optimistic-concurrency stale-write guard that prompts a reload rather than
+ * clobbering a newer save.
  *
- * Read path with lazy migration: if `descriptionDoc` already exists it is
- * rendered directly. If not, the legacy `description` Markdown is converted to
- * ProseMirror JSON on first load (client-side — the codec needs a DOM),
- * rendered, and persisted via `initDescriptionDoc` so the JSON becomes
- * canonical thereafter. The Markdown is never read back into the editor again.
+ * The Markdown projection is derived here (`editor.storage.markdown`) and sent
+ * alongside the JSON on save; the JSON stays canonical and the Markdown is never
+ * read back into the editor.
  */
 export function PrdDocument({
   featureId,
   descriptionDoc,
   description,
+  docVersion = 0,
+  editable = false,
 }: PrdDocumentProps) {
   const [doc, setDoc] = useState<JSONContent | null>(descriptionDoc);
   const migrationStarted = useRef(false);
+  const contentLoaded = useRef(false);
+
+  // Version the next save must match. Updated from each save's response; never
+  // reset from props mid-edit (we don't refetch the body while editing).
+  const versionRef = useRef(docVersion);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const conflictShown = useRef(false);
 
   const initDescriptionDoc = api.product.feature.initDescriptionDoc.useMutation();
+  const updateFeature = api.product.feature.update.useMutation();
 
   // Resolve the document to render, migrating legacy Markdown once.
   useEffect(() => {
@@ -57,11 +77,66 @@ export function PrdDocument({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [descriptionDoc, description, featureId]);
 
+  // Latest save fn behind a ref so the editor's onUpdate closure never goes stale.
+  const saveRef = useRef<(editor: Editor) => void>(() => undefined);
+  saveRef.current = (editor: Editor) => {
+    const json = editor.getJSON();
+    const markdown = (
+      editor.storage.markdown as { getMarkdown: () => string }
+    ).getMarkdown();
+    updateFeature.mutate(
+      {
+        id: featureId,
+        descriptionDoc: json,
+        description: markdown,
+        baseVersion: versionRef.current,
+      },
+      {
+        onSuccess: (res) => {
+          if (res && typeof (res as { docVersion?: number }).docVersion === "number") {
+            versionRef.current = (res as { docVersion: number }).docVersion;
+          }
+        },
+        onError: (err) => {
+          if (err.data?.code === "CONFLICT" && !conflictShown.current) {
+            conflictShown.current = true;
+            modals.openConfirmModal({
+              title: "This PRD changed",
+              children: (
+                <Text size="sm">
+                  Someone else saved a newer version of this PRD. Reload to get the
+                  latest? Unsaved changes in this tab will be lost.
+                </Text>
+              ),
+              labels: { confirm: "Reload", cancel: "Keep editing" },
+              onConfirm: () => window.location.reload(),
+              onCancel: () => {
+                conflictShown.current = false;
+              },
+            });
+          }
+        },
+      },
+    );
+  };
+
   const editor = useEditor({
-    editable: false,
-    extensions: buildPrdExtensions(),
+    editable,
+    extensions: editable
+      ? [...buildPrdExtensions(), SlashCommand]
+      : buildPrdExtensions(),
     content: doc ?? "",
     immediatelyRender: false,
+    onUpdate: ({ editor: e }) => {
+      if (!editable) return;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => saveRef.current(e), 1000);
+    },
+    onBlur: ({ editor: e }) => {
+      if (!editable) return;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      saveRef.current(e);
+    },
     editorProps: {
       attributes: {
         class: "prose prose-invert max-w-none focus:outline-none",
@@ -69,14 +144,15 @@ export function PrdDocument({
     },
   });
 
-  // Push the resolved doc into the editor once both are ready.
+  // Load the resolved doc into the editor exactly once (never clobber edits).
   useEffect(() => {
-    if (editor && doc) {
+    if (editor && doc && !contentLoaded.current) {
+      contentLoaded.current = true;
       editor.commands.setContent(doc);
     }
   }, [editor, doc]);
 
-  if (doc && isDocEmpty(doc)) {
+  if (!editable && doc && isDocEmpty(doc)) {
     return (
       <Text size="sm" className="text-text-muted">
         No description provided.
@@ -84,5 +160,35 @@ export function PrdDocument({
     );
   }
 
-  return <EditorContent editor={editor} className="prd-document" />;
+  if (!editable) {
+    return <EditorContent editor={editor} className="prd-document" />;
+  }
+
+  return (
+    <RichTextEditor
+      editor={editor}
+      className="prd-document"
+      styles={{
+        root: { border: "none", backgroundColor: "transparent" },
+        content: { backgroundColor: "transparent", padding: 0 },
+      }}
+    >
+      {editor && (
+        <BubbleMenu editor={editor} tippyOptions={{ duration: 150 }}>
+          <RichTextEditor.ControlsGroup>
+            <RichTextEditor.Bold />
+            <RichTextEditor.Italic />
+            <RichTextEditor.Code />
+            <RichTextEditor.Link />
+            <RichTextEditor.H1 />
+            <RichTextEditor.H2 />
+            <RichTextEditor.H3 />
+            <RichTextEditor.BulletList />
+            <RichTextEditor.OrderedList />
+          </RichTextEditor.ControlsGroup>
+        </BubbleMenu>
+      )}
+      <RichTextEditor.Content />
+    </RichTextEditor>
+  );
 }

--- a/src/lib/prd/__tests__/stale-write.test.ts
+++ b/src/lib/prd/__tests__/stale-write.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+
+import { checkStaleWrite } from "../stale-write";
+
+describe("checkStaleWrite", () => {
+  it("accepts a matching version and reports the next version", () => {
+    expect(checkStaleWrite({ storedVersion: 0, baseVersion: 0 })).toEqual({
+      accept: true,
+      nextVersion: 1,
+    });
+    expect(checkStaleWrite({ storedVersion: 7, baseVersion: 7 })).toEqual({
+      accept: true,
+      nextVersion: 8,
+    });
+  });
+
+  it("rejects a stale write when the stored version is newer", () => {
+    expect(checkStaleWrite({ storedVersion: 3, baseVersion: 2 })).toEqual({
+      accept: false,
+      reason: "stale",
+    });
+    expect(checkStaleWrite({ storedVersion: 100, baseVersion: 1 })).toEqual({
+      accept: false,
+      reason: "stale",
+    });
+  });
+
+  it("rejects as invalid when the claimed base was never persisted", () => {
+    expect(checkStaleWrite({ storedVersion: 2, baseVersion: 5 })).toEqual({
+      accept: false,
+      reason: "invalid",
+    });
+  });
+
+  it("rejects non-integer or negative versions as invalid", () => {
+    expect(checkStaleWrite({ storedVersion: 1.5, baseVersion: 1 }).accept).toBe(false);
+    expect(checkStaleWrite({ storedVersion: 1, baseVersion: -1 }).accept).toBe(false);
+    expect(checkStaleWrite({ storedVersion: NaN, baseVersion: 0 })).toEqual({
+      accept: false,
+      reason: "invalid",
+    });
+  });
+});

--- a/src/lib/prd/slash-command.tsx
+++ b/src/lib/prd/slash-command.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from "react";
+import { Extension, type Editor, type Range } from "@tiptap/core";
+import Suggestion, { type SuggestionOptions } from "@tiptap/suggestion";
+import { ReactRenderer } from "@tiptap/react";
+import { Paper, Text, UnstyledButton } from "@mantine/core";
+import {
+  IconH1,
+  IconH2,
+  IconH3,
+  IconList,
+  IconListCheck,
+  IconListNumbers,
+  IconCode,
+  IconQuote,
+  type TablerIcon,
+} from "@tabler/icons-react";
+import tippy, { type Instance, type GetReferenceClientRect } from "tippy.js";
+
+/**
+ * `/` slash-command block menu for the PRD editor (ADR-0024 Tier B). Built on
+ * `@tiptap/suggestion`: typing `/` opens a keyboard-navigable list that inserts
+ * structural blocks (headings, lists, task lists, code block, quote).
+ */
+interface SlashCommandItem {
+  title: string;
+  description: string;
+  icon: TablerIcon;
+  run: (args: { editor: Editor; range: Range }) => void;
+}
+
+const COMMANDS: SlashCommandItem[] = [
+  {
+    title: "Heading 1",
+    description: "Big section heading",
+    icon: IconH1,
+    run: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).setNode("heading", { level: 1 }).run(),
+  },
+  {
+    title: "Heading 2",
+    description: "Medium section heading",
+    icon: IconH2,
+    run: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).setNode("heading", { level: 2 }).run(),
+  },
+  {
+    title: "Heading 3",
+    description: "Small section heading",
+    icon: IconH3,
+    run: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).setNode("heading", { level: 3 }).run(),
+  },
+  {
+    title: "Bullet list",
+    description: "Unordered list",
+    icon: IconList,
+    run: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).toggleBulletList().run(),
+  },
+  {
+    title: "Numbered list",
+    description: "Ordered list",
+    icon: IconListNumbers,
+    run: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
+  },
+  {
+    title: "Task list",
+    description: "Checklist with checkboxes",
+    icon: IconListCheck,
+    run: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).toggleTaskList().run(),
+  },
+  {
+    title: "Code block",
+    description: "Fenced code with syntax",
+    icon: IconCode,
+    run: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).toggleCodeBlock().run(),
+  },
+  {
+    title: "Quote",
+    description: "Block quote",
+    icon: IconQuote,
+    run: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).toggleBlockquote().run(),
+  },
+];
+
+interface SlashCommandListProps {
+  items: SlashCommandItem[];
+  command: (item: SlashCommandItem) => void;
+}
+
+export interface SlashCommandListRef {
+  onKeyDown: (args: { event: KeyboardEvent }) => boolean;
+}
+
+const SlashCommandList = forwardRef<SlashCommandListRef, SlashCommandListProps>(
+  function SlashCommandList({ items, command }, ref) {
+    const [selected, setSelected] = useState(0);
+
+    useEffect(() => setSelected(0), [items]);
+
+    useImperativeHandle(ref, () => ({
+      onKeyDown: ({ event }) => {
+        if (event.key === "ArrowUp") {
+          setSelected((s) => (s + items.length - 1) % items.length);
+          return true;
+        }
+        if (event.key === "ArrowDown") {
+          setSelected((s) => (s + 1) % items.length);
+          return true;
+        }
+        if (event.key === "Enter") {
+          const item = items[selected];
+          if (item) command(item);
+          return true;
+        }
+        return false;
+      },
+    }));
+
+    if (items.length === 0) return null;
+
+    return (
+      <Paper
+        withBorder
+        shadow="md"
+        radius="md"
+        p={4}
+        className="bg-surface-secondary max-h-72 w-72 overflow-y-auto"
+      >
+        {items.map((item, index) => {
+          const Icon = item.icon;
+          return (
+            <UnstyledButton
+              key={item.title}
+              onClick={() => command(item)}
+              onMouseEnter={() => setSelected(index)}
+              className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left ${
+                index === selected ? "bg-surface-hover" : ""
+              }`}
+            >
+              <Icon size={18} className="text-text-muted shrink-0" />
+              <div className="min-w-0">
+                <Text size="sm" className="text-text-primary">
+                  {item.title}
+                </Text>
+                <Text size="xs" className="text-text-muted truncate">
+                  {item.description}
+                </Text>
+              </div>
+            </UnstyledButton>
+          );
+        })}
+      </Paper>
+    );
+  },
+);
+
+const suggestion: Omit<SuggestionOptions<SlashCommandItem>, "editor"> = {
+  char: "/",
+  startOfLine: false,
+  items: ({ query }) =>
+    COMMANDS.filter((item) =>
+      item.title.toLowerCase().startsWith(query.toLowerCase()),
+    ),
+  command: ({ editor, range, props }) => props.run({ editor, range }),
+  render: () => {
+    let component: ReactRenderer<SlashCommandListRef, SlashCommandListProps>;
+    let popup: Instance[];
+
+    return {
+      onStart: (props) => {
+        component = new ReactRenderer(SlashCommandList, {
+          props: {
+            items: props.items,
+            command: (item: SlashCommandItem) => props.command(item),
+          },
+          editor: props.editor,
+        });
+        if (!props.clientRect) return;
+        popup = tippy("body", {
+          getReferenceClientRect:
+            props.clientRect as unknown as GetReferenceClientRect,
+          appendTo: () => document.body,
+          content: component.element,
+          showOnCreate: true,
+          interactive: true,
+          trigger: "manual",
+          placement: "bottom-start",
+        });
+      },
+      onUpdate: (props) => {
+        component.updateProps({
+          items: props.items,
+          command: (item: SlashCommandItem) => props.command(item),
+        });
+        if (props.clientRect) {
+          popup?.[0]?.setProps({
+            getReferenceClientRect:
+              props.clientRect as unknown as GetReferenceClientRect,
+          });
+        }
+      },
+      onKeyDown: (props) => {
+        if (props.event.key === "Escape") {
+          popup?.[0]?.hide();
+          return true;
+        }
+        return component.ref?.onKeyDown({ event: props.event }) ?? false;
+      },
+      onExit: () => {
+        popup?.[0]?.destroy();
+        component?.destroy();
+      },
+    };
+  },
+};
+
+export const SlashCommand = Extension.create({
+  name: "slashCommand",
+  addProseMirrorPlugins() {
+    return [Suggestion({ editor: this.editor, ...suggestion })];
+  },
+});

--- a/src/lib/prd/stale-write.ts
+++ b/src/lib/prd/stale-write.ts
@@ -1,0 +1,46 @@
+/**
+ * Stale-write guard — the pure optimistic-concurrency decision for the
+ * single-writer PRD body (ADR-0024 §6).
+ *
+ * Each save carries the `docVersion` the client loaded (`baseVersion`). The
+ * server compares it against the version currently stored:
+ *
+ *  - **match** (`stored === base`) → accept; the write bumps the version.
+ *  - **stored is newer** (`stored > base`) → reject as stale: someone else saved
+ *    while this tab was open. The client is told to reload rather than clobber
+ *    the newer save.
+ *  - **stored is older** (`stored < base`) → reject as invalid: the client
+ *    claims a version that was never persisted (shouldn't happen).
+ *
+ * Pure and side-effect free so it can be unit-tested in isolation and reused on
+ * both sides of the wire.
+ */
+export type StaleWriteDecision =
+  | { accept: true; nextVersion: number }
+  | { accept: false; reason: "stale" | "invalid" };
+
+export function checkStaleWrite(params: {
+  storedVersion: number;
+  baseVersion: number;
+}): StaleWriteDecision {
+  const { storedVersion, baseVersion } = params;
+
+  if (
+    !Number.isInteger(storedVersion) ||
+    !Number.isInteger(baseVersion) ||
+    storedVersion < 0 ||
+    baseVersion < 0
+  ) {
+    return { accept: false, reason: "invalid" };
+  }
+
+  if (storedVersion === baseVersion) {
+    return { accept: true, nextVersion: baseVersion + 1 };
+  }
+
+  // stored > base: a newer save landed → stale. stored < base: impossible base.
+  return {
+    accept: false,
+    reason: storedVersion > baseVersion ? "stale" : "invalid",
+  };
+}

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -4,6 +4,7 @@ import { TRPCError } from "@trpc/server";
 import { loadProductWithAccess, assertWorkspaceMember } from "./product";
 import type { Prisma, PrismaClient } from "@prisma/client";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
+import { checkStaleWrite } from "~/lib/prd/stale-write";
 
 /** A ProseMirror document object (PRD body, ADR-0024). Validated structurally. */
 const prosemirrorDoc = z.record(z.string(), z.unknown());
@@ -222,6 +223,14 @@ export const featureRouter = createTRPCRouter({
         effort: z.number().optional(),
         priority: z.number().int().min(0).max(4).optional(),
         goalId: z.number().int().nullable().optional(),
+        // PRD body save (ADR-0024). `descriptionDoc` is the canonical document;
+        // `description` rides along as its derived Markdown projection (the
+        // client serialises it, since the projection needs the editor schema —
+        // a deviation from ADR-0024's "server derives", forced by there being no
+        // server-side DOM; the JSON-canonical, write-once-Markdown invariant
+        // still holds). `baseVersion` is the optimistic-concurrency check.
+        descriptionDoc: prosemirrorDoc.optional(),
+        baseVersion: z.number().int().min(0).optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -240,11 +249,58 @@ export const featureRouter = createTRPCRouter({
         }
       }
 
-      const { id, ...data } = input;
-      return ctx.db.feature.update({
+      const { id, descriptionDoc, baseVersion, ...rest } = input;
+
+      // PRD body autosave path: optimistic-concurrency guard + version bump.
+      if (descriptionDoc !== undefined) {
+        if (baseVersion === undefined) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "baseVersion is required when saving the PRD body",
+          });
+        }
+        const current = await ctx.db.feature.findUnique({
+          where: { id },
+          select: { docVersion: true },
+        });
+        const decision = checkStaleWrite({
+          storedVersion: current?.docVersion ?? 0,
+          baseVersion,
+        });
+        if (!decision.accept) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              decision.reason === "stale"
+                ? "This PRD was updated in another tab or by another member. Reload to get the latest version."
+                : "Stale document version — reload and try again.",
+          });
+        }
+        // Atomic compare-and-set: the WHERE on docVersion closes the read→write
+        // race so two concurrent saves can't both bump from the same base.
+        const res = await ctx.db.feature.updateMany({
+          where: { id, docVersion: baseVersion },
+          data: {
+            ...rest,
+            descriptionDoc: descriptionDoc as Prisma.InputJsonValue,
+            docVersion: { increment: 1 },
+          },
+        });
+        if (res.count === 0) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "This PRD was updated concurrently. Reload to get the latest version.",
+          });
+        }
+        return { id, docVersion: decision.nextVersion };
+      }
+
+      const updated = await ctx.db.feature.update({
         where: { id },
-        data,
+        data: rest,
       });
+      return updated;
     }),
 
   /**


### PR DESCRIPTION
## What

Builds on the read/storage path (#229). Turns the PRD body into an editable, Linear-grade WYSIWYG surface for workspace members, with safe autosave (ADR-0024).

- **One Tiptap component, `editable` toggled by permission.** Members edit in place; the read-only path is unchanged. (`getById` already gates workspace membership, so everyone who can load the page is a member.)
- **Tier B capability**: selection **bubble menu** (bold, italic, code, link, headings, lists), **`/` slash-command** block menu (headings, lists, task list, code block, quote), **task lists**, **code blocks**, **placeholder**.
- **Debounced autosave** (1s, + flush on blur). No save button.
- **Stale-write guard** (`src/lib/prd/stale-write.ts`, pure + unit-tested): the save carries the `docVersion` it loaded; the server runs the optimistic-concurrency check and an **atomic compare-and-set** (`updateMany WHERE docVersion = base`) before bumping. A stale tab gets a `CONFLICT` and is prompted to reload rather than clobbering a newer save.
- `feature.update` gains the doc-save path; editing reuses the existing `loadFeatureWithAccess` workspace-member gate.

## Acceptance criteria

- [x] A workspace member can edit the PRD body in place; a non-member gets read-only (non-members can't load the page at all — stronger than read-only)
- [x] Bubble menu, `/` slash menu, task lists, code blocks, and placeholder all work
- [x] Edits autosave (debounced); `description` Markdown projection and `docVersion` update on save
- [x] A save from a stale tab is rejected (`CONFLICT`) and the user is prompted to reload (no silent clobber)
- [x] Stale-write guard unit tests pass; `tsc`/ESLint clean; full unit suite 854 passing

## ADR note

ADR-0024 §API contracts says the **server** derives the Markdown projection. There's no server-side DOM to run the editor schema, so the projection is derived **client-side** (`editor.storage.markdown`) and sent alongside the canonical JSON. The load-bearing invariant — *JSON is the source of truth; Markdown is written from it one-way and never read back into the editor* — is preserved. Server-side derivation would need a headless DOM on the server (a later option if the projection must be authoritative).

---

Ships: ruby.daisy (Exponential ticket `cmqjs7cv90007lb04k6nyj0bg`)