### PR TITLE
feat(prd): image paste/drop in the PRD editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@tabler/icons-react": "^3.30.0",
         "@tanstack/react-query": "^5.50.0",
         "@tiptap/extension-highlight": "^2.11.5",
+        "@tiptap/extension-image": "2.11.5",
         "@tiptap/extension-link": "^2.11.5",
         "@tiptap/extension-placeholder": "^2.11.5",
         "@tiptap/extension-subscript": "^2.11.5",
@@ -8123,6 +8124,19 @@
       "peerDependencies": {
         "@tiptap/core": "^2.7.0",
         "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-image": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-2.11.5.tgz",
+      "integrity": "sha512-HbUq9AL8gb8eSuQfY/QKkvMc66ZFN/b6jvQAILGArNOgalUfGizoC6baKTJShaExMSPjBZlaAHtJiQKPaGRHaA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-italic": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@tabler/icons-react": "^3.30.0",
     "@tanstack/react-query": "^5.50.0",
     "@tiptap/extension-highlight": "^2.11.5",
+    "@tiptap/extension-image": "2.11.5",
     "@tiptap/extension-link": "^2.11.5",
     "@tiptap/extension-placeholder": "^2.11.5",
     "@tiptap/extension-subscript": "^2.11.5",

--- a/src/app/_components/prd/PrdDocument.tsx
+++ b/src/app/_components/prd/PrdDocument.tsx
@@ -10,6 +10,7 @@ import { api } from "~/trpc/react";
 import { buildPrdExtensions } from "~/lib/prd/extensions";
 import { SlashCommand } from "~/lib/prd/slash-command";
 import { markdownToDoc, EMPTY_DOC, isDocEmpty } from "~/lib/prd/codec";
+import { usePrdImageUpload } from "~/hooks/usePrdImageUpload";
 import "@mantine/tiptap/styles.css";
 
 interface PrdDocumentProps {
@@ -56,6 +57,7 @@ export function PrdDocument({
 
   const initDescriptionDoc = api.product.feature.initDescriptionDoc.useMutation();
   const updateFeature = api.product.feature.update.useMutation();
+  const imageHandlers = usePrdImageUpload(featureId);
 
   // Resolve the document to render, migrating legacy Markdown once.
   useEffect(() => {
@@ -141,6 +143,12 @@ export function PrdDocument({
       attributes: {
         class: "prose prose-invert max-w-none focus:outline-none",
       },
+      ...(editable
+        ? {
+            handlePaste: imageHandlers.handlePaste,
+            handleDrop: imageHandlers.handleDrop,
+          }
+        : {}),
     },
   });
 

--- a/src/hooks/usePrdImageUpload.ts
+++ b/src/hooks/usePrdImageUpload.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useMemo } from "react";
+import type { EditorView } from "@tiptap/pm/view";
+import { notifications } from "@mantine/notifications";
+import { api } from "~/trpc/react";
+
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Image paste/drop for the PRD editor (ADR-0024). Mirrors `useImagePaste` but
+ * targets the ProseMirror document: an uploaded image is inserted as an inline
+ * `image` node (which the codec serialises to a Markdown image link) rather than
+ * a Markdown string. Returns Tiptap `editorProps` handlers; upload runs via
+ * `feature.uploadImage`.
+ */
+export function usePrdImageUpload(featureId: string) {
+  const uploadImage = api.product.feature.uploadImage.useMutation();
+
+  return useMemo(() => {
+    const insertImage = (view: EditorView, file: File, pos?: number): boolean => {
+      if (!file.type.startsWith("image/")) return false;
+      if (file.size > MAX_IMAGE_BYTES) {
+        notifications.show({
+          title: "Image too large",
+          message: "Please use an image under 5MB.",
+          color: "red",
+        });
+        return true;
+      }
+
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        const result = reader.result;
+        if (typeof result !== "string") return;
+        const base64 = result.split(",")[1];
+        if (!base64) return;
+
+        uploadImage
+          .mutateAsync({ id: featureId, base64Data: base64 })
+          .then((res) => {
+            const { state } = view;
+            const node = state.schema.nodes.image?.create({ src: res.url });
+            if (!node) return;
+            const at = pos ?? state.selection.from;
+            view.dispatch(state.tr.insert(at, node));
+          })
+          .catch(() => {
+            notifications.show({
+              title: "Upload failed",
+              message: "Could not upload the image. Please try again.",
+              color: "red",
+            });
+          });
+      };
+      reader.readAsDataURL(file);
+      return true;
+    };
+
+    const firstImage = (list?: FileList | null): File | null => {
+      if (!list) return null;
+      for (const file of Array.from(list)) {
+        if (file.type.startsWith("image/")) return file;
+      }
+      return null;
+    };
+
+    return {
+      handlePaste: (view: EditorView, event: ClipboardEvent): boolean => {
+        const file = firstImage(event.clipboardData?.files);
+        if (!file) return false;
+        event.preventDefault();
+        return insertImage(view, file);
+      },
+      handleDrop: (view: EditorView, event: DragEvent): boolean => {
+        const file = firstImage(event.dataTransfer?.files);
+        if (!file) return false;
+        event.preventDefault();
+        const coords = view.posAtCoords({
+          left: event.clientX,
+          top: event.clientY,
+        });
+        return insertImage(view, file, coords?.pos);
+      },
+    };
+  }, [featureId, uploadImage]);
+}

--- a/src/lib/prd/__tests__/codec.test.ts
+++ b/src/lib/prd/__tests__/codec.test.ts
@@ -60,6 +60,22 @@ describe("PRD document codec", () => {
       expect(roundTrip(md)).toBe(md);
     });
 
+    it("images round-trip as a Markdown image link", () => {
+      const md = "![a mockup](https://blob.example/img.png)";
+      expect(roundTrip(md)).toBe(md);
+      // And a doc-authored image node serialises to the same link.
+      const doc = {
+        type: "doc",
+        content: [
+          {
+            type: "image",
+            attrs: { src: "https://blob.example/shot.png", alt: "shot" },
+          },
+        ],
+      };
+      expect(docToMarkdown(doc)).toBe("![shot](https://blob.example/shot.png)");
+    });
+
     it("nested lists survive and serialise stably", () => {
       const md = ["- Parent", "  - Child", "  - Child 2", "- Sibling"].join("\n");
       const out = roundTrip(md);

--- a/src/lib/prd/extensions.ts
+++ b/src/lib/prd/extensions.ts
@@ -4,6 +4,7 @@ import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
+import Image from "@tiptap/extension-image";
 import { Markdown } from "tiptap-markdown";
 import { CommentMark } from "./comment-mark";
 
@@ -47,6 +48,11 @@ export function buildPrdExtensions(
     }),
     TaskList,
     TaskItem.configure({ nested: true }),
+    Image.configure({
+      inline: false,
+      allowBase64: false,
+      HTMLAttributes: { class: "prd-image rounded-md max-w-full" },
+    }),
     CommentMark,
     Placeholder.configure({
       placeholder: options.placeholder ?? PRD_DEFAULT_PLACEHOLDER,

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -5,6 +5,7 @@ import { loadProductWithAccess, assertWorkspaceMember } from "./product";
 import type { Prisma, PrismaClient } from "@prisma/client";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 import { checkStaleWrite } from "~/lib/prd/stale-write";
+import { uploadToBlob } from "~/lib/blob";
 
 /** A ProseMirror document object (PRD body, ADR-0024). Validated structurally. */
 const prosemirrorDoc = z.record(z.string(), z.unknown());
@@ -332,6 +333,38 @@ export const featureRouter = createTRPCRouter({
         select: { descriptionDoc: true },
       });
       return { migrated: true, descriptionDoc: updated.descriptionDoc };
+    }),
+
+  /**
+   * Upload an image pasted/dropped into the PRD body (ADR-0024 Tier B), mirroring
+   * `action.uploadImage`: base64 in, public URL out, reusing the Vercel Blob
+   * backend. Gated by the same workspace-member check as editing. The returned
+   * URL is inserted as an inline image node in `descriptionDoc` and survives the
+   * Markdown projection as an image link.
+   */
+  uploadImage: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        base64Data: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await loadFeatureWithAccess(ctx.db, ctx.session.user.id, input.id);
+
+      // Same 5MB cap as action.uploadImage (base64 is ~4/3 the byte size).
+      const approxBytes = Math.floor((input.base64Data.length * 3) / 4);
+      if (approxBytes > 5 * 1024 * 1024) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Image too large. Please use an image under 5MB.",
+        });
+      }
+
+      const timestamp = new Date().toISOString().replace(/[/:]/g, "-");
+      const filename = `screenshots/features/${input.id}/${timestamp}.png`;
+      const blob = await uploadToBlob(input.base64Data, filename);
+      return { url: blob.url };
     }),
 
   delete: protectedProcedure


