### PR TITLE
feat(sentry-webhook): shared-secret header auth for unsigned senders (Glitchtip)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,12 @@ GITHUB_WEBHOOK_SECRET=""
 # Client Secret of the Sentry internal integration; used to verify the
 # Sentry-Hook-Signature on incoming webhooks. If unset, verification is skipped.
 SENTRY_WEBHOOK_SECRET=""
+# Shared-secret token for senders that can set a header but can't HMAC-sign the
+# body (e.g. Glitchtip). The sender echoes this verbatim in the X-Webhook-Token
+# header; we compare it constant-time. Use a long random value. If both this and
+# SENTRY_WEBHOOK_SECRET are set, both must pass; if neither is set, the endpoint
+# is unauthenticated.
+SENTRY_WEBHOOK_TOKEN=""
 # Product that Sentry-filed bugs land in (defaults to the Exponential product).
 SENTRY_BUG_PRODUCT_ID=""
 # Identity for the Errol system user that authors Sentry bugs (find-or-created lazily).

--- a/src/app/api/webhooks/sentry/route.ts
+++ b/src/app/api/webhooks/sentry/route.ts
@@ -4,6 +4,7 @@ import { ingestSentryBug } from "~/server/services/sentry/SentryBugService";
 import {
   normalizeSentryPayload,
   verifySentrySignature,
+  verifyWebhookToken,
 } from "~/server/services/sentry/sentryPayload";
 
 /**
@@ -14,15 +15,30 @@ import {
  * `status: BACKLOG`) in the configured product, authored by the Errol system
  * user. Recurring errors are collapsed onto one ticket in a later slice (dedup).
  *
- * Auth: Sentry signs the raw body with HMAC-SHA256 using the integration's
- * Client Secret (set as `SENTRY_WEBHOOK_SECRET`). Verification is one-way, like
- * the GitHub webhook — no token is issued to Sentry.
+ * Auth: two independent gates, each active only when its env var is set.
+ *  - `SENTRY_WEBHOOK_TOKEN`: a shared secret the sender echoes in the
+ *    `X-Webhook-Token` header. For senders that can set headers but can't sign
+ *    the body (e.g. Glitchtip, which has no HMAC signing yet).
+ *  - `SENTRY_WEBHOOK_SECRET`: real Sentry signs the raw body with HMAC-SHA256
+ *    using the integration's Client Secret and sends it in
+ *    `Sentry-Hook-Signature`. Verification is one-way, like the GitHub webhook.
+ * If both are set, both must pass; if neither is set, the endpoint is open
+ * (logged). Configure at least one in any internet-facing deployment.
  */
 export async function POST(request: NextRequest) {
   try {
     const signature = request.headers.get("sentry-hook-signature");
     const resource = request.headers.get("sentry-hook-resource");
     const rawBody = await request.text();
+
+    const token = process.env.SENTRY_WEBHOOK_TOKEN;
+    if (token) {
+      const provided = request.headers.get("x-webhook-token");
+      if (!provided || !verifyWebhookToken(provided, token)) {
+        console.error("[sentry webhook] invalid or missing webhook token");
+        return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+      }
+    }
 
     const secret = process.env.SENTRY_WEBHOOK_SECRET;
     if (secret) {
@@ -33,9 +49,11 @@ export async function POST(request: NextRequest) {
           { status: 401 },
         );
       }
-    } else {
+    }
+
+    if (!token && !secret) {
       console.warn(
-        "[sentry webhook] SENTRY_WEBHOOK_SECRET not set - skipping signature verification",
+        "[sentry webhook] neither SENTRY_WEBHOOK_TOKEN nor SENTRY_WEBHOOK_SECRET set - endpoint is unauthenticated",
       );
     }
 

--- a/src/server/services/sentry/__tests__/sentryPayload.test.ts
+++ b/src/server/services/sentry/__tests__/sentryPayload.test.ts
@@ -10,6 +10,7 @@ import {
   buildBugBody,
   normalizeSentryPayload,
   verifySentrySignature,
+  verifyWebhookToken,
   type SentryBug,
 } from "../sentryPayload";
 
@@ -45,6 +46,26 @@ describe("verifySentrySignature", () => {
 
   it("rejects a malformed (wrong-length) signature without throwing", () => {
     expect(verifySentrySignature(body, "deadbeef", SECRET)).toBe(false);
+  });
+});
+
+describe("verifyWebhookToken", () => {
+  const TOKEN = "long-random-shared-secret";
+
+  it("accepts an exact match", () => {
+    expect(verifyWebhookToken(TOKEN, TOKEN)).toBe(true);
+  });
+
+  it("rejects a different value of the same length", () => {
+    expect(verifyWebhookToken("long-random-shared-secrXt", TOKEN)).toBe(false);
+  });
+
+  it("rejects a wrong-length value without throwing", () => {
+    expect(verifyWebhookToken("short", TOKEN)).toBe(false);
+  });
+
+  it("rejects an empty provided token", () => {
+    expect(verifyWebhookToken("", TOKEN)).toBe(false);
   });
 });
 

--- a/src/server/services/sentry/sentryPayload.ts
+++ b/src/server/services/sentry/sentryPayload.ts
@@ -68,6 +68,28 @@ export function verifySentrySignature(
 }
 
 /**
+ * Verify a shared-secret webhook token sent in a plain request header.
+ *
+ * An alternative to HMAC for senders that can set custom headers but can't sign
+ * the body (e.g. Glitchtip, which is Sentry-API-compatible but has no HMAC
+ * signing yet). The sender puts the secret verbatim in `X-Webhook-Token`; we
+ * compare it constant-time against `SENTRY_WEBHOOK_TOKEN`. Weaker than HMAC — it
+ * proves the sender knows the secret but not that the body is untampered — yet
+ * far better than an open endpoint.
+ */
+export function verifyWebhookToken(
+  provided: string,
+  expected: string,
+): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+
+  // timingSafeEqual throws on length mismatch, so guard first.
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+/**
  * Turn a Sentry webhook body into a normalized {@link SentryBug}, or `null` if
  * the event isn't one we file as a bug.
  *


### PR DESCRIPTION
## Why

The Sentry/Glitchtip bug webhook (`/api/webhooks/sentry`) was HMAC-only. Glitchtip is Sentry-API-compatible but has **no HMAC signing yet**, so pointing it at this endpoint meant running with `SENTRY_WEBHOOK_SECRET` unset — i.e. **unauthenticated**: any POST in Sentry's shape could file BUG tickets and fire Zulip notifications.

## What

A second, **independent** auth gate alongside HMAC: a shared secret the sender echoes in the `X-Webhook-Token` header, compared constant-time against a new `SENTRY_WEBHOOK_TOKEN` env var.

- Each gate is active only when its env var is set.
- If **both** are set, both must pass.
- If **neither** is set, the endpoint logs that it is unauthenticated (unchanged open behavior, now with an explicit warning).
- The existing HMAC path is untouched — real Sentry (or a future signed Glitchtip) still works by setting `SENTRY_WEBHOOK_SECRET`.

## Scope

Entirely contained to this one route + its pure helper. No middleware, shared auth, or other endpoint is affected.

## How to configure (Glitchtip)

1. `openssl rand -hex 32` → set as `SENTRY_WEBHOOK_TOKEN` on the deployment.
2. In Glitchtip's webhook config, add header `X-Webhook-Token: <same value>`; URL stays `/api/webhooks/sentry`.
3. Leave `SENTRY_WEBHOOK_SECRET` unset (Glitchtip can't sign).

> Open question for the integrator: if your Glitchtip version can't set custom headers, a `?token=…` URL fallback is a small follow-up — the helper is already reusable.

## Tests

- New `verifyWebhookToken` unit tests (match/mismatch/wrong-length/empty).
- Full unit suite green (1066 passed) via pre-commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token-based authentication for Sentry webhooks as an alternative verification method.
  * Webhooks now support independent token and signature verification paths.

* **Configuration**
  * Introduced `SENTRY_WEBHOOK_TOKEN` environment variable for webhook verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->