### PR TITLE
feat: Add participants while manually creating a meeting

### DIFF
--- a/src/app/_components/CreateTranscriptionModal.tsx
+++ b/src/app/_components/CreateTranscriptionModal.tsx
@@ -8,13 +8,19 @@ import {
   Textarea,
   Stack,
   Input,
+  Pill,
+  Text,
 } from "@mantine/core";
 import { UnifiedDatePicker } from "~/app/_components/UnifiedDatePicker";
 import { useDisclosure } from "@mantine/hooks";
 import { useState } from "react";
 import { api } from "~/trpc/react";
 import { notifications } from "@mantine/notifications";
-import { IconPlus } from "@tabler/icons-react";
+import { IconPlus, IconUserPlus } from "@tabler/icons-react";
+import {
+  ParticipantPicker,
+  type PendingParticipant,
+} from "~/app/_components/meeting/ParticipantPicker";
 
 interface CreateTranscriptionModalProps {
   projectId?: string;
@@ -33,6 +39,10 @@ export function CreateTranscriptionModal({
   const [transcription, setTranscription] = useState("");
   const [notes, setNotes] = useState("");
   const [meetingDate, setMeetingDate] = useState<Date | null>(null);
+  const [pendingParticipants, setPendingParticipants] = useState<
+    PendingParticipant[]
+  >([]);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   const utils = api.useUtils();
 
@@ -52,6 +62,7 @@ export function CreateTranscriptionModal({
         setTranscription("");
         setNotes("");
         setMeetingDate(null);
+        setPendingParticipants([]);
 
         close();
 
@@ -70,6 +81,22 @@ export function CreateTranscriptionModal({
       },
     });
 
+  function handleAddPending(person: PendingParticipant) {
+    setPendingParticipants((prev) =>
+      prev.some((p) => p.key === person.key) ? prev : [...prev, person],
+    );
+  }
+
+  function handleRemovePending(key: string) {
+    setPendingParticipants((prev) => prev.filter((p) => p.key !== key));
+  }
+
+  function handleClose() {
+    setPickerOpen(false);
+    setPendingParticipants([]);
+    close();
+  }
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim() || !transcription.trim()) return;
@@ -82,10 +109,15 @@ export function CreateTranscriptionModal({
       meetingDate: meetingDate ?? undefined,
       projectId,
       workspaceId,
+      participants:
+        pendingParticipants.length > 0
+          ? pendingParticipants.map((p) => p.payload)
+          : undefined,
     });
   };
 
   const isValid = title.trim() && transcription.trim();
+  const existingParticipants = new Set(pendingParticipants.map((p) => p.key));
 
   return (
     <>
@@ -104,7 +136,7 @@ export function CreateTranscriptionModal({
 
       <Modal
         opened={opened}
-        onClose={close}
+        onClose={handleClose}
         size="lg"
         radius="md"
         padding="lg"
@@ -138,6 +170,43 @@ export function CreateTranscriptionModal({
               </div>
             </Input.Wrapper>
 
+            <Input.Wrapper
+              label="Participants"
+              description="Link CRM contacts or add new people by name and email."
+            >
+              <Stack gap="xs" mt={4}>
+                {pendingParticipants.length > 0 && (
+                  <Pill.Group>
+                    {pendingParticipants.map((p) => (
+                      <Pill
+                        key={p.key}
+                        withRemoveButton
+                        onRemove={() => handleRemovePending(p.key)}
+                        title={p.email}
+                      >
+                        {p.name}
+                      </Pill>
+                    ))}
+                  </Pill.Group>
+                )}
+                <Button
+                  variant="light"
+                  size="xs"
+                  leftSection={<IconUserPlus size={14} />}
+                  onClick={() => setPickerOpen(true)}
+                  disabled={!workspaceId}
+                  style={{ alignSelf: "flex-start" }}
+                >
+                  Add participant
+                </Button>
+                {!workspaceId && (
+                  <Text size="xs" c="dimmed">
+                    Select a workspace to add participants.
+                  </Text>
+                )}
+              </Stack>
+            </Input.Wrapper>
+
             <Textarea
               label="Transcript"
               placeholder="Paste or type the meeting transcript..."
@@ -160,7 +229,7 @@ export function CreateTranscriptionModal({
             />
 
             <Group justify="flex-end" mt="md">
-              <Button variant="subtle" color="gray" onClick={close}>
+              <Button variant="subtle" color="gray" onClick={handleClose}>
                 Cancel
               </Button>
               <Button
@@ -174,6 +243,14 @@ export function CreateTranscriptionModal({
           </Stack>
         </form>
       </Modal>
+
+      <ParticipantPicker
+        opened={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        workspaceId={workspaceId ?? null}
+        existing={existingParticipants}
+        onAdd={handleAddPending}
+      />
     </>
   );
 }

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -159,6 +159,193 @@ async function syncParticipantCount(
   });
 }
 
+// Shared shape for "a person to attach to a meeting": a workspace member
+// (userId), an existing CRM contact (contactId), or a free-text name/email.
+// Used by both addParticipant (one at a time) and createManualTranscription
+// (a batch attached at create time).
+const participantPersonSchema = z
+  .object({
+    userId: z.string().optional(),
+    contactId: z.string().optional(),
+    email: z.string().email().optional(),
+    name: z.string().trim().min(1).optional(),
+  })
+  .refine((v) => v.userId ?? v.contactId ?? v.email ?? v.name, {
+    message: "Provide a member, a contact, or a name/email",
+  });
+
+type ParticipantPerson = z.infer<typeof participantPersonSchema>;
+
+// Resolve one person into a meeting participant row and upsert it inside the
+// caller's transaction. Single source of truth for "turn a member / contact /
+// free-text person into a participant" — used by both addParticipant (detail
+// page, one at a time) and createManualTranscription (a batch on manual
+// create). Resolution covers workspace-member lookup, existing-contact linking
+// with email write-back for no-email contacts, and free-text emailHash
+// find-or-create (workspace-boundary safe). Does NOT recount participantCount —
+// the caller runs syncParticipantCount once after all participants resolve.
+async function upsertMeetingParticipant(
+  tx: Prisma.TransactionClient,
+  args: {
+    transcriptionSessionId: string;
+    workspaceId: string;
+    actorId: string;
+    person: ParticipantPerson;
+  },
+) {
+  const { transcriptionSessionId, workspaceId, actorId, person } = args;
+
+  // Denormalized fields stored on the participant row.
+  let userId: string | null = null;
+  let contactId: string | null = null;
+  let email: string | null = null;
+  let name: string | null = null;
+
+  if (person.userId) {
+    // Workspace member: verify membership in this Meeting's workspace.
+    const membership = await tx.workspaceUser.findFirst({
+      where: { userId: person.userId, workspaceId },
+    });
+    if (!membership) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "User is not a member of this workspace",
+      });
+    }
+    const user = await tx.user.findUnique({
+      where: { id: person.userId },
+      select: { id: true, name: true, email: true },
+    });
+    if (!user) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "User not found" });
+    }
+    userId = user.id;
+    email = user.email ?? null;
+    name = user.name ?? null;
+  } else if (person.contactId) {
+    // Existing CRM contact in this workspace.
+    const contact = await tx.crmContact.findUnique({
+      where: { id: person.contactId },
+      select: {
+        id: true,
+        workspaceId: true,
+        firstName: true,
+        lastName: true,
+        email: true,
+      },
+    });
+    if (!contact || contact.workspaceId !== workspaceId) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Contact must belong to this workspace",
+      });
+    }
+    contactId = contact.id;
+    name =
+      [contact.firstName, contact.lastName].filter(Boolean).join(" ") || null;
+
+    const existingEmail = decryptBuffer(contact.email);
+    if (existingEmail) {
+      email = existingEmail;
+    } else if (person.email) {
+      // The contact has no email on file: capture the one supplied at link
+      // time and write it back onto the CrmContact, so the contact record
+      // improves everywhere — not just this participant row.
+      const emailHash = createHash("sha256")
+        .update(person.email.toLowerCase().trim())
+        .digest("hex");
+      // emailHash is globally unique. If another contact already owns this
+      // email, don't collide on update — surface a clear error instead.
+      const owner = await tx.crmContact.findUnique({
+        where: { emailHash },
+        select: { id: true },
+      });
+      if (owner && owner.id !== contact.id) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "That email already belongs to another contact",
+        });
+      }
+      await tx.crmContact.update({
+        where: { id: contact.id },
+        data: { email: encryptString(person.email), emailHash },
+      });
+      email = person.email;
+    }
+  } else {
+    // Free-text. If we have an email, link (or create) a CRM contact so the
+    // person lands in the CRM.
+    name = person.name ?? null;
+    email = person.email ?? null;
+
+    if (person.email) {
+      const emailHash = createHash("sha256")
+        .update(person.email.toLowerCase().trim())
+        .digest("hex");
+      // emailHash is globally unique, so look it up globally — a workspace-
+      // scoped lookup would miss a contact owned by another workspace and then
+      // throw P2002 on create. Only create when no contact exists.
+      let contact = await tx.crmContact.findUnique({
+        where: { emailHash },
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          workspaceId: true,
+        },
+      });
+      if (!contact) {
+        const [firstName, ...rest] = (person.name ?? "").trim().split(/\s+/);
+        contact = await tx.crmContact.create({
+          data: {
+            workspaceId,
+            createdById: actorId,
+            firstName: firstName || null,
+            lastName: rest.length > 0 ? rest.join(" ") : null,
+            email: encryptString(person.email),
+            emailHash,
+            importSource: "MANUAL",
+          },
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            workspaceId: true,
+          },
+        });
+      }
+      // Only link the participant to a contact that lives in this Meeting's
+      // workspace; a contact owned by another workspace stays unlinked (the
+      // participant keeps its free-text email/name) rather than leaking across
+      // the workspace boundary.
+      if (contact.workspaceId === workspaceId) {
+        contactId = contact.id;
+        if (!name) {
+          name =
+            [contact.firstName, contact.lastName].filter(Boolean).join(" ") ||
+            null;
+        }
+      }
+    }
+  }
+
+  // The unique key is [transcriptionSessionId, email]. Real people have an
+  // email; name-only entries fall back to a stable `name:<lowercased>` sentinel
+  // so repeated adds dedupe instead of colliding on "".
+  const dedupeKey = email ?? `name:${(name ?? "").toLowerCase()}`;
+  const baseData = { workspaceId, userId, contactId, name };
+  return tx.transcriptionSessionParticipant.upsert({
+    where: {
+      transcriptionSessionId_email: {
+        transcriptionSessionId,
+        email: dedupeKey,
+      },
+    },
+    create: { transcriptionSessionId, email: dedupeKey, ...baseData },
+    update: baseData,
+  });
+}
+
 
 export const transcriptionRouter = createTRPCRouter({
   startSession: apiKeyMiddleware
@@ -598,41 +785,79 @@ export const transcriptionRouter = createTRPCRouter({
         notes: z.string().optional(),
         projectId: z.string().optional(),
         workspaceId: z.string().optional(),
+        // Participants to attach atomically with the meeting (linked CRM
+        // contacts and/or new name+email people). Resolved via the same
+        // helper as addParticipant.
+        participants: z.array(participantPersonSchema).optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const session = await ctx.db.transcriptionSession.create({
-        data: {
-          sessionId: `manual_${Date.now()}`,
-          title: input.title,
-          description: input.description ?? null,
-          transcription: input.transcription,
-          meetingDate: input.meetingDate ?? null,
-          notes: input.notes ?? null,
-          projectId: input.projectId ?? null,
-          workspaceId: input.workspaceId ?? null,
-          userId: ctx.session.user.id,
-        },
-        include: {
-          sourceIntegration: {
-            select: {
-              id: true,
-              provider: true,
-              name: true,
+      const participants = input.participants ?? [];
+      // Participants are workspace-scoped (members + CRM), so a meeting with no
+      // workspace can't carry them. Reject rather than silently dropping them.
+      if (participants.length > 0 && !input.workspaceId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Cannot add participants to a meeting with no workspace",
+        });
+      }
+      const workspaceId = input.workspaceId ?? null;
+
+      // Create the meeting and resolve every participant in ONE transaction: a
+      // meeting is never created with participants silently failing to attach,
+      // and there's no N+1 round-trip from the client. Any participant that
+      // fails to resolve rolls the whole thing back.
+      const session = await ctx.db.$transaction(
+        async (tx) => {
+          const created = await tx.transcriptionSession.create({
+            data: {
+              sessionId: `manual_${Date.now()}`,
+              title: input.title,
+              description: input.description ?? null,
+              transcription: input.transcription,
+              meetingDate: input.meetingDate ?? null,
+              notes: input.notes ?? null,
+              projectId: input.projectId ?? null,
+              workspaceId,
+              userId: ctx.session.user.id,
             },
-          },
-          actions: {
-            select: {
-              id: true,
-              name: true,
-              description: true,
-              status: true,
-              priority: true,
-              dueDate: true,
+            include: {
+              sourceIntegration: {
+                select: {
+                  id: true,
+                  provider: true,
+                  name: true,
+                },
+              },
+              actions: {
+                select: {
+                  id: true,
+                  name: true,
+                  description: true,
+                  status: true,
+                  priority: true,
+                  dueDate: true,
+                },
+              },
             },
-          },
+          });
+
+          if (participants.length > 0 && workspaceId) {
+            for (const person of participants) {
+              await upsertMeetingParticipant(tx, {
+                transcriptionSessionId: created.id,
+                workspaceId,
+                actorId: ctx.session.user.id,
+                person,
+              });
+            }
+            await syncParticipantCount(tx, created.id);
+          }
+
+          return created;
         },
-      });
+        { timeout: 20000 },
+      );
 
       // Record a workspace activity event when a meeting lands (ADR-0018): one
       // write surfaces it in the workspace feed, the aggregated /activity feed,
@@ -700,169 +925,16 @@ export const transcriptionRouter = createTRPCRouter({
       }
       const workspaceId = session.workspaceId;
 
-      // Resolve the target person into the denormalized fields stored on the
-      // participant row (userId / contactId / email / name).
-      let userId: string | null = null;
-      let contactId: string | null = null;
-      let email: string | null = null;
-      let name: string | null = null;
-
-      if (input.userId) {
-        // Workspace member: verify membership in this Meeting's workspace.
-        const membership = await ctx.db.workspaceUser.findFirst({
-          where: { userId: input.userId, workspaceId },
-        });
-        if (!membership) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "User is not a member of this workspace",
-          });
-        }
-        const user = await ctx.db.user.findUnique({
-          where: { id: input.userId },
-          select: { id: true, name: true, email: true },
-        });
-        if (!user) {
-          throw new TRPCError({ code: "NOT_FOUND", message: "User not found" });
-        }
-        userId = user.id;
-        email = user.email ?? null;
-        name = user.name ?? null;
-      } else if (input.contactId) {
-        // Existing CRM contact in this workspace.
-        const contact = await ctx.db.crmContact.findUnique({
-          where: { id: input.contactId },
-          select: {
-            id: true,
-            workspaceId: true,
-            firstName: true,
-            lastName: true,
-            email: true,
-          },
-        });
-        if (!contact || contact.workspaceId !== workspaceId) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "Contact must belong to this workspace",
-          });
-        }
-        contactId = contact.id;
-        name =
-          [contact.firstName, contact.lastName].filter(Boolean).join(" ") ||
-          null;
-
-        const existingEmail = decryptBuffer(contact.email);
-        if (existingEmail) {
-          email = existingEmail;
-        } else if (input.email) {
-          // The contact has no email on file: capture the one supplied at link
-          // time and write it back onto the CrmContact, so the contact record
-          // improves everywhere — not just this participant row.
-          const emailHash = createHash("sha256")
-            .update(input.email.toLowerCase().trim())
-            .digest("hex");
-          // emailHash is globally unique. If another contact already owns this
-          // email, don't collide on update — surface a clear error instead.
-          const owner = await ctx.db.crmContact.findUnique({
-            where: { emailHash },
-            select: { id: true },
-          });
-          if (owner && owner.id !== contact.id) {
-            throw new TRPCError({
-              code: "BAD_REQUEST",
-              message: "That email already belongs to another contact",
-            });
-          }
-          await ctx.db.crmContact.update({
-            where: { id: contact.id },
-            data: { email: encryptString(input.email), emailHash },
-          });
-          email = input.email;
-        }
-      } else {
-        // Free-text. If we have an email, link (or create) a CRM contact so
-        // the person lands in the CRM. Requires a workspace to attach to.
-        name = input.name ?? null;
-        email = input.email ?? null;
-
-        if (input.email) {
-          const emailHash = createHash("sha256")
-            .update(input.email.toLowerCase().trim())
-            .digest("hex");
-          // emailHash is globally unique, so look it up globally — a workspace-
-          // scoped lookup would miss a contact owned by another workspace and
-          // then throw P2002 on create. Only create when no contact exists.
-          let contact = await ctx.db.crmContact.findUnique({
-            where: { emailHash },
-            select: {
-              id: true,
-              firstName: true,
-              lastName: true,
-              workspaceId: true,
-            },
-          });
-          if (!contact) {
-            const [firstName, ...rest] = (input.name ?? "").trim().split(/\s+/);
-            contact = await ctx.db.crmContact.create({
-              data: {
-                workspaceId,
-                createdById: ctx.session.user.id,
-                firstName: firstName || null,
-                lastName: rest.length > 0 ? rest.join(" ") : null,
-                email: encryptString(input.email),
-                emailHash,
-                importSource: "MANUAL",
-              },
-              select: {
-                id: true,
-                firstName: true,
-                lastName: true,
-                workspaceId: true,
-              },
-            });
-          }
-          // Only link the participant to a contact that lives in this Meeting's
-          // workspace; a contact owned by another workspace stays unlinked (the
-          // participant keeps its free-text email/name) rather than leaking
-          // across the workspace boundary.
-          if (contact.workspaceId === workspaceId) {
-            contactId = contact.id;
-            if (!name) {
-              name =
-                [contact.firstName, contact.lastName]
-                  .filter(Boolean)
-                  .join(" ") || null;
-            }
-          }
-        }
-      }
-
-      // The unique key is [transcriptionSessionId, email]. Real people have an
-      // email; name-only entries fall back to a stable `name:<lowercased>`
-      // sentinel so repeated adds dedupe instead of colliding on "".
-      const dedupeKey = email ?? `name:${(name ?? "").toLowerCase()}`;
-      const baseData = {
-        workspaceId,
-        userId,
-        contactId,
-        name,
-      };
-      // Upsert the participant and recount in one transaction so the
+      // Resolve + upsert the participant and recount in one transaction so the
       // denormalized `participantCount` can't drift under concurrent edits.
