### PR TITLE
fix(okr): scope My Goals key results to the current user

### DIFF
--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -234,8 +234,19 @@ export const keyResultRouter = createTRPCRouter({
           keyResults: {
             where: {
               ...periodFilter,
-              // When workspace-scoped, show all key results; otherwise only user's own
-              ...(isWorkspaceScoped ? {} : { userId: ctx.session.user.id }),
+              // Show every key result only on the workspace-wide OKRs view.
+              // On the "My Goals" view (onlyMine) and outside any workspace,
+              // restrict to key results the user owns or is the DRI for — the
+              // same ownership test applied to goals above. Without this, a
+              // user's own objective would still surface other people's KRs.
+              ...(isWorkspaceScoped && !input.onlyMine
+                ? {}
+                : {
+                    OR: [
+                      { userId: ctx.session.user.id },
+                      { driUserId: ctx.session.user.id },
+                    ],
+                  }),
             },
             include: {
               checkIns: {
@@ -845,9 +856,18 @@ export const keyResultRouter = createTRPCRouter({
         periods.map(async (periodType) => {
           const period = `${periodType}-${input.year}`;
           const where = {
-            ...(isWorkspaceScoped
-              ? { workspaceId: input.workspaceId }
-              : { userId: ctx.session.user.id }),
+            ...(isWorkspaceScoped ? { workspaceId: input.workspaceId } : {}),
+            // Outside a workspace, or on the "My Goals" view, count only the
+            // KRs the user owns or is the DRI for — matching the cards, which
+            // render the same ownership-scoped key results.
+            ...(!isWorkspaceScoped || input.onlyMine
+              ? {
+                  OR: [
+                    { userId: ctx.session.user.id },
+                    { driUserId: ctx.session.user.id },
+                  ],
+                }
+              : {}),
             // Scope counts to KRs under my objectives so period-tab counts
             // match the cards shown in the "My Goals" view.
             ...(isWorkspaceScoped && input.onlyMine


### PR DESCRIPTION
## Problem

The **My Goals** tab (`/w/[slug]/goals?tab=my-goals`) showed key results that don't belong to the logged-in user — e.g. other people's OKRs like "learning to help other people" appeared under the user's own objectives.

## Root cause

The tab renders `<OkrDashboard scope="mine" />`, which calls `okr.getByObjective` with `onlyMine: true`. That query already scoped **goals** to the user (`userId`/`driUserId`), but each goal's embedded **key results** were returned unfiltered whenever the request was workspace-scoped:

```ts
...(isWorkspaceScoped ? {} : { userId: ctx.session.user.id })
```

Since the `/w/[slug]/goals` route is always workspace-scoped, every key result under any of the user's goals leaked in, regardless of owner.

## Fix

In `src/plugins/okr/server/routers/keyResult.ts`:

- **`getByObjective`** — embedded key results now restrict to owned-or-DRI (`userId`/`driUserId`) whenever `onlyMine` is set or the query isn't workspace-scoped. The unfiltered path is reserved for the workspace-wide **OKRs** tab.
- **`getCountsByYear`** — applied the same key-result ownership scope so the period-tab badge counts match the cards.

"Mine" now means owned-or-DRI consistently at both the goal and key-result level.

## Notes

- The workspace-wide **OKRs** tab (`scope="workspace"`, `onlyMine` unset) is unaffected — it still shows all workspace key results.
- If a specific *objective* still appears in My Goals after this, that objective itself has the user's `userId`/`driUserId` set (data, not code) — the existing goal-level filter governs that.

## Testing

- Full unit suite passes (1069 tests) via pre-push hook.
- Typecheck clean on the changed file.
- Not yet verified visually in the running app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed key results visibility filtering in OKR views. Workspace-wide OKR view now displays all key results correctly, while "My Goals" view properly restricts results to those you own or are assigned as DRI (Directly Responsible Individual).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->