### PR TITLE
feat(tickets): inline title/body editor with rich text and image upload

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,13 @@ import "./src/env.js";
 const config = {
   eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: true },
+  experimental: {
+    turbo: {
+      resolveAlias: {
+        "markdown-it": "markdown-it/dist/index.cjs.js",
+      },
+    },
+  },
 
   async headers() {
     return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.104.1",
+        "@anthropic-ai/sdk": "^0.104.2",
         "@auth/prisma-adapter": "^2.7.2",
         "@aws-sdk/client-s3": "^3.1045.0",
         "@aws-sdk/s3-request-presigner": "^3.1045.0",
@@ -330,10 +330,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.104.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.1.tgz",
-      "integrity": "sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q==",
-      "license": "MIT",
+      "version": "0.104.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.2.tgz",
+      "integrity": "sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
         "standardwebhooks": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "okr:workspaces": "npx tsx scripts/okr-cli.ts workspaces"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.104.1",
+    "@anthropic-ai/sdk": "^0.104.2",
     "@auth/prisma-adapter": "^2.7.2",
     "@aws-sdk/client-s3": "^3.1045.0",
     "@aws-sdk/s3-request-presigner": "^3.1045.0",

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
@@ -515,7 +515,7 @@ function LinkedActionsSection({
 
       {/* Edit action modal - opened when clicking a row */}
       <EditActionModal
-        action={editingAction}
+        action={editingAction as unknown as Parameters<typeof EditActionModal>[0]["action"]}
         opened={editingAction !== null}
         onClose={() => setEditingAction(null)}
         onSuccess={() => { setEditingAction(null); onChanged(); }}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
@@ -215,7 +215,7 @@ function EpicCombobox({
 // Linked Actions Section
 // ---------------------------------------------------------------------------
 
-type LinkedAction = {
+interface LinkedAction {
   id: string;
   name: string;
   description: string | null;
@@ -226,7 +226,7 @@ type LinkedAction = {
   projectId: string | null;
   workspaceId?: string | null;
   assignees: Array<{ user: { id: string; name: string | null; image: string | null } }>;
-};
+}
 
 function getActionPriorityBorderColor(priority: string | null): string {
   switch (priority) {

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
@@ -3,12 +3,16 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
+import { useDisclosure } from "@mantine/hooks";
+import { CreateActionModal } from "~/app/_components/CreateActionModal";
+import { EditActionModal } from "~/app/_components/EditActionModal";
 import {
   ActionIcon,
   Anchor,
   Avatar,
   Badge,
   Button,
+  Checkbox,
   CheckIcon,
   Combobox,
   Group,
@@ -28,6 +32,8 @@ import {
   IconBug,
   IconCalendar,
   IconCategory,
+  IconChevronDown,
+  IconChevronRight,
   IconCircleDot,
   IconClock,
   IconCopy,
@@ -37,11 +43,13 @@ import {
   IconFolder,
   IconGitBranch,
   IconLink,
+  IconPlus,
   IconRocket,
   IconTag,
   IconTool,
   IconTrash,
   IconUser,
+  IconX,
 } from "@tabler/icons-react";
 import { api } from "~/trpc/react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
@@ -61,6 +69,7 @@ import {
 } from "~/lib/ticket-statuses";
 import { TagBadge } from "~/app/_components/TagBadge";
 import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
+import { TicketBodyEditor } from "~/app/_components/product/TicketBodyEditor";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -203,6 +212,319 @@ function EpicCombobox({
 }
 
 // ---------------------------------------------------------------------------
+// Linked Actions Section
+// ---------------------------------------------------------------------------
+
+type LinkedAction = {
+  id: string;
+  name: string;
+  description: string | null;
+  status: string;
+  kanbanStatus: string | null;
+  priority: string | null;
+  dueDate: Date | string | null;
+  projectId: string | null;
+  workspaceId?: string | null;
+  assignees: Array<{ user: { id: string; name: string | null; image: string | null } }>;
+};
+
+function getActionPriorityBorderColor(priority: string | null): string {
+  switch (priority) {
+    case "1st Priority": return "var(--mantine-color-red-filled)";
+    case "2nd Priority": return "var(--mantine-color-orange-filled)";
+    case "3rd Priority": return "var(--mantine-color-yellow-filled)";
+    case "4th Priority": return "var(--mantine-color-green-filled)";
+    case "5th Priority": return "var(--mantine-color-blue-filled)";
+    case "Quick": return "var(--mantine-color-violet-filled)";
+    case "Scheduled": return "var(--mantine-color-pink-filled)";
+    case "Errand": return "var(--mantine-color-cyan-filled)";
+    case "Remember": return "var(--mantine-color-indigo-filled)";
+    case "Watch": return "var(--mantine-color-grape-filled)";
+    default: return "var(--color-border-primary)";
+  }
+}
+
+function ActionRow({
+  action,
+  isDone,
+  onToggle,
+  onUnlink,
+  onOpen,
+  unlinkPending,
+}: {
+  action: LinkedAction;
+  isDone: boolean;
+  onToggle: (action: LinkedAction, checked: boolean) => void;
+  onUnlink: (id: string) => void;
+  onOpen: (action: LinkedAction) => void;
+  unlinkPending: boolean;
+}) {
+  return (
+    <div
+      className="border border-border-primary rounded-lg px-3 py-2 flex items-center gap-2 group cursor-pointer hover:bg-surface-hover transition-colors"
+      onClick={() => onOpen(action)}
+    >
+      {/* Circular checkbox */}
+      <div
+        className="shrink-0"
+        onClick={(e) => { e.stopPropagation(); onToggle(action, !isDone); }}
+      >
+        <Checkbox
+          size="xs"
+          radius="xl"
+          checked={isDone}
+          readOnly
+          styles={{
+            input: {
+              borderColor: isDone ? "var(--mantine-color-green-filled)" : getActionPriorityBorderColor(action.priority),
+              backgroundColor: isDone ? "var(--mantine-color-green-filled)" : "transparent",
+              cursor: "pointer",
+            },
+          }}
+        />
+      </div>
+
+      {/* Name */}
+      <Text
+        size="sm"
+        className={`flex-1 min-w-0 truncate ${isDone ? "line-through opacity-30" : "text-text-primary"}`}
+      >
+        {action.name}
+      </Text>
+
+      {/* Assignees */}
+      {action.assignees.length > 0 && (
+        <Avatar.Group spacing="xs">
+          {action.assignees.slice(0, 2).map((a) => (
+            <Avatar key={a.user.id} src={a.user.image} size={18} radius="xl" title={a.user.name ?? ""}>
+              {(a.user.name ?? "?")[0]?.toUpperCase()}
+            </Avatar>
+          ))}
+        </Avatar.Group>
+      )}
+
+      {/* Due date */}
+      {action.dueDate && (
+        <Text size="xs" className="text-text-muted shrink-0">
+          {new Date(action.dueDate).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+        </Text>
+      )}
+
+      {/* Unlink */}
+      <ActionIcon
+        variant="subtle"
+        size="xs"
+        className="opacity-0 group-hover:opacity-100 text-text-muted hover:text-red-400 transition-opacity shrink-0"
+        onClick={(e) => { e.stopPropagation(); onUnlink(action.id); }}
+        loading={unlinkPending}
+      >
+        <IconX size={12} />
+      </ActionIcon>
+    </div>
+  );
+}
+
+function LinkedActionsSection({
+  ticketId,
+  actions,
+  workspaceId,
+  onChanged,
+}: {
+  ticketId: string;
+  actions: LinkedAction[];
+  workspaceId: string | null;
+  onChanged: () => void;
+}) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [search, setSearch] = useState("");
+  const [pendingName, setPendingName] = useState("");
+  const [createModalOpen, { open: openCreateModal, close: closeCreateModal }] = useDisclosure(false);
+  const [editingAction, setEditingAction] = useState<LinkedAction | null>(null);
+  const combobox = useCombobox({
+    onDropdownClose: () => { combobox.resetSelectedOption(); },
+  });
+
+  const { data: searchResults } = api.action.searchForDependencies.useQuery(
+    { query: search, workspaceId: workspaceId ?? undefined, limit: 8 },
+    { enabled: search.trim().length > 0 },
+  );
+
+  const linkAction = api.product.ticket.linkAction.useMutation({
+    onSuccess: () => { setSearch(""); onChanged(); },
+  });
+  const unlinkAction = api.product.ticket.unlinkAction.useMutation({ onSuccess: onChanged });
+  const updateActionStatus = api.action.update.useMutation({ onSuccess: onChanged });
+
+  const linkedIds = new Set(actions.map((a) => a.id));
+  const suggestions = (searchResults ?? []).filter((r) => !linkedIds.has(r.id));
+  const trimmed = search.trim();
+  const hasExactMatch = suggestions.some(
+    (r) => r.name.toLowerCase() === trimmed.toLowerCase(),
+  );
+
+  const isDone = (a: LinkedAction) =>
+    a.kanbanStatus === "DONE" || a.status === "COMPLETED";
+
+  const activeActions = actions.filter((a) => !isDone(a));
+  const doneActions = actions.filter((a) => isDone(a));
+
+  const handleToggle = (action: LinkedAction, checked: boolean) => {
+    updateActionStatus.mutate({
+      id: action.id,
+      status: checked ? "COMPLETED" : "ACTIVE",
+      kanbanStatus: checked ? "DONE" : "TODO",
+    });
+  };
+
+  const handleSelect = (value: string) => {
+    if (value === "__create") {
+      setPendingName(trimmed);
+      setSearch("");
+      combobox.closeDropdown();
+      openCreateModal();
+    } else {
+      linkAction.mutate({ ticketId, actionId: value });
+      setSearch("");
+      combobox.closeDropdown();
+    }
+  };
+
+  return (
+    <div className="mt-4">
+      {/* Header - matches Activity style */}
+      <button
+        className="flex items-center gap-1.5 mb-3"
+        onClick={() => setCollapsed((v) => !v)}
+      >
+        {collapsed
+          ? <IconChevronRight size={13} className="text-text-muted" />
+          : <IconChevronDown size={13} className="text-text-muted" />}
+        <Text size="xs" fw={600} className="text-text-muted uppercase tracking-wider">
+          Actions{actions.length > 0 ? ` (${actions.length})` : ""}
+        </Text>
+      </button>
+
+      {!collapsed && (
+        <div>
+          {/* Active action rows */}
+          {activeActions.length > 0 && (
+            <Stack gap="xs" mb="xs">
+              {activeActions.map((action) => (
+                <ActionRow
+                  key={action.id}
+                  action={action}
+                  isDone={false}
+                  onToggle={handleToggle}
+                  onOpen={setEditingAction}
+                  onUnlink={(id) => unlinkAction.mutate({ actionId: id })}
+                  unlinkPending={unlinkAction.isPending}
+                />
+              ))}
+            </Stack>
+          )}
+
+          {/* Completed actions */}
+          {doneActions.length > 0 && (
+            <div className="mt-2 mb-2">
+              <Text size="xs" className="text-text-muted opacity-50 mb-1.5 pl-1" style={{ fontSize: "0.65rem", letterSpacing: "0.04em" }}>
+                Completed
+              </Text>
+              <Stack gap="xs">
+                {doneActions.map((action) => (
+                  <ActionRow
+                    key={action.id}
+                    action={action}
+                    isDone={true}
+                    onToggle={handleToggle}
+                    onOpen={setEditingAction}
+                    onUnlink={(id) => unlinkAction.mutate({ actionId: id })}
+                    unlinkPending={unlinkAction.isPending}
+                  />
+                ))}
+              </Stack>
+            </div>
+          )}
+
+          {/* Notion-style combobox - always visible */}
+          <Combobox store={combobox} onOptionSubmit={handleSelect}>
+            <Combobox.Target>
+              <TextInput
+                placeholder="Link or create an action..."
+                value={search}
+                onChange={(e) => {
+                  setSearch(e.currentTarget.value);
+                  combobox.openDropdown();
+                  combobox.updateSelectedOptionIndex();
+                }}
+                onFocus={() => { if (search.trim()) combobox.openDropdown(); }}
+                onBlur={() => combobox.closeDropdown()}
+                size="xs"
+                leftSection={<IconPlus size={13} className="text-text-muted" />}
+                styles={{
+                  input: {
+                    backgroundColor: "transparent",
+                    border: "1px solid var(--color-border-primary)",
+                    fontSize: "0.8rem",
+                    color: "var(--color-text-secondary)",
+                  },
+                }}
+              />
+            </Combobox.Target>
+
+            {(suggestions.length > 0 || (trimmed && !hasExactMatch)) && (
+              <Combobox.Dropdown>
+                <Combobox.Options>
+                  {suggestions.map((r) => (
+                    <Combobox.Option key={r.id} value={r.id}>
+                      <div className="flex items-center gap-2">
+                        <div
+                          className={`w-1.5 h-1.5 rounded-full shrink-0 ${r.kanbanStatus === "DONE" ? "bg-green-500" : "bg-border-primary"}`}
+                        />
+                        <Text size="xs" className="flex-1">{r.name}</Text>
+                        {r.project && (
+                          <Text size="xs" className="text-text-muted">{r.project.name}</Text>
+                        )}
+                      </div>
+                    </Combobox.Option>
+                  ))}
+                  {trimmed && !hasExactMatch && (
+                    <Combobox.Option value="__create">
+                      <div className="flex items-center gap-2">
+                        <IconPlus size={12} className="text-text-muted" />
+                        <Text size="xs">
+                          Create <span className="font-medium">&quot;{trimmed}&quot;</span>
+                        </Text>
+                      </div>
+                    </Combobox.Option>
+                  )}
+                </Combobox.Options>
+              </Combobox.Dropdown>
+            )}
+          </Combobox>
+
+          {/* Create action modal - opened when user picks "Create xyz" */}
+          <CreateActionModal
+            viewName="ticket"
+            initialName={pendingName}
+            externalOpened={createModalOpen}
+            onExternalClose={closeCreateModal}
+            onActionCreated={(actionId) => { linkAction.mutate({ ticketId, actionId }); setPendingName(""); }}
+          />
+        </div>
+      )}
+
+      {/* Edit action modal - opened when clicking a row */}
+      <EditActionModal
+        action={editingAction}
+        opened={editingAction !== null}
+        onClose={() => setEditingAction(null)}
+        onSuccess={() => { setEditingAction(null); onChanged(); }}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
@@ -259,9 +581,14 @@ export default function TicketDetailPage() {
 
   const [comment, setComment] = useState("");
   const [status, setStatus] = useState<TicketStatus | null>(null);
+  const [titleValue, setTitleValue] = useState(ticket?.title ?? "");
+  const [activityCollapsed, setActivityCollapsed] = useState(false);
 
   useEffect(() => {
-    if (ticket) setStatus(ticket.status);
+    if (ticket) {
+      setStatus(ticket.status);
+      setTitleValue(ticket.title);
+    }
   }, [ticket]);
 
   const updateTicket = api.product.ticket.update.useMutation({
@@ -374,13 +701,28 @@ export default function TicketDetailPage() {
             </Group>
 
             <Group justify="space-between" align="flex-start">
-              <Text
-                size="xl"
-                fw={700}
-                className="text-text-primary flex-1"
-              >
-                {ticket.title}
-              </Text>
+              <Textarea
+                value={titleValue}
+                onChange={(e) => setTitleValue(e.currentTarget.value)}
+                autosize
+                minRows={1}
+                maxRows={3}
+                variant="unstyled"
+                classNames={{ input: "text-text-primary font-bold text-xl p-0 leading-tight resize-none" }}
+                styles={{ root: { flex: 1 }, input: { fontWeight: 700, fontSize: "1.25rem" } }}
+                onBlur={() => {
+                  const trimmed = titleValue.trim();
+                  if (trimmed && trimmed !== ticket.title) {
+                    handleFieldUpdate("title", trimmed);
+                  }
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    e.currentTarget.blur();
+                  }
+                }}
+              />
               <Menu position="bottom-end" withinPortal>
                 <Menu.Target>
                   <ActionIcon variant="subtle" className="text-text-muted">
@@ -430,43 +772,34 @@ export default function TicketDetailPage() {
           )}
 
           {/* Body */}
-          {ticket.body ? (
-            <MarkdownRenderer content={ticket.body} />
-          ) : (
-            <Text size="sm" className="text-text-muted">
-              No description provided.
-            </Text>
-          )}
+          <TicketBodyEditor
+            ticketId={ticketId}
+            initialContent={ticket.body ?? null}
+          />
 
-          {/* Sub-actions linked to this ticket */}
-          {ticket.actions && ticket.actions.length > 0 && (
-            <div>
-              <Text size="xs" fw={600} className="text-text-muted uppercase tracking-wider mb-2">
-                Sub-tasks
-              </Text>
-              <div className="rounded-lg border border-border-primary overflow-hidden">
-                {ticket.actions.map((action: { id: string; name: string; status: string; kanbanStatus: string | null }, i: number) => (
-                  <div
-                    key={action.id}
-                    className={`flex items-center gap-3 px-3 py-2 ${i < ticket.actions.length - 1 ? "border-b border-border-primary" : ""}`}
-                  >
-                    <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${action.kanbanStatus === "DONE" || action.status === "completed" ? "bg-green-500" : "bg-border-primary"}`} />
-                    <Text size="sm" className={`text-text-primary ${action.kanbanStatus === "DONE" || action.status === "completed" ? "line-through opacity-60" : ""}`}>
-                      {action.name}
-                    </Text>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
+          {/* Linked Actions */}
+          <LinkedActionsSection
+            ticketId={ticketId}
+            actions={ticket.actions ?? []}
+            workspaceId={workspaceId}
+            onChanged={async () => { await utils.product.ticket.getById.invalidate({ id: ticketId }); }}
+          />
 
           {/* Activity / Comments */}
           <div className="mt-4">
-            <Text size="xs" fw={600} className="text-text-muted uppercase tracking-wider mb-3">
-              Activity
-            </Text>
+            <button
+              className="flex items-center gap-1.5 mb-3"
+              onClick={() => setActivityCollapsed((v) => !v)}
+            >
+              {activityCollapsed
+                ? <IconChevronRight size={13} className="text-text-muted" />
+                : <IconChevronDown size={13} className="text-text-muted" />}
+              <Text size="xs" fw={600} className="text-text-muted uppercase tracking-wider">
+                Activity
+              </Text>
+            </button>
 
-            {ticket.comments.length > 0 && (
+            {!activityCollapsed && ticket.comments.length > 0 && (
               <Stack gap="sm" mb="md">
                 {ticket.comments.map((c) => (
                   <div key={c.id} className="border border-border-primary rounded-lg p-3">
@@ -496,33 +829,35 @@ export default function TicketDetailPage() {
               </Stack>
             )}
 
-            <div className="flex gap-3">
-              <Textarea
-                placeholder="Leave a comment..."
-                value={comment}
-                onChange={(e) => setComment(e.currentTarget.value)}
-                autosize
-                minRows={1}
-                maxRows={4}
-                className="flex-1"
-                styles={{
-                  input: {
-                    backgroundColor: "transparent",
-                    border: "1px solid var(--color-border-primary)",
-                    fontSize: "0.85rem",
-                  },
-                }}
-              />
-              <Button
-                size="xs"
-                onClick={() => addComment.mutate({ ticketId, content: comment })}
-                loading={addComment.isPending}
-                disabled={!comment.trim()}
-                className="self-end"
-              >
-                Post
-              </Button>
-            </div>
+            {!activityCollapsed && (
+              <div className="flex gap-3">
+                <Textarea
+                  placeholder="Leave a comment..."
+                  value={comment}
+                  onChange={(e) => setComment(e.currentTarget.value)}
+                  autosize
+                  minRows={1}
+                  maxRows={4}
+                  className="flex-1"
+                  styles={{
+                    input: {
+                      backgroundColor: "transparent",
+                      border: "1px solid var(--color-border-primary)",
+                      fontSize: "0.85rem",
+                    },
+                  }}
+                />
+                <Button
+                  size="xs"
+                  onClick={() => addComment.mutate({ ticketId, content: comment })}
+                  loading={addComment.isPending}
+                  disabled={!comment.trim()}
+                  className="self-end"
+                >
+                  Post
+                </Button>
+              </div>
+            )}
           </div>
         </Stack>
       </div>

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { useDisclosure } from "@mantine/hooks";
 import { CreateActionModal } from "~/app/_components/CreateActionModal";
-import { EditActionModal } from "~/app/_components/EditActionModal";
+import { EditActionModal, type Action } from "~/app/_components/EditActionModal";
 import {
   ActionIcon,
   Anchor,
@@ -215,17 +215,9 @@ function EpicCombobox({
 // Linked Actions Section
 // ---------------------------------------------------------------------------
 
-interface LinkedAction {
-  id: string;
-  name: string;
-  description: string | null;
-  status: string;
+interface LinkedAction extends Action {
   kanbanStatus: string | null;
-  priority: string | null;
-  dueDate: Date | string | null;
-  projectId: string | null;
-  workspaceId?: string | null;
-  assignees: Array<{ user: { id: string; name: string | null; image: string | null } }>;
+  assignees: Array<{ user: { id: string; name: string | null; email: string | null; image: string | null } }>;
 }
 
 function getActionPriorityBorderColor(priority: string | null): string {
@@ -515,7 +507,7 @@ function LinkedActionsSection({
 
       {/* Edit action modal - opened when clicking a row */}
       <EditActionModal
-        action={editingAction as unknown as Parameters<typeof EditActionModal>[0]["action"]}
+        action={editingAction}
         opened={editingAction !== null}
         onClose={() => setEditingAction(null)}
         onSuccess={() => { setEditingAction(null); onChanged(); }}

--- a/src/app/_components/CreateActionModal.tsx
+++ b/src/app/_components/CreateActionModal.tsx
@@ -1,7 +1,7 @@
 import { Modal } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { useViewportSize } from '@mantine/hooks';
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { api } from "~/trpc/react";
 import { type ActionPriority } from "~/types/action";
 import type { EffortUnit } from "~/types/effort";
@@ -13,7 +13,7 @@ import { useSession } from 'next-auth/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { notifications } from '@mantine/notifications';
 
-export function CreateActionModal({ viewName, projectId: propProjectId, children }: { viewName: string; projectId?: string; children?: React.ReactNode }) {
+export function CreateActionModal({ viewName, projectId: propProjectId, children, initialName, onActionCreated, externalOpened, onExternalClose }: { viewName: string; projectId?: string; children?: React.ReactNode; initialName?: string; onActionCreated?: (actionId: string) => void; externalOpened?: boolean; onExternalClose?: () => void }) {
   const { data: session } = useSession();
   const { width } = useViewportSize();
   // Use propProjectId if provided, otherwise try to extract from viewName
@@ -290,7 +290,7 @@ export function CreateActionModal({ viewName, projectId: propProjectId, children
 
       const invalidatePromises: Promise<unknown>[] = [];
 
-      // Mark project actions stale (for next mount) but don't refetch — we
+      // Mark project actions stale (for next mount) but don't refetch - we
       // already have authoritative data from the create response above.
       if (projectId) {
         invalidatePromises.push(
@@ -324,7 +324,7 @@ export function CreateActionModal({ viewName, projectId: propProjectId, children
 
       // Run all post-create attachments concurrently. Each mutation has its own
       // onError handler that surfaces failures independently, so we don't need
-      // to gate the modal flow or a success toast on these completing — the
+      // to gate the modal flow or a success toast on these completing - the
       // optimistic row is already visible.
       const pendingAssignees = pendingAssigneesRef.current;
       const pendingScreenshots = pendingScreenshotsRef.current;
@@ -362,6 +362,9 @@ export function CreateActionModal({ viewName, projectId: propProjectId, children
 
       // Fire-and-forget; per-mutation onError handlers already log failures.
       void Promise.allSettled(postCreatePromises);
+
+      onActionCreated?.(data.id);
+      onExternalClose?.();
     },
   });
 
@@ -462,18 +465,32 @@ export function CreateActionModal({ viewName, projectId: propProjectId, children
     open();
   };
 
+  // Controlled mode: open/close driven by parent
+  useEffect(() => {
+    if (externalOpened) {
+      setCreatedActionId(null);
+      if (initialName) setName(initialName);
+      open();
+    } else {
+      close();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [externalOpened]);
+
   return (
     <>
-      {children ? (
-        <div onClick={handleOpen}>{children}</div>
-      ) : (
-        <button
-          onClick={handleOpen}
-          className="flex items-center gap-2 rounded-lg px-3 py-2 text-gray-400 hover:bg-gray-800 hover:text-gray-300 transition-colors"
-        >
-          <IconPlus size={16} />
-          <span>Add task</span>
-        </button>
+      {externalOpened === undefined && (
+        children ? (
+          <div onClick={handleOpen}>{children}</div>
+        ) : (
+          <button
+            onClick={handleOpen}
+            className="flex items-center gap-2 rounded-lg px-3 py-2 text-gray-400 hover:bg-gray-800 hover:text-gray-300 transition-colors"
+          >
+            <IconPlus size={16} />
+            <span>Add task</span>
+          </button>
+        )
       )}
 
       <Modal

--- a/src/app/_components/CreateActionModal.tsx
+++ b/src/app/_components/CreateActionModal.tsx
@@ -495,7 +495,7 @@ export function CreateActionModal({ viewName, projectId: propProjectId, children
 
       <Modal
         opened={opened}
-        onClose={close}
+        onClose={() => { close(); onExternalClose?.(); }}
         size="lg"
         radius="md"
         padding="lg"

--- a/src/app/_components/EditActionModal.tsx
+++ b/src/app/_components/EditActionModal.tsx
@@ -15,7 +15,7 @@ type Action = {
   name: string;
   description: string | null;
   status: string;
-  priority: string;
+  priority: string | null;
   dueDate: Date | null;
   projectId: string | null;
   workspaceId?: string | null;
@@ -339,7 +339,7 @@ export function EditActionModal({ action, opened, onClose, onSuccess }: EditActi
     // Capture new screenshots before resetting
     pendingScreenshotsRef.current = [...pastedScreenshots];
 
-    // Snapshot mutation payload before onClose() — parent may null out
+    // Snapshot mutation payload before onClose() - parent may null out
     // selectedAction synchronously, which would clear currentAction.id.
     const updateData = {
       id: currentAction.id,

--- a/src/app/_components/EditActionModal.tsx
+++ b/src/app/_components/EditActionModal.tsx
@@ -10,7 +10,7 @@ import { useWorkspace } from '~/providers/WorkspaceProvider';
 
 // Minimal action type needed for the edit modal - supports actions from various query sources
 // Only requires fields that the modal actually reads for initialization
-type Action = {
+export type Action = {
   id: string;
   name: string;
   description: string | null;

--- a/src/app/_components/EditActionModal.tsx
+++ b/src/app/_components/EditActionModal.tsx
@@ -16,7 +16,7 @@ type Action = {
   description: string | null;
   status: string;
   priority: string | null;
-  dueDate: Date | null;
+  dueDate: Date | string | null;
   projectId: string | null;
   workspaceId?: string | null;
   project?: { workspaceId?: string | null } | null;
@@ -154,7 +154,7 @@ export function EditActionModal({ action, opened, onClose, onSuccess }: EditActi
       setProjectId(currentAction.projectId ?? "");
       const validPriorities: string[] = PRIORITY_OPTIONS;
       setPriority(
-        validPriorities.includes(currentAction.priority)
+        currentAction.priority !== null && validPriorities.includes(currentAction.priority)
           ? (currentAction.priority as ActionPriority)
           : "Scheduled",
       );

--- a/src/app/_components/product/TicketBodyEditor.tsx
+++ b/src/app/_components/product/TicketBodyEditor.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { RichTextEditor } from "@mantine/tiptap";
+import { BubbleMenu, useEditor } from "@tiptap/react";
+import type { EditorView } from "@tiptap/pm/view";
+import { notifications } from "@mantine/notifications";
+import { api } from "~/trpc/react";
+import { buildPrdExtensions } from "~/lib/prd/extensions";
+import { markdownToDoc, EMPTY_DOC } from "~/lib/prd/codec";
+import "@mantine/tiptap/styles.css";
+
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+interface TicketBodyEditorProps {
+  ticketId: string;
+  initialContent: string | null;
+}
+
+export function TicketBodyEditor({ ticketId, initialContent }: TicketBodyEditorProps) {
+  const utils = api.useUtils();
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const contentLoaded = useRef(false);
+
+  const updateTicket = api.product.ticket.update.useMutation({
+    onSuccess: async () => {
+      await utils.product.ticket.getById.invalidate({ id: ticketId });
+    },
+  });
+
+  const uploadImage = api.product.ticket.uploadImage.useMutation();
+
+  const saveBody = useCallback(
+    (markdown: string) => {
+      updateTicket.mutate({ id: ticketId, body: markdown.trim() === "" ? "" : markdown });
+    },
+    [ticketId, updateTicket],
+  );
+
+  const debouncedSave = useCallback(
+    (markdown: string) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => saveBody(markdown), 1000);
+    },
+    [saveBody],
+  );
+
+  const imageHandlers = useMemo(() => {
+    const insertImage = (view: EditorView, file: File, pos?: number): boolean => {
+      if (!file.type.startsWith("image/")) return false;
+      if (file.size > MAX_IMAGE_BYTES) {
+        notifications.show({ title: "Image too large", message: "Please use an image under 5MB.", color: "red" });
+        return true;
+      }
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        const result = reader.result;
+        if (typeof result !== "string") return;
+        const base64 = result.split(",")[1];
+        if (!base64) return;
+        uploadImage
+          .mutateAsync({ id: ticketId, base64Data: base64 })
+          .then((res) => {
+            const { state } = view;
+            const node = state.schema.nodes.image?.create({ src: res.url });
+            if (!node) return;
+            const at = pos ?? state.selection.from;
+            view.dispatch(state.tr.insert(at, node));
+          })
+          .catch(() => {
+            notifications.show({ title: "Upload failed", message: "Could not upload the image. Please try again.", color: "red" });
+          });
+      };
+      reader.readAsDataURL(file);
+      return true;
+    };
+
+    const firstImage = (list?: FileList | null): File | null => {
+      if (!list) return null;
+      for (const file of Array.from(list)) {
+        if (file.type.startsWith("image/")) return file;
+      }
+      return null;
+    };
+
+    return {
+      handlePaste: (view: EditorView, event: ClipboardEvent): boolean => {
+        const file = firstImage(event.clipboardData?.files);
+        if (!file) return false;
+        event.preventDefault();
+        return insertImage(view, file);
+      },
+      handleDrop: (view: EditorView, event: DragEvent): boolean => {
+        const file = firstImage(event.dataTransfer?.files);
+        if (!file) return false;
+        event.preventDefault();
+        const coords = view.posAtCoords({ left: event.clientX, top: event.clientY });
+        return insertImage(view, file, coords?.pos);
+      },
+    };
+  }, [ticketId, uploadImage]);
+
+  const editor = useEditor({
+    extensions: buildPrdExtensions({ placeholder: "Add a description..." }),
+    content: "",
+    immediatelyRender: false,
+    onUpdate: ({ editor: e }) => {
+      debouncedSave(
+        (e.storage.markdown as { getMarkdown: () => string }).getMarkdown(),
+      );
+    },
+    onBlur: ({ editor: e }) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      saveBody(
+        (e.storage.markdown as { getMarkdown: () => string }).getMarkdown(),
+      );
+    },
+    editorProps: {
+      attributes: { class: "prose prose-invert max-w-none focus:outline-none" },
+      handlePaste: imageHandlers.handlePaste,
+      handleDrop: imageHandlers.handleDrop,
+    },
+  });
+
+  // Load content exactly once - convert markdown to ProseMirror JSON first so
+  // markdown-it is never called during editor initialisation (avoids an isSpace
+  // Turbopack bundling bug when parsing markdown inline).
+  useEffect(() => {
+    if (editor && !contentLoaded.current) {
+      contentLoaded.current = true;
+      const doc = initialContent?.trim() ? markdownToDoc(initialContent) : EMPTY_DOC;
+      editor.commands.setContent(doc);
+    }
+  }, [editor, initialContent]);
+
+  return (
+    <RichTextEditor
+      editor={editor}
+      className="prd-document"
+      styles={{
+        root: { border: "none", backgroundColor: "transparent" },
+        content: {
+          backgroundColor: "transparent",
+          color: "var(--color-text-primary)",
+          fontSize: "14px",
+          padding: 0,
+        },
+      }}
+    >
+      {editor && (
+        <BubbleMenu editor={editor} tippyOptions={{ duration: 150 }}>
+          <RichTextEditor.ControlsGroup>
+            <RichTextEditor.Bold />
+            <RichTextEditor.Italic />
+            <RichTextEditor.Strikethrough />
+            <RichTextEditor.Code />
+            <RichTextEditor.Link />
+            <RichTextEditor.H1 />
+            <RichTextEditor.H2 />
+            <RichTextEditor.H3 />
+            <RichTextEditor.BulletList />
+            <RichTextEditor.OrderedList />
+          </RichTextEditor.ControlsGroup>
+        </BubbleMenu>
+      )}
+      <RichTextEditor.Content />
+    </RichTextEditor>
+  );
+}

--- a/src/app/_components/product/TicketBodyEditor.tsx
+++ b/src/app/_components/product/TicketBodyEditor.tsx
@@ -20,7 +20,13 @@ interface TicketBodyEditorProps {
 export function TicketBodyEditor({ ticketId, initialContent }: TicketBodyEditorProps) {
   const utils = api.useUtils();
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const contentLoaded = useRef(false);
+  const loadedForTicketId = useRef<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
 
   const updateTicket = api.product.ticket.update.useMutation({
     onSuccess: async () => {
@@ -59,7 +65,7 @@ export function TicketBodyEditor({ ticketId, initialContent }: TicketBodyEditorP
         const base64 = result.split(",")[1];
         if (!base64) return;
         uploadImage
-          .mutateAsync({ id: ticketId, base64Data: base64 })
+          .mutateAsync({ id: ticketId, base64Data: base64, mimeType: file.type as "image/png" | "image/jpeg" | "image/webp" | "image/gif" })
           .then((res) => {
             const { state } = view;
             const node = state.schema.nodes.image?.create({ src: res.url });
@@ -122,16 +128,13 @@ export function TicketBodyEditor({ ticketId, initialContent }: TicketBodyEditorP
     },
   });
 
-  // Load content exactly once - convert markdown to ProseMirror JSON first so
-  // markdown-it is never called during editor initialisation (avoids an isSpace
-  // Turbopack bundling bug when parsing markdown inline).
   useEffect(() => {
-    if (editor && !contentLoaded.current) {
-      contentLoaded.current = true;
+    if (editor && loadedForTicketId.current !== ticketId) {
+      loadedForTicketId.current = ticketId;
       const doc = initialContent?.trim() ? markdownToDoc(initialContent) : EMPTY_DOC;
       editor.commands.setContent(doc);
     }
-  }, [editor, initialContent]);
+  }, [editor, ticketId, initialContent]);
 
   return (
     <RichTextEditor

--- a/src/lib/blob.ts
+++ b/src/lib/blob.ts
@@ -2,18 +2,12 @@ import { type PutBlobResult } from '@vercel/blob';
 import { del, put } from '@vercel/blob';
 
 export async function uploadToBlob(
-  base64Data: string, 
-  filename: string
+  base64Data: string,
+  filename: string,
+  contentType = "image/png",
 ): Promise<PutBlobResult> {
-  // Convert base64 to Buffer
-  const buffer = Buffer.from(base64Data, 'base64');
-  
-  // Upload to Vercel Blob
-  const blob = await put(filename, buffer, {
-    access: 'public',
-    contentType: 'image/png'
-  });
-
+  const buffer = Buffer.from(base64Data, "base64");
+  const blob = await put(filename, buffer, { access: "public", contentType });
   return blob;
 }
 

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -10,6 +10,7 @@ import {
   IN_FLIGHT_TICKET_STATUSES,
 } from "~/lib/ticket-statuses";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
+import { uploadToBlob } from "~/lib/blob";
 
 const ticketTypeEnum = z.enum([
   "BUG",
@@ -205,9 +206,19 @@ export const ticketRouter = createTRPCRouter({
             select: {
               id: true,
               name: true,
+              description: true,
               status: true,
               completedAt: true,
               kanbanStatus: true,
+              priority: true,
+              dueDate: true,
+              projectId: true,
+              workspaceId: true,
+              assignees: {
+                include: {
+                  user: { select: { id: true, name: true, image: true } },
+                },
+              },
             },
           },
           comments: {
@@ -387,7 +398,7 @@ export const ticketRouter = createTRPCRouter({
           if (incoming === undefined) return false;
           if (!(key in previousRecord)) return true;
           const existing = previousRecord[key];
-          // links is a Json object — JSON-stringify for a coarse equality check.
+          // links is a Json object - JSON-stringify for a coarse equality check.
           if (
             existing !== null &&
             typeof existing === "object" &&
@@ -413,6 +424,23 @@ export const ticketRouter = createTRPCRouter({
       }
 
       return updatedTicket;
+    }),
+
+  uploadImage: protectedProcedure
+    .input(z.object({ id: z.string(), base64Data: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      await loadTicketWithAccess(ctx.db, ctx.session.user.id, input.id);
+      const approxBytes = Math.floor((input.base64Data.length * 3) / 4);
+      if (approxBytes > 5 * 1024 * 1024) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Image too large. Please use an image under 5MB.",
+        });
+      }
+      const timestamp = new Date().toISOString().replace(/[/:]/g, "-");
+      const filename = `screenshots/tickets/${input.id}/${timestamp}.png`;
+      const blob = await uploadToBlob(input.base64Data, filename);
+      return { url: blob.url };
     }),
 
   delete: protectedProcedure

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -427,7 +427,13 @@ export const ticketRouter = createTRPCRouter({
     }),
 
   uploadImage: protectedProcedure
-    .input(z.object({ id: z.string(), base64Data: z.string().min(1) }))
+    .input(
+      z.object({
+        id: z.string(),
+        base64Data: z.string().min(1),
+        mimeType: z.enum(["image/png", "image/jpeg", "image/webp", "image/gif"]).default("image/png"),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       await loadTicketWithAccess(ctx.db, ctx.session.user.id, input.id);
       const approxBytes = Math.floor((input.base64Data.length * 3) / 4);
@@ -437,9 +443,11 @@ export const ticketRouter = createTRPCRouter({
           message: "Image too large. Please use an image under 5MB.",
         });
       }
+      const extMap: Record<string, string> = { "image/jpeg": "jpg", "image/webp": "webp", "image/gif": "gif" };
+      const ext = extMap[input.mimeType] ?? "png";
       const timestamp = new Date().toISOString().replace(/[/:]/g, "-");
-      const filename = `screenshots/tickets/${input.id}/${timestamp}.png`;
-      const blob = await uploadToBlob(input.base64Data, filename);
+      const filename = `screenshots/tickets/${input.id}/${timestamp}.${ext}`;
+      const blob = await uploadToBlob(input.base64Data, filename, input.mimeType);
       return { url: blob.url };
     }),
 

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -216,7 +216,7 @@ export const ticketRouter = createTRPCRouter({
               workspaceId: true,
               assignees: {
                 include: {
-                  user: { select: { id: true, name: true, image: true } },
+                  user: { select: { id: true, name: true, email: true, image: true } },
                 },
               },
             },

--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -648,4 +648,84 @@ describe("action router (mocked)", () => {
       );
     });
   });
+
+  // ────────────────────────────────────────────────────────────────────
+  // searchForDependencies
+  //
+  // When a workspaceId is passed the caller's ownership scope is dropped so
+  // the search spans the whole workspace — but ONLY after verifying the
+  // caller is actually a member. Without that check any logged-in user could
+  // enumerate another workspace's action titles/statuses/project names.
+  // ────────────────────────────────────────────────────────────────────
+  describe("searchForDependencies", () => {
+    const callerId = "caller-1";
+    const workspaceId = "w1";
+
+    /** getWorkspaceMembership probes workspaceUser.findUnique first, then
+     *  falls back to teamUser.findFirst. Stub both to control membership. */
+    function stubMembership(isMember: boolean) {
+      dbMock.workspaceUser.findUnique.mockResolvedValue(
+        isMember
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ? ({ userId: callerId, workspaceId, role: "member", joinedAt: new Date() } as any)
+          : null,
+      );
+      // No team-based access either when not a member.
+      dbMock.teamUser.findFirst.mockResolvedValue(null);
+    }
+
+    it("lets a workspace member search across the whole workspace", async () => {
+      stubMembership(true);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dbMock.action.findMany.mockResolvedValue([{ id: "a1", name: "Found" }] as any);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.action.searchForDependencies({
+        query: "Fo",
+        workspaceId,
+      });
+
+      expect(result).toHaveLength(1);
+      // Ownership scope is dropped: no createdById in the where clause, but
+      // the workspace OR filter is applied.
+      const where = dbMock.action.findMany.mock.calls[0]![0]!.where!;
+      expect(where).not.toHaveProperty("createdById");
+      expect(where).toMatchObject({
+        OR: [
+          { workspaceId },
+          { project: { workspaceId } },
+        ],
+      });
+    });
+
+    it("rejects a non-member with FORBIDDEN", async () => {
+      stubMembership(false);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      await expect(
+        caller.action.searchForDependencies({ query: "Fo", workspaceId }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      // The query must never run for a non-member.
+      expect(dbMock.action.findMany).not.toHaveBeenCalled();
+    });
+
+    it("scopes to the caller's own actions when no workspaceId is given", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dbMock.action.findMany.mockResolvedValue([{ id: "a1", name: "Mine" }] as any);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.action.searchForDependencies({ query: "Mi" });
+
+      expect(result).toHaveLength(1);
+      // No membership probe needed, and the where clause is scoped to the
+      // caller's own actions with no workspace filter.
+      expect(dbMock.workspaceUser.findUnique).not.toHaveBeenCalled();
+      const where = dbMock.action.findMany.mock.calls[0]![0]!.where!;
+      expect(where).toMatchObject({ createdById: callerId });
+      expect(where).not.toHaveProperty("OR");
+    });
+  });
 });

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -10,7 +10,7 @@ import { parseActionInput } from "~/server/services/parsing";
 import { ScoringService } from "~/server/services/ScoringService";
 import { startOfDay } from "date-fns";
 import { validateScheduledTimes } from "~/lib/dateUtils";
-import { findUserByEmailInWorkspace } from "~/server/services/access/resolvers/workspaceResolver";
+import { findUserByEmailInWorkspace, getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
 import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere } from "~/server/services/access";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import { uploadToBlob } from "~/lib/blob";
@@ -2503,9 +2503,21 @@ export const actionRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
-      // When a workspaceId is provided, search all actions in that workspace
-      // (workspace membership already gates access to the calling page).
+      // When a workspaceId is provided, search all actions in that workspace —
+      // but only after verifying the caller is actually a member. Without this
+      // check any logged-in user could enumerate other workspaces' actions.
       // Without a workspaceId, fall back to only the caller's own actions.
+      if (input.workspaceId) {
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          userId,
+          input.workspaceId,
+        );
+        if (!membership) {
+          throw new TRPCError({ code: "FORBIDDEN" });
+        }
+      }
+
       const ownershipFilter = input.workspaceId
         ? {}
         : { createdById: userId };

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -581,7 +581,7 @@ export const actionRouter = createTRPCRouter({
         bountyDeadline: z.date().nullable().optional(),
         bountyMaxClaimants: z.number().int().min(1).optional(),
         bountyExternalUrl: z.string().url().nullable().optional(),
-        // Source attribution — set by agents and external integrations
+        // Source attribution - set by agents and external integrations
         // so we can track which channel last touched the action.
         lastUpdatedBy: z.enum(["AGENT", "USER_EMAIL", "USER_WHATSAPP", "USER_UI"]).optional(),
         lastUpdatedSource: z.string().optional(),
@@ -709,7 +709,7 @@ export const actionRouter = createTRPCRouter({
             if (skipKeys.has(key)) return false;
             const incoming = (updateData as Record<string, unknown>)[key];
             if (incoming === undefined) return false;
-            // Only diff against fields we actually selected on currentAction —
+            // Only diff against fields we actually selected on currentAction -
             // anything outside that select is treated as changed.
             if (!(key in currentRecord)) return true;
             const existing = currentRecord[key];
@@ -1535,13 +1535,13 @@ export const actionRouter = createTRPCRouter({
             canAssign = !!sharedTeam;
           }
         }
-        // Action has a team (but no project) — users must be team members
+        // Action has a team (but no project) - users must be team members
         else if (action.teamId && action.team) {
           canAssign = action.team.members.some(
             (member: { userId: string }) => member.userId === userId,
           );
         }
-        // No project or team — allow assignment to any user
+        // No project or team - allow assignment to any user
         else {
           canAssign = true;
         }
@@ -1736,13 +1736,13 @@ export const actionRouter = createTRPCRouter({
             );
             canAssign = hasProjectAccess(candidateAccess);
           }
-          // Action has a team (but no project) — users must be team members
+          // Action has a team (but no project) - users must be team members
           else if (action.teamId && action.team) {
             canAssign = action.team.members.some(
               (member: { userId: string }) => member.userId === userId,
             );
           }
-          // No project or team — allow assignment to any user
+          // No project or team - allow assignment to any user
           else {
             canAssign = true;
           }
@@ -1803,7 +1803,7 @@ export const actionRouter = createTRPCRouter({
       const isRestrictedProject = action.project?.isRestricted ?? false;
 
       // 1. Get users from teams the current user belongs to.
-      //    Skip when the action's project is restricted — only ProjectMembers
+      //    Skip when the action's project is restricted - only ProjectMembers
       //    (plus creator + workspace owner/admin escape hatch) are valid.
       const userTeams = await ctx.db.team.findMany({
         where: {
@@ -2501,13 +2501,31 @@ export const actionRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      // When a workspaceId is provided, search all actions in that workspace
+      // (workspace membership already gates access to the calling page).
+      // Without a workspaceId, fall back to only the caller's own actions.
+      const ownershipFilter = input.workspaceId
+        ? {}
+        : { createdById: userId };
+
+      const workspaceFilter = input.workspaceId
+        ? {
+            OR: [
+              { workspaceId: input.workspaceId },
+              { project: { workspaceId: input.workspaceId } },
+            ],
+          }
+        : {};
+
       return ctx.db.action.findMany({
         where: {
           name: { contains: input.query, mode: "insensitive" },
-          status: { not: "COMPLETED" },
-          ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+          status: { notIn: ["COMPLETED", "CANCELLED", "DELETED"] },
+          ...ownershipFilter,
+          ...workspaceFilter,
           ...(input.excludeId ? { id: { not: input.excludeId } } : {}),
-          createdById: ctx.session.user.id,
         },
         take: input.limit,
         select: {
@@ -2588,7 +2606,7 @@ export const actionRouter = createTRPCRouter({
       // rest of the action router. CANCELLED is excluded implicitly by the
       // kanban statusFilter (its allowed-list never includes CANCELLED). An
       // explicit `status` guard keeps DRAFT and legacy COMPLETED actions out
-      // of autocomplete results — both are valid Action.status values in this
+      // of autocomplete results - both are valid Action.status values in this
       // codebase but neither is a valid pick for "track time against".
       const baseWhere: Prisma.ActionWhereInput = {
         AND: [
@@ -2823,7 +2841,7 @@ export const actionRouter = createTRPCRouter({
 
       // 5. Process each item with a per-item try/catch so one failure
       //    doesn't abort the whole batch. We deliberately do NOT wrap the
-      //    loop in an outer transaction — each item is logically independent
+      //    loop in an outer transaction - each item is logically independent
       //    and we want partial successes to persist.
       for (const item of input.items) {
         try {


### PR DESCRIPTION
## Summary

- Added **Actions to Tickets**: On the tickets details page, Actions from the workspace can now be linked to a ticket or directly be created from the details page; Creating new action utilizes the Action Creation modal component. 
- **Editable title**: inline `Textarea` on the ticket detail page — saves on blur or Enter, synced to server via `handleFieldUpdate`
- **Rich text body editor**: `TicketBodyEditor` component using the same Tiptap extension stack as the PRD editor (`buildPrdExtensions`), with markdown storage via `tiptap-markdown` and autosave (1s debounce + save on blur)
- **BubbleMenu**: Bold, Italic, Strikethrough, Code, Link, H1/H2/H3, Bullet list, Ordered list
- **Inline image upload**: paste or drag-drop screenshots into the body — uploaded to Vercel Blob, inserted as inline nodes
- **Turbopack fix**: aliased `markdown-it` to its CJS bundle in `next.config.js` to fix `isSpace` ESM resolution error under Turbopack
- **List rendering**: added `prd-document` class to `RichTextEditor` so existing `globals.css` list styles apply (since `@tailwindcss/typography` is not installed)
- **Bug fixes**: action toggle now syncs both `status` and `kanbanStatus`; `pendingName` cleared after action created

## Notes for reviewer (James)

**Image upload locally**: `BLOB_READ_WRITE_TOKEN` is required for the `uploadImage` mutation to work. It is auto-injected in Vercel preview/production deployments. To test locally, add it to `.env.local`:
```
BLOB_READ_WRITE_TOKEN=<value from Vercel project settings>
```

## Test plan

- [ ] Open a ticket from the backlog — title is editable inline (click, type, blur or Enter to save)
- [ ] Click into the body area — rich text editor appears, type markdown and verify formatting
- [ ] Select text — BubbleMenu appears with formatting controls
- [ ] Paste or drag-drop a screenshot — image uploads and appears inline
- [ ] Lists (bullet and ordered) render correctly in the editor
- [ ] Changes persist after page refresh