### PR TITLE
fix(feature): wire up label picker on feature detail page

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
@@ -43,7 +43,7 @@ import {
   PropertyDivider,
 } from "~/app/_components/PropertiesSidebar";
 import { PriorityIcon } from "~/app/_components/product/PriorityIcon";
-import { TagBadge } from "~/app/_components/TagBadge";
+import { LabelsCombobox } from "~/app/_components/product/LabelsCombobox";
 import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
 import { PrdDocument } from "~/app/_components/prd/PrdDocument";
 import type { JSONContent } from "@tiptap/core";
@@ -92,13 +92,33 @@ export default function FeatureDetailPage() {
   const params = useParams();
   const featureId = params.featureId as string;
   const productSlug = params.productSlug as string;
-  const { workspace } = useWorkspace();
+  const { workspace, workspaceId } = useWorkspace();
   const utils = api.useUtils();
 
   const { data: feature, isLoading } = api.product.feature.getById.useQuery(
     { id: featureId },
     { enabled: !!featureId },
   );
+
+  const { data: tags } = api.tag.list.useQuery(
+    { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId },
+  );
+
+  const setFeatureTags = api.tag.setFeatureTags.useMutation({
+    onSuccess: async () => {
+      await utils.product.feature.getById.invalidate({ id: featureId });
+    },
+  });
+
+  const createTag = api.tag.create.useMutation({
+    onSuccess: async (newTag) => {
+      await utils.tag.list.invalidate();
+      // Auto-add the newly created tag to this feature
+      const currentIds = feature?.tags?.map((t: { tag: { id: string } }) => t.tag.id) ?? [];
+      setFeatureTags.mutate({ featureId, tagIds: [...currentIds, newTag.id] });
+    },
+  });
 
   const [moveModalOpen, setMoveModalOpen] = useState(false);
 
@@ -403,15 +423,15 @@ export default function FeatureDetailPage() {
         </PropertyRow>
 
         <PropertyRow icon={<IconTag size={14} />} label="Labels">
-          {feature.tags && feature.tags.length > 0 ? (
-            <Group gap={4}>
-              {feature.tags.map((t: { tag: { id: string; name: string; color: string } }) => (
-                <TagBadge key={t.tag.id} tag={t.tag} size="xs" />
-              ))}
-            </Group>
-          ) : (
-            <Text size="xs" className="text-text-muted">None</Text>
-          )}
+          <LabelsCombobox
+            selectedIds={feature.tags?.map((t: { tag: { id: string } }) => t.tag.id) ?? []}
+            allTags={tags?.allTags ?? []}
+            entityTags={feature.tags ?? []}
+            onChange={(tagIds) => setFeatureTags.mutate({ featureId, tagIds })}
+            onCreate={(name) => {
+              if (workspaceId) createTag.mutate({ name, color: "avatar-blue", workspaceId });
+            }}
+          />
         </PropertyRow>
 
         <PropertyDivider />

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
@@ -53,13 +53,13 @@ import {
 import { generateLinearId } from "~/lib/fun-ids";
 import { PriorityIcon } from "~/app/_components/product/PriorityIcon";
 import { TicketDependenciesSection } from "~/app/_components/product/TicketDependenciesSection";
+import { LabelsCombobox } from "~/app/_components/product/LabelsCombobox";
 import {
   STATUS_OPTIONS,
   STATUS_COLORS,
   type TicketStatus,
 } from "~/lib/ticket-statuses";
 import { TagBadge } from "~/app/_components/TagBadge";
-import { getTagMantineColor } from "~/utils/tagColors";
 import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
 
 // ---------------------------------------------------------------------------
@@ -194,98 +194,6 @@ function EpicCombobox({
           {!search.trim() && filtered.length === 0 && (
             <Combobox.Empty>
               <Text size="xs" className="text-text-muted">No epics</Text>
-            </Combobox.Empty>
-          )}
-        </Combobox.Options>
-      </Combobox.Dropdown>
-    </Combobox>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Combobox: Labels (multi-select with create)
-// ---------------------------------------------------------------------------
-
-function LabelsCombobox({
-  selectedIds,
-  allTags,
-  ticketTags,
-  onChange,
-  onCreate,
-}: {
-  selectedIds: string[];
-  allTags: Array<{ id: string; name: string; color: string }>;
-  ticketTags: Array<{ tag: { id: string; name: string; color: string } }>;
-  onChange: (tagIds: string[]) => void;
-  onCreate: (name: string) => void;
-}) {
-  const combobox = useCombobox({ onDropdownClose: () => { combobox.resetSelectedOption(); setSearch(""); } });
-  const [search, setSearch] = useState("");
-
-  const filtered = allTags.filter((t) => t.name.toLowerCase().includes(search.toLowerCase().trim()));
-  const exactMatch = allTags.some((t) => t.name.toLowerCase() === search.toLowerCase().trim());
-
-  const toggleTag = (tagId: string) => {
-    if (selectedIds.includes(tagId)) {
-      onChange(selectedIds.filter((id) => id !== tagId));
-    } else {
-      onChange([...selectedIds, tagId]);
-    }
-  };
-
-  return (
-    <Combobox store={combobox} onOptionSubmit={(val) => {
-      if (val === "__create") {
-        onCreate(search.trim());
-        combobox.closeDropdown();
-      } else {
-        toggleTag(val);
-        // Keep dropdown open for multi-select
-      }
-    }}>
-      <Combobox.Target>
-        <div
-          className="cursor-pointer min-h-[24px] flex items-center"
-          onClick={() => combobox.toggleDropdown()}
-        >
-          {ticketTags.length > 0 ? (
-            <Group gap={4}>
-              {ticketTags.map((t) => (
-                <TagBadge key={t.tag.id} tag={t.tag} size="xs" />
-              ))}
-            </Group>
-          ) : (
-            <Text size="xs" className="text-text-muted">None</Text>
-          )}
-        </div>
-      </Combobox.Target>
-      <Combobox.Dropdown>
-        <Combobox.Search
-          value={search}
-          onChange={(e) => { setSearch(e.currentTarget.value); combobox.updateSelectedOptionIndex(); }}
-          placeholder="Search or create..."
-          size="xs"
-        />
-        <Combobox.Options>
-          {filtered.map((tag) => {
-            const isSelected = selectedIds.includes(tag.id);
-            return (
-              <Combobox.Option key={tag.id} value={tag.id} active={isSelected}>
-                <div className="flex items-center gap-2">
-                  {isSelected && <CheckIcon size={12} />}
-                  <Badge size="xs" variant="light" color={getTagMantineColor(tag.color)}>{tag.name}</Badge>
-                </div>
-              </Combobox.Option>
-            );
-          })}
-          {search.trim() && !exactMatch && (
-            <Combobox.Option value="__create">
-              <Text size="xs" className="text-blue-400">+ Create &quot;{search.trim()}&quot;</Text>
-            </Combobox.Option>
-          )}
-          {!search.trim() && filtered.length === 0 && (
-            <Combobox.Empty>
-              <Text size="xs" className="text-text-muted">No labels</Text>
             </Combobox.Empty>
           )}
         </Combobox.Options>
@@ -758,7 +666,7 @@ export default function TicketDetailPage() {
           <LabelsCombobox
             selectedIds={ticket.tags?.map((t: { tag: { id: string } }) => t.tag.id) ?? []}
             allTags={tags?.allTags ?? []}
-            ticketTags={ticket.tags ?? []}
+            entityTags={ticket.tags ?? []}
             onChange={(tagIds) => setTicketTags.mutate({ ticketId, tagIds })}
             onCreate={(name) => {
               if (workspaceId) createTag.mutate({ name, color: "avatar-blue", workspaceId });

--- a/src/app/_components/product/LabelsCombobox.tsx
+++ b/src/app/_components/product/LabelsCombobox.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Badge,
+  CheckIcon,
+  Combobox,
+  Group,
+  Text,
+  useCombobox,
+} from "@mantine/core";
+import { TagBadge } from "~/app/_components/TagBadge";
+import { getTagMantineColor } from "~/utils/tagColors";
+
+type Tag = { id: string; name: string; color: string };
+
+/**
+ * Multi-select labels picker with inline create. Entity-agnostic — used by both
+ * the ticket and feature detail pages. The caller owns persistence via onChange
+ * (replace-all tag set) and onCreate.
+ */
+export function LabelsCombobox({
+  selectedIds,
+  allTags,
+  entityTags,
+  onChange,
+  onCreate,
+}: {
+  selectedIds: string[];
+  allTags: Tag[];
+  entityTags: Array<{ tag: Tag }>;
+  onChange: (tagIds: string[]) => void;
+  onCreate: (name: string) => void;
+}) {
+  const combobox = useCombobox({ onDropdownClose: () => { combobox.resetSelectedOption(); setSearch(""); } });
+  const [search, setSearch] = useState("");
+
+  const filtered = allTags.filter((t) => t.name.toLowerCase().includes(search.toLowerCase().trim()));
+  const exactMatch = allTags.some((t) => t.name.toLowerCase() === search.toLowerCase().trim());
+
+  const toggleTag = (tagId: string) => {
+    if (selectedIds.includes(tagId)) {
+      onChange(selectedIds.filter((id) => id !== tagId));
+    } else {
+      onChange([...selectedIds, tagId]);
+    }
+  };
+
+  return (
+    <Combobox store={combobox} onOptionSubmit={(val) => {
+      if (val === "__create") {
+        onCreate(search.trim());
+        combobox.closeDropdown();
+      } else {
+        toggleTag(val);
+        // Keep dropdown open for multi-select
+      }
+    }}>
+      <Combobox.Target>
+        <div
+          className="cursor-pointer min-h-[24px] flex items-center"
+          onClick={() => combobox.toggleDropdown()}
+        >
+          {entityTags.length > 0 ? (
+            <Group gap={4}>
+              {entityTags.map((t) => (
+                <TagBadge key={t.tag.id} tag={t.tag} size="xs" />
+              ))}
+            </Group>
+          ) : (
+            <Text size="xs" className="text-text-muted">None</Text>
+          )}
+        </div>
+      </Combobox.Target>
+      <Combobox.Dropdown>
+        <Combobox.Search
+          value={search}
+          onChange={(e) => { setSearch(e.currentTarget.value); combobox.updateSelectedOptionIndex(); }}
+          placeholder="Search or create..."
+          size="xs"
+        />
+        <Combobox.Options>
+          {filtered.map((tag) => {
+            const isSelected = selectedIds.includes(tag.id);
+            return (
+              <Combobox.Option key={tag.id} value={tag.id} active={isSelected}>
+                <div className="flex items-center gap-2">
+                  {isSelected && <CheckIcon size={12} />}
+                  <Badge size="xs" variant="light" color={getTagMantineColor(tag.color)}>{tag.name}</Badge>
+                </div>
+              </Combobox.Option>
+            );
+          })}
+          {search.trim() && !exactMatch && (
+            <Combobox.Option value="__create">
+              <Text size="xs" className="text-blue-400">+ Create &quot;{search.trim()}&quot;</Text>
+            </Combobox.Option>
+          )}
+          {!search.trim() && filtered.length === 0 && (
+            <Combobox.Empty>
+              <Text size="xs" className="text-text-muted">No labels</Text>
+            </Combobox.Empty>
+          )}
+        </Combobox.Options>
+      </Combobox.Dropdown>
+    </Combobox>
+  );
+}


### PR DESCRIPTION
## What

- Extract the ticket page's inline label picker into a shared `LabelsCombobox` component (`src/app/_components/product/LabelsCombobox.tsx`)
- Use it on the **feature** detail page Properties panel — the Labels row was previously static text with no way to add labels
- Refactor the **ticket** detail page to consume the shared component (removes ~90 lines of duplication)

Backed by the existing `tag.setFeatureTags` mutation and `tag.list` query — no schema or backend changes.

## Why

Features could not be tagged from the UI: the Labels row in the feature Properties panel rendered as static "None" with nothing clickable behind it. Now it's a searchable multi-select dropdown with inline label creation, matching the ticket page.