### PR TITLE
feat: Group the tickets board by Area

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/__tests__/ticketGrouping.test.ts
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/__tests__/ticketGrouping.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import {
+  groupTickets,
+  NO_AREA_KEY,
+  NO_AREA_LABEL,
+  type GroupableTicket,
+} from "../ticketGrouping";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+type Area = { id: string; name: string };
+
+function area(id: string, name: string) {
+  return { tag: { id, name, category: "area" as const } };
+}
+
+function label(name: string) {
+  // a non-area tag, must never affect Area grouping
+  return { tag: { id: `lbl-${name}`, name, category: "label" as const } };
+}
+
+function ticket(id: string, areas: Area[] = [], extraTags: Array<{ tag: { id: string; name: string; category: string | null } }> = []): GroupableTicket & { id: string } {
+  return {
+    id,
+    tags: [...areas.map((a) => area(a.id, a.name)), ...extraTags],
+  };
+}
+
+const keys = (groups: Array<{ key: string }>) => groups.map((g) => g.key);
+const labels = (groups: Array<{ label: string }>) => groups.map((g) => g.label);
+const idsIn = (group: { items: Array<{ id: string }> }) => group.items.map((i) => i.id);
+
+// ---------------------------------------------------------------------------
+
+describe("groupTickets — area", () => {
+  it("buckets a single Area per ticket under its Area group", () => {
+    const tickets = [
+      ticket("t1", [{ id: "a-api", name: "clear-api" }]),
+      ticket("t2", [{ id: "a-api", name: "clear-api" }]),
+    ];
+
+    const groups = groupTickets(tickets, "area");
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.key).toBe("a-api");
+    expect(groups[0]!.label).toBe("clear-api");
+    expect(idsIn(groups[0]!)).toEqual(["t1", "t2"]);
+  });
+
+  it("places a ticket with multiple Areas in each of its Area groups", () => {
+    const tickets = [
+      ticket("t1", [
+        { id: "a-api", name: "clear-api" },
+        { id: "a-platform", name: "clear-platform" },
+      ]),
+      ticket("t2", [{ id: "a-api", name: "clear-api" }]),
+    ];
+
+    const groups = groupTickets(tickets, "area");
+
+    const byKey = Object.fromEntries(groups.map((g) => [g.key, idsIn(g)]));
+    expect(byKey["a-api"]).toEqual(["t1", "t2"]);
+    expect(byKey["a-platform"]).toEqual(["t1"]);
+  });
+
+  it("collects tickets with no Area in a single 'No area' bucket", () => {
+    const tickets = [
+      ticket("t1"),
+      ticket("t2", [], [label("frontend")]), // only a non-area tag -> still no area
+      ticket("t3", [{ id: "a-api", name: "clear-api" }]),
+    ];
+
+    const groups = groupTickets(tickets, "area");
+
+    const noArea = groups.find((g) => g.key === NO_AREA_KEY);
+    expect(noArea).toBeDefined();
+    expect(noArea!.label).toBe(NO_AREA_LABEL);
+    expect(idsIn(noArea!)).toEqual(["t1", "t2"]);
+  });
+
+  it("orders Area groups alphabetically with 'No area' pinned last", () => {
+    const tickets = [
+      ticket("t1", [{ id: "a-platform", name: "clear-platform" }]),
+      ticket("t2"), // no area
+      ticket("t3", [{ id: "a-api", name: "clear-api" }]),
+      ticket("t4", [{ id: "a-pipeline", name: "clear-pipeline" }]),
+    ];
+
+    const groups = groupTickets(tickets, "area");
+
+    expect(labels(groups)).toEqual([
+      "clear-api",
+      "clear-pipeline",
+      "clear-platform",
+      NO_AREA_LABEL,
+    ]);
+  });
+
+  it("sorts alphabetically case-insensitively", () => {
+    const tickets = [
+      ticket("t1", [{ id: "z", name: "Zebra" }]),
+      ticket("t2", [{ id: "a", name: "apple" }]),
+      ticket("t3", [{ id: "m", name: "Mango" }]),
+    ];
+
+    expect(labels(groupTickets(tickets, "area"))).toEqual(["apple", "Mango", "Zebra"]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(groupTickets([], "area")).toEqual([]);
+  });
+});
+
+describe("groupTickets — non-area fields are unaffected (single-membership)", () => {
+  it("groups by status with one bucket per ticket", () => {
+    const tickets = [
+      { id: "t1", status: "IN_PROGRESS" },
+      { id: "t2", status: "IN_PROGRESS" },
+      { id: "t3", status: "DONE" },
+    ];
+
+    const groups = groupTickets(tickets, "status");
+
+    expect(keys(groups)).toEqual(["IN_PROGRESS", "DONE"]);
+    expect(idsIn(groups[0]!)).toEqual(["t1", "t2"]);
+    expect(idsIn(groups[1]!)).toEqual(["t3"]);
+  });
+
+  it("'none' returns a single unlabelled bucket with every ticket", () => {
+    const tickets = [{ id: "t1" }, { id: "t2" }];
+    const groups = groupTickets(tickets, "none");
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.key).toBe("all");
+    expect(groups[0]!.label).toBe("");
+    expect(idsIn(groups[0]!)).toEqual(["t1", "t2"]);
+  });
+
+  it("pins 'No cycle' last when grouping by cycle", () => {
+    const tickets = [
+      { id: "t1", cycle: null },
+      { id: "t2", cycle: { name: "Cycle 1", status: "ACTIVE", startDate: "2026-01-01" } },
+    ];
+    const groups = groupTickets(tickets, "cycle");
+    expect(keys(groups)).toEqual(["Cycle 1", "No cycle"]);
+  });
+});

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
@@ -50,6 +50,11 @@ import { BlockedIndicator } from "~/app/_components/product/TicketDependenciesSe
 import { EpicsList } from "~/app/_components/product/EpicsList";
 import { TagBadge } from "~/app/_components/TagBadge";
 import {
+  groupTickets,
+  GROUP_BY_OPTIONS,
+  type GroupByField,
+} from "./ticketGrouping";
+import {
   STATUS_LABELS,
   STATUS_COLORS,
   STATUS_ORDER,
@@ -94,43 +99,6 @@ function sortValue(t: Record<string, unknown>, field: SortField): string | numbe
     case "epic": return ((t.epic as { name?: string } | null)?.name ?? "zzz").toLowerCase();
     case "cycle": return ((t.cycle as { name?: string } | null)?.name ?? "zzz").toLowerCase();
   }
