### PR TITLE
feat(sentry): dedup — one Bug Ticket per Sentry issue

### DIFF
--- a/src/server/services/sentry/SentryBugService.ts
+++ b/src/server/services/sentry/SentryBugService.ts
@@ -55,6 +55,21 @@ export async function ingestSentryBug(
     throw new Error(`Sentry bug product not found: ${productId}`);
   }
 
+  // Dedup: one Ticket per Sentry issue. Look for an existing ticket in this
+  // product whose `links` JSON carries the incoming issue id (the same
+  // JSON-path filter the activity feed uses on `metadata.provider`). A
+  // recurring error collapses onto the existing ticket instead of duplicating.
+  const existing = await db.ticket.findFirst({
+    where: {
+      productId: product.id,
+      links: { path: ["sentryIssueId"], equals: bug.issueId },
+    },
+    select: { id: true },
+  });
+  if (existing) {
+    return { created: false, ticketId: existing.id };
+  }
+
   const errol = await findOrCreateErrol(db);
 
   const ticket = await createTicketWithNumber(db, {

--- a/src/server/services/sentry/__tests__/SentryBugService.test.ts
+++ b/src/server/services/sentry/__tests__/SentryBugService.test.ts
@@ -42,6 +42,8 @@ beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     { id: "prod-1", workspaceId: "ws-1" } as any,
   );
+  // No existing ticket by default — each test opts into a dedup hit.
+  dbMock.ticket.findFirst.mockResolvedValue(null);
   dbMock.user.upsert.mockResolvedValue(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     { id: "errol-id" } as any,
@@ -96,5 +98,41 @@ describe("ingestSentryBug", () => {
       /Sentry bug product not found/,
     );
     expect(createTicketWithNumber).not.toHaveBeenCalled();
+  });
+
+  describe("dedup", () => {
+    it("creates no new ticket for an already-seen issue id and returns the existing one", async () => {
+      dbMock.ticket.findFirst.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: "existing-ticket" } as any,
+      );
+
+      const result = await ingestSentryBug(dbMock, bug);
+
+      expect(createTicketWithNumber).not.toHaveBeenCalled();
+      expect(result).toEqual({ created: false, ticketId: "existing-ticket" });
+    });
+
+    it("scopes the dedup lookup to the product and the Sentry issue id", async () => {
+      await ingestSentryBug(dbMock, bug);
+
+      expect(dbMock.ticket.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            productId: "prod-1",
+            links: { path: ["sentryIssueId"], equals: "42" },
+          },
+        }),
+      );
+    });
+
+    it("creates exactly one ticket for a previously-unseen issue id", async () => {
+      dbMock.ticket.findFirst.mockResolvedValue(null);
+
+      const result = await ingestSentryBug(dbMock, bug);
+
+      expect(createTicketWithNumber).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ created: true, ticketId: "ticket-1" });
+    });
   });
 });


### PR DESCRIPTION
## What

Make Sentry ingestion idempotent. Before creating, look up an existing `Ticket` in the target product whose `Ticket.links` carries the incoming Sentry issue id (a JSON-path query — `{ path: ["sentryIssueId"], equals: issueId }` — the same pattern the activity feed uses on `metadata.provider`). On a hit, return the existing ticket and create nothing; otherwise create as in slice 2. A recurring error collapses onto a single ticket. Dedup is scoped to the target product.

## Acceptance criteria

- [x] A second webhook for an already-seen Sentry issue id creates no new ticket and returns the existing one.
- [x] A webhook for a previously-unseen issue id creates exactly one ticket.
- [x] Dedup is scoped to the target product.
- [x] Unit tests (mocked Prisma): known issue id → no create; new issue id → one create.

---

Refs: flat.nebula
Exponential-Ticket: cmqkzha6u000fl804zidob1kp