### PR TITLE
feat(workspace): edit member role from settings

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx
@@ -20,6 +20,7 @@ import {
 import { useDisclosure } from '@mantine/hooks';
 import {
   IconTrash,
+  IconPencil,
   IconUserPlus,
   IconPlug,
   IconFolder,
@@ -49,6 +50,7 @@ import { useRef, useState } from 'react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { api } from '~/trpc/react';
 import { InviteMemberModal } from '~/app/_components/InviteMemberModal';
+import { EditMemberRoleModal } from '~/app/_components/EditMemberRoleModal';
 import { PendingInvitationsTable } from '~/app/_components/PendingInvitationsTable';
 import { WorkspaceTeamsSection } from '~/app/_components/WorkspaceTeamsSection';
 import { SlackChannelSettings } from '~/app/_components/SlackChannelSettings';
@@ -96,6 +98,14 @@ export default function WorkspaceSettingsPage() {
   const [deleteConfirmName, setDeleteConfirmName] = useState('');
   const [deleteModalOpened, { open: openDeleteModal, close: closeDeleteModal }] = useDisclosure(false);
   const [inviteModalOpened, { open: openInviteModal, close: closeInviteModal }] = useDisclosure(false);
+  const [editRoleModalOpened, { open: openEditRoleModal, close: closeEditRoleModal }] = useDisclosure(false);
+  const [editingMember, setEditingMember] = useState<{
+    userId: string;
+    name: string | null;
+    email: string | null;
+    image: string | null;
+    role: string;
+  } | null>(null);
   const [firefliesModalOpened, { open: openFirefliesModal, close: closeFirefliesModal }] = useDisclosure(false);
   const [emailModalOpened, { open: openEmailModal, close: closeEmailModal }] = useDisclosure(false);
   const [emailProvider, setEmailProvider] = useState<string>('gmail');
@@ -449,6 +459,21 @@ export default function WorkspaceSettingsPage() {
     }
   };
 
+  const handleEditRole = (member: {
+    userId: string;
+    user: { name: string | null; email: string | null; image: string | null };
+    role: string;
+  }) => {
+    setEditingMember({
+      userId: member.userId,
+      name: member.user.name,
+      email: member.user.email,
+      image: member.user.image,
+      role: member.role,
+    });
+    openEditRoleModal();
+  };
+
   if (isLoading) {
     return (
       <div className="mx-auto max-w-[1200px] p-10">
@@ -781,7 +806,18 @@ export default function WorkspaceSettingsPage() {
                         {member.role}
                       </SettingsPill>
                     </div>
-                    <div className="flex items-center justify-end border-b border-border-primary px-3.5 py-2.5 group-hover:bg-background-elevated">
+                    <div className="flex items-center justify-end gap-1 border-b border-border-primary px-3.5 py-2.5 group-hover:bg-background-elevated">
+                      {userRole === 'owner' && member.role !== 'owner' && (
+                        <Tooltip label="Edit role">
+                          <ActionIcon
+                            variant="subtle"
+                            color="gray"
+                            onClick={() => handleEditRole(member)}
+                          >
+                            <IconPencil size={14} />
+                          </ActionIcon>
+                        </Tooltip>
+                      )}
                       {canManageMembers && member.role !== 'owner' && (
                         <Tooltip label="Remove member">
                           <ActionIcon
@@ -1312,6 +1348,16 @@ export default function WorkspaceSettingsPage() {
         workspaceId={workspaceId!}
         opened={inviteModalOpened}
         onClose={closeInviteModal}
+        onSuccess={() => {
+          refetchWorkspace();
+        }}
+      />
+
+      <EditMemberRoleModal
+        workspaceId={workspaceId!}
+        member={editingMember}
+        opened={editRoleModalOpened}
+        onClose={closeEditRoleModal}
         onSuccess={() => {
           refetchWorkspace();
         }}

--- a/src/app/_components/EditMemberRoleModal.tsx
+++ b/src/app/_components/EditMemberRoleModal.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import {
+  Modal,
+  Select,
+  Button,
+  Stack,
+  Group,
+  Avatar,
+  Text,
+} from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { IconDeviceFloppy } from "@tabler/icons-react";
+import { useEffect, useState } from "react";
+import { api } from "~/trpc/react";
+
+type EditableRole = "admin" | "member" | "viewer";
+
+interface EditMemberRoleModalMember {
+  userId: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  role: string;
+}
+
+interface EditMemberRoleModalProps {
+  workspaceId: string;
+  member: EditMemberRoleModalMember | null;
+  opened: boolean;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+const ROLE_OPTIONS = [
+  { value: "admin", label: "Admin - Can manage members and settings" },
+  { value: "member", label: "Member - Can view and edit content" },
+  { value: "viewer", label: "Viewer - Read-only access" },
+];
+
+function initials(label: string): string {
+  return label.trim().charAt(0).toUpperCase() || "?";
+}
+
+function toEditableRole(role: string): EditableRole {
+  return role === "admin" || role === "viewer" ? role : "member";
+}
+
+export function EditMemberRoleModal({
+  workspaceId,
+  member,
+  opened,
+  onClose,
+  onSuccess,
+}: EditMemberRoleModalProps) {
+  const [role, setRole] = useState<EditableRole>("member");
+
+  // Sync the select with the member being edited whenever the modal opens.
+  useEffect(() => {
+    if (member) {
+      setRole(toEditableRole(member.role));
+    }
+  }, [member]);
+
+  const updateRoleMutation = api.workspace.updateMemberRole.useMutation({
+    onSuccess: () => {
+      notifications.show({
+        title: "Role updated",
+        message: `${member?.name ?? member?.email ?? "Member"}'s role has been updated.`,
+        color: "green",
+      });
+      onSuccess?.();
+      onClose();
+    },
+    onError: (err) => {
+      notifications.show({
+        title: "Error",
+        message: err.message,
+        color: "red",
+      });
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!member) return;
+    updateRoleMutation.mutate({ workspaceId, userId: member.userId, role });
+  };
+
+  const unchanged = member ? role === toEditableRole(member.role) : true;
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title="Edit Role"
+      classNames={{
+        header: "bg-surface-secondary",
+        content: "bg-surface-secondary",
+      }}
+    >
+      <form onSubmit={handleSubmit}>
+        <Stack gap="md">
+          {member && (
+            <Group gap="sm" wrap="nowrap">
+              <Avatar src={member.image} size="md" radius="xl">
+                {initials(member.name ?? member.email ?? "?")}
+              </Avatar>
+              <Stack gap={0} className="min-w-0">
+                <Text size="sm" className="truncate text-text-primary">
+                  {member.name ?? member.email ?? "Unnamed"}
+                </Text>
+                {member.name && member.email && (
+                  <Text size="xs" className="truncate text-text-muted">
+                    {member.email}
+                  </Text>
+                )}
+              </Stack>
+            </Group>
+          )}
+
+          <Select
+            label="Role"
+            value={role}
+            onChange={(val) => setRole((val as EditableRole) ?? "member")}
+            data={ROLE_OPTIONS}
+            classNames={{
+              input:
+                "bg-surface-primary border-border-primary text-text-primary",
+              label: "text-text-secondary",
+              dropdown: "bg-surface-secondary border-border-primary",
+            }}
+          />
+
+          <Group justify="flex-end">
+            <Button
+              variant="subtle"
+              onClick={onClose}
+              className="text-text-secondary"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              loading={updateRoleMutation.isPending}
+              disabled={!member || unchanged}
+              leftSection={<IconDeviceFloppy size={16} />}
+            >
+              Save
+            </Button>
+          </Group>
+        </Stack>
+      </form>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## What

Adds the ability to **edit a workspace member's role** from the workspace settings members tab (`/w/[slug]/settings`).

- New **edit (pencil) icon** on each member row, next to the existing remove icon
- Opens an `EditMemberRoleModal` pre-loaded with the member and their current role
- Role select mirrors the **Invite Member** modal (Admin / Member / Viewer), with the same labels and styling
- Save is disabled until the role actually changes; success refreshes the member list

## Implementation

- New component: `src/app/_components/EditMemberRoleModal.tsx`
- Wired into `src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx`
- **No backend change** — reuses the existing `workspace.updateMemberRole` tRPC mutation

## Permissions

`updateMemberRole` is **owner-only** (unlike Invite/Remove, which allow owner or admin). To avoid showing admins a button that would error, the edit icon is gated on the owner role, and owner members are not editable. If we want admins to edit roles too, we'd relax the backend check to match `canManageMembers` — happy to follow up.

## Testing

- `npm run check` (lint + typecheck) clean on both files
- Full unit suite (972 tests) passed via pre-commit hook
- Not yet click-tested in the running app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added role management for workspace members. Owners can now edit team member roles directly from the Members settings section using a dedicated modal interface. Available roles include admin, member, and viewer. Simply click the edit icon next to a member, select the desired role, and save—changes apply instantly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->