### PR TITLE
feat(automation): autonomous AI bug-fixer via GitHub Actions

### DIFF
--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -1,0 +1,254 @@
+name: AI Bug Fixer
+
+# Autonomous bug-fixing worker. Polls Exponential for bugs that a human has
+# explicitly marked `ai-fixable`, attempts a narrow fix, runs validation, and
+# opens a PR for HUMAN REVIEW. It never merges and never deploys. Ticket
+# close-out happens via the existing PR-merge webhook (ADR-0021).
+#
+# See docs/agents/ai-bug-fixer.md for setup, required secrets, and the marker
+# convention; docs/adr/0029-ai-bug-fixer-workflow.md for the design rationale.
+
+on:
+  schedule:
+    - cron: "0 * * * *" # hourly; polling is the trigger (no event-driven path exists today)
+  workflow_dispatch:
+    inputs:
+      ticket_id:
+        description: "Specific ticket CUID to attempt (optional; otherwise picks the oldest eligible)"
+        required: false
+      model:
+        description: "Override the coding-agent model (default: the AI_BUG_FIXER_MODEL repo var or claude-haiku-4-5)"
+        required: false
+
+# One run at a time. The status flip READY_TO_PLAN -> IN_PROGRESS is the soft
+# lock; this guarantees runs queue rather than overlap, so two workers can't
+# grab the same ticket.
+concurrency:
+  group: ai-bug-fixer
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  EXPONENTIAL_API_URL: ${{ vars.EXPONENTIAL_API_URL }}
+  EXPONENTIAL_PRODUCT: ${{ vars.EXPONENTIAL_PRODUCT }}
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Cheap scan: just the CLI. Decides whether there's anything worth the
+  # heavyweight fix job (which does npm ci + runs a coding agent).
+  # ---------------------------------------------------------------------------
+  scan:
+    name: Scan for eligible bugs
+    runs-on: ubuntu-latest
+    outputs:
+      found: ${{ steps.select.outputs.found }}
+      ticket_id: ${{ steps.select.outputs.ticket_id }}
+      ticket_number: ${{ steps.select.outputs.ticket_number }}
+      ticket_title: ${{ steps.select.outputs.ticket_title }}
+      branch_slug: ${{ steps.select.outputs.branch_slug }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Preflight (required config)
+        run: |
+          : "${EXPONENTIAL_API_URL:?Set the EXPONENTIAL_API_URL repo variable}"
+          : "${EXPONENTIAL_PRODUCT:?Set the EXPONENTIAL_PRODUCT repo variable (product slug or CUID)}"
+          if [ -z "${EXPONENTIAL_TOKEN}" ]; then
+            echo "::error::Missing EXPONENTIAL_TOKEN secret"; exit 1
+          fi
+        env:
+          EXPONENTIAL_TOKEN: ${{ secrets.EXPONENTIAL_TOKEN }}
+
+      - name: Install + auth Exponential CLI
+        run: |
+          npm i -g exponential-cli
+          exponential auth login --token "$EXPONENTIAL_TOKEN" --api-url "$EXPONENTIAL_API_URL"
+        env:
+          EXPONENTIAL_TOKEN: ${{ secrets.EXPONENTIAL_TOKEN }}
+
+      - name: List candidates and exclusions
+        run: |
+          # A missing label (e.g. nobody has tagged anything `ai-fixable` yet) is
+          # "no candidates", not a failed run — fall back to an empty list.
+          # Eligible: ai-fixable bugs that are fully specified (READY_TO_PLAN).
+          exponential tickets list \
+            --product "$EXPONENTIAL_PRODUCT" \
+            --type BUG --status READY_TO_PLAN --label ai-fixable --json > candidates.json \
+            || echo '[]' > candidates.json
+          # Safety exclusion set: anything also tagged `security`.
+          exponential tickets list \
+            --product "$EXPONENTIAL_PRODUCT" \
+            --type BUG --status READY_TO_PLAN --label security --json > security.json \
+            || echo '[]' > security.json
+
+      - name: Count open AI PRs (cap guard)
+        id: prs
+        run: |
+          COUNT=$(gh pr list --state open --label ai-bug-fixer --json number --jq 'length' 2>/dev/null || echo 0)
+          echo "open=$COUNT" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Select one candidate
+        id: select
+        run: |
+          node scripts/ai-bug-fixer/select-candidate.mjs \
+            --candidates candidates.json \
+            --exclude security.json \
+            --open-prs "${{ steps.prs.outputs.open }}" \
+            --max-open-prs "${{ vars.AI_BUG_FIXER_MAX_OPEN_PRS || '3' }}" \
+            ${{ inputs.ticket_id && format('--only-ticket {0}', inputs.ticket_id) || '' }}
+
+  # ---------------------------------------------------------------------------
+  # Heavyweight fix: claim -> agent -> validate -> PR -> link back.
+  # ---------------------------------------------------------------------------
+  fix:
+    name: Fix bug #${{ needs.scan.outputs.ticket_number }}
+    needs: scan
+    if: needs.scan.outputs.found == 'true'
+    runs-on: ubuntu-latest
+    env:
+      TICKET_ID: ${{ needs.scan.outputs.ticket_id }}
+      TICKET_NUMBER: ${{ needs.scan.outputs.ticket_number }}
+      TICKET_TITLE: ${{ needs.scan.outputs.ticket_title }}
+      BRANCH: ai/bug-${{ needs.scan.outputs.ticket_number }}-${{ needs.scan.outputs.branch_slug }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      MODEL: ${{ inputs.model || vars.AI_BUG_FIXER_MODEL || 'claude-haiku-4-5' }}
+      EXPONENTIAL_TOKEN: ${{ secrets.EXPONENTIAL_TOKEN }}
+      # Prefer a PAT so the PR triggers CI; fall back to the default token.
+      GH_TOKEN: ${{ secrets.AI_BUG_FIXER_GH_TOKEN || github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AI_BUG_FIXER_GH_TOKEN || github.token }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install deps + CLI
+        run: |
+          npm ci
+          npm i -g exponential-cli
+          exponential auth login --token "$EXPONENTIAL_TOKEN" --api-url "$EXPONENTIAL_API_URL"
+
+      - name: Claim ticket (soft lock)
+        run: |
+          exponential tickets update --id "$TICKET_ID" \
+            --status IN_PROGRESS --add-label ai-in-progress --json
+          exponential tickets comment add --id "$TICKET_ID" \
+            -m "🤖 The AI bug-fixer picked this up. Working on it — [run log]($RUN_URL)."
+
+      - name: Render fix brief
+        run: |
+          exponential tickets get "$TICKET_ID" --json > ticket.json
+          node scripts/ai-bug-fixer/render-prompt.mjs --ticket ticket.json --out .ai-bug-fixer/prompt.md
+          git checkout -b "$BRANCH"
+
+      - name: Run coding agent
+        id: agent
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: "Read .ai-bug-fixer/prompt.md and implement the narrow fix it describes. Edit the working tree only — do NOT run git, commit, push, or open a PR."
+          claude_args: "--model ${{ inputs.model || vars.AI_BUG_FIXER_MODEL || 'claude-haiku-4-5' }} --max-turns 30"
+
+      - name: Validate (typecheck + lint)
+        id: validate
+        continue-on-error: true
+        env:
+          SKIP_ENV_VALIDATION: true
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: |
+          # Mirror the CI lint-and-typecheck job. Invoke npx directly so the 8GB
+          # heap applies (the `npm run check` script hardcodes 4GB inline).
+          npx tsc --noEmit
+          npx next lint
+
+      - name: Finalize — open PR or release the ticket
+        env:
+          GIT_AUTHOR_NAME: exponential-ai-bot
+          GIT_AUTHOR_EMAIL: ai-bot@bots.exponential.im
+          GIT_COMMITTER_NAME: exponential-ai-bot
+          GIT_COMMITTER_EMAIL: ai-bot@bots.exponential.im
+        run: |
+          set -euo pipefail
+
+          # Read the agent's bail-out note (if any) BEFORE deleting the scratch dir.
+          BAILED=""
+          if [ -f .ai-bug-fixer/needs-human.txt ]; then
+            BAILED="$(cat .ai-bug-fixer/needs-human.txt)"
+          fi
+          rm -rf .ai-bug-fixer   # keep the scratch brief out of the commit
+
+          # Detect changes from BOTH possible agent behaviours: uncommitted edits
+          # (stage them) and edits the action already committed to the branch.
+          git add -A
+          HAS_CHANGES=""
+          if ! git diff --cached --quiet; then HAS_CHANGES="yes"; fi
+          if ! git diff --quiet main...HEAD; then HAS_CHANGES="yes"; fi
+
+          # `if` guards (not `[ ] && cmd`) so a false condition can't trip set -e.
+          fail() {
+            reason="$1"
+            echo "::warning::AI fix did not produce a PR: $reason"
+            exponential tickets comment add --id "$TICKET_ID" \
+              -m "🤖 Couldn't open a PR automatically: ${reason}. Releasing the ticket for a human. [Run log]($RUN_URL)." || true
+            exponential tickets update --id "$TICKET_ID" \
+              --status READY_TO_PLAN --remove-label ai-in-progress --json
+            exit 0
+          }
+
+          if [ -n "$BAILED" ]; then fail "the agent flagged this as needing a human — ${BAILED}"; fi
+          if [ "${{ steps.agent.outcome }}" != "success" ]; then fail "the coding agent step failed"; fi
+          if [ -z "$HAS_CHANGES" ]; then fail "the agent made no code changes"; fi
+          if [ "${{ steps.validate.outcome }}" != "success" ]; then fail "validation (tsc/next lint) failed"; fi
+
+          # --- Success path: commit (if needed), push, PR (never merge) ---
+          gh label create ai-bug-fixer --color BFD4F2 --description "Opened by the AI bug-fixer" --force >/dev/null 2>&1 || true
+          # Commit staged edits if the agent left them uncommitted; if the action
+          # already committed to the branch, this is a no-op and we just push.
+          if ! git diff --cached --quiet; then
+            cat > .git-commit-msg <<EOF
+          fix: ${TICKET_TITLE} (bug #${TICKET_NUMBER})
+
+          Autonomous fix for Exponential ticket #${TICKET_NUMBER}.
+          Requires human review before merge.
+          EOF
+            git commit -F .git-commit-msg
+            rm -f .git-commit-msg
+          fi
+          git push origin "$BRANCH"
+
+          cat > .pr-body.md <<EOF
+          ## 🤖 Autonomous bug fix — needs human review
+
+          Fixes Exponential bug ticket **#${TICKET_NUMBER}** — ${TICKET_TITLE}.
+
+          Generated by the AI bug-fixer ([run log]($RUN_URL)) using \`${MODEL}\`.
+          Validation (\`tsc --noEmit\` + \`next lint\`) passed.
+
+          **A human must review and merge this PR.** On merge, the existing PR-merge
+          webhook (ADR-0021) promotes the ticket from QA to DONE.
+          EOF
+
+          PR_URL=$(gh pr create \
+            --base main --head "$BRANCH" \
+            --title "fix: ${TICKET_TITLE} (bug #${TICKET_NUMBER})" \
+            --label ai-bug-fixer \
+            --body-file .pr-body.md)
+          rm -f .pr-body.md
+          echo "Opened: $PR_URL"
+          exponential tickets update --id "$TICKET_ID" \
+            --status QA --branch "$BRANCH" --pr "$PR_URL" --remove-label ai-in-progress --json
+          exponential tickets comment add --id "$TICKET_ID" \
+            -m "🤖 Opened a PR for review: ${PR_URL} — moved to QA pending human review."

--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -97,13 +97,19 @@ jobs:
 
       - name: Select one candidate
         id: select
+        # ONLY_TICKET comes via env (never inlined into the script) so a crafted
+        # workflow_dispatch input can't inject shell.
+        env:
+          ONLY_TICKET: ${{ inputs.ticket_id }}
         run: |
-          node scripts/ai-bug-fixer/select-candidate.mjs \
-            --candidates candidates.json \
-            --exclude security.json \
-            --open-prs "${{ steps.prs.outputs.open }}" \
-            --max-open-prs "${{ vars.AI_BUG_FIXER_MAX_OPEN_PRS || '3' }}" \
-            ${{ inputs.ticket_id && format('--only-ticket {0}', inputs.ticket_id) || '' }}
+          args=(
+            --candidates candidates.json
+            --exclude security.json
+            --open-prs "${{ steps.prs.outputs.open }}"
+            --max-open-prs "${{ vars.AI_BUG_FIXER_MAX_OPEN_PRS || '3' }}"
+          )
+          if [ -n "$ONLY_TICKET" ]; then args+=(--only-ticket "$ONLY_TICKET"); fi
+          node scripts/ai-bug-fixer/select-candidate.mjs "${args[@]}"
 
   # ---------------------------------------------------------------------------
   # Heavyweight fix: claim -> agent -> validate -> PR -> link back.
@@ -141,11 +147,15 @@ jobs:
           exponential auth login --token "$EXPONENTIAL_TOKEN" --api-url "$EXPONENTIAL_API_URL"
 
       - name: Claim ticket (soft lock)
+        id: claim
         run: |
+          # The status flip is the claim and must succeed for claim.outcome to be
+          # 'success'. The comment is best-effort — a flaky comment call must not
+          # fail the step, or the ticket would be claimed yet never released.
           exponential tickets update --id "$TICKET_ID" \
             --status IN_PROGRESS --add-label ai-in-progress --json
           exponential tickets comment add --id "$TICKET_ID" \
-            -m "🤖 The AI bug-fixer picked this up. Working on it — [run log]($RUN_URL)."
+            -m "🤖 The AI bug-fixer picked this up. Working on it — [run log]($RUN_URL)." || true
 
       - name: Render fix brief
         run: |
@@ -175,6 +185,11 @@ jobs:
           npx next lint
 
       - name: Finalize — open PR or release the ticket
+        # Always run once the ticket has actually been claimed, even if an
+        # intervening step (render brief, branch checkout, agent, validate) hard-
+        # failed — otherwise the ticket would be stranded in IN_PROGRESS. Gated on
+        # claim success so we never comment on a ticket we never moved.
+        if: ${{ always() && steps.claim.outcome == 'success' }}
         env:
           GIT_AUTHOR_NAME: exponential-ai-bot
           GIT_AUTHOR_EMAIL: ai-bot@bots.exponential.im

--- a/docs/adr/0029-ai-bug-fixer-workflow.md
+++ b/docs/adr/0029-ai-bug-fixer-workflow.md
@@ -1,0 +1,83 @@
+# ADR-0029: Autonomous AI bug-fixer via GitHub Actions
+
+Status: Accepted
+
+## Context
+
+We want a worker that, when a bug in Exponential is explicitly marked safe for an
+AI to attempt, picks it up, writes a fix, validates it, and opens a PR — with the
+originating ticket kept in sync and **human review mandatory**.
+
+Discovery found that almost all the moving parts already exist:
+
+- Bugs are `Ticket` rows with `type = BUG` in the product plugin
+  (`src/plugins/product/`). `Ticket` already carries `status`, `priority`,
+  `branchName`, `prUrl`, tags, and comments.
+- `READY_TO_PLAN` already means "fully specified, ready for an AFK agent" — see
+  [docs/agents/triage-labels.md](../agents/triage-labels.md).
+- The `ticket` tRPC router (`list` / `getById` / `update` / `addComment`) exposes
+  the full read/write surface, all callable with a Bearer JWT (the CLI auth path
+  in `src/server/api/trpc.ts`).
+- The `exponential` CLI already wraps those (`tickets list/get/update`,
+  `tickets comment add`, label filters), and the `setup-merge-hook` skill already
+  establishes the blessed CI→Exponential pattern: `npm i -g exponential-cli` +
+  `exponential auth login --token $EXPONENTIAL_TOKEN`.
+- PR-merge → ticket close-out is already automated: [ADR-0021](0021-pr-merge-promotes-ticket-via-app-webhook.md)
+  promotes a ticket from `QA` to `DONE` when its linked PR merges.
+- The CLI's own roadmap already names this worker shape ("ACFS": a polling loop
+  that dispatches issues to AI agents).
+
+So the goal is **not to invent a system** — it is to add the thin orchestration
+layer that connects these existing pieces.
+
+## Decision
+
+Add one scheduled **GitHub Actions** workflow (`.github/workflows/ai-bug-fixer.yml`)
+plus two small helper scripts (`scripts/ai-bug-fixer/`). **No app code, no schema
+changes, no new tRPC procedures.**
+
+- **Marker:** a human opts a bug in by adding the **`ai-fixable`** label to a
+  `type = BUG` ticket in `READY_TO_PLAN`. Exclusions are enforced in the worker:
+  any ticket also tagged `security`, or with `priority = 0` (critical), is never
+  attempted. Reuses the existing tag system — no new field.
+- **Trigger:** the workflow polls hourly (`schedule`) plus `workflow_dispatch`.
+  Polling is used because **no outbound event path from Exponential exists today**;
+  a `repository_dispatch` upgrade is left as future work.
+- **Orchestration is GitHub Actions** because the fix needs a repo checkout, a
+  coding agent, and a PR — all native to Actions, and the repo already
+  standardises on Actions. No new queue/worker infrastructure.
+- **Coding agent:** `anthropics/claude-code-action`, authenticated with a Claude
+  subscription token (`CLAUDE_CODE_OAUTH_TOKEN`, a flat fee) and defaulting to a
+  cheap model (`claude-haiku-4-5`). Model and auth are configurable via repo vars.
+- **Worker interface is the `exponential` CLI + a bot JWT** (`EXPONENTIAL_TOKEN`),
+  mirroring `setup-merge-hook`. Zero new API surface.
+- **Soft lock:** a single-runner `concurrency` group plus a `READY_TO_PLAN →
+  IN_PROGRESS` status flip on claim. Good enough for one serial runner.
+- **Human review is structural:** the workflow only ever *opens* a PR (never
+  `--merge`, never deploys). Close-out stays with the ADR-0021 merge webhook.
+
+### Flow
+
+```
+hourly / manual → scan (CLI only): pick oldest eligible bug, minus security/critical, under PR cap
+  → fix: claim (IN_PROGRESS + ai-in-progress) → render brief → claude-code-action
+        → validate (tsc + next lint) → open PR (QA, link prUrl/branch) | release back to READY_TO_PLAN
+  → human reviews & merges → ADR-0021 webhook flips QA → DONE
+```
+
+## Consequences
+
+- **Cost is bounded** by: opt-in `ai-fixable` tag, one ticket per run, a cap on
+  open AI PRs, an hourly cadence, a cheap default model, and a subscription token.
+- **The claim is not atomic.** Two parallel workers could in principle race; the
+  single-runner `concurrency` group prevents that today. True parallelism would
+  need a conditional-claim mutation — deliberately deferred.
+- **Polling latency** is up to the cron interval. Acceptable; upgradeable to
+  `repository_dispatch` without changing the rest of the design.
+- **PRs opened by the default `GITHUB_TOKEN` do not trigger CI.** To run the test
+  suite on AI PRs, set an `AI_BUG_FIXER_GH_TOKEN` PAT (the workflow prefers it).
+- If validation fails, the agent makes no change, or the agent flags the bug as
+  needing a human, the ticket is **released back to `READY_TO_PLAN`** with an
+  explanatory comment — never left silently stuck in `IN_PROGRESS`.
+
+See [docs/agents/ai-bug-fixer.md](../agents/ai-bug-fixer.md) for setup and operations.

--- a/docs/agents/ai-bug-fixer.md
+++ b/docs/agents/ai-bug-fixer.md
@@ -1,0 +1,95 @@
+# AI Bug Fixer
+
+An autonomous worker that fixes bugs you explicitly hand it. When a `type = BUG`
+ticket is marked `ai-fixable` and is `READY_TO_PLAN`, a scheduled GitHub Action
+picks it up, writes a narrow fix, validates it, and opens a **pull request for
+human review**. It never merges and never deploys.
+
+Design rationale: [ADR-0029](../adr/0029-ai-bug-fixer-workflow.md). Close-out (PR
+merge → ticket `DONE`) is handled by the existing webhook in
+[ADR-0021](../adr/0021-pr-merge-promotes-ticket-via-app-webhook.md).
+
+## How a bug becomes eligible
+
+A ticket is attempted only when **all** of these hold:
+
+| Condition | Why |
+| --- | --- |
+| `type = BUG` | only bugs, not features/chores |
+| `status = READY_TO_PLAN` | the documented "ready for an AFK agent" state |
+| has the **`ai-fixable`** label | explicit human opt-in |
+| **not** labelled `security` | safety: humans handle security |
+| `priority` is not `0` (critical) | safety: humans handle critical |
+
+To hand a bug to the worker: write a clear reproduction in the ticket body, then
+
+```bash
+exponential tickets update --id <ticket-cuid> --status READY_TO_PLAN --add-label ai-fixable
+```
+
+The worker picks the **oldest** eligible ticket each run (FIFO).
+
+## What the worker does
+
+1. **Scan** (cheap, CLI only): list eligible bugs, subtract `security`, drop
+   `priority 0`, respect the open-PR cap, pick the oldest.
+2. **Claim:** move the ticket to `IN_PROGRESS`, add `ai-in-progress`, comment.
+3. **Brief + fix:** render the ticket into `.ai-bug-fixer/prompt.md` and run
+   `claude-code-action` against it on a new `ai/bug-<n>-<slug>` branch.
+4. **Validate:** `npx tsc --noEmit` + `npx next lint` (same checks as CI).
+5. **Open PR** (labelled `ai-bug-fixer`), set the ticket to `QA`, link `prUrl` +
+   `branchName`, remove `ai-in-progress`, comment with the PR link. **Never merges.**
+6. If the fix fails, is empty, or the agent flags it as needing a human, the
+   ticket is **released back to `READY_TO_PLAN`** with an explanatory comment.
+
+A human reviews and merges the PR. On merge, the ADR-0021 webhook flips the ticket
+`QA → DONE`.
+
+## One-time setup
+
+### Secrets (`gh secret set …`)
+
+| Secret | Required | Purpose |
+| --- | --- | --- |
+| `EXPONENTIAL_TOKEN` | yes | Bot JWT for the CLI. Get it with `exponential auth show --token`. Prefer a dedicated service-account user over a personal token. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | yes | Claude Pro/Max subscription token for the coding agent (flat fee). Alternatively switch the action to `anthropic_api_key`. |
+| `AI_BUG_FIXER_GH_TOKEN` | optional | A PAT used to push the branch and open the PR. Set this so the PR **triggers CI** — PRs opened by the default `GITHUB_TOKEN` do not. Falls back to `GITHUB_TOKEN`. |
+
+### Repository variables (`gh variable set …`)
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `EXPONENTIAL_API_URL` | yes | — | e.g. `https://www.exponential.im` |
+| `EXPONENTIAL_PRODUCT` | yes | — | Product slug or CUID whose bug backlog to scan |
+| `AI_BUG_FIXER_MODEL` | no | `claude-haiku-4-5` | Coding-agent model |
+| `AI_BUG_FIXER_MAX_OPEN_PRS` | no | `3` | Skip new fixes while this many AI PRs are open |
+
+### Running it
+
+- **Automatically:** hourly via cron.
+- **On demand:** Actions → *AI Bug Fixer* → *Run workflow*. Optional inputs:
+  `ticket_id` (target one specific ticket) and `model` (one-off model override).
+
+## Cost controls
+
+The biggest levers, all already wired in: the opt-in `ai-fixable` tag (nothing is
+touched unless tagged), **one ticket per run**, the **open-PR cap**, an **hourly**
+cadence, a **cheap default model**, a `--max-turns 30` ceiling, and the
+**subscription token** (flat fee rather than metered). Candidate scanning is
+free — agent tokens are only spent once a real ticket is claimed.
+
+## Safety guarantees
+
+- Never auto-merges, never auto-deploys — only opens PRs.
+- Never attempts `security`-labelled or `priority 0` (critical) tickets.
+- The brief instructs a **narrow** fix and tells the agent to bail (writing
+  `.ai-bug-fixer/needs-human.txt`) if the fix would be broad or risky.
+- A failed/empty/bailed attempt releases the ticket back to `READY_TO_PLAN`
+  rather than leaving it stuck.
+- Single-runner `concurrency` prevents overlapping runs grabbing the same ticket.
+
+## Files
+
+- `.github/workflows/ai-bug-fixer.yml` — the workflow (`scan` + `fix` jobs)
+- `scripts/ai-bug-fixer/select-candidate.mjs` — eligibility + oldest-first pick
+- `scripts/ai-bug-fixer/render-prompt.mjs` — ticket JSON → agent brief

--- a/scripts/ai-bug-fixer/render-prompt.mjs
+++ b/scripts/ai-bug-fixer/render-prompt.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * AI bug-fixer — prompt rendering.
+ *
+ * Turns the JSON of `exponential tickets get <id> --json` into a Markdown brief
+ * the coding agent reads from disk. We deliberately keep the agent prompt SHORT
+ * in the workflow ("read this file and fix it") and put all the ticket context
+ * here, so the YAML stays clean and the brief is auditable in the run logs.
+ *
+ * Usage: node render-prompt.mjs --ticket ticket.json --out .ai-bug-fixer/prompt.md
+ */
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const ticket = JSON.parse(readFileSync(arg("ticket"), "utf8"));
+const out = arg("out", ".ai-bug-fixer/prompt.md");
+
+const comments = Array.isArray(ticket.comments) ? ticket.comments : [];
+const commentBlock = comments.length
+  ? comments
+      .slice() // newest-first from the API; show oldest-first for reading order
+      .reverse()
+      .map((c) => `- **${c.author?.name ?? "someone"}:** ${String(c.content ?? "").trim()}`)
+      .join("\n")
+  : "_(none)_";
+
+const linkedActions = Array.isArray(ticket.actions) ? ticket.actions : [];
+const actionBlock = linkedActions.length
+  ? linkedActions.map((a) => `- ${a.name} (${a.status})`).join("\n")
+  : "_(none)_";
+
+const brief = `# Bug fix task — Ticket #${ticket.number ?? "?"}: ${ticket.title ?? ""}
+
+You are an autonomous engineer fixing ONE bug in this repository. A human will
+review your pull request before anything merges — your job is a correct,
+**narrow** fix, not a refactor.
+
+## Bug report
+
+${(ticket.body ?? "_(no description provided)_").trim()}
+
+## Discussion / comments
+
+${commentBlock}
+
+## Linked actions
+
+${actionBlock}
+
+## Rules
+
+1. Make the **smallest change** that fixes the reported bug. Do not refactor
+   unrelated code, rename things, or reformat files you didn't need to touch.
+2. Follow this repo's conventions in \`CLAUDE.md\` — especially: NO hardcoded
+   colors, use \`??\` not \`||\`, no \`any\`, proper \`import type\`, await all promises.
+3. If the bug is actually a security or data-loss issue, or you cannot fix it
+   without a broad/risky change, **STOP**: leave a short note in a file named
+   \`.ai-bug-fixer/needs-human.txt\` explaining why, and make no code changes.
+4. Add or update a focused test when it's reasonable to do so.
+5. Do **not** run git, commit, push, or open a PR — the workflow handles that.
+   Just edit the working tree.
+
+When done, the workflow runs \`npx tsc --noEmit\` and \`npx next lint\`; your change
+must pass both.
+`;
+
+mkdirSync(dirname(out), { recursive: true });
+writeFileSync(out, brief);
+console.log(`[ai-bug-fixer] wrote prompt for #${ticket.number ?? "?"} → ${out} (${brief.length} chars)`);

--- a/scripts/ai-bug-fixer/select-candidate.mjs
+++ b/scripts/ai-bug-fixer/select-candidate.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * AI bug-fixer — candidate selection.
+ *
+ * Pure, dependency-free. Given the JSON output of two `exponential tickets list`
+ * calls, decides which single bug (if any) the worker should attempt this run.
+ *
+ * Eligibility (server-side filters are applied by the CLI before this runs):
+ *   - type = BUG, status = READY_TO_PLAN, label = `ai-fixable`  (the candidates set)
+ * Exclusions (applied here — the safety gate):
+ *   - any ticket also carrying the `security` label  (the exclude set)
+ *   - any ticket with priority 0 (critical)
+ *   - if the number of already-open AI PRs is at/above the cap, select nothing
+ *
+ * Among survivors, picks the OLDEST by createdAt (FIFO — oldest bug waiting longest).
+ *
+ * Usage:
+ *   node select-candidate.mjs --candidates cand.json --exclude sec.json \
+ *     [--open-prs 1] [--max-open-prs 3] [--only-ticket <id>]
+ *
+ * Writes the chosen ticket to `chosen.json` (cwd) and, when running under GitHub
+ * Actions, emits `found`, `ticket_id`, `ticket_number`, `ticket_title`,
+ * `branch_slug` to $GITHUB_OUTPUT. Exit code is always 0 — "nothing to do" is a
+ * normal outcome, not a failure.
+ */
+import { readFileSync, writeFileSync, appendFileSync } from "node:fs";
+
+/** @param {string} name @param {string=} fallback */
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+/** Tolerate both `[...]` and `{ tickets: [...] }` shapes from the CLI. */
+function readTickets(path) {
+  if (!path) return [];
+  const raw = JSON.parse(readFileSync(path, "utf8"));
+  const list = Array.isArray(raw) ? raw : Array.isArray(raw?.tickets) ? raw.tickets : [];
+  return list;
+}
+
+function setOutput(key, value) {
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) appendFileSync(out, `${key}=${value}\n`);
+}
+
+function slugify(title) {
+  return String(title || "fix")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40) || "fix";
+}
+
+const candidates = readTickets(arg("candidates"));
+const excludeIds = new Set(readTickets(arg("exclude")).map((t) => t.id));
+const onlyTicket = arg("only-ticket"); // manual workflow_dispatch override
+const openPrs = parseInt(arg("open-prs", "0"), 10) || 0;
+const maxOpenPrs = parseInt(arg("max-open-prs", "3"), 10) || 0;
+
+function pickReason() {
+  if (maxOpenPrs > 0 && openPrs >= maxOpenPrs) {
+    return { chosen: null, reason: `cap reached: ${openPrs}/${maxOpenPrs} AI PRs already open` };
+  }
+
+  let pool = candidates.filter((t) => {
+    if (excludeIds.has(t.id)) return false; // `security`-labelled
+    if (t.priority === 0) return false; // critical
+    return true;
+  });
+
+  if (onlyTicket) {
+    pool = pool.filter((t) => t.id === onlyTicket);
+    if (pool.length === 0) {
+      return { chosen: null, reason: `requested ticket ${onlyTicket} is not eligible (missing, excluded, or critical)` };
+    }
+  }
+
+  if (pool.length === 0) {
+    return { chosen: null, reason: "no eligible bugs (ai-fixable + READY_TO_PLAN, minus security/critical)" };
+  }
+
+  pool.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  return { chosen: pool[0], reason: `selected oldest of ${pool.length} eligible` };
+}
+
+const { chosen, reason } = pickReason();
+
+console.log(`[ai-bug-fixer] candidates=${candidates.length} excluded=${excludeIds.size} → ${reason}`);
+
+if (!chosen) {
+  setOutput("found", "false");
+  process.exit(0);
+}
+
+writeFileSync("chosen.json", JSON.stringify(chosen, null, 2));
+setOutput("found", "true");
+setOutput("ticket_id", chosen.id);
+setOutput("ticket_number", String(chosen.number ?? ""));
+setOutput("ticket_title", String(chosen.title ?? "").replace(/\n/g, " "));
+setOutput("branch_slug", slugify(chosen.title));
+console.log(`[ai-bug-fixer] chosen: #${chosen.number ?? "?"} ${chosen.title} (${chosen.id})`);


### PR DESCRIPTION
## What

Adds an **autonomous AI bug-fixer**: when a `type=BUG` ticket is labelled `ai-fixable` and is `READY_TO_PLAN`, a scheduled GitHub Action picks it up, writes a narrow fix, validates it (`tsc` + `next lint`), and opens a **PR for human review**. It never merges and never deploys.

Built discovery-first. The hard parts already existed, so this is thin orchestration over them — **no app code, schema, or new tRPC procedures**.

## How it reuses what's here

- `ticket` router (`list`/`getById`/`update`/`addComment`) + the `exponential` CLI + Bearer-JWT auth — the same CI→Exponential pattern `setup-merge-hook` uses.
- `READY_TO_PLAN` is already the documented "ready for an AFK agent" status; `ai-fixable` is the explicit human opt-in on top.
- Close-out is already automated: ADR-0021's PR-merge webhook flips the ticket `QA → DONE` on merge.

## Flow

```
hourly / manual → scan (CLI-only): pick oldest eligible bug, minus security/critical, under PR cap
  → fix: claim (IN_PROGRESS + ai-in-progress) → render brief → claude-code-action
        → validate → open PR (QA, link prUrl/branch) | release back to READY_TO_PLAN on failure
  → human reviews & merges → ADR-0021 webhook → DONE
```

## Safety

- Never auto-merges / auto-deploys — only opens PRs.
- Skips `security`-labelled and `priority 0` (critical) tickets.
- Cost-bounded: opt-in tag, one ticket/run, open-PR cap, hourly cadence, `claude-haiku-4-5` default, `--max-turns 30`, subscription token (flat fee). Scanning is free; agent tokens only spent after a claim.
- Failed/empty/bailed attempts release the ticket back to `READY_TO_PLAN` with a comment — never left stuck.

## Files

- `.github/workflows/ai-bug-fixer.yml` — `scan` + `fix` jobs
- `scripts/ai-bug-fixer/{select-candidate,render-prompt}.mjs` — pure, smoke-tested
- `docs/adr/0029-ai-bug-fixer-workflow.md`, `docs/agents/ai-bug-fixer.md`

## Activation (not done in this PR)

1. Create `ai-fixable` + `security` labels in the workspace.
2. Secrets: `EXPONENTIAL_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, optional `AI_BUG_FIXER_GH_TOKEN` (PAT, so the AI PR triggers CI).
3. Vars: `EXPONENTIAL_API_URL`, `EXPONENTIAL_PRODUCT` (+ optional `AI_BUG_FIXER_MODEL`, `AI_BUG_FIXER_MAX_OPEN_PRS`).

## Verify before first run

- The pinned `anthropics/claude-code-action` input names (`claude_code_oauth_token` / `claude_args`).
- That `exponential tickets list --json` emits a bare array (selector tolerates both array and `{tickets:[]}`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added autonomous bug-fixing automation triggered hourly or manually.
  * Selects eligible bugs marked for automation and implements fixes with AI assistance.
  * Validates fixes using linting and type-checking before opening pull requests for review.

* **Documentation**
  * Added architecture decision record and user guide for the new automation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->