### PR TITLE
feat(sentry): announce new Sentry bugs in Zulip with a ticket link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,10 @@ SENTRY_BUG_PRODUCT_ID=""
 # Identity for the Errol system user that authors Sentry bugs (find-or-created lazily).
 SENTRY_BOT_EMAIL="errol@bots.exponential.im"
 SENTRY_BOT_NAME="Errol"
+# Optional: Zulip stream/topic for the "new Sentry bug" announcement. The stream
+# falls back to the workspace Zulip integration's default; the topic to "Sentry bugs".
+SENTRY_ZULIP_STREAM=""
+SENTRY_ZULIP_TOPIC=""
 
 # Slack
 SLACK_CLIENT_ID=""

--- a/src/server/services/sentry/SentryBugService.ts
+++ b/src/server/services/sentry/SentryBugService.ts
@@ -1,6 +1,7 @@
 import type { PrismaClient } from "@prisma/client";
 import { createTicketWithNumber } from "~/plugins/product/server/services/createTicket";
 import { buildBugBody, type SentryBug } from "./sentryPayload";
+import { notifyZulipOfSentryBug } from "./sentryZulip";
 
 /**
  * Ingests a normalized {@link SentryBug} as a Bug Ticket in Exponential.
@@ -49,7 +50,12 @@ export async function ingestSentryBug(
   const productId = process.env.SENTRY_BUG_PRODUCT_ID ?? DEFAULT_BUG_PRODUCT_ID;
   const product = await db.product.findUnique({
     where: { id: productId },
-    select: { id: true, workspaceId: true },
+    select: {
+      id: true,
+      workspaceId: true,
+      slug: true,
+      workspace: { select: { slug: true } },
+    },
   });
   if (!product) {
     throw new Error(`Sentry bug product not found: ${productId}`);
@@ -82,6 +88,18 @@ export async function ingestSentryBug(
     status: "BACKLOG",
     // Priority is left unset — a human assigns it during triage.
     links: { sentryIssueId: bug.issueId, sentryUrl: bug.url },
+  });
+
+  // Announce the new bug in Zulip (best-effort) with a deep link to the ticket.
+  // Only on creation — recurring errors that dedup above do not re-notify.
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://www.exponential.im";
+  const ticketUrl = `${baseUrl}/w/${product.workspace.slug}/products/${product.slug}/tickets/${ticket.id}`;
+  await notifyZulipOfSentryBug(db, {
+    workspaceId: product.workspaceId,
+    authorId: errol.id,
+    title: bug.title,
+    ticketUrl,
+    sentryUrl: bug.url,
   });
 
   return { created: true, ticketId: ticket.id };

--- a/src/server/services/sentry/__tests__/SentryBugService.test.ts
+++ b/src/server/services/sentry/__tests__/SentryBugService.test.ts
@@ -17,7 +17,14 @@ vi.mock("~/plugins/product/server/services/createTicket", () => ({
   createTicketWithNumber: vi.fn(() => Promise.resolve({ id: "ticket-1" })),
 }));
 
+// Zulip notify is exercised in its own test; here we just assert it's invoked
+// (or not) with the right deep link.
+vi.mock("../sentryZulip", () => ({
+  notifyZulipOfSentryBug: vi.fn(() => Promise.resolve()),
+}));
+
 import { createTicketWithNumber } from "~/plugins/product/server/services/createTicket";
+import { notifyZulipOfSentryBug } from "../sentryZulip";
 import { ingestSentryBug } from "../SentryBugService";
 import { type SentryBug } from "../sentryPayload";
 
@@ -38,9 +45,16 @@ beforeEach(() => {
   delete process.env.SENTRY_BUG_PRODUCT_ID;
   delete process.env.SENTRY_BOT_EMAIL;
   delete process.env.SENTRY_BOT_NAME;
+  delete process.env.NEXT_PUBLIC_APP_URL;
   dbMock.product.findUnique.mockResolvedValue(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    { id: "prod-1", workspaceId: "ws-1" } as any,
+    {
+      id: "prod-1",
+      workspaceId: "ws-1",
+      slug: "exponential",
+      workspace: { slug: "syntrofi" },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
   );
   // No existing ticket by default — each test opts into a dedup hit.
   dbMock.ticket.findFirst.mockResolvedValue(null);
@@ -92,6 +106,25 @@ describe("ingestSentryBug", () => {
     expect(arg.priority).toBeUndefined();
   });
 
+  it("notifies Zulip on creation with a deep link to the new ticket", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example";
+
+    await ingestSentryBug(dbMock, bug);
+
+    expect(notifyZulipOfSentryBug).toHaveBeenCalledTimes(1);
+    expect(notifyZulipOfSentryBug).toHaveBeenCalledWith(
+      dbMock,
+      expect.objectContaining({
+        workspaceId: "ws-1",
+        authorId: "errol-id",
+        title: "Boom",
+        sentryUrl: "https://sentry.io/issues/42",
+        ticketUrl:
+          "https://app.example/w/syntrofi/products/exponential/tickets/ticket-1",
+      }),
+    );
+  });
+
   it("throws when the configured product does not exist", async () => {
     dbMock.product.findUnique.mockResolvedValue(null);
     await expect(ingestSentryBug(dbMock, bug)).rejects.toThrow(
@@ -110,6 +143,8 @@ describe("ingestSentryBug", () => {
       const result = await ingestSentryBug(dbMock, bug);
 
       expect(createTicketWithNumber).not.toHaveBeenCalled();
+      // Recurring errors that dedup onto an existing ticket do not re-notify.
+      expect(notifyZulipOfSentryBug).not.toHaveBeenCalled();
       expect(result).toEqual({ created: false, ticketId: "existing-ticket" });
     });
 

--- a/src/server/services/sentry/__tests__/sentryZulip.test.ts
+++ b/src/server/services/sentry/__tests__/sentryZulip.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the Sentry → Zulip announcement. Mocks
+ * `ZulipNotificationService` so no HTTP/DB happens, and asserts the
+ * integration lookup, message shape, and best-effort (no-throw) behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+const { sendNotificationMock, ctorMock } = vi.hoisted(() => ({
+  sendNotificationMock: vi.fn(() =>
+    Promise.resolve({ success: true, messageId: "1" }),
+  ),
+  ctorMock: vi.fn(),
+}));
+
+vi.mock("~/server/services/notifications/ZulipNotificationService", () => ({
+  ZulipNotificationService: class {
+    sendNotification = sendNotificationMock;
+    constructor(config: unknown) {
+      ctorMock(config);
+    }
+  },
+}));
+
+import { notifyZulipOfSentryBug } from "../sentryZulip";
+
+const dbMock: DeepMockProxy<PrismaClient> = mockDeep<PrismaClient>();
+
+const base = {
+  workspaceId: "ws-1",
+  authorId: "errol-id",
+  title: "Boom",
+  ticketUrl: "https://app.example/w/syntrofi/products/exponential/tickets/t1",
+  sentryUrl: "https://sentry.io/issues/42",
+};
+
+beforeEach(() => {
+  mockReset(dbMock);
+  vi.clearAllMocks();
+  sendNotificationMock.mockResolvedValue({ success: true, messageId: "1" });
+  delete process.env.SENTRY_ZULIP_STREAM;
+  delete process.env.SENTRY_ZULIP_TOPIC;
+  dbMock.integration.findFirst.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { id: "int-1" } as any,
+  );
+});
+
+describe("notifyZulipOfSentryBug", () => {
+  it("sends a message with the ticket link to the workspace's Zulip integration", async () => {
+    await notifyZulipOfSentryBug(dbMock, base);
+
+    expect(dbMock.integration.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { provider: "zulip", status: "ACTIVE", workspaceId: "ws-1" },
+      }),
+    );
+    expect(ctorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationId: "int-1",
+        additionalConfig: { topic: "Sentry bugs" },
+      }),
+    );
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+    const payload = sendNotificationMock.mock.calls[0]![0] as {
+      message: string;
+    };
+    expect(payload.message).toContain(base.ticketUrl);
+    expect(payload.message).toContain("[View in Sentry](https://sentry.io/issues/42)");
+  });
+
+  it("no-ops when the workspace has no Zulip integration", async () => {
+    dbMock.integration.findFirst.mockResolvedValue(null);
+
+    await notifyZulipOfSentryBug(dbMock, base);
+
+    expect(ctorMock).not.toHaveBeenCalled();
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("honors SENTRY_ZULIP_STREAM / SENTRY_ZULIP_TOPIC overrides", async () => {
+    process.env.SENTRY_ZULIP_STREAM = "errors";
+    process.env.SENTRY_ZULIP_TOPIC = "prod";
+
+    await notifyZulipOfSentryBug(dbMock, base);
+
+    expect(ctorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "errors",
+        additionalConfig: { topic: "prod" },
+      }),
+    );
+  });
+
+  it("omits the Sentry link when there is no url", async () => {
+    await notifyZulipOfSentryBug(dbMock, { ...base, sentryUrl: null });
+
+    const payload = sendNotificationMock.mock.calls[0]![0] as { message: string };
+    expect(payload.message).not.toContain("View in Sentry");
+  });
+
+  it("never throws when the send fails (best-effort)", async () => {
+    sendNotificationMock.mockResolvedValue({ success: false, error: "boom" });
+    await expect(notifyZulipOfSentryBug(dbMock, base)).resolves.toBeUndefined();
+  });
+
+  it("never throws when the integration lookup rejects", async () => {
+    dbMock.integration.findFirst.mockRejectedValue(new Error("db down"));
+    await expect(notifyZulipOfSentryBug(dbMock, base)).resolves.toBeUndefined();
+  });
+});

--- a/src/server/services/sentry/sentryZulip.ts
+++ b/src/server/services/sentry/sentryZulip.ts
@@ -1,0 +1,70 @@
+import type { PrismaClient } from "@prisma/client";
+import { ZulipNotificationService } from "~/server/services/notifications/ZulipNotificationService";
+
+/**
+ * Post a short Zulip message announcing a newly-filed Sentry bug, with a deep
+ * link to the created Ticket. Reuses the existing per-workspace Zulip
+ * `Integration` (provider `zulip`) — the same path the notification scheduler
+ * uses — resolved by the bug product's workspace.
+ *
+ * This is best-effort: if no Zulip integration is configured for the workspace
+ * it is a silent no-op, and any send failure is swallowed so it can never break
+ * the webhook. Called only when a *new* ticket was created (recurring errors
+ * that dedup onto an existing ticket do not re-notify).
+ */
+export interface SentryBugNotification {
+  workspaceId: string;
+  /** Author of the ticket (Errol) — used as the notification config's userId. */
+  authorId: string;
+  /** The Sentry issue title, shown in bold. */
+  title: string;
+  /** Deep link to the created Ticket. */
+  ticketUrl: string;
+  /** Link back into Sentry, if the payload carried one. */
+  sentryUrl: string | null;
+}
+
+export async function notifyZulipOfSentryBug(
+  db: PrismaClient,
+  notification: SentryBugNotification,
+): Promise<void> {
+  try {
+    const integration = await db.integration.findFirst({
+      where: {
+        provider: "zulip",
+        status: "ACTIVE",
+        workspaceId: notification.workspaceId,
+      },
+      select: { id: true },
+    });
+    if (!integration) {
+      // No Zulip configured for this workspace — nothing to do.
+      return;
+    }
+
+    const service = new ZulipNotificationService({
+      userId: notification.authorId,
+      integrationId: integration.id,
+      // Stream falls back to the integration's default when the env knob is unset.
+      channel: process.env.SENTRY_ZULIP_STREAM,
+      additionalConfig: {
+        topic: process.env.SENTRY_ZULIP_TOPIC ?? "Sentry bugs",
+      },
+    });
+
+    const links = [`[Open ticket](${notification.ticketUrl})`];
+    if (notification.sentryUrl) {
+      links.push(`[View in Sentry](${notification.sentryUrl})`);
+    }
+
+    const result = await service.sendNotification({
+      title: "New Sentry bug filed",
+      message: `**${notification.title}**\n\n${links.join(" · ")}`,
+    });
+    if (!result.success) {
+      console.error("[sentry webhook] Zulip notify failed:", result.error);
+    }
+  } catch (error) {
+    console.error("[sentry webhook] Zulip notify error:", error);
+  }
+}