### PR DESCRIPTION
## What

Lets authors paste or drag-drop an image directly into the PRD body, inline (ADR-0024 Tier B). Builds on the editable editor (#230).

- **`feature.uploadImage`** mutation mirroring `action.uploadImage`: base64 in, public URL out, 5MB cap (client + server), reusing the Vercel Blob backend, gated by the same workspace-member check as editing.
- **`usePrdImageUpload`**: Tiptap `editorProps.handlePaste`/`handleDrop` handlers (edit mode only) that upload the image, then insert an inline `image` node at the cursor (paste) or drop point. The insert flows through autosave, so the image persists in `descriptionDoc`.
- **`Image` extension** added to the shared PRD schema; images survive the Markdown projection as `![alt](url)` (codec round-trip test added).

## Acceptance criteria

- [x] Pasting an image into the PRD body uploads it and inserts it inline
- [x] Drag-dropping an image file does the same
- [x] Oversized images are rejected with clear feedback (same 5MB cap as `action.uploadImage`)
- [x] The image survives reload (persisted in `descriptionDoc`) and appears as an image link in the derived Markdown
- [x] `tsc`/ESLint clean; codec image round-trip test passes; full unit suite 855 passing

---

Ships: violet.flask (Exponential ticket `cmqjs7od5000flb04j4cqufrg`)