### PR TITLE
feat(prd): anchored comments — create & view a thread

### DIFF
--- a/prisma/migrations/20260618183317_add_feature_comment/migration.sql
+++ b/prisma/migrations/20260618183317_add_feature_comment/migration.sql
@@ -1,0 +1,36 @@
+-- CreateTable
+CREATE TABLE "FeatureComment" (
+    "id" TEXT NOT NULL,
+    "featureId" TEXT NOT NULL,
+    "threadId" TEXT,
+    "parentId" TEXT,
+    "body" TEXT NOT NULL,
+    "quotedText" TEXT,
+    "resolvedAt" TIMESTAMP(3),
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FeatureComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "FeatureComment_featureId_idx" ON "FeatureComment"("featureId");
+
+-- CreateIndex
+CREATE INDEX "FeatureComment_threadId_idx" ON "FeatureComment"("threadId");
+
+-- CreateIndex
+CREATE INDEX "FeatureComment_parentId_idx" ON "FeatureComment"("parentId");
+
+-- CreateIndex
+CREATE INDEX "FeatureComment_createdById_idx" ON "FeatureComment"("createdById");
+
+-- AddForeignKey
+ALTER TABLE "FeatureComment" ADD CONSTRAINT "FeatureComment_featureId_fkey" FOREIGN KEY ("featureId") REFERENCES "Feature"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FeatureComment" ADD CONSTRAINT "FeatureComment_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "FeatureComment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FeatureComment" ADD CONSTRAINT "FeatureComment_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -174,6 +174,7 @@ model User {
   keyResultComments           KeyResultComment[]          @relation("KeyResultCommentAuthor")
   // Action Discussion relations
   actionComments              ActionComment[]             @relation("ActionCommentAuthor")
+  featureComments             FeatureComment[]            @relation("FeatureCommentAuthor")
   // Blog Discussion relations
   blogComments                BlogComment[]               @relation("BlogCommentAuthor")
   // Daily Planning relations
@@ -3733,11 +3734,41 @@ model Feature {
   insights    FeatureInsight[]
   tickets     Ticket[]
   tags        FeatureTag[]
+  comments    FeatureComment[]
 
   @@index([productId])
   @@index([goalId])
   @@index([createdById])
   @@index([status])
+}
+
+/// Discussion note on a PRD body (ADR-0024). Either anchored — pinned via a
+/// `comment` mark in `Feature.descriptionDoc` to a span that stays highlighted
+/// as the text is edited — or doc-level (`threadId` null). Grouped into threads
+/// (a root plus `parentId` replies) and resolvable (`resolvedAt`). `quotedText`
+/// snapshots the selected text so an orphaned thread still renders. Bodies are
+/// Markdown (ADR-0017 still governs comment prose).
+model FeatureComment {
+  id          String    @id @default(cuid())
+  featureId   String
+  threadId    String?
+  parentId    String?
+  body        String
+  quotedText  String?
+  resolvedAt  DateTime?
+  createdById String
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  feature   Feature          @relation(fields: [featureId], references: [id], onDelete: Cascade)
+  parent    FeatureComment?  @relation("FeatureCommentReplies", fields: [parentId], references: [id], onDelete: Cascade)
+  replies   FeatureComment[] @relation("FeatureCommentReplies")
+  createdBy User             @relation("FeatureCommentAuthor", fields: [createdById], references: [id])
+
+  @@index([featureId])
+  @@index([threadId])
+  @@index([parentId])
+  @@index([createdById])
 }
 
 enum FeatureScopeStatus {

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
@@ -224,6 +224,7 @@ export default function FeatureDetailPage() {
             description={feature.description ?? null}
             docVersion={feature.docVersion}
             editable
+            enableComments
           />
 
           {/* Vision */}

--- a/src/app/_components/prd/PrdCommentsPanel.tsx
+++ b/src/app/_components/prd/PrdCommentsPanel.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { Badge, Paper, Stack, Text } from "@mantine/core";
+import { CommentInput } from "~/app/_components/shared/CommentInput";
+import { CommentThread, type Comment } from "~/app/_components/shared/CommentThread";
+import type {
+  ThreadStatus,
+  ReconcilableComment,
+} from "~/lib/prd/thread-reconciliation";
+
+export interface FeatureCommentRow extends ReconcilableComment {
+  body: string;
+  createdAt: string | Date;
+  createdBy: { id: string; name: string | null; image: string | null };
+}
+
+/** The subset the panel renders — satisfied by a reconciled thread or a
+ *  just-created pending thread that has no persisted comments yet. */
+export interface PanelThread {
+  threadId: string;
+  status: ThreadStatus;
+  quotedText: string | null;
+  comments: FeatureCommentRow[];
+}
+
+interface PrdCommentsPanelProps {
+  threads: PanelThread[];
+  activeThreadId: string | null;
+  pendingThreadId: string | null;
+  onSelect: (threadId: string) => void;
+  onSubmit: (threadId: string, body: string) => Promise<void>;
+  currentUserId?: string;
+  isSubmitting?: boolean;
+}
+
+function toThreadComments(rows: FeatureCommentRow[]): Comment[] {
+  return rows.map((row) => ({
+    id: row.id,
+    content: row.body,
+    createdAt: new Date(row.createdAt),
+    author: row.createdBy,
+  }));
+}
+
+/**
+ * Discussion panel for the PRD body (ADR-0024). Lists reconciled comment threads
+ * — anchored (highlight live in the doc) and orphaned (anchor deleted, rendered
+ * from `quotedText`) — and lets a member open one to read it and add a comment.
+ * Replies, resolve/unresolve, and resolved-thread hiding land in the polish
+ * slice; here a thread is its root comment(s).
+ */
+export function PrdCommentsPanel({
+  threads,
+  activeThreadId,
+  pendingThreadId,
+  onSelect,
+  onSubmit,
+  currentUserId,
+  isSubmitting = false,
+}: PrdCommentsPanelProps) {
+  const visible = threads.filter((t) => t.status !== "resolved");
+
+  return (
+    <div>
+      <Text size="xs" fw={600} className="text-text-muted uppercase tracking-wider mb-2">
+        Discussion {visible.length > 0 ? `(${visible.length})` : ""}
+      </Text>
+
+      {visible.length === 0 && !pendingThreadId ? (
+        <Text size="xs" className="text-text-muted">
+          Select text in the body and choose Comment to start a thread.
+        </Text>
+      ) : (
+        <Stack gap="sm">
+          {visible.map((thread) => {
+            const isActive =
+              thread.threadId === activeThreadId ||
+              thread.threadId === pendingThreadId;
+            return (
+              <Paper
+                key={thread.threadId}
+                withBorder
+                radius="md"
+                p="sm"
+                className={`bg-surface-secondary cursor-pointer ${
+                  isActive ? "border-border-focus" : ""
+                }`}
+                onClick={() => onSelect(thread.threadId)}
+                data-thread-card={thread.threadId}
+              >
+                <div className="flex items-center justify-between gap-2 mb-2">
+                  {thread.quotedText ? (
+                    <Text size="xs" className="text-text-muted italic truncate">
+                      “{thread.quotedText}”
+                    </Text>
+                  ) : (
+                    <span />
+                  )}
+                  {thread.status === "orphaned" && (
+                    <Badge size="xs" variant="light" color="gray">
+                      orphaned
+                    </Badge>
+                  )}
+                </div>
+
+                <CommentThread
+                  comments={toThreadComments(thread.comments)}
+                  currentUserId={currentUserId}
+                  variant="inline"
+                  emptyMessage={null}
+                />
+
+                {isActive && (
+                  <div className="mt-2" onClick={(e) => e.stopPropagation()}>
+                    <CommentInput
+                      placeholder="Reply…"
+                      isSubmitting={isSubmitting}
+                      onSubmit={(body) => onSubmit(thread.threadId, body)}
+                    />
+                  </div>
+                )}
+              </Paper>
+            );
+          })}
+        </Stack>
+      )}
+    </div>
+  );
+}

--- a/src/app/_components/prd/PrdDocument.tsx
+++ b/src/app/_components/prd/PrdDocument.tsx
@@ -1,16 +1,24 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { EditorContent, BubbleMenu, useEditor } from "@tiptap/react";
 import { RichTextEditor } from "@mantine/tiptap";
 import type { Editor, JSONContent } from "@tiptap/core";
-import { Text } from "@mantine/core";
+import { Stack, Text } from "@mantine/core";
 import { modals } from "@mantine/modals";
+import { notifications } from "@mantine/notifications";
+import { IconMessagePlus } from "@tabler/icons-react";
 import { api } from "~/trpc/react";
 import { buildPrdExtensions } from "~/lib/prd/extensions";
 import { SlashCommand } from "~/lib/prd/slash-command";
 import { markdownToDoc, EMPTY_DOC, isDocEmpty } from "~/lib/prd/codec";
+import { reconcileThreads } from "~/lib/prd/thread-reconciliation";
 import { usePrdImageUpload } from "~/hooks/usePrdImageUpload";
+import {
+  PrdCommentsPanel,
+  type FeatureCommentRow,
+  type PanelThread,
+} from "~/app/_components/prd/PrdCommentsPanel";
 import "@mantine/tiptap/styles.css";
 
 interface PrdDocumentProps {
@@ -23,20 +31,28 @@ interface PrdDocumentProps {
   docVersion?: number;
   /** Workspace members edit in place; everyone else gets a read-only render. */
   editable?: boolean;
+  /** Show the anchored-comments affordances + discussion panel. */
+  enableComments?: boolean;
+}
+
+function newThreadId(): string {
+  const c = globalThis.crypto;
+  return c?.randomUUID ? c.randomUUID() : `thread-${Date.now()}-${Math.round(performance.now())}`;
 }
 
 /**
  * The single Tiptap component for the **PRD body** (ADR-0024), with `editable`
  * toggled by permission. Read mode renders `descriptionDoc` (lazily migrating a
  * legacy Markdown `description` on first load). Edit mode adds the Tier B
- * surface — selection bubble menu, `/` slash-command block menu, task lists,
- * code blocks, placeholder — with debounced autosave and an
- * optimistic-concurrency stale-write guard that prompts a reload rather than
- * clobbering a newer save.
+ * surface — bubble menu, `/` slash menu, task lists, code blocks, image
+ * paste/drop, placeholder — with debounced autosave and an optimistic-
+ * concurrency stale-write guard.
  *
- * The Markdown projection is derived here (`editor.storage.markdown`) and sent
- * alongside the JSON on save; the JSON stays canonical and the Markdown is never
- * read back into the editor.
+ * With `enableComments`, a workspace member can select text and pin a comment
+ * thread to it via a `comment` mark; the highlight stays glued to the words via
+ * ProseMirror position mapping, and the discussion panel lists reconciled
+ * threads (anchored vs orphaned). The Markdown projection is derived here and
+ * sent alongside the JSON on save; comment marks drop from it.
  */
 export function PrdDocument({
   featureId,
@@ -44,20 +60,32 @@ export function PrdDocument({
   description,
   docVersion = 0,
   editable = false,
+  enableComments = false,
 }: PrdDocumentProps) {
   const [doc, setDoc] = useState<JSONContent | null>(descriptionDoc);
   const migrationStarted = useRef(false);
   const contentLoaded = useRef(false);
 
-  // Version the next save must match. Updated from each save's response; never
-  // reset from props mid-edit (we don't refetch the body while editing).
   const versionRef = useRef(docVersion);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const conflictShown = useRef(false);
 
+  // Bumped on every doc change so thread reconciliation re-reads the live marks.
+  const [docTick, setDocTick] = useState(0);
+  const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
+  const [pending, setPending] = useState<{ threadId: string; quotedText: string } | null>(null);
+
+  const utils = api.useUtils();
   const initDescriptionDoc = api.product.feature.initDescriptionDoc.useMutation();
   const updateFeature = api.product.feature.update.useMutation();
+  const createComment = api.product.featureComment.create.useMutation();
   const imageHandlers = usePrdImageUpload(featureId);
+
+  const commentsQuery = api.product.featureComment.list.useQuery(
+    { featureId },
+    { enabled: enableComments },
+  );
+  const comments = (commentsQuery.data ?? []) as FeatureCommentRow[];
 
   // Resolve the document to render, migrating legacy Markdown once.
   useEffect(() => {
@@ -130,6 +158,7 @@ export function PrdDocument({
     content: doc ?? "",
     immediatelyRender: false,
     onUpdate: ({ editor: e }) => {
+      if (enableComments) setDocTick((t) => t + 1);
       if (!editable) return;
       if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => saveRef.current(e), 1000);
@@ -149,6 +178,19 @@ export function PrdDocument({
             handleDrop: imageHandlers.handleDrop,
           }
         : {}),
+      ...(enableComments
+        ? {
+            handleClick: (view, pos) => {
+              const mark = view.state.doc
+                .resolve(pos)
+                .marks()
+                .find((m) => m.type.name === "comment");
+              const threadId = mark?.attrs.threadId as string | undefined;
+              if (threadId) setActiveThreadId(threadId);
+              return false;
+            },
+          }
+        : {}),
     },
   });
 
@@ -160,43 +202,121 @@ export function PrdDocument({
     }
   }, [editor, doc]);
 
+  // Reconcile threads against the live document; include a pending (just-created,
+  // not-yet-saved) thread so its composer shows immediately.
+  const panelThreads: PanelThread[] = useMemo(() => {
+    const liveDoc = editor?.getJSON() ?? doc ?? null;
+    const reconciled: PanelThread[] = reconcileThreads<FeatureCommentRow>(
+      liveDoc,
+      comments,
+    );
+    if (pending && !reconciled.some((t) => t.threadId === pending.threadId)) {
+      return [
+        {
+          threadId: pending.threadId,
+          status: "anchored",
+          quotedText: pending.quotedText,
+          comments: [],
+        },
+        ...reconciled,
+      ];
+    }
+    return reconciled;
+    // docTick drives recompute as marks change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor, doc, comments, pending, docTick]);
+
+  const startComment = () => {
+    if (!editor) return;
+    const { from, to } = editor.state.selection;
+    if (from === to) {
+      notifications.show({
+        message: "Select some text to comment on.",
+        color: "yellow",
+      });
+      return;
+    }
+    const quotedText = editor.state.doc.textBetween(from, to, " ").slice(0, 1000);
+    const threadId = newThreadId();
+    editor.chain().focus().setMark("comment", { threadId }).run();
+    // Persist the mark right away so the thread is anchored on reload.
+    saveRef.current(editor);
+    setPending({ threadId, quotedText });
+    setActiveThreadId(threadId);
+  };
+
+  const submitComment = async (threadId: string, body: string) => {
+    const quotedText =
+      pending?.threadId === threadId ? pending.quotedText : undefined;
+    await createComment.mutateAsync({ featureId, threadId, body, quotedText });
+    setPending((p) => (p?.threadId === threadId ? null : p));
+    setActiveThreadId(threadId);
+    await utils.product.featureComment.list.invalidate({ featureId });
+  };
+
+  const commentsPanel = enableComments ? (
+    <PrdCommentsPanel
+      threads={panelThreads}
+      activeThreadId={activeThreadId}
+      pendingThreadId={pending?.threadId ?? null}
+      onSelect={setActiveThreadId}
+      onSubmit={submitComment}
+      isSubmitting={createComment.isPending}
+    />
+  ) : null;
+
+  let body: React.ReactNode;
   if (!editable && doc && isDocEmpty(doc)) {
-    return (
+    body = (
       <Text size="sm" className="text-text-muted">
         No description provided.
       </Text>
     );
-  }
-
-  if (!editable) {
-    return <EditorContent editor={editor} className="prd-document" />;
+  } else if (!editable) {
+    body = <EditorContent editor={editor} className="prd-document" />;
+  } else {
+    body = (
+      <RichTextEditor
+        editor={editor}
+        className="prd-document"
+        styles={{
+          root: { border: "none", backgroundColor: "transparent" },
+          content: { backgroundColor: "transparent", padding: 0 },
+        }}
+      >
+        {editor && (
+          <BubbleMenu editor={editor} tippyOptions={{ duration: 150 }}>
+            <RichTextEditor.ControlsGroup>
+              <RichTextEditor.Bold />
+              <RichTextEditor.Italic />
+              <RichTextEditor.Code />
+              <RichTextEditor.Link />
+              <RichTextEditor.H1 />
+              <RichTextEditor.H2 />
+              <RichTextEditor.H3 />
+              <RichTextEditor.BulletList />
+              <RichTextEditor.OrderedList />
+              {enableComments && (
+                <RichTextEditor.Control
+                  onClick={startComment}
+                  aria-label="Comment on selection"
+                  title="Comment on selection"
+                >
+                  <IconMessagePlus size={16} />
+                </RichTextEditor.Control>
+              )}
+            </RichTextEditor.ControlsGroup>
+          </BubbleMenu>
+        )}
+        <RichTextEditor.Content />
+      </RichTextEditor>
+    );
   }
 
   return (
-    <RichTextEditor
-      editor={editor}
-      className="prd-document"
-      styles={{
-        root: { border: "none", backgroundColor: "transparent" },
-        content: { backgroundColor: "transparent", padding: 0 },
-      }}
-    >
-      {editor && (
-        <BubbleMenu editor={editor} tippyOptions={{ duration: 150 }}>
-          <RichTextEditor.ControlsGroup>
-            <RichTextEditor.Bold />
-            <RichTextEditor.Italic />
-            <RichTextEditor.Code />
-            <RichTextEditor.Link />
-            <RichTextEditor.H1 />
-            <RichTextEditor.H2 />
-            <RichTextEditor.H3 />
-            <RichTextEditor.BulletList />
-            <RichTextEditor.OrderedList />
-          </RichTextEditor.ControlsGroup>
-        </BubbleMenu>
-      )}
-      <RichTextEditor.Content />
-    </RichTextEditor>
+    <Stack gap="lg">
+      {body}
+      {commentsPanel}
+    </Stack>
   );
 }

--- a/src/app/_components/prd/PrdDocument.tsx
+++ b/src/app/_components/prd/PrdDocument.tsx
@@ -239,7 +239,11 @@ export function PrdDocument({
     const quotedText = editor.state.doc.textBetween(from, to, " ").slice(0, 1000);
     const threadId = newThreadId();
     editor.chain().focus().setMark("comment", { threadId }).run();
-    // Persist the mark right away so the thread is anchored on reload.
+    // setMark's onUpdate scheduled a debounced autosave; cancel it so we don't
+    // fire two concurrent saves with the same baseVersion (which can race into a
+    // spurious stale-write conflict). Persist the mark right away instead so the
+    // thread is anchored on reload.
+    if (debounceRef.current) clearTimeout(debounceRef.current);
     saveRef.current(editor);
     setPending({ threadId, quotedText });
     setActiveThreadId(threadId);

--- a/src/lib/prd/__tests__/thread-reconciliation.test.ts
+++ b/src/lib/prd/__tests__/thread-reconciliation.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import type { JSONContent } from "@tiptap/core";
+
+import {
+  reconcileThreads,
+  collectAnchoredThreadIds,
+  type ReconcilableComment,
+} from "../thread-reconciliation";
+
+function comment(
+  over: Partial<ReconcilableComment> & { id: string; threadId: string | null },
+): ReconcilableComment {
+  return {
+    parentId: null,
+    quotedText: null,
+    resolvedAt: null,
+    ...over,
+  };
+}
+
+/** A doc with `text` carrying a comment mark for `threadId`. */
+function docWithThread(threadId: string, text = "anchored"): JSONContent {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "before " },
+          {
+            type: "text",
+            text,
+            marks: [{ type: "comment", attrs: { threadId } }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("collectAnchoredThreadIds", () => {
+  it("finds threadIds on comment marks, nested anywhere", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "text",
+                      text: "x",
+                      marks: [{ type: "comment", attrs: { threadId: "t1" } }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(collectAnchoredThreadIds(doc)).toEqual(new Set(["t1"]));
+  });
+
+  it("returns empty for null/empty docs", () => {
+    expect(collectAnchoredThreadIds(null)).toEqual(new Set());
+    expect(collectAnchoredThreadIds({ type: "doc", content: [] })).toEqual(
+      new Set(),
+    );
+  });
+});
+
+describe("reconcileThreads", () => {
+  it("marks a thread anchored when its mark is present", () => {
+    const doc = docWithThread("t1");
+    const comments = [comment({ id: "c1", threadId: "t1", quotedText: "anchored" })];
+    const [thread] = reconcileThreads(doc, comments);
+    expect(thread?.status).toBe("anchored");
+    expect(thread?.anchored).toBe(true);
+  });
+
+  it("marks a thread orphaned (and surfaces quotedText) when the mark is gone", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "edited away" }] }],
+    };
+    const comments = [
+      comment({ id: "c1", threadId: "t1", quotedText: "the original words" }),
+    ];
+    const [thread] = reconcileThreads(doc, comments);
+    expect(thread?.status).toBe("orphaned");
+    expect(thread?.anchored).toBe(false);
+    expect(thread?.quotedText).toBe("the original words");
+  });
+
+  it("classifies multiple threads in one doc independently", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "still here",
+              marks: [{ type: "comment", attrs: { threadId: "t1" } }],
+            },
+            { type: "text", text: " and gone" },
+          ],
+        },
+      ],
+    };
+    const comments = [
+      comment({ id: "a", threadId: "t1" }),
+      comment({ id: "b", threadId: "t2", quotedText: "deleted span" }),
+    ];
+    const byId = Object.fromEntries(
+      reconcileThreads(doc, comments).map((t) => [t.threadId, t.status]),
+    );
+    expect(byId.t1).toBe("anchored");
+    expect(byId.t2).toBe("orphaned");
+  });
+
+  it("groups replies under their thread and picks the parentless root", () => {
+    const doc = docWithThread("t1");
+    const comments = [
+      comment({ id: "root", threadId: "t1", quotedText: "anchored" }),
+      comment({ id: "reply", threadId: "t1", parentId: "root" }),
+    ];
+    const [thread] = reconcileThreads(doc, comments);
+    expect(thread?.comments).toHaveLength(2);
+    expect(thread?.root.id).toBe("root");
+  });
+
+  it("treats a resolved root as resolved regardless of anchoring", () => {
+    const doc = docWithThread("t1");
+    const comments = [
+      comment({
+        id: "root",
+        threadId: "t1",
+        resolvedAt: new Date("2026-06-18T00:00:00Z"),
+      }),
+    ];
+    const [thread] = reconcileThreads(doc, comments);
+    expect(thread?.status).toBe("resolved");
+  });
+
+  it("ignores doc-level (null threadId) comments", () => {
+    const threads = reconcileThreads(docWithThread("t1"), [
+      comment({ id: "c1", threadId: null }),
+    ]);
+    expect(threads).toHaveLength(0);
+  });
+});

--- a/src/lib/prd/thread-reconciliation.ts
+++ b/src/lib/prd/thread-reconciliation.ts
@@ -1,0 +1,100 @@
+import type { JSONContent } from "@tiptap/core";
+
+/**
+ * Thread reconciliation — the pure classifier that reconciles the PRD document
+ * against its {@link FeatureComment} rows (ADR-0024 §Modules). A comment thread
+ * is one of:
+ *
+ *  - **anchored** — its `comment` mark is still present in the document, so the
+ *    highlight is glued to live text.
+ *  - **orphaned** — the marked text was deleted; the mark is gone. The thread is
+ *    kept (never lost) and rendered from its `quotedText` snapshot.
+ *  - **resolved** — explicitly settled (`resolvedAt` set); collapsed and its
+ *    highlight hidden. Resolution wins over anchored/orphaned.
+ *
+ * Pure and DOM-free: it walks the ProseMirror JSON for `comment` marks and
+ * groups the rows, so it is unit-testable in isolation and reusable on client
+ * and server.
+ */
+export type ThreadStatus = "anchored" | "orphaned" | "resolved";
+
+export interface ReconcilableComment {
+  id: string;
+  threadId: string | null;
+  parentId: string | null;
+  quotedText: string | null;
+  resolvedAt: Date | null;
+}
+
+export interface ReconciledThread<C extends ReconcilableComment> {
+  threadId: string;
+  status: ThreadStatus;
+  /** Whether the comment mark is still present in the document. */
+  anchored: boolean;
+  /** Snapshot of the originally-selected text (for orphan rendering). */
+  quotedText: string | null;
+  /** Root comment (no parent) plus its replies, in input order. */
+  comments: C[];
+  root: C;
+}
+
+/** Collect every `threadId` referenced by a `comment` mark in the document. */
+export function collectAnchoredThreadIds(
+  doc: JSONContent | null | undefined,
+): Set<string> {
+  const ids = new Set<string>();
+  const walk = (node: JSONContent | undefined) => {
+    if (!node) return;
+    if (node.marks) {
+      for (const mark of node.marks) {
+        if (mark.type === "comment") {
+          const threadId = (mark.attrs as { threadId?: unknown } | undefined)
+            ?.threadId;
+          if (typeof threadId === "string" && threadId) ids.add(threadId);
+        }
+      }
+    }
+    if (node.content) {
+      for (const child of node.content) walk(child);
+    }
+  };
+  walk(doc ?? undefined);
+  return ids;
+}
+
+export function reconcileThreads<C extends ReconcilableComment>(
+  doc: JSONContent | null | undefined,
+  comments: C[],
+): ReconciledThread<C>[] {
+  const anchoredIds = collectAnchoredThreadIds(doc);
+
+  const groups = new Map<string, C[]>();
+  for (const comment of comments) {
+    if (!comment.threadId) continue; // doc-level comments are a future concern
+    const arr = groups.get(comment.threadId) ?? [];
+    arr.push(comment);
+    groups.set(comment.threadId, arr);
+  }
+
+  const result: ReconciledThread<C>[] = [];
+  for (const [threadId, group] of groups) {
+    const root = group.find((c) => !c.parentId) ?? group[0];
+    if (!root) continue;
+    const anchored = anchoredIds.has(threadId);
+    const resolved = group.some((c) => !c.parentId && c.resolvedAt != null);
+    const status: ThreadStatus = resolved
+      ? "resolved"
+      : anchored
+        ? "anchored"
+        : "orphaned";
+    result.push({
+      threadId,
+      status,
+      anchored,
+      quotedText: root.quotedText,
+      comments: group,
+      root,
+    });
+  }
+  return result;
+}

--- a/src/plugins/product/server/routers/__tests__/featureComment.integration.test.ts
+++ b/src/plugins/product/server/routers/__tests__/featureComment.integration.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestDb } from "~/test/test-db";
+import { createTestCaller } from "~/test/trpc-helpers";
+import {
+  createUser,
+  createWorkspace,
+  createProduct,
+  createFeature,
+} from "~/test/factories";
+
+async function setupFeature() {
+  const db = getTestDb();
+  const user = await createUser(db);
+  const ws = await createWorkspace(db, { ownerId: user.id });
+  const product = await createProduct(db, {
+    workspaceId: ws.id,
+    createdById: user.id,
+  });
+  const feature = await createFeature(db, {
+    productId: product.id,
+    createdById: user.id,
+  });
+  return { db, user, ws, product, feature };
+}
+
+describe("featureComment router", () => {
+  beforeEach(() => {
+    getTestDb();
+  });
+
+  it("creates an anchored comment and lists it with its author", async () => {
+    const { user, feature } = await setupFeature();
+    const caller = createTestCaller(user.id);
+
+    const created = await caller.product.featureComment.create({
+      featureId: feature.id,
+      threadId: "thread-1",
+      body: "This sentence needs work.",
+      quotedText: "the original words",
+    });
+
+    expect(created.threadId).toBe("thread-1");
+    expect(created.quotedText).toBe("the original words");
+    expect(created.createdBy.id).toBe(user.id);
+
+    const list = await caller.product.featureComment.list({
+      featureId: feature.id,
+    });
+    expect(list).toHaveLength(1);
+    expect(list[0]?.body).toBe("This sentence needs work.");
+    expect(list[0]?.createdBy.name).toBe(user.name);
+  });
+
+  it("supports a doc-level comment (null threadId)", async () => {
+    const { user, feature } = await setupFeature();
+    const caller = createTestCaller(user.id);
+
+    const created = await caller.product.featureComment.create({
+      featureId: feature.id,
+      body: "Overall this looks good.",
+    });
+    expect(created.threadId).toBeNull();
+  });
+
+  it("groups multiple comments under one thread (list returns all)", async () => {
+    const { user, feature } = await setupFeature();
+    const caller = createTestCaller(user.id);
+
+    await caller.product.featureComment.create({
+      featureId: feature.id,
+      threadId: "t-shared",
+      body: "first",
+      quotedText: "span",
+    });
+    await caller.product.featureComment.create({
+      featureId: feature.id,
+      threadId: "t-shared",
+      body: "second",
+    });
+
+    const list = await caller.product.featureComment.list({
+      featureId: feature.id,
+    });
+    const inThread = list.filter((c) => c.threadId === "t-shared");
+    expect(inThread).toHaveLength(2);
+  });
+
+  it("denies a non-member from commenting or listing", async () => {
+    const { db, feature } = await setupFeature();
+    const outsider = await createUser(db);
+    const caller = createTestCaller(outsider.id);
+
+    await expect(
+      caller.product.featureComment.create({
+        featureId: feature.id,
+        body: "I shouldn't be able to post this.",
+      }),
+    ).rejects.toThrow();
+
+    await expect(
+      caller.product.featureComment.list({ featureId: feature.id }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -26,9 +26,10 @@ const scopeStatusEnum = z.enum([
 ]);
 
 /**
- * Load a feature and verify workspace membership via its product.
+ * Load a feature and verify workspace membership via its product. Shared with
+ * the featureComment router so comments reuse the exact same access gate.
  */
-async function loadFeatureWithAccess(
+export async function loadFeatureWithAccess(
   db: PrismaClient,
   userId: string,
   featureId: string,

--- a/src/plugins/product/server/routers/featureComment.ts
+++ b/src/plugins/product/server/routers/featureComment.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
+import { loadFeatureWithAccess } from "./feature";
+
+const authorSelect = {
+  id: true,
+  name: true,
+  image: true,
+} as const;
+
+/**
+ * Comments on a PRD body (ADR-0024). Anchored comments carry a `threadId` that
+ * matches a `comment` mark in `Feature.descriptionDoc`; doc-level comments leave
+ * `threadId` null. Bodies are Markdown (ADR-0017). Every procedure reuses the
+ * same `loadFeatureWithAccess` workspace-member gate that `feature.update` uses —
+ * editing the body and commenting share one access path.
+ *
+ * This slice ships `list` + `create`; threaded `reply`, `resolve`, and
+ * `unresolve` arrive in the polish slice.
+ */
+export const featureCommentRouter = createTRPCRouter({
+  list: protectedProcedure
+    .input(z.object({ featureId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      await loadFeatureWithAccess(ctx.db, ctx.session.user.id, input.featureId);
+
+      return ctx.db.featureComment.findMany({
+        where: { featureId: input.featureId },
+        include: { createdBy: { select: authorSelect } },
+        orderBy: { createdAt: "asc" },
+      });
+    }),
+
+  create: protectedProcedure
+    .input(
+      z.object({
+        featureId: z.string(),
+        threadId: z.string().min(1).optional(),
+        body: boundedText("Comment", TEXT_LIMITS.LARGE, { min: 1 }),
+        quotedText: boundedText("Quoted text", TEXT_LIMITS.LARGE).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await loadFeatureWithAccess(ctx.db, ctx.session.user.id, input.featureId);
+
+      return ctx.db.featureComment.create({
+        data: {
+          featureId: input.featureId,
+          threadId: input.threadId,
+          body: input.body,
+          quotedText: input.quotedText,
+          createdById: ctx.session.user.id,
+        },
+        include: { createdBy: { select: authorSelect } },
+      });
+    }),
+});

--- a/src/plugins/product/server/routers/index.ts
+++ b/src/plugins/product/server/routers/index.ts
@@ -1,6 +1,7 @@
 import { createTRPCRouter } from "~/server/api/trpc";
 import { productRouter } from "./product";
 import { featureRouter } from "./feature";
+import { featureCommentRouter } from "./featureComment";
 import { ticketRouter } from "./ticket";
 import { researchRouter } from "./research";
 import { cycleRouter } from "./cycle";
@@ -11,6 +12,7 @@ import { problemRouter } from "./problem";
 export const productPluginRouter = createTRPCRouter({
   product: productRouter,
   feature: featureRouter,
+  featureComment: featureCommentRouter,
   ticket: ticketRouter,
   research: researchRouter,
   insight: insightRouter,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2157,3 +2157,19 @@
   background: var(--color-bg-hover);
   color: var(--color-text-primary);
 }
+
+/* PRD body anchored comments (ADR-0024) — highlight glued to the marked words */
+.prd-comment-highlight {
+  background-color: color-mix(in srgb, var(--color-brand-warning) 22%, transparent);
+  border-bottom: 2px solid
+    color-mix(in srgb, var(--color-brand-warning) 55%, transparent);
+  border-radius: 2px;
+  cursor: pointer;
+  transition: background-color 120ms;
+}
+.prd-comment-highlight:hover {
+  background-color: color-mix(in srgb, var(--color-brand-warning) 38%, transparent);
+}
+.prd-document img.prd-image {
+  margin: 0.5rem 0;
+}


### PR DESCRIPTION
## What

The core of the feature (ADR-0024). A workspace member selects text in the PRD body, leaves a comment pinned to those words, and the highlight stays glued to the text as it's edited. Create + view a thread (replies/resolve come in the polish slice). Builds on the editable editor (#230).

- **`comment` mark** (introduced read-side in #229) applied to the selection via a **Comment** button in the bubble menu; it lives in `descriptionDoc` and moves with the text via ProseMirror position mapping. Persisted immediately on create so the anchor survives reload.
- **`FeatureComment` model** keyed by `threadId` (`parentId` self-relation for replies, `body` Markdown, `quotedText` snapshot, `resolvedAt`) + additive migration. **`featureComment`** router (`create`, `list`) gated by the shared `loadFeatureWithAccess` workspace-member check.
- **Thread reconciliation** (`src/lib/prd/thread-reconciliation.ts`, pure + 8 unit tests): classifies each thread **anchored** (mark present) vs **orphaned** (mark gone → falls back to `quotedText`); `resolved` is wired for the next slice.
- **Discussion panel** reusing `CommentInput`/`CommentThread`: click a highlight to open its thread; orphaned threads render from their quoted text. Comment bodies stay Markdown (@mentions render via `MarkdownRenderer`).

## Acceptance criteria

- [x] Selecting text and choosing Comment creates a highlighted thread anchored to that span
- [x] The highlight stays on the same words after the body is edited (ProseMirror mark mapping)
- [x] Comments persist (`FeatureComment`) and are listed in a thread panel; @mentions render
- [x] A non-member is read-only; any workspace member can comment (shared access gate, integration-tested)
- [x] A thread whose marked text is deleted renders as an orphan using `quotedText`
- [x] Thread-reconciliation unit tests + `featureComment` router integration tests pass (4/4 vs real DB); `tsc`/ESLint clean; full unit suite 863

---

Ships: violet.olive (Exponential ticket `cmqjs7zl4000nlb048j7ccgax`)