### PR TITLE
fix(crm): contact-create endpoints honor the requested workspace

### DIFF
--- a/src/server/api/routers/__tests__/mastra.integration.test.ts
+++ b/src/server/api/routers/__tests__/mastra.integration.test.ts
@@ -193,3 +193,148 @@ describe("mastra.addGoalUpdate", () => {
     expect(after?.health ?? null).toBeNull();
   });
 });
+
+describe("mastra.createFullCrmContact workspace resolution", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("creates the contact in the supplied workspace the caller is a member of", async () => {
+    const user = await createUser(db);
+    // The user belongs to two workspaces; without an explicit workspaceId the
+    // endpoint's findFirst fallback could pick either. The explicit id must win.
+    const wsA = await createWorkspace(db, { ownerId: user.id, slug: "crm-ws-a" });
+    const wsB = await createWorkspace(db, { ownerId: user.id, slug: "crm-ws-b" });
+
+    const caller = createTestCaller(user.id);
+    const contact = await caller.mastra.createFullCrmContact({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      workspaceId: wsB.id,
+    });
+
+    const persisted = await db.crmContact.findUnique({ where: { id: contact.id } });
+    expect(persisted?.workspaceId).toBe(wsB.id);
+    expect(persisted?.workspaceId).not.toBe(wsA.id);
+    expect(persisted?.createdById).toBe(user.id);
+  });
+
+  it("rejects a workspaceId the caller is not a member of", async () => {
+    const owner = await createUser(db);
+    const stranger = await createUser(db);
+    const ownedWs = await createWorkspace(db, { ownerId: owner.id, slug: "crm-private-ws" });
+    // The stranger has their own workspace so the findFirst fallback would
+    // succeed — proving the rejection is about the explicit id, not "no workspace".
+    await createWorkspace(db, { ownerId: stranger.id, slug: "crm-stranger-ws" });
+
+    const strangerCaller = createTestCaller(stranger.id);
+    await expect(
+      strangerCaller.mastra.createFullCrmContact({
+        firstName: "Mallory",
+        workspaceId: ownedWs.id,
+      }),
+    ).rejects.toThrow(/not found or access denied/i);
+
+    const count = await db.crmContact.count({ where: { workspaceId: ownedWs.id } });
+    expect(count).toBe(0);
+  });
+
+  it("honors workspace access granted via team membership", async () => {
+    const owner = await createUser(db);
+    const teammate = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: owner.id, slug: "crm-team-ws" });
+    // Grant the teammate workspace access via a team link (the resolver's
+    // second access path), without a direct WorkspaceUser row.
+    await db.team.create({
+      data: {
+        name: "CRM Team",
+        slug: `crm-team-${ws.id}`,
+        workspaceId: ws.id,
+        members: { create: { userId: teammate.id, role: "member" } },
+      },
+    });
+
+    const caller = createTestCaller(teammate.id);
+    const contact = await caller.mastra.createFullCrmContact({
+      firstName: "Grace",
+      workspaceId: ws.id,
+    });
+
+    const persisted = await db.crmContact.findUnique({ where: { id: contact.id } });
+    expect(persisted?.workspaceId).toBe(ws.id);
+  });
+
+  it("falls back to the user's first workspace when no workspaceId is supplied", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id, slug: "crm-fallback-ws" });
+
+    const caller = createTestCaller(user.id);
+    const contact = await caller.mastra.createFullCrmContact({ firstName: "Edsger" });
+
+    const persisted = await db.crmContact.findUnique({ where: { id: contact.id } });
+    expect(persisted?.workspaceId).toBe(ws.id);
+  });
+});
+
+describe("mastra.createCrmContact (legacy) workspace resolution", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("creates the contact in the supplied workspace the caller is a member of", async () => {
+    const user = await createUser(db);
+    const wsA = await createWorkspace(db, { ownerId: user.id, slug: "legacy-ws-a" });
+    const wsB = await createWorkspace(db, { ownerId: user.id, slug: "legacy-ws-b" });
+
+    const caller = createTestCaller(user.id);
+    const result = await caller.mastra.createCrmContact({
+      email: "ada@example.com",
+      phone: "+15551230000",
+      firstName: "Ada",
+      workspaceId: wsB.id,
+    });
+
+    expect(result.created).toBe(true);
+    const persisted = await db.crmContact.findUnique({ where: { id: result.contactId! } });
+    expect(persisted?.workspaceId).toBe(wsB.id);
+    expect(persisted?.workspaceId).not.toBe(wsA.id);
+  });
+
+  it("rejects a workspaceId the caller is not a member of", async () => {
+    const owner = await createUser(db);
+    const stranger = await createUser(db);
+    const ownedWs = await createWorkspace(db, { ownerId: owner.id, slug: "legacy-private-ws" });
+    await createWorkspace(db, { ownerId: stranger.id, slug: "legacy-stranger-ws" });
+
+    const strangerCaller = createTestCaller(stranger.id);
+    const result = await strangerCaller.mastra.createCrmContact({
+      email: "mallory@example.com",
+      phone: "+15559990000",
+      workspaceId: ownedWs.id,
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.error).toMatch(/not found or access denied/i);
+    const count = await db.crmContact.count({ where: { workspaceId: ownedWs.id } });
+    expect(count).toBe(0);
+  });
+
+  it("falls back to the user's first workspace when no workspaceId is supplied", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id, slug: "legacy-fallback-ws" });
+
+    const caller = createTestCaller(user.id);
+    const result = await caller.mastra.createCrmContact({
+      email: "edsger@example.com",
+      phone: "+15550001111",
+    });
+
+    expect(result.created).toBe(true);
+    const persisted = await db.crmContact.findUnique({ where: { id: result.contactId! } });
+    expect(persisted?.workspaceId).toBe(ws.id);
+  });
+});

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -2325,16 +2325,34 @@ export const mastraRouter = createTRPCRouter({
       phone: z.string(),
       firstName: z.string().optional(),
       lastName: z.string().optional(),
+      workspaceId: z.string().optional(),
     }))
     .mutation(async ({ ctx, input }) => {
-      // Get user's first workspace
-      const workspace = await ctx.db.workspaceUser.findFirst({
-        where: { userId: ctx.session.user.id },
-        select: { workspaceId: true },
-      });
+      // Resolve the target workspace. When the caller forwards the active chat
+      // workspace, honor it after verifying membership; otherwise fall back to
+      // the user's first workspace for backward compatibility with callers that
+      // don't yet send it.
+      let workspaceId: string;
+      if (input.workspaceId) {
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          ctx.session.user.id,
+          input.workspaceId,
+        );
+        if (!membership) {
+          return { created: false, updated: false, error: "Workspace not found or access denied" };
+        }
+        workspaceId = membership.workspaceId;
+      } else {
+        const workspace = await ctx.db.workspaceUser.findFirst({
+          where: { userId: ctx.session.user.id },
+          select: { workspaceId: true },
+        });
 
-      if (!workspace) {
-        return { created: false, updated: false, error: "No workspace found" };
+        if (!workspace) {
+          return { created: false, updated: false, error: "No workspace found" };
+        }
+        workspaceId = workspace.workspaceId;
       }
 
       // Generate emailHash for deduplication
@@ -2346,7 +2364,7 @@ export const mastraRouter = createTRPCRouter({
       // Check if contact already exists
       const existing = await ctx.db.crmContact.findFirst({
         where: {
-          workspaceId: workspace.workspaceId,
+          workspaceId,
           emailHash,
         },
       });
@@ -2366,7 +2384,7 @@ export const mastraRouter = createTRPCRouter({
       // Create new contact
       const contact = await ctx.db.crmContact.create({
         data: {
-          workspaceId: workspace.workspaceId,
+          workspaceId,
           createdById: ctx.session.user.id,
           firstName: input.firstName,
           lastName: input.lastName,
@@ -2684,18 +2702,35 @@ export const mastraRouter = createTRPCRouter({
       skills: z.array(z.string()).optional(),
       tags: z.array(z.string()).optional(),
       organizationId: z.string().optional(),
+      workspaceId: z.string().optional(),
     }))
     .mutation(async ({ ctx, input }) => {
-      const workspaceUser = await ctx.db.workspaceUser.findFirst({
-        where: { userId: ctx.session.user.id },
-        select: { workspaceId: true },
-      });
+      // Resolve the target workspace. When the caller forwards the active chat
+      // workspace, honor it after verifying membership; otherwise fall back to
+      // the user's first workspace for backward compatibility with callers that
+      // don't yet send it.
+      let workspaceId: string;
+      if (input.workspaceId) {
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          ctx.session.user.id,
+          input.workspaceId,
+        );
+        if (!membership) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Workspace not found or access denied" });
+        }
+        workspaceId = membership.workspaceId;
+      } else {
+        const workspaceUser = await ctx.db.workspaceUser.findFirst({
+          where: { userId: ctx.session.user.id },
+          select: { workspaceId: true },
+        });
 
-      if (!workspaceUser) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "No workspace found" });
+        if (!workspaceUser) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "No workspace found" });
+        }
+        workspaceId = workspaceUser.workspaceId;
       }
-
-      const workspaceId = workspaceUser.workspaceId;
 
       // Validate organizationId belongs to same workspace
       if (input.organizationId) {

--- a/src/test/integration-setup.ts
+++ b/src/test/integration-setup.ts
@@ -9,6 +9,9 @@ process.env.OPENAI_API_KEY = "sk-test-dummy-key-for-integration-tests";
 process.env.GOOGLE_CLIENT_ID = "test";
 process.env.GOOGLE_CLIENT_SECRET = "test";
 process.env.MASTRA_API_URL = "http://localhost:4111";
+// Dummy 32-byte (base64) key so encryptString works for PII-writing paths
+// (e.g. CRM contacts). Read at import time by src/server/utils/encryption.ts.
+process.env.DATABASE_ENCRYPTION_KEY = "MMeRcJFimqp98NsQ5i2cawtF4LbcftnfiCNJWLhO/YQ=";
 
 // Mock next-auth and related modules that depend on Next.js runtime
 vi.mock("next-auth", () => ({


### PR DESCRIPTION
## Ticket

Fixes **thick.ocean** (#193) — _CRM contact-create endpoints honor the requested workspace_.

First of two coordinated BUG fixes for the root cause: agent-created CRM contacts landing in the wrong workspace. This is the endpoint half (exponential repo). The companion mastra tool change (**eager.moth** / #194) forwards the active `workspaceId` and depends on this PR being merged first.

## Problem

`mastra.createFullCrmContact` and `mastra.createCrmContact` resolved the target workspace with `ctx.db.workspaceUser.findFirst({ where: { userId } })` — no `orderBy` — so the contact landed in whichever `WorkspaceUser` row came back first (typically the oldest / Personal), unrelated to the workspace the chat was scoped to.

## Change

- Both endpoints accept an optional `workspaceId`.
- When supplied, membership is verified via the existing `getWorkspaceMembership` resolver (direct **or** team-based access) and that workspace is used.
- A `workspaceId` the caller is **not** a member of is **rejected** (`createFullCrmContact` throws `NOT_FOUND`; legacy `createCrmContact` returns `{ created: false, error }`) — not silently ignored.
- When omitted, the prior `findFirst` fallback is preserved, so **existing callers are unaffected** (backward compatible).
- The organization-belongs-to-same-workspace validation now runs against the resolved workspace.

## Tests

Adds integration coverage in `mastra.integration.test.ts` for both endpoints:
- explicit workspace honored (member of two workspaces → explicit id wins over `findFirst`)
- team-based workspace access honored
- non-member workspace rejected (no contact written)
- omitting `workspaceId` preserves the fallback

Also sets a dummy `DATABASE_ENCRYPTION_KEY` in `integration-setup.ts` so PII-writing paths (CRM contacts) can run under test — neither the setup file nor CI previously defined it.

All 15 tests in the file pass; `tsc --noEmit` and `eslint` clean; full unit suite (959) green via pre-commit.