### PR TITLE
feat(feature-move): move a Feature across workspaces (ADR-0027)

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
@@ -19,6 +19,7 @@ import {
 import { modals } from "@mantine/modals";
 import {
   IconArrowLeft,
+  IconArrowRight,
   IconCalendar,
   IconCategory,
   IconCircleDot,
@@ -35,6 +36,7 @@ import {
 } from "@tabler/icons-react";
 import { api } from "~/trpc/react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
+import { MoveFeatureModal } from "~/app/_components/product/MoveFeatureModal";
 import {
   PropertiesSidebar,
   PropertyRow,
@@ -97,6 +99,8 @@ export default function FeatureDetailPage() {
     { id: featureId },
     { enabled: !!featureId },
   );
+
+  const [moveModalOpen, setMoveModalOpen] = useState(false);
 
   // Scope form
   const [scopeVersion, setScopeVersion] = useState("");
@@ -198,6 +202,9 @@ export default function FeatureDetailPage() {
                 <Menu.Dropdown>
                   <Menu.Item leftSection={<IconCopy size={14} />} onClick={() => { void navigator.clipboard.writeText(window.location.href); }}>
                     Copy link
+                  </Menu.Item>
+                  <Menu.Item leftSection={<IconArrowRight size={14} />} onClick={() => setMoveModalOpen(true)}>
+                    Move to another workspace…
                   </Menu.Item>
                   <Menu.Divider />
                   <Menu.Item color="red" leftSection={<IconTrash size={14} />} onClick={() => {
@@ -426,6 +433,14 @@ export default function FeatureDetailPage() {
           </Text>
         </PropertyRow>
       </PropertiesSidebar>
+
+      <MoveFeatureModal
+        opened={moveModalOpen}
+        onClose={() => setMoveModalOpen(false)}
+        featureId={featureId}
+        currentProductId={feature.product.id}
+        currentWorkspaceId={feature.product.workspaceId}
+      />
     </div>
   );
 }

--- a/src/app/_components/product/MoveFeatureModal.tsx
+++ b/src/app/_components/product/MoveFeatureModal.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Alert,
+  Button,
+  Group,
+  Modal,
+  Select,
+  Stack,
+  Text,
+} from "@mantine/core";
+import { IconAlertTriangle } from "@tabler/icons-react";
+import { api } from "~/trpc/react";
+
+/**
+ * Two-step "move this Feature to another workspace" confirm modal (ADR-0027).
+ *
+ * A Feature has no workspace of its own — its only container link is
+ * `productId` — so moving "to a workspace" means re-pointing it at a Product in
+ * that workspace. Step 1 picks the destination workspace (only those the caller
+ * can write to, i.e. owner/admin/member); step 2 picks a Product within it. The
+ * move is a lossy cross-workspace cascade, so it lives behind an explicit
+ * button + confirm rather than an always-live inline dropdown.
+ */
+export function MoveFeatureModal({
+  opened,
+  onClose,
+  featureId,
+  currentProductId,
+  currentWorkspaceId,
+}: {
+  opened: boolean;
+  onClose: () => void;
+  featureId: string;
+  currentProductId: string;
+  currentWorkspaceId: string;
+}) {
+  const router = useRouter();
+  const utils = api.useUtils();
+
+  const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const [productId, setProductId] = useState<string | null>(null);
+
+  // Reset the picker each time the modal opens.
+  useEffect(() => {
+    if (opened) {
+      setWorkspaceId(null);
+      setProductId(null);
+    }
+  }, [opened]);
+
+  const { data: workspaces } = api.workspace.list.useQuery(undefined, {
+    enabled: opened,
+  });
+  const { data: products, isLoading: productsLoading } =
+    api.product.product.list.useQuery(
+      { workspaceId: workspaceId ?? "" },
+      { enabled: opened && !!workspaceId },
+    );
+
+  // Only workspaces the caller can write to (owner/admin/member), excluding the
+  // Feature's current workspace. Viewer-only / guest workspaces are hidden.
+  const writableRoles = new Set(["owner", "admin", "member"]);
+  const workspaceOptions = (workspaces ?? [])
+    .filter(
+      (w) =>
+        w.id !== currentWorkspaceId &&
+        w.currentUserRole != null &&
+        writableRoles.has(w.currentUserRole),
+    )
+    .map((w) => ({ value: w.id, label: w.name }));
+
+  const productOptions = (products ?? [])
+    .filter((p) => p.id !== currentProductId)
+    .map((p) => ({ value: p.id, label: p.name }));
+
+  const move = api.product.feature.move.useMutation({
+    onSuccess: async (res) => {
+      await utils.product.feature.getById.invalidate({ id: featureId });
+      onClose();
+      if (res.workspaceSlug) {
+        router.push(
+          `/w/${res.workspaceSlug}/products/${res.productSlug}/features/${res.featureId}`,
+        );
+      }
+    },
+  });
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="Move feature" centered>
+      <Stack gap="md">
+        <Text size="sm" className="text-text-muted">
+          Move this feature to a Product in another workspace. Its PRD, scopes,
+          user stories, and comments come along.
+        </Text>
+
+        <Select
+          label="Destination workspace"
+          placeholder="Choose a workspace"
+          data={workspaceOptions}
+          value={workspaceId}
+          onChange={(val) => {
+            setWorkspaceId(val);
+            setProductId(null);
+          }}
+          searchable
+          nothingFoundMessage="No workspaces you can write to"
+          comboboxProps={{ withinPortal: true }}
+        />
+
+        <Select
+          label="Destination product"
+          placeholder={
+            workspaceId ? "Choose a product" : "Pick a workspace first"
+          }
+          data={productOptions}
+          value={productId}
+          onChange={setProductId}
+          disabled={!workspaceId || productsLoading}
+          searchable
+          nothingFoundMessage="No products in this workspace"
+          comboboxProps={{ withinPortal: true }}
+        />
+
+        <Alert
+          variant="light"
+          color="yellow"
+          icon={<IconAlertTriangle size={16} />}
+        >
+          <Text size="xs">
+            Crossing a workspace boundary severs workspace- and product-scoped
+            links (goal alignment, insights, workspace tags, and more). This
+            can&apos;t be undone by moving the feature back.
+          </Text>
+        </Alert>
+
+        {move.isError && (
+          <Text size="sm" className="text-brand-error">
+            {move.error.message}
+          </Text>
+        )}
+
+        <Group justify="flex-end" gap="sm">
+          <Button variant="default" onClick={onClose} disabled={move.isPending}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() =>
+              productId &&
+              move.mutate({ featureId, destinationProductId: productId })
+            }
+            loading={move.isPending}
+            disabled={!productId}
+          >
+            Move feature
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/app/_components/product/MoveFeatureModal.tsx
+++ b/src/app/_components/product/MoveFeatureModal.tsx
@@ -13,6 +13,37 @@ import {
 } from "@mantine/core";
 import { IconAlertTriangle } from "@tabler/icons-react";
 import { api } from "~/trpc/react";
+import type { MoveLossSummary } from "~/plugins/product/server/services/featureMove";
+
+/** Pluralize a count: `count(2, "ticket")` → "2 tickets". */
+function count(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * Enumerate the lossy consequences of a move from its loss summary. Only
+ * non-empty categories are listed; an otherwise-clean move says so.
+ */
+function consequenceLines(loss: MoveLossSummary): string[] {
+  const lines: string[] = [];
+  if (loss.ticketsRenumbered > 0)
+    lines.push(`${count(loss.ticketsRenumbered, "ticket")} renumbered into the destination product`);
+  if (loss.cyclesDropped > 0)
+    lines.push(`${count(loss.cyclesDropped, "ticket")} unlinked from their cycle`);
+  if (loss.dependenciesDropped > 0)
+    lines.push(`${count(loss.dependenciesDropped, "ticket dependency")} dropped (crosses the move boundary)`);
+  if (loss.assigneesCleared > 0)
+    lines.push(`${count(loss.assigneesCleared, "assignee")} cleared (not in the destination workspace)`);
+  if (loss.childActionsUnlinked > 0)
+    lines.push(`${count(loss.childActionsUnlinked, "child action")} unlinked (left in the source workspace)`);
+  if (loss.insightLinksDropped > 0)
+    lines.push(`${count(loss.insightLinksDropped, "insight link")} dropped`);
+  if (loss.tagsDropped > 0)
+    lines.push(`${count(loss.tagsDropped, "workspace tag")} dropped`);
+  if (loss.goalAlignmentRemoved) lines.push("Goal alignment removed");
+  if (lines.length === 0) lines.push("No workspace- or product-scoped links to sever.");
+  return lines;
+}
 
 /**
  * Two-step "move this Feature to another workspace" confirm modal (ADR-0027).
@@ -76,6 +107,14 @@ export function MoveFeatureModal({
     .filter((p) => p.id !== currentProductId)
     .map((p) => ({ value: p.id, label: p.name }));
 
+  // Loss preview — same planFeatureMove the move runs, so the dialog can never
+  // disagree with what actually happens (ADR-0027).
+  const { data: preview, isFetching: previewLoading } =
+    api.product.feature.getMovePreview.useQuery(
+      { featureId, destinationProductId: productId ?? "" },
+      { enabled: opened && !!productId },
+    );
+
   const move = api.product.feature.move.useMutation({
     onSuccess: async (res) => {
       await utils.product.feature.getById.invalidate({ id: featureId });
@@ -124,17 +163,31 @@ export function MoveFeatureModal({
           comboboxProps={{ withinPortal: true }}
         />
 
-        <Alert
-          variant="light"
-          color="yellow"
-          icon={<IconAlertTriangle size={16} />}
-        >
-          <Text size="xs">
-            Crossing a workspace boundary severs workspace- and product-scoped
-            links (goal alignment, insights, workspace tags, and more). This
-            can&apos;t be undone by moving the feature back.
-          </Text>
-        </Alert>
+        {productId && (
+          <Alert
+            variant="light"
+            color="yellow"
+            icon={<IconAlertTriangle size={16} />}
+            title="This move is lossy and can't be undone"
+          >
+            {previewLoading || !preview ? (
+              <Text size="xs" className="text-text-muted">
+                Calculating consequences…
+              </Text>
+            ) : (
+              <Stack gap={2}>
+                {consequenceLines(preview).map((line) => (
+                  <Text key={line} size="xs">
+                    {line}
+                  </Text>
+                ))}
+                <Text size="xs" className="text-text-muted">
+                  PRD body, scopes, user stories, and comments move unchanged.
+                </Text>
+              </Stack>
+            )}
+          </Alert>
+        )}
 
         {move.isError && (
           <Text size="sm" className="text-brand-error">
@@ -149,10 +202,14 @@ export function MoveFeatureModal({
           <Button
             onClick={() =>
               productId &&
-              move.mutate({ featureId, destinationProductId: productId })
+              move.mutate({
+                featureId,
+                destinationProductId: productId,
+                expectedSourceProductId: currentProductId,
+              })
             }
             loading={move.isPending}
-            disabled={!productId}
+            disabled={!productId || previewLoading}
           >
             Move feature
           </Button>

--- a/src/plugins/product/server/routers/__tests__/featureMove.integration.test.ts
+++ b/src/plugins/product/server/routers/__tests__/featureMove.integration.test.ts
@@ -270,6 +270,82 @@ describe("feature.move (integration)", () => {
     expect(t.productId).toBe(srcProduct.id);
     expect(t.number).toBe(5);
   });
+
+  it("getMovePreview returns the loss summary without mutating anything", async () => {
+    const mover = await createUser(db);
+    const srcWs = await createWorkspace(db, { ownerId: mover.id });
+    const srcProduct = await createProduct(db, {
+      workspaceId: srcWs.id,
+      createdById: mover.id,
+    });
+    const destWs = await createWorkspace(db, { ownerId: mover.id });
+    const destProduct = await createProduct(db, {
+      workspaceId: destWs.id,
+      createdById: mover.id,
+    });
+
+    const goal = await createGoal(db, {
+      userId: mover.id,
+      workspaceId: srcWs.id,
+      title: "g",
+    });
+    const feature = await createFeature(db, {
+      productId: srcProduct.id,
+      createdById: mover.id,
+    });
+    await db.feature.update({ where: { id: feature.id }, data: { goalId: goal.id } });
+    await createTicket(db, {
+      productId: srcProduct.id,
+      createdById: mover.id,
+      featureId: feature.id,
+      number: 3,
+    });
+
+    const caller = createTestCaller(mover.id);
+    const preview = await caller.product.feature.getMovePreview({
+      featureId: feature.id,
+      destinationProductId: destProduct.id,
+    });
+
+    expect(preview.ticketsRenumbered).toBe(1);
+    expect(preview.goalAlignmentRemoved).toBe(true);
+
+    // Side-effect free: feature and ticket are unchanged.
+    const f = await db.feature.findUniqueOrThrow({ where: { id: feature.id } });
+    expect(f.productId).toBe(srcProduct.id);
+    expect(f.goalId).toBe(goal.id);
+  });
+
+  it("rejects a stale move when the expected source product no longer matches", async () => {
+    const mover = await createUser(db);
+    const srcWs = await createWorkspace(db, { ownerId: mover.id });
+    const srcProduct = await createProduct(db, {
+      workspaceId: srcWs.id,
+      createdById: mover.id,
+    });
+    const destWs = await createWorkspace(db, { ownerId: mover.id });
+    const destProduct = await createProduct(db, {
+      workspaceId: destWs.id,
+      createdById: mover.id,
+    });
+    const feature = await createFeature(db, {
+      productId: srcProduct.id,
+      createdById: mover.id,
+    });
+
+    const caller = createTestCaller(mover.id);
+    await expect(
+      caller.product.feature.move({
+        featureId: feature.id,
+        destinationProductId: destProduct.id,
+        expectedSourceProductId: "some-other-product-id",
+      }),
+    ).rejects.toThrow(TRPCError);
+
+    // Unchanged.
+    const f = await db.feature.findUniqueOrThrow({ where: { id: feature.id } });
+    expect(f.productId).toBe(srcProduct.id);
+  });
 });
 
 /**

--- a/src/plugins/product/server/routers/__tests__/featureMove.integration.test.ts
+++ b/src/plugins/product/server/routers/__tests__/featureMove.integration.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Integration tests for the `feature.move` transactional cascade (ADR-0027).
+ *
+ * Exercises the real end-to-end move against a testcontainers Postgres: tickets
+ * renumbered into the destination Product; cycles / dependencies / assignees /
+ * child-action links in their expected end-state; transaction atomicity (a
+ * forced mid-transaction failure leaves the source Feature untouched); and
+ * access denial when the caller lacks destination membership.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+import { getTestDb } from "~/test/test-db";
+import { createTestCaller, createMockCaller } from "~/test/trpc-helpers";
+import {
+  createUser,
+  createWorkspace,
+  addWorkspaceMember,
+  createProduct,
+  createFeature,
+  createTicket,
+  createGoal,
+  createTag,
+  createCycle,
+  createAction,
+} from "~/test/factories";
+
+describe("feature.move (integration)", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("moves a feature with tickets, renumbering and severing relations end-to-end", async () => {
+    const mover = await createUser(db);
+    const destMember = await createUser(db);
+    const stranger = await createUser(db);
+
+    // Source workspace + product (mover is owner).
+    const srcWs = await createWorkspace(db, { ownerId: mover.id });
+    const srcProduct = await createProduct(db, {
+      workspaceId: srcWs.id,
+      createdById: mover.id,
+    });
+
+    // Destination workspace + product. Mover and destMember belong; stranger
+    // does not. Seed a pre-existing ticket so renumbering must avoid it.
+    const destWs = await createWorkspace(db, { ownerId: mover.id });
+    await addWorkspaceMember(db, destWs.id, destMember.id, "member");
+    const destProduct = await createProduct(db, {
+      workspaceId: destWs.id,
+      createdById: mover.id,
+    });
+    await createTicket(db, {
+      productId: destProduct.id,
+      createdById: mover.id,
+      number: 1,
+    });
+
+    // Feature with a goal, an insight link, and one ws-scoped + one global tag.
+    const goal = await createGoal(db, {
+      userId: mover.id,
+      workspaceId: srcWs.id,
+      title: "Source goal",
+    });
+    const feature = await createFeature(db, {
+      productId: srcProduct.id,
+      createdById: mover.id,
+    });
+    await db.feature.update({
+      where: { id: feature.id },
+      data: { goalId: goal.id },
+    });
+    const insight = await db.insight.create({
+      data: {
+        productId: srcProduct.id,
+        type: "OPPORTUNITY",
+        title: "Source insight",
+        createdById: mover.id,
+      },
+    });
+    await db.featureInsight.create({
+      data: { featureId: feature.id, insightId: insight.id },
+    });
+    const wsTag = await createTag(db, { workspaceId: srcWs.id });
+    const globalTag = await createTag(db, {}); // workspaceId null = global
+    await db.featureTag.createMany({
+      data: [
+        { featureId: feature.id, tagId: wsTag.id },
+        { featureId: feature.id, tagId: globalTag.id },
+      ],
+    });
+
+    // Cycle (source-product scoped) for tk1.
+    const cycle = await createCycle(db, {
+      workspaceId: srcWs.id,
+      createdById: mover.id,
+    });
+
+    // Moving tickets: tk1 (cycle + dest-member assignee), tk2 (stranger
+    // assignee + a child action). Plus tk3 left behind (not in the feature).
+    const tk1 = await createTicket(db, {
+      productId: srcProduct.id,
+      createdById: mover.id,
+      featureId: feature.id,
+      number: 10,
+      cycleId: cycle.id,
+      assigneeId: destMember.id,
+    });
+    const tk2 = await createTicket(db, {
+      productId: srcProduct.id,
+      createdById: mover.id,
+      featureId: feature.id,
+      number: 11,
+      assigneeId: stranger.id,
+    });
+    const tk3 = await createTicket(db, {
+      productId: srcProduct.id,
+      createdById: mover.id,
+      number: 12,
+    });
+
+    const action = await createAction(db, { createdById: mover.id });
+    await db.action.update({
+      where: { id: action.id },
+      data: { ticketId: tk2.id },
+    });
+
+    // Dependencies: tk1↔tk2 both move (preserved); tk1→tk3 crosses (dropped).
+    await db.ticketDependency.create({
+      data: { ticketId: tk1.id, dependsOnId: tk2.id },
+    });
+    await db.ticketDependency.create({
+      data: { ticketId: tk1.id, dependsOnId: tk3.id },
+    });
+
+    const caller = createTestCaller(mover.id);
+    const res = await caller.product.feature.move({
+      featureId: feature.id,
+      destinationProductId: destProduct.id,
+    });
+    expect(res.workspaceSlug).toBe(destWs.slug);
+    expect(res.productSlug).toBe(destProduct.slug);
+
+    // Feature re-pointed; goal alignment dropped.
+    const movedFeature = await db.feature.findUniqueOrThrow({
+      where: { id: feature.id },
+    });
+    expect(movedFeature.productId).toBe(destProduct.id);
+    expect(movedFeature.goalId).toBeNull();
+
+    // Insight links dropped; ws tag dropped; global tag kept.
+    expect(await db.featureInsight.count({ where: { featureId: feature.id } })).toBe(0);
+    const remainingTags = await db.featureTag.findMany({
+      where: { featureId: feature.id },
+    });
+    expect(remainingTags.map((t) => t.tagId)).toEqual([globalTag.id]);
+
+    // Tickets re-pointed + renumbered uniquely (above the dest's used number 1).
+    const movedTk1 = await db.ticket.findUniqueOrThrow({ where: { id: tk1.id } });
+    const movedTk2 = await db.ticket.findUniqueOrThrow({ where: { id: tk2.id } });
+    expect(movedTk1.productId).toBe(destProduct.id);
+    expect(movedTk2.productId).toBe(destProduct.id);
+    expect(movedTk1.number).toBeGreaterThan(1);
+    expect(movedTk2.number).toBeGreaterThan(1);
+    expect(movedTk1.number).not.toBe(movedTk2.number);
+
+    // Cycle nulled.
+    expect(movedTk1.cycleId).toBeNull();
+
+    // Assignee kept for the dest member, cleared for the stranger.
+    expect(movedTk1.assigneeId).toBe(destMember.id);
+    expect(movedTk2.assigneeId).toBeNull();
+
+    // Intra-set dependency preserved; cross-boundary dependency dropped.
+    const deps = await db.ticketDependency.findMany({
+      where: { OR: [{ ticketId: tk1.id }, { dependsOnId: tk1.id }] },
+    });
+    expect(deps).toHaveLength(1);
+    expect(deps[0]!.dependsOnId).toBe(tk2.id);
+
+    // Child action unlinked but not deleted; still in source workspace.
+    const movedAction = await db.action.findUniqueOrThrow({
+      where: { id: action.id },
+    });
+    expect(movedAction.ticketId).toBeNull();
+
+    // tk3 untouched in the source product.
+    const leftBehind = await db.ticket.findUniqueOrThrow({ where: { id: tk3.id } });
+    expect(leftBehind.productId).toBe(srcProduct.id);
+    expect(leftBehind.featureId).toBeNull();
+  });
+
+  it("rejects a move when the caller is not a member of the destination workspace", async () => {
+    const mover = await createUser(db);
+    const other = await createUser(db);
+
+    const srcWs = await createWorkspace(db, { ownerId: mover.id });
+    const srcProduct = await createProduct(db, {
+      workspaceId: srcWs.id,
+      createdById: mover.id,
+    });
+    const feature = await createFeature(db, {
+      productId: srcProduct.id,
+      createdById: mover.id,
+    });
+
+    // Destination workspace the mover does NOT belong to.
+    const destWs = await createWorkspace(db, { ownerId: other.id });
+    const destProduct = await createProduct(db, {
+      workspaceId: destWs.id,
+      createdById: other.id,
+    });
+
+    const caller = createTestCaller(mover.id);
+    await expect(
+      caller.product.feature.move({
+        featureId: feature.id,
+        destinationProductId: destProduct.id,
+      }),
+    ).rejects.toThrow(TRPCError);
+
+    // Feature untouched.
+    const unchanged = await db.feature.findUniqueOrThrow({ where: { id: feature.id } });
+    expect(unchanged.productId).toBe(srcProduct.id);
+  });
+
+  it("rolls back the whole move when a mid-transaction write fails", async () => {
+    const mover = await createUser(db);
+    const srcWs = await createWorkspace(db, { ownerId: mover.id });
+    const srcProduct = await createProduct(db, {
+      workspaceId: srcWs.id,
+      createdById: mover.id,
+    });
+    const destWs = await createWorkspace(db, { ownerId: mover.id });
+    const destProduct = await createProduct(db, {
+      workspaceId: destWs.id,
+      createdById: mover.id,
+    });
+
+    const feature = await createFeature(db, {
+      productId: srcProduct.id,
+      createdById: mover.id,
+    });
+    const tk = await createTicket(db, {
+      productId: srcProduct.id,
+      createdById: mover.id,
+      featureId: feature.id,
+      number: 5,
+    });
+
+    // Wrap the real test DB so the interactive transaction's `feature.update`
+    // throws — after the ticket update has already run — forcing a rollback.
+    const failingDb = makeDbFailingOn(db, "feature", "update");
+    const caller = createMockCaller({ userId: mover.id, db: failingDb });
+
+    await expect(
+      caller.product.feature.move({
+        featureId: feature.id,
+        destinationProductId: destProduct.id,
+      }),
+    ).rejects.toThrow();
+
+    // Nothing committed: feature and ticket are still in the source product.
+    const f = await db.feature.findUniqueOrThrow({ where: { id: feature.id } });
+    expect(f.productId).toBe(srcProduct.id);
+    const t = await db.ticket.findUniqueOrThrow({ where: { id: tk.id } });
+    expect(t.productId).toBe(srcProduct.id);
+    expect(t.number).toBe(5);
+  });
+});
+
+/**
+ * Wrap a real PrismaClient so that, inside an interactive `$transaction`, calls
+ * to `tx[model][method]` throw. Everything else forwards to the real client.
+ * Used to force a deterministic mid-transaction failure for the rollback test.
+ */
+function makeDbFailingOn(
+  realDb: PrismaClient,
+  model: string,
+  method: string,
+): PrismaClient {
+  const bind = (obj: unknown, prop: string | symbol) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const val = (obj as any)[prop];
+    return typeof val === "function" ? val.bind(obj) : val;
+  };
+  return new Proxy(realDb, {
+    get(target, prop) {
+      if (prop === "$transaction") {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (arg: any, opts: any) => {
+          if (typeof arg === "function") {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return (target as any).$transaction((tx: any) => {
+              const wrappedTx = new Proxy(tx, {
+                get(t, p) {
+                  if (p === model) {
+                    return new Proxy(t[model], {
+                      get(m, mp) {
+                        if (mp === method) {
+                          return () => {
+                            throw new Error("injected mid-transaction failure");
+                          };
+                        }
+                        return bind(m, mp);
+                      },
+                    });
+                  }
+                  return bind(t, p);
+                },
+              });
+              return arg(wrappedTx);
+            }, opts);
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return (target as any).$transaction(arg, opts);
+        };
+      }
+      return bind(target, prop);
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+}

--- a/src/plugins/product/server/routers/__tests__/featureMove.test.ts
+++ b/src/plugins/product/server/routers/__tests__/featureMove.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the `feature.move` mutation's both-ends access gate (ADR-0027).
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` (no real DB), mirroring
+ * the harness in `problem.test.ts`. The move must be rejected unless the caller
+ * is a non-viewer (owner/admin/member) of *both* the source and destination
+ * workspaces. The transactional cascade itself is exercised by the integration
+ * test (`featureMove.integration.test.ts`).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(_opts?: any) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({
+    auth: () => null,
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = {
+  current: null,
+};
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) {
+    dbHolder.current = mockDeep<PrismaClient>();
+  }
+  return dbHolder.current;
+}
+
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+vi.mock("~/server/services/notifications/EmailNotificationService", () => ({
+  sendAssignmentNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/server/services/onboarding/syncOnboardingProgress", () => ({
+  completeOnboardingStep: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/lib/blob", () => ({
+  uploadToBlob: vi.fn().mockResolvedValue({ url: "blob://test" }),
+}));
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const callerId = "user-1";
+const sourceWs = "ws-source";
+const destWs = "ws-dest";
+const featureId = "feat-1";
+const sourceProduct = "prod-source";
+const destProduct = "prod-dest";
+
+/** Role the caller holds in a given workspace, or null for non-member. */
+function stubRoles(
+  dbMock: DeepMockProxy<PrismaClient>,
+  roles: Record<string, string | null>,
+) {
+  dbMock.workspaceUser.findUnique.mockImplementation((args) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wsId = (args as any)?.where?.userId_workspaceId?.workspaceId as string;
+    const role = roles[wsId] ?? null;
+    return Promise.resolve(
+      role ? ({ role, workspaceId: wsId } as never) : (null as never),
+    );
+  });
+  // No team-based fallback in these tests.
+  dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+}
+
+function stubFeature(dbMock: DeepMockProxy<PrismaClient>) {
+  dbMock.feature.findUnique.mockResolvedValue({
+    id: featureId,
+    productId: sourceProduct,
+    goalId: null,
+    product: { workspaceId: sourceWs },
+    tags: [],
+    insights: [],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+function stubDestProduct(dbMock: DeepMockProxy<PrismaClient>) {
+  dbMock.product.findUnique.mockResolvedValue({
+    id: destProduct,
+    slug: "dest",
+    workspaceId: destWs,
+    ticketCounter: 0,
+    funTicketIds: false,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+describe("feature.move — both-ends access gate (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  it("rejects when the caller is only a viewer of the source workspace", async () => {
+    stubFeature(dbMock);
+    stubRoles(dbMock, { [sourceWs]: "viewer", [destWs]: "owner" });
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.feature.move({ featureId, destinationProductId: destProduct }),
+    ).rejects.toThrow(TRPCError);
+  });
+
+  it("rejects when the caller is not a member of the destination workspace", async () => {
+    stubFeature(dbMock);
+    stubDestProduct(dbMock);
+    stubRoles(dbMock, { [sourceWs]: "owner", [destWs]: null });
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.feature.move({ featureId, destinationProductId: destProduct }),
+    ).rejects.toThrow(TRPCError);
+  });
+
+  it("rejects when the caller is only a viewer of the destination workspace", async () => {
+    stubFeature(dbMock);
+    stubDestProduct(dbMock);
+    stubRoles(dbMock, { [sourceWs]: "owner", [destWs]: "viewer" });
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.feature.move({ featureId, destinationProductId: destProduct }),
+    ).rejects.toThrow(TRPCError);
+  });
+});

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -37,6 +37,129 @@ async function assertWorkspaceWriteRole(
   return membership;
 }
 
+/**
+ * Load everything a Feature move needs, run both-ends access checks, and shape
+ * the {@link FeatureMoveGraph} + {@link FeatureMoveDestination} the pure
+ * planner consumes. Shared by the read-only `getMovePreview` and the executing
+ * `move` mutation so the dialog preview and the actual move are computed from
+ * identical inputs (ADR-0027 — preview must never disagree with execution).
+ */
+async function loadFeatureMoveContext(
+  db: PrismaClient,
+  userId: string,
+  featureId: string,
+  destinationProductId: string,
+) {
+  // Source: feature graph + workspace, require write role.
+  const feature = await db.feature.findUnique({
+    where: { id: featureId },
+    select: {
+      id: true,
+      productId: true,
+      goalId: true,
+      product: { select: { workspaceId: true } },
+      tags: { select: { tagId: true, tag: { select: { workspaceId: true } } } },
+      insights: { select: { insightId: true } },
+    },
+  });
+  if (!feature) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Feature not found" });
+  }
+  await assertWorkspaceWriteRole(db, userId, feature.product.workspaceId);
+
+  // Destination Product (and its workspace), require write role.
+  const destProduct = await db.product.findUnique({
+    where: { id: destinationProductId },
+    select: {
+      id: true,
+      slug: true,
+      workspaceId: true,
+      ticketCounter: true,
+      funTicketIds: true,
+    },
+  });
+  if (!destProduct) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Destination product not found",
+    });
+  }
+  if (destProduct.id === feature.productId) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "The feature is already in this product",
+    });
+  }
+  await assertWorkspaceWriteRole(db, userId, destProduct.workspaceId);
+
+  // The rest of the graph the planner needs.
+  const tickets = await db.ticket.findMany({
+    where: { featureId: feature.id },
+    select: {
+      id: true,
+      number: true,
+      shortId: true,
+      cycleId: true,
+      assigneeId: true,
+      actions: { select: { id: true } },
+    },
+  });
+  const movingIds = tickets.map((t) => t.id);
+  const dependencies =
+    movingIds.length > 0
+      ? await db.ticketDependency.findMany({
+          where: {
+            OR: [
+              { ticketId: { in: movingIds } },
+              { dependsOnId: { in: movingIds } },
+            ],
+          },
+          select: { id: true, ticketId: true, dependsOnId: true },
+        })
+      : [];
+  const [destUsed, destMembers] = await Promise.all([
+    db.ticket.findMany({
+      where: { productId: destProduct.id },
+      select: { number: true, shortId: true },
+    }),
+    db.workspaceUser.findMany({
+      where: { workspaceId: destProduct.workspaceId },
+      select: { userId: true },
+    }),
+  ]);
+
+  const graph: FeatureMoveGraph = {
+    featureId: feature.id,
+    goalId: feature.goalId,
+    tags: feature.tags.map((t) => ({
+      tagId: t.tagId,
+      tagWorkspaceId: t.tag.workspaceId,
+    })),
+    insightIds: feature.insights.map((i) => i.insightId),
+    tickets: tickets.map((t) => ({
+      id: t.id,
+      number: t.number,
+      shortId: t.shortId,
+      cycleId: t.cycleId,
+      assigneeId: t.assigneeId,
+      childActionIds: t.actions.map((a) => a.id),
+    })),
+    dependencies,
+  };
+  const destination: FeatureMoveDestination = {
+    productId: destProduct.id,
+    ticketCounter: destProduct.ticketCounter,
+    funTicketIds: destProduct.funTicketIds,
+    usedNumbers: destUsed.map((t) => t.number),
+    usedShortIds: destUsed
+      .map((t) => t.shortId)
+      .filter((s): s is string => s !== null),
+    memberUserIds: destMembers.map((m) => m.userId),
+  };
+
+  return { feature, destProduct, graph, destination };
+}
+
 /** A ProseMirror document object (PRD body, ADR-0024). Validated structurally. */
 const prosemirrorDoc = z.record(z.string(), z.unknown());
 
@@ -419,132 +542,69 @@ export const featureRouter = createTRPCRouter({
    * Access: the caller must be a non-viewer member of *both* the source and the
    * destination workspaces.
    */
-  move: protectedProcedure
+  /**
+   * Read-only preview of a move's loss summary (ADR-0027). Runs the exact same
+   * fetch + {@link planFeatureMove} as `move`, but applies nothing — so the
+   * confirm dialog can enumerate every consequence before the user commits,
+   * and can never disagree with what `move` will do. Same both-ends access
+   * checks as the move itself.
+   */
+  getMovePreview: protectedProcedure
     .input(
       z.object({
         featureId: z.string(),
         destinationProductId: z.string(),
       }),
     )
+    .query(async ({ ctx, input }) => {
+      const { graph, destination } = await loadFeatureMoveContext(
+        ctx.db,
+        ctx.session.user.id,
+        input.featureId,
+        input.destinationProductId,
+      );
+      return planFeatureMove(graph, destination).loss;
+    }),
+
+  move: protectedProcedure
+    .input(
+      z.object({
+        featureId: z.string(),
+        destinationProductId: z.string(),
+        /**
+         * Stale-state guard: the source Product the modal saw when it computed
+         * the preview. If the Feature has since moved (its `productId` no longer
+         * matches), the cached plan is stale and we refuse rather than apply it.
+         */
+        expectedSourceProductId: z.string().optional(),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
-      // 1. Source: load the feature graph + source workspace, require write role.
-      const feature = await ctx.db.feature.findUnique({
-        where: { id: input.featureId },
-        select: {
-          id: true,
-          productId: true,
-          goalId: true,
-          product: { select: { workspaceId: true } },
-          tags: {
-            select: { tagId: true, tag: { select: { workspaceId: true } } },
-          },
-          insights: { select: { insightId: true } },
-        },
-      });
-      if (!feature) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Feature not found" });
-      }
-      await assertWorkspaceWriteRole(
-        ctx.db,
-        userId,
-        feature.product.workspaceId,
-      );
+      const { feature, destProduct, graph, destination } =
+        await loadFeatureMoveContext(
+          ctx.db,
+          userId,
+          input.featureId,
+          input.destinationProductId,
+        );
 
-      // 2. Destination Product (and its workspace), require write role.
-      const destProduct = await ctx.db.product.findUnique({
-        where: { id: input.destinationProductId },
-        select: {
-          id: true,
-          slug: true,
-          workspaceId: true,
-          ticketCounter: true,
-          funTicketIds: true,
-        },
-      });
-      if (!destProduct) {
+      // Stale-state guard: the Feature moved out from under the open modal.
+      if (
+        input.expectedSourceProductId !== undefined &&
+        input.expectedSourceProductId !== feature.productId
+      ) {
         throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Destination product not found",
+          code: "CONFLICT",
+          message:
+            "This feature changed since you opened the move dialog. Reload and try again.",
         });
       }
-      if (destProduct.id === feature.productId) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "The feature is already in this product",
-        });
-      }
-      await assertWorkspaceWriteRole(ctx.db, userId, destProduct.workspaceId);
-
-      // 3. Fetch the rest of the graph the planner needs.
-      const tickets = await ctx.db.ticket.findMany({
-        where: { featureId: feature.id },
-        select: {
-          id: true,
-          number: true,
-          shortId: true,
-          cycleId: true,
-          assigneeId: true,
-          actions: { select: { id: true } },
-        },
-      });
-      const movingIds = tickets.map((t) => t.id);
-      const dependencies =
-        movingIds.length > 0
-          ? await ctx.db.ticketDependency.findMany({
-              where: {
-                OR: [
-                  { ticketId: { in: movingIds } },
-                  { dependsOnId: { in: movingIds } },
-                ],
-              },
-              select: { id: true, ticketId: true, dependsOnId: true },
-            })
-          : [];
-      const [destUsed, destMembers] = await Promise.all([
-        ctx.db.ticket.findMany({
-          where: { productId: destProduct.id },
-          select: { number: true, shortId: true },
-        }),
-        ctx.db.workspaceUser.findMany({
-          where: { workspaceId: destProduct.workspaceId },
-          select: { userId: true },
-        }),
-      ]);
-
-      const graph: FeatureMoveGraph = {
-        featureId: feature.id,
-        goalId: feature.goalId,
-        tags: feature.tags.map((t) => ({
-          tagId: t.tagId,
-          tagWorkspaceId: t.tag.workspaceId,
-        })),
-        insightIds: feature.insights.map((i) => i.insightId),
-        tickets: tickets.map((t) => ({
-          id: t.id,
-          number: t.number,
-          shortId: t.shortId,
-          cycleId: t.cycleId,
-          assigneeId: t.assigneeId,
-          childActionIds: t.actions.map((a) => a.id),
-        })),
-        dependencies,
-      };
-      const destination: FeatureMoveDestination = {
-        productId: destProduct.id,
-        ticketCounter: destProduct.ticketCounter,
-        funTicketIds: destProduct.funTicketIds,
-        usedNumbers: destUsed.map((t) => t.number),
-        usedShortIds: destUsed
-          .map((t) => t.shortId)
-          .filter((s): s is string => s !== null),
-        memberUserIds: destMembers.map((m) => m.userId),
-      };
 
       const { mutations } = planFeatureMove(graph, destination);
 
-      // 4. Apply the whole plan in one transaction (driven by the plan only).
+      // Apply the whole plan in one transaction (driven by the plan only).
       await ctx.db.$transaction(async (tx) => {
         // Per-ticket: re-point to the destination Product, renumber, and clear
         // the source-scoped cycle / assignee links the plan flagged.

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -6,6 +6,36 @@ import type { Prisma, PrismaClient } from "@prisma/client";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 import { checkStaleWrite } from "~/lib/prd/stale-write";
 import { uploadToBlob } from "~/lib/blob";
+import { getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
+import { hasMinimumWorkspaceRole } from "~/server/services/access";
+import {
+  planFeatureMove,
+  type FeatureMoveGraph,
+  type FeatureMoveDestination,
+} from "../services/featureMove";
+
+/**
+ * Require the caller to be a non-viewer (owner/admin/member) of the workspace.
+ * A cross-workspace Feature move is a lossy cascade, so — per ADR-0027 — the
+ * mover must be able to *write* to both the source and destination workspaces,
+ * not merely read them. This is stricter than {@link assertWorkspaceMember},
+ * which admits viewers.
+ */
+async function assertWorkspaceWriteRole(
+  db: PrismaClient,
+  userId: string,
+  workspaceId: string,
+) {
+  const membership = await getWorkspaceMembership(db, userId, workspaceId);
+  if (!membership || !hasMinimumWorkspaceRole(membership.role, "member")) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message:
+        "You need owner, admin, or member access to this workspace to move a feature here",
+    });
+  }
+  return membership;
+}
 
 /** A ProseMirror document object (PRD body, ADR-0024). Validated structurally. */
 const prosemirrorDoc = z.record(z.string(), z.unknown());
@@ -374,6 +404,219 @@ export const featureRouter = createTRPCRouter({
       await loadFeatureWithAccess(ctx.db, ctx.session.user.id, input.id);
       await ctx.db.feature.delete({ where: { id: input.id } });
       return { success: true };
+    }),
+
+  /**
+   * Move a Feature to a Product in another workspace (ADR-0027).
+   *
+   * A Feature has no workspace of its own — its only container link is
+   * `productId` — so "move to a workspace" is re-pointing `productId` at a
+   * Product in the destination workspace. The move is a single-transaction
+   * lossy cascade whose rules (and the loss counts shown in the confirm dialog)
+   * are computed by the pure {@link planFeatureMove}, so preview and execution
+   * can never diverge.
+   *
+   * Access: the caller must be a non-viewer member of *both* the source and the
+   * destination workspaces.
+   */
+  move: protectedProcedure
+    .input(
+      z.object({
+        featureId: z.string(),
+        destinationProductId: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      // 1. Source: load the feature graph + source workspace, require write role.
+      const feature = await ctx.db.feature.findUnique({
+        where: { id: input.featureId },
+        select: {
+          id: true,
+          productId: true,
+          goalId: true,
+          product: { select: { workspaceId: true } },
+          tags: {
+            select: { tagId: true, tag: { select: { workspaceId: true } } },
+          },
+          insights: { select: { insightId: true } },
+        },
+      });
+      if (!feature) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Feature not found" });
+      }
+      await assertWorkspaceWriteRole(
+        ctx.db,
+        userId,
+        feature.product.workspaceId,
+      );
+
+      // 2. Destination Product (and its workspace), require write role.
+      const destProduct = await ctx.db.product.findUnique({
+        where: { id: input.destinationProductId },
+        select: {
+          id: true,
+          slug: true,
+          workspaceId: true,
+          ticketCounter: true,
+          funTicketIds: true,
+        },
+      });
+      if (!destProduct) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Destination product not found",
+        });
+      }
+      if (destProduct.id === feature.productId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "The feature is already in this product",
+        });
+      }
+      await assertWorkspaceWriteRole(ctx.db, userId, destProduct.workspaceId);
+
+      // 3. Fetch the rest of the graph the planner needs.
+      const tickets = await ctx.db.ticket.findMany({
+        where: { featureId: feature.id },
+        select: {
+          id: true,
+          number: true,
+          shortId: true,
+          cycleId: true,
+          assigneeId: true,
+          actions: { select: { id: true } },
+        },
+      });
+      const movingIds = tickets.map((t) => t.id);
+      const dependencies =
+        movingIds.length > 0
+          ? await ctx.db.ticketDependency.findMany({
+              where: {
+                OR: [
+                  { ticketId: { in: movingIds } },
+                  { dependsOnId: { in: movingIds } },
+                ],
+              },
+              select: { id: true, ticketId: true, dependsOnId: true },
+            })
+          : [];
+      const [destUsed, destMembers] = await Promise.all([
+        ctx.db.ticket.findMany({
+          where: { productId: destProduct.id },
+          select: { number: true, shortId: true },
+        }),
+        ctx.db.workspaceUser.findMany({
+          where: { workspaceId: destProduct.workspaceId },
+          select: { userId: true },
+        }),
+      ]);
+
+      const graph: FeatureMoveGraph = {
+        featureId: feature.id,
+        goalId: feature.goalId,
+        tags: feature.tags.map((t) => ({
+          tagId: t.tagId,
+          tagWorkspaceId: t.tag.workspaceId,
+        })),
+        insightIds: feature.insights.map((i) => i.insightId),
+        tickets: tickets.map((t) => ({
+          id: t.id,
+          number: t.number,
+          shortId: t.shortId,
+          cycleId: t.cycleId,
+          assigneeId: t.assigneeId,
+          childActionIds: t.actions.map((a) => a.id),
+        })),
+        dependencies,
+      };
+      const destination: FeatureMoveDestination = {
+        productId: destProduct.id,
+        ticketCounter: destProduct.ticketCounter,
+        funTicketIds: destProduct.funTicketIds,
+        usedNumbers: destUsed.map((t) => t.number),
+        usedShortIds: destUsed
+          .map((t) => t.shortId)
+          .filter((s): s is string => s !== null),
+        memberUserIds: destMembers.map((m) => m.userId),
+      };
+
+      const { mutations } = planFeatureMove(graph, destination);
+
+      // 4. Apply the whole plan in one transaction (driven by the plan only).
+      await ctx.db.$transaction(async (tx) => {
+        // Per-ticket: re-point to the destination Product, renumber, and clear
+        // the source-scoped cycle / assignee links the plan flagged.
+        for (const r of mutations.ticketRenumber) {
+          await tx.ticket.update({
+            where: { id: r.ticketId },
+            data: {
+              productId: mutations.destinationProductId,
+              number: r.number,
+              shortId: r.shortId,
+              ...(mutations.clearCycleTicketIds.includes(r.ticketId)
+                ? { cycleId: null }
+                : {}),
+              ...(mutations.clearAssigneeTicketIds.includes(r.ticketId)
+                ? { assigneeId: null }
+                : {}),
+            },
+          });
+        }
+        if (mutations.dropDependencyIds.length > 0) {
+          await tx.ticketDependency.deleteMany({
+            where: { id: { in: mutations.dropDependencyIds } },
+          });
+        }
+        if (mutations.unlinkActionTicketIds.length > 0) {
+          await tx.action.updateMany({
+            where: { ticketId: { in: mutations.unlinkActionTicketIds } },
+            data: { ticketId: null },
+          });
+        }
+        // Feature-level: re-point + sever goal / insights / workspace tags.
+        await tx.feature.update({
+          where: { id: mutations.featureId },
+          data: {
+            productId: mutations.destinationProductId,
+            ...(mutations.nullGoal ? { goalId: null } : {}),
+          },
+        });
+        if (mutations.dropInsightIds.length > 0) {
+          await tx.featureInsight.deleteMany({
+            where: {
+              featureId: mutations.featureId,
+              insightId: { in: mutations.dropInsightIds },
+            },
+          });
+        }
+        if (mutations.dropTagIds.length > 0) {
+          await tx.featureTag.deleteMany({
+            where: {
+              featureId: mutations.featureId,
+              tagId: { in: mutations.dropTagIds },
+            },
+          });
+        }
+        if (mutations.nextTicketCounter !== destProduct.ticketCounter) {
+          await tx.product.update({
+            where: { id: destProduct.id },
+            data: { ticketCounter: mutations.nextTicketCounter },
+          });
+        }
+      });
+
+      // 5. Navigation target: the feature in its new Product/workspace.
+      const destWorkspace = await ctx.db.workspace.findUnique({
+        where: { id: destProduct.workspaceId },
+        select: { slug: true },
+      });
+      return {
+        featureId: feature.id,
+        productSlug: destProduct.slug,
+        workspaceSlug: destWorkspace?.slug ?? null,
+      };
     }),
 
   // ────────────────── Feature Scopes ──────────────────

--- a/src/plugins/product/server/services/__tests__/featureMove.test.ts
+++ b/src/plugins/product/server/services/__tests__/featureMove.test.ts
@@ -78,6 +78,23 @@ describe("planFeatureMove — feature-level rules", () => {
     expect(loss.tagsDropped).toBe(2);
   });
 
+  it("renumbers moving tickets into the destination sequence", () => {
+    const { mutations, loss } = planFeatureMove(
+      graph({
+        tickets: [
+          { id: "tk-1", number: 7, shortId: null, cycleId: null, assigneeId: null, childActionIds: [] },
+          { id: "tk-2", number: 8, shortId: null, cycleId: null, assigneeId: null, childActionIds: [] },
+        ],
+      }),
+      { ...DEST, ticketCounter: 40, usedNumbers: [40] },
+    );
+    expect(mutations.ticketIds).toEqual(["tk-1", "tk-2"]);
+    expect(mutations.ticketRenumber.map((r) => r.number)).toEqual([41, 42]);
+    expect(mutations.nextTicketCounter).toBe(42);
+    expect(loss.ticketsMoved).toBe(2);
+    expect(loss.ticketsRenumbered).toBe(2);
+  });
+
   it("reports an empty loss summary for a clean ticket-less move", () => {
     const { mutations, loss } = planFeatureMove(graph(), DEST);
     expect(mutations.ticketIds).toEqual([]);

--- a/src/plugins/product/server/services/__tests__/featureMove.test.ts
+++ b/src/plugins/product/server/services/__tests__/featureMove.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the pure {@link planFeatureMove} planner (ADR-0027).
+ *
+ * No DB, no harness — the planner is a pure function, so these import it
+ * directly and assert on the returned plan + loss summary. This slice covers
+ * the feature-level rules (goal / insights / tags) and the ticket-less path;
+ * ticket renumbering and per-ticket severances are exercised by later slices.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  planFeatureMove,
+  type FeatureMoveGraph,
+  type FeatureMoveDestination,
+} from "../featureMove";
+
+const DEST: FeatureMoveDestination = {
+  productId: "dest-product",
+  ticketCounter: 0,
+  funTicketIds: false,
+  usedNumbers: [],
+  usedShortIds: [],
+  memberUserIds: [],
+};
+
+function graph(overrides: Partial<FeatureMoveGraph> = {}): FeatureMoveGraph {
+  return {
+    featureId: "feat-1",
+    goalId: null,
+    tags: [],
+    insightIds: [],
+    tickets: [],
+    dependencies: [],
+    ...overrides,
+  };
+}
+
+describe("planFeatureMove — feature-level rules", () => {
+  it("re-points the feature at the destination product", () => {
+    const { mutations } = planFeatureMove(graph(), DEST);
+    expect(mutations.featureId).toBe("feat-1");
+    expect(mutations.destinationProductId).toBe("dest-product");
+  });
+
+  it("nulls a set goal alignment and reports the loss", () => {
+    const { mutations, loss } = planFeatureMove(graph({ goalId: 42 }), DEST);
+    expect(mutations.nullGoal).toBe(true);
+    expect(loss.goalAlignmentRemoved).toBe(true);
+  });
+
+  it("leaves goal untouched when there is no alignment", () => {
+    const { mutations, loss } = planFeatureMove(graph({ goalId: null }), DEST);
+    expect(mutations.nullGoal).toBe(false);
+    expect(loss.goalAlignmentRemoved).toBe(false);
+  });
+
+  it("drops all feature-insight links", () => {
+    const { mutations, loss } = planFeatureMove(
+      graph({ insightIds: ["ins-1", "ins-2"] }),
+      DEST,
+    );
+    expect(mutations.dropInsightIds).toEqual(["ins-1", "ins-2"]);
+    expect(loss.insightLinksDropped).toBe(2);
+  });
+
+  it("drops workspace-scoped tags but keeps global tags", () => {
+    const { mutations, loss } = planFeatureMove(
+      graph({
+        tags: [
+          { tagId: "global", tagWorkspaceId: null },
+          { tagId: "ws-scoped-a", tagWorkspaceId: "ws-src" },
+          { tagId: "ws-scoped-b", tagWorkspaceId: "ws-src" },
+        ],
+      }),
+      DEST,
+    );
+    expect(mutations.dropTagIds).toEqual(["ws-scoped-a", "ws-scoped-b"]);
+    expect(loss.tagsDropped).toBe(2);
+  });
+
+  it("reports an empty loss summary for a clean ticket-less move", () => {
+    const { mutations, loss } = planFeatureMove(graph(), DEST);
+    expect(mutations.ticketIds).toEqual([]);
+    expect(mutations.ticketRenumber).toEqual([]);
+    expect(mutations.nextTicketCounter).toBe(0);
+    expect(loss).toEqual({
+      ticketsMoved: 0,
+      ticketsRenumbered: 0,
+      cyclesDropped: 0,
+      dependenciesPreserved: 0,
+      dependenciesDropped: 0,
+      assigneesCleared: 0,
+      childActionsUnlinked: 0,
+      goalAlignmentRemoved: false,
+      insightLinksDropped: 0,
+      tagsDropped: 0,
+    });
+  });
+});

--- a/src/plugins/product/server/services/__tests__/featureMove.test.ts
+++ b/src/plugins/product/server/services/__tests__/featureMove.test.ts
@@ -114,3 +114,94 @@ describe("planFeatureMove — feature-level rules", () => {
     });
   });
 });
+
+function ticket(over: Partial<import("../featureMove").MoveTicket> & { id: string }) {
+  return {
+    number: 1,
+    shortId: null,
+    cycleId: null,
+    assigneeId: null,
+    childActionIds: [],
+    ...over,
+  };
+}
+
+describe("planFeatureMove — per-ticket severances", () => {
+  it("nulls cycleId on tickets that have a cycle", () => {
+    const { mutations, loss } = planFeatureMove(
+      graph({
+        tickets: [
+          ticket({ id: "a", cycleId: "cyc-1" }),
+          ticket({ id: "b", cycleId: null }),
+        ],
+      }),
+      DEST,
+    );
+    expect(mutations.clearCycleTicketIds).toEqual(["a"]);
+    expect(loss.cyclesDropped).toBe(1);
+  });
+
+  it("keeps an assignee who is a destination member, clears one who is not", () => {
+    const { mutations, loss } = planFeatureMove(
+      graph({
+        tickets: [
+          ticket({ id: "keep", assigneeId: "u-member" }),
+          ticket({ id: "clear", assigneeId: "u-stranger" }),
+          ticket({ id: "none", assigneeId: null }),
+        ],
+      }),
+      { ...DEST, memberUserIds: ["u-member"] },
+    );
+    expect(mutations.clearAssigneeTicketIds).toEqual(["clear"]);
+    expect(loss.assigneesCleared).toBe(1);
+  });
+
+  it("preserves intra-set dependencies and drops cross-boundary ones", () => {
+    const { mutations, loss } = planFeatureMove(
+      graph({
+        tickets: [ticket({ id: "a" }), ticket({ id: "b" })],
+        dependencies: [
+          // both endpoints move → preserved
+          { id: "d-keep", ticketId: "a", dependsOnId: "b" },
+          // crosses to a ticket left behind → dropped
+          { id: "d-out", ticketId: "a", dependsOnId: "outside-1" },
+          { id: "d-in", ticketId: "outside-2", dependsOnId: "b" },
+        ],
+      }),
+      DEST,
+    );
+    expect(loss.dependenciesPreserved).toBe(1);
+    expect(mutations.dropDependencyIds.sort()).toEqual(["d-in", "d-out"]);
+    expect(loss.dependenciesDropped).toBe(2);
+  });
+
+  it("does not double-count a preserved dependency seen from both endpoints", () => {
+    const { loss } = planFeatureMove(
+      graph({
+        tickets: [ticket({ id: "a" }), ticket({ id: "b" })],
+        dependencies: [
+          { id: "d1", ticketId: "a", dependsOnId: "b" },
+          { id: "d1", ticketId: "a", dependsOnId: "b" }, // duplicate row
+        ],
+      }),
+      DEST,
+    );
+    expect(loss.dependenciesPreserved).toBe(1);
+    expect(loss.dependenciesDropped).toBe(0);
+  });
+
+  it("unlinks child actions and surfaces the total count", () => {
+    const { mutations, loss } = planFeatureMove(
+      graph({
+        tickets: [
+          ticket({ id: "a", childActionIds: ["act-1", "act-2"] }),
+          ticket({ id: "b", childActionIds: ["act-3"] }),
+          ticket({ id: "c", childActionIds: [] }),
+        ],
+      }),
+      DEST,
+    );
+    expect(mutations.unlinkActionTicketIds.sort()).toEqual(["a", "b"]);
+    expect(loss.childActionsUnlinked).toBe(3);
+  });
+});

--- a/src/plugins/product/server/services/__tests__/ticketRenumber.test.ts
+++ b/src/plugins/product/server/services/__tests__/ticketRenumber.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the pure {@link allocateTicketNumbers} renumber allocator
+ * (ADR-0027). The contract is external behavior: assigned numbers/shortIds must
+ * be unique and disjoint from the destination's used set, so no
+ * `@@unique([productId, number])` / `([productId, shortId])` violation is
+ * possible after a move.
+ */
+
+import { describe, it, expect } from "vitest";
+import { allocateTicketNumbers } from "../ticketRenumber";
+
+const ids = (n: number) => Array.from({ length: n }, (_, i) => `t-${i}`);
+
+describe("allocateTicketNumbers", () => {
+  it("numbers start clean against an empty destination", () => {
+    const { assignments, nextTicketCounter } = allocateTicketNumbers({
+      ticketIds: ids(3),
+      ticketCounter: 0,
+      usedNumbers: [],
+      funTicketIds: false,
+      usedShortIds: [],
+    });
+    expect(assignments.map((a) => a.number)).toEqual([1, 2, 3]);
+    expect(nextTicketCounter).toBe(3);
+    expect(assignments.every((a) => a.shortId === null)).toBe(true);
+  });
+
+  it("allocates above a dense used-number set with no collisions", () => {
+    const used = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const { assignments } = allocateTicketNumbers({
+      ticketIds: ids(3),
+      ticketCounter: 10,
+      usedNumbers: used,
+      funTicketIds: false,
+      usedShortIds: [],
+    });
+    const assigned = assignments.map((a) => a.number);
+    expect(assigned).toEqual([11, 12, 13]);
+    expect(assigned.some((n) => used.includes(n))).toBe(false);
+  });
+
+  it("stays above the max even with interleaved gaps (does not backfill)", () => {
+    const used = [1, 3, 5];
+    const { assignments } = allocateTicketNumbers({
+      ticketIds: ids(2),
+      ticketCounter: 5,
+      usedNumbers: used,
+      funTicketIds: false,
+      usedShortIds: [],
+    });
+    const assigned = assignments.map((a) => a.number);
+    expect(assigned).toEqual([6, 7]);
+    expect(new Set([...assigned, ...used]).size).toBe(assigned.length + used.length);
+  });
+
+  it("allocates N tickets larger than any gap, all unique and disjoint", () => {
+    const used = [2, 4, 6];
+    const { assignments, nextTicketCounter } = allocateTicketNumbers({
+      ticketIds: ids(10),
+      ticketCounter: 6,
+      usedNumbers: used,
+      funTicketIds: false,
+      usedShortIds: [],
+    });
+    const assigned = assignments.map((a) => a.number);
+    expect(assigned).toEqual([7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    expect(new Set(assigned).size).toBe(assigned.length); // unique
+    expect(assigned.some((n) => used.includes(n))).toBe(false); // disjoint
+    expect(nextTicketCounter).toBe(16);
+  });
+
+  it("guards against a counter that lags behind the real max number", () => {
+    // Defensive: if ticketCounter is stale, allocation still clears used max.
+    const { assignments } = allocateTicketNumbers({
+      ticketIds: ids(1),
+      ticketCounter: 2,
+      usedNumbers: [99],
+      funTicketIds: false,
+      usedShortIds: [],
+    });
+    expect(assignments[0]!.number).toBe(100);
+  });
+
+  it("issues fun shortIds disjoint from used and from each other", () => {
+    let seq = 0;
+    const deterministic = (taken: Set<string>) => {
+      let candidate = `gen-${seq++}`;
+      while (taken.has(candidate)) candidate = `gen-${seq++}`;
+      return candidate;
+    };
+    const { assignments } = allocateTicketNumbers({
+      ticketIds: ids(4),
+      ticketCounter: 0,
+      usedNumbers: [],
+      funTicketIds: true,
+      usedShortIds: ["gen-0", "gen-1"], // force the generator past collisions
+      generateShortId: deterministic,
+    });
+    const shortIds = assignments.map((a) => a.shortId);
+    expect(shortIds.every((s) => s !== null)).toBe(true);
+    expect(new Set(shortIds).size).toBe(shortIds.length); // unique among batch
+    expect(shortIds).not.toContain("gen-0");
+    expect(shortIds).not.toContain("gen-1");
+  });
+});

--- a/src/plugins/product/server/services/featureMove.ts
+++ b/src/plugins/product/server/services/featureMove.ts
@@ -1,0 +1,182 @@
+/**
+ * Feature move planner (ADR-0027) — the single source of truth for what a
+ * cross-workspace Feature move does. Both the confirm-dialog preview and the
+ * executed mutation derive from {@link planFeatureMove}, so the preview can
+ * never disagree with what actually happens.
+ *
+ * This module is **pure**: no DB, no I/O, no `Date`/`Math.random`. The caller
+ * fetches the Feature graph and the destination context, calls
+ * `planFeatureMove`, and applies the returned mutations inside one transaction.
+ *
+ * The cascade is lossy by design — moving a Feature across a workspace boundary
+ * re-homes or severs a graph of workspace- and product-scoped relations. Every
+ * loss is both applied (via {@link MovePlanMutations}) and counted (via
+ * {@link MoveLossSummary}) so the user sees the consequences before committing.
+ *
+ * The rules are implemented incrementally across the move tickets:
+ *   - Feature-level severances (goal / insights / workspace-scoped tags): here.
+ *   - Ticket renumbering into the destination sequence: see `ticketRenumber`.
+ *   - Per-ticket severances (cycles / dependencies / assignees / actions): see
+ *     the corresponding `*TicketIds` / `dropDependencyIds` fields.
+ */
+
+// ── Input: the fetched Feature graph ────────────────────────────────────────
+
+/** A `FeatureTag` join row, carrying its tag's workspace scope. */
+export interface MoveFeatureTag {
+  tagId: string;
+  /** `null` = global tag (kept); non-null = workspace-scoped (dropped). */
+  tagWorkspaceId: string | null;
+}
+
+/** A `TicketDependency` edge incident to one of the moving tickets. */
+export interface MoveTicketDependency {
+  id: string;
+  ticketId: string;
+  dependsOnId: string;
+}
+
+/** A Ticket in the moving set (the Feature's Tickets). */
+export interface MoveTicket {
+  id: string;
+  number: number;
+  shortId: string | null;
+  cycleId: string | null;
+  assigneeId: string | null;
+  /** Ids of child Actions linked to this ticket (`Action.ticketId`). */
+  childActionIds: string[];
+}
+
+export interface FeatureMoveGraph {
+  featureId: string;
+  /** Source workspace's Goal alignment — nulled on a cross-workspace move. */
+  goalId: number | null;
+  tags: MoveFeatureTag[];
+  /** `FeatureInsight.insightId`s — product-scoped, dropped on move. */
+  insightIds: string[];
+  tickets: MoveTicket[];
+  /** All dependency edges touching any moving ticket (deduped by id). */
+  dependencies: MoveTicketDependency[];
+}
+
+// ── Input: the destination context ──────────────────────────────────────────
+
+export interface FeatureMoveDestination {
+  productId: string;
+  /** Destination Product's current `ticketCounter` (monotonic number source). */
+  ticketCounter: number;
+  /** Destination Product's `funTicketIds` toggle (drives shortId generation). */
+  funTicketIds: boolean;
+  /** Numbers already used in the destination Product. */
+  usedNumbers: number[];
+  /** ShortIds already used in the destination Product. */
+  usedShortIds: string[];
+  /** User ids of destination-workspace members (any role). */
+  memberUserIds: string[];
+}
+
+// ── Output: the plan ────────────────────────────────────────────────────────
+
+export interface TicketRenumber {
+  ticketId: string;
+  number: number;
+  shortId: string | null;
+}
+
+export interface MovePlanMutations {
+  featureId: string;
+  destinationProductId: string;
+  /** Whether to null `Feature.goalId`. */
+  nullGoal: boolean;
+  /** `FeatureInsight.insightId`s whose join rows are deleted. */
+  dropInsightIds: string[];
+  /** `FeatureTag.tagId`s whose join rows are deleted (workspace-scoped tags). */
+  dropTagIds: string[];
+  /** All moving ticket ids (re-pointed to the destination Product). */
+  ticketIds: string[];
+  /** New number/shortId for each moving ticket, from the destination sequence. */
+  ticketRenumber: TicketRenumber[];
+  /** Ticket ids whose `cycleId` is cleared. */
+  clearCycleTicketIds: string[];
+  /** Ticket ids whose `assigneeId` is cleared (assignee not in destination ws). */
+  clearAssigneeTicketIds: string[];
+  /** `TicketDependency` ids dropped (cross-boundary edges). */
+  dropDependencyIds: string[];
+  /** Ticket ids whose child Actions are unlinked (`Action.ticketId` → null). */
+  unlinkActionTicketIds: string[];
+  /** Destination Product's `ticketCounter` after allocating moved numbers. */
+  nextTicketCounter: number;
+}
+
+export interface MoveLossSummary {
+  ticketsMoved: number;
+  ticketsRenumbered: number;
+  cyclesDropped: number;
+  dependenciesPreserved: number;
+  dependenciesDropped: number;
+  assigneesCleared: number;
+  childActionsUnlinked: number;
+  goalAlignmentRemoved: boolean;
+  insightLinksDropped: number;
+  tagsDropped: number;
+}
+
+export interface MovePlan {
+  mutations: MovePlanMutations;
+  loss: MoveLossSummary;
+}
+
+/**
+ * Compute the full move plan for re-pointing a Feature at `destination`.
+ *
+ * Feature-level rules (this slice):
+ *   - `goalId` is nulled (the Goal lives in the source workspace).
+ *   - All `FeatureInsight` links are dropped (Insights stay with the source).
+ *   - Workspace-scoped tags are dropped; global tags (`workspaceId === null`)
+ *     are kept.
+ *   - PRD body, scopes, user stories, and comments are carried unchanged (they
+ *     hang off the Feature row, which is not deleted — nothing to do here).
+ *
+ * Ticket migration (renumbering) and per-ticket severances are layered in by
+ * later slices; for a ticket-less Feature the ticket-related outputs are empty.
+ */
+export function planFeatureMove(
+  graph: FeatureMoveGraph,
+  destination: FeatureMoveDestination,
+): MovePlan {
+  const dropTagIds = graph.tags
+    .filter((t) => t.tagWorkspaceId !== null)
+    .map((t) => t.tagId);
+
+  const ticketIds = graph.tickets.map((t) => t.id);
+
+  const mutations: MovePlanMutations = {
+    featureId: graph.featureId,
+    destinationProductId: destination.productId,
+    nullGoal: graph.goalId !== null,
+    dropInsightIds: [...graph.insightIds],
+    dropTagIds,
+    ticketIds,
+    ticketRenumber: [],
+    clearCycleTicketIds: [],
+    clearAssigneeTicketIds: [],
+    dropDependencyIds: [],
+    unlinkActionTicketIds: [],
+    nextTicketCounter: destination.ticketCounter,
+  };
+
+  const loss: MoveLossSummary = {
+    ticketsMoved: ticketIds.length,
+    ticketsRenumbered: 0,
+    cyclesDropped: 0,
+    dependenciesPreserved: 0,
+    dependenciesDropped: 0,
+    assigneesCleared: 0,
+    childActionsUnlinked: 0,
+    goalAlignmentRemoved: mutations.nullGoal,
+    insightLinksDropped: mutations.dropInsightIds.length,
+    tagsDropped: dropTagIds.length,
+  };
+
+  return { mutations, loss };
+}

--- a/src/plugins/product/server/services/featureMove.ts
+++ b/src/plugins/product/server/services/featureMove.ts
@@ -157,6 +157,7 @@ export function planFeatureMove(
     .map((t) => t.tagId);
 
   const ticketIds = graph.tickets.map((t) => t.id);
+  const movingSet = new Set(ticketIds);
 
   // Tickets travel with the Feature, renumbered into the destination sequence
   // (per-product numbering forbids carrying their source numbers across).
@@ -169,6 +170,43 @@ export function planFeatureMove(
     generateShortId,
   });
 
+  // Per-ticket severances (the lossy cross-boundary contract):
+  const destMembers = new Set(destination.memberUserIds);
+  // Cycle: source-Product cycles don't exist in the destination Product.
+  const clearCycleTicketIds = graph.tickets
+    .filter((t) => t.cycleId !== null)
+    .map((t) => t.id);
+  // Assignee: kept only when the assignee is a destination-workspace member.
+  const clearAssigneeTicketIds = graph.tickets
+    .filter((t) => t.assigneeId !== null && !destMembers.has(t.assigneeId))
+    .map((t) => t.id);
+  // Child Actions: stay in the source workspace/Project, ticketId nulled. We
+  // record which tickets *have* actions (the mutation nulls them by ticketId).
+  const ticketsWithActions = graph.tickets.filter(
+    (t) => t.childActionIds.length > 0,
+  );
+  const unlinkActionTicketIds = ticketsWithActions.map((t) => t.id);
+  const childActionsUnlinked = ticketsWithActions.reduce(
+    (sum, t) => sum + t.childActionIds.length,
+    0,
+  );
+  // Dependencies: keep an edge only when BOTH endpoints move (still same-Product
+  // after the move); drop edges that cross to tickets left behind. De-dupe by
+  // id so an edge counted from either endpoint isn't double-counted.
+  const seenDeps = new Set<string>();
+  let dependenciesPreserved = 0;
+  const dropDependencyIds: string[] = [];
+  for (const dep of graph.dependencies) {
+    if (seenDeps.has(dep.id)) continue;
+    seenDeps.add(dep.id);
+    const bothMove = movingSet.has(dep.ticketId) && movingSet.has(dep.dependsOnId);
+    if (bothMove) {
+      dependenciesPreserved += 1;
+    } else {
+      dropDependencyIds.push(dep.id);
+    }
+  }
+
   const mutations: MovePlanMutations = {
     featureId: graph.featureId,
     destinationProductId: destination.productId,
@@ -177,21 +215,21 @@ export function planFeatureMove(
     dropTagIds,
     ticketIds,
     ticketRenumber: assignments,
-    clearCycleTicketIds: [],
-    clearAssigneeTicketIds: [],
-    dropDependencyIds: [],
-    unlinkActionTicketIds: [],
+    clearCycleTicketIds,
+    clearAssigneeTicketIds,
+    dropDependencyIds,
+    unlinkActionTicketIds,
     nextTicketCounter,
   };
 
   const loss: MoveLossSummary = {
     ticketsMoved: ticketIds.length,
     ticketsRenumbered: assignments.length,
-    cyclesDropped: 0,
-    dependenciesPreserved: 0,
-    dependenciesDropped: 0,
-    assigneesCleared: 0,
-    childActionsUnlinked: 0,
+    cyclesDropped: clearCycleTicketIds.length,
+    dependenciesPreserved,
+    dependenciesDropped: dropDependencyIds.length,
+    assigneesCleared: clearAssigneeTicketIds.length,
+    childActionsUnlinked,
     goalAlignmentRemoved: mutations.nullGoal,
     insightLinksDropped: mutations.dropInsightIds.length,
     tagsDropped: dropTagIds.length,

--- a/src/plugins/product/server/services/featureMove.ts
+++ b/src/plugins/product/server/services/featureMove.ts
@@ -20,6 +20,8 @@
  *     the corresponding `*TicketIds` / `dropDependencyIds` fields.
  */
 
+import { allocateTicketNumbers } from "./ticketRenumber";
+
 // ── Input: the fetched Feature graph ────────────────────────────────────────
 
 /** A `FeatureTag` join row, carrying its tag's workspace scope. */
@@ -137,18 +139,35 @@ export interface MovePlan {
  *   - PRD body, scopes, user stories, and comments are carried unchanged (they
  *     hang off the Feature row, which is not deleted — nothing to do here).
  *
- * Ticket migration (renumbering) and per-ticket severances are layered in by
- * later slices; for a ticket-less Feature the ticket-related outputs are empty.
+ * Ticket migration (renumbering) is applied here; per-ticket severances
+ * (cycles / dependencies / assignees / actions) are layered in by a later
+ * slice. For a ticket-less Feature the ticket-related outputs are empty.
+ *
+ * `generateShortId` is forwarded to the renumber allocator so callers (and
+ * tests) can supply a deterministic shortId generator; it defaults to the
+ * random one.
  */
 export function planFeatureMove(
   graph: FeatureMoveGraph,
   destination: FeatureMoveDestination,
+  generateShortId?: (taken: Set<string>) => string,
 ): MovePlan {
   const dropTagIds = graph.tags
     .filter((t) => t.tagWorkspaceId !== null)
     .map((t) => t.tagId);
 
   const ticketIds = graph.tickets.map((t) => t.id);
+
+  // Tickets travel with the Feature, renumbered into the destination sequence
+  // (per-product numbering forbids carrying their source numbers across).
+  const { assignments, nextTicketCounter } = allocateTicketNumbers({
+    ticketIds,
+    ticketCounter: destination.ticketCounter,
+    usedNumbers: destination.usedNumbers,
+    funTicketIds: destination.funTicketIds,
+    usedShortIds: destination.usedShortIds,
+    generateShortId,
+  });
 
   const mutations: MovePlanMutations = {
     featureId: graph.featureId,
@@ -157,17 +176,17 @@ export function planFeatureMove(
     dropInsightIds: [...graph.insightIds],
     dropTagIds,
     ticketIds,
-    ticketRenumber: [],
+    ticketRenumber: assignments,
     clearCycleTicketIds: [],
     clearAssigneeTicketIds: [],
     dropDependencyIds: [],
     unlinkActionTicketIds: [],
-    nextTicketCounter: destination.ticketCounter,
+    nextTicketCounter,
   };
 
   const loss: MoveLossSummary = {
     ticketsMoved: ticketIds.length,
-    ticketsRenumbered: 0,
+    ticketsRenumbered: assignments.length,
     cyclesDropped: 0,
     dependenciesPreserved: 0,
     dependenciesDropped: 0,

--- a/src/plugins/product/server/services/ticketRenumber.ts
+++ b/src/plugins/product/server/services/ticketRenumber.ts
@@ -1,0 +1,74 @@
+/**
+ * Ticket renumber allocator (ADR-0027) — a pure module that assigns
+ * collision-free `number`/`shortId` values from a destination Product's
+ * sequence to a set of moving tickets.
+ *
+ * Tickets are hard-scoped to one Product with per-product numbering
+ * (`@@unique([productId, number])`, `@@unique([productId, shortId])`), so a
+ * moved ticket cannot carry its source number across — it must be re-issued a
+ * fresh number from the destination. Numbers are allocated *above* everything
+ * already in the destination (both its monotonic `ticketCounter` and any
+ * number actually present), so the result is always disjoint from the used set
+ * and from the other moving tickets — no unique-constraint violation is
+ * possible.
+ *
+ * Pure: the only non-determinism is the optional `generateShortId` (defaults to
+ * the random {@link generateFunId}); number allocation is fully deterministic.
+ */
+
+import { generateFunId } from "~/lib/fun-ids";
+import type { TicketRenumber } from "./featureMove";
+
+export interface AllocateTicketNumbersInput {
+  /** Ids of the moving tickets, in the order numbers should be assigned. */
+  ticketIds: string[];
+  /** Destination Product's current monotonic `ticketCounter`. */
+  ticketCounter: number;
+  /** Numbers already present in the destination Product. */
+  usedNumbers: number[];
+  /** Whether the destination Product issues fun shortIds. */
+  funTicketIds: boolean;
+  /** ShortIds already present in the destination Product. */
+  usedShortIds: string[];
+  /**
+   * ShortId generator, injectable for deterministic tests. Receives the set of
+   * shortIds already taken (destination + previously allocated this batch) and
+   * must return one not in it. Defaults to {@link generateFunId}.
+   */
+  generateShortId?: (taken: Set<string>) => string;
+}
+
+export interface AllocateTicketNumbersResult {
+  assignments: TicketRenumber[];
+  /** The destination Product's `ticketCounter` after this allocation. */
+  nextTicketCounter: number;
+}
+
+/**
+ * Allocate fresh, collision-free `number`/`shortId` values for the moving
+ * tickets from the destination Product's sequence.
+ */
+export function allocateTicketNumbers(
+  input: AllocateTicketNumbersInput,
+): AllocateTicketNumbersResult {
+  const gen = input.generateShortId ?? generateFunId;
+
+  // Start above both the monotonic counter and any number actually present, so
+  // assignments can never collide with the destination or each other.
+  const base = Math.max(input.ticketCounter, 0, ...input.usedNumbers);
+
+  const takenShortIds = new Set(input.usedShortIds);
+  const assignments: TicketRenumber[] = input.ticketIds.map((ticketId, i) => {
+    let shortId: string | null = null;
+    if (input.funTicketIds) {
+      shortId = gen(takenShortIds);
+      takenShortIds.add(shortId);
+    }
+    return { ticketId, number: base + i + 1, shortId };
+  });
+
+  return {
+    assignments,
+    nextTicketCounter: base + input.ticketIds.length,
+  };
+}


### PR DESCRIPTION
Implements the four-ticket chain for **moving a Feature to a Product in another workspace** (ADR-0027 · CONTEXT.md glossary **Feature** / **Feature move**). No schema change and no migration — a move re-points existing FKs (`Feature.productId`, `Ticket.productId`).

A Feature has no workspace of its own; its only container link is `Feature.productId → Product`, and the Product carries `workspaceId`. So "move to a workspace" is re-pointing `productId` at a Product in the destination workspace, run as a single-transaction lossy cascade behind an explicit confirm modal.

### Tickets in this PR (dependency order)

| # | shortId | What it adds |
|---|---------|--------------|
| 1 | `extra.cedar` | End-to-end tracer: `planFeatureMove` (pure), `feature.move` mutation (both-ends non-viewer access + one `$transaction`), workspace→product picker modal. Feature-level severances: null `goalId`, drop `FeatureInsight`, drop workspace-scoped tags (keep global). |
| 2 | `sleek.frog` | `ticketRenumber` (pure allocator) + planner/mutation migrate Tickets, renumbered into the destination Product's sequence (per-product `@@unique` forbids carrying source numbers). |
| 3 | `zen.fjord` | Per-ticket severances: clear `cycleId`; preserve intra-set dependencies, drop cross-boundary ones; keep assignee only if a destination member; unlink child Actions (`ticketId` → null). Integration test for the full cascade + atomic rollback + access denial. |
| 4 | `slow.clover` | `getMovePreview` (read-only, same planner → preview can't diverge from execution); modal enumerates every consequence; `expectedSourceProductId` stale-state guard. |

### Design

- **Two pure, isolation-tested modules** are the core: `planFeatureMove` (the loss/cascade contract) and `allocateTicketNumbers` (collision-free renumbering). No DB/I-O.
- **Preview and execution share `loadFeatureMoveContext` + `planFeatureMove`**, so the confirm dialog can never disagree with what the move does.
- The cascade is lossy by design; the confirm dialog is the safety mechanism. Adding a relation to `Feature`/`Ticket` later means updating the planner (and therefore the dialog) together.

### Tests

- Unit: `planFeatureMove` feature-level + every severance branch; `allocateTicketNumbers` (empty / dense / gapped / oversized destinations + shortId disjointness); `feature.move` both-ends access gate (mocked Prisma).
- Integration (testcontainers): full transactional cascade end-state, atomic rollback on a forced mid-transaction failure, destination-access denial, side-effect-free preview, stale-guard rejection.
- Full unit suite (885) + targeted typecheck/lint green; no hardcoded colors.

Closes the `extra.cedar` → `sleek.frog` → `zen.fjord` → `slow.clover` chain under feature `cmqjzvh390005kw04i3rreog9`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to move features to another workspace with a dedicated modal interface.
  * Included a preview step to show what data will be affected before completing the move.
  * Features are automatically renumbered and updated to match the destination workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->