### PR TITLE
fix(feature): make Effort and Goal editable on feature detail page

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Group,
   Menu,
+  NumberInput,
   Select,
   Skeleton,
   Stack,
@@ -102,6 +103,11 @@ export default function FeatureDetailPage() {
 
   const { data: tags } = api.tag.list.useQuery(
     { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId },
+  );
+
+  const { data: goals } = api.goal.getAllMyGoals.useQuery(
+    { workspaceId: workspaceId ?? undefined },
     { enabled: !!workspaceId },
   );
 
@@ -397,17 +403,35 @@ export default function FeatureDetailPage() {
         </PropertyRow>
 
         <PropertyRow icon={<IconFlame size={14} />} label="Effort">
-          <Text size="xs" className="text-text-primary">
-            {feature.effort != null ? String(feature.effort) : "None"}
-          </Text>
+          <NumberInput
+            value={feature.effort ?? ""}
+            onChange={(val) => handleFieldUpdate("effort", val === "" ? null : Number(val))}
+            size="xs"
+            variant="unstyled"
+            min={0}
+            placeholder="None"
+            classNames={{ input: "text-text-primary text-xs font-medium cursor-pointer" }}
+            styles={{ input: { height: 24, minHeight: 24, width: 80 } }}
+          />
         </PropertyRow>
 
         <PropertyDivider />
 
         <PropertyRow icon={<IconTarget size={14} />} label="Goal">
-          <Text size="xs" className={feature.goal ? "text-text-primary" : "text-text-muted"}>
-            {feature.goal?.title ?? "None"}
-          </Text>
+          <Select
+            value={feature.goalId != null ? String(feature.goalId) : null}
+            onChange={(val) => handleFieldUpdate("goalId", val != null ? Number(val) : null)}
+            data={(goals ?? []).map((g) => ({ value: String(g.id), label: g.title }))}
+            size="xs"
+            variant="unstyled"
+            clearable
+            searchable
+            placeholder="None"
+            nothingFoundMessage="No goals"
+            comboboxProps={{ withinPortal: true }}
+            classNames={{ input: "text-text-primary text-xs font-medium cursor-pointer" }}
+            styles={{ input: { height: 24, minHeight: 24 } }}
+          />
         </PropertyRow>
 
         <PropertyRow icon={<IconTicket size={14} />} label="Tickets">

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -375,7 +375,7 @@ export const featureRouter = createTRPCRouter({
         description: boundedText("Description", TEXT_LIMITS.LARGE).optional(),
         vision: boundedText("Vision", TEXT_LIMITS.SHORT).optional(),
         status: featureStatusEnum.optional(),
-        effort: z.number().optional(),
+        effort: z.number().nullable().optional(),
         priority: z.number().int().min(0).max(4).optional(),
         goalId: z.number().int().nullable().optional(),
         // PRD body save (ADR-0024). `descriptionDoc` is the canonical document;


### PR DESCRIPTION
## What

- **Effort** row: static text → `NumberInput` (writes `feature.update({ effort })`)
- **Goal** row: static text → searchable, clearable `Select` populated from `goal.getAllMyGoals` (writes `feature.update({ goalId })`)
- Made the `feature.update` schema's `effort` field `.nullable()` so it can be cleared (column is already `Float?`)

Follow-up to #242 (Labels row). Status and Priority were already editable Selects.

## Why

The Effort and Goal rows in the feature Properties panel rendered as static text, so neither could be changed from the UI.