### PR TITLE
feat(meetings): participant picker on the project transcriptions modal

### DIFF
--- a/src/app/_components/TranscriptionDetailsModal.tsx
+++ b/src/app/_components/TranscriptionDetailsModal.tsx
@@ -25,6 +25,7 @@ import { api } from "~/trpc/react";
 import { ActionsPane } from "./transcription-detail/ActionsPane";
 import { MeetingHeader } from "./transcription-detail/MeetingHeader";
 import { NotesPane } from "./transcription-detail/NotesPane";
+import { ParticipantPicker } from "./transcription-detail/ParticipantPicker";
 import { Rail } from "./transcription-detail/Rail";
 import { ScreenshotsPane } from "./transcription-detail/ScreenshotsPane";
 import { SummaryPane } from "./transcription-detail/SummaryPane";
@@ -57,7 +58,7 @@ export function TranscriptionDetailsModal({
   transcription,
   onTranscriptionUpdate,
 }: TranscriptionDetailsModalProps) {
-  const { workspace } = useWorkspace();
+  const { workspace, workspaceId, userRole } = useWorkspace();
   const { data: authSession } = useSession();
 
   // Refetch full data (with participants + actions) once the modal opens.
@@ -84,6 +85,7 @@ export function TranscriptionDetailsModal({
   const [editedTranscript, setEditedTranscript] = useState("");
   const [editingNotes, setEditingNotes] = useState(false);
   const [editedNotes, setEditedNotes] = useState("");
+  const [participantPickerOpen, setParticipantPickerOpen] = useState(false);
 
   useEffect(() => {
     if (!opened) {
@@ -92,11 +94,26 @@ export function TranscriptionDetailsModal({
       setEditingTitle(false);
       setEditingTranscript(false);
       setEditingNotes(false);
+      setParticipantPickerOpen(false);
     }
   }, [opened]);
 
   // ---------- mutations ----------
   const utils = api.useUtils();
+
+  const removeParticipantMutation =
+    api.transcription.removeParticipant.useMutation({
+      onSuccess: () => {
+        void refetch();
+      },
+      onError: (error) => {
+        notifications.show({
+          title: "Couldn't remove participant",
+          message: error.message,
+          color: "red",
+        });
+      },
+    });
 
   const updateTitleMutation = api.transcription.updateTitle.useMutation({
     onSuccess: (updated) => {
@@ -271,6 +288,7 @@ export function TranscriptionDetailsModal({
       email: string;
       isHost: boolean;
       userId: string | null;
+      contactId: string | null;
     }> | undefined) ?? [];
     if (raw.length > 0) {
       return raw.map((p) => ({
@@ -279,6 +297,7 @@ export function TranscriptionDetailsModal({
         email: p.email,
         isHost: p.isHost,
         isMe: p.email?.toLowerCase() === meEmail,
+        isPersisted: true,
       }));
     }
     // Derive from turns
@@ -299,8 +318,33 @@ export function TranscriptionDetailsModal({
       isHost: false,
       isMe:
         !!meName && p.name.toLowerCase().includes(meName.toLowerCase().split(" ")[0]!),
+      isPersisted: false,
     }));
   }, [data?.participants, turns, meEmail, meName]);
+
+  // Participants are workspace-scoped (members + CRM), so editing needs a
+  // workspace and a non-viewer role. The server enforces the real edit rule.
+  const participantWorkspaceId =
+    (data?.workspace?.id as string | undefined) ?? workspaceId ?? null;
+  const canEditParticipants =
+    !!participantWorkspaceId &&
+    (userRole === "owner" || userRole === "admin" || userRole === "member");
+
+  // Identity keys already on the meeting, so the picker can hide them.
+  const existingParticipantKeys = useMemo(() => {
+    const keys = new Set<string>();
+    const raw = (data?.participants as Array<{
+      email: string;
+      userId: string | null;
+      contactId: string | null;
+    }> | undefined) ?? [];
+    for (const p of raw) {
+      if (p.userId) keys.add(`user:${p.userId}`);
+      if (p.contactId) keys.add(`contact:${p.contactId}`);
+      if (p.email) keys.add(`email:${p.email.toLowerCase()}`);
+    }
+    return keys;
+  }, [data?.participants]);
 
   // Type pill: from Fireflies meeting_type, capitalized. Fallback "Meeting".
   const meetingTypeLabel = useMemo(() => {
@@ -602,6 +646,16 @@ export function TranscriptionDetailsModal({
 
           <Rail
             participants={participants}
+            onAddParticipant={
+              canEditParticipants
+                ? () => setParticipantPickerOpen(true)
+                : undefined
+            }
+            onRemoveParticipant={
+              canEditParticipants
+                ? (id) => removeParticipantMutation.mutate({ id })
+                : undefined
+            }
             analyticsJson={data?.analyticsJson}
             links={links}
             source={{
@@ -669,6 +723,17 @@ export function TranscriptionDetailsModal({
             ]}
           />
         </div>
+
+        {participantWorkspaceId && (
+          <ParticipantPicker
+            opened={participantPickerOpen}
+            onClose={() => setParticipantPickerOpen(false)}
+            sessionId={data?.id ?? ""}
+            workspaceId={participantWorkspaceId}
+            existing={existingParticipantKeys}
+            onAdded={() => void refetch()}
+          />
+        )}
 
         <LoadingOverlay
           visible={

--- a/src/app/_components/transcription-detail/ParticipantPicker.tsx
+++ b/src/app/_components/transcription-detail/ParticipantPicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Loader, Modal, ScrollArea, TextInput } from "@mantine/core";
+import { useDebouncedValue } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
 import { IconPlus, IconSearch, IconUserPlus } from "@tabler/icons-react";
 import { useMemo, useState } from "react";
@@ -51,17 +52,31 @@ export function ParticipantPicker({
   onAdded,
 }: ParticipantPickerProps) {
   const { workspace } = useWorkspace();
+  const utils = api.useUtils();
   const [query, setQuery] = useState("");
+  // Debounce the term sent to the server so we don't refetch on every keystroke.
+  const [debouncedQuery] = useDebouncedValue(query.trim(), 200);
 
+  // Search server-side (by name) so contacts beyond the first page are findable
+  // — getAll defaults to 50 ordered by recency, which would otherwise hide the
+  // long tail. Client-side filtering below still narrows the loaded rows further
+  // and is the only filter for members (which come from the workspace context).
   const { data: contactsData, isLoading: contactsLoading } =
     api.crmContact.getAll.useQuery(
-      { workspaceId: workspaceId ?? "" },
+      {
+        workspaceId: workspaceId ?? "",
+        search: debouncedQuery || undefined,
+        limit: 100,
+      },
       { enabled: opened && !!workspaceId },
     );
 
   const addMutation = api.transcription.addParticipant.useMutation({
     onSuccess: () => {
       onAdded();
+      // A free-text email may have inline-created a CRM contact; refresh the
+      // contact list so it reflects reality for subsequent adds this session.
+      void utils.crmContact.getAll.invalidate();
       setQuery("");
     },
     onError: (error) => {
@@ -74,7 +89,10 @@ export function ParticipantPicker({
   });
 
   const members = useMemo<PickerItem[]>(() => {
-    const rows = workspace?.members ?? [];
+    // Members come from the active workspace context. Only show them when that
+    // matches the meeting's workspace — otherwise addParticipant would reject
+    // them as non-members, so listing them would be misleading.
+    const rows = workspace?.id === workspaceId ? (workspace?.members ?? []) : [];
     return rows
       .filter(
         (m) =>
@@ -88,7 +106,7 @@ export function ParticipantPicker({
         sub: m.role,
         payload: { userId: m.user.id },
       }));
-  }, [workspace?.members, existing]);
+  }, [workspace?.members, workspace?.id, workspaceId, existing]);
 
   const contacts = useMemo<PickerItem[]>(() => {
     const rows = contactsData?.contacts ?? [];

--- a/src/app/_components/transcription-detail/ParticipantPicker.tsx
+++ b/src/app/_components/transcription-detail/ParticipantPicker.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { Loader, Modal, ScrollArea, TextInput } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { IconPlus, IconSearch, IconUserPlus } from "@tabler/icons-react";
+import { useMemo, useState } from "react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import { api } from "~/trpc/react";
+import {
+  getAvatarColor,
+  getColorSeed,
+  getInitial,
+  getTextColor,
+} from "~/utils/avatarColors";
+
+interface ParticipantPickerProps {
+  opened: boolean;
+  onClose: () => void;
+  sessionId: string;
+  workspaceId: string | null;
+  /**
+   * Lowercased identity keys already on the meeting — `user:<id>`,
+   * `contact:<id>`, and `email:<addr>` — used to hide existing participants.
+   */
+  existing: Set<string>;
+  /** Called after a successful add so the parent can refetch. */
+  onAdded: () => void;
+}
+
+interface PickerItem {
+  key: string;
+  name: string;
+  email: string | null;
+  /** Sub-label, e.g. role or "Contact". */
+  sub: string;
+  /** Mutation payload identifying the person. */
+  payload:
+    | { userId: string }
+    | { contactId: string }
+    | { email?: string; name?: string };
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function ParticipantPicker({
+  opened,
+  onClose,
+  sessionId,
+  workspaceId,
+  existing,
+  onAdded,
+}: ParticipantPickerProps) {
+  const { workspace } = useWorkspace();
+  const [query, setQuery] = useState("");
+
+  const { data: contactsData, isLoading: contactsLoading } =
+    api.crmContact.getAll.useQuery(
+      { workspaceId: workspaceId ?? "" },
+      { enabled: opened && !!workspaceId },
+    );
+
+  const addMutation = api.transcription.addParticipant.useMutation({
+    onSuccess: () => {
+      onAdded();
+      setQuery("");
+    },
+    onError: (error) => {
+      notifications.show({
+        title: "Couldn't add participant",
+        message: error.message,
+        color: "red",
+      });
+    },
+  });
+
+  const members = useMemo<PickerItem[]>(() => {
+    const rows = workspace?.members ?? [];
+    return rows
+      .filter(
+        (m) =>
+          !existing.has(`user:${m.user.id}`) &&
+          !(m.user.email && existing.has(`email:${m.user.email.toLowerCase()}`)),
+      )
+      .map((m) => ({
+        key: `member-${m.userId}`,
+        name: m.user.name ?? m.user.email ?? "Unknown",
+        email: m.user.email,
+        sub: m.role,
+        payload: { userId: m.user.id },
+      }));
+  }, [workspace?.members, existing]);
+
+  const contacts = useMemo<PickerItem[]>(() => {
+    const rows = contactsData?.contacts ?? [];
+    return rows
+      .filter(
+        (c) =>
+          !existing.has(`contact:${c.id}`) &&
+          !(c.email && existing.has(`email:${c.email.toLowerCase()}`)),
+      )
+      .map((c) => ({
+        key: `contact-${c.id}`,
+        name:
+          [c.firstName, c.lastName].filter(Boolean).join(" ") ||
+          c.email ||
+          "Unnamed contact",
+        email: c.email,
+        sub: "Contact",
+        payload: { contactId: c.id },
+      }));
+  }, [contactsData?.contacts, existing]);
+
+  const q = query.trim().toLowerCase();
+  const matchItem = (i: PickerItem) =>
+    !q ||
+    i.name.toLowerCase().includes(q) ||
+    (i.email?.toLowerCase().includes(q) ?? false);
+
+  const filteredMembers = members.filter(matchItem);
+  const filteredContacts = contacts.filter(matchItem);
+
+  // Offer a free-text "add" when the query doesn't exactly match an existing
+  // option. An email-looking query is added as an email (→ CRM contact on the
+  // server); anything else is added as a name-only participant.
+  const trimmed = query.trim();
+  const exactMatch = [...filteredMembers, ...filteredContacts].some(
+    (i) =>
+      i.name.toLowerCase() === q || (i.email?.toLowerCase() ?? "") === q,
+  );
+  const showFreeText = trimmed.length > 0 && !exactMatch;
+  const isEmail = EMAIL_RE.test(trimmed);
+
+  const handleAdd = (payload: PickerItem["payload"]) => {
+    addMutation.mutate({ transcriptionSessionId: sessionId, ...payload });
+  };
+
+  const handleFreeText = () => {
+    if (isEmail) {
+      handleAdd({ email: trimmed });
+    } else {
+      handleAdd({ name: trimmed });
+    }
+  };
+
+  const noResults =
+    filteredMembers.length === 0 &&
+    filteredContacts.length === 0 &&
+    !showFreeText;
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title="Add participant"
+      centered
+      size="md"
+    >
+      <TextInput
+        placeholder="Search members and contacts, or type a name/email"
+        leftSection={<IconSearch size={16} />}
+        value={query}
+        onChange={(e) => setQuery(e.currentTarget.value)}
+        data-autofocus
+        mb="sm"
+      />
+
+      <ScrollArea.Autosize mah={360} type="hover">
+        {contactsLoading && (
+          <div className="flex justify-center py-6">
+            <Loader size="sm" />
+          </div>
+        )}
+
+        {filteredMembers.length > 0 && (
+          <PickerGroup
+            label="Team members"
+            items={filteredMembers}
+            disabled={addMutation.isPending}
+            onPick={handleAdd}
+          />
+        )}
+
+        {filteredContacts.length > 0 && (
+          <PickerGroup
+            label="CRM contacts"
+            items={filteredContacts}
+            disabled={addMutation.isPending}
+            onPick={handleAdd}
+          />
+        )}
+
+        {showFreeText && (
+          <button
+            type="button"
+            className="mdm-picker__freetext"
+            onClick={handleFreeText}
+            disabled={addMutation.isPending}
+          >
+            <span className="mdm-picker__freetext-icon">
+              <IconUserPlus size={16} />
+            </span>
+            <span className="min-w-0">
+              <span className="mdm-picker__name truncate">
+                Add &ldquo;{trimmed}&rdquo;
+              </span>
+              <span className="mdm-picker__sub">
+                {isEmail
+                  ? "New contact — added to the CRM"
+                  : "One-off participant (name only)"}
+              </span>
+            </span>
+            <IconPlus size={14} className="mdm-picker__plus" />
+          </button>
+        )}
+
+        {noResults && !contactsLoading && (
+          <div className="mdm-picker__empty">No people found.</div>
+        )}
+      </ScrollArea.Autosize>
+    </Modal>
+  );
+}
+
+function PickerGroup({
+  label,
+  items,
+  disabled,
+  onPick,
+}: {
+  label: string;
+  items: PickerItem[];
+  disabled: boolean;
+  onPick: (payload: PickerItem["payload"]) => void;
+}) {
+  return (
+    <div className="mdm-picker__group">
+      <div className="mdm-picker__group-label">{label}</div>
+      {items.map((i) => {
+        const seed = getColorSeed(i.name, i.email);
+        const bg = getAvatarColor(seed);
+        return (
+          <button
+            key={i.key}
+            type="button"
+            className="mdm-picker__row"
+            onClick={() => onPick(i.payload)}
+            disabled={disabled}
+          >
+            <span
+              className="mdm-picker__avatar"
+              style={{ backgroundColor: bg, color: getTextColor(bg) }}
+            >
+              {getInitial(i.name, i.email)}
+            </span>
+            <span className="min-w-0 flex-1 text-left">
+              <span className="mdm-picker__name truncate">{i.name}</span>
+              <span className="mdm-picker__sub truncate">
+                {i.email ?? i.sub}
+              </span>
+            </span>
+            <IconPlus size={14} className="mdm-picker__plus" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/_components/transcription-detail/Rail.tsx
+++ b/src/app/_components/transcription-detail/Rail.tsx
@@ -5,6 +5,7 @@ import {
   IconArrowUpRight,
   IconPlayerPlayFilled,
   IconPlus,
+  IconX,
 } from "@tabler/icons-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
@@ -22,6 +23,8 @@ interface RailParticipant {
   email: string;
   isHost: boolean;
   isMe: boolean;
+  /** True for stored participant rows; false for transcript-derived placeholders. */
+  isPersisted: boolean;
 }
 
 type RailTone = "blue" | "amber" | "purple" | "green";
@@ -66,6 +69,7 @@ interface RailProps {
   details: RailDetail[];
   actions: RailAction[];
   onAddParticipant?: () => void;
+  onRemoveParticipant?: (id: string) => void;
 }
 
 export function Rail({
@@ -76,6 +80,7 @@ export function Rail({
   details,
   actions,
   onAddParticipant,
+  onRemoveParticipant,
 }: RailProps) {
   const talkShares = extractTalkShares(analyticsJson);
   const getShare = (p: RailParticipant): string | null => {
@@ -129,6 +134,17 @@ export function Rail({
                     <span className="mdm-person__talk" title="Talk-time share">
                       {share}
                     </span>
+                  )}
+                  {p.isPersisted && onRemoveParticipant && (
+                    <button
+                      type="button"
+                      className="mdm-person__remove"
+                      onClick={() => onRemoveParticipant(p.id)}
+                      aria-label={`Remove ${display}`}
+                      title="Remove participant"
+                    >
+                      <IconX size={13} />
+                    </button>
                   )}
                 </div>
               );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1949,7 +1949,7 @@
 }
 .mdm-person {
   display: grid;
-  grid-template-columns: 28px 1fr auto;
+  grid-template-columns: 28px 1fr auto auto;
   align-items: center;
   gap: 10px;
 }
@@ -1988,6 +1988,105 @@
   padding: 2px 8px;
   border-radius: 6px;
   background: var(--color-surface-muted);
+}
+.mdm-person__remove {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: color 120ms, background 120ms, opacity 120ms;
+}
+.mdm-person:hover .mdm-person__remove,
+.mdm-person__remove:focus-visible {
+  opacity: 1;
+}
+.mdm-person__remove:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-hover);
+}
+
+/* ---- Participant picker ---- */
+.mdm-picker__group {
+  margin-bottom: 8px;
+}
+.mdm-picker__group-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+  padding: 6px 4px;
+}
+.mdm-picker__row,
+.mdm-picker__freetext {
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  transition: background 120ms;
+}
+.mdm-picker__row:hover,
+.mdm-picker__freetext:hover {
+  background: var(--color-bg-hover);
+}
+.mdm-picker__row:disabled,
+.mdm-picker__freetext:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.mdm-picker__avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.mdm-picker__freetext-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: var(--color-text-muted);
+  background: var(--color-surface-muted);
+}
+.mdm-picker__name {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  line-height: 1.3;
+}
+.mdm-picker__sub {
+  display: block;
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  line-height: 1.3;
+}
+.mdm-picker__plus {
+  color: var(--color-text-muted);
+}
+.mdm-picker__empty {
+  padding: 16px 10px;
+  font-size: 13px;
+  color: var(--color-text-muted);
+  text-align: center;
 }
 .mdm-link-row {
   display: grid;


### PR DESCRIPTION
## What

Adds the participant picker to the **project transcriptions modal** (`TranscriptionDetailsModal`, opened from a project's Transcriptions tab — e.g. `…/projects/<id>?tab=transcriptions&transcription=…`). You can search workspace members + CRM contacts, free-text a name/email, and remove participants you've added.

## Scope (narrowed)

The participant **backend** (`addParticipant`/`removeParticipant`) and the CONTEXT.md glossary shipped separately in #250, which added a picker to the *new* `/recording/[id]` meeting detail page. #250 did **not** touch the project transcriptions modal — the original surface this work targets. This PR was rebased onto main to drop the now-duplicate backend + glossary and keep **only the modal/Rail frontend**, which calls the same `addParticipant`/`removeParticipant` API already on main.

## Changes

- New `transcription-detail/ParticipantPicker` modal: searchable, grouped **Team members** / **CRM contacts** (already-added excluded), plus a free-text "Add …" action. Contact search runs server-side (debounced, `limit: 100`); members are only listed when the active workspace matches the meeting's workspace.
- `Rail` gains a hover **×** remove on managed participants (never on transcript-derived placeholders).
- `TranscriptionDetailsModal` wires the picker + remove; gated on a workspace + non-viewer role (server enforces the real rule).

## Note / future cleanup

This leaves two picker components — `meeting/ParticipantPicker` (#250, detail page) and `transcription-detail/ParticipantPicker` (this PR, modal) — for two surfaces. Consolidating them is a reasonable follow-up.