### PR TITLE
fix(crm): retry CRM onboarding automations after a failed run

### DIFF
--- a/src/server/services/crm/automation/__tests__/dispatchContactTypeAutomations.test.ts
+++ b/src/server/services/crm/automation/__tests__/dispatchContactTypeAutomations.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the impure CRM automation dispatcher's idempotency rule.
+ *
+ * The pure firing decision lives in `triggerResolver.test.ts`; here we only
+ * pin the DB-facing behaviour the resolver can't see: a FAILED prior run must
+ * NOT count as "already fired", so a failed onboarding (transient email/Adobe
+ * error, missing template) is retried on the next save, while a SUCCESS/RUNNING
+ * run keeps firing idempotent.
+ *
+ * `WorkflowEngine` is mocked so no real step executes and no DB/network is hit.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+const executeMock = vi.fn().mockResolvedValue({ id: "run-new" });
+
+vi.mock("~/server/services/workflows/WorkflowEngine", () => ({
+  WorkflowEngine: class {
+    execute = executeMock;
+  },
+}));
+
+vi.mock("~/server/services/workflows/StepRegistry", () => ({
+  createStepRegistry: vi.fn(() => ({})),
+}));
+
+import { dispatchContactTypeAutomations } from "../dispatchContactTypeAutomations";
+import { CRM_CONTACT_TYPE_TRIGGER } from "../triggerResolver";
+
+const db = mockDeep<PrismaClient>();
+
+const baseInput = {
+  contactId: "contact-1",
+  workspaceId: "ws-1",
+  oldProfileType: null,
+  newProfileType: "Channel Partner",
+  triggeredById: "user-1",
+};
+
+beforeEach(() => {
+  mockReset(db);
+  executeMock.mockClear();
+  db.workflowDefinition.findMany.mockResolvedValue([
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { id: "def-cp", config: { targetCustomerType: "Channel Partner" } } as any,
+  ]);
+});
+
+describe("dispatchContactTypeAutomations idempotency", () => {
+  it("excludes FAILED runs from the idempotency check", async () => {
+    db.workflowPipelineRun.findMany.mockResolvedValue([]);
+
+    await dispatchContactTypeAutomations(db, baseInput);
+
+    const where = db.workflowPipelineRun.findMany.mock.calls[0]?.[0]?.where;
+    expect(where?.status).toEqual({ not: "FAILED" });
+  });
+
+  it("retries an automation whose only prior run FAILED", async () => {
+    // The query already filters out FAILED rows, so a contact with only a
+    // failed run comes back empty here → the automation fires again.
+    db.workflowPipelineRun.findMany.mockResolvedValue([]);
+
+    const result = await dispatchContactTypeAutomations(db, baseInput);
+
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(result.firedDefinitionIds).toEqual(["def-cp"]);
+  });
+
+  it("does not re-fire when a non-failed run already exists", async () => {
+    db.workflowPipelineRun.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { definitionId: "def-cp" } as any,
+    ]);
+
+    const result = await dispatchContactTypeAutomations(db, baseInput);
+
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(result.firedDefinitionIds).toEqual([]);
+  });
+
+  it("queries only this contact's runs for the active CRM trigger", async () => {
+    db.workflowPipelineRun.findMany.mockResolvedValue([]);
+
+    await dispatchContactTypeAutomations(db, baseInput);
+
+    const defWhere = db.workflowDefinition.findMany.mock.calls[0]?.[0]?.where;
+    expect(defWhere?.triggerType).toBe(CRM_CONTACT_TYPE_TRIGGER);
+    expect(defWhere?.isActive).toBe(true);
+
+    const runWhere = db.workflowPipelineRun.findMany.mock.calls[0]?.[0]?.where;
+    expect(runWhere?.input).toEqual({
+      path: ["contactId"],
+      equals: "contact-1",
+    });
+  });
+});

--- a/src/server/services/crm/automation/dispatchContactTypeAutomations.ts
+++ b/src/server/services/crm/automation/dispatchContactTypeAutomations.ts
@@ -65,10 +65,15 @@ export async function dispatchContactTypeAutomations(
 
   // Idempotency: which of these definitions already produced a run for this
   // contact? Runs carry `{ contactId }` in their input JSON, so no extra column.
+  // Exclude FAILED runs — a failed onboarding (e.g. a transient email/Adobe
+  // error, or a missing template) must be retryable on the next save. Only a
+  // SUCCESS or in-flight RUNNING run counts as "already fired", so a genuine
+  // re-tag never re-onboards a contact that was already successfully handled.
   const priorRuns = await db.workflowPipelineRun.findMany({
     where: {
       definitionId: { in: definitions.map((d) => d.id) },
       input: { path: ["contactId"], equals: input.contactId },
+      status: { not: "FAILED" },
     },
     select: { definitionId: true },
   });


### PR DESCRIPTION
## What

Follow-up to #241 (CRM automations core). Fixes a **High-severity bug found in PR review of #241**, now live in `main`.

## The bug

`dispatchContactTypeAutomations` keys idempotency off prior `WorkflowPipelineRun`s for a `(definition, contact)` pair — but it counted runs of **any** status, including `FAILED`. So the first failed run latched the automation permanently: re-saving the contact found the failed run and skipped firing forever.

A partner/advisor who hit a single transient failure could never be onboarded without manual DB surgery. This is especially likely because:

- `generate_document` reads templates from `process.cwd()` and `ENOENT`s on a Vercel build (already flagged as deferred PoC hardening in `agreementTemplates.ts`), and
- `send_email` throws when a contact has no email.

In both cases `send_email` may succeed first, then a later step fails → the whole run is `FAILED` → onboarding can never retry.

## The fix

Exclude `FAILED` runs from the idempotency query (`status: { not: "FAILED" }`). A failed onboarding now retries on the next save, while `SUCCESS`/`RUNNING` runs keep firing idempotent — so a genuine re-tag never re-onboards a contact that was already handled.

Adds a mocked-Prisma regression test for the dispatcher (FAILED excluded, retry after failure, no re-fire on existing non-failed run, query scoping).

## Test

- `npx vitest run src/server/services/crm/automation` — 18 passing (4 new)
- Full unit suite green via pre-commit (903 passing); typecheck + lint clean.

No schema change, no migration.