### PR TITLE
fix(ai-bug-fixer): make label ops best-effort so claim can't strand a ticket

### DIFF
--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -34,6 +34,9 @@ permissions:
 env:
   EXPONENTIAL_API_URL: ${{ vars.EXPONENTIAL_API_URL }}
   EXPONENTIAL_PRODUCT: ${{ vars.EXPONENTIAL_PRODUCT }}
+  # Required: the CLI resolves `--label` slugs against the workspace, so label
+  # filtering fails without it even when --product is a CUID.
+  EXPONENTIAL_WORKSPACE: ${{ vars.EXPONENTIAL_WORKSPACE }}
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -59,6 +62,7 @@ jobs:
         run: |
           : "${EXPONENTIAL_API_URL:?Set the EXPONENTIAL_API_URL repo variable}"
           : "${EXPONENTIAL_PRODUCT:?Set the EXPONENTIAL_PRODUCT repo variable (product slug or CUID)}"
+          : "${EXPONENTIAL_WORKSPACE:?Set the EXPONENTIAL_WORKSPACE repo variable (needed to resolve label slugs)}"
           if [ -z "${EXPONENTIAL_TOKEN}" ]; then
             echo "::error::Missing EXPONENTIAL_TOKEN secret"; exit 1
           fi
@@ -74,18 +78,19 @@ jobs:
 
       - name: List candidates and exclusions
         run: |
-          # A missing label (e.g. nobody has tagged anything `ai-fixable` yet) is
-          # "no candidates", not a failed run — fall back to an empty list.
+          # --workspace is REQUIRED: the CLI resolves `--label` slugs against the
+          # workspace. We do NOT swallow errors here — a CLI failure (bad token,
+          # wrong workspace, missing label) must fail the scan loudly rather than
+          # leave the worker silently idle. An unused-but-existing label resolves
+          # cleanly to {tickets:[]}; only a genuine misconfig errors out.
           # Eligible: ai-fixable bugs that are fully specified (READY_TO_PLAN).
           exponential tickets list \
-            --product "$EXPONENTIAL_PRODUCT" \
-            --type BUG --status READY_TO_PLAN --label ai-fixable --json > candidates.json \
-            || echo '[]' > candidates.json
+            --product "$EXPONENTIAL_PRODUCT" --workspace "$EXPONENTIAL_WORKSPACE" \
+            --type BUG --status READY_TO_PLAN --label ai-fixable --json > candidates.json
           # Safety exclusion set: anything also tagged `security`.
           exponential tickets list \
-            --product "$EXPONENTIAL_PRODUCT" \
-            --type BUG --status READY_TO_PLAN --label security --json > security.json \
-            || echo '[]' > security.json
+            --product "$EXPONENTIAL_PRODUCT" --workspace "$EXPONENTIAL_WORKSPACE" \
+            --type BUG --status READY_TO_PLAN --label security --json > security.json
 
       - name: Count open AI PRs (cap guard)
         id: prs

--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -155,10 +155,11 @@ jobs:
         id: claim
         run: |
           # The status flip is the claim and must succeed for claim.outcome to be
-          # 'success'. The comment is best-effort — a flaky comment call must not
-          # fail the step, or the ticket would be claimed yet never released.
-          exponential tickets update --id "$TICKET_ID" \
-            --status IN_PROGRESS --add-label ai-in-progress --json
+          # 'success'. The label and comment are cosmetic and MUST be best-effort:
+          # they run as separate calls so a missing/flaky label can't leave the
+          # ticket flipped to IN_PROGRESS yet error the step (which would strand it).
+          exponential tickets update --id "$TICKET_ID" --status IN_PROGRESS --json
+          exponential tickets update --id "$TICKET_ID" --add-label ai-in-progress --json || true
           exponential tickets comment add --id "$TICKET_ID" \
             -m "🤖 The AI bug-fixer picked this up. Working on it — [run log]($RUN_URL)." || true
 