-}
-
-// ---------------------------------------------------------------------------
-// Group by
-// ---------------------------------------------------------------------------
-
-type GroupByField = "none" | "status" | "priority" | "cycle" | "epic" | "type" | "assignee";
-
-const GROUP_BY_OPTIONS = [
-  { value: "none", label: "No grouping" },
-  { value: "status", label: "Status" },
-  { value: "priority", label: "Priority" },
-  { value: "cycle", label: "Cycle" },
-  { value: "epic", label: "Epic" },
-  { value: "type", label: "Type" },
-  { value: "assignee", label: "DRI" },
-];
-
-function groupKey(t: Record<string, unknown>, field: GroupByField): string {
-  switch (field) {
-    case "status": return (t.status as string) ?? "UNKNOWN";
-    case "priority": return t.priority != null ? String(t.priority as number) : "unset";
-    case "cycle": return (t.cycle as { name?: string } | null)?.name ?? "No cycle";
-    case "epic": return (t.epic as { name?: string } | null)?.name ?? "No epic";
-    case "type": return (t.type as string) ?? "UNKNOWN";
-    case "assignee": return (t.assignee as { name?: string } | null)?.name ?? "Unassigned";
-    default: return "all";
-  }
-}
-
-function groupLabel(key: string, field: GroupByField): string {
-  if (field === "status") return STATUS_LABELS[key] ?? key;
-  if (field === "priority") {
-    if (key === "unset") return "No priority";
-    return PRIORITY_LABELS[Number(key)] ?? key;
-  }
-  return key;
 }
 
 // ---------------------------------------------------------------------------
@@ -429,43 +397,11 @@ export default function TicketsBacklogPage() {
     return { active, completed };
   }, [sorted]);
 
