### PR TITLE
feat(broadcasts): edit and delete existing Broadcasts

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/broadcasts/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/broadcasts/page.tsx
@@ -17,12 +17,28 @@ import {
   Select,
   NumberInput,
   Switch,
+  ActionIcon,
+  Menu,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconBroadcast, IconPlus, IconSend } from '@tabler/icons-react';
+import {
+  IconBroadcast,
+  IconPlus,
+  IconSend,
+  IconDots,
+  IconPencil,
+  IconTrash,
+} from '@tabler/icons-react';
 import { notifications } from '@mantine/notifications';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { api } from '~/trpc/react';
+
+/** Shape of the `config` JSON stored on a Broadcast's WorkflowDefinition. */
+type BroadcastConfig = {
+  schedule?: { kind?: string; hour?: number; weekday?: number };
+  collectionId?: string;
+  subject?: string;
+};
 
 export default function CrmBroadcastsPage() {
   const { workspaceId, isLoading: wsLoading } = useWorkspace();
@@ -37,8 +53,10 @@ export default function CrmBroadcastsPage() {
     { enabled: !!workspaceId },
   );
 
-  const [createOpened, { open: openCreate, close: closeCreate }] =
+  const [formOpened, { open: openForm, close: closeForm }] =
     useDisclosure(false);
+  // null = creating a new broadcast; otherwise the id of the one being edited.
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [name, setName] = useState('What Shipped Today');
   const [subject, setSubject] = useState('What Shipped Today');
   const [collectionId, setCollectionId] = useState<string | null>(null);
@@ -47,14 +65,48 @@ export default function CrmBroadcastsPage() {
   const invalidate = () =>
     utils.broadcast.list.invalidate({ workspaceId: workspaceId ?? '' });
 
+  const openCreate = () => {
+    setEditingId(null);
+    setName('What Shipped Today');
+    setSubject('What Shipped Today');
+    setCollectionId(null);
+    setHour(8);
+    openForm();
+  };
+
+  const openEdit = (b: { id: string; name: string; config: unknown }) => {
+    const cfg = (b.config ?? {}) as BroadcastConfig;
+    setEditingId(b.id);
+    setName(b.name);
+    setSubject(cfg.subject ?? 'What Shipped Today');
+    setCollectionId(cfg.collectionId ?? null);
+    setHour(typeof cfg.schedule?.hour === 'number' ? cfg.schedule.hour : 8);
+    openForm();
+  };
+
   const create = api.broadcast.create.useMutation({
     onSuccess: async () => {
-      closeCreate();
+      closeForm();
       setCollectionId(null);
       await invalidate();
     },
     onError: (e) =>
       notifications.show({ title: 'Could not create', message: e.message, color: 'red' }),
+  });
+
+  const update = api.broadcast.update.useMutation({
+    onSuccess: async () => {
+      closeForm();
+      await invalidate();
+    },
+    onError: (e) =>
+      notifications.show({ title: 'Could not update', message: e.message, color: 'red' }),
+  });
+
+  const remove = api.broadcast.remove.useMutation({
+    onSuccess: invalidate,
+    onError: (e) =>
+      notifications.show({ title: 'Could not delete', message: e.message, color: 'red' }),
   });
 
   const setActive = api.broadcast.setActive.useMutation({
@@ -140,17 +192,49 @@ export default function CrmBroadcastsPage() {
                     </Text>
                   )}
                 </Box>
-                <Switch
-                  checked={b.isActive}
-                  label={b.isActive ? 'Active' : 'Draft'}
-                  onChange={(e) =>
-                    setActive.mutate({
-                      workspaceId,
-                      id: b.id,
-                      isActive: e.currentTarget.checked,
-                    })
-                  }
-                />
+                <Group gap="sm">
+                  <Switch
+                    checked={b.isActive}
+                    label={b.isActive ? 'Active' : 'Draft'}
+                    onChange={(e) =>
+                      setActive.mutate({
+                        workspaceId,
+                        id: b.id,
+                        isActive: e.currentTarget.checked,
+                      })
+                    }
+                  />
+                  <Menu position="bottom-end" withinPortal>
+                    <Menu.Target>
+                      <ActionIcon variant="subtle" color="gray" aria-label="Broadcast actions">
+                        <IconDots size={18} />
+                      </ActionIcon>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                      <Menu.Item
+                        leftSection={<IconPencil size={16} />}
+                        onClick={() => openEdit(b)}
+                      >
+                        Edit
+                      </Menu.Item>
+                      <Menu.Item
+                        color="red"
+                        leftSection={<IconTrash size={16} />}
+                        onClick={() => {
+                          if (
+                            window.confirm(
+                              `Delete broadcast “${b.name}”? This can't be undone.`,
+                            )
+                          ) {
+                            remove.mutate({ workspaceId, id: b.id });
+                          }
+                        }}
+                      >
+                        Delete
+                      </Menu.Item>
+                    </Menu.Dropdown>
+                  </Menu>
+                </Group>
               </Group>
             </Card>
           ))}
