### PR TITLE
fix(meetings): project-linked manual transcript inherits the project's workspace

### DIFF
--- a/scripts/backfill-transcription-workspace.ts
+++ b/scripts/backfill-transcription-workspace.ts
@@ -1,0 +1,97 @@
+/**
+ * One-off backfill: set TranscriptionSession.workspaceId from the linked project.
+ *
+ * A project-linked Meeting always inherits its Project's Workspace
+ * (CONTEXT.md → Meeting↔Workspace). Manual transcripts uploaded from a Project
+ * page were saved with workspaceId NULL even though their Project sat in a
+ * Workspace, which broke participant management ("Cannot manage participants on
+ * a meeting with no workspace"). The mutation now derives the workspace; this
+ * backfills the rows that already landed in the incoherent state.
+ *
+ * For every TranscriptionSession where workspaceId IS NULL AND projectId IS NOT NULL,
+ * copies workspaceId from the row's Project (Project.workspaceId).
+ *
+ * Rows with no projectId (legitimately "personal" meetings), or whose project
+ * has no workspaceId, are left as null.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-transcription-workspace.ts           # dry-run (default)
+ *   npx tsx scripts/backfill-transcription-workspace.ts --apply   # actually update
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const db = new PrismaClient();
+const apply = process.argv.includes("--apply");
+
+async function main() {
+  console.log(`Mode: ${apply ? "APPLY" : "DRY-RUN"}\n`);
+
+  const rows = await db.transcriptionSession.findMany({
+    where: {
+      workspaceId: null,
+      projectId: { not: null },
+    },
+    select: {
+      id: true,
+      sessionId: true,
+      projectId: true,
+      project: { select: { workspaceId: true } },
+    },
+  });
+
+  console.log(
+    `Found ${rows.length} candidate meetings (workspaceId null, projectId set)\n`,
+  );
+
+  let skippedNoProjectWorkspace = 0;
+  let totalUpdated = 0;
+
+  for (const row of rows) {
+    const workspaceId = row.project?.workspaceId;
+    if (!workspaceId) {
+      // Project itself has no workspace — leave the meeting alone rather than
+      // inventing a workspace. Surfaced so a human can investigate.
+      skippedNoProjectWorkspace++;
+      console.log(
+        `  SKIP  meeting=${row.id} (${row.sessionId}) project=${row.projectId} has no workspaceId`,
+      );
+      continue;
+    }
+
+    if (apply) {
+      // Re-check workspaceId: null in the where clause so a concurrent write
+      // can't be clobbered, and so a re-run is idempotent.
+      const result = await db.transcriptionSession.updateMany({
+        where: { id: row.id, workspaceId: null },
+        data: { workspaceId },
+      });
+      console.log(
+        `  ${result.count ? "OK   " : "NOOP "} meeting=${row.id} (${row.sessionId}) → workspace=${workspaceId}`,
+      );
+      totalUpdated += result.count;
+    } else {
+      console.log(
+        `  WOULD meeting=${row.id} (${row.sessionId}) → workspace=${workspaceId}`,
+      );
+      totalUpdated++;
+    }
+  }
+
+  console.log(
+    `\nMeetings skipped (project has no workspaceId): ${skippedNoProjectWorkspace}`,
+  );
+  console.log(`${apply ? "Updated" : "Would update"}: ${totalUpdated} meetings`);
+  if (!apply) {
+    console.log("\nRe-run with --apply to commit changes.");
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error("Backfill failed:", err);
+    process.exit(1);
+  })
+  .finally(() => {
+    void db.$disconnect();
+  });

--- a/src/app/_components/ProjectContent.tsx
+++ b/src/app/_components/ProjectContent.tsx
@@ -655,7 +655,10 @@ export function ProjectContent({
                 <Group justify="space-between" align="center">
                   <Group gap="md">
                     <Title order={4}>Project Meetings</Title>
-                    <CreateTranscriptionModal projectId={resolvedProjectId} />
+                    <CreateTranscriptionModal
+                      projectId={resolvedProjectId}
+                      workspaceId={project.workspaceId ?? undefined}
+                    />
                   </Group>
                   <Group gap="md">
                     {hasFirefliesWorkflow && (

--- a/src/app/_components/TranscriptionDetailsModal.tsx
+++ b/src/app/_components/TranscriptionDetailsModal.tsx
@@ -373,8 +373,12 @@ export function TranscriptionDetailsModal({
       value: formatMeetingDate(meetingDate).fullLabel,
     });
     rows.push({
+      // Show the meeting's OWN workspace, never the browsing-context workspace
+      // from the URL — falling back to `workspace?.name` masked meetings that
+      // were wrongly saved with no workspace. A meeting with no workspace is
+      // genuinely "Personal".
       label: "Workspace",
-      value: data?.workspace?.name ?? workspace?.name ?? "—",
+      value: data?.workspace?.name ?? "Personal",
     });
     if (data?.createdAt) {
       rows.push({ label: "Created", value: formatTimestamp(data.createdAt) });
@@ -392,7 +396,6 @@ export function TranscriptionDetailsModal({
     data?.createdAt,
     data?.sessionId,
     data?.workspace?.name,
-    workspace?.name,
   ]);
 
   const hasScreenshots =
@@ -450,7 +453,7 @@ export function TranscriptionDetailsModal({
           durationSeconds={data?.durationSeconds ?? null}
           participantCount={participants.length}
           projectName={data?.project?.name ?? null}
-          workspaceName={data?.workspace?.name ?? workspace?.name ?? null}
+          workspaceName={data?.workspace?.name ?? null}
           editingTitle={editingTitle}
           editedTitle={editedTitle}
           onEditedTitleChange={setEditedTitle}

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -793,15 +793,45 @@ export const transcriptionRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const participants = input.participants ?? [];
+
+      // A project-linked Meeting always inherits its Project's Workspace
+      // (CONTEXT.md → Meeting↔Workspace): a meeting with a Project but no
+      // Workspace is an incoherent state that breaks participant management
+      // (TranscriptionSessionParticipant.workspaceId is non-null). Enforce the
+      // invariant server-side so it holds regardless of caller — when a project
+      // is supplied the project's workspace is authoritative, never the caller's
+      // workspaceId. A caller-supplied workspaceId that disagrees with the
+      // project is a coherence bug, so reject it rather than silently override.
+      let workspaceId = input.workspaceId ?? null;
+      if (input.projectId) {
+        const project = await ctx.db.project.findUnique({
+          where: { id: input.projectId },
+          select: { workspaceId: true },
+        });
+        if (
+          input.workspaceId &&
+          project?.workspaceId &&
+          input.workspaceId !== project.workspaceId
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "workspaceId does not match the project's workspace; a project-linked meeting inherits its project's workspace.",
+          });
+        }
+        workspaceId = project?.workspaceId ?? null;
+      }
+
       // Participants are workspace-scoped (members + CRM), so a meeting with no
       // workspace can't carry them. Reject rather than silently dropping them.
-      if (participants.length > 0 && !input.workspaceId) {
+      // Use the resolved workspaceId so a project-linked meeting can carry
+      // participants via the project's workspace even without an explicit one.
+      if (participants.length > 0 && !workspaceId) {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: "Cannot add participants to a meeting with no workspace",
         });
       }
-      const workspaceId = input.workspaceId ?? null;
 
       // Create the meeting and resolve every participant in ONE transaction: a
       // meeting is never created with participants silently failing to attach,


### PR DESCRIPTION
Fixes Exponential ticket **micro.coyote** (#190) — *Manual transcript uploaded from a project page lands with no workspace*.

## Problem
A Meeting (`TranscriptionSession`) created via manual upload from a **Project** page was saved with `workspaceId: null` even though its Project belongs to a Workspace. The orphaned meeting then couldn't manage **Participants** — `addParticipant` threw `"Cannot manage participants on a meeting with no workspace"` — and the DETAILS panel masked the problem by showing the *current URL's* workspace.

Per CONTEXT.md (Meeting↔Workspace): a project-linked Meeting always inherits the project's Workspace; workspace-less ("Personal") meetings are legal only when there is also no project.

## Changes
- **Server invariant** — `createManualTranscription` derives `workspaceId` from the project when absent but a `projectId` is present. Authoritative fix; the server guarantees the invariant regardless of caller.
- **Caller** — `ProjectContent` now passes the project's `workspaceId` to `<CreateTranscriptionModal>`.
- **Detail panel** — `TranscriptionDetailsModal` DETAILS "Workspace" row (and the header crumb) shows the meeting's own workspace, or the literal `"Personal"` when it has none — dropping the `?? workspace?.name` URL fallback that masked the bug.
- **Backfill** — `scripts/backfill-transcription-workspace.ts`: guarded one-off (dry-run by default, `--apply` to commit) that sets `workspaceId` from `projectId` for project-linked meetings missing a workspace. **To be run against prod by a human** — fixes the stuck `manual_1781869219525` row.

## Verification
- Typecheck + lint clean (`tsc --noEmit`, `eslint` on changed files).
- Pre-push hook: full unit suite (959 tests) passes, incl. `transcription` + `transcriptionSessionParticipant` routers; migration + hardcoded-color checks pass.

## Acceptance criteria
- [x] Manual transcript from a project page produces a meeting whose `workspaceId` equals the project's workspace.
- [x] Adding a participant to such a meeting succeeds (no "no workspace" error).
- [x] DETAILS "Workspace" row shows the meeting's real workspace, or "Personal" — never the browsing-context workspace.
- [x] Backfill script exists; the stuck `manual_1781869219525` meeting is fixed after a human runs it.
- [x] `npm run check` passes (typecheck + lint; run via the documented 8GB-heap workaround for this repo's known 4GB OOM).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved inconsistent workspace associations in transcription sessions linked to projects.
  * Improved accuracy of workspace information displayed in meeting details.
  * Ensured manual transcriptions properly inherit workspace assignment from linked projects.

* **Chores**
  * Executed data backfill to correct historical workspace reference inconsistencies in transcription records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->