### PR TITLE
fix(prd): restore ordered/bulleted list markers in PRD body

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2180,3 +2180,38 @@
 .prd-document img.prd-image {
   margin: 0.5rem 0;
 }
+
+/* PRD body lists — visible markers + Linear-style spacing.
+   The editor sets `prose prose-invert`, but @tailwindcss/typography isn't
+   installed, so those classes are inert and Tailwind Preflight strips list
+   markers/padding. Restore them explicitly here. Task lists (checkbox lists)
+   keep their own layout and are excluded. */
+.prd-document ol,
+.prd-document ul:not([data-type="taskList"]) {
+  margin: 0.5rem 0;
+  padding-left: 1.625rem;
+}
+.prd-document ol {
+  list-style: decimal;
+}
+.prd-document ul:not([data-type="taskList"]) {
+  list-style: disc;
+}
+.prd-document ul:not([data-type="taskList"]) ul {
+  list-style: circle;
+}
+.prd-document ul:not([data-type="taskList"]) ul ul {
+  list-style: square;
+}
+.prd-document li {
+  margin: 0.25rem 0;
+  padding-left: 0.25rem;
+}
+.prd-document li::marker {
+  color: var(--color-text-muted);
+}
+/* Loose lists wrap each item's content in a <p>; drop its default gap so
+   numbered/bulleted items stay tight against their markers. */
+.prd-document li > p {
+  margin: 0;
+}


### PR DESCRIPTION
## Problem

Ordered/bulleted lists in the PRD/feature body rendered as plain wrapped text with **no `1.`/`2.` numbers, bullets, or indentation**.

The PRD editor sets \`class="prose prose-invert"\`, but \`@tailwindcss/typography\` isn't installed, so those classes are inert. Tailwind's Preflight reset then strips list markers and padding from \`ol\`/\`ul\`, leaving lists looking like flat paragraphs.

## Fix

Add explicit list CSS scoped to \`.prd-document\` in \`globals.css\`:

- \`ol\` → decimal, \`ul\` → disc (nested → circle/square)
- Hanging indent via \`padding-left\` so wrapped text aligns under the first character (Linear-style)
- \`li::marker\` colored with \`var(--color-text-muted)\` — the muted number/bullet look
- \`li > p { margin: 0 }\` so loose lists don't double-space
- Task lists (\`[data-type="taskList"]\`) excluded so checkboxes aren't doubled with bullets

No hardcoded colors (uses \`--color-text-muted\` token).

## Test

\`npm run test\` — 864 passing.