### PR TITLE
feat(favourites): favourite any page, starting with the Products section

### DIFF
--- a/prisma/migrations/20260619210000_add_favorite_label_icon/migration.sql
+++ b/prisma/migrations/20260619210000_add_favorite_label_icon/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable: add snapshot label + icon for generic "page" favourites.
+-- Entity favourites (objective/keyResult) leave these NULL and resolve titles live.
+ALTER TABLE "Favorite" ADD COLUMN "label" TEXT;
+ALTER TABLE "Favorite" ADD COLUMN "icon" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2960,8 +2960,10 @@ model Favorite {
   id          String   @id @default(cuid())
   userId      String
   workspaceId String?
-  entityType  String // "objective" | "keyResult"
-  entityId    String // Goal id (as string) or KeyResult cuid
+  entityType  String // "objective" | "keyResult" | "page"
+  entityId    String // Goal id (as string), KeyResult cuid, or workspace-relative path (page)
+  label       String? // Snapshot display label for "page" favourites (entity rows resolve titles live)
+  icon        String? // Optional icon-name snapshot for "page" favourites
   createdAt   DateTime @default(now())
 
   user      User       @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/__tests__/favoriteTarget.test.ts
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/__tests__/favoriteTarget.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+import { buildProductFavoriteTarget } from "../favoriteTarget";
+
+const common = {
+  workspaceSlug: "clear",
+  productSlug: "acme",
+  productName: "Acme",
+};
+
+describe("buildProductFavoriteTarget", () => {
+  test("overview uses the bare product name and the product icon", () => {
+    expect(
+      buildProductFavoriteTarget({ ...common, pathname: "/w/clear/products/acme" }),
+    ).toEqual({ entityId: "products/acme", label: "Acme", icon: "product" });
+  });
+
+  test.each([
+    ["problems", "Problems", "problems"],
+    ["tickets", "Backlog", "backlog"],
+    ["features", "Features", "features"],
+    ["graph", "Graph", "graph"],
+    ["cycles", "Cycles", "cycles"],
+    ["research", "Insights", "research"],
+    ["retrospectives", "Retro", "retro"],
+    ["settings", "Settings", "settings"],
+  ])("sub-page /%s gets a tab label + icon", (segment, label, icon) => {
+    expect(
+      buildProductFavoriteTarget({
+        ...common,
+        pathname: `/w/clear/products/acme/${segment}`,
+      }),
+    ).toEqual({
+      entityId: `products/acme/${segment}`,
+      label: `Acme · ${label}`,
+      icon,
+    });
+  });
+
+  test("nested detail route resolves to its parent tab label, keeping the full path", () => {
+    expect(
+      buildProductFavoriteTarget({
+        ...common,
+        pathname: "/w/clear/products/acme/tickets/abc123",
+      }),
+    ).toEqual({
+      entityId: "products/acme/tickets/abc123",
+      label: "Acme · Backlog",
+      icon: "backlog",
+    });
+  });
+
+  test("strips the workspace prefix to a workspace-relative entityId", () => {
+    const { entityId } = buildProductFavoriteTarget({
+      ...common,
+      pathname: "/w/clear/products/acme/features",
+    });
+    expect(entityId).toBe("products/acme/features");
+  });
+});

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/favoriteTarget.ts
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/favoriteTarget.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure derivation of a "page" favourite target for any page in the Products
+ * section. Kept free of React so it can be unit-tested in isolation: given the
+ * current pathname + workspace/product slugs + product name, it returns the
+ * workspace-relative path (the favourite's entityId), a snapshot label, and an
+ * icon name the sidebar maps to a glyph.
+ *
+ * Nested detail routes (e.g. a specific ticket) resolve to their parent tab's
+ * label — accurate path, tab-level label — per the products favourites design.
+ */
+
+interface ProductTab {
+  /** First path segment after the product base ("" = overview). */
+  segment: string;
+  /** Label suffix; null for the overview (which uses the bare product name). */
+  label: string | null;
+  /** Icon name persisted on the favourite and mapped by the sidebar. */
+  icon: string;
+}
+
+// Canonical product sub-pages. Includes Settings (which renders outside the
+// shared tab layout) so the helper covers the whole section in one place.
+const PRODUCT_TABS: ProductTab[] = [
+  { segment: "", label: null, icon: "product" },
+  { segment: "problems", label: "Problems", icon: "problems" },
+  { segment: "tickets", label: "Backlog", icon: "backlog" },
+  { segment: "features", label: "Features", icon: "features" },
+  { segment: "graph", label: "Graph", icon: "graph" },
+  { segment: "cycles", label: "Cycles", icon: "cycles" },
+  { segment: "research", label: "Insights", icon: "research" },
+  { segment: "retrospectives", label: "Retro", icon: "retro" },
+  { segment: "settings", label: "Settings", icon: "settings" },
+];
+
+export interface ProductFavoriteTarget {
+  /** Workspace-relative path, e.g. "products/acme/features". */
+  entityId: string;
+  /** Snapshot display label, e.g. "Acme · Features" (or "Acme" for overview). */
+  label: string;
+  /** Icon name, mapped to a glyph by the sidebar. */
+  icon: string;
+}
+
+export function buildProductFavoriteTarget(args: {
+  pathname: string;
+  workspaceSlug: string;
+  productSlug: string;
+  productName: string;
+}): ProductFavoriteTarget {
+  const { pathname, workspaceSlug, productSlug, productName } = args;
+
+  // Workspace-relative path (strip the /w/<slug>/ prefix).
+  const wsPrefix = `/w/${workspaceSlug}/`;
+  const entityId = pathname.startsWith(wsPrefix)
+    ? pathname.slice(wsPrefix.length)
+    : pathname.replace(/^\//, "");
+
+  // First segment after the product base determines the tab.
+  const base = `/w/${workspaceSlug}/products/${productSlug}`;
+  const rest = pathname.startsWith(base)
+    ? pathname.slice(base.length).replace(/^\//, "")
+    : "";
+  const segment = rest.split("/")[0] ?? "";
+
+  const tab =
+    PRODUCT_TABS.find((t) => t.segment === segment) ?? PRODUCT_TABS[0]!;
+  const label = tab.label ? `${productName} · ${tab.label}` : productName;
+
+  return { entityId, label, icon: tab.icon };
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
@@ -24,6 +24,8 @@ import {
 } from "@mantine/core";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
+import { FavoriteButton } from "~/app/_components/shared/FavoriteButton";
+import { buildProductFavoriteTarget } from "./favoriteTarget";
 
 const tabs = [
   { value: "overview", href: "", label: "Overview", icon: IconHome },
@@ -165,6 +167,20 @@ export default function ProductLayout({
             )}
           </div>
           <Group gap="xs">
+            {product && workspaceId && (
+              <FavoriteButton
+                entityType="page"
+                {...buildProductFavoriteTarget({
+                  pathname,
+                  workspaceSlug: workspace.slug,
+                  productSlug,
+                  productName: product.name,
+                })}
+                workspaceId={workspaceId}
+                size="lg"
+                variant="default"
+              />
+            )}
             <ActionIcon
               variant="filled"
               size="lg"

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/settings/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/settings/page.tsx
@@ -30,6 +30,8 @@ import { getTagMantineColor } from "~/utils/tagColors";
 import type { TagColor } from "~/types/tag";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
+import { FavoriteButton } from "~/app/_components/shared/FavoriteButton";
+import { buildProductFavoriteTarget } from "../favoriteTarget";
 import {
   SettingsShell,
   SettingsHero,
@@ -548,7 +550,7 @@ export default function ProductSettingsPage() {
 
   return (
     <SettingsShell>
-      <div className="px-6 md:px-10 pt-6">
+      <div className="px-6 md:px-10 pt-6 flex items-center justify-between">
         <Link
           href={backPath}
           className="inline-flex items-center gap-1.5 text-sm text-text-muted hover:text-text-primary transition-colors"
@@ -556,6 +558,18 @@ export default function ProductSettingsPage() {
           <IconArrowLeft size={16} />
           Back to {product.name}
         </Link>
+        {workspaceId && (
+          <FavoriteButton
+            entityType="page"
+            {...buildProductFavoriteTarget({
+              pathname: `${backPath}/settings`,
+              workspaceSlug: workspace.slug,
+              productSlug,
+              productName: product.name,
+            })}
+            workspaceId={workspaceId}
+          />
+        )}
       </div>
 
       <SettingsHero

--- a/src/app/_components/layout/FavouritesNav.tsx
+++ b/src/app/_components/layout/FavouritesNav.tsx
@@ -1,17 +1,44 @@
 "use client";
 
 import React from "react";
-import { IconTarget, IconTrendingUp } from "@tabler/icons-react";
+import {
+  IconTarget,
+  IconTrendingUp,
+  IconBox,
+  IconTargetArrow,
+  IconLayoutList,
+  IconBulb,
+  IconAffiliate,
+  IconCalendarClock,
+  IconClipboardList,
+  IconSettings,
+  IconFile,
+  type IconProps,
+} from "@tabler/icons-react";
 import { NavLink } from "./NavLinks";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
 
+// Maps a stored page-favourite icon name to a glyph. Names are produced by the
+// products favourite-target helper; unknown names fall back to a generic file.
+const PAGE_ICONS: Record<string, React.ComponentType<IconProps>> = {
+  product: IconBox,
+  problems: IconTargetArrow,
+  backlog: IconLayoutList,
+  features: IconBulb,
+  graph: IconAffiliate,
+  cycles: IconCalendarClock,
+  research: IconBulb,
+  retro: IconClipboardList,
+  settings: IconSettings,
+};
+
 /**
- * "Favourites" sidebar section. Lists the current user's favourited OKR items
- * scoped to the active workspace (per-user dynamic data from a tRPC query, not
- * the plugin manifest). Each row deep-links to the OKRs page and opens that
- * item's drawer via the `?drawer=<type>:<id>` URL state. Renders nothing when
- * there are no favourites for the workspace.
+ * "Favourites" sidebar section. Lists the current user's favourites scoped to
+ * the active workspace (per-user dynamic data from a tRPC query). OKR rows
+ * (objective / keyResult) deep-link to the OKRs page drawer via the
+ * `?drawer=<type>:<id>` URL state; "page" rows link straight to their stored
+ * workspace-relative path. Renders nothing when there are no favourites.
  */
 export function FavouritesNav(): React.JSX.Element | null {
   const { workspaceId, workspaceSlug } = useWorkspace();
@@ -30,15 +57,27 @@ export function FavouritesNav(): React.JSX.Element | null {
       <div className="sb-divider" />
       <div className="sb-section-label">Favourites</div>
       <div className="sb-group sb-group--secondary">
-        {favourites.map((fav) => (
-          <NavLink
-            key={fav.id}
-            href={`/w/${workspaceSlug}/goals?tab=okrs&drawer=${fav.entityType}:${fav.entityId}`}
-            icon={fav.entityType === "objective" ? IconTarget : IconTrendingUp}
-          >
-            {fav.title}
-          </NavLink>
-        ))}
+        {favourites.map((fav) => {
+          const href =
+            fav.entityType === "page"
+              ? `/w/${workspaceSlug}/${fav.entityId}`
+              : `/w/${workspaceSlug}/goals?tab=okrs&drawer=${fav.entityType}:${fav.entityId}`;
+
+          let icon: React.ComponentType<IconProps>;
+          if (fav.entityType === "objective") {
+            icon = IconTarget;
+          } else if (fav.entityType === "keyResult") {
+            icon = IconTrendingUp;
+          } else {
+            icon = (fav.icon ? PAGE_ICONS[fav.icon] : undefined) ?? IconFile;
+          }
+
+          return (
+            <NavLink key={fav.id} href={href} icon={icon}>
+              {fav.title}
+            </NavLink>
+          );
+        })}
       </div>
     </>
   );

--- a/src/app/_components/shared/FavoriteButton.tsx
+++ b/src/app/_components/shared/FavoriteButton.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import React from "react";
+import { ActionIcon, Tooltip } from "@mantine/core";
+import { IconStar, IconStarFilled } from "@tabler/icons-react";
+import { useFavorite, type FavoriteTarget } from "./useFavorite";
+
+interface FavoriteButtonProps extends FavoriteTarget {
+  size?: string | number;
+  variant?: string;
+  iconSize?: number;
+  /** CSS color for the filled (favourited) star. Defaults to the warning gold. */
+  color?: string;
+}
+
+/**
+ * Reusable star toggle for favouriting any entity or page. Drives its state
+ * from `useFavorite`, so dropping it into a header/row is all that's needed to
+ * make that surface favouritable. Pass page details (label/icon/workspaceId)
+ * for "page" favourites; entity favourites only need entityType + entityId.
+ */
+export function FavoriteButton({
+  size = "md",
+  variant = "subtle",
+  iconSize = 16,
+  color = "var(--color-brand-warning)",
+  ...target
+}: FavoriteButtonProps) {
+  const { favorited, toggle } = useFavorite(target);
+  const label = favorited ? "Remove from favourites" : "Add to favourites";
+
+  return (
+    <Tooltip label={label} withArrow>
+      <ActionIcon
+        variant={variant}
+        size={size}
+        aria-label={label}
+        aria-pressed={favorited}
+        onClick={toggle}
+      >
+        {favorited ? (
+          <IconStarFilled size={iconSize} style={{ color }} />
+        ) : (
+          <IconStar size={iconSize} />
+        )}
+      </ActionIcon>
+    </Tooltip>
+  );
+}

--- a/src/app/_components/shared/__tests__/FavoriteButton.test.tsx
+++ b/src/app/_components/shared/__tests__/FavoriteButton.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Component-render tests for FavoriteButton. The hook is mocked so we assert the
+ * button's external behaviour: it reflects favourited vs not-favourited state
+ * (aria-pressed + label) and calls the hook's toggle on click.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import { render, screen, fireEvent } from "~/test/test-utils";
+
+const toggle = vi.fn();
+const favoritedHolder = { current: false };
+
+vi.mock("../useFavorite", () => ({
+  useFavorite: () => ({
+    favorited: favoritedHolder.current,
+    toggle,
+    isPending: false,
+    isLoading: false,
+  }),
+}));
+
+import { FavoriteButton } from "../FavoriteButton";
+
+describe("FavoriteButton", () => {
+  test("renders the add-to-favourites affordance when not favourited", () => {
+    favoritedHolder.current = false;
+    render(<FavoriteButton entityType="page" entityId="products/acme" />);
+    const btn = screen.getByLabelText("Add to favourites");
+    expect(btn.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  test("reflects favourited state", () => {
+    favoritedHolder.current = true;
+    render(<FavoriteButton entityType="page" entityId="products/acme" />);
+    const btn = screen.getByLabelText("Remove from favourites");
+    expect(btn.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  test("calls toggle on click", () => {
+    favoritedHolder.current = false;
+    toggle.mockClear();
+    render(<FavoriteButton entityType="page" entityId="products/acme" />);
+    fireEvent.click(screen.getByLabelText("Add to favourites"));
+    expect(toggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/_components/shared/__tests__/useFavorite.test.ts
+++ b/src/app/_components/shared/__tests__/useFavorite.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for the shared `useFavorite` hook.
+ *
+ * Mocks `~/trpc/react` so we can drive the toggle mutation's lifecycle
+ * callbacks directly (mirrors useActionMutations.test.ts) and assert the
+ * optimistic flip, rollback on error, and dual invalidation (item state +
+ * sidebar list) without a real network or QueryClient.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+type ToggleConfig = {
+  onMutate?: () => Promise<{ prev: unknown } | undefined> | { prev: unknown } | undefined;
+  onError?: (err: unknown, vars: unknown, ctx: { prev?: unknown } | undefined) => void;
+  onSettled?: () => void;
+};
+
+const { utils, lastConfig, mockMutate } = vi.hoisted(() => {
+  const utils = {
+    isFavorite: {
+      cancel: vi.fn(async () => {}),
+      getData: vi.fn(() => ({ favorited: false }) as { favorited: boolean } | undefined),
+      setData: vi.fn(),
+      invalidate: vi.fn(),
+    },
+    list: { invalidate: vi.fn() },
+  };
+  const lastConfig = { current: undefined as ToggleConfig | undefined };
+  const mockMutate = vi.fn();
+  return { utils, lastConfig, mockMutate };
+});
+
+vi.mock("~/trpc/react", () => ({
+  api: {
+    useUtils: () => ({ favorite: utils }),
+    favorite: {
+      isFavorite: {
+        useQuery: () => ({ data: { favorited: false }, isLoading: false }),
+      },
+      toggle: {
+        useMutation: (config: ToggleConfig) => {
+          lastConfig.current = config;
+          return { mutate: mockMutate, isPending: false };
+        },
+      },
+    },
+  },
+}));
+
+import { useFavorite } from "../useFavorite";
+
+beforeEach(() => {
+  utils.isFavorite.cancel.mockClear();
+  utils.isFavorite.getData.mockClear();
+  utils.isFavorite.setData.mockClear();
+  utils.isFavorite.invalidate.mockClear();
+  utils.list.invalidate.mockClear();
+  mockMutate.mockClear();
+  lastConfig.current = undefined;
+});
+
+describe("useFavorite", () => {
+  test("toggle() passes page label/icon/workspaceId through to the mutation", () => {
+    const { result } = renderHook(() =>
+      useFavorite({
+        entityType: "page",
+        entityId: "products/acme/features",
+        label: "Acme · Features",
+        icon: "features",
+        workspaceId: "ws-1",
+      }),
+    );
+
+    result.current.toggle();
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      entityType: "page",
+      entityId: "products/acme/features",
+      label: "Acme · Features",
+      icon: "features",
+      workspaceId: "ws-1",
+    });
+  });
+
+  test("toggle() is a no-op when entityId is empty", () => {
+    const { result } = renderHook(() =>
+      useFavorite({ entityType: "page", entityId: "" }),
+    );
+    result.current.toggle();
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  test("onMutate optimistically flips the cached favourited state", async () => {
+    renderHook(() => useFavorite({ entityType: "objective", entityId: "42" }));
+
+    await lastConfig.current?.onMutate?.();
+
+    expect(utils.isFavorite.cancel).toHaveBeenCalledTimes(1);
+    // setData called with the key + an updater that flips favorited.
+    const updater = utils.isFavorite.setData.mock.calls[0]?.[1] as (
+      old: { favorited: boolean } | undefined,
+    ) => { favorited: boolean };
+    expect(updater({ favorited: false })).toEqual({ favorited: true });
+    expect(updater({ favorited: true })).toEqual({ favorited: false });
+  });
+
+  test("onError restores the previous cached state", () => {
+    renderHook(() => useFavorite({ entityType: "objective", entityId: "42" }));
+
+    const prev = { favorited: true };
+    lastConfig.current?.onError?.(new Error("boom"), undefined, { prev });
+
+    const restoreCall = utils.isFavorite.setData.mock.calls.at(-1);
+    expect(restoreCall?.[1]).toBe(prev);
+  });
+
+  test("onSettled invalidates both the item state and the sidebar list", () => {
+    renderHook(() => useFavorite({ entityType: "objective", entityId: "42" }));
+
+    lastConfig.current?.onSettled?.();
+
+    expect(utils.isFavorite.invalidate).toHaveBeenCalledTimes(1);
+    expect(utils.list.invalidate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/_components/shared/useFavorite.ts
+++ b/src/app/_components/shared/useFavorite.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { api } from "~/trpc/react";
+
+/**
+ * Describes the favourite target. For entity favourites ("objective" /
+ * "keyResult") only `entityType` + `entityId` matter — the server resolves the
+ * workspace and title. For "page" favourites `entityId` is the workspace-
+ * relative path and `label`/`icon`/`workspaceId` are snapshotted on the row.
+ */
+export interface FavoriteTarget {
+  entityType: "objective" | "keyResult" | "page";
+  entityId: string;
+  label?: string | null;
+  icon?: string | null;
+  workspaceId?: string | null;
+  /** Gate the underlying isFavorite query (e.g. only when a drawer is open). */
+  enabled?: boolean;
+}
+
+/**
+ * Reusable favourite toggle. Encapsulates the `isFavorite` read plus the
+ * `toggle` mutation with an optimistic flip, rollback on error, and
+ * invalidation of BOTH the per-item state and the sidebar `list`. Extracted
+ * from the OKR detail drawer so any surface (page headers, drawers, rows) can
+ * add a favourite control with one call.
+ */
+export function useFavorite(target: FavoriteTarget) {
+  const utils = api.useUtils();
+  // The isFavorite query/cache is keyed by (entityType, entityId) only.
+  const key = { entityType: target.entityType, entityId: target.entityId };
+  const enabled = (target.enabled ?? true) && key.entityId.length > 0;
+
+  const query = api.favorite.isFavorite.useQuery(key, { enabled });
+  const favorited = query.data?.favorited ?? false;
+
+  const mutation = api.favorite.toggle.useMutation({
+    // Optimistic flip; reconcile on settle.
+    onMutate: async () => {
+      await utils.favorite.isFavorite.cancel(key);
+      const prev = utils.favorite.isFavorite.getData(key);
+      utils.favorite.isFavorite.setData(key, (old) => ({
+        favorited: !(old?.favorited ?? false),
+      }));
+      return { prev };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.prev) {
+        utils.favorite.isFavorite.setData(key, context.prev);
+      }
+    },
+    onSettled: () => {
+      void utils.favorite.isFavorite.invalidate(key);
+      // Refresh the sidebar Favourites section.
+      void utils.favorite.list.invalidate();
+    },
+  });
+
+  const toggle = () => {
+    if (!key.entityId) return;
+    mutation.mutate({
+      entityType: target.entityType,
+      entityId: target.entityId,
+      label: target.label ?? undefined,
+      icon: target.icon ?? undefined,
+      workspaceId: target.workspaceId ?? undefined,
+    });
+  };
+
+  return {
+    favorited,
+    toggle,
+    isPending: mutation.isPending,
+    isLoading: query.isLoading,
+  };
+}

--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -23,6 +23,7 @@ import {
 } from "@tabler/icons-react";
 import { formatDistanceToNow, format } from "date-fns";
 import { api, type RouterOutputs } from "~/trpc/react";
+import { useFavorite } from "~/app/_components/shared/useFavorite";
 import {
   clamp01,
   effectiveConfidence,
@@ -1493,41 +1494,14 @@ export function OkrDetailDrawer({
   const isSettingStatus =
     setObjectiveOverride.isPending || setKrOverride.isPending;
 
-  // Favourite state for the Star CTA. entityId is stringified so objectives
-  // (numeric id) and key results (cuid) share one polymorphic key.
-  const favoriteKey = {
+  // Favourite state for the Star CTA, via the shared hook. entityId is
+  // stringified so objectives (numeric id) and key results (cuid) share one
+  // polymorphic key. The hook owns the optimistic flip + sidebar invalidation.
+  const { favorited, toggle: handleToggleFavorite } = useFavorite({
     entityType: type,
     entityId: String(itemId ?? ""),
-  };
-  const favoriteQuery = api.favorite.isFavorite.useQuery(favoriteKey, {
     enabled: opened && itemId != null,
   });
-  const favorited = favoriteQuery.data?.favorited ?? false;
-  const toggleFavorite = api.favorite.toggle.useMutation({
-    // Optimistic flip; reconcile on settle.
-    onMutate: async () => {
-      await utils.favorite.isFavorite.cancel(favoriteKey);
-      const prev = utils.favorite.isFavorite.getData(favoriteKey);
-      utils.favorite.isFavorite.setData(favoriteKey, (old) => ({
-        favorited: !(old?.favorited ?? false),
-      }));
-      return { prev };
-    },
-    onError: (_err, _vars, context) => {
-      if (context?.prev) {
-        utils.favorite.isFavorite.setData(favoriteKey, context.prev);
-      }
-    },
-    onSettled: () => {
-      void utils.favorite.isFavorite.invalidate(favoriteKey);
-      // Refresh the sidebar Favourites section (warm.wren).
-      void utils.favorite.list.invalidate();
-    },
-  });
-  const handleToggleFavorite = () => {
-    if (itemId == null) return;
-    toggleFavorite.mutate({ entityType: type, entityId: String(itemId) });
-  };
 
   const isObjective = type === "objective";
   const data = isObjective ? objectiveQuery.data : krQuery.data;

--- a/src/server/api/routers/__tests__/favorite.test.ts
+++ b/src/server/api/routers/__tests__/favorite.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for the `favorite` router.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety"). Covers the new "page" favourite kind:
+ * the workspace-membership gate (via the centralized `getWorkspaceMembership`
+ * resolver), idempotent toggle on/off, and `list` returning the snapshot label
+ * for page rows vs the live-resolved title for entity rows (stale rows skipped).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const WORKSPACE_ID = "ws-1";
+const USER_ID = "user-1";
+const PAGE_PATH = "products/acme/features";
+
+function mockMember(
+  dbMock: DeepMockProxy<PrismaClient>,
+  isMember: boolean,
+) {
+  // getWorkspaceMembership → direct WorkspaceUser lookup, then team fallback
+  dbMock.workspaceUser.findUnique.mockResolvedValue(
+    isMember ? ({ role: "member", workspaceId: WORKSPACE_ID } as never) : null,
+  );
+  dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+}
+
+describe("favorite router (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  describe("toggle — page favourites", () => {
+    it("creates a page favourite for a workspace member, snapshotting label/icon", async () => {
+      mockMember(dbMock, true);
+      dbMock.favorite.findUnique.mockResolvedValue(null as never); // not yet favourited
+      dbMock.favorite.create.mockResolvedValue({ id: "fav-1" } as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.favorite.toggle({
+          entityType: "page",
+          entityId: PAGE_PATH,
+          label: "Acme · Features",
+          icon: "features",
+          workspaceId: WORKSPACE_ID,
+        }),
+      ).resolves.toEqual({ favorited: true });
+
+      expect(dbMock.favorite.create).toHaveBeenCalledWith({
+        data: {
+          userId: USER_ID,
+          entityType: "page",
+          entityId: PAGE_PATH,
+          workspaceId: WORKSPACE_ID,
+          label: "Acme · Features",
+          icon: "features",
+        },
+      });
+    });
+
+    it("removes an existing page favourite (idempotent toggle off)", async () => {
+      mockMember(dbMock, true);
+      dbMock.favorite.findUnique.mockResolvedValue({ id: "fav-1" } as never);
+      dbMock.favorite.delete.mockResolvedValue({ id: "fav-1" } as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.favorite.toggle({
+          entityType: "page",
+          entityId: PAGE_PATH,
+          workspaceId: WORKSPACE_ID,
+        }),
+      ).resolves.toEqual({ favorited: false });
+
+      expect(dbMock.favorite.delete).toHaveBeenCalledWith({ where: { id: "fav-1" } });
+      expect(dbMock.favorite.create).not.toHaveBeenCalled();
+    });
+
+    it("forbids a non-member from favouriting a page", async () => {
+      mockMember(dbMock, false);
+      dbMock.favorite.findUnique.mockResolvedValue(null as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.favorite.toggle({
+          entityType: "page",
+          entityId: PAGE_PATH,
+          label: "Acme · Features",
+          workspaceId: WORKSPACE_ID,
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" } satisfies Partial<TRPCError>);
+
+      expect(dbMock.favorite.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects a page favourite missing a workspaceId", async () => {
+      dbMock.favorite.findUnique.mockResolvedValue(null as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.favorite.toggle({
+          entityType: "page",
+          entityId: PAGE_PATH,
+          label: "Acme · Features",
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" } satisfies Partial<TRPCError>);
+
+      expect(dbMock.favorite.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("list", () => {
+    it("uses the snapshot label/icon for page rows and the live title for entity rows, skipping stale entity rows", async () => {
+      dbMock.favorite.findMany.mockResolvedValue([
+        {
+          id: "fav-page",
+          entityType: "page",
+          entityId: PAGE_PATH,
+          label: "Acme · Features",
+          icon: "features",
+          workspaceId: WORKSPACE_ID,
+        },
+        {
+          id: "fav-obj",
+          entityType: "objective",
+          entityId: "42",
+          label: null,
+          icon: null,
+          workspaceId: WORKSPACE_ID,
+        },
+        {
+          id: "fav-stale",
+          entityType: "objective",
+          entityId: "999",
+          label: null,
+          icon: null,
+          workspaceId: WORKSPACE_ID,
+        },
+      ] as never);
+      // Only goal 42 still exists; 999 is stale and must be skipped.
+      dbMock.goal.findMany.mockResolvedValue([
+        { id: 42, title: "Grow revenue" },
+      ] as never);
+      dbMock.keyResult.findMany.mockResolvedValue([] as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      const items = await caller.favorite.list({ workspaceId: WORKSPACE_ID });
+
+      expect(items).toEqual([
+        {
+          id: "fav-page",
+          entityType: "page",
+          entityId: PAGE_PATH,
+          title: "Acme · Features",
+          icon: "features",
+          workspaceId: WORKSPACE_ID,
+        },
+        {
+          id: "fav-obj",
+          entityType: "objective",
+          entityId: "42",
+          title: "Grow revenue",
+          icon: null,
+          workspaceId: WORKSPACE_ID,
+        },
+      ]);
+    });
+  });
+
+  describe("isFavorite", () => {
+    it("reports whether a page path is favourited", async () => {
+      dbMock.favorite.findUnique.mockResolvedValue({ id: "fav-1" } as never);
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.favorite.isFavorite({ entityType: "page", entityId: PAGE_PATH }),
+      ).resolves.toEqual({ favorited: true });
+    });
+
+    it("reports not-favourited when absent", async () => {
+      dbMock.favorite.findUnique.mockResolvedValue(null as never);
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.favorite.isFavorite({ entityType: "page", entityId: PAGE_PATH }),
+      ).resolves.toEqual({ favorited: false });
+    });
+  });
+});

--- a/src/server/api/routers/favorite.ts
+++ b/src/server/api/routers/favorite.ts
@@ -3,10 +3,13 @@ import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import type { Context } from "~/server/auth/types";
 import { verifyGoalAccess } from "~/server/services/goalService";
+import { getWorkspaceMembership } from "~/server/services/access";
 
-// Polymorphic favourites. v1 wires "objective" and "keyResult"; the model is
-// deliberately extensible to projects/meetings later.
-const entityTypeEnum = z.enum(["objective", "keyResult"]);
+// Polymorphic favourites. Wires "objective" and "keyResult" (entity favourites,
+// titles resolved live) plus "page" — a generic bookmark of any workspace page
+// whose `entityId` is the workspace-relative path and whose label/icon are
+// snapshotted at favourite time. The model stays deliberately extensible.
+const entityTypeEnum = z.enum(["objective", "keyResult", "page"]);
 type EntityType = z.infer<typeof entityTypeEnum>;
 
 /**
@@ -14,10 +17,13 @@ type EntityType = z.infer<typeof entityTypeEnum>;
  * workspaceId (captured on the Favorite row for workspace-scoped surfaces).
  * Objectives use goal access (owner / DRI / workspace member); key results use
  * ownership, matching how the KR drawer already gates reads.
+ *
+ * NB: "page" favourites are NOT handled here — they carry their own workspaceId
+ * input and are gated by workspace membership in `toggle`.
  */
 async function resolveEntityWorkspace(
   ctx: Context,
-  entityType: EntityType,
+  entityType: Exclude<EntityType, "page">,
   entityId: string,
 ): Promise<string | null> {
   if (entityType === "objective") {
@@ -44,13 +50,15 @@ interface FavoriteListItem {
   entityType: EntityType;
   entityId: string;
   title: string;
+  icon: string | null;
   workspaceId: string | null;
 }
 
 export const favoriteRouter = createTRPCRouter({
   // The current user's favourites, optionally scoped to a workspace (the
-  // sidebar passes the active workspace). Titles are resolved per entity type;
-  // favourites whose target no longer exists are skipped (stale rows).
+  // sidebar passes the active workspace). Entity titles are resolved per type;
+  // page titles come from the snapshot label. Favourites whose target no longer
+  // exists are skipped (stale rows) — pages, being plain paths, never go stale.
   list: protectedProcedure
     .input(z.object({ workspaceId: z.string().nullish() }).optional())
     .query(async ({ ctx, input }): Promise<FavoriteListItem[]> => {
@@ -92,23 +100,29 @@ export const favoriteRouter = createTRPCRouter({
       const items: FavoriteListItem[] = [];
       for (const f of favorites) {
         const entityType = f.entityType as EntityType;
-        const title =
-          entityType === "objective"
-            ? goalTitle.get(f.entityId)
-            : krTitle.get(f.entityId);
-        if (!title) continue; // target deleted — skip stale favourite
+        let title: string | undefined;
+        if (entityType === "objective") {
+          title = goalTitle.get(f.entityId);
+        } else if (entityType === "keyResult") {
+          title = krTitle.get(f.entityId);
+        } else {
+          // page — snapshot label, falling back to the path if somehow unset
+          title = f.label ?? f.entityId;
+        }
+        if (!title) continue; // entity target deleted — skip stale favourite
         items.push({
           id: f.id,
           entityType,
           entityId: f.entityId,
           title,
+          icon: f.icon,
           workspaceId: f.workspaceId,
         });
       }
       return items;
     }),
 
-  // Whether the current user has favourited a given entity.
+  // Whether the current user has favourited a given entity (or page path).
   isFavorite: protectedProcedure
     .input(z.object({ entityType: entityTypeEnum, entityId: z.string() }))
     .query(async ({ ctx, input }) => {
@@ -125,10 +139,20 @@ export const favoriteRouter = createTRPCRouter({
       return { favorited: fav !== null };
     }),
 
-  // Toggle a favourite for the current user + entity. Captures the entity's
-  // workspaceId on create so the sidebar can scope by workspace.
+  // Toggle a favourite for the current user + entity/page. For entity types the
+  // workspaceId is resolved (and access gated) from the entity. For "page" the
+  // caller supplies workspaceId + label (+ optional icon); access is gated by
+  // workspace membership and the label/icon are snapshotted onto the row.
   toggle: protectedProcedure
-    .input(z.object({ entityType: entityTypeEnum, entityId: z.string() }))
+    .input(
+      z.object({
+        entityType: entityTypeEnum,
+        entityId: z.string(),
+        label: z.string().nullish(),
+        icon: z.string().nullish(),
+        workspaceId: z.string().nullish(),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
       const existing = await ctx.db.favorite.findUnique({
@@ -145,6 +169,37 @@ export const favoriteRouter = createTRPCRouter({
       if (existing) {
         await ctx.db.favorite.delete({ where: { id: existing.id } });
         return { favorited: false };
+      }
+
+      if (input.entityType === "page") {
+        if (!input.workspaceId) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "workspaceId is required for page favourites",
+          });
+        }
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          userId,
+          input.workspaceId,
+        );
+        if (!membership) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Not a member of this workspace",
+          });
+        }
+        await ctx.db.favorite.create({
+          data: {
+            userId,
+            entityType: input.entityType,
+            entityId: input.entityId,
+            workspaceId: input.workspaceId,
+            label: input.label ?? null,
+            icon: input.icon ?? null,
+          },
+        });
+        return { favorited: true };
       }
 
       const workspaceId = await resolveEntityWorkspace(


### PR DESCRIPTION
## Summary

Extends the existing polymorphic favourites feature so that **any page** can be favourited, and lights it up across the entire **Products** section. A star button in the shared product header (and on the standalone Settings page) bookmarks the current page; it appears immediately in the left-nav "Favourites" section, scoped to the active workspace, and links straight back.

Reuses the existing `Favorite` model, `favorite` tRPC router, and `FavouritesNav` sidebar rather than building a parallel system. The new `"page"` favourite kind stores a workspace-relative path + a snapshot label, so the same primitive now works for product pages and any other page later.

PRD: feature `cmqlegs8g0001la04i6oayvg5`. Tickets: `mint.peak` (backend), `windy.mist` (hook/button), `bright.shark` (products + nav).

## What changed

**Backend (`mint.peak`)**
- `Favorite` gains nullable `label` + `icon` columns (migration `20260619210000_add_favorite_label_icon`).
- `favorite` router: new `"page"` entity type. `toggle` accepts `label`/`icon`/`workspaceId`; for pages it gates on workspace membership (`getWorkspaceMembership`) and snapshots label/icon. `list` returns label/icon (page rows use the snapshot label; entity rows still resolve titles live and skip stale rows). The existing `@@unique([userId, entityType, entityId])` makes re-favouriting a path idempotent.

**Reusable primitives (`windy.mist`)**
- `useFavorite` hook — extracts the optimistic toggle + rollback + dual invalidation that was inlined in the OKR drawer.
- `FavoriteButton` — a star `ActionIcon` built on the hook; drop it into any header/row.
- OKR detail drawer refactored to use the hook (no behaviour change).

**Products + sidebar (`bright.shark`)**
- `buildProductFavoriteTarget` — pure helper turning the pathname into a workspace-relative path + label (product name, or product + tab) + icon name.
- `FavoriteButton` wired into the shared product header (covers overview + all 8 sub-pages + nested routes) and the standalone Settings header.
- `FavouritesNav` switches href + icon by entity type: OKR rows keep deep-linking to the drawer; page rows link to `/w/<slug>/<path>`.

## Tests

- `favorite` router (mocked Prisma): page toggle on/off, non-member rejection, missing-workspaceId rejection, `list` label/icon resolution + stale skip, `isFavorite`.
- `useFavorite`: arg pass-through, no-op on empty id, optimistic flip, rollback, dual invalidation.
- `FavoriteButton`: state render + click.
- `buildProductFavoriteTarget`: overview, every sub-page, nested detail route, prefix stripping.

All new tests pass; lint + typecheck clean on changed files.

> Note: one pre-existing unrelated test (`weeklyNarrativeService.test.ts`) fails because it hard-codes "today = Wednesday"; it fails on any other weekday and is independent of this change.

## ⚠️ Migration required

This adds a Prisma migration (`20260619210000_add_favorite_label_icon`). Per repo rules I did **not** run it. Apply it manually:

```
npx prisma migrate dev
```

## Out of scope

Other sections (Projects/CRM); per-record labels for nested detail pages (v1 uses the tab label); reorder/pin; live re-resolution of a page label after a product rename (snapshot refreshes on re-favourite).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pages can now be favorited alongside objectives and key results.
  * Favorited pages display custom labels and icons in the sidebar.
  * Favorite buttons added to product pages for quick access.
  * Favorites sidebar now links directly to favorited pages with accurate icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->