### PR TITLE
feat: editable email + agreement content per Automation step

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/automations/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/automations/[id]/page.tsx
@@ -30,6 +30,8 @@ import {
   ActionIcon,
   Paper,
   Anchor,
+  Drawer,
+  Textarea,
 } from '@mantine/core';
 import {
   IconArrowLeft,
@@ -38,6 +40,7 @@ import {
   IconArrowUp,
   IconArrowDown,
   IconBolt,
+  IconSettings,
 } from '@tabler/icons-react';
 import { notifications } from '@mantine/notifications';
 import { api } from '~/trpc/react';
@@ -52,6 +55,7 @@ interface BuilderStep {
   key: string;
   type: string;
   label: string;
+  config: Record<string, unknown>;
 }
 
 interface TriggerNodeData {
@@ -62,8 +66,29 @@ interface StepNodeData {
   label: string;
   index: number;
   count: number;
+  customized: boolean;
+  onConfigure: (index: number) => void;
   onRemove: (index: number) => void;
   onMove: (index: number, direction: -1 | 1) => void;
+}
+
+function asConfig(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function cfgString(config: Record<string, unknown>, key: string): string {
+  const value = config[key];
+  return typeof value === 'string' ? value : '';
+}
+
+function isStepCustomized(config: Record<string, unknown>): boolean {
+  return (
+    cfgString(config, 'body').trim().length > 0 ||
+    cfgString(config, 'subject').trim().length > 0 ||
+    cfgString(config, 'title').trim().length > 0
+  );
 }
 
 function TriggerNodeComponent({ data }: NodeProps) {
@@ -93,10 +118,25 @@ function StepNodeComponent({ data }: NodeProps) {
     <Paper withBorder p="sm" radius="md" style={{ width: 280 }}>
       <Handle type="target" position={Position.Top} />
       <Group justify="space-between" wrap="nowrap">
-        <Text fw={600} size="sm">
-          {d.label}
-        </Text>
+        <Group gap={6} wrap="nowrap">
+          <Text fw={600} size="sm">
+            {d.label}
+          </Text>
+          {d.customized && (
+            <Badge size="xs" variant="light" color="blue">
+              edited
+            </Badge>
+          )}
+        </Group>
         <Group gap={2} wrap="nowrap">
+          <ActionIcon
+            variant="subtle"
+            size="sm"
+            onClick={() => d.onConfigure(d.index)}
+            aria-label="Edit step content"
+          >
+            <IconSettings size={14} />
+          </ActionIcon>
           <ActionIcon
             variant="subtle"
             size="sm"
@@ -147,6 +187,7 @@ export default function CrmAutomationBuilderPage() {
   const [isActive, setIsActive] = useState(false);
   const [isDefault, setIsDefault] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const [configuringIndex, setConfiguringIndex] = useState<number | null>(null);
 
   useEffect(() => {
     const data = query.data;
@@ -160,6 +201,7 @@ export default function CrmAutomationBuilderPage() {
         key: `${s.id ?? 'step'}-${i}`,
         type: s.type,
         label: s.label,
+        config: asConfig(s.config),
       })),
     );
     setDirty(false);
@@ -198,8 +240,22 @@ export default function CrmAutomationBuilderPage() {
   const addStep = (type: string) => {
     setSteps((prev) => [
       ...prev,
-      { key: `new-${type}-${prev.length}-${Date.now()}`, type, label: stepLabelForType(type) },
+      {
+        key: `new-${type}-${prev.length}-${Date.now()}`,
+        type,
+        label: stepLabelForType(type),
+        config: {},
+      },
     ]);
+    setDirty(true);
+  };
+
+  const updateStepConfig = (index: number, patch: Record<string, unknown>) => {
+    setSteps((prev) =>
+      prev.map((s, i) =>
+        i === index ? { ...s, config: { ...s.config, ...patch } } : s,
+      ),
+    );
     setDirty(true);
   };
 
@@ -241,6 +297,8 @@ export default function CrmAutomationBuilderPage() {
         label: step.label,
         index: i,
         count: steps.length,
+        customized: isStepCustomized(step.config),
+        onConfigure: setConfiguringIndex,
         onRemove: removeStep,
         onMove: moveStep,
       } as unknown as Record<string, unknown>,
@@ -267,6 +325,10 @@ export default function CrmAutomationBuilderPage() {
   if (query.isLoading || !query.data) {
     return <Loader />;
   }
+
+  const editing =
+    configuringIndex !== null ? (steps[configuringIndex] ?? null) : null;
+  const editingIndex = configuringIndex;
 
   return (
     <Stack gap="md" p="md" h="calc(100vh - 120px)">
@@ -314,7 +376,11 @@ export default function CrmAutomationBuilderPage() {
                 id,
                 name: name.trim() || 'Untitled automation',
                 targetCustomerType: targetType ?? '',
-                steps: steps.map((s) => ({ type: s.type, label: s.label })),
+                steps: steps.map((s) => ({
+                  type: s.type,
+                  label: s.label,
+                  config: s.config,
+                })),
               })
             }
           >
@@ -380,6 +446,81 @@ export default function CrmAutomationBuilderPage() {
           <Controls showInteractive={false} />
         </ReactFlow>
       </Box>
+
+      <Drawer
+        opened={editing !== null}
+        onClose={() => setConfiguringIndex(null)}
+        position="right"
+        size="md"
+        title={editing ? stepLabelForType(editing.type) : ''}
+      >
+        {editing && editingIndex !== null && (
+          <Stack gap="sm">
+            <Text size="xs" c="dimmed">
+              Leave a field blank to use the built-in default. Variables:{' '}
+              {'{{firstName}} {{fullName}} {{customerType}} {{companyName}} {{date}}'}
+            </Text>
+
+            {editing.type === 'send_email' && (
+              <>
+                <TextInput
+                  label="Subject"
+                  placeholder="Welcome — you're signed up as a {{customerType}}"
+                  value={cfgString(editing.config, 'subject')}
+                  onChange={(e) =>
+                    updateStepConfig(editingIndex, {
+                      subject: e.currentTarget.value,
+                    })
+                  }
+                />
+                <Textarea
+                  label="Email body"
+                  placeholder="Hi {{firstName}},&#10;&#10;Welcome aboard as a {{customerType}}…"
+                  autosize
+                  minRows={8}
+                  value={cfgString(editing.config, 'body')}
+                  onChange={(e) =>
+                    updateStepConfig(editingIndex, {
+                      body: e.currentTarget.value,
+                    })
+                  }
+                />
+              </>
+            )}
+
+            {editing.type === 'generate_document' && (
+              <>
+                <TextInput
+                  label="Agreement title"
+                  placeholder="{{customerType}} Agreement"
+                  value={cfgString(editing.config, 'title')}
+                  onChange={(e) =>
+                    updateStepConfig(editingIndex, {
+                      title: e.currentTarget.value,
+                    })
+                  }
+                />
+                <Textarea
+                  label="Agreement body"
+                  placeholder="This agreement is entered into between the Company and {{fullName}}…"
+                  autosize
+                  minRows={10}
+                  value={cfgString(editing.config, 'body')}
+                  onChange={(e) =>
+                    updateStepConfig(editingIndex, {
+                      body: e.currentTarget.value,
+                    })
+                  }
+                />
+              </>
+            )}
+
+            <Group justify="flex-end">
+              <Button onClick={() => setConfiguringIndex(null)}>Done</Button>
+            </Group>
+          </Stack>
+        )}
+      </Drawer>
     </Stack>
   );
 }

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/automations/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/automations/[id]/page.tsx
@@ -28,10 +28,10 @@ import {
   Switch,
   Menu,
   ActionIcon,
-  Paper,
   Anchor,
   Drawer,
   Textarea,
+  useComputedColorScheme,
 } from '@mantine/core';
 import {
   IconArrowLeft,
@@ -94,7 +94,10 @@ function isStepCustomized(config: Record<string, unknown>): boolean {
 function TriggerNodeComponent({ data }: NodeProps) {
   const d = data as unknown as TriggerNodeData;
   return (
-    <Paper withBorder p="sm" radius="md" style={{ width: 280 }}>
+    <div
+      className="rounded-md border border-border-primary bg-surface-secondary"
+      style={{ width: 280, padding: 12 }}
+    >
       <Group gap={6} mb={4}>
         <IconBolt size={16} />
         <Text size="xs" c="dimmed" fw={600} tt="uppercase">
@@ -108,14 +111,17 @@ function TriggerNodeComponent({ data }: NodeProps) {
         {d.targetType ?? 'no type set'}
       </Badge>
       <Handle type="source" position={Position.Bottom} />
-    </Paper>
+    </div>
   );
 }
 
 function StepNodeComponent({ data }: NodeProps) {
   const d = data as unknown as StepNodeData;
   return (
-    <Paper withBorder p="sm" radius="md" style={{ width: 280 }}>
+    <div
+      className="rounded-md border border-border-primary bg-surface-secondary"
+      style={{ width: 280, padding: 12 }}
+    >
       <Handle type="target" position={Position.Top} />
       <Group justify="space-between" wrap="nowrap">
         <Group gap={6} wrap="nowrap">
@@ -167,7 +173,7 @@ function StepNodeComponent({ data }: NodeProps) {
         </Group>
       </Group>
       <Handle type="source" position={Position.Bottom} />
-    </Paper>
+    </div>
   );
 }
 
@@ -178,6 +184,7 @@ export default function CrmAutomationBuilderPage() {
   const pathname = usePathname();
   const overviewHref = pathname.split('/').slice(0, -1).join('/');
   const utils = api.useUtils();
+  const colorScheme = useComputedColorScheme('dark');
 
   const query = api.crmAutomation.get.useQuery({ id }, { enabled: !!id });
 
@@ -437,6 +444,7 @@ export default function CrmAutomationBuilderPage() {
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}
+          colorMode={colorScheme}
           nodesDraggable={false}
           nodesConnectable={false}
           fitView

--- a/src/server/services/EmailService.ts
+++ b/src/server/services/EmailService.ts
@@ -911,6 +911,37 @@ The ${appName} team`;
   return { subject, htmlBody, textBody };
 }
 
+/**
+ * Send a CRM Automation email with **user-authored** content (subject + body)
+ * from the Automation builder. The body HTML is already rendered + escaped by
+ * the caller (`contentRendering`); here we only wrap it in the branded shell.
+ * Returns the composed content so the caller can log it as a CrmCommunication.
+ */
+export async function sendCrmAutomationEmail(params: {
+  to: string;
+  subject: string;
+  bodyHtml: string;
+  bodyText: string;
+}): Promise<{ subject: string; htmlBody: string; textBody: string }> {
+  const appName = PRODUCT_NAME;
+  const htmlBody = `
+<!DOCTYPE html>
+<html lang="en">
+  <body style="font-family: Arial, Helvetica, sans-serif; color: #1a1a1a; line-height: 1.6; padding: 24px;">
+    ${params.bodyHtml}
+    <p style="color: ${EMAIL_BRAND_COLOR}; margin-top: 24px;">— The ${appName} team</p>
+  </body>
+</html>`;
+
+  await sendEmail({
+    to: params.to,
+    subject: params.subject,
+    htmlBody,
+    textBody: params.bodyText,
+  });
+  return { subject: params.subject, htmlBody, textBody: params.bodyText };
+}
+
 export const EmailService = {
   sendMagicLinkEmail,
   sendWelcomeEmail,
@@ -920,4 +951,5 @@ export const EmailService = {
   sendAssignmentNotificationEmail,
   sendMentionNotificationEmail,
   sendCrmOnboardingWelcomeEmail,
+  sendCrmAutomationEmail,
 };

--- a/src/server/services/crm/automation/__tests__/contentRendering.test.ts
+++ b/src/server/services/crm/automation/__tests__/contentRendering.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildContactTemplateData,
+  renderInline,
+  renderTextBodyToHtml,
+} from "../contentRendering";
+
+const DATA = {
+  firstName: "Ada",
+  fullName: "Ada Lovelace",
+  customerType: "Advisor",
+  companyName: "Analytical Engines",
+};
+
+describe("renderInline", () => {
+  it("substitutes tokens with no HTML escaping", () => {
+    expect(
+      renderInline("Welcome {{firstName}} — {{customerType}}", DATA),
+    ).toBe("Welcome Ada — Advisor");
+  });
+
+  it("replaces a missing token with empty string", () => {
+    expect(renderInline("Hi {{nickname}}!", DATA)).toBe("Hi !");
+  });
+});
+
+describe("renderTextBodyToHtml", () => {
+  it("wraps blank-line-separated paragraphs and single newlines", () => {
+    const html = renderTextBodyToHtml("Line one\nLine two\n\nNext para", DATA);
+    expect(html).toBe("<p>Line one<br/>Line two</p>\n<p>Next para</p>");
+  });
+
+  it("substitutes variables", () => {
+    expect(renderTextBodyToHtml("Dear {{fullName}},", DATA)).toBe(
+      "<p>Dear Ada Lovelace,</p>",
+    );
+  });
+
+  it("escapes HTML in the template and in substituted values (injection-safe)", () => {
+    const html = renderTextBodyToHtml("Hi {{firstName}} <script>x</script>", {
+      firstName: "<b>Eve</b>",
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("<b>Eve</b>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&lt;b&gt;Eve&lt;/b&gt;");
+  });
+
+  it("never leaks a raw token", () => {
+    expect(renderTextBodyToHtml("Value: {{missing}}", DATA)).not.toContain(
+      "{{",
+    );
+  });
+});
+
+describe("buildContactTemplateData", () => {
+  it("derives fullName and pulls the organization name", () => {
+    const data = buildContactTemplateData(
+      { firstName: "Ada", lastName: "Lovelace", organization: { name: "AE" } },
+      "Advisor",
+      new Date("2026-06-19T00:00:00Z"),
+    );
+    expect(data.fullName).toBe("Ada Lovelace");
+    expect(data.companyName).toBe("AE");
+    expect(data.customerType).toBe("Advisor");
+    expect(data.date).toBe("2026-06-19");
+  });
+
+  it("falls back to 'there' when the contact has no name", () => {
+    const data = buildContactTemplateData(
+      { firstName: null, lastName: null },
+      "Developer",
+      new Date("2026-06-19T00:00:00Z"),
+    );
+    expect(data.fullName).toBe("there");
+    expect(data.companyName).toBe("");
+  });
+});

--- a/src/server/services/crm/automation/contentRendering.ts
+++ b/src/server/services/crm/automation/contentRendering.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared rendering for **user-authored** Automation step content — the welcome
+ * email body/subject and the agreement title/body edited in the builder
+ * (CONTEXT.md → Automation builder). Authored as plain text with `{{variable}}`
+ * tokens; rendered to safe HTML (escaped) for email/agreement output.
+ *
+ * Distinct from `templateRenderer.renderTemplate`, which substitutes into
+ * *trusted* built-in HTML templates and does NOT escape. User text must be
+ * escaped to stay injection-safe, so it lives here. Pure — unit-tested.
+ */
+
+export interface ContactForTemplate {
+  firstName: string | null;
+  lastName: string | null;
+  organization?: { name: string | null } | null;
+}
+
+/** The variables a step's content can reference. */
+export function buildContactTemplateData(
+  contact: ContactForTemplate,
+  customerType: string,
+  now: Date,
+): Record<string, string> {
+  const fullName =
+    [contact.firstName, contact.lastName].filter(Boolean).join(" ").trim() ||
+    "there";
+  return {
+    firstName: contact.firstName ?? "",
+    lastName: contact.lastName ?? "",
+    fullName,
+    customerType,
+    companyName: contact.organization?.name ?? "",
+    date: now.toISOString().slice(0, 10),
+  };
+}
+
+const TOKEN = /\{\{\s*([\w.]+)\s*\}\}/g;
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Substitute `{{vars}}` into a single line (no HTML). For subjects/titles. */
+export function renderInline(
+  template: string,
+  data: Record<string, string>,
+): string {
+  return template.replace(TOKEN, (_m, key: string) => data[key.trim()] ?? "");
+}
+
+/**
+ * Escape user text, substitute `{{vars}}` (values also escaped), and turn
+ * blank-line breaks into `<p>` and single newlines into `<br/>`. Injection-safe:
+ * any HTML the user typed is escaped, so a raw `{{token}}` never leaks and no
+ * markup the user types is executed.
+ */
+export function renderTextBodyToHtml(
+  template: string,
+  data: Record<string, string>,
+): string {
+  const substituted = escapeHtml(template).replace(
+    TOKEN,
+    (_m, key: string) => escapeHtml(data[key.trim()] ?? ""),
+  );
+  return substituted
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph.length > 0)
+    .map((paragraph) => `<p>${paragraph.replace(/\n/g, "<br/>")}</p>`)
+    .join("\n");
+}
+
+/** Plain-text body: substitute `{{vars}}`, no escaping. For the email text part. */
+export function renderTextBodyToPlain(
+  template: string,
+  data: Record<string, string>,
+): string {
+  return renderInline(template, data);
+}
+
+/** Wrap a user-authored agreement body in a minimal, color-free HTML document. */
+export function wrapAgreementHtml(title: string, bodyHtml: string): string {
+  const safeTitle = escapeHtml(title);
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>${safeTitle}</title>
+  </head>
+  <body style="font-family: Arial, Helvetica, sans-serif; line-height: 1.5; max-width: 720px; margin: 0 auto; padding: 40px;">
+    <h1 style="font-size: 22px;">${safeTitle}</h1>
+    ${bodyHtml}
+    <p style="margin-top: 48px;">[DIGITAL SIGNATURE FIELD]</p>
+  </body>
+</html>`;
+}

--- a/src/server/services/crm/automation/steps/GenerateDocumentStep.ts
+++ b/src/server/services/crm/automation/steps/GenerateDocumentStep.ts
@@ -6,6 +6,12 @@ import {
 } from "~/server/services/workflows/steps/IStepExecutor";
 import { loadAgreementTemplate } from "../agreementTemplates";
 import { renderTemplate } from "../templateRenderer";
+import {
+  buildContactTemplateData,
+  renderInline,
+  renderTextBodyToHtml,
+  wrapAgreementHtml,
+} from "../contentRendering";
 
 /**
  * `generate_document` step — renders the per-Customer-type **Agreement** HTML
@@ -45,32 +51,36 @@ export class GenerateDocumentStep implements IStepExecutor {
       throw new Error(`generate_document: contact ${contactId} not found`);
     }
 
-    const fullName =
-      [contact.firstName, contact.lastName].filter(Boolean).join(" ").trim() ||
-      "there";
+    const data = buildContactTemplateData(contact, customerType, new Date());
 
-    const data: Record<string, string> = {
-      firstName: contact.firstName ?? "",
-      lastName: contact.lastName ?? "",
-      fullName,
-      customerType,
-      companyName: contact.organization?.name ?? "",
-      date: new Date().toISOString().slice(0, 10),
-    };
+    // User-authored agreement body from the builder (config) overrides the
+    // built-in per-type HTML template; an empty body falls back to the default.
+    const customBody =
+      typeof config.body === "string" && config.body.trim()
+        ? config.body
+        : null;
 
-    const template = loadAgreementTemplate(customerType);
-    const { html, missingVariables } = renderTemplate(template, data);
-
-    if (missingVariables.length > 0) {
-      console.warn(
-        `[generate_document] contact ${contactId}: missing template variables: ${missingVariables.join(", ")}`,
-      );
+    let html: string;
+    if (customBody) {
+      const title =
+        typeof config.title === "string" && config.title.trim()
+          ? renderInline(config.title, data)
+          : `${customerType} Agreement`;
+      html = wrapAgreementHtml(title, renderTextBodyToHtml(customBody, data));
+    } else {
+      const template = loadAgreementTemplate(customerType);
+      const rendered = renderTemplate(template, data);
+      html = rendered.html;
+      if (rendered.missingVariables.length > 0) {
+        console.warn(
+          `[generate_document] contact ${contactId}: missing template variables: ${rendered.missingVariables.join(", ")}`,
+        );
+      }
     }
 
     return {
       agreementHtml: html,
       agreementCustomerType: customerType,
-      agreementMissingVariables: missingVariables,
     };
   }
 }

--- a/src/server/services/crm/automation/steps/SendEmailStep.ts
+++ b/src/server/services/crm/automation/steps/SendEmailStep.ts
@@ -6,6 +6,12 @@ import {
 } from "~/server/services/workflows/steps/IStepExecutor";
 import { EmailService } from "~/server/services/EmailService";
 import { encryptString, decryptBuffer } from "~/server/utils/encryption";
+import {
+  buildContactTemplateData,
+  renderInline,
+  renderTextBodyToHtml,
+  renderTextBodyToPlain,
+} from "../contentRendering";
 
 /**
  * `send_email` step — sends the branded onboarding **welcome** email to the
@@ -39,6 +45,7 @@ export class SendEmailStep implements IStepExecutor {
 
     const contact = await this.db.crmContact.findUnique({
       where: { id: contactId },
+      include: { organization: { select: { name: true } } },
     });
     if (!contact) {
       throw new Error(`send_email: contact ${contactId} not found`);
@@ -55,12 +62,44 @@ export class SendEmailStep implements IStepExecutor {
       [contact.firstName, contact.lastName].filter(Boolean).join(" ").trim() ||
       null;
 
-    const { subject, htmlBody, textBody } =
-      await EmailService.sendCrmOnboardingWelcomeEmail({
+    // User-authored content from the builder (config) overrides the built-in
+    // welcome template; an empty body falls back to the default.
+    const customBody =
+      typeof config.body === "string" && config.body.trim()
+        ? config.body
+        : null;
+    const customSubject =
+      typeof config.subject === "string" && config.subject.trim()
+        ? config.subject
+        : null;
+
+    let subject: string;
+    let htmlBody: string;
+    let textBody: string;
+
+    if (customBody) {
+      const data = buildContactTemplateData(contact, customerType, new Date());
+      const rendered = await EmailService.sendCrmAutomationEmail({
+        to: toEmail,
+        subject: customSubject
+          ? renderInline(customSubject, data)
+          : `Welcome — you're signed up as a ${customerType}`,
+        bodyHtml: renderTextBodyToHtml(customBody, data),
+        bodyText: renderTextBodyToPlain(customBody, data),
+      });
+      subject = rendered.subject;
+      htmlBody = rendered.htmlBody;
+      textBody = rendered.textBody;
+    } else {
+      const rendered = await EmailService.sendCrmOnboardingWelcomeEmail({
         to: toEmail,
         name,
         customerType,
       });
+      subject = rendered.subject;
+      htmlBody = rendered.htmlBody;
+      textBody = rendered.textBody;
+    }
 
     await this.db.crmCommunication.create({
       data: {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2314,3 +2314,25 @@
 .prd-document li > p {
   margin: 0;
 }
+
+/* React Flow (CRM Automation builder) — theme the canvas chrome to the app's
+   navy surfaces instead of React Flow's default light styling. Colors come from
+   semantic tokens so this follows light/dark like the rest of the app. */
+.react-flow__controls {
+  box-shadow: none;
+}
+.react-flow__controls-button {
+  background-color: var(--color-surface-secondary);
+  border-bottom-color: var(--color-border-primary);
+  color: var(--color-text-primary);
+}
+.react-flow__controls-button:hover {
+  background-color: var(--color-surface-hover);
+}
+.react-flow__controls-button svg {
+  fill: currentColor;
+}
+.react-flow__attribution {
+  background-color: transparent;
+  color: var(--color-text-secondary);
+}


### PR DESCRIPTION
## What

Make Automation step content editable in the builder (the "editable message copy" deferred in ADR-0028).

- Click a step's **settings icon** → a config **Drawer** opens. For **Send welcome email**: edit Subject + Body. For **Generate agreement**: edit Title + Body. Both support `{{firstName}}` `{{fullName}}` `{{customerType}}` `{{companyName}}` `{{date}}` variables.
- **Empty fields fall back to the built-in defaults**, so existing automations are unchanged.
- A step with custom content shows an **"edited"** badge.

## How it's safe

`contentRendering` is pure and **injection-safe** — it HTML-escapes both the user's template text and the substituted values, turns blank lines into paragraphs, and never leaks a raw `{{token}}`. Custom email bodies are wrapped in the branded shell via `EmailService.sendCrmAutomationEmail`; custom agreements in a color-free HTML document.

Step config round-trips through the existing `saveDefinition` (steps already store a `config` JSON) — **no migration**.

## Tests

8 new unit tests on `contentRendering` (substitution, paragraph wrapping, HTML-escaping/injection-safety, missing-token handling, template-data derivation).

---

Ships: dusty.reed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CRM automation steps can now be individually configured with custom settings displayed in a dedicated editor panel.
  * Email automation steps support custom subject lines and body content with template variable substitution (e.g., contact names, company info).
  * Document automation steps support custom agreement content and titles with dynamic variable replacement.

* **Tests**
  * Added test coverage for template rendering and variable substitution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->