### PR TITLE
feat: Link & manage meeting participants on the detail page

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,7 +26,7 @@ A task extracted from a meeting by Zoe and persisted in the `Action` table. The 
 _Avoid_: Task, todo, item.
 
 **Participant**:
-A person on the meeting invite, stored in `TranscriptionSessionParticipant` with email, optional name, optional linked `User` or `CrmContact`. Authoritative source for "who was in this meeting". Silent attendees count.
+A person on the meeting invite, stored in `TranscriptionSessionParticipant` with email, optional name, optional linked `User` or `CrmContact`. Authoritative source for "who was in this meeting". Silent attendees count. **Email is required and unique per meeting** (`@@unique([transcriptionSessionId, email])`), so every Participant carries an email even when it must be captured at link time. Participants are **user-managed from the meeting side** — both the manual-add modal and the `/recording/[id]` detail page let a user search workspace **CrmContacts** by name and link one, or add a name+email that **inline-creates a CrmContact** (emailHash dedup, `importSource: "MANUAL"`). Linking a contact that has no email captures one and writes it back to the contact. This is the *write* side of the Meeting↔CRM link; the contact-detail Meetings tab is the (separate) *read* side.
 _Avoid_: Attendee (only as a count word — "4 attendees"), invitee.
 
 **Speaker**:
@@ -166,6 +166,7 @@ _Avoid_: Task, story, item, issue.
 
 **Feature**:
 A coherent slice of product capability inside a Product, stored as `Feature`. Has `status` (`IDEA`, `DEFINED`, `IN_PROGRESS`, `SHIPPED`, `ARCHIVED`), optional `vision`, optional alignment to a Goal (`Feature.goalId`). Groups Tickets (`Ticket.featureId`).
+_Avoid_: Task, story, item, issue.
 
 **Objective**:
 A strategic outcome — what Exponential schemas call `Goal`. Use the word "Objective" in OKR conversation and UI affordances ("Aligned to objective: …"); the underlying table is `Goal` for historical reasons. An Objective can nest under a parent Objective (`Goal.parentGoalId`), be scoped to a `period` (e.g. `Q2-2026`), and have many **Key results**.

--- a/src/app/_components/meeting/ContextRail.tsx
+++ b/src/app/_components/meeting/ContextRail.tsx
@@ -11,7 +11,9 @@ import {
   IconExternalLink,
   IconArchive,
   IconPlus,
+  IconX,
 } from "@tabler/icons-react";
+import { Loader } from "@mantine/core";
 import { MpAvatar } from "./MpAvatar";
 import type { MeetingParticipant } from "~/lib/meeting-view-model";
 
