### PR TITLE
fix(okr): refresh OKR dashboard after the assistant writes OKRs

### DIFF
--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -1376,6 +1376,15 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
         void utils.scoring.getTodayScore.invalidate();
         void utils.scoring.getProductivityStats.invalidate();
       }
+      if (toRefresh.has('okr')) {
+        // Objective cards, hero stats, the year/period counts, and the
+        // create-KR objective picker — the full set the OKR dashboard mounts,
+        // so agent-created objectives/KRs and (un)links appear without reload.
+        void utils.okr.getByObjective.invalidate();
+        void utils.okr.getStats.invalidate();
+        void utils.okr.getCountsByYear.invalidate();
+        void utils.okr.getAvailableGoals.invalidate();
+      }
 
       const responseTime = Date.now() - startTime;
       // A turn that did tool work but produced no prose is NOT empty —

--- a/src/app/_components/manyChatToolRefresh.test.ts
+++ b/src/app/_components/manyChatToolRefresh.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   toolTriggersGoalActivityRefresh,
   toolTriggersActionRefresh,
+  toolTriggersOkrRefresh,
   entitiesToRefresh,
 } from "./manyChatToolRefresh";
 
@@ -49,6 +50,36 @@ describe("toolTriggersActionRefresh", () => {
   });
 });
 