@@ -158,9 +242,9 @@ export default function CrmBroadcastsPage() {
       )}
 
       <Modal
-        opened={createOpened}
-        onClose={closeCreate}
-        title="Create broadcast"
+        opened={formOpened}
+        onClose={closeForm}
+        title={editingId ? 'Edit broadcast' : 'Create broadcast'}
       >
         <Stack gap="sm">
           <TextInput
@@ -189,23 +273,34 @@ export default function CrmBroadcastsPage() {
             onChange={(v) => setHour(typeof v === 'number' ? v : 8)}
           />
           <Group justify="flex-end" mt="xs">
-            <Button variant="default" onClick={closeCreate}>
+            <Button variant="default" onClick={closeForm}>
               Cancel
             </Button>
             <Button
-              loading={create.isPending}
+              loading={create.isPending || update.isPending}
               disabled={!name.trim() || !collectionId}
-              onClick={() =>
-                create.mutate({
-                  workspaceId,
-                  name: name.trim(),
-                  subject: subject.trim() || undefined,
-                  collectionId: collectionId!,
-                  cadence: { kind: 'daily', hour },
-                })
-              }
+              onClick={() => {
+                if (editingId) {
+                  update.mutate({
+                    workspaceId,
+                    id: editingId,
+                    name: name.trim(),
+                    subject: subject.trim() || undefined,
+                    collectionId: collectionId!,
+                    cadence: { kind: 'daily', hour },
+                  });
+                } else {
+                  create.mutate({
+                    workspaceId,
+                    name: name.trim(),
+                    subject: subject.trim() || undefined,
+                    collectionId: collectionId!,
+                    cadence: { kind: 'daily', hour },
+                  });
+                }
+              }}
             >
-              Create draft
+              {editingId ? 'Save changes' : 'Create draft'}
             </Button>
           </Group>
         </Stack>

--- a/src/server/api/routers/broadcast.ts
+++ b/src/server/api/routers/broadcast.ts
@@ -8,6 +8,7 @@ import { SCHEDULED_TRIGGER } from "~/server/services/workflows/TriggerRegistry";
 import {
   createBroadcast,
   runBroadcastTestSend,
+  updateBroadcast,
 } from "~/server/services/crm/broadcast/broadcastService";
 
 const cadenceSchema = z.discriminatedUnion("kind", [
@@ -96,6 +97,44 @@ export const broadcastRouter = createTRPCRouter({
         subject: input.subject,
         createdById: ctx.session.user.id,
       });
+    }),
+
+  update: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        id: z.string(),
+        name: z.string().min(1).max(255),
+        collectionId: z.string(),
+        cadence: cadenceSchema,
+        subject: z.string().max(255).optional(),
+      }),
+    )
+    .use(requireWorkspaceMembership("edit"))
+    .mutation(async ({ ctx, input }) => {
+      await assertInWorkspace(ctx.db, input.id, input.workspaceId);
+      await assertCollectionInWorkspace(
+        ctx.db,
+        input.collectionId,
+        input.workspaceId,
+      );
+      return updateBroadcast(ctx.db, {
+        id: input.id,
+        name: input.name,
+        collectionId: input.collectionId,
+        cadence: input.cadence,
+        subject: input.subject,
+      });
+    }),
+
+  remove: protectedProcedure
+    .input(z.object({ workspaceId: z.string(), id: z.string() }))
+    .use(requireWorkspaceMembership("edit"))
+    .mutation(async ({ ctx, input }) => {
+      await assertInWorkspace(ctx.db, input.id, input.workspaceId);
+      // steps + runs cascade-delete (schema onDelete: Cascade).
+      await ctx.db.workflowDefinition.delete({ where: { id: input.id } });
+      return { success: true };
     }),
 
   setActive: protectedProcedure

