### PR TITLE
fix(ai-bug-fixer): pass --workspace so label filtering resolves

### DIFF
--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -34,6 +34,9 @@ permissions:
 env:
   EXPONENTIAL_API_URL: ${{ vars.EXPONENTIAL_API_URL }}
   EXPONENTIAL_PRODUCT: ${{ vars.EXPONENTIAL_PRODUCT }}
+  # Required: the CLI resolves `--label` slugs against the workspace, so label
+  # filtering fails without it even when --product is a CUID.
+  EXPONENTIAL_WORKSPACE: ${{ vars.EXPONENTIAL_WORKSPACE }}
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -59,6 +62,7 @@ jobs:
         run: |
           : "${EXPONENTIAL_API_URL:?Set the EXPONENTIAL_API_URL repo variable}"
           : "${EXPONENTIAL_PRODUCT:?Set the EXPONENTIAL_PRODUCT repo variable (product slug or CUID)}"
+          : "${EXPONENTIAL_WORKSPACE:?Set the EXPONENTIAL_WORKSPACE repo variable (needed to resolve label slugs)}"
           if [ -z "${EXPONENTIAL_TOKEN}" ]; then
             echo "::error::Missing EXPONENTIAL_TOKEN secret"; exit 1
           fi
@@ -74,18 +78,19 @@ jobs:
 
       - name: List candidates and exclusions
         run: |
-          # A missing label (e.g. nobody has tagged anything `ai-fixable` yet) is
-          # "no candidates", not a failed run — fall back to an empty list.
+          # --workspace is REQUIRED: the CLI resolves `--label` slugs against the
+          # workspace. We do NOT swallow errors here — a CLI failure (bad token,
+          # wrong workspace, missing label) must fail the scan loudly rather than
+          # leave the worker silently idle. An unused-but-existing label resolves
+          # cleanly to {tickets:[]}; only a genuine misconfig errors out.
           # Eligible: ai-fixable bugs that are fully specified (READY_TO_PLAN).
           exponential tickets list \
-            --product "$EXPONENTIAL_PRODUCT" \
-            --type BUG --status READY_TO_PLAN --label ai-fixable --json > candidates.json \
-            || echo '[]' > candidates.json
+            --product "$EXPONENTIAL_PRODUCT" --workspace "$EXPONENTIAL_WORKSPACE" \
+            --type BUG --status READY_TO_PLAN --label ai-fixable --json > candidates.json
           # Safety exclusion set: anything also tagged `security`.
           exponential tickets list \
-            --product "$EXPONENTIAL_PRODUCT" \
-            --type BUG --status READY_TO_PLAN --label security --json > security.json \
-            || echo '[]' > security.json
+            --product "$EXPONENTIAL_PRODUCT" --workspace "$EXPONENTIAL_WORKSPACE" \
+            --type BUG --status READY_TO_PLAN --label security --json > security.json
 
       - name: Count open AI PRs (cap guard)
         id: prs

--- a/docs/agents/ai-bug-fixer.md
+++ b/docs/agents/ai-bug-fixer.md
@@ -61,6 +61,7 @@ A human reviews and merges the PR. On merge, the ADR-0021 webhook flips the tick
 | --- | --- | --- | --- |
 | `EXPONENTIAL_API_URL` | yes | — | e.g. `https://www.exponential.im` |
 | `EXPONENTIAL_PRODUCT` | yes | — | Product slug or CUID whose bug backlog to scan |
+| `EXPONENTIAL_WORKSPACE` | yes | — | Workspace slug or CUID (e.g. `syntrofi`). Required — the CLI resolves `--label` slugs against the workspace, so label filtering fails without it even with a CUID product. |
 | `AI_BUG_FIXER_MODEL` | no | `claude-haiku-4-5` | Coding-agent model |
 | `AI_BUG_FIXER_MAX_OPEN_PRS` | no | `3` | Skip new fixes while this many AI PRs are open |
 


### PR DESCRIPTION
## What

Stage-1 testing of the AI bug-fixer (#269) surfaced a real bug: the scan job filtered `tickets list` by `--label ai-fixable` **without `--workspace`**. The CLI resolves label slugs against the workspace, so the call fails with `Unknown label slug(s): ai-fixable` — and the old `|| echo '[]'` fallback swallowed it, leaving the worker to silently find **zero candidates forever**.

## Fix

- Add required `EXPONENTIAL_WORKSPACE` repo variable (top-level env + preflight check).
- Pass `--workspace` to both `tickets list` calls.
- Drop the silent `|| echo '[]'` fallback — a CLI error (bad token, wrong workspace, missing label) must fail the scan **loudly**, not idle quietly. An unused-but-existing label resolves cleanly to `{tickets:[]}`, so the empty case still works.

## Verified locally (Stage 1)

- Without `--workspace`: `tickets list --label ai-fixable` → exit 1, `Unknown label slug(s)`.
- With `--workspace`: resolves; an unused label returns `{tickets:[], total:0}`.
- Tagged a real `READY_TO_PLAN` bug `ai-fixable` → list returns it, selector picks it and emits the correct `GITHUB_OUTPUT`.
- `tickets get` + `render-prompt.mjs` validated on the same ticket.

## ⚠️ Action required before the worker can find anything

Set the new repo variable:
```bash
gh variable set EXPONENTIAL_WORKSPACE --body "syntrofi"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new required environment variable to CI/CD workflow configuration.
  * Enhanced error handling to provide explicit failures instead of silent fallbacks when configuration is incorrect.

* **Documentation**
  * Updated documentation to clarify new environment variable requirement and its impact on label filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->