@@ -36,6 +38,9 @@ interface ContextRailProps {
   canExport: boolean;
   onArchive: () => void;
   onAddParticipant?: () => void;
+  onRemoveParticipant?: (id: string) => void;
+  /** Id of the participant currently being removed, for a per-row spinner. */
+  removingParticipantId?: string | null;
 }
 
 export function ContextRail({
@@ -59,10 +64,12 @@ export function ContextRail({
   canExport,
   onArchive,
   onAddParticipant,
+  onRemoveParticipant,
+  removingParticipantId,
 }: ContextRailProps) {
   return (
     <aside className="mp-rail">
-      {participants.length > 0 && (
+      {(participants.length > 0 || onAddParticipant) && (
         <div className="mp-rail__section">
           <div className="mp-rail__label">
             <span>Participants</span>
@@ -77,18 +84,37 @@ export function ContextRail({
               </button>
             )}
           </div>
-          <div className="mp-people">
-            {participants.map((p) => (
-              <div key={p.id} className="mp-person">
-                <MpAvatar initial={p.initial} flavor={p.flavor} />
-                <div style={{ minWidth: 0 }}>
-                  <div className="mp-person__name">{p.name}</div>
-                  {p.role && <div className="mp-person__role">{p.role}</div>}
-                </div>
-                {p.talk && <span className="mp-person__talk" title="Talk-time">{p.talk}</span>}
-              </div>
-            ))}
-          </div>
+          {participants.length > 0 ? (
+            <div className="mp-people">
+              {participants.map((p) => {
+                const removing = removingParticipantId === p.id;
+                return (
+                  <div key={p.id} className="mp-person">
+                    <MpAvatar initial={p.initial} flavor={p.flavor} />
+                    <div style={{ minWidth: 0 }}>
+                      <div className="mp-person__name">{p.name}</div>
+                      {p.role && <div className="mp-person__role">{p.role}</div>}
+                    </div>
+                    {p.talk && <span className="mp-person__talk" title="Talk-time">{p.talk}</span>}
+                    {onRemoveParticipant && (
+                      <button
+                        type="button"
+                        className="mp-person__remove"
+                        onClick={() => onRemoveParticipant(p.id)}
+                        disabled={removing}
+                        aria-label={`Remove ${p.name}`}
+                        title={`Remove ${p.name}`}
+                      >
+                        {removing ? <Loader size={12} /> : <IconX size={13} />}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="mp-rail__empty">No participants yet.</div>
+          )}
         </div>
       )}
 

--- a/src/app/_components/meeting/MeetingDetail.tsx
+++ b/src/app/_components/meeting/MeetingDetail.tsx
@@ -9,9 +9,13 @@ import { SummaryTab } from "./SummaryTab";
 import { TranscriptTab } from "./TranscriptTab";
 import { ScreenshotsTab } from "./ScreenshotsTab";
 import { ContextRail } from "./ContextRail";
+import {
+  ParticipantPicker,
+  type PendingParticipant,
+} from "./ParticipantPicker";
 import { buildMeetingViewModel } from "~/lib/meeting-view-model";
 import type { MeetingSession } from "~/lib/meeting-view-model";
-import type { RouterOutputs } from "~/trpc/react";
+import { api, type RouterOutputs } from "~/trpc/react";
 
 type TranscriptAction = RouterOutputs["action"]["getByTranscription"][number];
 type Tab = "summary" | "transcript" | "screenshots";
@@ -60,7 +64,54 @@ export function MeetingDetail({
   onArchive,
 }: MeetingDetailProps) {
   const [tab, setTab] = useState<Tab>("summary");
+  const [pickerOpen, setPickerOpen] = useState(false);
   const vm = useMemo(() => buildMeetingViewModel(session), [session]);
+
+  const utils = api.useUtils();
+  // Identity keys already on the meeting so the picker hides existing people.
+  const existingParticipants = useMemo(() => {
+    const keys = new Set<string>();
+    for (const p of session.participants) {
+      if (p.contactId) keys.add(`contact:${p.contactId}`);
+      if (p.email?.includes("@")) keys.add(`email:${p.email.toLowerCase()}`);
+    }
+    return keys;
+  }, [session.participants]);
+
+  const addParticipant = api.transcription.addParticipant.useMutation({
+    onSuccess: () => {
+      void utils.transcription.getById.invalidate({ id: session.id });
+    },
+    onError: (error) =>
+      notifications.show({
+        title: "Couldn't add participant",
+        message: error.message,
+        color: "red",
+      }),
+  });
+
+  const removeParticipant = api.transcription.removeParticipant.useMutation({
+    onSuccess: () => {
+      void utils.transcription.getById.invalidate({ id: session.id });
+    },
+    onError: (error) =>
+      notifications.show({
+        title: "Couldn't remove participant",
+        message: error.message,
+        color: "red",
+      }),
+  });
+
+  function handleAddPerson(person: PendingParticipant) {
+    addParticipant.mutate({
+      transcriptionSessionId: session.id,
+      ...person.payload,
+    });
+  }
+
+  function handleRemoveParticipant(id: string) {
+    removeParticipant.mutate({ id });
+  }
 
   const meetingDateObj = session.meetingDate ? new Date(session.meetingDate) : null;
   const displayDate = meetingDateObj ?? new Date(session.createdAt);
@@ -109,10 +160,7 @@ export function MeetingDetail({
   }
 
   function handleAddParticipant() {
-    notifications.show({
-      message: "Editing participants is coming soon",
-      color: "blue",
-    });
+    setPickerOpen(true);
   }
 
   return (
@@ -216,9 +264,24 @@ export function MeetingDetail({
             canExport={Boolean(session.transcription)}
             onArchive={onArchive}
             onAddParticipant={handleAddParticipant}
+            onRemoveParticipant={handleRemoveParticipant}
+            removingParticipantId={
+              removeParticipant.isPending
+                ? removeParticipant.variables?.id ?? null
+                : null
+            }
           />
         </div>
       </div>
+
+      <ParticipantPicker
+        opened={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        workspaceId={session.workspaceId ?? null}
+        existing={existingParticipants}
+        onAdd={handleAddPerson}
+        busy={addParticipant.isPending}
+      />
     </div>
   );
 }

--- a/src/app/_components/meeting/ParticipantPicker.tsx
+++ b/src/app/_components/meeting/ParticipantPicker.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import {
+  Avatar,
+  Button,
+  Group,
+  Loader,
+  Modal,
+  ScrollArea,
+  Stack,
+  Text,
+  TextInput,
+  UnstyledButton,
+} from "@mantine/core";
+import {
+  IconArrowLeft,
+  IconPlus,
+  IconSearch,
+  IconUserPlus,
+} from "@tabler/icons-react";
+import { useEffect, useMemo, useState } from "react";
+import { api } from "~/trpc/react";
+import { getInitial } from "~/utils/avatarColors";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Theme-aware avatar tints — Mantine palette names (never hardcoded colors), so
+// a contact keeps a stable tint that adapts to light/dark mode.
+const AVATAR_COLORS = [
+  "blue",
+  "grape",
+  "teal",
+  "orange",
+  "cyan",
+  "pink",
+  "lime",
+  "violet",
+] as const;
+
+function avatarColor(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+  }
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length]!;
+}
+
+/**
+ * A participant the user picked or created in the picker, not necessarily
+ * persisted yet. `payload` is exactly what `transcription.addParticipant` and
+ * `createManualTranscription` accept; `name`/`email` drive the display. The
+ * picker is selection-only — the parent decides whether to persist immediately
+ * (meeting detail page) or stage it for an atomic save (create-meeting modal).
+ */
+export interface PendingParticipant {
+  /** Stable identity key — `contact:<id>` or `email:<addr>` — for deduping a
+   *  pending list and hiding people already on the meeting. */
+  key: string;
+  name: string;
+  email: string;
+  payload:
+    | { contactId: string; email?: string }
+    | { email: string; name?: string };
+}
+
+interface ParticipantPickerProps {
+  opened: boolean;
+  onClose: () => void;
+  /** The meeting's workspace. CRM contacts are workspace-scoped, so the picker
+   *  is inert without one. */
+  workspaceId: string | null;
+  /** Identity keys already on the meeting (`contact:<id>` and lowercased
+   *  `email:<addr>`) so existing participants are hidden from the results. */
+  existing: Set<string>;
+  /** Emitted when the user links a contact or adds a new person. */
+  onAdd: (participant: PendingParticipant) => void;
+  /** Disables interaction while the parent persists an add. */
+  busy?: boolean;
+}
+
+type Capture =
+  | { kind: "contact"; contactId: string; name: string; email: string }
+  | { kind: "new"; name: string; email: string };
+
+export function ParticipantPicker({
+  opened,
+  onClose,
+  workspaceId,
+  existing,
+  onAdd,
+  busy = false,
+}: ParticipantPickerProps) {
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  // Email-capture sub-form: shown for a brand-new person, or an existing
+  // contact that has no email on file (captured + written back server-side).
+  const [capture, setCapture] = useState<Capture | null>(null);
+
+  // Debounce the contact search so we don't fire a query per keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query.trim()), 250);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const { data, isLoading } = api.crmContact.getAll.useQuery(
+    {
+      workspaceId: workspaceId ?? "",
+      search: debouncedQuery || undefined,
+      limit: 20,
+    },
+    { enabled: opened && !!workspaceId },
+  );
+
+  const contacts = useMemo(() => {
+    const rows = data?.contacts ?? [];
+    return rows
+      .map((c) => ({
+        id: c.id,
+        name:
+          [c.firstName, c.lastName].filter(Boolean).join(" ") ||
+          c.email ||
+          "Unnamed contact",
+        email: c.email ?? null,
+      }))
+      .filter(
+        (c) =>
+          !existing.has(`contact:${c.id}`) &&
+          !(c.email && existing.has(`email:${c.email.toLowerCase()}`)),
+      );
+  }, [data?.contacts, existing]);
+
+  const trimmed = query.trim();
+  const q = trimmed.toLowerCase();
+  const isEmail = EMAIL_RE.test(trimmed);
+  // Offer "add new" only when the search doesn't already name an existing,
+  // not-yet-added contact.
+  const exactMatch = contacts.some(
+    (c) => c.name.toLowerCase() === q || (c.email?.toLowerCase() ?? "") === q,
+  );
+  const showAddNew = trimmed.length > 0 && !exactMatch;
+
+  function resetAndClose() {
+    setQuery("");
+    setCapture(null);
+    onClose();
+  }
+
+  function emit(participant: PendingParticipant) {
+    onAdd(participant);
+    setQuery("");
+    setCapture(null);
+  }
+
+  function pickContact(c: { id: string; name: string; email: string | null }) {
+    if (c.email) {
+      emit({
+        key: `contact:${c.id}`,
+        name: c.name,
+        email: c.email,
+        payload: { contactId: c.id },
+      });
+    } else {
+      // No email on file — capture one so the participant carries a required,
+      // unique email and the contact record improves everywhere.
+      setCapture({ kind: "contact", contactId: c.id, name: c.name, email: "" });
+    }
+  }
+
+  function startNew() {
+    setCapture({
+      kind: "new",
+      name: isEmail ? "" : trimmed,
+      email: isEmail ? trimmed : "",
+    });
+  }
+
+  const captureEmail = capture?.email.trim() ?? "";
+  const captureValid = EMAIL_RE.test(captureEmail);
+
+  function submitCapture() {
+    if (!capture || !captureValid) return;
+    if (capture.kind === "contact") {
+      emit({
+        key: `contact:${capture.contactId}`,
+        name: capture.name,
+        email: captureEmail,
+        payload: { contactId: capture.contactId, email: captureEmail },
+      });
+    } else {
+      const name = capture.name.trim();
+      emit({
+        key: `email:${captureEmail.toLowerCase()}`,
+        name: name || captureEmail,
+        email: captureEmail,
+        payload: { email: captureEmail, name: name || undefined },
+      });
+    }
+  }
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={resetAndClose}
+      title="Add participant"
+      centered
+      size="md"
+    >
+      {capture ? (
+        <Stack gap="sm">
+          <Group gap="xs" wrap="nowrap">
+            <UnstyledButton
+              onClick={() => setCapture(null)}
+              aria-label="Back to search"
+            >
+              <IconArrowLeft size={16} />
+            </UnstyledButton>
+            <Text fw={600} size="sm">
+              {capture.kind === "contact"
+                ? `Add an email for ${capture.name}`
+                : "Add a new participant"}
+            </Text>
+          </Group>
+
+          {capture.kind === "contact" ? (
+            <Text size="xs" c="dimmed">
+              {capture.name} has no email on file. Adding one links them to this
+              meeting and saves the email back onto their contact.
+            </Text>
+          ) : (
+            <TextInput
+              label="Name"
+              placeholder="Full name"
+              value={capture.name}
+              onChange={(e) =>
+                setCapture({ ...capture, name: e.currentTarget.value })
+              }
+            />
+          )}
+
+          <TextInput
+            label="Email"
+            placeholder="name@company.com"
+            required
+            type="email"
+            data-autofocus
+            value={capture.email}
+            onChange={(e) =>
+              setCapture({ ...capture, email: e.currentTarget.value })
+            }
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && captureValid) submitCapture();
+            }}
+            error={
+              captureEmail.length > 0 && !captureValid
+                ? "Enter a valid email"
+                : undefined
+            }
+          />
+
+          <Group justify="flex-end" gap="xs">
+            <Button variant="subtle" onClick={() => setCapture(null)}>
+              Back
+            </Button>
+            <Button
+              onClick={submitCapture}
+              disabled={!captureValid || busy}
+              leftSection={<IconPlus size={14} />}
+            >
+              Add participant
+            </Button>
+          </Group>
+        </Stack>
+      ) : (
+        <Stack gap="sm">
+          <TextInput
+            placeholder="Search contacts by name, or type a new email"
+            leftSection={<IconSearch size={16} />}
+            value={query}
+            onChange={(e) => setQuery(e.currentTarget.value)}
+            data-autofocus
+            disabled={!workspaceId}
+          />
+
+          <ScrollArea.Autosize mah={360} type="hover">
+            <Stack gap={4}>
+              {isLoading && (
+                <Group justify="center" py="md">
+                  <Loader size="sm" />
+                </Group>
+              )}
+
+              {contacts.map((c) => (
+                <UnstyledButton
+                  key={c.id}
+                  onClick={() => pickContact(c)}
+                  disabled={busy}
+                  className="flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-left hover:bg-surface-hover disabled:opacity-50"
+                >
+                  <Avatar radius="xl" size="sm" color={avatarColor(c.id)}>
+                    {getInitial(c.name, c.email)}
+                  </Avatar>
+                  <div className="min-w-0 flex-1">
+                    <Text size="sm" truncate>
+                      {c.name}
+                    </Text>
+                    <Text size="xs" c="dimmed" truncate>
+                      {c.email ?? "No email on file"}
+                    </Text>
+                  </div>
+                  <IconPlus size={14} />
+                </UnstyledButton>
+              ))}
+
+              {showAddNew && (
+                <UnstyledButton
+                  onClick={startNew}
+                  disabled={busy}
+                  className="flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-left hover:bg-surface-hover disabled:opacity-50"
+                >
+                  <Avatar radius="xl" size="sm" color="gray">
+                    <IconUserPlus size={16} />
+                  </Avatar>
+                  <div className="min-w-0 flex-1">
+                    <Text size="sm" truncate>
+                      Add &ldquo;{trimmed}&rdquo;
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                      {isEmail
+                        ? "New contact — added to the CRM"
+                        : "New participant — add their email next"}
+                    </Text>
+                  </div>
+                  <IconPlus size={14} />
+                </UnstyledButton>
+              )}
+
+              {!isLoading && contacts.length === 0 && !showAddNew && (
+                <Text size="sm" c="dimmed" ta="center" py="md">
+                  {workspaceId
+                    ? "No contacts found. Type a name or email to add someone."
+                    : "This meeting has no workspace, so participants can't be managed."}
+                </Text>
+              )}
+            </Stack>
+          </ScrollArea.Autosize>
+        </Stack>
+      )}
+    </Modal>
+  );
+}

--- a/src/app/_components/meeting/meeting-detail.css
+++ b/src/app/_components/meeting/meeting-detail.css
@@ -230,11 +230,15 @@
 .mp-rail__add { display: grid; place-items: center; width: 20px; height: 20px; border-radius: var(--radius-sm); color: var(--color-text-muted); transition: color 120ms, background 120ms; }
 .mp-rail__add:hover { color: var(--color-text-primary); background: var(--color-bg-hover); }
 .mp-people { display: flex; flex-direction: column; gap: 12px; }
-.mp-person { display: grid; grid-template-columns: 30px 1fr auto; align-items: center; gap: 11px; }
+.mp-person { display: grid; grid-template-columns: 30px 1fr auto auto; align-items: center; gap: 11px; }
 .mp-person .mp-av { width: 30px; height: 30px; font-size: 10px; }
 .mp-person__name { font-size: 13px; font-weight: 500; color: var(--color-text-primary); line-height: 1.2; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .mp-person__role { font-size: 11.5px; color: var(--color-text-muted); line-height: 1.2; margin-top: 1px; }
 .mp-person__talk { font-family: var(--font-mono); font-size: 10.5px; color: var(--color-text-muted); font-variant-numeric: tabular-nums; padding: 3px 7px; border-radius: 3px; background: var(--color-surface-muted); }
+.mp-person__remove { display: grid; place-items: center; width: 20px; height: 20px; border-radius: var(--radius-sm); color: var(--color-text-muted); transition: color 120ms, background 120ms; }
+.mp-person__remove:hover:not(:disabled) { color: var(--color-text-primary); background: var(--color-bg-hover); }
+.mp-person__remove:disabled { opacity: 0.6; cursor: default; }
+.mp-rail__empty { font-size: 12px; color: var(--color-text-muted); }
 .mp-linkrow { display: grid; grid-template-columns: 26px 1fr 14px; gap: 11px; align-items: center; padding: 9px 10px; margin: 0 -10px; border-radius: var(--radius-md); transition: background 120ms; }
 .mp-linkrow:hover { background: var(--color-bg-hover); }
 .mp-linkrow__glyph { width: 26px; height: 26px; border-radius: 7px; display: grid; place-items: center; font-size: 11px; font-weight: 700; color: var(--mp-on-accent); }

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { PrismaClient } from "@prisma/client";
+import type { Prisma, PrismaClient } from "@prisma/client";
 import {
   createTRPCRouter,
   protectedProcedure,
@@ -30,6 +30,8 @@ import {
   requireProjectAccess,
 } from "~/server/services/access";
 import { recordActivity } from "~/server/services/activity/recordActivity";
+import { encryptString, decryptBuffer } from "~/server/utils/encryption";
+import { createHash } from "crypto";
 
 // Keep in-memory store for development/debugging
 const transcriptionStore: Record<string, string[]> = {};
@@ -137,6 +139,23 @@ async function ensureTranscriptionAccess(
       permission === "view"
         ? "Not authorized to view this transcription"
         : "Not authorized to update this transcription",
+  });
+}
+
+// Keep the denormalized `participantCount` in sync with the persisted
+// participant rows after an add/remove so the Meeting header stays honest.
+// Accepts a transaction client so the recount can run atomically with the
+// add/remove that triggered it.
+async function syncParticipantCount(
+  db: Prisma.TransactionClient,
+  transcriptionSessionId: string,
+): Promise<void> {
+  const count = await db.transcriptionSessionParticipant.count({
+    where: { transcriptionSessionId },
+  });
+  await db.transcriptionSession.update({
+    where: { id: transcriptionSessionId },
+    data: { participantCount: count },
   });
 }
 
@@ -636,6 +655,263 @@ export const transcriptionRouter = createTRPCRouter({
       }
 
       return session;
+    }),
+
+  // Add a participant to a Meeting. The person may be a workspace member
+  // (userId), an existing CRM contact (contactId), or a free-text name/email.
+  // Free-text people who aren't workspace members are persisted as CRM
+  // contacts in the Meeting's workspace so the CRM stays the source of truth.
+  addParticipant: protectedProcedure
+    .input(
+      z
+        .object({
+          transcriptionSessionId: z.string(),
+          userId: z.string().optional(),
+          contactId: z.string().optional(),
+          email: z.string().email().optional(),
+          name: z.string().trim().min(1).optional(),
+        })
+        .refine((v) => v.userId ?? v.contactId ?? v.email ?? v.name, {
+          message: "Provide a member, a contact, or a name/email",
+        }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const session = await ctx.db.transcriptionSession.findUnique({
+        where: { id: input.transcriptionSessionId },
+        select: { id: true, userId: true, projectId: true, workspaceId: true },
+      });
+      if (!session) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
+      }
+      await ensureTranscriptionAccess(
+        ctx.db,
+        ctx.session.user.id,
+        session,
+        "edit",
+      );
+
+      // Participant rows require a workspace (members + CRM are workspace
+      // scoped), so a meeting with no workspace can't have managed participants.
+      if (!session.workspaceId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Cannot manage participants on a meeting with no workspace",
+        });
+      }
+      const workspaceId = session.workspaceId;
+
+      // Resolve the target person into the denormalized fields stored on the
+      // participant row (userId / contactId / email / name).
+      let userId: string | null = null;
+      let contactId: string | null = null;
+      let email: string | null = null;
+      let name: string | null = null;
+
+      if (input.userId) {
+        // Workspace member: verify membership in this Meeting's workspace.
+        const membership = await ctx.db.workspaceUser.findFirst({
+          where: { userId: input.userId, workspaceId },
+        });
+        if (!membership) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "User is not a member of this workspace",
+          });
+        }
+        const user = await ctx.db.user.findUnique({
+          where: { id: input.userId },
+          select: { id: true, name: true, email: true },
+        });
+        if (!user) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "User not found" });
+        }
+        userId = user.id;
+        email = user.email ?? null;
+        name = user.name ?? null;
+      } else if (input.contactId) {
+        // Existing CRM contact in this workspace.
+        const contact = await ctx.db.crmContact.findUnique({
+          where: { id: input.contactId },
+          select: {
+            id: true,
+            workspaceId: true,
+            firstName: true,
+            lastName: true,
+            email: true,
+          },
+        });
+        if (!contact || contact.workspaceId !== workspaceId) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Contact must belong to this workspace",
+          });
+        }
+        contactId = contact.id;
+        name =
+          [contact.firstName, contact.lastName].filter(Boolean).join(" ") ||
+          null;
+
+        const existingEmail = decryptBuffer(contact.email);
+        if (existingEmail) {
+          email = existingEmail;
+        } else if (input.email) {
+          // The contact has no email on file: capture the one supplied at link
+          // time and write it back onto the CrmContact, so the contact record
+          // improves everywhere — not just this participant row.
+          const emailHash = createHash("sha256")
+            .update(input.email.toLowerCase().trim())
+            .digest("hex");
+          // emailHash is globally unique. If another contact already owns this
+          // email, don't collide on update — surface a clear error instead.
+          const owner = await ctx.db.crmContact.findUnique({
+            where: { emailHash },
+            select: { id: true },
+          });
+          if (owner && owner.id !== contact.id) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: "That email already belongs to another contact",
+            });
+          }
+          await ctx.db.crmContact.update({
+            where: { id: contact.id },
+            data: { email: encryptString(input.email), emailHash },
+          });
+          email = input.email;
+        }
+      } else {
+        // Free-text. If we have an email, link (or create) a CRM contact so
+        // the person lands in the CRM. Requires a workspace to attach to.
+        name = input.name ?? null;
+        email = input.email ?? null;
+
+        if (input.email) {
+          const emailHash = createHash("sha256")
+            .update(input.email.toLowerCase().trim())
+            .digest("hex");
+          // emailHash is globally unique, so look it up globally — a workspace-
+          // scoped lookup would miss a contact owned by another workspace and
+          // then throw P2002 on create. Only create when no contact exists.
+          let contact = await ctx.db.crmContact.findUnique({
+            where: { emailHash },
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              workspaceId: true,
+            },
+          });
+          if (!contact) {
+            const [firstName, ...rest] = (input.name ?? "").trim().split(/\s+/);
+            contact = await ctx.db.crmContact.create({
+              data: {
+                workspaceId,
+                createdById: ctx.session.user.id,
+                firstName: firstName || null,
+                lastName: rest.length > 0 ? rest.join(" ") : null,
+                email: encryptString(input.email),
+                emailHash,
+                importSource: "MANUAL",
+              },
+              select: {
+                id: true,
+                firstName: true,
+                lastName: true,
+                workspaceId: true,
+              },
+            });
+          }
+          // Only link the participant to a contact that lives in this Meeting's
+          // workspace; a contact owned by another workspace stays unlinked (the
+          // participant keeps its free-text email/name) rather than leaking
+          // across the workspace boundary.
+          if (contact.workspaceId === workspaceId) {
+            contactId = contact.id;
+            if (!name) {
+              name =
+                [contact.firstName, contact.lastName]
+                  .filter(Boolean)
+                  .join(" ") || null;
+            }
+          }
+        }
+      }
+
+      // The unique key is [transcriptionSessionId, email]. Real people have an
+      // email; name-only entries fall back to a stable `name:<lowercased>`
+      // sentinel so repeated adds dedupe instead of colliding on "".
+      const dedupeKey = email ?? `name:${(name ?? "").toLowerCase()}`;
+      const baseData = {
+        workspaceId,
+        userId,
+        contactId,
+        name,
+      };
+      // Upsert the participant and recount in one transaction so the
+      // denormalized `participantCount` can't drift under concurrent edits.
+      const participant = await ctx.db.$transaction(async (tx) => {
+        const row = await tx.transcriptionSessionParticipant.upsert({
+          where: {
+            transcriptionSessionId_email: {
+              transcriptionSessionId: session.id,
+              email: dedupeKey,
+            },
+          },
+          create: {
+            transcriptionSessionId: session.id,
+            email: dedupeKey,
+            ...baseData,
+          },
+          update: baseData,
+        });
+        await syncParticipantCount(tx, session.id);
+        return row;
+      });
+      return participant;
+    }),
+
+  // Remove a persisted participant row. Derived (transcript-speaker) entries
+  // are not real rows and can't be removed here.
+  removeParticipant: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const participant =
+        await ctx.db.transcriptionSessionParticipant.findUnique({
+          where: { id: input.id },
+          select: {
+            id: true,
+            transcriptionSessionId: true,
+            transcriptionSession: {
+              select: {
+                id: true,
+                userId: true,
+                projectId: true,
+                workspaceId: true,
+              },
+            },
+          },
+        });
+      if (!participant) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Participant not found",
+        });
+      }
+      await ensureTranscriptionAccess(
+        ctx.db,
+        ctx.session.user.id,
+        participant.transcriptionSession,
+        "edit",
+      );
+      // Delete the row and recount atomically so `participantCount` stays
+      // consistent with the surviving rows.
+      await ctx.db.$transaction(async (tx) => {
+        await tx.transcriptionSessionParticipant.delete({
+          where: { id: participant.id },
+        });
+        await syncParticipantCount(tx, participant.transcriptionSessionId);
+      });
+      return { success: true };
     }),
 
   // Get transcriptions for a specific project (used by ManyChat agent context).