@@ -223,8 +224,9 @@ jobs:
             echo "::warning::AI fix did not produce a PR: $reason"
             exponential tickets comment add --id "$TICKET_ID" \
               -m "🤖 Couldn't open a PR automatically: ${reason}. Releasing the ticket for a human. [Run log]($RUN_URL)." || true
-            exponential tickets update --id "$TICKET_ID" \
-              --status READY_TO_PLAN --remove-label ai-in-progress --json
+            # Releasing the status is essential; dropping the label is cosmetic.
+            exponential tickets update --id "$TICKET_ID" --status READY_TO_PLAN --json
+            exponential tickets update --id "$TICKET_ID" --remove-label ai-in-progress --json || true
             exit 0
           }
 
@@ -268,7 +270,9 @@ jobs:
             --body-file .pr-body.md)
           rm -f .pr-body.md
           echo "Opened: $PR_URL"
+          # Linking the PR + moving to QA is essential; dropping the label is cosmetic.
           exponential tickets update --id "$TICKET_ID" \
-            --status QA --branch "$BRANCH" --pr "$PR_URL" --remove-label ai-in-progress --json
+            --status QA --branch "$BRANCH" --pr "$PR_URL" --json
+          exponential tickets update --id "$TICKET_ID" --remove-label ai-in-progress --json || true
           exponential tickets comment add --id "$TICKET_ID" \
-            -m "🤖 Opened a PR for review: ${PR_URL} — moved to QA pending human review."
+            -m "🤖 Opened a PR for review: ${PR_URL} — moved to QA pending human review." || true

--- a/docs/agents/ai-bug-fixer.md
+++ b/docs/agents/ai-bug-fixer.md
@@ -61,6 +61,7 @@ A human reviews and merges the PR. On merge, the ADR-0021 webhook flips the tick
 | --- | --- | --- | --- |
 | `EXPONENTIAL_API_URL` | yes | — | e.g. `https://www.exponential.im` |
 | `EXPONENTIAL_PRODUCT` | yes | — | Product slug or CUID whose bug backlog to scan |
+| `EXPONENTIAL_WORKSPACE` | yes | — | Workspace slug or CUID (e.g. `syntrofi`). Required — the CLI resolves `--label` slugs against the workspace, so label filtering fails without it even with a CUID product. |
 | `AI_BUG_FIXER_MODEL` | no | `claude-haiku-4-5` | Coding-agent model |
 | `AI_BUG_FIXER_MAX_OPEN_PRS` | no | `3` | Skip new fixes while this many AI PRs are open |
 


### PR DESCRIPTION
## What

The first live run (`workflow_dispatch` against test bug #204) got the **whole scan job green** — preflight, auth, the workspace-fixed list, and candidate selection all passed. It then failed at the **Claim** step:

```
Unknown label slug(s): ai-in-progress
```

The `ai-in-progress` label didn't exist, and the claim combined the **essential** status flip with the **cosmetic** label in one call: `tickets update --status IN_PROGRESS --add-label ai-in-progress`. The API applied the status change *first*, then errored on label resolution — so the ticket was stranded in `IN_PROGRESS` with the step red and no release. Exactly the non-atomic-claim hazard, caught on a throwaway ticket.

## Fix

The status transition is the real state; the `ai-in-progress` label is just a visible marker. Split them and make every label add/remove best-effort (`|| true`) in all three places:

- **claim** — status flip must succeed; label + comment best-effort
- **fail path** — release to `READY_TO_PLAN` must succeed; remove-label best-effort
- **success path** — `QA` + prUrl/branch must succeed; remove-label + comment best-effort

A missing or flaky label can no longer block or strand a claim.

Also created the `ai-in-progress` label in the `syntrofi` workspace, so the marker shows on the happy path. The stranded test ticket #204 was reset to `READY_TO_PLAN`.

## Validated

YAML + finalize bash syntax checked; full unit suite (1020) green via pre-commit.