-  // Group active tickets
-  const groups = useMemo(() => {
-    if (groupBy === "none") return [{ key: "all", label: "", items: activeTickets }];
-    const map = new Map<string, typeof activeTickets>();
-    for (const t of activeTickets) {
-      const k = groupKey(t as unknown as Record<string, unknown>, groupBy);
-      const arr = map.get(k);
-      if (arr) arr.push(t);
-      else map.set(k, [t]);
-    }
-    const result = Array.from(map.entries()).map(([key, items]) => ({
-      key,
-      label: groupLabel(key, groupBy),
-      items,
-    }));
-
-    // Smart cycle ordering: ACTIVE first, then PLANNED by startDate, then "No cycle"
-    if (groupBy === "cycle") {
-      const cycleStatusOrder: Record<string, number> = { ACTIVE: 0, PLANNED: 1, COMPLETED: 2, ARCHIVED: 3 };
-      result.sort((a, b) => {
-        if (a.key === "No cycle") return 1;
-        if (b.key === "No cycle") return -1;
-        // Find cycle data from any ticket in the group
-        const aCycle = a.items[0]?.cycle;
-        const bCycle = b.items[0]?.cycle;
-        const aStatus = cycleStatusOrder[aCycle?.status ?? ""] ?? 99;
-        const bStatus = cycleStatusOrder[bCycle?.status ?? ""] ?? 99;
-        if (aStatus !== bStatus) return aStatus - bStatus;
-        // Same status: sort by startDate ascending
-        const aStart = aCycle?.startDate ? new Date(aCycle.startDate).getTime() : Infinity;
-        const bStart = bCycle?.startDate ? new Date(bCycle.startDate).getTime() : Infinity;
-        return aStart - bStart;
-      });
-    }
-
-    return result;
-  }, [activeTickets, groupBy]);
+  // Group active tickets (pure grouping core lives in ./ticketGrouping)
+  const groups = useMemo(
+    () => groupTickets(activeTickets, groupBy),
+    [activeTickets, groupBy],
+  );
 
   if (!workspace) return null;
   const basePath = `/w/${workspace.slug}/products/${productSlug}/tickets`;

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/ticketGrouping.ts
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/ticketGrouping.ts
@@ -1,0 +1,170 @@
+import { STATUS_LABELS } from "~/lib/ticket-statuses";
+import { PRIORITY_LABELS } from "~/app/_components/product/PriorityIcon";
+
+// ---------------------------------------------------------------------------
+// Group by — pure, testable core of the tickets board grouping.
+//
+// Maps (tickets, groupByField) → an ordered list of { key, label, items }
+// buckets. Most fields produce exactly one bucket per ticket; "area" is
+// multi-membership (a ticket may land in several Area buckets, or in the
+// pinned-last "No area" bucket).
+// ---------------------------------------------------------------------------
+
+export type GroupByField =
+  | "none"
+  | "status"
+  | "priority"
+  | "cycle"
+  | "epic"
+  | "type"
+  | "assignee"
+  | "area";
+
+export const GROUP_BY_OPTIONS: Array<{ value: GroupByField; label: string }> = [
+  { value: "none", label: "No grouping" },
+  { value: "status", label: "Status" },
+  { value: "priority", label: "Priority" },
+  { value: "cycle", label: "Cycle" },
+  { value: "epic", label: "Epic" },
+  { value: "area", label: "Area" },
+  { value: "type", label: "Type" },
+  { value: "assignee", label: "DRI" },
+];
+
+export interface TicketGroup<T> {
+  key: string;
+  label: string;
+  items: T[];
+}
+
+/** Sentinel key/label for tickets carrying no Area tag. */
+export const NO_AREA_KEY = "__no_area__";
+export const NO_AREA_LABEL = "No area";
+
+/** Category value that marks a Tag as an Area (sub-product / repository). */
+export const AREA_CATEGORY = "area";
+
+const NO_CYCLE_KEY = "No cycle";
+
+/** Minimal ticket shape the grouping logic reads. */
+export interface GroupableTicket {
+  status?: string | null;
+  priority?: number | null;
+  cycle?: {
+    name?: string | null;
+    status?: string | null;
+    startDate?: string | Date | null;
+  } | null;
+  epic?: { name?: string | null } | null;
+  type?: string | null;
+  assignee?: { name?: string | null } | null;
+  tags?: Array<{ tag: { id: string; name: string; category?: string | null } }> | null;
+}
+
+/**
+ * The (key, label) buckets a single ticket belongs to for a given field.
+ * Returns one entry for single-valued fields, and one-per-Area (or the
+ * "No area" sentinel) for the multi-membership "area" field.
+ */
+function bucketsForTicket(
+  t: GroupableTicket,
+  field: Exclude<GroupByField, "none">,
+): Array<{ key: string; label: string }> {
+  switch (field) {
+    case "status": {
+      const key = t.status ?? "UNKNOWN";
+      return [{ key, label: STATUS_LABELS[key] ?? key }];
+    }
+    case "priority": {
+      if (t.priority == null) return [{ key: "unset", label: "No priority" }];
+      const key = String(t.priority);
+      return [{ key, label: PRIORITY_LABELS[t.priority] ?? key }];
+    }
+    case "cycle": {
+      const name = t.cycle?.name ?? NO_CYCLE_KEY;
+      return [{ key: name, label: name }];
+    }
+    case "epic": {
+      const name = t.epic?.name ?? "No epic";
+      return [{ key: name, label: name }];
+    }
+    case "type": {
+      const key = t.type ?? "UNKNOWN";
+      return [{ key, label: key }];
+    }
+    case "assignee": {
+      const name = t.assignee?.name ?? "Unassigned";
+      return [{ key: name, label: name }];
+    }
+    case "area": {
+      const areas = (t.tags ?? []).filter((x) => x.tag.category === AREA_CATEGORY);
+      if (areas.length === 0) return [{ key: NO_AREA_KEY, label: NO_AREA_LABEL }];
+      return areas.map((x) => ({ key: x.tag.id, label: x.tag.name }));
+    }
+  }
+}
+
+/** Smart cycle ordering: ACTIVE first, then PLANNED by startDate, "No cycle" last. */
+function sortCycleGroups<T extends GroupableTicket>(groups: Array<TicketGroup<T>>): void {
+  const cycleStatusOrder: Record<string, number> = {
+    ACTIVE: 0,
+    PLANNED: 1,
+    COMPLETED: 2,
+    ARCHIVED: 3,
+  };
+  groups.sort((a, b) => {
+    if (a.key === NO_CYCLE_KEY) return 1;
+    if (b.key === NO_CYCLE_KEY) return -1;
+    const aCycle = a.items[0]?.cycle;
+    const bCycle = b.items[0]?.cycle;
+    const aStatus = cycleStatusOrder[aCycle?.status ?? ""] ?? 99;
+    const bStatus = cycleStatusOrder[bCycle?.status ?? ""] ?? 99;
+    if (aStatus !== bStatus) return aStatus - bStatus;
+    const aStart = aCycle?.startDate ? new Date(aCycle.startDate).getTime() : Infinity;
+    const bStart = bCycle?.startDate ? new Date(bCycle.startDate).getTime() : Infinity;
+    return aStart - bStart;
+  });
+}
+
+/** Area ordering: alphabetical by name, "No area" pinned last. */
+function sortAreaGroups<T>(groups: Array<TicketGroup<T>>): void {
+  groups.sort((a, b) => {
+    if (a.key === NO_AREA_KEY) return 1;
+    if (b.key === NO_AREA_KEY) return -1;
+    return a.label.localeCompare(b.label, undefined, { sensitivity: "base" });
+  });
+}
+
+/**
+ * Bucket tickets into ordered groups for the board's group-by control.
+ *
+ * - `none` → a single unlabelled bucket containing every ticket.
+ * - Single-valued fields (status/priority/cycle/epic/type/assignee) → one
+ *   bucket per ticket, in first-seen order (with cycle smart-ordered).
+ * - `area` → multi-membership: a ticket appears under each of its Area tags,
+ *   or in the "No area" bucket; ordered alphabetically with "No area" last.
+ */
+export function groupTickets<T extends GroupableTicket>(
+  tickets: T[],
+  field: GroupByField,
+): Array<TicketGroup<T>> {
+  if (field === "none") {
+    return [{ key: "all", label: "", items: tickets }];
+  }
+
+  const map = new Map<string, TicketGroup<T>>();
+  for (const t of tickets) {
+    for (const { key, label } of bucketsForTicket(t, field)) {
+      const existing = map.get(key);
+      if (existing) existing.items.push(t);
+      else map.set(key, { key, label, items: [t] });
+    }
+  }
+
+  const result = Array.from(map.values());
+
+  if (field === "cycle") sortCycleGroups(result);
+  else if (field === "area") sortAreaGroups(result);
+
+  return result;
+}


