### PR TITLE
feat: generic public Forms subsystem (submission → CRM → automation)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -387,6 +387,30 @@ _Avoid_: Contract, document (too generic), DocuSign (the provider is Adobe Sign)
 **Recipient email experience**:
 Two emails, each with one job: **(1)** a branded "Welcome — you're signed up as a {Customer type}" email we send and log as a `CrmCommunication`; **(2)** Adobe Sign's own secure "review & sign" email, where signing happens on Adobe's hosted page. We deliberately do **not** attach the unsigned agreement to our email or self-host the signing link in the PoC.
 
+### Forms
+
+A **generic** public-intake subsystem (a mini-Typeform), deliberately **decoupled from the CRM** — the CRM is just one **destination** a form can be wired to ([ADR-0029](docs/adr/0029-generic-forms-subsystem.md)). First use case: a public job-application form whose submission creates a contact and fires the existing automation.
+
+**Form**:
+A workspace-owned public intake definition — `Form { workspaceId, name, slug, fields Json, destinations Json, isActive, confirmationMessage? }`. Rendered unauthenticated at **`/f/[slug]`**; authored in a minimal in-app admin under CRM (`/crm/forms`). Knows nothing about the CRM itself.
+_Avoid_: Survey, lead form (it's generic; CRM is one destination), CrmForm (it is **not** CRM-coupled — don't name it that).
+
+**Form field**:
+One entry in `Form.fields` — `{ key, label, type, required, options? }`, type ∈ `text | email | textarea | select | checkbox | url`. Stored as JSON (no per-field table) and validated at submit time by the pure `validateSubmission` (`src/server/services/forms/formSchema.ts`).
+_Avoid_: Question, input (use "field").
+
+**Form submission**:
+An immutable `FormSubmission { formId, data Json, metadata Json, result Json?, createdContactId? }` — captures the validated payload plus anti-abuse `metadata` (ip, honeypotTripped, emailHash). **Always stored**, even for repeats and honeypot hits (audit). `data` holds plaintext while `CrmContact.email` stays encrypted — an accepted v1 posture difference (ADR-0029).
+_Avoid_: Response, entry.
+
+**Form destination**:
+A `{ type, config }` entry in `Form.destinations` run **synchronously** on submit via the **`FormDestinationRegistry`** — the exact mirror of the automation `StepRegistry`. v1 ships one: **`create_crm_contact`** `{ customerType, fieldMap }`, which maps fields → a contact, stamps the Customer type, and (via the shared `createCrmContact`) fires the CRM **Automation trigger**. New destinations (notify, webhook, create deal) register with no core change.
+_Avoid_: Action, hook (use "destination"); coupling the Form model to any one destination.
+
+**Intake**:
+The public `POST /api/forms/[slug]/submit` route: rate-limit → honeypot check → load active form → `validateSubmission` → store **Form submission** → run **Form destinations**. Unauthenticated; protected by a hidden honeypot field + per-IP/per-email **in-memory** rate limiting (a documented stopgap — [ADR-0030](docs/adr/0030-form-automation-execution-sync-then-qstash.md)). The chain end-to-end: **Intake → `create_crm_contact` → `createCrmContact` (emailHash dedup) → `dispatchContactTypeAutomations` → CRM Automation (`send_email`)**.
+_Avoid_: Webhook (that's inbound-from-a-provider), submit endpoint.
+
 ## Flagged ambiguities
 
 - **"Meeting type" is not yet stored.** The Meetings v2 redesign surfaces `All / 1:1s / Rituals` tabs, but no `meetingType` column exists on `TranscriptionSession`. v1 ships with: All = full list, 1:1s = derived live from `participantCount = 2`, Rituals = empty state until a recurrence classifier exists. When Rituals gets real, the resolution will be either calendar recurrence data or a `meetingType` enum field with mutually exclusive values `one_on_one | ritual | other`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -392,7 +392,7 @@ Two emails, each with one job: **(1)** a branded "Welcome — you're signed up a
 A **generic** public-intake subsystem (a mini-Typeform), deliberately **decoupled from the CRM** — the CRM is just one **destination** a form can be wired to ([ADR-0029](docs/adr/0029-generic-forms-subsystem.md)). First use case: a public job-application form whose submission creates a contact and fires the existing automation.
 
 **Form**:
-A workspace-owned public intake definition — `Form { workspaceId, name, slug, fields Json, destinations Json, isActive, confirmationMessage? }`. Rendered unauthenticated at **`/f/[slug]`**; authored in a minimal in-app admin under CRM (`/crm/forms`). Knows nothing about the CRM itself.
+A workspace-owned public intake definition — `Form { workspaceId, name, slug, fields Json, destinations Json, isActive, confirmationMessage? }`. Rendered unauthenticated at **`/f/[slug]`**; authored in a minimal in-app admin under CRM (`/crm/forms`). Knows nothing about the CRM itself. The `slug` is **globally unique** (not per-workspace) — the public URL carries no workspace, so the lookup must be unambiguous; `uniqueFormSlug` dedupes across all workspaces.
 _Avoid_: Survey, lead form (it's generic; CRM is one destination), CrmForm (it is **not** CRM-coupled — don't name it that).
 
 **Form field**:

--- a/docs/adr/0029-generic-forms-subsystem.md
+++ b/docs/adr/0029-generic-forms-subsystem.md
@@ -1,0 +1,68 @@
+# A generic Forms subsystem, decoupled from the CRM
+
+## Status
+
+Accepted — 2026-06-19.
+
+## Context
+
+We needed a public **job-application form** whose submission lands in the CRM as a
+contact and fires the existing automation (welcome email). Rather than a
+CRM-specific form, we built a **generic Forms subsystem** (a mini-Typeform) so
+the form layer knows nothing about the CRM — "create a contact" is just one
+configurable destination. This keeps Forms → CRM → Automations decoupled, each
+reusing what's already built.
+
+## Decision
+
+1. **JSON field model.** `Form.fields` is a JSON array `[{ key, label, type,
+   required, options? }]` (types `text|email|textarea|select|checkbox|url`) — no
+   per-field table. Validated at submit by the **pure `validateSubmission`**
+   (unit-tested).
+2. **Destination registry.** `Form.destinations` is a JSON array `[{ type,
+   config }]` run by a **`FormDestinationRegistry`** — a deliberate mirror of the
+   automation `StepRegistry`. v1 ships one handler, `create_crm_contact
+   { customerType, fieldMap }`, which maps fields → a contact, stamps the
+   Customer type, and (via the shared `createCrmContact`, which dedupes by
+   `emailHash`) fires `dispatchContactTypeAutomations`. New destinations register
+   with no core change.
+3. **Public, unauthenticated intake.** A Next API route `POST
+   /api/forms/[slug]/submit` (not a tRPC `publicProcedure`) — an explicit public
+   boundary matching the existing webhook routes. Validate → store a
+   `FormSubmission` (always, even on repeat/honeypot) → run destinations.
+4. **Anti-abuse.** Hidden honeypot field + per-IP/per-email **in-memory** rate
+   limiting (the `extension-token` pattern). Matters more than a normal form
+   because a submission sends a real email.
+5. **Idempotency via `emailHash`.** The shared `createCrmContact` dedupes on the
+   globally-unique `emailHash`, so a repeat submission from an existing contact
+   does **not** re-create or re-fire — "new applicants email, repeats don't".
+6. **Public renderer** at `/f/[slug]` in a new `(public)` route group (no auth),
+   with a confirmation state.
+7. **Authoring**: a minimal in-app admin under CRM (`/crm/forms`) — a field-list
+   editor (no drag-drop) + destination config.
+
+## Considered alternatives
+
+- **CRM-coupled `CrmForm`** with a hardcoded contact hook. Rejected — contradicts
+  the generic goal; every new destination would be a schema change.
+- **Relational `FormField` table.** Rejected — heavier; JSON matches how the
+  codebase already stores config (`WorkflowStep.config`).
+- **tRPC `publicProcedure` for intake.** Rejected — a muddier public boundary;
+  honeypot/rate-limit are cleaner in an API route.
+- **Refactor `crmContact.create` to share the new service.** Rejected for v1:
+  routing it through the deduping/`emailHash`-setting service would change
+  manual-create semantics (duplicate-email entries would start throwing on the
+  `@unique` constraint, and collide with imported contacts). Left untouched; the
+  new `createCrmContact` is intake-only.
+
+## Consequences
+
+- **PII posture differs**: `FormSubmission.data` stores plaintext (admin reads
+  submissions) while `CrmContact.email` stays encrypted; only `emailHash` is kept
+  in submission metadata. Accepted, documented.
+- **Edge case**: a form submission whose email matches a *manually*-created
+  contact (which has no `emailHash`) won't dedupe → a duplicate contact. Imports
+  and form contacts do have `emailHash`. Accepted for v1.
+- `company` is stored as a contact tag in v1 (no auto-`CrmOrganization`).
+- **Deferred**: drag-drop form builder, file/résumé upload (S3 exists; a `url`
+  field stands in), multiple destination types, slug rename.

--- a/docs/adr/0029-generic-forms-subsystem.md
+++ b/docs/adr/0029-generic-forms-subsystem.md
@@ -63,6 +63,20 @@ reusing what's already built.
 - **Edge case**: a form submission whose email matches a *manually*-created
   contact (which has no `emailHash`) won't dedupe → a duplicate contact. Imports
   and form contacts do have `emailHash`. Accepted for v1.
+- **Globally-unique slug**: the public `/f/[slug]` URL carries no workspace, so
+  `Form.slug` is globally unique (not `@@unique([workspaceId, slug])`) and
+  `uniqueFormSlug` dedupes across all workspaces — otherwise two workspaces could
+  share a slug and a public submission would route to the wrong tenant.
+- **Cross-workspace email**: `CrmContact.emailHash` is globally unique by
+  existing design. If a submission's email already belongs to a contact in
+  *another* workspace, `createCrmContact` refuses (it neither links the foreign
+  contact nor creates a colliding one) and the destination is recorded as failed
+  — matching how `transcription` handles the same boundary. The submission is
+  still stored; only the CRM destination no-ops.
+- **`create_crm_contact` requires a mapped Email field** (validated on save, and
+  enforced again at submit): the email is the dedup key, so without it every
+  submission would create a fresh, never-deduped contact and fire an automation
+  with no recipient.
 - `company` is stored as a contact tag in v1 (no auto-`CrmOrganization`).
 - **Deferred**: drag-drop form builder, file/résumé upload (S3 exists; a `url`
   field stands in), multiple destination types, slug rename.

--- a/docs/adr/0030-form-automation-execution-sync-then-qstash.md
+++ b/docs/adr/0030-form-automation-execution-sync-then-qstash.md
@@ -1,0 +1,49 @@
+# Form/automation execution is synchronous now; async via QStash/Inngest later, not BullMQ
+
+## Status
+
+Accepted — 2026-06-19.
+
+## Context
+
+A form intake runs its destinations — including `create_crm_contact`, which fires
+the CRM automation engine (`WorkflowEngine`), which sends emails. The same is true
+of the in-app contact-create dispatch. The "proper" end-state is event-driven:
+emit an event, return immediately, a worker runs the work with retries. The
+question is what that worker should be on **this** stack.
+
+This app deploys on **Vercel (serverless)** — there is no always-on process.
+**BullMQ** needs Redis *and* a persistent worker, so it's the worst fit here
+(you'd have to host a worker elsewhere, e.g. the Railway gateway). Serverless-
+native options (QStash, Inngest) provide durable queues/retries with no worker to
+run. At current volume (a welcome email per submission) the work is small and the
+run is already recorded in `WorkflowPipelineRun`.
+
+## Decision
+
+For v1, **destinations and the automation dispatch run synchronously inline** in
+the intake request (awaited; failures are caught and recorded, never 500 the
+intake). No queue. The single enqueue seam is `dispatchContactTypeAutomations`
+(and `runFormDestinations`), so going async later is a localized change — swap
+"await execute" for "enqueue", and the worker calls the same engine.
+
+When we do go async (triggers: slow/external destinations like Adobe Sign,
+retries needed, or fan-out), use **QStash or Inngest — explicitly NOT BullMQ** on
+this Vercel deployment.
+
+## Considered alternatives
+
+- **BullMQ + Redis + worker.** Rejected for this stack — most infra, worst
+  serverless fit; only sensible if we already run persistent workers.
+- **`after()` (Next 15).** Unblocks the response but isn't durable (dies with the
+  function) — not a queue.
+- **DB job table + Vercel Cron drain.** Viable, no new infra, but ~1-min latency
+  and we'd reinvent retries/visibility.
+
+## Consequences
+
+- The public submit response waits on the email send (acceptable at this volume).
+- The **in-memory per-IP/per-email rate limit** in the intake is a known stopgap
+  (per-serverless-instance, not shared) — replace with Upstash/Redis when async
+  lands.
+- No new infrastructure or dependency added in v1.

--- a/prisma/migrations/20260619183128_add_forms/migration.sql
+++ b/prisma/migrations/20260619183128_add_forms/migration.sql
@@ -1,0 +1,54 @@
+-- CreateTable
+CREATE TABLE "Form" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "fields" JSONB NOT NULL DEFAULT '[]',
+    "destinations" JSONB NOT NULL DEFAULT '[]',
+    "isActive" BOOLEAN NOT NULL DEFAULT false,
+    "confirmationMessage" TEXT,
+    "createdById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Form_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FormSubmission" (
+    "id" TEXT NOT NULL,
+    "formId" TEXT NOT NULL,
+    "data" JSONB NOT NULL,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "result" JSONB,
+    "createdContactId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FormSubmission_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Form_workspaceId_idx" ON "Form"("workspaceId");
+
+-- CreateIndex
+CREATE INDEX "Form_slug_idx" ON "Form"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Form_workspaceId_slug_key" ON "Form"("workspaceId", "slug");
+
+-- CreateIndex
+CREATE INDEX "FormSubmission_formId_idx" ON "FormSubmission"("formId");
+
+-- CreateIndex
+CREATE INDEX "FormSubmission_createdAt_idx" ON "FormSubmission"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "Form" ADD CONSTRAINT "Form_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Form" ADD CONSTRAINT "Form_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FormSubmission" ADD CONSTRAINT "FormSubmission_formId_fkey" FOREIGN KEY ("formId") REFERENCES "Form"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260619190000_form_slug_global_unique/migration.sql
+++ b/prisma/migrations/20260619190000_form_slug_global_unique/migration.sql
@@ -1,0 +1,11 @@
+-- The public Forms renderer/intake resolve a form by slug alone (`/f/[slug]`,
+-- `POST /api/forms/[slug]/submit`) with no workspace in the URL. A per-workspace
+-- unique slug therefore allowed two workspaces to share a slug and route public
+-- submissions to the wrong tenant. Make the slug globally unique instead.
+
+-- DropIndex (per-workspace unique + redundant secondary index)
+DROP INDEX "Form_workspaceId_slug_key";
+DROP INDEX "Form_slug_idx";
+
+-- CreateIndex (global unique — also serves slug lookups)
+CREATE UNIQUE INDEX "Form_slug_key" ON "Form"("slug");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -146,6 +146,7 @@ model User {
   // CRM relations
   crmContactsCreated          CrmContact[]                @relation("CrmContactCreatedBy")
   crmOrganizationsCreated     CrmOrganization[]           @relation("CrmOrganizationCreatedBy")
+  formsCreated                Form[]                      @relation("FormCreatedBy")
   crmInteractions             CrmContactInteraction[]     @relation("CrmInteractionUser")
   crmCommunicationsCreated    CrmCommunication[]          @relation("CrmCommunicationCreatedBy")
   crmTemplatesCreated         CrmCommunicationTemplate[]  @relation("CrmTemplateCreatedBy")
@@ -330,6 +331,8 @@ model Workspace {
   crmCommunications       CrmCommunication[]
   crmTemplates            CrmCommunicationTemplate[]
   crmImportBatches        ContactImportBatch[]
+  // Forms relations
+  forms                   Form[]
   // Plugin and OKR relations
   pluginConfigs           PluginConfig[]
   keyResults              KeyResult[]
@@ -2675,6 +2678,53 @@ model ContactImportBatch {
   @@index([workspaceId])
   @@index([createdById])
   @@index([status])
+  @@index([createdAt])
+}
+
+// ============================================
+// Forms (generic public intake) Models
+// ============================================
+
+model Form {
+  id                  String   @id @default(cuid())
+  workspaceId         String
+  name                String
+  slug                String
+  description         String?  @db.Text
+  // FormField[]: [{ key, label, type, required, options?, placeholder? }]
+  fields              Json     @default("[]")
+  // FormDestination[]: [{ type, config }] — run synchronously on submit
+  destinations        Json     @default("[]")
+  isActive            Boolean  @default(false)
+  confirmationMessage String?  @db.Text
+  createdById         String?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  workspace   Workspace        @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  createdBy   User?            @relation("FormCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+  submissions FormSubmission[]
+
+  @@unique([workspaceId, slug])
+  @@index([workspaceId])
+  @@index([slug])
+}
+
+model FormSubmission {
+  id               String   @id @default(cuid())
+  formId           String
+  // Validated submission payload keyed by field.key.
+  data             Json
+  // { ip, userAgent, honeypotTripped, emailHash? } — diagnostics & anti-abuse.
+  metadata         Json     @default("{}")
+  // Per-destination outcome: [{ type, ok, detail|error }].
+  result           Json?
+  createdContactId String?
+  createdAt        DateTime @default(now())
+
+  form Form @relation(fields: [formId], references: [id], onDelete: Cascade)
+
+  @@index([formId])
   @@index([createdAt])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2689,7 +2689,10 @@ model Form {
   id                  String   @id @default(cuid())
   workspaceId         String
   name                String
-  slug                String
+  // Globally unique — the public renderer/intake resolve a form by slug alone
+  // (`/f/[slug]`), with no workspace in the URL, so the slug must be unique
+  // across all workspaces or submissions could route to the wrong tenant.
+  slug                String   @unique
   description         String?  @db.Text
   // FormField[]: [{ key, label, type, required, options?, placeholder? }]
   fields              Json     @default("[]")
@@ -2705,9 +2708,7 @@ model Form {
   createdBy   User?            @relation("FormCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
   submissions FormSubmission[]
 
-  @@unique([workspaceId, slug])
   @@index([workspaceId])
-  @@index([slug])
 }
 
 model FormSubmission {

--- a/src/app/(public)/f/[slug]/_components/PublicForm.tsx
+++ b/src/app/(public)/f/[slug]/_components/PublicForm.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Container,
+  Card,
+  Title,
+  Text,
+  Stack,
+  TextInput,
+  Textarea,
+  Select,
+  Checkbox,
+  Button,
+  ThemeIcon,
+} from '@mantine/core';
+import { IconCircleCheck } from '@tabler/icons-react';
+
+interface PublicField {
+  key: string;
+  label: string;
+  type: 'text' | 'email' | 'textarea' | 'select' | 'checkbox' | 'url';
+  required: boolean;
+  options?: string[];
+  placeholder?: string;
+}
+
+interface PublicFormProps {
+  slug: string;
+  name: string;
+  description: string | null;
+  fields: PublicField[];
+  confirmationMessage: string | null;
+}
+
+export function PublicForm({
+  slug,
+  name,
+  description,
+  fields,
+  confirmationMessage,
+}: PublicFormProps) {
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const [honeypot, setHoneypot] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [generalError, setGeneralError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState<string | null>(null);
+
+  const setValue = (key: string, value: unknown) =>
+    setValues((prev) => ({ ...prev, [key]: value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setGeneralError(null);
+    setErrors({});
+    try {
+      const res = await fetch(`/api/forms/${slug}/submit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: values, honeypot }),
+      });
+      const body = (await res.json()) as {
+        ok: boolean;
+        errors?: Record<string, string>;
+        error?: string;
+        confirmationMessage?: string | null;
+      };
+      if (res.ok && body.ok) {
+        setDone(
+          body.confirmationMessage ??
+            confirmationMessage ??
+            'Thanks — we’ve received your submission.',
+        );
+      } else if (res.status === 422 && body.errors) {
+        setErrors(body.errors);
+      } else {
+        setGeneralError(body.error ?? 'Something went wrong. Please try again.');
+      }
+    } catch {
+      setGeneralError('Network error. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <Container size="sm" py={64}>
+        <Card withBorder padding="xl">
+          <Stack align="center" gap="md">
+            <ThemeIcon size="xl" radius="xl" color="green" variant="light">
+              <IconCircleCheck />
+            </ThemeIcon>
+            <Title order={3}>Submitted</Title>
+            <Text c="dimmed" ta="center">
+              {done}
+            </Text>
+          </Stack>
+        </Card>
+      </Container>
+    );
+  }
+
+  return (
+    <Container size="sm" py={64}>
+      <Card withBorder padding="xl">
+        <Stack gap="xs" mb="md">
+          <Title order={2}>{name}</Title>
+          {description && (
+            <Text c="dimmed" size="sm">
+              {description}
+            </Text>
+          )}
+        </Stack>
+        <form onSubmit={handleSubmit}>
+          <Stack gap="md">
+            {fields.map((field) => {
+              const common = {
+                key: field.key,
+                label: field.label,
+                required: field.required,
+                error: errors[field.key],
+                placeholder: field.placeholder,
+              };
+              const value =
+                typeof values[field.key] === 'string'
+                  ? (values[field.key] as string)
+                  : '';
+
+              if (field.type === 'textarea') {
+                return (
+                  <Textarea
+                    {...common}
+                    key={field.key}
+                    autosize
+                    minRows={3}
+                    value={value}
+                    onChange={(e) => setValue(field.key, e.currentTarget.value)}
+                  />
+                );
+              }
+              if (field.type === 'select') {
+                return (
+                  <Select
+                    {...common}
+                    key={field.key}
+                    data={field.options ?? []}
+                    value={(values[field.key] as string) ?? null}
+                    onChange={(v) => setValue(field.key, v ?? '')}
+                  />
+                );
+              }
+              if (field.type === 'checkbox') {
+                return (
+                  <Checkbox
+                    key={field.key}
+                    label={field.label}
+                    required={field.required}
+                    error={errors[field.key]}
+                    checked={values[field.key] === true}
+                    onChange={(e) =>
+                      setValue(field.key, e.currentTarget.checked)
+                    }
+                  />
+                );
+              }
+              return (
+                <TextInput
+                  {...common}
+                  key={field.key}
+                  type={field.type === 'email' ? 'email' : 'text'}
+                  value={value}
+                  onChange={(e) => setValue(field.key, e.currentTarget.value)}
+                />
+              );
+            })}
+
+            {/* Honeypot — hidden from humans, bots fill it. */}
+            <input
+              type="text"
+              name="_company_url"
+              tabIndex={-1}
+              autoComplete="off"
+              value={honeypot}
+              onChange={(e) => setHoneypot(e.currentTarget.value)}
+              style={{
+                position: 'absolute',
+                left: '-9999px',
+                width: 1,
+                height: 1,
+                opacity: 0,
+              }}
+              aria-hidden="true"
+            />
+
+            {generalError && (
+              <Text c="red" size="sm">
+                {generalError}
+              </Text>
+            )}
+
+            <Button type="submit" loading={submitting}>
+              Submit
+            </Button>
+          </Stack>
+        </form>
+      </Card>
+    </Container>
+  );
+}

--- a/src/app/(public)/f/[slug]/page.tsx
+++ b/src/app/(public)/f/[slug]/page.tsx
@@ -1,0 +1,27 @@
+import { notFound } from "next/navigation";
+
+import { db } from "~/server/db";
+import { parseFormFields } from "~/server/services/forms/formSchema";
+import { PublicForm } from "./_components/PublicForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function PublicFormPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const form = await db.form.findFirst({ where: { slug, isActive: true } });
+  if (!form) notFound();
+
+  return (
+    <PublicForm
+      slug={form.slug}
+      name={form.name}
+      description={form.description}
+      fields={parseFormFields(form.fields)}
+      confirmationMessage={form.confirmationMessage}
+    />
+  );
+}

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,37 @@
+import "~/styles/globals.css";
+import { GeistSans } from "geist/font/sans";
+import { MantineProvider } from "@mantine/core";
+import "@mantine/core/styles.css";
+import { ThemeProvider } from "~/providers/ThemeProvider";
+import { mantineThemes } from "~/config/themes";
+import { getThemeDomain } from "~/config/site";
+
+/**
+ * Bare shell for public, unauthenticated pages (the Forms renderer at /f/[slug]).
+ * Provides the theme + Mantine but no sidemenu, no auth, no tRPC.
+ */
+export default async function PublicLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const domain = getThemeDomain();
+  const mantineTheme = mantineThemes[domain];
+
+  return (
+    <html
+      lang="en"
+      data-mantine-color-scheme="dark"
+      className={`${GeistSans.variable} h-full`}
+      suppressHydrationWarning
+    >
+      <body className="h-full w-full overflow-x-hidden bg-background-primary">
+        <ThemeProvider domain={domain}>
+          <MantineProvider defaultColorScheme="dark" theme={mantineTheme}>
+            {children}
+          </MantineProvider>
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
@@ -1,0 +1,452 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter, usePathname } from 'next/navigation';
+import {
+  Title,
+  Text,
+  Button,
+  Group,
+  Stack,
+  Loader,
+  Box,
+  Badge,
+  Card,
+  TextInput,
+  Textarea,
+  Select,
+  Switch,
+  ActionIcon,
+  Anchor,
+  TagsInput,
+  Divider,
+} from '@mantine/core';
+import {
+  IconArrowLeft,
+  IconPlus,
+  IconTrash,
+  IconArrowUp,
+  IconArrowDown,
+} from '@tabler/icons-react';
+import { notifications } from '@mantine/notifications';
+import { api } from '~/trpc/react';
+import { slugify } from '~/utils/slugify';
+import { CRM_CUSTOMER_TYPE_OPTIONS } from '~/lib/crm/automationCatalog';
+
+type FieldType = 'text' | 'email' | 'textarea' | 'select' | 'checkbox' | 'url';
+
+interface EditorField {
+  key: string;
+  label: string;
+  type: FieldType;
+  required: boolean;
+  options: string[];
+}
+
+const FIELD_TYPE_OPTIONS = [
+  { value: 'text', label: 'Text' },
+  { value: 'email', label: 'Email' },
+  { value: 'textarea', label: 'Long text' },
+  { value: 'select', label: 'Dropdown' },
+  { value: 'checkbox', label: 'Checkbox' },
+  { value: 'url', label: 'URL / link' },
+];
+
+const CONTACT_SLOTS = [
+  { key: 'email', label: 'Email', required: true },
+  { key: 'firstName', label: 'First name', required: false },
+  { key: 'lastName', label: 'Last name', required: false },
+  { key: 'company', label: 'Company', required: false },
+] as const;
+
+type ContactSlot = (typeof CONTACT_SLOTS)[number]['key'];
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+export default function FormEditorPage() {
+  const params = useParams<{ formId: string }>();
+  const id = params.formId;
+  const router = useRouter();
+  const pathname = usePathname();
+  const overviewHref = pathname.split('/').slice(0, -1).join('/');
+  const utils = api.useUtils();
+
+  const query = api.form.get.useQuery({ id }, { enabled: !!id });
+
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [isActive, setIsActive] = useState(false);
+  const [confirmationMessage, setConfirmationMessage] = useState('');
+  const [fields, setFields] = useState<EditorField[]>([]);
+  const [crmEnabled, setCrmEnabled] = useState(false);
+  const [customerType, setCustomerType] = useState<string | null>(null);
+  const [fieldMap, setFieldMap] = useState<Record<ContactSlot, string | null>>({
+    email: null,
+    firstName: null,
+    lastName: null,
+    company: null,
+  });
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    const data = query.data;
+    if (!data) return;
+    setName(data.name);
+    setSlug(data.slug);
+    setIsActive(data.isActive);
+    setConfirmationMessage(data.confirmationMessage ?? '');
+    setFields(
+      asArray(data.fields).map((f) => {
+        const field = f as Partial<EditorField>;
+        return {
+          key: field.key ?? '',
+          label: field.label ?? '',
+          type: field.type ?? 'text',
+          required: field.required ?? false,
+          options: Array.isArray(field.options) ? field.options : [],
+        };
+      }),
+    );
+    const crm = asArray(data.destinations).find(
+      (d) => (d as { type?: string }).type === 'create_crm_contact',
+    ) as { config?: Record<string, unknown> } | undefined;
+    if (crm?.config) {
+      setCrmEnabled(true);
+      setCustomerType(
+        typeof crm.config.customerType === 'string'
+          ? crm.config.customerType
+          : null,
+      );
+      const map = (crm.config.fieldMap ?? {}) as Record<string, unknown>;
+      setFieldMap({
+        email: typeof map.email === 'string' ? map.email : null,
+        firstName: typeof map.firstName === 'string' ? map.firstName : null,
+        lastName: typeof map.lastName === 'string' ? map.lastName : null,
+        company: typeof map.company === 'string' ? map.company : null,
+      });
+    } else {
+      setCrmEnabled(false);
+    }
+    setDirty(false);
+  }, [query.data]);
+
+  const save = api.form.update.useMutation({
+    onSuccess: () => {
+      setDirty(false);
+      notifications.show({ title: 'Saved', message: 'Form saved.', color: 'green' });
+      void utils.form.get.invalidate({ id });
+      void utils.form.list.invalidate();
+    },
+    onError: (error) =>
+      notifications.show({ title: 'Save failed', message: error.message, color: 'red' }),
+  });
+
+  const remove = api.form.remove.useMutation({
+    onSuccess: () => {
+      void utils.form.list.invalidate();
+      router.push(overviewHref);
+    },
+    onError: (error) =>
+      notifications.show({ title: 'Could not delete', message: error.message, color: 'red' }),
+  });
+
+  const touch = () => setDirty(true);
+
+  const addField = () => {
+    setFields((prev) => [
+      ...prev,
+      { key: '', label: '', type: 'text', required: false, options: [] },
+    ]);
+    touch();
+  };
+
+  const updateField = (index: number, patch: Partial<EditorField>) => {
+    setFields((prev) =>
+      prev.map((f, i) => (i === index ? { ...f, ...patch } : f)),
+    );
+    touch();
+  };
+
+  const removeField = (index: number) => {
+    setFields((prev) => prev.filter((_, i) => i !== index));
+    touch();
+  };
+
+  const moveField = (index: number, dir: -1 | 1) => {
+    setFields((prev) => {
+      const next = [...prev];
+      const target = index + dir;
+      if (target < 0 || target >= next.length) return prev;
+      const [moved] = next.splice(index, 1);
+      next.splice(target, 0, moved!);
+      return next;
+    });
+    touch();
+  };
+
+  if (query.isLoading || !query.data) return <Loader />;
+
+  const fieldKeyOptions = fields
+    .filter((f) => f.key.trim())
+    .map((f) => ({ value: f.key, label: `${f.label || f.key} (${f.key})` }));
+
+  const handleSave = () => {
+    const cleanedFields = fields.map((f) => ({
+      key: f.key.trim() || slugify(f.label) || 'field',
+      label: f.label.trim() || f.key,
+      type: f.type,
+      required: f.required,
+      ...(f.type === 'select' ? { options: f.options } : {}),
+    }));
+    const destinations = crmEnabled
+      ? [
+          {
+            type: 'create_crm_contact',
+            config: {
+              customerType: customerType ?? '',
+              fieldMap: Object.fromEntries(
+                CONTACT_SLOTS.map((s) => [s.key, fieldMap[s.key]]).filter(
+                  ([, v]) => v,
+                ),
+              ),
+            },
+          },
+        ]
+      : [];
+    save.mutate({
+      id,
+      name: name.trim() || 'Untitled form',
+      fields: cleanedFields,
+      destinations,
+      isActive,
+      confirmationMessage: confirmationMessage.trim() || null,
+    });
+  };
+
+  return (
+    <Stack gap="md" p="md">
+      <Group justify="space-between" align="flex-start">
+        <Box>
+          <Anchor href={overviewHref} c="dimmed" size="sm">
+            <Group gap={4}>
+              <IconArrowLeft size={14} />
+              All forms
+            </Group>
+          </Anchor>
+          <Group gap="xs" mt={4} align="center">
+            <Title order={3}>{name || 'Untitled form'}</Title>
+            <Badge color={isActive ? 'green' : 'gray'} variant="light">
+              {isActive ? 'active' : 'inactive'}
+            </Badge>
+            <Text c="dimmed" size="sm">
+              /f/{slug}
+            </Text>
+          </Group>
+        </Box>
+        <Group gap="sm">
+          <Switch
+            label="Active"
+            checked={isActive}
+            onChange={(e) => {
+              setIsActive(e.currentTarget.checked);
+              touch();
+            }}
+          />
+          <Button
+            variant="subtle"
+            color="red"
+            leftSection={<IconTrash size={16} />}
+            loading={remove.isPending}
+            onClick={() => remove.mutate({ id })}
+          >
+            Delete
+          </Button>
+          <Button loading={save.isPending} disabled={!dirty} onClick={handleSave}>
+            Save
+          </Button>
+        </Group>
+      </Group>
+
+      <Group align="flex-end" gap="sm">
+        <TextInput
+          label="Name"
+          value={name}
+          onChange={(e) => {
+            setName(e.currentTarget.value);
+            touch();
+          }}
+          w={300}
+        />
+      </Group>
+
+      <Card withBorder padding="md">
+        <Group justify="space-between" mb="sm">
+          <Text fw={600}>Fields</Text>
+          <Button
+            size="xs"
+            variant="light"
+            leftSection={<IconPlus size={14} />}
+            onClick={addField}
+          >
+            Add field
+          </Button>
+        </Group>
+        <Stack gap="sm">
+          {fields.length === 0 && (
+            <Text c="dimmed" size="sm">
+              No fields yet. Add at least one (e.g. an Email field).
+            </Text>
+          )}
+          {fields.map((field, index) => (
+            <Card key={index} withBorder padding="sm" bg="surface-secondary">
+              <Group align="flex-end" gap="sm" wrap="wrap">
+                <TextInput
+                  label="Label"
+                  value={field.label}
+                  onChange={(e) =>
+                    updateField(index, {
+                      label: e.currentTarget.value,
+                      key:
+                        field.key.trim() === '' ||
+                        field.key === slugify(field.label)
+                          ? slugify(e.currentTarget.value)
+                          : field.key,
+                    })
+                  }
+                  w={200}
+                />
+                <TextInput
+                  label="Key"
+                  value={field.key}
+                  onChange={(e) =>
+                    updateField(index, { key: e.currentTarget.value })
+                  }
+                  w={160}
+                />
+                <Select
+                  label="Type"
+                  data={FIELD_TYPE_OPTIONS}
+                  value={field.type}
+                  onChange={(value) =>
+                    updateField(index, { type: (value as FieldType) ?? 'text' })
+                  }
+                  w={150}
+                  allowDeselect={false}
+                />
+                <Switch
+                  label="Required"
+                  checked={field.required}
+                  onChange={(e) =>
+                    updateField(index, { required: e.currentTarget.checked })
+                  }
+                />
+                {field.type === 'select' && (
+                  <TagsInput
+                    label="Options"
+                    value={field.options}
+                    onChange={(value) => updateField(index, { options: value })}
+                    w={220}
+                  />
+                )}
+                <Group gap={2}>
+                  <ActionIcon
+                    variant="subtle"
+                    disabled={index === 0}
+                    onClick={() => moveField(index, -1)}
+                    aria-label="Move up"
+                  >
+                    <IconArrowUp size={16} />
+                  </ActionIcon>
+                  <ActionIcon
+                    variant="subtle"
+                    disabled={index === fields.length - 1}
+                    onClick={() => moveField(index, 1)}
+                    aria-label="Move down"
+                  >
+                    <IconArrowDown size={16} />
+                  </ActionIcon>
+                  <ActionIcon
+                    variant="subtle"
+                    color="red"
+                    onClick={() => removeField(index)}
+                    aria-label="Remove field"
+                  >
+                    <IconTrash size={16} />
+                  </ActionIcon>
+                </Group>
+              </Group>
+            </Card>
+          ))}
+        </Stack>
+      </Card>
+
+      <Card withBorder padding="md">
+        <Group justify="space-between" mb="sm">
+          <Box>
+            <Text fw={600}>When submitted → Create CRM contact</Text>
+            <Text c="dimmed" size="xs">
+              Creates a contact tagged with the Customer type, firing matching
+              automations.
+            </Text>
+          </Box>
+          <Switch
+            checked={crmEnabled}
+            onChange={(e) => {
+              setCrmEnabled(e.currentTarget.checked);
+              touch();
+            }}
+          />
+        </Group>
+        {crmEnabled && (
+          <Stack gap="sm">
+            <Select
+              label="Customer type"
+              placeholder="Select a Customer type"
+              data={CRM_CUSTOMER_TYPE_OPTIONS}
+              value={customerType}
+              onChange={(value) => {
+                setCustomerType(value);
+                touch();
+              }}
+              searchable
+              w={260}
+            />
+            <Divider label="Map form fields → contact" labelPosition="left" />
+            <Group gap="sm" wrap="wrap">
+              {CONTACT_SLOTS.map((slot) => (
+                <Select
+                  key={slot.key}
+                  label={`${slot.label}${slot.required ? ' *' : ''}`}
+                  placeholder="Select a field"
+                  data={fieldKeyOptions}
+                  value={fieldMap[slot.key]}
+                  onChange={(value) => {
+                    setFieldMap((prev) => ({ ...prev, [slot.key]: value }));
+                    touch();
+                  }}
+                  clearable
+                  w={200}
+                />
+              ))}
+            </Group>
+          </Stack>
+        )}
+      </Card>
+
+      <Textarea
+        label="Confirmation message"
+        description="Shown after a successful submission."
+        placeholder="Thanks — we’ve received your application and will be in touch."
+        value={confirmationMessage}
+        onChange={(e) => {
+          setConfirmationMessage(e.currentTarget.value);
+          touch();
+        }}
+        autosize
+        minRows={2}
+      />
+    </Stack>
+  );
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/page.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import {
+  Title,
+  Text,
+  Button,
+  Card,
+  Badge,
+  Group,
+  Stack,
+  Loader,
+  Box,
+  ThemeIcon,
+  Modal,
+  TextInput,
+  CopyButton,
+  ActionIcon,
+  Tooltip,
+} from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import {
+  IconForms,
+  IconPlus,
+  IconCopy,
+  IconCheck,
+  IconExternalLink,
+} from '@tabler/icons-react';
+import { notifications } from '@mantine/notifications';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { api } from '~/trpc/react';
+
+export default function CrmFormsPage() {
+  const { workspaceId, isLoading: wsLoading } = useWorkspace();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const formsQuery = api.form.list.useQuery(
+    { workspaceId: workspaceId ?? '' },
+    { enabled: !!workspaceId },
+  );
+
+  const [createOpened, { open: openCreate, close: closeCreate }] =
+    useDisclosure(false);
+  const [newName, setNewName] = useState('');
+
+  const create = api.form.create.useMutation({
+    onSuccess: ({ id }) => {
+      closeCreate();
+      setNewName('');
+      router.push(`${pathname}/${id}`);
+    },
+    onError: (error) =>
+      notifications.show({
+        title: 'Could not create form',
+        message: error.message,
+        color: 'red',
+      }),
+  });
+
+  if (wsLoading || !workspaceId) return <Loader />;
+
+  const forms = formsQuery.data ?? [];
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+
+  return (
+    <Stack gap="lg" p="md">
+      <Group justify="space-between" align="flex-start">
+        <Box>
+          <Title order={2}>Forms</Title>
+          <Text c="dimmed" size="sm">
+            Public forms whose submissions can create CRM contacts and fire
+            automations.
+          </Text>
+        </Box>
+        <Button leftSection={<IconPlus size={16} />} onClick={openCreate}>
+          Create new form
+        </Button>
+      </Group>
+
+      {formsQuery.isLoading ? (
+        <Loader />
+      ) : forms.length === 0 ? (
+        <Card withBorder padding="xl">
+          <Stack align="center" gap="sm">
+            <ThemeIcon size="xl" variant="light">
+              <IconForms />
+            </ThemeIcon>
+            <Text fw={600}>No forms yet</Text>
+            <Text c="dimmed" size="sm" ta="center">
+              Create a form, add fields, wire a “Create CRM contact” destination,
+              and share its public link.
+            </Text>
+          </Stack>
+        </Card>
+      ) : (
+        <Stack gap="sm">
+          {forms.map((form) => {
+            const publicUrl = `${origin}/f/${form.slug}`;
+            return (
+              <Card
+                key={form.id}
+                withBorder
+                padding="md"
+                style={{ cursor: 'pointer' }}
+                onClick={() => router.push(`${pathname}/${form.id}`)}
+              >
+                <Group justify="space-between" align="flex-start">
+                  <Box>
+                    <Group gap="xs">
+                      <Text fw={600}>{form.name}</Text>
+                      <Badge
+                        color={form.isActive ? 'green' : 'gray'}
+                        variant="light"
+                      >
+                        {form.isActive ? 'active' : 'inactive'}
+                      </Badge>
+                    </Group>
+                    <Text c="dimmed" size="sm" mt={4}>
+                      /f/{form.slug}
+                    </Text>
+                  </Box>
+                  <Group
+                    gap="xs"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <Badge variant="outline">
+                      {form._count.submissions}{' '}
+                      {form._count.submissions === 1
+                        ? 'submission'
+                        : 'submissions'}
+                    </Badge>
+                    <CopyButton value={publicUrl}>
+                      {({ copied, copy }) => (
+                        <Tooltip label={copied ? 'Copied' : 'Copy public link'}>
+                          <ActionIcon variant="subtle" onClick={copy}>
+                            {copied ? (
+                              <IconCheck size={16} />
+                            ) : (
+                              <IconCopy size={16} />
+                            )}
+                          </ActionIcon>
+                        </Tooltip>
+                      )}
+                    </CopyButton>
+                    <Tooltip label="Open public form">
+                      <ActionIcon
+                        variant="subtle"
+                        component="a"
+                        href={publicUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        <IconExternalLink size={16} />
+                      </ActionIcon>
+                    </Tooltip>
+                  </Group>
+                </Group>
+              </Card>
+            );
+          })}
+        </Stack>
+      )}
+
+      <Modal opened={createOpened} onClose={closeCreate} title="Create new form">
+        <Stack gap="sm">
+          <TextInput
+            label="Form name"
+            placeholder="e.g. Job Application"
+            value={newName}
+            onChange={(e) => setNewName(e.currentTarget.value)}
+          />
+          <Group justify="flex-end" mt="xs">
+            <Button variant="default" onClick={closeCreate}>
+              Cancel
+            </Button>
+            <Button
+              loading={create.isPending}
+              disabled={!newName.trim()}
+              onClick={() =>
+                create.mutate({ workspaceId, name: newName.trim() })
+              }
+            >
+              Create
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Stack>
+  );
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/layout.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/layout.tsx
@@ -10,6 +10,7 @@ import {
   IconLayoutKanban,
   IconMail,
   IconBolt,
+  IconForms,
 } from '@tabler/icons-react';
 
 const crmNavigation = [
@@ -21,6 +22,7 @@ const crmNavigation = [
       { title: 'Contacts', href: '/contacts', icon: IconUsers },
       { title: 'Organizations', href: '/organizations', icon: IconBuilding },
       { title: 'Automations', href: '/automations', icon: IconBolt },
+      { title: 'Forms', href: '/forms', icon: IconForms },
     ],
   },
   {

--- a/src/app/api/forms/[slug]/submit/route.ts
+++ b/src/app/api/forms/[slug]/submit/route.ts
@@ -1,0 +1,169 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { type Prisma } from "@prisma/client";
+
+import { db } from "~/server/db";
+import {
+  parseFormFields,
+  validateSubmission,
+} from "~/server/services/forms/formSchema";
+import { runFormDestinations } from "~/server/services/forms/runDestinations";
+import { emailHashFor } from "~/server/services/crm/createCrmContact";
+
+/**
+ * Public **Forms intake** (ADR-0029): POST /api/forms/[slug]/submit. Validates
+ * against the form's field schema, stores a FormSubmission, then runs the form's
+ * destinations synchronously. Unauthenticated — protected by a hidden honeypot
+ * field + per-IP/per-email rate limiting (in-memory; ADR-0030 notes Upstash as
+ * the real fix).
+ */
+export const dynamic = "force-dynamic";
+
+type LimitMap = Map<string, { count: number; resetAt: number }>;
+const ipLimitMap: LimitMap = new Map();
+const emailLimitMap: LimitMap = new Map();
+const WINDOW_MS = 60_000;
+const IP_MAX = 5;
+const EMAIL_MAX = 3;
+
+function limited(map: LimitMap, key: string, max: number): boolean {
+  const now = Date.now();
+  const entry = map.get(key);
+  if (!entry || now > entry.resetAt) {
+    map.set(key, { count: 1, resetAt: now + WINDOW_MS });
+    return false;
+  }
+  entry.count++;
+  return entry.count > max;
+}
+
+if (typeof globalThis !== "undefined") {
+  const cleanup = () => {
+    const now = Date.now();
+    for (const map of [ipLimitMap, emailLimitMap]) {
+      for (const [key, entry] of map.entries()) {
+        if (now > entry.resetAt) map.delete(key);
+      }
+    }
+  };
+  setInterval(cleanup, 5 * 60_000).unref?.();
+}
+
+function clientIp(request: NextRequest): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    request.headers.get("x-real-ip") ??
+    "unknown"
+  );
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  const ip = clientIp(request);
+
+  if (limited(ipLimitMap, ip, IP_MAX)) {
+    return NextResponse.json(
+      { ok: false, error: "Too many submissions. Please try again shortly." },
+      { status: 429 },
+    );
+  }
+
+  let body: { data?: unknown; honeypot?: unknown };
+  try {
+    body = (await request.json()) as { data?: unknown; honeypot?: unknown };
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const data =
+    body.data && typeof body.data === "object"
+      ? (body.data as Record<string, unknown>)
+      : {};
+  const honeypotTripped =
+    typeof body.honeypot === "string" && body.honeypot.trim().length > 0;
+
+  const form = await db.form.findFirst({ where: { slug, isActive: true } });
+  if (!form) {
+    return NextResponse.json(
+      { ok: false, error: "Form not found" },
+      { status: 404 },
+    );
+  }
+
+  const fields = parseFormFields(form.fields);
+
+  // Honeypot: bots fill the hidden field. Record it, skip destinations, fake success.
+  if (honeypotTripped) {
+    await db.formSubmission.create({
+      data: {
+        formId: form.id,
+        data: {},
+        metadata: { ip, honeypotTripped: true } as Prisma.InputJsonValue,
+      },
+    });
+    return NextResponse.json({ ok: true });
+  }
+
+  const validation = validateSubmission(fields, data);
+  if (!validation.ok) {
+    return NextResponse.json(
+      { ok: false, errors: validation.errors },
+      { status: 422 },
+    );
+  }
+
+  const emailField = fields.find((f) => f.type === "email");
+  const email =
+    emailField && typeof validation.clean[emailField.key] === "string"
+      ? (validation.clean[emailField.key] as string)
+      : null;
+  if (email && limited(emailLimitMap, email, EMAIL_MAX)) {
+    return NextResponse.json(
+      { ok: false, error: "Too many submissions for this email." },
+      { status: 429 },
+    );
+  }
+
+  const submission = await db.formSubmission.create({
+    data: {
+      formId: form.id,
+      data: validation.clean as Prisma.InputJsonValue,
+      metadata: {
+        ip,
+        userAgent: request.headers.get("user-agent") ?? null,
+        honeypotTripped: false,
+        emailHash: email ? emailHashFor(email) : null,
+      } as Prisma.InputJsonValue,
+    },
+  });
+
+  const { outcomes, createdContactId } = await runFormDestinations(
+    db,
+    form.destinations,
+    validation.clean,
+    {
+      formId: form.id,
+      workspaceId: form.workspaceId,
+      submissionId: submission.id,
+      ownerId: form.createdById,
+    },
+  );
+
+  await db.formSubmission.update({
+    where: { id: submission.id },
+    data: {
+      result: outcomes as unknown as Prisma.InputJsonValue,
+      createdContactId,
+    },
+  });
+
+  return NextResponse.json({
+    ok: true,
+    confirmationMessage: form.confirmationMessage ?? null,
+  });
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -45,6 +45,7 @@ import { transcriptionSessionParticipantRouter } from "./routers/transcriptionSe
 import { crmContactRouter } from "./routers/crmContact";
 import { crmOrganizationRouter } from "./routers/crmOrganization";
 import { crmAutomationRouter } from "./routers/crmAutomation";
+import { formRouter } from "./routers/form";
 import { tagRouter } from "./routers/tag";
 import { schedulingRouter } from "./routers/scheduling";
 import { taskScheduleRouter } from "./routers/taskSchedule";
@@ -131,6 +132,7 @@ export const appRouter = createTRPCRouter({
   crmContact: crmContactRouter,
   crmOrganization: crmOrganizationRouter,
   crmAutomation: crmAutomationRouter,
+  form: formRouter,
   tag: tagRouter,
   scheduling: schedulingRouter,
   taskSchedule: taskScheduleRouter,

--- a/src/server/api/routers/form.ts
+++ b/src/server/api/routers/form.ts
@@ -1,0 +1,158 @@
+import { z } from "zod";
+import { type PrismaClient, type Prisma } from "@prisma/client";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { TRPCError } from "@trpc/server";
+import { uniqueFormSlug } from "~/server/services/forms/formSlug";
+import {
+  formFieldSchema,
+  formDestinationSchema,
+} from "~/server/services/forms/formSchema";
+import { createFormDestinationRegistry } from "~/server/services/forms/FormDestinationRegistry";
+
+/**
+ * Admin router for the generic **Forms** subsystem (CONTEXT.md → Forms,
+ * ADR-0029). Authenticated + workspace-membership-checked. The public intake is
+ * a separate unauthenticated API route. Slugs are stable after creation so
+ * shared public links don't break.
+ */
+async function assertMember(
+  db: PrismaClient,
+  workspaceId: string,
+  userId: string,
+) {
+  const membership = await db.workspaceUser.findFirst({
+    where: { workspaceId, userId },
+  });
+  if (!membership) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You do not have access to this workspace",
+    });
+  }
+}
+
+async function loadFormForUser(db: PrismaClient, id: string, userId: string) {
+  const form = await db.form.findUnique({ where: { id } });
+  if (!form) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Form not found" });
+  }
+  await assertMember(db, form.workspaceId, userId);
+  return form;
+}
+
+export const formRouter = createTRPCRouter({
+  list: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      await assertMember(ctx.db, input.workspaceId, ctx.session.user.id);
+      return ctx.db.form.findMany({
+        where: { workspaceId: input.workspaceId },
+        include: { _count: { select: { submissions: true } } },
+        orderBy: { createdAt: "desc" },
+      });
+    }),
+
+  get: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      return loadFormForUser(ctx.db, input.id, ctx.session.user.id);
+    }),
+
+  create: protectedProcedure
+    .input(
+      z.object({ workspaceId: z.string(), name: z.string().min(1).max(200) }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertMember(ctx.db, input.workspaceId, ctx.session.user.id);
+      const slug = await uniqueFormSlug(ctx.db, input.workspaceId, input.name);
+      const form = await ctx.db.form.create({
+        data: {
+          workspaceId: input.workspaceId,
+          createdById: ctx.session.user.id,
+          name: input.name,
+          slug,
+          isActive: false,
+        },
+      });
+      return { id: form.id };
+    }),
+
+  update: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        name: z.string().min(1).max(200).optional(),
+        fields: z.array(formFieldSchema).optional(),
+        destinations: z.array(formDestinationSchema).optional(),
+        isActive: z.boolean().optional(),
+        confirmationMessage: z.string().max(2000).nullable().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const form = await loadFormForUser(ctx.db, input.id, ctx.session.user.id);
+
+      if (input.destinations) {
+        const registry = createFormDestinationRegistry(ctx.db);
+        for (const dest of input.destinations) {
+          if (!registry.has(dest.type)) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `Unknown destination type: ${dest.type}`,
+            });
+          }
+          if (
+            dest.type === "create_crm_contact" &&
+            !(
+              typeof dest.config.customerType === "string" &&
+              dest.config.customerType.trim()
+            )
+          ) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: "Create CRM contact requires a Customer type.",
+            });
+          }
+        }
+      }
+
+      await ctx.db.form.update({
+        where: { id: form.id },
+        data: {
+          name: input.name,
+          fields: input.fields as Prisma.InputJsonValue | undefined,
+          destinations: input.destinations as Prisma.InputJsonValue | undefined,
+          isActive: input.isActive,
+          confirmationMessage:
+            input.confirmationMessage === undefined
+              ? undefined
+              : input.confirmationMessage,
+        },
+      });
+      return { id: form.id };
+    }),
+
+  remove: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const form = await loadFormForUser(ctx.db, input.id, ctx.session.user.id);
+      await ctx.db.form.delete({ where: { id: form.id } });
+      return { id: form.id };
+    }),
+
+  listSubmissions: protectedProcedure
+    .input(
+      z.object({
+        formId: z.string(),
+        limit: z.number().min(1).max(100).default(50),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      await loadFormForUser(ctx.db, input.formId, ctx.session.user.id);
+      return ctx.db.formSubmission.findMany({
+        where: { formId: input.formId },
+        orderBy: { createdAt: "desc" },
+        take: input.limit,
+      });
+    }),
+});

--- a/src/server/api/routers/form.ts
+++ b/src/server/api/routers/form.ts
@@ -7,6 +7,7 @@ import { uniqueFormSlug } from "~/server/services/forms/formSlug";
 import {
   formFieldSchema,
   formDestinationSchema,
+  parseFormFields,
 } from "~/server/services/forms/formSchema";
 import { createFormDestinationRegistry } from "~/server/services/forms/FormDestinationRegistry";
 
@@ -65,7 +66,7 @@ export const formRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       await assertMember(ctx.db, input.workspaceId, ctx.session.user.id);
-      const slug = await uniqueFormSlug(ctx.db, input.workspaceId, input.name);
+      const slug = await uniqueFormSlug(ctx.db, input.name);
       const form = await ctx.db.form.create({
         data: {
           workspaceId: input.workspaceId,
@@ -93,6 +94,10 @@ export const formRouter = createTRPCRouter({
       const form = await loadFormForUser(ctx.db, input.id, ctx.session.user.id);
 
       if (input.destinations) {
+        // Validate destination config against the form's effective fields (the
+        // ones being saved, or the stored ones if fields aren't part of this
+        // update).
+        const effectiveFields = input.fields ?? parseFormFields(form.fields);
         const registry = createFormDestinationRegistry(ctx.db);
         for (const dest of input.destinations) {
           if (!registry.has(dest.type)) {
@@ -101,17 +106,35 @@ export const formRouter = createTRPCRouter({
               message: `Unknown destination type: ${dest.type}`,
             });
           }
-          if (
-            dest.type === "create_crm_contact" &&
-            !(
-              typeof dest.config.customerType === "string" &&
-              dest.config.customerType.trim()
-            )
-          ) {
-            throw new TRPCError({
-              code: "BAD_REQUEST",
-              message: "Create CRM contact requires a Customer type.",
-            });
+          if (dest.type === "create_crm_contact") {
+            if (
+              !(
+                typeof dest.config.customerType === "string" &&
+                dest.config.customerType.trim()
+              )
+            ) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message: "Create CRM contact requires a Customer type.",
+              });
+            }
+            // The email is the dedup key: without an Email field mapped, every
+            // submission would create a fresh, never-deduped contact and fire an
+            // automation with no recipient. Require a mapping to an email field.
+            const fieldMap =
+              dest.config.fieldMap && typeof dest.config.fieldMap === "object"
+                ? (dest.config.fieldMap as Record<string, unknown>)
+                : {};
+            const emailKey =
+              typeof fieldMap.email === "string" ? fieldMap.email : "";
+            const emailField = effectiveFields.find((f) => f.key === emailKey);
+            if (!emailField || emailField.type !== "email") {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message:
+                  "Create CRM contact requires an Email field mapped to the contact's email.",
+              });
+            }
           }
         }
       }

--- a/src/server/services/crm/createCrmContact.ts
+++ b/src/server/services/crm/createCrmContact.ts
@@ -54,9 +54,18 @@ export async function createCrmContact(
   if (emailHash) {
     const existing = await db.crmContact.findUnique({
       where: { emailHash },
-      select: { id: true },
+      select: { id: true, workspaceId: true },
     });
     if (existing) {
+      // emailHash is globally unique. A contact owned by ANOTHER workspace must
+      // not be linked into this one — returning its id would leak a cross-tenant
+      // reference, and the create below would throw P2002 anyway. Surface a
+      // clear error (recorded by runFormDestinations; intake still 200s).
+      if (existing.workspaceId !== input.workspaceId) {
+        throw new Error(
+          "A contact with this email already exists in another workspace",
+        );
+      }
       return { contactId: existing.id, created: false, fired: false };
     }
   }

--- a/src/server/services/crm/createCrmContact.ts
+++ b/src/server/services/crm/createCrmContact.ts
@@ -1,0 +1,101 @@
+import crypto from "crypto";
+import { type PrismaClient } from "@prisma/client";
+
+import { encryptString } from "~/server/utils/encryption";
+import { dispatchContactTypeAutomations } from "./automation/dispatchContactTypeAutomations";
+
+/**
+ * Shared contact-create used by non-session paths (notably the public Forms
+ * intake, ADR-0029). Dedupes by the globally-unique `emailHash`, encrypts the
+ * email at rest, stamps the Customer type (`profileType`), and fires the CRM
+ * automation trigger — so a form submission lands as a contact and the existing
+ * automation engine takes over.
+ *
+ * Distinct from `crmContact.create` (the authenticated tRPC mutation), which is
+ * intentionally left unchanged: it allows duplicate-email manual entries and
+ * does not set `emailHash`. This service is the deduping, automation-firing path
+ * for machine/public intake.
+ */
+export function emailHashFor(email: string): string {
+  return crypto
+    .createHash("sha256")
+    .update(email.toLowerCase().trim())
+    .digest("hex");
+}
+
+export interface CreateCrmContactInput {
+  workspaceId: string;
+  email?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  /** Free-text company; stored as a tag in v1 (no auto-organization). */
+  company?: string | null;
+  /** The Customer type to stamp, e.g. "Applicant" — drives the automation. */
+  profileType?: string | null;
+  createdById?: string | null;
+  importSource?: string;
+  triggeredById?: string;
+}
+
+export interface CreateCrmContactResult {
+  contactId: string;
+  created: boolean;
+  fired: boolean;
+}
+
+export async function createCrmContact(
+  db: PrismaClient,
+  input: CreateCrmContactInput,
+): Promise<CreateCrmContactResult> {
+  const email = input.email?.trim() ? input.email.trim() : null;
+  const emailHash = email ? emailHashFor(email) : null;
+
+  // Dedupe by globally-unique emailHash — repeats do not re-create or re-fire.
+  if (emailHash) {
+    const existing = await db.crmContact.findUnique({
+      where: { emailHash },
+      select: { id: true },
+    });
+    if (existing) {
+      return { contactId: existing.id, created: false, fired: false };
+    }
+  }
+
+  const tags = input.company?.trim() ? [input.company.trim()] : [];
+
+  const contact = await db.crmContact.create({
+    data: {
+      workspaceId: input.workspaceId,
+      createdById: input.createdById ?? undefined,
+      firstName: input.firstName?.trim() ?? undefined,
+      lastName: input.lastName?.trim() ?? undefined,
+      profileType: input.profileType ?? undefined,
+      importSource: input.importSource ?? undefined,
+      tags,
+      ...(email ? { email: encryptString(email), emailHash } : {}),
+    },
+    select: { id: true },
+  });
+
+  let fired = false;
+  if (input.profileType) {
+    try {
+      const result = await dispatchContactTypeAutomations(db, {
+        contactId: contact.id,
+        workspaceId: input.workspaceId,
+        oldProfileType: null,
+        newProfileType: input.profileType,
+        triggeredById: input.triggeredById,
+      });
+      fired = result.firedDefinitionIds.length > 0;
+    } catch (e) {
+      console.error(
+        "createCrmContact: automation dispatch failed for contact",
+        contact.id,
+        e,
+      );
+    }
+  }
+
+  return { contactId: contact.id, created: true, fired };
+}

--- a/src/server/services/forms/FormDestinationRegistry.ts
+++ b/src/server/services/forms/FormDestinationRegistry.ts
@@ -1,0 +1,42 @@
+import { type PrismaClient } from "@prisma/client";
+
+import { type IFormDestination } from "./destinations/IFormDestination";
+import { CreateCrmContactDestination } from "./destinations/CreateCrmContactDestination";
+
+/**
+ * Registry of **Form destinations**, mirroring the automation `StepRegistry`.
+ * Forms stay generic — the core runs whatever destinations are configured; new
+ * destination types (notify, webhook, create deal) register here with no core
+ * change.
+ */
+export class FormDestinationRegistry {
+  private handlers = new Map<string, IFormDestination>();
+
+  register(handler: IFormDestination): void {
+    this.handlers.set(handler.type, handler);
+  }
+
+  has(type: string): boolean {
+    return this.handlers.has(type);
+  }
+
+  get(type: string): IFormDestination {
+    const handler = this.handlers.get(type);
+    if (!handler) {
+      throw new Error(`No form destination registered for type: ${type}`);
+    }
+    return handler;
+  }
+
+  listTypes(): string[] {
+    return [...this.handlers.keys()];
+  }
+}
+
+export function createFormDestinationRegistry(
+  db: PrismaClient,
+): FormDestinationRegistry {
+  const registry = new FormDestinationRegistry();
+  registry.register(new CreateCrmContactDestination(db));
+  return registry;
+}

--- a/src/server/services/forms/__tests__/formSchema.test.ts
+++ b/src/server/services/forms/__tests__/formSchema.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+
+import { validateSubmission, type FormField } from "../formSchema";
+
+const fields: FormField[] = [
+  { key: "email", label: "Email", type: "email", required: true },
+  { key: "first_name", label: "First name", type: "text", required: false },
+  { key: "resume_url", label: "Résumé link", type: "url", required: false },
+  {
+    key: "role",
+    label: "Role",
+    type: "select",
+    required: true,
+    options: ["Engineer", "Designer"],
+  },
+  { key: "agree", label: "Agree", type: "checkbox", required: true },
+];
+
+function base(overrides: Record<string, unknown>) {
+  return {
+    email: "Ada@Example.com",
+    first_name: "Ada",
+    role: "Engineer",
+    agree: true,
+    ...overrides,
+  };
+}
+
+describe("validateSubmission", () => {
+  it("accepts a valid submission and lowercases the email", () => {
+    const result = validateSubmission(fields, base({}));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.clean.email).toBe("ada@example.com");
+      expect(result.clean.role).toBe("Engineer");
+      expect(result.clean.agree).toBe(true);
+    }
+  });
+
+  it("reports a missing required field", () => {
+    const result = validateSubmission(fields, base({ email: "" }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.email).toMatch(/required/i);
+  });
+
+  it("rejects a malformed email", () => {
+    const result = validateSubmission(fields, base({ email: "not-an-email" }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.email).toMatch(/valid email/i);
+  });
+
+  it("rejects a non-http url", () => {
+    const result = validateSubmission(
+      fields,
+      base({ resume_url: "javascript:alert(1)" }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.resume_url).toMatch(/valid URL/i);
+  });
+
+  it("accepts a valid https url", () => {
+    const result = validateSubmission(
+      fields,
+      base({ resume_url: "https://example.com/cv.pdf" }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a select value not in options", () => {
+    const result = validateSubmission(fields, base({ role: "Marketer" }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.role).toMatch(/not a valid option/i);
+  });
+
+  it("requires a checkbox when required", () => {
+    const result = validateSubmission(fields, base({ agree: false }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.agree).toMatch(/required/i);
+  });
+
+  it("drops unknown keys not in the field set", () => {
+    const result = validateSubmission(fields, base({ injected: "x" }));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.clean.injected).toBeUndefined();
+  });
+
+  it("rejects text longer than the cap", () => {
+    const result = validateSubmission(fields, base({ first_name: "a".repeat(5001) }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.first_name).toMatch(/too long/i);
+  });
+});

--- a/src/server/services/forms/__tests__/formSlug.test.ts
+++ b/src/server/services/forms/__tests__/formSlug.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+
+import { nextAvailableSlug } from "../formSlug";
+
+describe("nextAvailableSlug", () => {
+  it("returns the base when it is free", () => {
+    expect(nextAvailableSlug("job_application", new Set())).toBe(
+      "job_application",
+    );
+  });
+
+  it("appends the first free numeric suffix", () => {
+    expect(
+      nextAvailableSlug(
+        "job_application",
+        new Set(["job_application", "job_application_2"]),
+      ),
+    ).toBe("job_application_3");
+  });
+
+  it("skips gaps correctly", () => {
+    expect(
+      nextAvailableSlug("contact", new Set(["contact"])),
+    ).toBe("contact_2");
+  });
+
+  it("falls back to 'form' for an empty base", () => {
+    expect(nextAvailableSlug("", new Set())).toBe("form");
+  });
+});

--- a/src/server/services/forms/destinations/CreateCrmContactDestination.ts
+++ b/src/server/services/forms/destinations/CreateCrmContactDestination.ts
@@ -43,9 +43,17 @@ export class CreateCrmContactDestination implements IFormDestination {
       return typeof value === "string" && value.trim() ? value.trim() : null;
     };
 
+    // Email is the dedup key. Without it every submission would create a fresh,
+    // never-deduped contact and fire an automation with no recipient — refuse
+    // rather than create a useless contact (recorded by runFormDestinations).
+    const email = pick(fieldMap.email);
+    if (!email) {
+      throw new Error("create_crm_contact: submission has no email to dedupe on");
+    }
+
     const result = await createCrmContact(this.db, {
       workspaceId: context.workspaceId,
-      email: pick(fieldMap.email),
+      email,
       firstName: pick(fieldMap.firstName),
       lastName: pick(fieldMap.lastName),
       company: pick(fieldMap.company),

--- a/src/server/services/forms/destinations/CreateCrmContactDestination.ts
+++ b/src/server/services/forms/destinations/CreateCrmContactDestination.ts
@@ -1,0 +1,64 @@
+import { type PrismaClient } from "@prisma/client";
+
+import { createCrmContact } from "~/server/services/crm/createCrmContact";
+import {
+  type IFormDestination,
+  type FormDestinationContext,
+} from "./IFormDestination";
+
+interface FieldMap {
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  company?: string;
+}
+
+/**
+ * `create_crm_contact` — maps submission fields to a CRM contact, stamps the
+ * configured Customer type, and (via `createCrmContact`) fires the CRM
+ * automation engine. Config: `{ customerType, fieldMap: { email, firstName,
+ * lastName, company } }` where values are form field keys.
+ */
+export class CreateCrmContactDestination implements IFormDestination {
+  type = "create_crm_contact";
+  label = "Create CRM contact";
+
+  constructor(private db: PrismaClient) {}
+
+  async run(
+    data: Record<string, unknown>,
+    config: Record<string, unknown>,
+    context: FormDestinationContext,
+  ): Promise<Record<string, unknown>> {
+    const customerType =
+      typeof config.customerType === "string" ? config.customerType : null;
+    const fieldMap =
+      config.fieldMap && typeof config.fieldMap === "object"
+        ? (config.fieldMap as FieldMap)
+        : {};
+
+    const pick = (key?: string): string | null => {
+      if (!key) return null;
+      const value = data[key];
+      return typeof value === "string" && value.trim() ? value.trim() : null;
+    };
+
+    const result = await createCrmContact(this.db, {
+      workspaceId: context.workspaceId,
+      email: pick(fieldMap.email),
+      firstName: pick(fieldMap.firstName),
+      lastName: pick(fieldMap.lastName),
+      company: pick(fieldMap.company),
+      profileType: customerType,
+      createdById: context.ownerId,
+      importSource: "FORM",
+      triggeredById: context.ownerId ?? undefined,
+    });
+
+    return {
+      contactId: result.contactId,
+      created: result.created,
+      automationFired: result.fired,
+    };
+  }
+}

--- a/src/server/services/forms/destinations/IFormDestination.ts
+++ b/src/server/services/forms/destinations/IFormDestination.ts
@@ -1,0 +1,26 @@
+/**
+ * A **Form destination** — what a form submission does, run synchronously on
+ * intake (CONTEXT.md → Forms, ADR-0029). Mirrors the automation `IStepExecutor`
+ * pattern. v1 ships one: `create_crm_contact`.
+ */
+export interface FormDestinationContext {
+  formId: string;
+  workspaceId: string;
+  submissionId: string;
+  /** The form owner — used to attribute the created contact + automation run. */
+  ownerId: string | null;
+}
+
+export interface IFormDestination {
+  type: string;
+  label: string;
+  /**
+   * Run the destination against the validated submission data + this
+   * destination's config. Returns a PII-free result detail for logging.
+   */
+  run(
+    data: Record<string, unknown>,
+    config: Record<string, unknown>,
+    context: FormDestinationContext,
+  ): Promise<Record<string, unknown>>;
+}

--- a/src/server/services/forms/formSchema.ts
+++ b/src/server/services/forms/formSchema.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+
+/**
+ * Generic Forms field + destination schema and the pure submission validator
+ * (CONTEXT.md → Forms, ADR-0029). A Form's fields and destinations are stored as
+ * JSON; these types/schemas parse that JSON, and `validateSubmission` validates a
+ * public submission against the field definitions. Pure — no I/O — so it is
+ * unit-tested in isolation.
+ */
+
+export const FORM_FIELD_TYPES = [
+  "text",
+  "email",
+  "textarea",
+  "select",
+  "checkbox",
+  "url",
+] as const;
+export type FormFieldType = (typeof FORM_FIELD_TYPES)[number];
+
+export interface FormField {
+  key: string;
+  label: string;
+  type: FormFieldType;
+  required: boolean;
+  options?: string[];
+  placeholder?: string;
+}
+
+export interface FormDestinationConfig {
+  type: string;
+  config: Record<string, unknown>;
+}
+
+export const formFieldSchema = z.object({
+  key: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(/^[a-zA-Z0-9_]+$/, "Key may only contain letters, numbers, _"),
+  label: z.string().min(1).max(200),
+  type: z.enum(FORM_FIELD_TYPES),
+  required: z.boolean(),
+  options: z.array(z.string()).optional(),
+  placeholder: z.string().max(200).optional(),
+});
+
+export const formDestinationSchema = z.object({
+  type: z.string().min(1),
+  config: z.record(z.unknown()),
+});
+
+const MAX_TEXT_LENGTH = 5000;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export type ValidateSubmissionResult =
+  | { ok: true; clean: Record<string, unknown> }
+  | { ok: false; errors: Record<string, string> };
+
+/**
+ * Validate a raw submission against a form's fields. Unknown keys are dropped;
+ * the returned `clean` is keyed by `field.key`. On any error, returns all field
+ * errors at once.
+ */
+export function validateSubmission(
+  fields: FormField[],
+  data: Record<string, unknown>,
+): ValidateSubmissionResult {
+  const errors: Record<string, string> = {};
+  const clean: Record<string, unknown> = {};
+
+  for (const field of fields) {
+    const raw = data[field.key];
+
+    if (field.type === "checkbox") {
+      const value = raw === true || raw === "true" || raw === "on";
+      if (field.required && !value) {
+        errors[field.key] = `${field.label} is required`;
+      } else {
+        clean[field.key] = value;
+      }
+      continue;
+    }
+
+    const str = typeof raw === "string" ? raw.trim() : "";
+    if (!str) {
+      if (field.required) errors[field.key] = `${field.label} is required`;
+      else clean[field.key] = "";
+      continue;
+    }
+    if (str.length > MAX_TEXT_LENGTH) {
+      errors[field.key] = `${field.label} is too long`;
+      continue;
+    }
+
+    switch (field.type) {
+      case "email": {
+        const lower = str.toLowerCase();
+        if (!EMAIL_RE.test(lower)) {
+          errors[field.key] = `${field.label} must be a valid email`;
+        } else {
+          clean[field.key] = lower;
+        }
+        break;
+      }
+      case "url": {
+        let valid = false;
+        try {
+          const url = new URL(str);
+          valid = url.protocol === "http:" || url.protocol === "https:";
+        } catch {
+          valid = false;
+        }
+        if (!valid) errors[field.key] = `${field.label} must be a valid URL`;
+        else clean[field.key] = str;
+        break;
+      }
+      case "select": {
+        if (!field.options?.includes(str)) {
+          errors[field.key] = `${field.label} is not a valid option`;
+        } else {
+          clean[field.key] = str;
+        }
+        break;
+      }
+      default:
+        clean[field.key] = str;
+    }
+  }
+
+  if (Object.keys(errors).length > 0) return { ok: false, errors };
+  return { ok: true, clean };
+}
+
+/** Parse a Form's stored `fields` JSON into typed FormFields (lenient on read). */
+export function parseFormFields(value: unknown): FormField[] {
+  const result = z.array(formFieldSchema).safeParse(value);
+  return result.success ? result.data : [];
+}
+
+/** Parse a Form's stored `destinations` JSON. */
+export function parseFormDestinations(value: unknown): FormDestinationConfig[] {
+  const result = z.array(formDestinationSchema).safeParse(value);
+  return result.success ? result.data : [];
+}

--- a/src/server/services/forms/formSlug.ts
+++ b/src/server/services/forms/formSlug.ts
@@ -3,8 +3,8 @@ import { type PrismaClient } from "@prisma/client";
 import { slugify } from "~/utils/slugify";
 
 /**
- * Pure: given a base slug and the set of slugs already taken in a workspace,
- * return the first free slug (appending `_2`, `_3`, … like the Project router).
+ * Pure: given a base slug and the set of slugs already taken, return the first
+ * free slug (appending `_2`, `_3`, … like the Project router).
  */
 export function nextAvailableSlug(
   base: string,
@@ -17,19 +17,19 @@ export function nextAvailableSlug(
   return `${safeBase}_${i}`;
 }
 
-/** Resolve a unique slug for a Form within its workspace. */
+/**
+ * Resolve a globally-unique slug for a Form. Slugs are unique across all
+ * workspaces (the public `/f/[slug]` route carries no workspace), so dedupe
+ * against every existing form, not just the current workspace's.
+ */
 export async function uniqueFormSlug(
   db: PrismaClient,
-  workspaceId: string,
   name: string,
   excludeId?: string,
 ): Promise<string> {
   const base = slugify(name) || "form";
   const existing = await db.form.findMany({
-    where: {
-      workspaceId,
-      ...(excludeId ? { NOT: { id: excludeId } } : {}),
-    },
+    where: excludeId ? { NOT: { id: excludeId } } : undefined,
     select: { slug: true },
   });
   return nextAvailableSlug(base, new Set(existing.map((f) => f.slug)));

--- a/src/server/services/forms/formSlug.ts
+++ b/src/server/services/forms/formSlug.ts
@@ -1,0 +1,36 @@
+import { type PrismaClient } from "@prisma/client";
+
+import { slugify } from "~/utils/slugify";
+
+/**
+ * Pure: given a base slug and the set of slugs already taken in a workspace,
+ * return the first free slug (appending `_2`, `_3`, … like the Project router).
+ */
+export function nextAvailableSlug(
+  base: string,
+  taken: ReadonlySet<string>,
+): string {
+  const safeBase = base || "form";
+  if (!taken.has(safeBase)) return safeBase;
+  let i = 2;
+  while (taken.has(`${safeBase}_${i}`)) i++;
+  return `${safeBase}_${i}`;
+}
+
+/** Resolve a unique slug for a Form within its workspace. */
+export async function uniqueFormSlug(
+  db: PrismaClient,
+  workspaceId: string,
+  name: string,
+  excludeId?: string,
+): Promise<string> {
+  const base = slugify(name) || "form";
+  const existing = await db.form.findMany({
+    where: {
+      workspaceId,
+      ...(excludeId ? { NOT: { id: excludeId } } : {}),
+    },
+    select: { slug: true },
+  });
+  return nextAvailableSlug(base, new Set(existing.map((f) => f.slug)));
+}

--- a/src/server/services/forms/runDestinations.ts
+++ b/src/server/services/forms/runDestinations.ts
@@ -1,0 +1,55 @@
+import { type PrismaClient } from "@prisma/client";
+
+import { createFormDestinationRegistry } from "./FormDestinationRegistry";
+import { parseFormDestinations } from "./formSchema";
+import { type FormDestinationContext } from "./destinations/IFormDestination";
+
+export interface DestinationOutcome {
+  type: string;
+  ok: boolean;
+  detail?: Record<string, unknown>;
+  error?: string;
+}
+
+/**
+ * Run a form's destinations synchronously against a validated submission
+ * (ADR-0029/0030). Each destination is isolated — one failure is recorded and
+ * the rest still run; the intake never 500s on a destination error.
+ */
+export async function runFormDestinations(
+  db: PrismaClient,
+  destinationsJson: unknown,
+  data: Record<string, unknown>,
+  context: FormDestinationContext,
+): Promise<{ outcomes: DestinationOutcome[]; createdContactId: string | null }> {
+  const registry = createFormDestinationRegistry(db);
+  const destinations = parseFormDestinations(destinationsJson);
+  const outcomes: DestinationOutcome[] = [];
+  let createdContactId: string | null = null;
+
+  for (const dest of destinations) {
+    if (!registry.has(dest.type)) {
+      outcomes.push({
+        type: dest.type,
+        ok: false,
+        error: "Unknown destination type",
+      });
+      continue;
+    }
+    try {
+      const detail = await registry.get(dest.type).run(data, dest.config, context);
+      if (typeof detail.contactId === "string") {
+        createdContactId = detail.contactId;
+      }
+      outcomes.push({ type: dest.type, ok: true, detail });
+    } catch (e) {
+      outcomes.push({
+        type: dest.type,
+        ok: false,
+        error: e instanceof Error ? e.message : "destination failed",
+      });
+    }
+  }
+
+  return { outcomes, createdContactId };
+}


### PR DESCRIPTION
## What

A workspace-owned **generic Forms subsystem** (a mini-Typeform), deliberately decoupled from the CRM — a form submission runs configurable **destinations**, and v1 ships one: `create_crm_contact`, which stamps a Customer type and fires the **existing** automation engine. First use case: a public **job-application form** → contact created → applicant emailed. See [ADR-0029](docs/adr/0029-generic-forms-subsystem.md), [ADR-0030](docs/adr/0030-form-automation-execution-sync-then-qstash.md), and CONTEXT.md → Forms.

- **Schema**: `Form` + `FormSubmission` (JSON `fields`/`destinations`; `@@unique([workspaceId, slug])`). **Migration included.**
- **Server**: pure `validateSubmission` + slug helper (**13 unit tests**), `FormDestinationRegistry` (mirrors the automation `StepRegistry`), `create_crm_contact` destination, `runDestinations`, and a lean deduping `createCrmContact` service.
- **Intake**: public `POST /api/forms/[slug]/submit` — honeypot + per-IP/email rate limit → validate → store submission → run destinations (synchronous).
- **Admin**: `form` tRPC router + a Forms area under CRM (field-list editor + destination config).
- **Public**: a `(public)` route group + `/f/[slug]` renderer + confirmation state.

The chain: **Intake → create_crm_contact → createCrmContact (emailHash dedup) → dispatchContactTypeAutomations → CRM Automation (send_email)**.

## Deliberate deviation from the plan

`crmContact.create` is **left untouched** (the plan suggested refactoring it through the new service). Routing it through the deduping/`emailHash` service would change manual-create semantics and risk a `@unique` violation on duplicate-email manual entries. `createCrmContact` is intake-only. Documented in ADR-0029.

## Verification

typecheck ✅ · ESLint ✅ (no hardcoded colors) · 972 unit tests ✅. End-to-end: create a form with a `create_crm_contact` destination (customerType `Applicant`), build + activate an "Applicant" automation, submit `/f/[slug]` → submission stored, contact created, automation run + welcome email. Repeat email → no duplicate, no re-fire.

## Deferred

Drag-drop form builder, file/résumé upload (a `url` field stands in), multiple destination types, async execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a public forms subsystem with workspace admin configuration UI
  * Forms support customizable fields, honeypot and rate limiting, and submission tracking
  * Form submissions can automatically create CRM contacts and trigger automations
  * Public forms accessible via shareable links with optional confirmation messages

* **Tests**
  * Added validation tests for form submission handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->