### PR TITLE
fix(crm): only fire list_member_added for genuinely-new members

### DIFF
--- a/src/server/api/routers/collection.ts
+++ b/src/server/api/routers/collection.ts
@@ -107,13 +107,13 @@ export const collectionRouter = createTRPCRouter({
       );
 
       // Fire any `list_member_added` Automations subscribed to this List
-      // (ADR-0031). Only when at least one member was genuinely added; the
-      // dispatcher's per-(definition, contact) idempotency guards the rest.
-      if (result.count > 0) {
+      // (ADR-0031), but only for members that were *genuinely* added — never
+      // for ones already in the List — so re-adding can't re-trigger.
+      if (result.addedMemberIds.length > 0) {
         await dispatchListMemberAddedAutomations(ctx.db, {
           collectionId: input.collectionId,
           workspaceId: input.workspaceId,
-          addedMemberIds: input.memberIds,
+          addedMemberIds: result.addedMemberIds,
           triggeredById: ctx.session.user.id,
         });
       }

--- a/src/server/services/collections/CollectionService.ts
+++ b/src/server/services/collections/CollectionService.ts
@@ -62,21 +62,41 @@ export class CollectionService {
    * Add members. The `memberType` is taken from the parent collection (members
    * are homogeneous), so callers pass only ids. Duplicate (collectionId,
    * memberId) pairs are ignored.
+   *
+   * Returns the ids that were *genuinely* inserted (`addedMemberIds`) — already-
+   * present members are excluded. Callers that fire side effects on add (e.g.
+   * the `list_member_added` Automation trigger, ADR-0031) must key off this, not
+   * the input list, so re-adding an existing member never re-triggers.
    */
-  async addMembers(collectionId: string, memberIds: string[]) {
-    if (memberIds.length === 0) return { count: 0 };
+  async addMembers(
+    collectionId: string,
+    memberIds: string[],
+  ): Promise<{ count: number; addedMemberIds: string[] }> {
+    if (memberIds.length === 0) return { count: 0, addedMemberIds: [] };
     const collection = await this.db.collection.findUniqueOrThrow({
       where: { id: collectionId },
       select: { memberType: true },
     });
-    return this.db.collectionMember.createMany({
-      data: memberIds.map((memberId) => ({
+
+    const uniqueIds = [...new Set(memberIds)];
+    const existing = await this.db.collectionMember.findMany({
+      where: { collectionId, memberId: { in: uniqueIds } },
+      select: { memberId: true },
+    });
+    const existingIds = new Set(existing.map((m) => m.memberId));
+    const addedMemberIds = uniqueIds.filter((id) => !existingIds.has(id));
+
+    if (addedMemberIds.length === 0) return { count: 0, addedMemberIds };
+
+    await this.db.collectionMember.createMany({
+      data: addedMemberIds.map((memberId) => ({
         collectionId,
         memberType: collection.memberType,
         memberId,
       })),
       skipDuplicates: true,
     });
+    return { count: addedMemberIds.length, addedMemberIds };
   }
 
   removeMember(collectionId: string, memberId: string) {

--- a/src/server/services/collections/__tests__/CollectionService.test.ts
+++ b/src/server/services/collections/__tests__/CollectionService.test.ts
@@ -30,11 +30,12 @@ describe("CollectionService.addMembers", () => {
     db.collection.findUniqueOrThrow.mockResolvedValue({
       memberType: "crm_contact",
     } as never);
+    db.collectionMember.findMany.mockResolvedValue([] as never);
     db.collectionMember.createMany.mockResolvedValue({ count: 2 } as never);
     const { registry } = makeRegistry("crm_contact", []);
 
     const svc = new CollectionService(db, registry);
-    await svc.addMembers("col1", ["c1", "c2"]);
+    const res = await svc.addMembers("col1", ["c1", "c2"]);
 
     expect(db.collectionMember.createMany).toHaveBeenCalledWith({
       data: [
@@ -43,6 +44,46 @@ describe("CollectionService.addMembers", () => {
       ],
       skipDuplicates: true,
     });
+    expect(res).toEqual({ count: 2, addedMemberIds: ["c1", "c2"] });
+  });
+
+  it("returns only genuinely-new ids and never re-inserts an existing member", async () => {
+    const db = mockDeep<PrismaClient>();
+    db.collection.findUniqueOrThrow.mockResolvedValue({
+      memberType: "crm_contact",
+    } as never);
+    // c1 is already a member; only c2 is new.
+    db.collectionMember.findMany.mockResolvedValue([
+      { memberId: "c1" },
+    ] as never);
+    db.collectionMember.createMany.mockResolvedValue({ count: 1 } as never);
+    const { registry } = makeRegistry("crm_contact", []);
+
+    const svc = new CollectionService(db, registry);
+    const res = await svc.addMembers("col1", ["c1", "c2"]);
+
+    expect(db.collectionMember.createMany).toHaveBeenCalledWith({
+      data: [{ collectionId: "col1", memberType: "crm_contact", memberId: "c2" }],
+      skipDuplicates: true,
+    });
+    expect(res).toEqual({ count: 1, addedMemberIds: ["c2"] });
+  });
+
+  it("no-ops when every id is already a member (no DB write)", async () => {
+    const db = mockDeep<PrismaClient>();
+    db.collection.findUniqueOrThrow.mockResolvedValue({
+      memberType: "crm_contact",
+    } as never);
+    db.collectionMember.findMany.mockResolvedValue([
+      { memberId: "c1" },
+    ] as never);
+    const { registry } = makeRegistry("crm_contact", []);
+
+    const svc = new CollectionService(db, registry);
+    const res = await svc.addMembers("col1", ["c1"]);
+
+    expect(res).toEqual({ count: 0, addedMemberIds: [] });
+    expect(db.collectionMember.createMany).not.toHaveBeenCalled();
   });
 
   it("no-ops on an empty id list (no DB write)", async () => {
@@ -51,7 +92,7 @@ describe("CollectionService.addMembers", () => {
     const svc = new CollectionService(db, registry);
 
     const res = await svc.addMembers("col1", []);
-    expect(res).toEqual({ count: 0 });
+    expect(res).toEqual({ count: 0, addedMemberIds: [] });
     expect(db.collectionMember.createMany).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/crm/automation/dispatchListMemberAddedAutomations.ts
+++ b/src/server/services/crm/automation/dispatchListMemberAddedAutomations.ts
@@ -57,11 +57,16 @@ export async function dispatchListMemberAddedAutomations(
 
   // Idempotency: a (definition, contact) pair fires once. Runs carry
   // `{ contactId }` in their input JSON, so no extra column. FAILED runs are
-  // excluded so a failed send retries on the next add.
+  // excluded so a failed send retries on the next add. Scoped to just these
+  // candidate contacts so the scan stays bounded as run history grows (rather
+  // than loading every run the definition ever produced).
   const priorRuns = await db.workflowPipelineRun.findMany({
     where: {
       definitionId: { in: definitionIds },
       status: { not: "FAILED" },
+      OR: input.addedMemberIds.map((memberId) => ({
+        input: { path: ["contactId"], equals: memberId },
+      })),
     },
     select: { definitionId: true, input: true },
   });


### PR DESCRIPTION
## What

Follow-up hardening for the `list_member_added` trigger shipped in #281. Addresses two findings from an adversarial review of that PR.

## Findings fixed

**[Medium] Over-fired for pre-existing members.** `addMembers` returned only `{ count }`, so the router fired the trigger for **every** passed `memberId` whenever `count > 0`. A contact already in the List — e.g. added before the automation existed, so with no prior run — got re-onboarded whenever any *other* new member was added.

**[Medium] Unbounded `priorRuns` scan.** The dispatcher loaded **every** non-FAILED run for the matching definitions on each `addMembers` call to build its dedupe set — a scan that grows with run history, on a user-facing path.

## Fix

- `CollectionService.addMembers` now computes and returns `addedMemberIds` (genuinely inserted; existing members excluded) alongside `count`. Empty / all-duplicate adds write nothing and fire nothing.
- `collection.addMembers` fires the trigger only for `result.addedMemberIds`, so re-adding an existing member can never re-trigger.
- The dispatcher scopes its `priorRuns` query to just the candidate contacts (`OR` of `input.contactId` equals), bounding the scan.
- Added unit tests for existing-member filtering, the new return shape, and the all-duplicate no-op.

## Tests

Full unit suite green locally (1078 tests). Integration tests run in CI.

## Not changed (intentional)

- Sends remain synchronous/awaited — correct on Vercel (fire-and-forget would let the function terminate mid-send). Large bulk adds can still be slow; queueing is a separate follow-up.
- Consent (`emailOptedOutAt`) is still not checked on this path — a product decision flagged in #281, unchanged here.
