### PR TITLE
feat(prd): comment threads polish — replies, resolve/unresolve, orphan rendering

### DIFF
--- a/src/app/_components/prd/PrdCommentsPanel.tsx
+++ b/src/app/_components/prd/PrdCommentsPanel.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { Badge, Paper, Stack, Text } from "@mantine/core";
+import { useState } from "react";
+import { Badge, Button, Paper, Stack, Text } from "@mantine/core";
+import { IconCheck, IconArrowBackUp } from "@tabler/icons-react";
 import { CommentInput } from "~/app/_components/shared/CommentInput";
 import { CommentThread, type Comment } from "~/app/_components/shared/CommentThread";
 import type {
@@ -29,6 +31,8 @@ interface PrdCommentsPanelProps {
   pendingThreadId: string | null;
   onSelect: (threadId: string) => void;
   onSubmit: (threadId: string, body: string) => Promise<void>;
+  onResolve: (threadId: string) => Promise<void>;
+  onUnresolve: (threadId: string) => Promise<void>;
   currentUserId?: string;
   isSubmitting?: boolean;
 }
@@ -43,11 +47,11 @@ function toThreadComments(rows: FeatureCommentRow[]): Comment[] {
 }
 
 /**
- * Discussion panel for the PRD body (ADR-0024). Lists reconciled comment threads
- * — anchored (highlight live in the doc) and orphaned (anchor deleted, rendered
- * from `quotedText`) — and lets a member open one to read it and add a comment.
- * Replies, resolve/unresolve, and resolved-thread hiding land in the polish
- * slice; here a thread is its root comment(s).
+ * Discussion panel for the PRD body (ADR-0024). Lists reconciled threads —
+ * anchored, orphaned (rendered from `quotedText`), and resolved — with threaded
+ * replies and resolve/unresolve. Resolved threads are hidden behind a toggle and
+ * never deleted, so a settled discussion stays out of the way but is always
+ * retrievable and reopenable.
  */
 export function PrdCommentsPanel({
   threads,
@@ -55,74 +59,136 @@ export function PrdCommentsPanel({
   pendingThreadId,
   onSelect,
   onSubmit,
+  onResolve,
+  onUnresolve,
   currentUserId,
   isSubmitting = false,
 }: PrdCommentsPanelProps) {
-  const visible = threads.filter((t) => t.status !== "resolved");
+  const [showResolved, setShowResolved] = useState(false);
+
+  const open = threads.filter((t) => t.status !== "resolved");
+  const resolved = threads.filter((t) => t.status === "resolved");
+  const visible = showResolved ? [...open, ...resolved] : open;
+
+  const renderThread = (thread: PanelThread) => {
+    const isResolved = thread.status === "resolved";
+    const isActive =
+      thread.threadId === activeThreadId || thread.threadId === pendingThreadId;
+    const root = thread.comments.find((c) => !c.parentId);
+    const rootRows = root ? [root] : [];
+    const replyRows = thread.comments.filter((c) => c.parentId);
+
+    return (
+      <Paper
+        key={thread.threadId}
+        withBorder
+        radius="md"
+        p="sm"
+        className={`bg-surface-secondary cursor-pointer ${
+          isActive ? "border-border-focus" : ""
+        } ${isResolved ? "opacity-70" : ""}`}
+        onClick={() => onSelect(thread.threadId)}
+        data-thread-card={thread.threadId}
+      >
+        <div className="flex items-center justify-between gap-2 mb-2">
+          {thread.quotedText ? (
+            <Text size="xs" className="text-text-muted italic truncate">
+              “{thread.quotedText}”
+            </Text>
+          ) : (
+            <span />
+          )}
+          <div className="flex items-center gap-1 shrink-0">
+            {thread.status === "orphaned" && (
+              <Badge size="xs" variant="light" color="gray">
+                orphaned
+              </Badge>
+            )}
+            {isResolved ? (
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                color="gray"
+                leftSection={<IconArrowBackUp size={13} />}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void onUnresolve(thread.threadId);
+                }}
+              >
+                Reopen
+              </Button>
+            ) : (
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                color="teal"
+                leftSection={<IconCheck size={13} />}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void onResolve(thread.threadId);
+                }}
+              >
+                Resolve
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <CommentThread
+          comments={toThreadComments(rootRows)}
+          currentUserId={currentUserId}
+          variant="inline"
+          emptyMessage={null}
+        />
+
+        {replyRows.length > 0 && (
+          <div className="mt-2 ml-3 border-l border-border-primary pl-3">
+            <CommentThread
+              comments={toThreadComments(replyRows)}
+              currentUserId={currentUserId}
+              variant="inline"
+              emptyMessage={null}
+            />
+          </div>
+        )}
+
+        {isActive && !isResolved && (
+          <div className="mt-2" onClick={(e) => e.stopPropagation()}>
+            <CommentInput
+              placeholder={rootRows.length === 0 ? "Comment…" : "Reply…"}
+              isSubmitting={isSubmitting}
+              onSubmit={(body) => onSubmit(thread.threadId, body)}
+            />
+          </div>
+        )}
+      </Paper>
+    );
+  };
 
   return (
     <div>
-      <Text size="xs" fw={600} className="text-text-muted uppercase tracking-wider mb-2">
-        Discussion {visible.length > 0 ? `(${visible.length})` : ""}
-      </Text>
+      <div className="flex items-center justify-between mb-2">
+        <Text size="xs" fw={600} className="text-text-muted uppercase tracking-wider">
+          Discussion {open.length > 0 ? `(${open.length})` : ""}
+        </Text>
+        {resolved.length > 0 && (
+          <Button
+            size="compact-xs"
+            variant="subtle"
+            color="gray"
+            onClick={() => setShowResolved((s) => !s)}
+          >
+            {showResolved ? "Hide" : "Show"} resolved ({resolved.length})
+          </Button>
+        )}
+      </div>
 
       {visible.length === 0 && !pendingThreadId ? (
         <Text size="xs" className="text-text-muted">
           Select text in the body and choose Comment to start a thread.
         </Text>
       ) : (
-        <Stack gap="sm">
-          {visible.map((thread) => {
-            const isActive =
-              thread.threadId === activeThreadId ||
-              thread.threadId === pendingThreadId;
-            return (
-              <Paper
-                key={thread.threadId}
-                withBorder
-                radius="md"
-                p="sm"
-                className={`bg-surface-secondary cursor-pointer ${
-                  isActive ? "border-border-focus" : ""
-                }`}
-                onClick={() => onSelect(thread.threadId)}
-                data-thread-card={thread.threadId}
-              >
-                <div className="flex items-center justify-between gap-2 mb-2">
-                  {thread.quotedText ? (
-                    <Text size="xs" className="text-text-muted italic truncate">
-                      “{thread.quotedText}”
-                    </Text>
-                  ) : (
-                    <span />
-                  )}
-                  {thread.status === "orphaned" && (
-                    <Badge size="xs" variant="light" color="gray">
-                      orphaned
-                    </Badge>
-                  )}
-                </div>
-
-                <CommentThread
-                  comments={toThreadComments(thread.comments)}
-                  currentUserId={currentUserId}
-                  variant="inline"
-                  emptyMessage={null}
-                />
-
-                {isActive && (
-                  <div className="mt-2" onClick={(e) => e.stopPropagation()}>
-                    <CommentInput
-                      placeholder="Reply…"
-                      isSubmitting={isSubmitting}
-                      onSubmit={(body) => onSubmit(thread.threadId, body)}
-                    />
-                  </div>
-                )}
-              </Paper>
-            );
-          })}
-        </Stack>
+        <Stack gap="sm">{visible.map(renderThread)}</Stack>
       )}
     </div>
   );

--- a/src/app/_components/prd/PrdDocument.tsx
+++ b/src/app/_components/prd/PrdDocument.tsx
@@ -13,6 +13,10 @@ import { buildPrdExtensions } from "~/lib/prd/extensions";
 import { SlashCommand } from "~/lib/prd/slash-command";
 import { markdownToDoc, EMPTY_DOC, isDocEmpty } from "~/lib/prd/codec";
 import { reconcileThreads } from "~/lib/prd/thread-reconciliation";
+import {
+  CommentResolution,
+  setResolvedThreadIds,
+} from "~/lib/prd/comment-resolution";
 import { usePrdImageUpload } from "~/hooks/usePrdImageUpload";
 import {
   PrdCommentsPanel,
@@ -79,13 +83,19 @@ export function PrdDocument({
   const initDescriptionDoc = api.product.feature.initDescriptionDoc.useMutation();
   const updateFeature = api.product.feature.update.useMutation();
   const createComment = api.product.featureComment.create.useMutation();
+  const replyComment = api.product.featureComment.reply.useMutation();
+  const resolveThread = api.product.featureComment.resolve.useMutation();
+  const unresolveThread = api.product.featureComment.unresolve.useMutation();
   const imageHandlers = usePrdImageUpload(featureId);
 
   const commentsQuery = api.product.featureComment.list.useQuery(
     { featureId },
     { enabled: enableComments },
   );
-  const comments = (commentsQuery.data ?? []) as FeatureCommentRow[];
+  const comments = useMemo(
+    () => (commentsQuery.data ?? []) as FeatureCommentRow[],
+    [commentsQuery.data],
+  );
 
   // Resolve the document to render, migrating legacy Markdown once.
   useEffect(() => {
@@ -152,9 +162,11 @@ export function PrdDocument({
 
   const editor = useEditor({
     editable,
-    extensions: editable
-      ? [...buildPrdExtensions(), SlashCommand]
-      : buildPrdExtensions(),
+    extensions: [
+      ...buildPrdExtensions(),
+      ...(enableComments ? [CommentResolution] : []),
+      ...(editable ? [SlashCommand] : []),
+    ],
     content: doc ?? "",
     immediatelyRender: false,
     onUpdate: ({ editor: e }) => {
@@ -201,6 +213,18 @@ export function PrdDocument({
       editor.commands.setContent(doc);
     }
   }, [editor, doc]);
+
+  // Push the set of resolved threads to the editor so their highlights hide.
+  useEffect(() => {
+    if (!editor || !enableComments) return;
+    const resolved = new Set(
+      comments
+        .filter((c) => !c.parentId && c.resolvedAt != null)
+        .map((c) => c.threadId)
+        .filter((t): t is string => !!t),
+    );
+    setResolvedThreadIds(editor, resolved);
+  }, [editor, comments, enableComments]);
 
   // Reconcile threads against the live document; include a pending (just-created,
   // not-yet-saved) thread so its composer shows immediately.
@@ -250,11 +274,36 @@ export function PrdDocument({
   };
 
   const submitComment = async (threadId: string, body: string) => {
-    const quotedText =
-      pending?.threadId === threadId ? pending.quotedText : undefined;
-    await createComment.mutateAsync({ featureId, threadId, body, quotedText });
-    setPending((p) => (p?.threadId === threadId ? null : p));
+    if (pending?.threadId === threadId) {
+      // First comment on a brand-new thread → create the root (carries quotedText).
+      await createComment.mutateAsync({
+        featureId,
+        threadId,
+        body,
+        quotedText: pending.quotedText,
+      });
+      setPending((p) => (p?.threadId === threadId ? null : p));
+    } else {
+      // Existing thread → threaded reply hanging off its root.
+      const thread = panelThreads.find((t) => t.threadId === threadId);
+      const root = thread?.comments.find((c) => !c.parentId) ?? thread?.comments[0];
+      if (root) {
+        await replyComment.mutateAsync({ parentId: root.id, body });
+      } else {
+        await createComment.mutateAsync({ featureId, threadId, body });
+      }
+    }
     setActiveThreadId(threadId);
+    await utils.product.featureComment.list.invalidate({ featureId });
+  };
+
+  const handleResolve = async (threadId: string) => {
+    await resolveThread.mutateAsync({ featureId, threadId });
+    await utils.product.featureComment.list.invalidate({ featureId });
+  };
+
+  const handleUnresolve = async (threadId: string) => {
+    await unresolveThread.mutateAsync({ featureId, threadId });
     await utils.product.featureComment.list.invalidate({ featureId });
   };
 
@@ -265,7 +314,11 @@ export function PrdDocument({
       pendingThreadId={pending?.threadId ?? null}
       onSelect={setActiveThreadId}
       onSubmit={submitComment}
-      isSubmitting={createComment.isPending}
+      onResolve={handleResolve}
+      onUnresolve={handleUnresolve}
+      isSubmitting={
+        createComment.isPending || replyComment.isPending
+      }
     />
   ) : null;
 

--- a/src/lib/prd/__tests__/thread-reconciliation.test.ts
+++ b/src/lib/prd/__tests__/thread-reconciliation.test.ts
@@ -151,6 +151,24 @@ describe("reconcileThreads", () => {
     expect(thread?.status).toBe("resolved");
   });
 
+  it("treats a resolved thread as resolved even when its anchor was deleted", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "gone" }] }],
+    };
+    const comments = [
+      comment({
+        id: "root",
+        threadId: "t1",
+        quotedText: "deleted span",
+        resolvedAt: new Date("2026-06-18T00:00:00Z"),
+      }),
+    ];
+    const [thread] = reconcileThreads(doc, comments);
+    expect(thread?.status).toBe("resolved");
+    expect(thread?.anchored).toBe(false);
+  });
+
   it("ignores doc-level (null threadId) comments", () => {
     const threads = reconcileThreads(docWithThread("t1"), [
       comment({ id: "c1", threadId: null }),

--- a/src/lib/prd/comment-resolution.ts
+++ b/src/lib/prd/comment-resolution.ts
@@ -1,0 +1,61 @@
+import { Extension, type Editor } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+/**
+ * Hides the highlight of **resolved** comment threads without touching the
+ * document (ADR-0024 §Resolve: resolving hides the highlight but never deletes
+ * the mark or the thread, so it can be reopened). The resolved set is the
+ * reconciliation's truth (DB `resolvedAt`), pushed in via {@link setResolvedThreadIds};
+ * this plugin renders a `prd-comment-resolved` inline decoration over those
+ * spans, and CSS neutralises the highlight there.
+ */
+const resolutionKey = new PluginKey<{ resolved: Set<string> }>("prdCommentResolution");
+
+export const CommentResolution = Extension.create({
+  name: "commentResolution",
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: resolutionKey,
+        state: {
+          init: () => ({ resolved: new Set<string>() }),
+          apply(tr, value) {
+            const meta = tr.getMeta(resolutionKey) as
+              | { resolved: Set<string> }
+              | undefined;
+            return meta ?? value;
+          },
+        },
+        props: {
+          decorations(state) {
+            const pluginState = resolutionKey.getState(state);
+            const resolved = pluginState?.resolved;
+            if (!resolved || resolved.size === 0) return DecorationSet.empty;
+
+            const decorations: Decoration[] = [];
+            state.doc.descendants((node, pos) => {
+              if (!node.isText) return;
+              const mark = node.marks.find((m) => m.type.name === "comment");
+              const threadId = mark?.attrs.threadId as string | undefined;
+              if (mark && threadId && resolved.has(threadId)) {
+                decorations.push(
+                  Decoration.inline(pos, pos + node.nodeSize, {
+                    class: "prd-comment-resolved",
+                  }),
+                );
+              }
+            });
+            return DecorationSet.create(state.doc, decorations);
+          },
+        },
+      }),
+    ];
+  },
+});
+
+/** Update which thread highlights are hidden as resolved. */
+export function setResolvedThreadIds(editor: Editor, ids: Set<string>): void {
+  const { state, view } = editor;
+  view.dispatch(state.tr.setMeta(resolutionKey, { resolved: ids }));
+}

--- a/src/plugins/product/server/routers/__tests__/featureComment.integration.test.ts
+++ b/src/plugins/product/server/routers/__tests__/featureComment.integration.test.ts
@@ -85,6 +85,60 @@ describe("featureComment router", () => {
     expect(inThread).toHaveLength(2);
   });
 
+  it("threads a reply under its parent's thread", async () => {
+    const { user, feature } = await setupFeature();
+    const caller = createTestCaller(user.id);
+
+    const root = await caller.product.featureComment.create({
+      featureId: feature.id,
+      threadId: "t-reply",
+      body: "root question",
+      quotedText: "span",
+    });
+    const reply = await caller.product.featureComment.reply({
+      parentId: root.id,
+      body: "an answer",
+    });
+
+    expect(reply.parentId).toBe(root.id);
+    expect(reply.threadId).toBe("t-reply");
+    expect(reply.featureId).toBe(feature.id);
+
+    // A reply to a reply still hangs off the root (one level deep).
+    const nested = await caller.product.featureComment.reply({
+      parentId: reply.id,
+      body: "follow-up",
+    });
+    expect(nested.parentId).toBe(root.id);
+  });
+
+  it("resolves and unresolves a thread (root resolvedAt toggles, never deletes)", async () => {
+    const { user, feature } = await setupFeature();
+    const caller = createTestCaller(user.id);
+
+    const root = await caller.product.featureComment.create({
+      featureId: feature.id,
+      threadId: "t-resolve",
+      body: "discuss this",
+      quotedText: "span",
+    });
+
+    await caller.product.featureComment.resolve({
+      featureId: feature.id,
+      threadId: "t-resolve",
+    });
+    let list = await caller.product.featureComment.list({ featureId: feature.id });
+    expect(list.find((c) => c.id === root.id)?.resolvedAt).not.toBeNull();
+    expect(list).toHaveLength(1); // still present, not deleted
+
+    await caller.product.featureComment.unresolve({
+      featureId: feature.id,
+      threadId: "t-resolve",
+    });
+    list = await caller.product.featureComment.list({ featureId: feature.id });
+    expect(list.find((c) => c.id === root.id)?.resolvedAt).toBeNull();
+  });
+
   it("denies a non-member from commenting or listing", async () => {
     const { db, feature } = await setupFeature();
     const outsider = await createUser(db);

--- a/src/plugins/product/server/routers/featureComment.ts
+++ b/src/plugins/product/server/routers/featureComment.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 import { loadFeatureWithAccess } from "./feature";
@@ -16,8 +17,8 @@ const authorSelect = {
  * same `loadFeatureWithAccess` workspace-member gate that `feature.update` uses —
  * editing the body and commenting share one access path.
  *
- * This slice ships `list` + `create`; threaded `reply`, `resolve`, and
- * `unresolve` arrive in the polish slice.
+ * Procedures: `list`, `create` (root comment), `reply` (threaded), and
+ * `resolve`/`unresolve` (toggle the root's `resolvedAt`).
  */
 export const featureCommentRouter = createTRPCRouter({
   list: protectedProcedure
@@ -54,5 +55,57 @@ export const featureCommentRouter = createTRPCRouter({
         },
         include: { createdBy: { select: authorSelect } },
       });
+    }),
+
+  reply: protectedProcedure
+    .input(
+      z.object({
+        parentId: z.string(),
+        body: boundedText("Comment", TEXT_LIMITS.LARGE, { min: 1 }),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const parent = await ctx.db.featureComment.findUnique({
+        where: { id: input.parentId },
+        select: { featureId: true, threadId: true, parentId: true },
+      });
+      if (!parent) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Comment not found" });
+      }
+      await loadFeatureWithAccess(ctx.db, ctx.session.user.id, parent.featureId);
+
+      return ctx.db.featureComment.create({
+        data: {
+          featureId: parent.featureId,
+          threadId: parent.threadId,
+          // Keep threads one level deep: a reply to a reply still hangs off the root.
+          parentId: parent.parentId ?? input.parentId,
+          body: input.body,
+          createdById: ctx.session.user.id,
+        },
+        include: { createdBy: { select: authorSelect } },
+      });
+    }),
+
+  resolve: protectedProcedure
+    .input(z.object({ featureId: z.string(), threadId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      await loadFeatureWithAccess(ctx.db, ctx.session.user.id, input.featureId);
+      await ctx.db.featureComment.updateMany({
+        where: { featureId: input.featureId, threadId: input.threadId, parentId: null },
+        data: { resolvedAt: new Date() },
+      });
+      return { success: true };
+    }),
+
+  unresolve: protectedProcedure
+    .input(z.object({ featureId: z.string(), threadId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      await loadFeatureWithAccess(ctx.db, ctx.session.user.id, input.featureId);
+      await ctx.db.featureComment.updateMany({
+        where: { featureId: input.featureId, threadId: input.threadId, parentId: null },
+        data: { resolvedAt: null },
+      });
+      return { success: true };
     }),
 });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2170,6 +2170,13 @@
 .prd-comment-highlight:hover {
   background-color: color-mix(in srgb, var(--color-brand-warning) 38%, transparent);
 }
+/* Resolved threads keep their mark but hide the highlight (ADR-0024 §Resolve).
+   The decoration may wrap the mark span or land on it directly — cover both. */
+.prd-comment-resolved.prd-comment-highlight,
+.prd-comment-resolved .prd-comment-highlight {
+  background-color: transparent;
+  border-bottom: none;
+}
 .prd-document img.prd-image {
   margin: 0.5rem 0;
 }


### PR DESCRIPTION
## What

Completes the discussion experience (ADR-0024). Builds on anchored comments (#232).

- **Threaded replies** via `FeatureComment.parentId` (`featureComment.reply`): a thread is a root plus replies, rendered indented under the root. Replies are kept one level deep (a reply to a reply still hangs off the root).
- **Resolve / unresolve** (`featureComment.resolve`/`unresolve`, toggling the root's `resolvedAt`): resolving collapses the thread out of the panel (behind a "Show resolved" toggle) and **hides its highlight** via a ProseMirror decoration plugin that dims `comment` marks for resolved threadIds. Never deleted — fully reopenable.
- **Reconciliation** treats `resolved` as a third state, taking precedence over orphaned; **orphaned** threads (anchor deleted) render from their `quotedText`.

## Acceptance criteria

- [x] A member can reply within a thread; replies render threaded
- [x] A member can resolve a thread (collapses, highlight hidden) and unresolve it (reopens)
- [x] Resolved threads are hidden by default but retrievable — never deleted
- [x] Orphaned threads render with their quoted text
- [x] Reconciliation tests cover resolved/orphaned; `featureComment` integration tests cover reply/resolve/unresolve (6/6 vs real DB); `tsc`/ESLint clean; full unit suite 864

## Notes

No schema change — reuses the `FeatureComment` columns (`parentId`, `resolvedAt`) added in #232.

---

Ships: ivory.palm (Exponential ticket `cmqjs89t20003le04iklx0gm7`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment threads can now be resolved and reopened with dedicated controls, helping manage discussion progress.
  * Toggle to show or hide resolved comment threads for a cleaner interface.
  * Reply directly to comments to create nested conversation threads, improving comment organization.
  * Resolved comments are visually distinguished with reduced opacity for clear identification of their status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->