### PR TITLE
feat(sentry): signed Sentry issue webhook files a BUG Ticket as Errol

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,16 @@ GITHUB_PRIVATE_KEY=""
 GITHUB_APP_SLUG=""
 GITHUB_WEBHOOK_SECRET=""
 
+# Sentry -> Exponential bug webhook (/api/webhooks/sentry)
+# Client Secret of the Sentry internal integration; used to verify the
+# Sentry-Hook-Signature on incoming webhooks. If unset, verification is skipped.
+SENTRY_WEBHOOK_SECRET=""
+# Product that Sentry-filed bugs land in (defaults to the Exponential product).
+SENTRY_BUG_PRODUCT_ID=""
+# Identity for the Errol system user that authors Sentry bugs (find-or-created lazily).
+SENTRY_BOT_EMAIL="errol@bots.exponential.im"
+SENTRY_BOT_NAME="Errol"
+
 # Slack
 SLACK_CLIENT_ID=""
 SLACK_CLIENT_SECRET=""

--- a/src/app/api/webhooks/sentry/__tests__/route.test.ts
+++ b/src/app/api/webhooks/sentry/__tests__/route.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the Sentry webhook route. The route reads only
+ * `request.headers.get()` and `request.text()`, so a tiny fake request is
+ * enough — no Next.js Web-API plumbing. The ingest service and `~/server/db`
+ * are mocked so the route is tested in isolation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import crypto from "crypto";
+import type { NextRequest } from "next/server";
+
+vi.hoisted(() => {
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+vi.mock("~/server/db", () => ({ db: {} }));
+
+// Defined via vi.hoisted so the mock factory (hoisted above imports) can close
+// over it without a temporal-dead-zone error.
+const { ingestSentryBug } = vi.hoisted(() => ({ ingestSentryBug: vi.fn() }));
+vi.mock("~/server/services/sentry/SentryBugService", () => ({
+  ingestSentryBug,
+}));
+
+import { POST } from "../route";
+
+const SECRET = "test-client-secret";
+
+function sign(body: string): string {
+  return crypto.createHmac("sha256", SECRET).update(body, "utf8").digest("hex");
+}
+
+/** Minimal NextRequest stand-in exposing only what the route uses. */
+function fakeRequest(opts: {
+  body: string;
+  resource?: string;
+  signature?: string;
+}): NextRequest {
+  const headers = new Map<string, string>();
+  if (opts.signature !== undefined)
+    headers.set("sentry-hook-signature", opts.signature);
+  if (opts.resource !== undefined)
+    headers.set("sentry-hook-resource", opts.resource);
+  return {
+    headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+    text: () => Promise.resolve(opts.body),
+  } as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ingestSentryBug.mockResolvedValue({ created: true, ticketId: "ticket-1" });
+  process.env.SENTRY_WEBHOOK_SECRET = SECRET;
+});
+
+describe("POST /api/webhooks/sentry", () => {
+  const issueBody = JSON.stringify({
+    action: "created",
+    data: { issue: { id: "42", title: "Boom" } },
+  });
+
+  it("rejects a missing signature with 401 and does not ingest", async () => {
+    const res = await POST(
+      fakeRequest({ body: issueBody, resource: "issue" }),
+    );
+    expect(res.status).toBe(401);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid signature with 401", async () => {
+    const res = await POST(
+      fakeRequest({ body: issueBody, resource: "issue", signature: "deadbeef" }),
+    );
+    expect(res.status).toBe(401);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 and ingests nothing for a valid signed non-bug event", async () => {
+    const body = JSON.stringify({ action: "created", installation: {} });
+    const res = await POST(
+      fakeRequest({ body, resource: "installation", signature: sign(body) }),
+    );
+    expect(res.status).toBe(200);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("dispatches a valid signed issue/created event to the ingest service", async () => {
+    const res = await POST(
+      fakeRequest({ body: issueBody, resource: "issue", signature: sign(issueBody) }),
+    );
+    expect(res.status).toBe(200);
+    expect(ingestSentryBug).toHaveBeenCalledTimes(1);
+    const arg = ingestSentryBug.mock.calls[0]![1] as unknown as { issueId: string };
+    expect(arg.issueId).toBe("42");
+  });
+});

--- a/src/app/api/webhooks/sentry/route.ts
+++ b/src/app/api/webhooks/sentry/route.ts
@@ -1,0 +1,67 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { db } from "~/server/db";
+import { ingestSentryBug } from "~/server/services/sentry/SentryBugService";
+import {
+  normalizeSentryPayload,
+  verifySentrySignature,
+} from "~/server/services/sentry/sentryPayload";
+
+/**
+ * Sentry → Exponential bug webhook (ADR-0027).
+ *
+ * Configure a Sentry internal integration to POST here on the `issue` (created)
+ * resource. Each new Sentry issue becomes a Bug Ticket (`type: BUG`,
+ * `status: BACKLOG`) in the configured product, authored by the Errol system
+ * user. Recurring errors are collapsed onto one ticket in a later slice (dedup).
+ *
+ * Auth: Sentry signs the raw body with HMAC-SHA256 using the integration's
+ * Client Secret (set as `SENTRY_WEBHOOK_SECRET`). Verification is one-way, like
+ * the GitHub webhook — no token is issued to Sentry.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const signature = request.headers.get("sentry-hook-signature");
+    const resource = request.headers.get("sentry-hook-resource");
+    const rawBody = await request.text();
+
+    const secret = process.env.SENTRY_WEBHOOK_SECRET;
+    if (secret) {
+      if (!signature || !verifySentrySignature(rawBody, signature, secret)) {
+        console.error("[sentry webhook] invalid signature");
+        return NextResponse.json(
+          { error: "Invalid signature" },
+          { status: 401 },
+        );
+      }
+    } else {
+      console.warn(
+        "[sentry webhook] SENTRY_WEBHOOK_SECRET not set - skipping signature verification",
+      );
+    }
+
+    if (!resource) {
+      return NextResponse.json(
+        { error: "Missing Sentry-Hook-Resource header" },
+        { status: 400 },
+      );
+    }
+
+    const bug = normalizeSentryPayload(resource, JSON.parse(rawBody) as unknown);
+    if (!bug) {
+      // Not an event we file as a bug (installation, comment, resolved, etc.).
+      return NextResponse.json({ message: `Ignored Sentry ${resource} event` });
+    }
+
+    const result = await ingestSentryBug(db, bug);
+    console.log(
+      `[sentry webhook] issue ${bug.issueId} -> ticket ${result.ticketId} (created=${result.created})`,
+    );
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("[sentry webhook] processing error:", error);
+    return NextResponse.json(
+      { error: "Webhook processing failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/server/services/sentry/SentryBugService.ts
+++ b/src/server/services/sentry/SentryBugService.ts
@@ -1,0 +1,73 @@
+import type { PrismaClient } from "@prisma/client";
+import { createTicketWithNumber } from "~/plugins/product/server/services/createTicket";
+import { buildBugBody, type SentryBug } from "./sentryPayload";
+
+/**
+ * Ingests a normalized {@link SentryBug} as a Bug Ticket in Exponential.
+ *
+ * Runs in-process (direct Prisma access) — the webhook route lives inside this
+ * app, so no API token / JWT is involved. The ticket is authored by the
+ * **Errol** system user (find-or-created lazily) and created through the shared
+ * `createTicketWithNumber` service. See ADR-0027.
+ *
+ * Access control is intentionally absent: the route already verified Sentry's
+ * signature, and Errol is not a workspace member (so the usual membership check
+ * would reject it). We load the product directly for the `workspaceId` the
+ * activity write needs.
+ */
+
+// The Exponential product is the default bug destination (overridable via env).
+const DEFAULT_BUG_PRODUCT_ID = "cmp2ztu9y0003jv04kk2l8sm0";
+const DEFAULT_BOT_EMAIL = "errol@bots.exponential.im";
+const DEFAULT_BOT_NAME = "Errol";
+
+/**
+ * Find-or-create the Errol system user. A real `User` row that never signs in
+ * and is not a `WorkspaceUser` — it exists purely to author Sentry-filed bugs.
+ */
+async function findOrCreateErrol(db: PrismaClient): Promise<{ id: string }> {
+  const email = process.env.SENTRY_BOT_EMAIL ?? DEFAULT_BOT_EMAIL;
+  const name = process.env.SENTRY_BOT_NAME ?? DEFAULT_BOT_NAME;
+
+  return db.user.upsert({
+    where: { email },
+    create: { email, name },
+    update: {},
+    select: { id: true },
+  });
+}
+
+export interface IngestResult {
+  created: boolean;
+  ticketId: string;
+}
+
+export async function ingestSentryBug(
+  db: PrismaClient,
+  bug: SentryBug,
+): Promise<IngestResult> {
+  const productId = process.env.SENTRY_BUG_PRODUCT_ID ?? DEFAULT_BUG_PRODUCT_ID;
+  const product = await db.product.findUnique({
+    where: { id: productId },
+    select: { id: true, workspaceId: true },
+  });
+  if (!product) {
+    throw new Error(`Sentry bug product not found: ${productId}`);
+  }
+
+  const errol = await findOrCreateErrol(db);
+
+  const ticket = await createTicketWithNumber(db, {
+    productId: product.id,
+    workspaceId: product.workspaceId,
+    createdById: errol.id,
+    title: bug.title,
+    body: buildBugBody(bug),
+    type: "BUG",
+    status: "BACKLOG",
+    // Priority is left unset — a human assigns it during triage.
+    links: { sentryIssueId: bug.issueId, sentryUrl: bug.url },
+  });
+
+  return { created: true, ticketId: ticket.id };
+}

--- a/src/server/services/sentry/__tests__/SentryBugService.test.ts
+++ b/src/server/services/sentry/__tests__/SentryBugService.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the Sentry ingest service. Mocks `createTicketWithNumber` (the
+ * shared create path) and uses `mockDeep<PrismaClient>()` so no real DB is
+ * touched. Slice 2 has no dedup yet — every ingest creates exactly one ticket.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+vi.mock("~/plugins/product/server/services/createTicket", () => ({
+  createTicketWithNumber: vi.fn(() => Promise.resolve({ id: "ticket-1" })),
+}));
+
+import { createTicketWithNumber } from "~/plugins/product/server/services/createTicket";
+import { ingestSentryBug } from "../SentryBugService";
+import { type SentryBug } from "../sentryPayload";
+
+const dbMock: DeepMockProxy<PrismaClient> = mockDeep<PrismaClient>();
+
+const bug: SentryBug = {
+  issueId: "42",
+  title: "Boom",
+  level: "error",
+  culprit: "app/page.tsx",
+  url: "https://sentry.io/issues/42",
+  shortId: "EXPONENTIAL-1AB",
+};
+
+beforeEach(() => {
+  mockReset(dbMock);
+  vi.clearAllMocks();
+  delete process.env.SENTRY_BUG_PRODUCT_ID;
+  delete process.env.SENTRY_BOT_EMAIL;
+  delete process.env.SENTRY_BOT_NAME;
+  dbMock.product.findUnique.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { id: "prod-1", workspaceId: "ws-1" } as any,
+  );
+  dbMock.user.upsert.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { id: "errol-id" } as any,
+  );
+});
+
+describe("ingestSentryBug", () => {
+  it("creates exactly one BUG/BACKLOG ticket via the shared service, authored by Errol", async () => {
+    const result = await ingestSentryBug(dbMock, bug);
+
+    expect(createTicketWithNumber).toHaveBeenCalledTimes(1);
+    expect(createTicketWithNumber).toHaveBeenCalledWith(
+      dbMock,
+      expect.objectContaining({
+        productId: "prod-1",
+        workspaceId: "ws-1",
+        createdById: "errol-id",
+        title: "Boom",
+        type: "BUG",
+        status: "BACKLOG",
+        links: { sentryIssueId: "42", sentryUrl: "https://sentry.io/issues/42" },
+      }),
+    );
+    expect(result).toEqual({ created: true, ticketId: "ticket-1" });
+  });
+
+  it("find-or-creates Errol via upsert keyed on the bot email (no duplicate users)", async () => {
+    process.env.SENTRY_BOT_EMAIL = "errol@bots.exponential.im";
+    process.env.SENTRY_BOT_NAME = "Errol";
+
+    await ingestSentryBug(dbMock, bug);
+
+    expect(dbMock.user.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { email: "errol@bots.exponential.im" },
+        create: { email: "errol@bots.exponential.im", name: "Errol" },
+        update: {},
+        select: { id: true },
+      }),
+    );
+  });
+
+  it("does not set a priority — left for human triage", async () => {
+    await ingestSentryBug(dbMock, bug);
+    const arg = vi.mocked(createTicketWithNumber).mock.calls[0]![1];
+    expect(arg.priority).toBeUndefined();
+  });
+
+  it("throws when the configured product does not exist", async () => {
+    dbMock.product.findUnique.mockResolvedValue(null);
+    await expect(ingestSentryBug(dbMock, bug)).rejects.toThrow(
+      /Sentry bug product not found/,
+    );
+    expect(createTicketWithNumber).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/sentry/__tests__/sentryPayload.test.ts
+++ b/src/server/services/sentry/__tests__/sentryPayload.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for the pure Sentry webhook helpers — signature verification,
+ * payload normalization, and Markdown body building. No DB, no env, no mocks:
+ * these are deliberately side-effect-free so they can be exhaustively tested.
+ */
+
+import { describe, it, expect } from "vitest";
+import crypto from "crypto";
+import {
+  buildBugBody,
+  normalizeSentryPayload,
+  verifySentrySignature,
+  type SentryBug,
+} from "../sentryPayload";
+
+const SECRET = "test-client-secret";
+
+function sign(body: string, secret = SECRET): string {
+  return crypto.createHmac("sha256", secret).update(body, "utf8").digest("hex");
+}
+
+describe("verifySentrySignature", () => {
+  const body = JSON.stringify({ action: "created", data: { issue: { id: "1" } } });
+
+  it("accepts a signature computed with the right secret over the exact body", () => {
+    expect(verifySentrySignature(body, sign(body), SECRET)).toBe(true);
+  });
+
+  it("rejects a wrong signature", () => {
+    const wrong = sign(body).replace(/.$/, (c) => (c === "0" ? "1" : "0"));
+    expect(verifySentrySignature(body, wrong, SECRET)).toBe(false);
+  });
+
+  it("rejects when the body was tampered after signing", () => {
+    const signature = sign(body);
+    const tampered = body.replace('"1"', '"999"');
+    expect(verifySentrySignature(tampered, signature, SECRET)).toBe(false);
+  });
+
+  it("rejects a signature made with a different secret", () => {
+    expect(verifySentrySignature(body, sign(body, "other-secret"), SECRET)).toBe(
+      false,
+    );
+  });
+
+  it("rejects a malformed (wrong-length) signature without throwing", () => {
+    expect(verifySentrySignature(body, "deadbeef", SECRET)).toBe(false);
+  });
+});
+
+describe("normalizeSentryPayload", () => {
+  it("normalizes an issue/created event into a SentryBug", () => {
+    const bug = normalizeSentryPayload("issue", {
+      action: "created",
+      data: {
+        issue: {
+          id: 42,
+          title: "TypeError: undefined is not a function",
+          level: "error",
+          culprit: "app/page.tsx",
+          permalink: "https://sentry.io/issues/42",
+          shortId: "EXPONENTIAL-1AB",
+        },
+      },
+    });
+    expect(bug).toEqual({
+      issueId: "42",
+      title: "TypeError: undefined is not a function",
+      level: "error",
+      culprit: "app/page.tsx",
+      url: "https://sentry.io/issues/42",
+      shortId: "EXPONENTIAL-1AB",
+    });
+  });
+
+  it("returns null for issue/created without an id (malformed)", () => {
+    expect(
+      normalizeSentryPayload("issue", { action: "created", data: { issue: {} } }),
+    ).toBeNull();
+  });
+
+  it("ignores a non-created issue action (e.g. resolved)", () => {
+    expect(
+      normalizeSentryPayload("issue", {
+        action: "resolved",
+        data: { issue: { id: "1" } },
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores unrelated resources (e.g. installation)", () => {
+    expect(normalizeSentryPayload("installation", { action: "created" })).toBeNull();
+  });
+
+  it("does not throw on null/garbage bodies", () => {
+    expect(normalizeSentryPayload("issue", null)).toBeNull();
+    expect(normalizeSentryPayload("issue", "not-an-object")).toBeNull();
+  });
+});
+
+describe("buildBugBody", () => {
+  const base: SentryBug = {
+    issueId: "42",
+    title: "Boom",
+    level: "error",
+    culprit: "app/page.tsx",
+    url: "https://sentry.io/issues/42",
+    shortId: "EXPONENTIAL-1AB",
+  };
+
+  it("includes provenance, level, culprit, short id, and a Sentry link", () => {
+    const md = buildBugBody(base);
+    expect(md).toContain("Reported automatically from Sentry.");
+    expect(md).toContain("**Level:** error");
+    expect(md).toContain("**Culprit:** app/page.tsx");
+    expect(md).toContain("**Sentry issue:** EXPONENTIAL-1AB");
+    expect(md).toContain("[View in Sentry](https://sentry.io/issues/42)");
+  });
+
+  it("omits absent fields without leaving empty bullets", () => {
+    const md = buildBugBody({
+      issueId: "1",
+      title: "Boom",
+      level: null,
+      culprit: null,
+      url: null,
+      shortId: null,
+    });
+    expect(md).toContain("Reported automatically from Sentry.");
+    expect(md).not.toContain("**Level:**");
+    expect(md).not.toContain("View in Sentry");
+  });
+});

--- a/src/server/services/sentry/sentryPayload.ts
+++ b/src/server/services/sentry/sentryPayload.ts
@@ -1,0 +1,111 @@
+import crypto from "crypto";
+
+/**
+ * Pure (DB-free) helpers for the Sentry → Exponential bug webhook.
+ *
+ * Kept separate from `SentryBugService` so signature verification and payload
+ * normalization can be unit-tested without pulling in Prisma. See ADR-0027.
+ */
+
+/** Normalized shape we turn into a Bug Ticket, regardless of which Sentry resource fired. */
+export interface SentryBug {
+  /** Stable Sentry issue id — the dedup key (stored in `Ticket.links`). */
+  issueId: string;
+  title: string;
+  level: string | null;
+  culprit: string | null;
+  /** Human-facing link into the Sentry UI. */
+  url: string | null;
+  /** Short, friendly id like "EXPONENTIAL-1AB" (only present on the `issue` resource). */
+  shortId: string | null;
+}
+
+/** Minimal view of the Sentry webhook body — only the fields we read. */
+interface SentryWebhookBody {
+  action?: string;
+  data?: {
+    issue?: {
+      id?: string | number;
+      title?: string;
+      level?: string;
+      culprit?: string;
+      permalink?: string;
+      shortId?: string;
+    };
+  };
+}
+
+/**
+ * Verify a Sentry integration-platform webhook signature.
+ *
+ * Sentry signs the raw request body with HMAC-SHA256 using the integration's
+ * Client Secret and sends the hex digest in the `Sentry-Hook-Signature` header
+ * (no `sha256=` prefix, unlike GitHub).
+ */
+export function verifySentrySignature(
+  rawBody: string,
+  signature: string,
+  secret: string,
+): boolean {
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(rawBody, "utf8")
+    .digest("hex");
+
+  const provided = Buffer.from(signature);
+  const computed = Buffer.from(expected);
+
+  // timingSafeEqual throws on length mismatch, so guard first.
+  if (provided.length !== computed.length) return false;
+  return crypto.timingSafeEqual(provided, computed);
+}
+
+/**
+ * Turn a Sentry webhook body into a normalized {@link SentryBug}, or `null` if
+ * the event isn't one we file as a bug.
+ *
+ * Slice 2 files on the `issue` resource, action `created` (a brand-new issue).
+ * The `event_alert` resource is handled in a later slice; every other
+ * resource/action returns `null` (the route answers `200` with no ticket).
+ *
+ * Accepts `unknown` because the body comes straight from `JSON.parse` — it is
+ * narrowed to the small shape we read here.
+ */
+export function normalizeSentryPayload(
+  resource: string,
+  body: unknown,
+): SentryBug | null {
+  const payload = (body ?? {}) as SentryWebhookBody;
+
+  if (resource === "issue" && payload.action === "created") {
+    const issue = payload.data?.issue;
+    if (!issue?.id) return null;
+    return {
+      issueId: String(issue.id),
+      title: issue.title ?? "Untitled Sentry issue",
+      level: issue.level ?? null,
+      culprit: issue.culprit ?? null,
+      url: issue.permalink ?? null,
+      shortId: issue.shortId ?? null,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Build the Markdown body stored on the Bug Ticket (the canonical content
+ * format, ADR-0017): a provenance line, level / culprit / short-id metadata,
+ * and a deep link back into Sentry.
+ */
+export function buildBugBody(bug: SentryBug): string {
+  const lines: string[] = ["Reported automatically from Sentry.", ""];
+  if (bug.level) lines.push(`- **Level:** ${bug.level}`);
+  if (bug.culprit) lines.push(`- **Culprit:** ${bug.culprit}`);
+  if (bug.shortId) lines.push(`- **Sentry issue:** ${bug.shortId}`);
+  if (bug.url) {
+    lines.push("");
+    lines.push(`[View in Sentry](${bug.url})`);
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## What

A signed inbound Sentry webhook at `/api/webhooks/sentry` that turns a new Sentry **issue** into a Bug Ticket — the end-to-end tracer bullet for [ADR-0027](https://github.com/positonic/exponential/blob/main/docs/adr/0027-sentry-errors-as-bug-tickets.md).

- Verifies `Sentry-Hook-Signature` (HMAC-SHA256 of the raw body against `SENTRY_WEBHOOK_SECRET`).
- Normalizes the `issue`/`created` resource; find-or-creates the **Errol** system user (env email/name; a real `User`, never a workspace member).
- Files a `Ticket` (`type: BUG`, `status: BACKLOG`) in `SENTRY_BUG_PRODUCT_ID` (default the Exponential product) via the shared `createTicketWithNumber` service (slice 1). Title = issue title; body = Markdown (level, culprit, short id, "View in Sentry"); `{ sentryIssueId, sentryUrl }` stored in `Ticket.links`. Priority left unset for human triage.
- Any other resource/action → `200` no-op. Missing/invalid signature → `401`.
- New env knobs: `SENTRY_WEBHOOK_SECRET`, `SENTRY_BUG_PRODUCT_ID`, `SENTRY_BOT_EMAIL`, `SENTRY_BOT_NAME`. Replaces the earlier Action-based prototype.

Dedup (one ticket per recurring issue) is the next slice — slice 2 always creates.

## Acceptance criteria

- [x] A signed Sentry `issue/created` POST creates a `Ticket` (type=BUG, status=BACKLOG) in the configured product, authored by Errol.
- [x] The ticket body links back to the Sentry issue; the Sentry issue id is stored in `Ticket.links`.
- [x] A request with a missing or invalid signature is rejected with `401`.
- [x] A valid signed non-bug event returns `200` and creates nothing.
- [x] Errol is find-or-created — repeated calls don't create duplicate users.
- [x] Unit tests: payload parser (signature accept/reject/tamper/wrong-secret/malformed; normalize `issue/created`; ignore non-bug; Markdown body); route returns `401` on bad signature; ingest creates one ticket via the shared service.

---

Refs: peppy.coyote
Exponential-Ticket: cmqkzgyo30007l804cjlq874x