### PR DESCRIPTION
## What

Replaces the "Editing participants is coming soon" toast on `/recording/[id]` with a working `ParticipantPicker`:

- Search workspace **CRM contacts by name** (emails are encrypted, so search is name-only — an accepted limitation) and link one as a **participant** (`contactId`).
- Add a brand-new person by **name + email** — the server inline-creates a `CrmContact` (emailHash dedup, `importSource: "MANUAL"`) and links it.
- Linking a contact with **no email on file** prompts for one; it's written back onto the `CrmContact` (the one backend change) so the contact record improves everywhere, not just the participant row.
- Remove a participant inline; the denormalized `participantCount` stays in sync.

The `ParticipantPicker` is **selection-only** (it emits a resolved participant; the parent decides whether to persist immediately or stage it), so Slice 2's create-meeting modal (`proto.ingot`) can reuse it unchanged.

This PR also carries the `addParticipant` / `removeParticipant` backend (which is not yet on `main`) so the slice is self-contained and functional once merged.

## Acceptance criteria

- [ ] On `/recording/[id]`, the participants "+" opens the `ParticipantPicker` instead of the "coming soon" toast.
- [ ] Searching by name returns matching workspace CrmContacts; selecting one links it (`contactId`).
- [ ] Adding a brand-new person by name+email inline-creates a CrmContact and links it (emailHash dedup: re-adding the same email does not duplicate).
- [ ] Linking a contact with no email prompts for one, persists it onto the CrmContact, and the participant row carries that email.
- [ ] A participant can be removed; the participant count stays correct.
- [ ] UI copy uses "participant"/"meeting"; no hardcoded colors; checks pass.

## Notes

- **Scope**: no team-members group in the picker — ticket 1 scopes it to CRM contacts + new-by-email, and `/recording/[id]` is not workspace-scoped (so `useWorkspace().members` is unavailable there). The backend still accepts `userId` for other callers.
- **Verification**: `tsc --noEmit` clean, ESLint clean on changed files, full unit suite (907 tests) passes via the pre-commit hook, no hardcoded colors. No unit test was added for the `addParticipant` email-writeback branch — that flow (access resolver + `$transaction` + encryption + CRM find/create) is impractical to unit-test without brittle over-mocking, and this repo prefers rare integration tests over heavy mocks.

---

Ships: gentle.vault