### PR TITLE
feat(crm): surface list-triggered automations on the List page

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/lists/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/lists/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
   Text,
   Button,
   Card,
+  Badge,
   Group,
   Stack,
   Loader,
@@ -16,10 +17,23 @@ import {
   ActionIcon,
   Tooltip,
 } from '@mantine/core';
-import { IconUsers, IconPlus, IconTrash } from '@tabler/icons-react';
+import { IconUsers, IconPlus, IconTrash, IconBolt } from '@tabler/icons-react';
 import { notifications } from '@mantine/notifications';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { api } from '~/trpc/react';
+
+function runStatusColor(status: string): string {
+  switch (status) {
+    case 'SUCCESS':
+      return 'green';
+    case 'FAILED':
+      return 'red';
+    case 'RUNNING':
+      return 'blue';
+    default:
+      return 'gray';
+  }
+}
 
 export default function CrmListDetailPage() {
   const { workspaceId, isLoading: wsLoading } = useWorkspace();
@@ -39,6 +53,16 @@ export default function CrmListDetailPage() {
     { enabled: !!workspaceId },
   );
 
+  const automationsQuery = api.listAutomation.list.useQuery(
+    { workspaceId: workspaceId ?? '', collectionId },
+    { enabled: !!workspaceId },
+  );
+
+  const runsQuery = api.listAutomation.runs.useQuery(
+    { workspaceId: workspaceId ?? '', collectionId, limit: 10 },
+    { enabled: !!workspaceId },
+  );
+
   const invalidate = () =>
     utils.collection.members.invalidate({
       workspaceId: workspaceId ?? '',
@@ -49,6 +73,12 @@ export default function CrmListDetailPage() {
     onSuccess: async () => {
       setToAdd([]);
       await invalidate();
+      // Adding a member may have fired a list_member_added Automation — refresh
+      // the runs so the user sees it land.
+      await utils.listAutomation.runs.invalidate({
+        workspaceId: workspaceId ?? '',
+        collectionId,
+      });
     },
     onError: (e) =>
       notifications.show({ title: 'Could not add', message: e.message, color: 'red' }),
@@ -74,6 +104,9 @@ export default function CrmListDetailPage() {
         'Unnamed contact',
     }));
 
+  const automations = automationsQuery.data ?? [];
+  const runs = runsQuery.data ?? [];
+
   return (
     <Stack gap="lg" p="md">
       <Box>
@@ -83,6 +116,74 @@ export default function CrmListDetailPage() {
           skipped when a Broadcast sends.
         </Text>
       </Box>
+
+      <Card withBorder padding="md">
+        <Group gap="xs" mb="xs">
+          <ThemeIcon size="sm" variant="light" color="yellow">
+            <IconBolt size={14} />
+          </ThemeIcon>
+          <Text fw={600}>Automations</Text>
+          <Text c="dimmed" size="sm">
+            run when a contact is added to this list
+          </Text>
+        </Group>
+
+        {automationsQuery.isLoading ? (
+          <Loader size="sm" />
+        ) : automations.length === 0 ? (
+          <Text c="dimmed" size="sm">
+            No automations are wired to this list yet.
+          </Text>
+        ) : (
+          <Stack gap="xs">
+            {automations.map((a) => (
+              <Group key={a.id} justify="space-between" align="center" wrap="nowrap">
+                <Box>
+                  <Group gap="xs">
+                    <Text fw={500}>{a.name}</Text>
+                    <Badge
+                      size="sm"
+                      variant="light"
+                      color={a.isActive ? 'green' : 'gray'}
+                    >
+                      {a.isActive ? 'Active' : 'Inactive'}
+                    </Badge>
+                  </Group>
+                  <Text c="dimmed" size="sm">
+                    {a.steps.length > 0
+                      ? a.steps.map((s) => s.label).join(' → ')
+                      : 'No steps yet'}
+                  </Text>
+                </Box>
+                <Text c="dimmed" size="sm" style={{ whiteSpace: 'nowrap' }}>
+                  {a._count.runs} {a._count.runs === 1 ? 'run' : 'runs'}
+                </Text>
+              </Group>
+            ))}
+
+            {runs.length > 0 && (
+              <Box mt="xs">
+                <Text c="dimmed" size="xs" tt="uppercase" fw={600} mb={4}>
+                  Recent runs
+                </Text>
+                <Stack gap={4}>
+                  {runs.map((r) => (
+                    <Group key={r.id} gap="xs" wrap="nowrap">
+                      <Badge size="xs" variant="light" color={runStatusColor(r.status)}>
+                        {r.status}
+                      </Badge>
+                      <Text size="sm">{r.definition.name}</Text>
+                      <Text c="dimmed" size="xs">
+                        {new Date(r.startedAt).toLocaleString()}
+                      </Text>
+                    </Group>
+                  ))}
+                </Stack>
+              </Box>
+            )}
+          </Stack>
+        )}
+      </Card>
 
       <Card withBorder padding="md">
         <Group align="flex-end" gap="sm">

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -47,6 +47,7 @@ import { crmOrganizationRouter } from "./routers/crmOrganization";
 import { crmAutomationRouter } from "./routers/crmAutomation";
 import { formRouter } from "./routers/form";
 import { collectionRouter } from "./routers/collection";
+import { listAutomationRouter } from "./routers/listAutomation";
 import { broadcastRouter } from "./routers/broadcast";
 import { tagRouter } from "./routers/tag";
 import { schedulingRouter } from "./routers/scheduling";
@@ -136,6 +137,7 @@ export const appRouter = createTRPCRouter({
   crmAutomation: crmAutomationRouter,
   form: formRouter,
   collection: collectionRouter,
+  listAutomation: listAutomationRouter,
   broadcast: broadcastRouter,
   tag: tagRouter,
   scheduling: schedulingRouter,

--- a/src/server/api/routers/listAutomation.ts
+++ b/src/server/api/routers/listAutomation.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { requireWorkspaceMembership } from "~/server/services/access/middleware";
+import { LIST_MEMBER_ADDED_TRIGGER } from "~/server/services/crm/automation/listMemberTrigger";
+
+/**
+ * Read-only surface for **List-triggered Automations** (`list_member_added`,
+ * [ADR-0031]). The `crmAutomation` router is contact-type-shaped (its builder
+ * assumes a "Customer type set" trigger), so List automations live here and are
+ * rendered on the List detail page — the home that matches the model: an
+ * Automation is a hook on the List it fires for.
+ *
+ * Creation/editing is still seed-script-only (`scripts/seed-list-automations.ts`);
+ * a List-trigger builder is a deliberate follow-up.
+ */
+export const listAutomationRouter = createTRPCRouter({
+  /** The Automations that fire when a contact is added to this List. */
+  list: protectedProcedure
+    .input(z.object({ workspaceId: z.string(), collectionId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
+    .query(({ ctx, input }) =>
+      ctx.db.workflowDefinition.findMany({
+        where: {
+          workspaceId: input.workspaceId,
+          triggerType: LIST_MEMBER_ADDED_TRIGGER,
+          config: { path: ["listId"], equals: input.collectionId },
+        },
+        include: {
+          steps: {
+            orderBy: { order: "asc" },
+            select: { id: true, label: true, type: true, order: true },
+          },
+          _count: { select: { runs: true } },
+        },
+        orderBy: { name: "asc" },
+      }),
+    ),
+
+  /** Recent runs of this List's Automations (newest first). */
+  runs: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        collectionId: z.string(),
+        limit: z.number().min(1).max(50).default(10),
+      }),
+    )
+    .use(requireWorkspaceMembership("view"))
+    .query(({ ctx, input }) =>
+      ctx.db.workflowPipelineRun.findMany({
+        where: {
+          definition: {
+            workspaceId: input.workspaceId,
+            triggerType: LIST_MEMBER_ADDED_TRIGGER,
+            config: { path: ["listId"], equals: input.collectionId },
+          },
+        },
+        include: {
+          definition: { select: { name: true } },
+          stepRuns: {
+            orderBy: { startedAt: "asc" },
+            select: { id: true, status: true },
+          },
+        },
+        orderBy: { startedAt: "desc" },
+        take: input.limit,
+      }),
+    ),
+});


### PR DESCRIPTION
## What

Makes `list_member_added` automations (from #281) **visible in the UI**. They previously had no surface — the `/crm/automations` page filters to the contact-type trigger, so list automations were invisible.

Per [ADR-0031](docs/adr/0031-state-transitions-are-triggers-not-a-merged-table.md), an Automation is a hook on the List it fires for, so the **List detail page** (`/crm/lists/[id]`) is its home.

## How

- **`listAutomation` router** (read-only): `list` (a collection's `list_member_added` definitions with steps + run count) and `runs` (recent runs), both workspace-membership-checked.
- **List detail page**: an "Automations" card showing each automation — name, Active/Inactive, step summary (`Welcome → …`), run count — plus a "Recent runs" list. Runs auto-refresh after a member is added, so you can watch a send land.

## Scope

Read-only on purpose — creation/editing of list automations stays seed-script-only for now (`scripts/seed-list-automations.ts`); a List-trigger builder is a deliberate follow-up. Deliberately did **not** fold these into the contact-type `/crm/automations` builder, which assumes a "Customer type set" trigger.

## Tests

Full unit suite green locally (1076). New router is read-only and membership-checked; integration tests run in CI.

## Relationship to other PRs

Independent of #282 (the dispatcher hardening) — different files, depends only on #281 which is in `main`. Either can merge first.