+      // Resolution (member / contact / free-text) is shared with
+      // createManualTranscription via upsertMeetingParticipant.
       const participant = await ctx.db.$transaction(async (tx) => {
-        const row = await tx.transcriptionSessionParticipant.upsert({
-          where: {
-            transcriptionSessionId_email: {
-              transcriptionSessionId: session.id,
-              email: dedupeKey,
-            },
-          },
-          create: {
-            transcriptionSessionId: session.id,
-            email: dedupeKey,
-            ...baseData,
-          },
-          update: baseData,
+        const row = await upsertMeetingParticipant(tx, {
+          transcriptionSessionId: session.id,
+          workspaceId,
+          actorId: ctx.session.user.id,
+          person: input,
         });
         await syncParticipantCount(tx, session.id);
         return row;


### PR DESCRIPTION
## What

Lets a user attach participants while manually creating a meeting, saved atomically with the meeting. Builds on `gentle.vault` (#250).

- Embeds the `ParticipantPicker` (from the detail-page slice) into `CreateTranscriptionModal`; selected/added people show as **removable chips** before save.
- Extends `transcription.createManualTranscription` with a `participants[]` input, resolved **in the same transaction** as the meeting — a meeting is never created with participants silently failing to attach, and there's no N+1 round-trip from the client. If any participant fails to resolve, the meeting isn't created.
- Extracts the per-participant resolution (member / contact / free-text, emailHash find-or-create, no-email-contact email write-back, `[transcriptionSessionId, email]` upsert) into a shared **`upsertMeetingParticipant`** helper used by both `addParticipant` and `createManualTranscription` — one source of truth.

Same domain rules as the detail-page slice: name-only contact search, "participant"/"meeting" copy, required-and-unique email per meeting.

## Acceptance criteria

- [ ] `CreateTranscriptionModal` shows the `ParticipantPicker`; selected/added participants appear as removable chips before save.
- [ ] `createManualTranscription` accepts `participants[]` and creates the meeting + all participant rows in a single transaction; if any participant fails to resolve, the meeting is not created.
- [ ] New-by-email participants inline-create CrmContacts (emailHash dedup); existing contacts link by `contactId`; no-email contacts get an email written back.
- [ ] Participant resolution is implemented once in a shared helper used by both `addParticipant` and `createManualTranscription` (no duplicated logic).
- [ ] `npm run check` passes; no hardcoded colors.

## Notes

- `addParticipant` was refactored to call the shared helper inside its transaction (resolution is now atomic with the upsert — a strict improvement). Existing `transcription` / `transcriptionSessionParticipant` router tests still pass.
- The modal disables the participant affordance when it has no `workspaceId` (participants are workspace-scoped). The backend also rejects `participants[]` for a no-workspace meeting.
- Verified: `tsc` clean, ESLint clean on changed files, full unit suite (907 tests) passes, no hardcoded colors.

---

Ships: proto.ingot