### PR TITLE
refactor(product): extract shared ticket-create service

### DIFF
--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -3,8 +3,8 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { loadProductWithAccess, assertWorkspaceMember } from "./product";
 import type { PrismaClient, Prisma } from "@prisma/client";
-import { generateFunId } from "~/lib/fun-ids";
 import { recordActivity } from "~/server/services/activity/recordActivity";
+import { createTicketWithNumber } from "../services/createTicket";
 import {
   COMPLETED_TICKET_STATUSES,
   IN_FLIGHT_TICKET_STATUSES,
@@ -289,65 +289,30 @@ export const ticketRouter = createTRPCRouter({
         }
       }
 
-      // Increment product ticket counter atomically and generate IDs
-      const updated = await ctx.db.product.update({
-        where: { id: input.productId },
-        data: { ticketCounter: { increment: 1 } },
-        select: { ticketCounter: true, funTicketIds: true },
-      });
-      const ticketNumber = updated.ticketCounter;
-
-      // Generate fun ID if enabled
-      let shortId: string | null = null;
-      if (updated.funTicketIds) {
-        const existing = await ctx.db.ticket.findMany({
-          where: { productId: input.productId },
-          select: { shortId: true },
-        });
-        const existingIds = new Set(existing.map((t) => t.shortId).filter(Boolean) as string[]);
-        shortId = generateFunId(existingIds);
-      }
-
-      const createdTicket = await ctx.db.ticket.create({
-        data: {
-          productId: input.productId,
-          number: ticketNumber,
-          shortId,
-          title: input.title,
-          body,
-          type: input.type ?? "FEATURE",
-          status: input.status ?? "BACKLOG",
-          priority: input.priority,
-          points: input.points,
-          branchName: input.branchName,
-          prUrl: input.prUrl,
-          designUrl: input.designUrl,
-          specUrl: input.specUrl,
-          links: input.links ?? undefined,
-          epicId: input.epicId,
-          featureId: input.featureId,
-          cycleId: input.cycleId,
-          scopeId: input.scopeId,
-          assigneeId: input.assigneeId,
-          createdById: ctx.session.user.id,
-        },
-      });
-
-      // T7: workspace activity feed instrumentation. workspaceId comes from
-      // the product loaded above; loadProductWithAccess already verified
-      // membership so we know it's authoritative.
-      await recordActivity(ctx.db, {
+      // Counter increment, shortId, create, and activity-feed write all live
+      // in the shared service (ADR-0016). Access was already verified by
+      // loadProductWithAccess above; the service trusts the caller.
+      return createTicketWithNumber(ctx.db, {
+        productId: input.productId,
         workspaceId: product.workspaceId,
-        userId: ctx.session.user.id,
-        entityType: "ticket",
-        entityId: createdTicket.id,
-        action: "created",
-        metadata: { title: input.title },
-      }).catch(() => {
-        /* instrumentation failure is non-fatal */
+        createdById: ctx.session.user.id,
+        title: input.title,
+        body,
+        type: input.type,
+        status: input.status,
+        priority: input.priority,
+        points: input.points,
+        branchName: input.branchName,
+        prUrl: input.prUrl,
+        designUrl: input.designUrl,
+        specUrl: input.specUrl,
+        links: input.links,
+        epicId: input.epicId,
+        featureId: input.featureId,
+        cycleId: input.cycleId,
+        scopeId: input.scopeId,
+        assigneeId: input.assigneeId,
       });
-
-      return createdTicket;
     }),
 
   update: protectedProcedure

--- a/src/plugins/product/server/services/__tests__/createTicket.test.ts
+++ b/src/plugins/product/server/services/__tests__/createTicket.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for the shared `createTicketWithNumber` service.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` so the test runs in
+ * milliseconds and CANNOT touch a real DB. `recordActivity` and `generateFunId`
+ * are mocked so we can assert on their inputs deterministically. The service
+ * itself does no access control — these tests cover the create-mechanics only.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+// Deterministic fun ID so we can assert when it's used.
+vi.mock("~/lib/fun-ids", () => ({
+  generateFunId: vi.fn(() => "fun.id"),
+}));
+
+// Spy on the activity write so we can assert its args without a real DB row.
+vi.mock("~/server/services/activity/recordActivity", () => ({
+  recordActivity: vi.fn(() => Promise.resolve()),
+}));
+
+import { generateFunId } from "~/lib/fun-ids";
+import { recordActivity } from "~/server/services/activity/recordActivity";
+import { createTicketWithNumber, type CreateTicketInput } from "../createTicket";
+
+const dbMock: DeepMockProxy<PrismaClient> = mockDeep<PrismaClient>();
+
+function baseInput(
+  overrides: Partial<CreateTicketInput> = {},
+): CreateTicketInput {
+  return {
+    productId: "prod-1",
+    workspaceId: "ws-1",
+    createdById: "user-1",
+    title: "A ticket",
+    ...overrides,
+  };
+}
+
+/** Set up product.update + ticket.create + (optional) ticket.findMany mocks. */
+function primeDb(opts: { ticketCounter: number; funTicketIds: boolean }) {
+  dbMock.product.update.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { ticketCounter: opts.ticketCounter, funTicketIds: opts.funTicketIds } as any,
+  );
+  dbMock.ticket.findMany.mockResolvedValue([
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { shortId: "existing.one" } as any,
+  ]);
+  dbMock.ticket.create.mockImplementation(
+    // create echoes the data so we can assert on what was written.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ((args: any) =>
+      Promise.resolve({ id: "ticket-1", ...args.data })) as any,
+  );
+}
+
+beforeEach(() => {
+  mockReset(dbMock);
+  vi.clearAllMocks();
+});
+
+describe("createTicketWithNumber", () => {
+  it("increments the product counter and uses it as the ticket number", async () => {
+    primeDb({ ticketCounter: 42, funTicketIds: false });
+
+    const ticket = await createTicketWithNumber(dbMock, baseInput());
+
+    expect(dbMock.product.update).toHaveBeenCalledWith({
+      where: { id: "prod-1" },
+      data: { ticketCounter: { increment: 1 } },
+      select: { ticketCounter: true, funTicketIds: true },
+    });
+    expect(dbMock.ticket.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ number: 42 }),
+      }),
+    );
+    expect(ticket.number).toBe(42);
+  });
+
+  it("generates a shortId only when the product has fun IDs enabled", async () => {
+    // Disabled → no shortId, generator never called.
+    primeDb({ ticketCounter: 1, funTicketIds: false });
+    await createTicketWithNumber(dbMock, baseInput());
+    expect(generateFunId).not.toHaveBeenCalled();
+    expect(dbMock.ticket.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ shortId: null }) }),
+    );
+
+    vi.clearAllMocks();
+    mockReset(dbMock);
+
+    // Enabled → shortId minted from the existing-id set.
+    primeDb({ ticketCounter: 2, funTicketIds: true });
+    await createTicketWithNumber(dbMock, baseInput());
+    expect(generateFunId).toHaveBeenCalledTimes(1);
+    expect(generateFunId).toHaveBeenCalledWith(new Set(["existing.one"]));
+    expect(dbMock.ticket.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ shortId: "fun.id" }) }),
+    );
+  });
+
+  it("passes links through to the created ticket", async () => {
+    primeDb({ ticketCounter: 3, funTicketIds: false });
+    const links = { sentryIssueId: "abc", sentryUrl: "https://sentry.example/abc" };
+
+    await createTicketWithNumber(dbMock, baseInput({ links }));
+
+    expect(dbMock.ticket.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ links }) }),
+    );
+  });
+
+  it("records a 'created' activity event with the product's workspaceId", async () => {
+    primeDb({ ticketCounter: 4, funTicketIds: false });
+
+    const ticket = await createTicketWithNumber(
+      dbMock,
+      baseInput({ workspaceId: "ws-42", createdById: "user-7" }),
+    );
+
+    expect(recordActivity).toHaveBeenCalledWith(
+      dbMock,
+      expect.objectContaining({
+        workspaceId: "ws-42",
+        userId: "user-7",
+        entityType: "ticket",
+        entityId: ticket.id,
+        action: "created",
+      }),
+    );
+  });
+
+  it("honors the supplied createdById, type, and status", async () => {
+    primeDb({ ticketCounter: 5, funTicketIds: false });
+
+    await createTicketWithNumber(
+      dbMock,
+      baseInput({ createdById: "errol-id", type: "BUG", status: "BACKLOG" }),
+    );
+
+    expect(dbMock.ticket.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          createdById: "errol-id",
+          type: "BUG",
+          status: "BACKLOG",
+        }),
+      }),
+    );
+  });
+
+  it("defaults type to FEATURE and status to BACKLOG when unset", async () => {
+    primeDb({ ticketCounter: 6, funTicketIds: false });
+
+    await createTicketWithNumber(dbMock, baseInput());
+
+    expect(dbMock.ticket.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ type: "FEATURE", status: "BACKLOG" }),
+      }),
+    );
+  });
+});

--- a/src/plugins/product/server/services/createTicket.ts
+++ b/src/plugins/product/server/services/createTicket.ts
@@ -1,0 +1,122 @@
+import type {
+  Prisma,
+  PrismaClient,
+  Ticket,
+  TicketStatus,
+  TicketType,
+} from "@prisma/client";
+import { generateFunId } from "~/lib/fun-ids";
+import { recordActivity } from "~/server/services/activity/recordActivity";
+
+/**
+ * Fields a caller supplies to create a Ticket. Mirrors the writable columns of
+ * the `Ticket` model; `number` and `shortId` are derived by the service, never
+ * passed in.
+ */
+export interface CreateTicketInput {
+  /** Product the ticket belongs to. Its `ticketCounter` is incremented. */
+  productId: string;
+  /**
+   * Workspace the product lives in — used only for the activity-feed write.
+   * The caller already has this (it loaded the product), so we don't re-query.
+   */
+  workspaceId: string;
+  /**
+   * Author of the ticket. The service performs **no** access control — the
+   * caller is responsible for authorizing this user (or, for trusted callers
+   * like the Sentry webhook, for choosing a system author). `recordActivity`
+   * attributes the `created` event to this same id.
+   */
+  createdById: string;
+  title: string;
+  body?: string | null;
+  type?: TicketType;
+  status?: TicketStatus;
+  priority?: number | null;
+  points?: number | null;
+  branchName?: string | null;
+  prUrl?: string | null;
+  designUrl?: string | null;
+  specUrl?: string | null;
+  links?: Prisma.InputJsonValue | null;
+  epicId?: string | null;
+  featureId?: string | null;
+  cycleId?: string | null;
+  scopeId?: string | null;
+  assigneeId?: string | null;
+}
+
+/**
+ * Shared Ticket create-mechanics: atomically increment the product's ticket
+ * counter for the `number`, mint a fun `shortId` when the product has fun IDs
+ * enabled, create the `Ticket`, and record the workspace activity event.
+ *
+ * This is the single source of truth for "how a Ticket is born", reused by the
+ * product-UI `ticket.create` mutation, the agent's `mastra.createTicket`, and
+ * the Sentry bug webhook (ADR-0016: collapse the duplicate copies; ADR-0027:
+ * the webhook builds on this). Access control stays at the call boundary — this
+ * function trusts `createdById`.
+ */
+export async function createTicketWithNumber(
+  db: PrismaClient,
+  input: CreateTicketInput,
+): Promise<Ticket> {
+  // Atomically increment the product's ticket counter to get the number.
+  const updated = await db.product.update({
+    where: { id: input.productId },
+    data: { ticketCounter: { increment: 1 } },
+    select: { ticketCounter: true, funTicketIds: true },
+  });
+
+  // Generate a fun short ID only when the product has them enabled.
+  let shortId: string | null = null;
+  if (updated.funTicketIds) {
+    const existing = await db.ticket.findMany({
+      where: { productId: input.productId },
+      select: { shortId: true },
+    });
+    const existingIds = new Set(
+      existing.map((t) => t.shortId).filter(Boolean) as string[],
+    );
+    shortId = generateFunId(existingIds);
+  }
+
+  const ticket = await db.ticket.create({
+    data: {
+      productId: input.productId,
+      number: updated.ticketCounter,
+      shortId,
+      title: input.title,
+      body: input.body ?? undefined,
+      type: input.type ?? "FEATURE",
+      status: input.status ?? "BACKLOG",
+      priority: input.priority ?? undefined,
+      points: input.points ?? undefined,
+      branchName: input.branchName ?? undefined,
+      prUrl: input.prUrl ?? undefined,
+      designUrl: input.designUrl ?? undefined,
+      specUrl: input.specUrl ?? undefined,
+      links: input.links ?? undefined,
+      epicId: input.epicId ?? undefined,
+      featureId: input.featureId ?? undefined,
+      cycleId: input.cycleId ?? undefined,
+      scopeId: input.scopeId ?? undefined,
+      assigneeId: input.assigneeId ?? undefined,
+      createdById: input.createdById,
+    },
+  });
+
+  // Workspace activity feed instrumentation — non-fatal if it fails.
+  await recordActivity(db, {
+    workspaceId: input.workspaceId,
+    userId: input.createdById,
+    entityType: "ticket",
+    entityId: ticket.id,
+    action: "created",
+    metadata: { title: input.title },
+  }).catch(() => {
+    /* instrumentation failure is non-fatal */
+  });
+
+  return ticket;
+}

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -23,6 +23,7 @@ import { getAiInteractionLogger } from "~/server/services/AiInteractionLogger";
 import { PRODUCT_NAME } from "~/lib/brand";
 import { filterAgentInstructions } from "~/server/services/agent-routing/agentInstructionFilter";
 import { loadProductWithAccess } from "~/plugins/product/server/routers/product";
+import { createTicketWithNumber } from "~/plugins/product/server/services/createTicket";
 import { generateFunId } from "~/lib/fun-ids";
 import { recordActivity } from "~/server/services/activity/recordActivity";
 import { ingestChannelSummary } from "~/server/services/activity/ingestChannelSummary";
@@ -4158,53 +4159,19 @@ export const mastraRouter = createTRPCRouter({
       // Verifies the product exists and the user is a member of its workspace.
       const product = await loadProductWithAccess(ctx.db, userId, input.productId);
 
-      // Atomically increment the product's ticket counter to get the number.
-      const updated = await ctx.db.product.update({
-        where: { id: input.productId },
-        data: { ticketCounter: { increment: 1 } },
-        select: { ticketCounter: true, funTicketIds: true },
-      });
-      const ticketNumber = updated.ticketCounter;
-
-      // Generate a fun short ID if the product has them enabled.
-      let shortId: string | null = null;
-      if (updated.funTicketIds) {
-        const existing = await ctx.db.ticket.findMany({
-          where: { productId: input.productId },
-          select: { shortId: true },
-        });
-        const existingIds = new Set(
-          existing.map((t) => t.shortId).filter(Boolean) as string[],
-        );
-        shortId = generateFunId(existingIds);
-      }
-
-      const ticket = await ctx.db.ticket.create({
-        data: {
-          productId: input.productId,
-          number: ticketNumber,
-          shortId,
-          title: input.title,
-          body: input.body,
-          type: input.type ?? "FEATURE",
-          status: input.status ?? "BACKLOG",
-          priority: input.priority,
-          points: input.points,
-          assigneeId: input.assigneeId,
-          createdById: userId,
-        },
-      });
-
-      // Workspace activity feed (non-fatal if it fails).
-      await recordActivity(ctx.db, {
+      // Counter increment, shortId, create, and activity-feed write live in the
+      // shared service (ADR-0016). Access was already verified above.
+      const ticket = await createTicketWithNumber(ctx.db, {
+        productId: input.productId,
         workspaceId: product.workspaceId,
-        userId,
-        entityType: "ticket",
-        entityId: ticket.id,
-        action: "created",
-        metadata: { title: input.title },
-      }).catch(() => {
-        /* instrumentation failure is non-fatal */
+        createdById: userId,
+        title: input.title,
+        body: input.body,
+        type: input.type,
+        status: input.status,
+        priority: input.priority,
+        points: input.points,
+        assigneeId: input.assigneeId,
       });
 
       console.log(`✅ [tRPC createTicket] CREATED: id=${ticket.id}, number=${ticket.number}, shortId=${ticket.shortId ?? 'none'}`);


### PR DESCRIPTION
## What

Extract the duplicated Ticket create-mechanics into one shared service and rewire the existing callers onto it (ADR-0016). The mechanics: atomically increment the product's `ticketCounter` for the `number`, mint a fun `shortId` when the product has fun IDs enabled, `db.ticket.create`, and record the workspace activity event.

- New `createTicketWithNumber(db, input)` in `src/plugins/product/server/services/createTicket.ts`. Takes an explicit `createdById` + `workspaceId` + ticket fields; performs **no** access control — callers authorize.
- Rewired `product` plugin's `ticket.create` mutation and `mastra.createTicket` onto it; both keep their existing `loadProductWithAccess` check ahead of the call.
- `mastra.bulkCreateTickets` left as-is (its batched fun-id loop is out of this ticket's scope).

This is the foundation the Sentry bug webhook (next slice) builds on.

## Acceptance criteria

- [x] A single shared service performs counter increment, shortId generation, ticket creation, and activity recording.
- [x] The product-UI `ticket.create` mutation and `mastra.createTicket` both call it; their existing access checks are unchanged.
- [x] No change to created-ticket numbering, shortIds, or activity-feed behavior — existing tests still pass.
- [x] Unit tests (mocked Prisma) cover: counter increments and is used as `number`; shortId generated only when fun IDs are enabled; `links` passed through; activity recorded with the product's `workspaceId`; supplied `createdById`/type/status honored.

---

Refs: prime.lynx
Exponential-Ticket: cmqkzgn5p0001l804p2ih8z2d