### PR TITLE
feat(sentry): label Sentry-filed bug tickets with a "Sentry" tag

### DIFF
--- a/src/server/services/sentry/SentryBugService.ts
+++ b/src/server/services/sentry/SentryBugService.ts
@@ -38,6 +38,44 @@ async function findOrCreateErrol(db: PrismaClient): Promise<{ id: string }> {
   });
 }
 
+// Workspace label applied to every Sentry-filed ticket. `avatar-plum` ≈ Sentry's purple.
+const SENTRY_TAG = { name: "Sentry", slug: "sentry", color: "avatar-plum" } as const;
+
+/**
+ * Find-or-create the workspace's "Sentry" label and attach it to the ticket.
+ * Idempotent (both upserts) and best-effort — a tagging failure is logged but
+ * never breaks ingestion, since the ticket itself is already created.
+ */
+async function tagTicketAsSentry(
+  db: PrismaClient,
+  ticketId: string,
+  workspaceId: string,
+  authorId: string,
+): Promise<void> {
+  try {
+    const tag = await db.tag.upsert({
+      where: { slug_workspaceId: { slug: SENTRY_TAG.slug, workspaceId } },
+      create: {
+        name: SENTRY_TAG.name,
+        slug: SENTRY_TAG.slug,
+        color: SENTRY_TAG.color,
+        category: "label",
+        workspaceId,
+        createdById: authorId,
+      },
+      update: {},
+      select: { id: true },
+    });
+    await db.ticketTag.upsert({
+      where: { ticketId_tagId: { ticketId, tagId: tag.id } },
+      create: { ticketId, tagId: tag.id },
+      update: {},
+    });
+  } catch (error) {
+    console.error("[sentry webhook] failed to attach Sentry label:", error);
+  }
+}
+
 export interface IngestResult {
   created: boolean;
   ticketId: string;
@@ -89,6 +127,9 @@ export async function ingestSentryBug(
     // Priority is left unset — a human assigns it during triage.
     links: { sentryIssueId: bug.issueId, sentryUrl: bug.url },
   });
+
+  // Tag it with the workspace's "Sentry" label so these are filterable.
+  await tagTicketAsSentry(db, ticket.id, product.workspaceId, errol.id);
 
   // Announce the new bug in Zulip (best-effort) with a deep link to the ticket.
   // Only on creation — recurring errors that dedup above do not re-notify.

--- a/src/server/services/sentry/__tests__/SentryBugService.test.ts
+++ b/src/server/services/sentry/__tests__/SentryBugService.test.ts
@@ -62,6 +62,14 @@ beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     { id: "errol-id" } as any,
   );
+  dbMock.tag.upsert.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { id: "tag-1" } as any,
+  );
+  dbMock.ticketTag.upsert.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { id: "tt-1" } as any,
+  );
 });
 
 describe("ingestSentryBug", () => {
@@ -106,6 +114,28 @@ describe("ingestSentryBug", () => {
     expect(arg.priority).toBeUndefined();
   });
 
+  it("find-or-creates a workspace 'Sentry' label and attaches it to the ticket", async () => {
+    await ingestSentryBug(dbMock, bug);
+
+    expect(dbMock.tag.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { slug_workspaceId: { slug: "sentry", workspaceId: "ws-1" } },
+        create: expect.objectContaining({
+          name: "Sentry",
+          slug: "sentry",
+          category: "label",
+          workspaceId: "ws-1",
+        }),
+      }),
+    );
+    expect(dbMock.ticketTag.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { ticketId_tagId: { ticketId: "ticket-1", tagId: "tag-1" } },
+        create: { ticketId: "ticket-1", tagId: "tag-1" },
+      }),
+    );
+  });
+
   it("notifies Zulip on creation with a deep link to the new ticket", async () => {
     process.env.NEXT_PUBLIC_APP_URL = "https://app.example";
 
@@ -143,7 +173,8 @@ describe("ingestSentryBug", () => {
       const result = await ingestSentryBug(dbMock, bug);
 
       expect(createTicketWithNumber).not.toHaveBeenCalled();
-      // Recurring errors that dedup onto an existing ticket do not re-notify.
+      // Recurring errors that dedup onto an existing ticket do not re-tag or re-notify.
+      expect(dbMock.tag.upsert).not.toHaveBeenCalled();
       expect(notifyZulipOfSentryBug).not.toHaveBeenCalled();
       expect(result).toEqual({ created: false, ticketId: "existing-ticket" });
     });


### PR DESCRIPTION
## What

Every Sentry-filed bug ticket now gets a **"Sentry"** label, so they're easy to filter in the product backlog.

- After the ticket is created, find-or-create the workspace's `Sentry` tag (slug `sentry`, category `label`, colour `avatar-plum` ≈ Sentry purple) and attach it via `TicketTag`.
- **Idempotent**: both the tag and the ticket↔tag link are upserts, so there's one reused tag per workspace and no duplicate links.
- **Best-effort**: a tagging failure is logged but never breaks the webhook (the ticket is already created). Only on creation — dedup hits aren't re-tagged.

## Tests

`SentryBugService.test.ts`: asserts the `Sentry` tag is find-or-created scoped to the workspace and linked to the new ticket; and that a dedup hit does **not** tag.

No migration (uses existing `Tag` / `TicketTag` models).