--- a/src/server/services/crm/broadcast/broadcastService.ts
+++ b/src/server/services/crm/broadcast/broadcastService.ts
@@ -65,6 +65,52 @@ export function createBroadcast(db: PrismaClient, input: CreateBroadcastInput) {
   });
 }
 
+export interface UpdateBroadcastInput {
+  id: string;
+  name: string;
+  /** The contact List that receives it. */
+  collectionId: string;
+  cadence: BroadcastCadence;
+  subject?: string;
+}
+
+/**
+ * Patches an existing Broadcast's user-editable knobs (name, subject, target
+ * List, cadence). These live in two places — the definition's `config` and the
+ * `generate_ai_digest` / `send_email_to_list` step configs — so we mirror exactly
+ * how `createBroadcast` wires them. `isActive` is left untouched (use `setActive`).
+ */
+export async function updateBroadcast(
+  db: PrismaClient,
+  input: UpdateBroadcastInput,
+) {
+  const subject = input.subject ?? "What Shipped Today";
+  return db.$transaction(async (tx) => {
+    const def = await tx.workflowDefinition.update({
+      where: { id: input.id },
+      data: {
+        name: input.name,
+        config: {
+          schedule: input.cadence,
+          collectionId: input.collectionId,
+          subject,
+        } as Prisma.InputJsonValue,
+      },
+    });
+    await tx.workflowStep.updateMany({
+      where: { definitionId: input.id, type: "generate_ai_digest" },
+      data: { config: { subject } as Prisma.InputJsonValue },
+    });
+    await tx.workflowStep.updateMany({
+      where: { definitionId: input.id, type: "send_email_to_list" },
+      data: {
+        config: { collectionId: input.collectionId } as Prisma.InputJsonValue,
+      },
+    });
+    return def;
+  });
+}
+
 export interface TestSendResult {
   skipped: boolean;
   reason?: string;


### PR DESCRIPTION
## What

Broadcasts were create-only (plus a draft↔active toggle). Once created, a Broadcast's name, subject, target List, and send-hour were frozen — the only post-create action was activate/deactivate. This adds full editing and deletion.

## Changes

**Backend** — `broadcast` router:
- `update` — patches name, subject, target List, and cadence. Reuses the same workspace-membership and cross-workspace-List guards as `create`.
- `remove` — deletes a Broadcast. Steps and runs cascade automatically (`onDelete: Cascade` on the `Workflow*` relations).

**Service** — `updateBroadcast` mirrors exactly how `createBroadcast` wires a Broadcast: the editable values live in three places (the `WorkflowDefinition.config`, the `generate_ai_digest` step's `subject`, and the `send_email_to_list` step's `collectionId`), all updated in one transaction. `isActive` is intentionally left to `setActive`.

**UI** — Broadcasts page:
- Per-card `⋯` menu with **Edit** and **Delete** (delete is confirm-guarded).
- The existing create modal now serves both create and edit — pre-filled from the Broadcast's config when editing; title and submit button switch on mode.

## Notes

- No schema migration — only reads/writes existing `Workflow*` tables.
- `npm run check` (typecheck + lint) and the full unit suite pass.
- Scoped deliberately to the user-editable knobs; the 3-step pipeline shape stays fixed (consistent with Broadcasts being an opinionated, pre-wired Automation per ADR-0029).