### PR TITLE
feat(prd): anchor comment threads inline under the highlighted text

### DIFF
--- a/src/app/_components/prd/PrdCommentsPanel.tsx
+++ b/src/app/_components/prd/PrdCommentsPanel.tsx
@@ -33,6 +33,8 @@ interface PrdCommentsPanelProps {
   onSubmit: (threadId: string, body: string) => Promise<void>;
   onResolve: (threadId: string) => Promise<void>;
   onUnresolve: (threadId: string) => Promise<void>;
+  /** Whether the list owns the composer (false while the anchored popover does). */
+  composerActive?: boolean;
   currentUserId?: string;
   isSubmitting?: boolean;
 }
@@ -61,6 +63,7 @@ export function PrdCommentsPanel({
   onSubmit,
   onResolve,
   onUnresolve,
+  composerActive = true,
   currentUserId,
   isSubmitting = false,
 }: PrdCommentsPanelProps) {
@@ -152,7 +155,7 @@ export function PrdCommentsPanel({
           </div>
         )}
 
-        {isActive && !isResolved && (
+        {isActive && !isResolved && composerActive && (
           <div className="mt-2" onClick={(e) => e.stopPropagation()}>
             <CommentInput
               placeholder={rootRows.length === 0 ? "Comment…" : "Reply…"}

--- a/src/app/_components/prd/PrdDocument.tsx
+++ b/src/app/_components/prd/PrdDocument.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { EditorContent, BubbleMenu, useEditor } from "@tiptap/react";
 import { RichTextEditor } from "@mantine/tiptap";
 import type { Editor, JSONContent } from "@tiptap/core";
+import type { EditorView } from "@tiptap/pm/view";
 import { Stack, Text } from "@mantine/core";
 import { modals } from "@mantine/modals";
 import { notifications } from "@mantine/notifications";
@@ -23,7 +24,14 @@ import {
   type FeatureCommentRow,
   type PanelThread,
 } from "~/app/_components/prd/PrdCommentsPanel";
+import { PrdThreadPopover } from "~/app/_components/prd/PrdThreadPopover";
 import "@mantine/tiptap/styles.css";
+
+interface AnchorPos {
+  top: number;
+  left: number;
+}
+const POPOVER_WIDTH = 360;
 
 interface PrdDocumentProps {
   featureId: string;
@@ -78,6 +86,33 @@ export function PrdDocument({
   const [docTick, setDocTick] = useState(0);
   const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
   const [pending, setPending] = useState<{ threadId: string; quotedText: string } | null>(null);
+  // When set, the active thread shows as a popover anchored under its highlight;
+  // when null, the active thread's composer lives in the bottom Discussion list.
+  const [anchorPos, setAnchorPos] = useState<AnchorPos | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Position (relative to the editor wrapper) just below a doc range, so a
+  // thread popover sits directly under the highlighted text (Linear-style).
+  const computeAnchor = (
+    view: EditorView,
+    fromPos: number,
+    toPos: number,
+  ): AnchorPos | null => {
+    const wrap = wrapperRef.current;
+    if (!wrap) return null;
+    const start = view.coordsAtPos(fromPos);
+    const end = view.coordsAtPos(toPos);
+    const rect = wrap.getBoundingClientRect();
+    const maxLeft = Math.max(0, wrap.clientWidth - POPOVER_WIDTH);
+    const left = Math.min(Math.max(0, start.left - rect.left), maxLeft);
+    const top = Math.max(start.bottom, end.bottom) - rect.top + 6;
+    return { top, left };
+  };
+
+  const closeThread = () => {
+    setActiveThreadId(null);
+    setAnchorPos(null);
+  };
 
   const utils = api.useUtils();
   const initDescriptionDoc = api.product.feature.initDescriptionDoc.useMutation();
@@ -198,7 +233,12 @@ export function PrdDocument({
                 .marks()
                 .find((m) => m.type.name === "comment");
               const threadId = mark?.attrs.threadId as string | undefined;
-              if (threadId) setActiveThreadId(threadId);
+              if (threadId) {
+                setActiveThreadId(threadId);
+                setAnchorPos(computeAnchor(view, pos, pos));
+              } else {
+                closeThread();
+              }
               return false;
             },
           }
@@ -262,6 +302,7 @@ export function PrdDocument({
     }
     const quotedText = editor.state.doc.textBetween(from, to, " ").slice(0, 1000);
     const threadId = newThreadId();
+    const anchor = computeAnchor(editor.view, from, to);
     editor.chain().focus().setMark("comment", { threadId }).run();
     // setMark's onUpdate scheduled a debounced autosave; cancel it so we don't
     // fire two concurrent saves with the same baseVersion (which can race into a
@@ -271,6 +312,41 @@ export function PrdDocument({
     saveRef.current(editor);
     setPending({ threadId, quotedText });
     setActiveThreadId(threadId);
+    setAnchorPos(anchor);
+  };
+
+  // Find the document position of a thread's comment mark (for anchoring the
+  // popover when a thread is opened from the bottom list).
+  const findThreadPos = (threadId: string): number | null => {
+    if (!editor) return null;
+    let found: number | null = null;
+    editor.state.doc.descendants((node, pos) => {
+      if (found != null) return false;
+      if (
+        node.isText &&
+        node.marks.some(
+          (m) => m.type.name === "comment" && m.attrs.threadId === threadId,
+        )
+      ) {
+        found = pos;
+        return false;
+      }
+      return undefined;
+    });
+    return found;
+  };
+
+  // Opening a thread from the bottom list: anchor the popover at its highlight if
+  // the anchor still exists; orphaned threads (no mark) fall back to the list's
+  // own inline composer.
+  const openThreadFromList = (threadId: string) => {
+    setActiveThreadId(threadId);
+    const pos = findThreadPos(threadId);
+    if (pos != null && editor) {
+      setAnchorPos(computeAnchor(editor.view, pos, pos));
+    } else {
+      setAnchorPos(null);
+    }
   };
 
   const submitComment = async (threadId: string, body: string) => {
@@ -312,15 +388,40 @@ export function PrdDocument({
       threads={panelThreads}
       activeThreadId={activeThreadId}
       pendingThreadId={pending?.threadId ?? null}
-      onSelect={setActiveThreadId}
+      onSelect={openThreadFromList}
       onSubmit={submitComment}
       onResolve={handleResolve}
       onUnresolve={handleUnresolve}
-      isSubmitting={
-        createComment.isPending || replyComment.isPending
-      }
+      // When the anchored popover is open it owns the composer; the list shows
+      // its inline composer only for orphaned/list-opened threads.
+      composerActive={anchorPos === null}
+      isSubmitting={createComment.isPending || replyComment.isPending}
     />
   ) : null;
+
+  const activeThread =
+    activeThreadId != null
+      ? panelThreads.find((t) => t.threadId === activeThreadId) ?? null
+      : null;
+
+  const threadPopover =
+    enableComments && activeThreadId && anchorPos ? (
+      <PrdThreadPopover
+        threadId={activeThreadId}
+        quotedText={
+          activeThread?.quotedText ??
+          (pending?.threadId === activeThreadId ? pending.quotedText : null)
+        }
+        comments={activeThread?.comments ?? []}
+        status={activeThread?.status ?? "pending"}
+        position={anchorPos}
+        onSubmit={(body) => submitComment(activeThreadId, body)}
+        onResolve={() => void handleResolve(activeThreadId)}
+        onUnresolve={() => void handleUnresolve(activeThreadId)}
+        onClose={closeThread}
+        isSubmitting={createComment.isPending || replyComment.isPending}
+      />
+    ) : null;
 
   let body: React.ReactNode;
   if (!editable && doc && isDocEmpty(doc)) {
@@ -372,7 +473,10 @@ export function PrdDocument({
 
   return (
     <Stack gap="lg">
-      {body}
+      <div ref={wrapperRef} className="relative">
+        {body}
+        {threadPopover}
+      </div>
       {commentsPanel}
     </Stack>
   );

--- a/src/app/_components/prd/PrdThreadPopover.tsx
+++ b/src/app/_components/prd/PrdThreadPopover.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { ActionIcon, Button, Paper } from "@mantine/core";
+import { IconCheck, IconArrowBackUp, IconX } from "@tabler/icons-react";
+import { CommentInput } from "~/app/_components/shared/CommentInput";
+import { CommentThread, type Comment } from "~/app/_components/shared/CommentThread";
+import type { FeatureCommentRow } from "~/app/_components/prd/PrdCommentsPanel";
+import type { ThreadStatus } from "~/lib/prd/thread-reconciliation";
+
+interface PrdThreadPopoverProps {
+  threadId: string;
+  quotedText: string | null;
+  comments: FeatureCommentRow[];
+  /** "pending" = a just-created thread with no persisted comments yet. */
+  status: ThreadStatus | "pending";
+  position: { top: number; left: number };
+  onSubmit: (body: string) => Promise<void>;
+  onResolve: () => void;
+  onUnresolve: () => void;
+  onClose: () => void;
+  isSubmitting: boolean;
+}
+
+function toThreadComments(rows: FeatureCommentRow[]): Comment[] {
+  return rows.map((row) => ({
+    id: row.id,
+    content: row.body,
+    createdAt: new Date(row.createdAt),
+    author: row.createdBy,
+  }));
+}
+
+/**
+ * Linear/Notion-style floating thread card, anchored directly beneath the
+ * highlighted span (ADR-0024). Opening a thread — by selecting text and choosing
+ * Comment, or by clicking an existing highlight — shows the discussion in place
+ * so you write where you read; the same threads also appear in the Discussion
+ * list at the bottom of the page.
+ */
+export function PrdThreadPopover({
+  threadId,
+  quotedText,
+  comments,
+  status,
+  position,
+  onSubmit,
+  onResolve,
+  onUnresolve,
+  onClose,
+  isSubmitting,
+}: PrdThreadPopoverProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on outside click / Escape (editor clicks on other highlights reopen
+  // via the editor's own click handler, so this just dismisses stray clicks).
+  useEffect(() => {
+    const onMouseDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  const root = comments.find((c) => !c.parentId);
+  const rootRows = root ? [root] : [];
+  const replyRows = comments.filter((c) => c.parentId);
+  const isResolved = status === "resolved";
+  const hasComments = comments.length > 0;
+
+  return (
+    <Paper
+      ref={ref}
+      withBorder
+      shadow="md"
+      radius="md"
+      p="sm"
+      data-thread-popover={threadId}
+      className="bg-surface-secondary absolute z-50 w-[360px] max-w-[90vw]"
+      style={{ top: position.top, left: position.left }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-between gap-2 mb-2">
+        {quotedText ? (
+          <span className="text-text-muted text-xs italic truncate">
+            “{quotedText}”
+          </span>
+        ) : (
+          <span />
+        )}
+        <div className="flex items-center gap-1 shrink-0">
+          {hasComments &&
+            (isResolved ? (
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                color="gray"
+                leftSection={<IconArrowBackUp size={13} />}
+                onClick={onUnresolve}
+              >
+                Reopen
+              </Button>
+            ) : (
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                color="teal"
+                leftSection={<IconCheck size={13} />}
+                onClick={onResolve}
+              >
+                Resolve
+              </Button>
+            ))}
+          <ActionIcon
+            size="sm"
+            variant="subtle"
+            color="gray"
+            onClick={onClose}
+            aria-label="Close thread"
+          >
+            <IconX size={14} />
+          </ActionIcon>
+        </div>
+      </div>
+
+      {rootRows.length > 0 && (
+        <CommentThread
+          comments={toThreadComments(rootRows)}
+          variant="inline"
+          emptyMessage={null}
+        />
+      )}
+      {replyRows.length > 0 && (
+        <div className="mt-2 ml-3 border-l border-border-primary pl-3">
+          <CommentThread
+            comments={toThreadComments(replyRows)}
+            variant="inline"
+            emptyMessage={null}
+          />
+        </div>
+      )}
+
+      {!isResolved && (
+        <div className="mt-2">
+          <CommentInput
+            placeholder={hasComments ? "Reply…" : "Comment…"}
+            isSubmitting={isSubmitting}
+            onSubmit={onSubmit}
+          />
+        </div>
+      )}
+    </Paper>
+  );
+}


### PR DESCRIPTION
## What

Follow-up UX polish on the anchored-comments feature. Previously the comment composer only lived in the **Discussion** list at the bottom of the page — on a long PRD that's far from the text you selected, so commenting didn't feel "in place".

Now it works like Linear/Notion:

- **Select text → Comment**, or **click an existing highlight** → the thread opens as a **floating card anchored directly beneath the highlighted span** (comment(s) + Reply box + Resolve), so you write where you read.
- The same threads still appear in the **bottom Discussion list**. Opening a thread from the list anchors the popover at its highlight; **orphaned** threads (anchor deleted, no position to point at) fall back to the list's own inline composer.
- Popover closes on outside-click / Escape; the bottom list owns the composer only when the popover isn't open (no double composer).

Pure positioning via `view.coordsAtPos` relative to the editor wrapper, so the card scrolls with the text.

## Test

On a feature page: select text → click the 💬 control → card appears under the selection → type → ⌘+Enter. Click an existing highlight → its thread opens in place. Both also show in Discussion at the bottom.

No schema/router changes — purely the comment UI. `tsc`/ESLint clean; unit suite 864 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment threads now render as anchored popovers positioned relative to their location in the document for better context and visibility.
  * Enhanced comment composer visibility control, allowing flexible management of when the input field appears for active threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->