### PR TITLE
fix(crm): auto-refresh contacts list after agent writes

### DIFF
--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -1506,6 +1506,14 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
         void utils.okr.getCountsByYear.invalidate();
         void utils.okr.getAvailableGoals.invalidate();
       }
+      if (toRefresh.has('crmContact')) {
+        // Contact list + the dashboard stat cards + per-contact interaction feed,
+        // so agent-created/updated contacts and logged interactions appear without
+        // a reload.
+        void utils.crmContact.getAll.invalidate();
+        void utils.crmContact.getStats.invalidate();
+        void utils.crmContact.getInteractions.invalidate();
+      }
 
       const responseTime = Date.now() - startTime;
       // A turn that did tool work but produced no prose is NOT empty —

--- a/src/app/_components/manyChatToolRefresh.test.ts
+++ b/src/app/_components/manyChatToolRefresh.test.ts
@@ -3,6 +3,7 @@ import {
   toolTriggersGoalActivityRefresh,
   toolTriggersActionRefresh,
   toolTriggersOkrRefresh,
+  toolTriggersCrmContactRefresh,
   entitiesToRefresh,
 } from "./manyChatToolRefresh";
 
@@ -80,6 +81,34 @@ describe("toolTriggersOkrRefresh", () => {
   });
 });
 
