### PR TITLE
fix: WhatsApp groups card reports gateway errors honestly

### DIFF
--- a/src/app/_components/home/activity/WhatsAppGroupsPanel.tsx
+++ b/src/app/_components/home/activity/WhatsAppGroupsPanel.tsx
@@ -164,7 +164,21 @@ export function WhatsAppGroupsPanel() {
         </div>
       ) : null}
 
-      {connected ? (
+      {!connected ? (
+        <p className="wsa-card__caption" style={{ marginTop: 4 }}>
+          {groupsLoading
+            ? 'Checking WhatsApp connection…'
+            : 'Connect WhatsApp to link groups to this workspace.'}
+        </p>
+      ) : gateway?.groupsError ? (
+        // Connected, but the gateway couldn't return the group list. Show why
+        // rather than implying you're disconnected.
+        <p className="wsa-card__caption" style={{ marginTop: 4 }}>
+          Connected{gateway.phoneNumber ? ` as ${gateway.phoneNumber}` : ''}, but
+          couldn&apos;t load groups ({gateway.groupsError}). The WhatsApp gateway
+          may need redeploying.
+        </p>
+      ) : (
         <Select
           size="xs"
           placeholder="Search WhatsApp groups…"
@@ -179,12 +193,6 @@ export function WhatsAppGroupsPanel() {
             groupsLoading ? 'Loading groups…' : 'No more groups to link'
           }
         />
-      ) : (
-        <p className="wsa-card__caption" style={{ marginTop: 4 }}>
-          {groupsLoading
-            ? 'Checking WhatsApp connection…'
-            : 'Connect WhatsApp to link groups to this workspace.'}
-        </p>
       )}
     </section>
   );

--- a/src/server/api/routers/whatsappGateway.ts
+++ b/src/server/api/routers/whatsappGateway.ts
@@ -233,18 +233,34 @@ export const whatsappGatewayRouter = createTRPCRouter({
   // list (never throws) when the gateway is unconfigured, no session is
   // connected, or the gateway call fails — the card renders a connect hint.
   getGroups: protectedProcedure.query(async ({ ctx }) => {
-    if (!WHATSAPP_GATEWAY_URL) {
-      return { configured: false, connected: false, groups: [] as WhatsAppGroup[] };
-    }
+    const empty = {
+      configured: false,
+      connected: false,
+      phoneNumber: null as string | null,
+      groups: [] as WhatsAppGroup[],
+      groupsError: null as string | null,
+    };
 
+    if (!WHATSAPP_GATEWAY_URL) return empty;
+
+    // `connected` reflects the user's CONNECTED gateway session (same source
+    // the WhatsApp Connection modal trusts via `listSessions`) — NOT whether
+    // the live group fetch succeeds. A failed fetch is reported separately in
+    // `groupsError` so the card never claims "not connected" when you are.
     const session = await ctx.db.whatsAppGatewaySession.findFirst({
       where: { userId: ctx.session.user.id, status: "CONNECTED" },
       orderBy: { connectedAt: "desc" },
     });
 
-    if (!session) {
-      return { configured: true, connected: false, groups: [] as WhatsAppGroup[] };
-    }
+    if (!session) return { ...empty, configured: true };
+
+    const base = {
+      configured: true,
+      connected: true,
+      phoneNumber: session.phoneNumber,
+      groups: [] as WhatsAppGroup[],
+      groupsError: null as string | null,
+    };
 
     const authToken = generateJWT(ctx.session.user, {
       tokenType: "whatsapp-gateway",
@@ -257,20 +273,24 @@ export const whatsappGatewayRouter = createTRPCRouter({
       );
 
       if (!response.ok) {
-        // 503 = session not connected to WhatsApp; treat as "not connected".
-        console.error("[whatsappGateway] getGroups failed:", response.status);
-        return { configured: true, connected: false, groups: [] as WhatsAppGroup[] };
+        const body = await response.text().catch(() => "");
+        // A 404 here usually means the deployed gateway predates the
+        // `GET /sessions/{id}/groups` route (needs a `railway up`); 503 means
+        // the live socket isn't connected. Surface it instead of hiding it.
+        const groupsError = `gateway ${response.status}${
+          body ? `: ${body.slice(0, 200)}` : ""
+        }`;
+        console.error("[whatsappGateway] getGroups failed:", groupsError);
+        return { ...base, groupsError };
       }
 
       const data = (await response.json()) as { groups?: WhatsAppGroup[] };
-      return {
-        configured: true,
-        connected: true,
-        groups: data.groups ?? [],
-      };
+      return { ...base, groups: data.groups ?? [] };
     } catch (error) {
-      console.error("[whatsappGateway] getGroups error:", error);
-      return { configured: true, connected: false, groups: [] as WhatsAppGroup[] };
+      const groupsError =
+        error instanceof Error ? error.message : String(error);
+      console.error("[whatsappGateway] getGroups error:", groupsError);
+      return { ...base, groupsError };
     }
   }),
 


### PR DESCRIPTION
## Problem

The new WhatsApp Groups card showed **"Connect WhatsApp"** even when a session is clearly **CONNECTED** (confirmed via the WhatsApp Connection modal). Root cause: `whatsappGateway.getGroups` collapsed *every* failure of the live gateway group-fetch into `connected: false` — so a connected user whose gateway call 404s/503s looked disconnected.

The likely real trigger: the deployed WhatsApp gateway predates the `GET /sessions/{id}/groups` route (added 2026-06-15; the gateway doesn't auto-deploy — needs `railway up`), so the fetch 404s.

## Fix

- `getGroups` now derives **`connected`** from the user's `CONNECTED` `WhatsAppGatewaySession` (the same source `listSessions`/the modal trust), and reports a failed live fetch separately in **`groupsError`** (HTTP status + body snippet) plus `phoneNumber`.
- The card:
  - `connected` + groups → the picker (unchanged).
  - `connected` + `groupsError` → "Connected as `<phone>`, but couldn't load groups (`gateway 404…`). The WhatsApp gateway may need redeploying." — diagnosable instead of mislabeled.
  - not connected → the connect hint (unchanged).

This makes the gateway state visible so we can tell "you're not connected" apart from "the gateway build is missing the groups route."

## Note

If this confirms a `gateway 404`, the deployed mastra gateway needs a `railway up` to pick up the `/sessions/{id}/groups` route (and the channel-summarizer from mastra PR #35).

Refs: thick.salmon