### PR TITLE
fix(meetings): Participants panel shows only managed participants, not derived speakers

### DIFF
--- a/src/app/_components/TranscriptionDetailsModal.tsx
+++ b/src/app/_components/TranscriptionDetailsModal.tsx
@@ -275,9 +275,12 @@ export function TranscriptionDetailsModal({
     setJumpToSeconds(startSeconds);
   }, []);
 
-  // Build participants list. If we have structured participants, use them;
-  // otherwise derive a placeholder list from transcript speaker names so the
-  // rail isn't empty for legacy records.
+  // Build the participants list. The PARTICIPANTS panel shows ONLY managed
+  // Participant rows (DB), never transcript-derived Speakers (CONTEXT.md →
+  // Speaker: "Derived Speakers never populate the Participants panel"). Deriving
+  // placeholders from parsed turns conflated the two concepts and, for manual
+  // pastes, surfaced header lines ("Meeting Title:", "Date:", …) as bogus
+  // "Guest" participants. When there are none, the rail shows an empty state.
   const meEmail = authSession?.user?.email?.toLowerCase();
   const meName = authSession?.user?.name ?? null;
 
@@ -290,37 +293,15 @@ export function TranscriptionDetailsModal({
       userId: string | null;
       contactId: string | null;
     }> | undefined) ?? [];
-    if (raw.length > 0) {
-      return raw.map((p) => ({
-        id: p.id,
-        name: p.name,
-        email: p.email,
-        isHost: p.isHost,
-        isMe: p.email?.toLowerCase() === meEmail,
-        isPersisted: true,
-      }));
-    }
-    // Derive from turns
-    const seen = new Map<string, { id: string; name: string; email: string }>();
-    for (const t of turns) {
-      if (!seen.has(t.speaker)) {
-        seen.set(t.speaker, {
-          id: `derived-${seen.size}`,
-          name: t.speaker,
-          email: "",
-        });
-      }
-    }
-    return [...seen.values()].map((p) => ({
+    return raw.map((p) => ({
       id: p.id,
       name: p.name,
       email: p.email,
-      isHost: false,
-      isMe:
-        !!meName && p.name.toLowerCase().includes(meName.toLowerCase().split(" ")[0]!),
-      isPersisted: false,
+      isHost: p.isHost,
+      isMe: p.email?.toLowerCase() === meEmail,
+      isPersisted: true,
     }));
-  }, [data?.participants, turns, meEmail, meName]);
+  }, [data?.participants, meEmail]);
 
   // Participants are workspace-scoped (members + CRM), so editing needs a
   // workspace and a non-viewer role. The server enforces the real edit rule.

--- a/src/app/_components/transcription-detail/Rail.tsx
+++ b/src/app/_components/transcription-detail/Rail.tsx
@@ -23,7 +23,10 @@ interface RailParticipant {
   email: string;
   isHost: boolean;
   isMe: boolean;
-  /** True for stored participant rows; false for transcript-derived placeholders. */
+  /**
+   * Always true now — the panel only renders managed Participant rows. Kept so
+   * the remove affordance stays explicit about acting on persisted rows.
+   */
   isPersisted: boolean;
 }
 