### PR DESCRIPTION
## What

Make **Area** a grouping dimension on the product tickets board. Areas are existing Tags with `category = "area"`, already loaded on each ticket via its `tags` relation — so this slice is purely client-side, no server change.

The board grouping is factored out of the page component into a **pure, exported `groupTickets()` function** (`ticketGrouping.ts`) that maps `(tickets, groupByField)` → an ordered list of `{ key, label, items }` buckets, generalised from one-key-per-ticket to one-to-many membership. An "Area" option is added to the group-by control.

- One group per Area present on the visible tickets.
- A ticket carrying multiple Areas appears under **each** of its Area groups.
- Tickets with no Area collect in a single **"No area"** group, pinned last.
- Area groups sort alphabetically by name (case-insensitive).
- The selection persists through the existing board-preferences mechanism (`groupBy`).

Existing single-valued fields (status/priority/cycle/epic/type/assignee) and the smart cycle ordering move into the same pure function unchanged.

## Acceptance criteria

- [x] "Area" appears in the board's group-by control and renders one group per Area.
- [x] A ticket with two Areas shows in both corresponding groups.
- [x] Tickets with no Area appear in a "No area" group pinned last; other Area groups are alphabetical.
- [x] The Area grouping choice survives a reload (persisted with other board view prefs).
- [x] The grouping logic lives in a pure exported function with unit tests (single Area, multi-Area membership, "No area" bucket, alphabetical ordering with "No area" last, empty input).
- [x] No hardcoded colours; group headers reuse existing semantic tag-colour tokens.

## Testing

- New unit suite `ticketGrouping.test.ts` (9 tests) covering all the cases above.
- `npx tsc --noEmit` clean; eslint clean on changed files; full unit suite (894 tests) green.

---

Refs: scarlet.elk