### PR TITLE
feat(sentry): handle the event_alert resource

### DIFF
--- a/src/server/services/sentry/__tests__/sentryPayload.test.ts
+++ b/src/server/services/sentry/__tests__/sentryPayload.test.ts
@@ -92,6 +92,47 @@ describe("normalizeSentryPayload", () => {
     expect(normalizeSentryPayload("installation", { action: "created" })).toBeNull();
   });
 
+  it("normalizes an event_alert/triggered event keyed on issue_id, link from web_url", () => {
+    const bug = normalizeSentryPayload("event_alert", {
+      action: "triggered",
+      data: {
+        event: {
+          issue_id: 99,
+          title: "RangeError: invalid array length",
+          level: "fatal",
+          culprit: "lib/parse.ts",
+          web_url: "https://sentry.io/issues/99/events/abc",
+        },
+      },
+    });
+    expect(bug).toEqual({
+      issueId: "99",
+      title: "RangeError: invalid array length",
+      level: "fatal",
+      culprit: "lib/parse.ts",
+      url: "https://sentry.io/issues/99/events/abc",
+      shortId: null,
+    });
+  });
+
+  it("returns null for event_alert/triggered without an issue_id", () => {
+    expect(
+      normalizeSentryPayload("event_alert", {
+        action: "triggered",
+        data: { event: { title: "no id" } },
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores non-triggered event_alert actions (200 no-op)", () => {
+    expect(
+      normalizeSentryPayload("event_alert", {
+        action: "resolved",
+        data: { event: { issue_id: "99" } },
+      }),
+    ).toBeNull();
+  });
+
   it("does not throw on null/garbage bodies", () => {
     expect(normalizeSentryPayload("issue", null)).toBeNull();
     expect(normalizeSentryPayload("issue", "not-an-object")).toBeNull();

--- a/src/server/services/sentry/sentryPayload.ts
+++ b/src/server/services/sentry/sentryPayload.ts
@@ -32,6 +32,13 @@ interface SentryWebhookBody {
       permalink?: string;
       shortId?: string;
     };
+    event?: {
+      issue_id?: string | number;
+      title?: string;
+      level?: string;
+      culprit?: string;
+      web_url?: string;
+    };
   };
 }
 
@@ -64,8 +71,12 @@ export function verifySentrySignature(
  * Turn a Sentry webhook body into a normalized {@link SentryBug}, or `null` if
  * the event isn't one we file as a bug.
  *
- * Slice 2 files on the `issue` resource, action `created` (a brand-new issue).
- * The `event_alert` resource is handled in a later slice; every other
+ * We file on:
+ *  - `issue` resource, action `created` (a brand-new issue) — preferred.
+ *  - `event_alert` resource, action `triggered` (a Sentry alert rule fired).
+ *
+ * Both key on the Sentry issue id, so dedup collapses an alert and an
+ * `issue/created` for the same underlying issue onto one ticket. Every other
  * resource/action returns `null` (the route answers `200` with no ticket).
  *
  * Accepts `unknown` because the body comes straight from `JSON.parse` — it is
@@ -87,6 +98,20 @@ export function normalizeSentryPayload(
       culprit: issue.culprit ?? null,
       url: issue.permalink ?? null,
       shortId: issue.shortId ?? null,
+    };
+  }
+
+  if (resource === "event_alert" && payload.action === "triggered") {
+    const event = payload.data?.event;
+    if (!event?.issue_id) return null;
+    return {
+      issueId: String(event.issue_id),
+      title: event.title ?? "Untitled Sentry issue",
+      level: event.level ?? null,
+      culprit: event.culprit ?? null,
+      url: event.web_url ?? null,
+      // `event_alert` payloads don't carry a short id.
+      shortId: null,
     };
   }
 


### PR DESCRIPTION
## What

Extend the webhook to also handle Sentry's `event_alert` resource with action `triggered` (fired by Sentry alert rules), normalizing it into the same bug shape keyed on the event's `issue_id`, with the link taken from the event's `web_url`. Because dedup (slice 3) keys on the Sentry issue id, an alert and an `issue/created` for the same underlying issue collapse onto one ticket — so enabling alert-rule delivery never double-creates. Other `event_alert` actions are ignored with a `200` no-op.

## Acceptance criteria

- [x] A signed `event_alert/triggered` POST creates (or dedups onto) a BUG ticket for the event's issue.
- [x] An `issue/created` and an `event_alert` for the same issue id produce exactly one ticket (both normalize to the same `issueId`; dedup collapses them).
- [x] Other `event_alert` actions are ignored with a `200` no-op.
- [x] Unit tests: normalize `event_alert/triggered` (issue_id, title, level, culprit, web_url); ignore other actions.

---

Refs: vivid.cove
Exponential-Ticket: cmqkzhkjr000nl804bd23vj09