@@ -95,21 +98,27 @@ export function Rail({
 
   return (
     <aside className="mdm-rail">
-      {participants.length > 0 && (
-        <div className="mdm-rail__section">
-          <div className="mdm-rail__label">
-            <span>Participants</span>
-            {onAddParticipant && (
-              <button
-                type="button"
-                className="mdm-rail__add"
-                onClick={onAddParticipant}
-                aria-label="Add participant"
-              >
-                <IconPlus size={14} />
-              </button>
-            )}
+      <div className="mdm-rail__section">
+        <div className="mdm-rail__label">
+          <span>Participants</span>
+          {onAddParticipant && (
+            <button
+              type="button"
+              className="mdm-rail__add"
+              onClick={onAddParticipant}
+              aria-label="Add participant"
+            >
+              <IconPlus size={14} />
+            </button>
+          )}
+        </div>
+        {participants.length === 0 ? (
+          // Only managed Participant rows populate this panel — never derived
+          // transcript Speakers (CONTEXT.md → Speaker). Empty state, not fakes.
+          <div className="mdm-people__empty">
+            {onAddParticipant ? "No participants yet — add one" : "No participants yet"}
           </div>
+        ) : (
           <div className="mdm-people">
             {participants.map((p) => {
               const share = getShare(p);
@@ -150,8 +159,8 @@ export function Rail({
               );
             })}
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
       {links.length > 0 && (
         <div className="mdm-rail__section">

--- a/src/app/_components/transcription-detail/__tests__/helpers.test.ts
+++ b/src/app/_components/transcription-detail/__tests__/helpers.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { parseTurns } from "../helpers";
+
+describe("parseTurns — plain-text speaker parsing", () => {
+  it("does not treat metadata header lines as speakers", () => {
+    // Shape of a manually pasted transcript with a header block, like the
+    // stuck meeting manual_1781869219525.
+    const raw = [
+      "Meeting Title: Weekly Sync",
+      "Date: 04 Jun 2026",
+      "Meeting participants: Alice, Bob",
+      "Transcript:",
+      "Me: Hello there",
+      "Them: Hi, how are you?",
+    ].join("\n");
+
+    const turns = parseTurns(raw, null);
+    const speakers = new Set(turns.map((t) => t.speaker));
+
+    // Header keys must never surface as speakers (CONTEXT.md → Speaker). They
+    // collapse into the generic "Transcript" orphan-text bucket instead of
+    // becoming fake speakers named after each header key.
+    expect(speakers.has("Meeting Title")).toBe(false);
+    expect(speakers.has("Date")).toBe(false);
+    expect(speakers.has("Meeting participants")).toBe(false);
+
+    // Real speakers from the dialogue are still parsed.
+    expect(speakers.has("Me")).toBe(true);
+    expect(speakers.has("Them")).toBe(true);
+
+    // The only non-dialogue "speaker" is the generic orphan-text bucket — no
+    // header key leaked through as its own speaker.
+    expect([...speakers].sort()).toEqual(["Me", "Them", "Transcript"]);
+  });
+
+  it("keeps the dialogue turns intact for transcript navigation", () => {
+    const raw = ["Me: First line", "Them: Second line", "Me: Third line"].join(
+      "\n",
+    );
+
+    const turns = parseTurns(raw, null);
+    const dialogue = turns.filter((t) => t.speaker === "Me" || t.speaker === "Them");
+
+    expect(dialogue).toHaveLength(3);
+    expect(dialogue[0]).toMatchObject({ speaker: "Me", text: "First line" });
+    expect(dialogue[1]).toMatchObject({ speaker: "Them", text: "Second line" });
+    expect(dialogue[2]).toMatchObject({ speaker: "Me", text: "Third line" });
+  });
+
+  it("matching is case-insensitive for header keys", () => {
+    const raw = ["DATE: today", "notes: be brief", "Speaker A: real turn"].join(
+      "\n",
+    );
+
+    const turns = parseTurns(raw, null);
+    const speakers = new Set(turns.map((t) => t.speaker));
+
+    expect(speakers.has("DATE")).toBe(false);
+    expect(speakers.has("notes")).toBe(false);
+    expect(speakers.has("Speaker A")).toBe(true);
+  });
+});

--- a/src/app/_components/transcription-detail/helpers.ts
+++ b/src/app/_components/transcription-detail/helpers.ts
@@ -66,6 +66,32 @@ export function extractChapters(summary: FirefliesSummary | null): Chapter[] {
     .sort((a, b) => a.startSeconds - b.startSeconds);
 }
 
+// Header/metadata keys that a manually pasted transcript commonly puts at the
+// top as "Key: value" lines. These look like speaker labels to the plain-text
+// turn parser but are NOT speakers — skip them so the transcript view (and,
+// before the panel was fixed, the derived Participants list) isn't polluted.
+const METADATA_HEADER_KEYS: ReadonlySet<string> = new Set([
+  "meeting title",
+  "title",
+  "date",
+  "time",
+  "meeting participants",
+  "participants",
+  "attendees",
+  "summary",
+  "transcript",
+  "notes",
+  "agenda",
+  "location",
+  "duration",
+]);
+
+/** True when a parsed "Name:" label is actually a metadata header key. */
+function isMetadataHeaderLabel(label: string | undefined): boolean {
+  if (!label) return false;
+  return METADATA_HEADER_KEYS.has(label.trim().toLowerCase());
+}
+
 /**
  * Parse the transcription field into turns. Supports Fireflies JSON (with sentences)
  * or plain-text fallback. Returns an empty array if nothing usable is found.
@@ -123,6 +149,24 @@ export function parseTurns(
       const trimmed = line.trim();
       if (!trimmed) continue;
       const match = speakerPattern.exec(trimmed);
+      // A "Name:" prefix that is actually a metadata header key (e.g.
+      // "Meeting Title:", "Date:") must NOT be read as a speaker — otherwise a
+      // manual paste with a header block pollutes the transcript with bogus
+      // speakers (CONTEXT.md → Speaker). Treat those lines as plain text.
+      if (match && isMetadataHeaderLabel(match[1])) {
+        if (current) {
+          current.text = `${current.text} ${trimmed}`.trim();
+        } else {
+          current = {
+            id: `p-${idx++}`,
+            time: "",
+            startSeconds: 0,
+            speaker: "Transcript",
+            text: trimmed,
+          };
+        }
+        continue;
+      }
       if (match) {
         if (current) turns.push(current);
         current = {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1947,6 +1947,11 @@
   flex-direction: column;
   gap: 10px;
 }
+.mdm-people__empty {
+  font-size: 12.5px;
+  color: var(--color-text-muted);
+  line-height: 1.3;
+}
 .mdm-person {
   display: grid;
   grid-template-columns: 28px 1fr auto auto;


### PR DESCRIPTION
Fixes Exponential ticket **jolly.cosmos** (#191) — *Participants panel shows derived speaker labels as bogus Guest participants*.

## Problem
The transcription detail **PARTICIPANTS** rail derived "participants" from parsed transcript **speaker** labels whenever a Meeting had no managed **Participant** rows, rendering each as a "Guest". For a manually pasted transcript with a header block, the over-permissive turn parser read metadata lines (`Meeting Title:`, `Date:`, `Meeting participants:`, `Transcript:`) as speakers, surfacing them as bogus participants.

Per CONTEXT.md (**Speaker**): Speaker ≠ Participant — *"Derived Speakers never populate the Participants panel."*

## Changes
- **Panel** — `TranscriptionDetailsModal` builds the participants list from persisted **Participant** DB rows only; the derive-from-turns fallback is gone. `Rail` renders the Participants section unconditionally with an empty state ("No participants yet — add one") instead of fake Guest entries.
- **Parser hardening** — `transcription-detail/helpers.ts` `parseTurns` skips known metadata header keys (Meeting Title / Date / Participants / Summary / Transcript / Notes / …) in its plain-text path, so the *transcript view* of a manual paste isn't polluted with header-line "speakers" either. Real dialogue speakers (`Me`/`Them`) still parse for navigation.
- **Tests** — unit tests for the parser hardening (header keys aren't speakers; dialogue turns intact; case-insensitive).

## Verification
- Typecheck + lint clean.
- Pre-push hook: full unit suite (962 tests) passes incl. the new parser tests; migration + hardcoded-color checks pass.

## Acceptance criteria
- [x] PARTICIPANTS panel never shows derived speaker labels — only managed Participant rows.
- [x] A meeting with zero managed participants shows an empty state, not fake "Guest" entries.
- [x] `manual_1781869219525` no longer lists "Meeting Title", "Date", "Meeting participants", "Transcript", "Me", "Them" as participants (panel now persisted-only).
- [x] Transcript navigation still works; header/metadata lines aren't treated as speakers.
- [x] `npm run check` passes (typecheck + lint via the documented 8GB-heap workaround for this repo's 4GB OOM).