+describe("toolTriggersOkrRefresh", () => {
+  it("matches the objective + key-result mutations across name forms", () => {
+    // createTool ids
+    expect(toolTriggersOkrRefresh("create-okr-objective")).toBe(true);
+    expect(toolTriggersOkrRefresh("update-okr-objective")).toBe(true);
+    expect(toolTriggersOkrRefresh("delete-okr-objective")).toBe(true);
+    expect(toolTriggersOkrRefresh("create-okr-key-result")).toBe(true);
+    expect(toolTriggersOkrRefresh("update-okr-key-result")).toBe(true);
+    expect(toolTriggersOkrRefresh("delete-okr-key-result")).toBe(true);
+    expect(toolTriggersOkrRefresh("checkin-okr-key-result")).toBe(true);
+    // Registration key + humanized label normalize the same.
+    expect(toolTriggersOkrRefresh("createOkrKeyResultTool")).toBe(true);
+    expect(toolTriggersOkrRefresh("Update okr objective")).toBe(true);
+  });
+
+  it("matches the (un)link / nest tools that restructure the OKR tree", () => {
+    expect(toolTriggersOkrRefresh("link-project-to-goal")).toBe(true);
+    expect(toolTriggersOkrRefresh("unlink-project-from-goal")).toBe(true);
+    expect(toolTriggersOkrRefresh("link-objective-to-parent")).toBe(true);
+  });
+
+  it("does not match read-only OKR tools or unrelated tools", () => {
+    // Carry the noun but no mutating verb.
+    expect(toolTriggersOkrRefresh("get-okr-objectives")).toBe(false);
+    expect(toolTriggersOkrRefresh("get-okr-stats")).toBe(false);
+    expect(toolTriggersOkrRefresh("createActionTool")).toBe(false);
+    expect(toolTriggersOkrRefresh("")).toBe(false);
+  });
+});
+
 describe("entitiesToRefresh", () => {
   it("returns 'action' for each action tool-name variant, regardless of page", () => {
     for (const name of [
@@ -62,6 +93,21 @@ describe("entitiesToRefresh", () => {
       // Action surfaces on many pages, so no page guard.
       expect(entitiesToRefresh([name], "goal").has("action")).toBe(true);
       expect(entitiesToRefresh([name], "workspace").has("action")).toBe(true);
+    }
+  });
+
+  it("returns 'okr' for OKR mutations on any page (no page guard)", () => {
+    for (const name of [
+      "create-okr-objective",
+      "update-okr-objective",
+      "create-okr-key-result",
+      "checkin-okr-key-result",
+      "link-project-to-goal",
+    ]) {
+      expect(entitiesToRefresh([name], "okrs").has("okr")).toBe(true);
+      // OKR queries only mount on the dashboard, so firing anywhere is near-free.
+      expect(entitiesToRefresh([name], undefined).has("okr")).toBe(true);
+      expect(entitiesToRefresh([name], "workspace").has("okr")).toBe(true);
     }
   });
 

--- a/src/app/_components/manyChatToolRefresh.ts
+++ b/src/app/_components/manyChatToolRefresh.ts
@@ -17,7 +17,7 @@
  */
 
 /** Entities whose mounted views ManyChat knows how to refresh after an agent write. */
-export type RefreshEntity = "goalActivity" | "action";
+export type RefreshEntity = "goalActivity" | "action" | "okr";
 
 /** Lowercase, letters-only — collapses registration-key / createTool-id / humanized forms. */
 function normalize(toolName: string): string {
@@ -55,6 +55,31 @@ export function toolTriggersActionRefresh(toolName: string): boolean {
   );
 }
 
+/**
+ * Whether a tool name mutates OKR data the dashboard renders. Recognises the
+ * objective and key-result writes (create / update / delete / checkin — all
+ * carry the `okrObjective` or `okrKeyResult` noun) and the (un)link / nest tools
+ * that restructure the OKR tree and the projects shown on KR cards. Read tools
+ * (`get-okr-objectives`, `get-okr-stats`) carry the noun but no mutating verb, so
+ * they don't match — mirroring the action matcher's read/write split.
+ */
+export function toolTriggersOkrRefresh(toolName: string): boolean {
+  const normalized = normalize(toolName);
+  const isOkrEntity =
+    normalized.includes("okrobjective") || normalized.includes("okrkeyresult");
+  const hasMutatingVerb =
+    normalized.includes("create") ||
+    normalized.includes("update") ||
+    normalized.includes("delete") ||
+    normalized.includes("checkin");
+  if (isOkrEntity && hasMutatingVerb) return true;
+  // link-project-to-goal, unlink-project-from-goal, link-objective-to-parent.
+  return (
+    normalized.includes("link") &&
+    (normalized.includes("goal") || normalized.includes("objective"))
+  );
+}
+
 interface RefreshRule {
   entity: RefreshEntity;
   matches: (toolName: string) => boolean;
@@ -77,6 +102,14 @@ const RULES: RefreshRule[] = [
   {
     entity: "action",
     matches: toolTriggersActionRefresh,
+  },
+  {
+    // No page guard — OKR queries are only observed by the OKR dashboard, so
+    // invalidating them off the OKRs page is a no-op (same rationale as action),
+    // and it sidesteps the goals page's three sibling panels racing for the
+    // single page-context slot.
+    entity: "okr",
+    matches: toolTriggersOkrRefresh,
   },
 ];
 


### PR DESCRIPTION
## What

When the in-app assistant (Zoe) creates or updates OKRs via chat tools — objectives, key results, check-ins, and (un)link/nest tools — the OKRs tab now refreshes automatically, instead of staying stale until a manual page reload. This brings OKRs in line with how Actions and Goal activity already refresh after an agent write (ADR-0023).

## How

- Add an `okr` entity to the agent-write → client-refresh rule registry (`manyChatToolRefresh.ts`): a `toolTriggersOkrRefresh` matcher (objective/key-result create·update·delete·checkin, plus link/unlink/nest; read tools excluded) and an unguarded rule.
- Wire `ManyChat` to invalidate `okr.getByObjective` / `getStats` / `getCountsByYear` / `getAvailableGoals` when an OKR-mutating tool ran.
- The rule has **no page guard** — OKR queries only mount on the OKR dashboard, so invalidating elsewhere is a no-op, and it avoids the goals page's three sibling panels racing for the single page-context slot.
- Unit tests cover the matcher (all name forms, reads excluded) and the registry.

## Why

Reported from the OKRs tab: KRs created via the assistant didn't appear until reload. The Goals tab already refreshes; this makes OKRs behave the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* OKR objectives and key results now properly refresh after making changes through the agent interface, ensuring up-to-date data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->