### PR TITLE
feat(prd): Linear-style comment thread card

### DIFF
--- a/src/app/_components/prd/PrdDocument.tsx
+++ b/src/app/_components/prd/PrdDocument.tsx
@@ -9,6 +9,7 @@ import { Stack, Text } from "@mantine/core";
 import { modals } from "@mantine/modals";
 import { notifications } from "@mantine/notifications";
 import { IconMessagePlus } from "@tabler/icons-react";
+import { useSession } from "next-auth/react";
 import { api } from "~/trpc/react";
 import { buildPrdExtensions } from "~/lib/prd/extensions";
 import { SlashCommand } from "~/lib/prd/slash-command";
@@ -119,9 +120,13 @@ export function PrdDocument({
   const updateFeature = api.product.feature.update.useMutation();
   const createComment = api.product.featureComment.create.useMutation();
   const replyComment = api.product.featureComment.reply.useMutation();
+  const updateComment = api.product.featureComment.update.useMutation();
+  const deleteComment = api.product.featureComment.delete.useMutation();
   const resolveThread = api.product.featureComment.resolve.useMutation();
   const unresolveThread = api.product.featureComment.unresolve.useMutation();
   const imageHandlers = usePrdImageUpload(featureId);
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id;
 
   const commentsQuery = api.product.featureComment.list.useQuery(
     { featureId },
@@ -383,6 +388,22 @@ export function PrdDocument({
     await utils.product.featureComment.list.invalidate({ featureId });
   };
 
+  const handleEditComment = async (commentId: string, body: string) => {
+    await updateComment.mutateAsync({ commentId, body });
+    await utils.product.featureComment.list.invalidate({ featureId });
+  };
+
+  const handleDeleteComment = (commentId: string) => {
+    deleteComment.mutate(
+      { commentId },
+      {
+        onSuccess: () => {
+          void utils.product.featureComment.list.invalidate({ featureId });
+        },
+      },
+    );
+  };
+
   const commentsPanel = enableComments ? (
     <PrdCommentsPanel
       threads={panelThreads}
@@ -392,6 +413,7 @@ export function PrdDocument({
       onSubmit={submitComment}
       onResolve={handleResolve}
       onUnresolve={handleUnresolve}
+      currentUserId={currentUserId}
       // When the anchored popover is open it owns the composer; the list shows
       // its inline composer only for orphaned/list-opened threads.
       composerActive={anchorPos === null}
@@ -408,14 +430,13 @@ export function PrdDocument({
     enableComments && activeThreadId && anchorPos ? (
       <PrdThreadPopover
         threadId={activeThreadId}
-        quotedText={
-          activeThread?.quotedText ??
-          (pending?.threadId === activeThreadId ? pending.quotedText : null)
-        }
         comments={activeThread?.comments ?? []}
         status={activeThread?.status ?? "pending"}
         position={anchorPos}
+        currentUserId={currentUserId}
         onSubmit={(body) => submitComment(activeThreadId, body)}
+        onEdit={handleEditComment}
+        onDelete={handleDeleteComment}
         onResolve={() => void handleResolve(activeThreadId)}
         onUnresolve={() => void handleUnresolve(activeThreadId)}
         onClose={closeThread}

--- a/src/app/_components/prd/PrdThreadPopover.tsx
+++ b/src/app/_components/prd/PrdThreadPopover.tsx
@@ -1,62 +1,92 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { ActionIcon, Button, Paper } from "@mantine/core";
-import { IconCheck, IconArrowBackUp, IconX } from "@tabler/icons-react";
+import { useEffect, useRef, useState } from "react";
+import { ActionIcon, Button, Menu, Paper, Textarea } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import {
+  IconCheck,
+  IconArrowBackUp,
+  IconDots,
+  IconPencil,
+  IconTrash,
+  IconCopy,
+  IconLink,
+} from "@tabler/icons-react";
+import { formatDistanceToNow } from "date-fns";
+import {
+  getAvatarColor,
+  getInitial,
+  getColorSeed,
+  getTextColor,
+} from "~/utils/avatarColors";
+import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
 import { CommentInput } from "~/app/_components/shared/CommentInput";
-import { CommentThread, type Comment } from "~/app/_components/shared/CommentThread";
 import type { FeatureCommentRow } from "~/app/_components/prd/PrdCommentsPanel";
 import type { ThreadStatus } from "~/lib/prd/thread-reconciliation";
 
 interface PrdThreadPopoverProps {
   threadId: string;
-  quotedText: string | null;
   comments: FeatureCommentRow[];
   /** "pending" = a just-created thread with no persisted comments yet. */
   status: ThreadStatus | "pending";
   position: { top: number; left: number };
+  currentUserId?: string;
   onSubmit: (body: string) => Promise<void>;
+  onEdit: (commentId: string, body: string) => Promise<void>;
+  onDelete: (commentId: string) => void;
   onResolve: () => void;
   onUnresolve: () => void;
   onClose: () => void;
   isSubmitting: boolean;
 }
 
-function toThreadComments(rows: FeatureCommentRow[]): Comment[] {
-  return rows.map((row) => ({
-    id: row.id,
-    content: row.body,
-    createdAt: new Date(row.createdAt),
-    author: row.createdBy,
-  }));
+function Avatar({ name }: { name: string | null }) {
+  const seed = getColorSeed(name, null);
+  const bg = getAvatarColor(seed);
+  return (
+    <div
+      className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-medium"
+      style={{ backgroundColor: bg, color: getTextColor(bg) }}
+    >
+      {getInitial(name)}
+    </div>
+  );
 }
 
 /**
  * Linear/Notion-style floating thread card, anchored directly beneath the
- * highlighted span (ADR-0024). Opening a thread — by selecting text and choosing
- * Comment, or by clicking an existing highlight — shows the discussion in place
- * so you write where you read; the same threads also appear in the Discussion
- * list at the bottom of the page.
+ * highlighted span (ADR-0024). Matches Linear's card chrome: per-comment
+ * avatar + author + relative time, a thread-level resolve check, and a `⋯`
+ * overflow menu (edit / resolve / copy / delete), with a reply composer at the
+ * foot. The same threads also appear in the Discussion list at the page foot.
  */
 export function PrdThreadPopover({
   threadId,
-  quotedText,
   comments,
   status,
   position,
+  currentUserId,
   onSubmit,
+  onEdit,
+  onDelete,
   onResolve,
   onUnresolve,
   onClose,
   isSubmitting,
 }: PrdThreadPopoverProps) {
   const ref = useRef<HTMLDivElement>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const [savingEdit, setSavingEdit] = useState(false);
 
-  // Close on outside click / Escape (editor clicks on other highlights reopen
-  // via the editor's own click handler, so this just dismisses stray clicks).
+  // Close on outside click / Escape. Ignore clicks inside the card or inside a
+  // portalled Mantine menu (role="menu"), which live outside the card's DOM.
   useEffect(() => {
     const onMouseDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+      const target = e.target as HTMLElement;
+      if (ref.current?.contains(target)) return;
+      if (target.closest('[role="menu"]')) return;
+      onClose();
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -69,11 +99,33 @@ export function PrdThreadPopover({
     };
   }, [onClose]);
 
-  const root = comments.find((c) => !c.parentId);
-  const rootRows = root ? [root] : [];
-  const replyRows = comments.filter((c) => c.parentId);
+  const ordered = [
+    ...comments.filter((c) => !c.parentId),
+    ...comments.filter((c) => c.parentId),
+  ];
   const isResolved = status === "resolved";
   const hasComments = comments.length > 0;
+
+  const copy = (text: string, message: string) => {
+    void navigator.clipboard?.writeText(text);
+    notifications.show({ message, color: "gray" });
+  };
+
+  const startEdit = (c: FeatureCommentRow) => {
+    setEditingId(c.id);
+    setEditValue(c.body);
+  };
+
+  const saveEdit = async () => {
+    if (!editingId || !editValue.trim()) return;
+    setSavingEdit(true);
+    try {
+      await onEdit(editingId, editValue.trim());
+      setEditingId(null);
+    } finally {
+      setSavingEdit(false);
+    }
+  };
 
   return (
     <Paper
@@ -81,74 +133,160 @@ export function PrdThreadPopover({
       withBorder
       shadow="md"
       radius="md"
-      p="sm"
       data-thread-popover={threadId}
-      className="bg-surface-secondary absolute z-50 w-[360px] max-w-[90vw]"
+      className="bg-surface-secondary absolute z-50 w-[380px] max-w-[90vw] overflow-hidden"
       style={{ top: position.top, left: position.left }}
       onClick={(e) => e.stopPropagation()}
     >
-      <div className="flex items-center justify-between gap-2 mb-2">
-        {quotedText ? (
-          <span className="text-text-muted text-xs italic truncate">
-            “{quotedText}”
-          </span>
-        ) : (
-          <span />
-        )}
-        <div className="flex items-center gap-1 shrink-0">
-          {hasComments &&
-            (isResolved ? (
-              <Button
-                size="compact-xs"
-                variant="subtle"
-                color="gray"
-                leftSection={<IconArrowBackUp size={13} />}
-                onClick={onUnresolve}
-              >
-                Reopen
-              </Button>
-            ) : (
-              <Button
-                size="compact-xs"
-                variant="subtle"
-                color="teal"
-                leftSection={<IconCheck size={13} />}
-                onClick={onResolve}
-              >
-                Resolve
-              </Button>
-            ))}
-          <ActionIcon
-            size="sm"
-            variant="subtle"
-            color="gray"
-            onClick={onClose}
-            aria-label="Close thread"
+      {ordered.map((c, i) => {
+        const isRoot = !c.parentId;
+        const isOwn = currentUserId != null && c.createdBy.id === currentUserId;
+        return (
+          <div
+            key={c.id}
+            className={`group px-3 py-2.5 ${i > 0 ? "border-t border-border-primary" : ""}`}
           >
-            <IconX size={14} />
-          </ActionIcon>
-        </div>
-      </div>
+            <div className="flex items-center gap-2">
+              <Avatar name={c.createdBy.name} />
+              <span className="text-text-primary text-sm font-medium">
+                {c.createdBy.name ?? "Unknown"}
+              </span>
+              <span className="text-text-muted text-xs">
+                {formatDistanceToNow(new Date(c.createdAt), { addSuffix: true })}
+              </span>
+              <div className="ml-auto flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                {isRoot &&
+                  (isResolved ? (
+                    <ActionIcon
+                      size="sm"
+                      variant="subtle"
+                      color="gray"
+                      title="Reopen thread"
+                      aria-label="Reopen thread"
+                      onClick={onUnresolve}
+                    >
+                      <IconArrowBackUp size={15} />
+                    </ActionIcon>
+                  ) : (
+                    <ActionIcon
+                      size="sm"
+                      variant="subtle"
+                      color="teal"
+                      title="Resolve thread"
+                      aria-label="Resolve thread"
+                      onClick={onResolve}
+                    >
+                      <IconCheck size={15} />
+                    </ActionIcon>
+                  ))}
+                <Menu position="bottom-end" withinPortal shadow="md">
+                  <Menu.Target>
+                    <ActionIcon
+                      size="sm"
+                      variant="subtle"
+                      color="gray"
+                      aria-label="Comment actions"
+                    >
+                      <IconDots size={15} />
+                    </ActionIcon>
+                  </Menu.Target>
+                  <Menu.Dropdown>
+                    {isOwn && (
+                      <Menu.Item
+                        leftSection={<IconPencil size={14} />}
+                        onClick={() => startEdit(c)}
+                      >
+                        Edit
+                      </Menu.Item>
+                    )}
+                    {isRoot &&
+                      (isResolved ? (
+                        <Menu.Item
+                          leftSection={<IconArrowBackUp size={14} />}
+                          onClick={onUnresolve}
+                        >
+                          Reopen thread
+                        </Menu.Item>
+                      ) : (
+                        <Menu.Item
+                          leftSection={<IconCheck size={14} />}
+                          onClick={onResolve}
+                        >
+                          Resolve thread
+                        </Menu.Item>
+                      ))}
+                    <Menu.Item
+                      leftSection={<IconCopy size={14} />}
+                      onClick={() => copy(c.body, "Copied as Markdown")}
+                    >
+                      Copy content as Markdown
+                    </Menu.Item>
+                    <Menu.Item
+                      leftSection={<IconLink size={14} />}
+                      onClick={() =>
+                        copy(
+                          `${window.location.origin}${window.location.pathname}#thread-${threadId}`,
+                          "Link copied",
+                        )
+                      }
+                    >
+                      Copy link to comment
+                    </Menu.Item>
+                    {isOwn && (
+                      <>
+                        <Menu.Divider />
+                        <Menu.Item
+                          color="red"
+                          leftSection={<IconTrash size={14} />}
+                          onClick={() => onDelete(c.id)}
+                        >
+                          Delete
+                        </Menu.Item>
+                      </>
+                    )}
+                  </Menu.Dropdown>
+                </Menu>
+              </div>
+            </div>
 
-      {rootRows.length > 0 && (
-        <CommentThread
-          comments={toThreadComments(rootRows)}
-          variant="inline"
-          emptyMessage={null}
-        />
-      )}
-      {replyRows.length > 0 && (
-        <div className="mt-2 ml-3 border-l border-border-primary pl-3">
-          <CommentThread
-            comments={toThreadComments(replyRows)}
-            variant="inline"
-            emptyMessage={null}
-          />
-        </div>
-      )}
+            <div className="mt-1 pl-8">
+              {editingId === c.id ? (
+                <div>
+                  <Textarea
+                    value={editValue}
+                    onChange={(e) => setEditValue(e.currentTarget.value)}
+                    autosize
+                    minRows={2}
+                    size="sm"
+                  />
+                  <div className="mt-1 flex justify-end gap-2">
+                    <Button
+                      size="compact-xs"
+                      variant="subtle"
+                      color="gray"
+                      onClick={() => setEditingId(null)}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      size="compact-xs"
+                      onClick={() => void saveEdit()}
+                      loading={savingEdit}
+                    >
+                      Save
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <MarkdownRenderer content={c.body} variant="compact" />
+              )}
+            </div>
+          </div>
+        );
+      })}
 
       {!isResolved && (
-        <div className="mt-2">
+        <div className="border-t border-border-primary px-3 py-2">
           <CommentInput
             placeholder={hasComments ? "Reply…" : "Comment…"}
             isSubmitting={isSubmitting}

--- a/src/plugins/product/server/routers/__tests__/featureComment.integration.test.ts
+++ b/src/plugins/product/server/routers/__tests__/featureComment.integration.test.ts
@@ -139,6 +139,43 @@ describe("featureComment router", () => {
     expect(list.find((c) => c.id === root.id)?.resolvedAt).toBeNull();
   });
 
+  it("edits and deletes only the author's own comment", async () => {
+    const { db, user, feature, ws } = await setupFeature();
+    const author = createTestCaller(user.id);
+
+    const root = await author.product.featureComment.create({
+      featureId: feature.id,
+      threadId: "t-edit",
+      body: "original",
+    });
+
+    const edited = await author.product.featureComment.update({
+      commentId: root.id,
+      body: "edited body",
+    });
+    expect(edited.body).toBe("edited body");
+
+    // A different member cannot edit or delete someone else's comment.
+    const other = await createUser(db);
+    await db.workspaceUser.create({
+      data: { workspaceId: ws.id, userId: other.id, role: "member" },
+    });
+    const otherCaller = createTestCaller(other.id);
+    await expect(
+      otherCaller.product.featureComment.update({
+        commentId: root.id,
+        body: "hijacked",
+      }),
+    ).rejects.toThrow();
+    await expect(
+      otherCaller.product.featureComment.delete({ commentId: root.id }),
+    ).rejects.toThrow();
+
+    await author.product.featureComment.delete({ commentId: root.id });
+    const list = await author.product.featureComment.list({ featureId: feature.id });
+    expect(list).toHaveLength(0);
+  });
+
   it("denies a non-member from commenting or listing", async () => {
     const { db, feature } = await setupFeature();
     const outsider = await createUser(db);

--- a/src/plugins/product/server/routers/featureComment.ts
+++ b/src/plugins/product/server/routers/featureComment.ts
@@ -87,6 +87,49 @@ export const featureCommentRouter = createTRPCRouter({
       });
     }),
 
+  update: protectedProcedure
+    .input(
+      z.object({
+        commentId: z.string(),
+        body: boundedText("Comment", TEXT_LIMITS.LARGE, { min: 1 }),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const existing = await ctx.db.featureComment.findFirst({
+        where: { id: input.commentId, createdById: ctx.session.user.id },
+        select: { id: true },
+      });
+      if (!existing) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Comment not found or not yours",
+        });
+      }
+      return ctx.db.featureComment.update({
+        where: { id: input.commentId },
+        data: { body: input.body },
+        include: { createdBy: { select: authorSelect } },
+      });
+    }),
+
+  delete: protectedProcedure
+    .input(z.object({ commentId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const existing = await ctx.db.featureComment.findFirst({
+        where: { id: input.commentId, createdById: ctx.session.user.id },
+        select: { id: true },
+      });
+      if (!existing) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Comment not found or not yours",
+        });
+      }
+      // Replies cascade via the parentId self-relation FK.
+      await ctx.db.featureComment.delete({ where: { id: input.commentId } });
+      return { success: true };
+    }),
+
   resolve: protectedProcedure
     .input(z.object({ featureId: z.string(), threadId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
## What

Reshapes the anchored thread popover to match Linear's comment card (per request, with screenshot reference). Builds on the inline-anchored composer (#235).

Each comment now renders:
- **avatar + author name + relative timestamp** (matching the rest of the app's comment chrome),
- a thread-level **resolve check** (✓ / reopen) on the root comment, and
- a **⋯ overflow menu**: **Edit** (own), **Resolve/Reopen thread** (root), **Copy content as Markdown**, **Copy link to comment**, **Delete** (own).

The reply composer sits at the foot; the old quoted-text line is dropped (the highlight itself is the anchor). Edit is inline; menu actions are gated to your own comments via the new author-only `featureComment.update` / `delete` mutations (server-enforced). Outside-click/Escape still dismiss the card, and clicks inside the portalled menu don't.

## Tests

- `featureComment` integration tests extended to cover edit/delete + author-only enforcement (7/7 vs real DB).
- `tsc`/ESLint clean; full unit suite 864 passing.

## Notes

No schema change — `update`/`delete` operate on the existing `FeatureComment` columns. Emoji reactions / subscribe / "new issue from comment" from Linear's menu are intentionally omitted (no backing model yet).