+describe("toolTriggersCrmContactRefresh", () => {
+  it("matches the contact-mutating tools across name forms", () => {
+    // createTool ids
+    expect(toolTriggersCrmContactRefresh("create-crm-contact")).toBe(true);
+    expect(toolTriggersCrmContactRefresh("create-full-crm-contact")).toBe(true);
+    expect(toolTriggersCrmContactRefresh("update-crm-contact")).toBe(true);
+    expect(toolTriggersCrmContactRefresh("delete-crm-contact")).toBe(true);
+    // Registration key + humanized label normalize the same.
+    expect(toolTriggersCrmContactRefresh("createFullCrmContactTool")).toBe(true);
+    expect(toolTriggersCrmContactRefresh("Create full crm contact")).toBe(true);
+  });
+
+  it("matches logging an interaction (reorders + restats the list)", () => {
+    expect(toolTriggersCrmContactRefresh("add-crm-interaction")).toBe(true);
+    expect(toolTriggersCrmContactRefresh("addCrmInteractionTool")).toBe(true);
+  });
+
+  it("does not match read-only contact tools or unrelated CRM tools", () => {
+    // Carry the noun but no mutating verb.
+    expect(toolTriggersCrmContactRefresh("search-crm-contacts")).toBe(false);
+    expect(toolTriggersCrmContactRefresh("get-crm-contact")).toBe(false);
+    // Organization writes aren't rendered by the contacts list.
+    expect(toolTriggersCrmContactRefresh("create-crm-organization")).toBe(false);
+    expect(toolTriggersCrmContactRefresh("createActionTool")).toBe(false);
+    expect(toolTriggersCrmContactRefresh("")).toBe(false);
+  });
+});
+
 describe("entitiesToRefresh", () => {
   it("returns 'action' for each action tool-name variant, regardless of page", () => {
     for (const name of [
@@ -108,6 +137,22 @@ describe("entitiesToRefresh", () => {
       // OKR queries only mount on the dashboard, so firing anywhere is near-free.
       expect(entitiesToRefresh([name], undefined).has("okr")).toBe(true);
       expect(entitiesToRefresh([name], "workspace").has("okr")).toBe(true);
+    }
+  });
+
+  it("returns 'crmContact' for contact mutations on any page (no page guard)", () => {
+    for (const name of [
+      "create-crm-contact",
+      "create-full-crm-contact",
+      "update-crm-contact",
+      "delete-crm-contact",
+      "add-crm-interaction",
+    ]) {
+      // crmContact queries only mount on the CRM contacts page, so firing
+      // anywhere is near-free.
+      expect(entitiesToRefresh([name], "contacts").has("crmContact")).toBe(true);
+      expect(entitiesToRefresh([name], undefined).has("crmContact")).toBe(true);
+      expect(entitiesToRefresh([name], "workspace").has("crmContact")).toBe(true);
     }
   });
 

--- a/src/app/_components/manyChatToolRefresh.ts
+++ b/src/app/_components/manyChatToolRefresh.ts
@@ -17,7 +17,7 @@
  */
 
 /** Entities whose mounted views ManyChat knows how to refresh after an agent write. */
-export type RefreshEntity = "goalActivity" | "action" | "okr";
+export type RefreshEntity = "goalActivity" | "action" | "okr" | "crmContact";
 
 /** Lowercase, letters-only — collapses registration-key / createTool-id / humanized forms. */
 function normalize(toolName: string): string {
@@ -80,6 +80,27 @@ export function toolTriggersOkrRefresh(toolName: string): boolean {
   );
 }
 
+/**
+ * Whether a tool name mutates the CRM contacts the contacts list renders.
+ * Recognises the contact writes (create-crm-contact, create-full-crm-contact,
+ * update-crm-contact, delete-crm-contact — all carry the `crmContact` noun + a
+ * mutating verb) and add-crm-interaction, which reorders the "recently contacted"
+ * list and bumps the contact stat cards. Read tools (search-crm-contacts,
+ * get-crm-contact) carry the noun but no verb, and create-crm-organization lacks
+ * the contact noun, so neither matches.
+ */
+export function toolTriggersCrmContactRefresh(toolName: string): boolean {
+  const normalized = normalize(toolName);
+  if (normalized.includes("crmcontact")) {
+    return (
+      normalized.includes("create") ||
+      normalized.includes("update") ||
+      normalized.includes("delete")
+    );
+  }
+  return normalized.includes("crminteraction") && normalized.includes("add");
+}
+
 interface RefreshRule {
   entity: RefreshEntity;
   matches: (toolName: string) => boolean;
@@ -110,6 +131,13 @@ const RULES: RefreshRule[] = [
     // single page-context slot.
     entity: "okr",
     matches: toolTriggersOkrRefresh,
+  },
+  {
+    // No page guard — crmContact queries are only observed by the CRM contacts
+    // page (and the dashboard stat cards), so invalidating them elsewhere is a
+    // no-op (same rationale as action / okr).
+    entity: "crmContact",
+    matches: toolTriggersCrmContactRefresh,
   },
 ];
 


### PR DESCRIPTION
## Problem

When you create a CRM contact via the in-app assistant (Zoe) — e.g. the "Create full crm contact" tool — the agent reports success but the contacts listing doesn't refresh. You have to reload the page to see the new contact.

The codebase already has a generic mechanism for this (`manyChatToolRefresh`, ADR-0023): it maps the names of the tools the agent just ran to the entities whose React Query caches need invalidating, and ManyChat invalidates them after the stream completes. This is what makes goals / OKR / action views auto-refresh. CRM contacts was simply never registered in that registry.

## Fix

- **`manyChatToolRefresh.ts`** — add a `"crmContact"` entity, a `toolTriggersCrmContactRefresh()` matcher, and a rule. The matcher fires on the contact writes (`create-crm-contact`, `create-full-crm-contact`, `update-crm-contact`, `delete-crm-contact`) and on `add-crm-interaction` (which reorders the "recently contacted" list and updates the stat cards). Read tools (`search-crm-contacts`, `get-crm-contact`) lack a mutating verb and org writes lack the contact noun, so neither matches. No page guard — same rationale as `action` / `okr`: the queries only mount on the contacts page, so invalidating elsewhere is a no-op.
- **`ManyChat.tsx`** — invalidate `crmContact.getAll` / `getStats` / `getInteractions` when the rule matches.
- **`manyChatToolRefresh.test.ts`** — unit tests mirroring the existing matcher/registry tests.

## Testing

- New unit tests pass; full unit suite green (950 tests).
- Typecheck clean for the changed files.

Note: takes effect once deployed — the matcher runs client-side from the tool names the Mastra stream emits; no change to the `../mastra` repo is needed (the tool IDs were already correct).