### PR DESCRIPTION
## What

When the Sentry webhook files a **new** Bug ticket, post a short message to the workspace's Zulip integration with a deep link to the created ticket.

- Reuses the existing `ZulipNotificationService` + per-workspace `Integration` (provider `zulip`) path — the same one the notification scheduler uses. The integration is resolved by the **bug product's workspace**, so no session/credentials are needed in the webhook.
- Message: **"New Sentry bug filed"** → bold issue title → `[Open ticket](…)` (+ `[View in Sentry](…)` when present). Posted to the integration's default stream, topic `Sentry bugs` — both overridable via `SENTRY_ZULIP_STREAM` / `SENTRY_ZULIP_TOPIC`.
- **Best-effort**: silent no-op if the workspace has no Zulip integration; any send failure is caught so it can never break the webhook (the ticket is already created).
- Fires **only on creation** — recurring errors that dedup onto an existing ticket don't re-notify (no channel spam).

## Tests

- `sentryZulip.test.ts` (new): integration lookup, message contains the ticket link, env overrides, omits Sentry link when absent, never throws on send failure / DB error.
- `SentryBugService.test.ts`: notifies on create with the correct `/w/<ws>/products/<product>/tickets/<id>` deep link; does **not** notify on a dedup hit.

No migration. New optional env knobs documented in `.env.example`.