### PR TITLE
CRM: scope starter automations, contact meetings timeline, stats refresh

### DIFF
--- a/scripts/cleanup-crm-starter-automations.ts
+++ b/scripts/cleanup-crm-starter-automations.ts
@@ -1,0 +1,118 @@
+/**
+ * Cleanup Script: Remove CRM starter automations from all workspaces except one.
+ *
+ * The CRM Automations page used to auto-seed two "starter" onboarding automations
+ * ("Channel Partner onboarding", "Advisor onboarding") into a workspace the first
+ * time anyone opened its Automations page. That auto-seed has been removed, but the
+ * starters it already created in other workspaces remain. This script deletes those
+ * leftover starters everywhere EXCEPT the keep-workspace (default: `butterflies`).
+ *
+ * Starters are identified by `triggerType = crm.contact.customer_type` AND
+ * `config.isDefault = true`. Deleting a WorkflowDefinition cascades to its steps,
+ * runs, and step-runs (all `onDelete: Cascade`).
+ *
+ * Dry-run by default — pass `--delete` to actually remove rows.
+ *
+ *   # Dry run (lists what would be deleted):
+ *   DATABASE_URL="<target-db-url>" npx tsx scripts/cleanup-crm-starter-automations.ts
+ *
+ *   # Execute the deletion:
+ *   DATABASE_URL="<target-db-url>" npx tsx scripts/cleanup-crm-starter-automations.ts --delete
+ *
+ * Override the keep-workspace slug with --keep=<slug> (default: butterflies).
+ */
+
+// Reads DATABASE_URL straight from the environment — pass it on the command line
+// (e.g. DATABASE_URL="..." npx tsx scripts/cleanup-crm-starter-automations.ts).
+import { PrismaClient } from '@prisma/client';
+
+import { CRM_CONTACT_TYPE_TRIGGER } from '../src/server/services/crm/automation/triggerResolver';
+
+const db = new PrismaClient();
+
+function getKeepSlug(): string {
+  const arg = process.argv.find((a) => a.startsWith('--keep='));
+  return arg ? arg.slice('--keep='.length) : 'butterflies';
+}
+
+async function cleanupStarterAutomations() {
+  const keepSlug = getKeepSlug();
+  const shouldDelete = process.argv.includes('--delete');
+
+  console.log(
+    `🔍 Cleaning up CRM starter automations (keeping workspace "${keepSlug}")...`,
+  );
+
+  // Safety: make sure the keep-workspace actually exists before touching anything.
+  const keepWorkspace = await db.workspace.findFirst({
+    where: { slug: keepSlug },
+    select: { id: true, slug: true, name: true },
+  });
+
+  if (!keepWorkspace) {
+    console.error(
+      `❌ Keep-workspace "${keepSlug}" not found. Aborting — refusing to run without a confirmed workspace to preserve.`,
+    );
+    console.error(
+      `   Pass the correct slug with --keep=<slug>, e.g. --keep=butterflies`,
+    );
+    return;
+  }
+
+  console.log(
+    `✅ Keep-workspace found: ${keepWorkspace.name} (${keepWorkspace.slug})`,
+  );
+
+  // Find starter automations in every OTHER workspace.
+  const candidates = await db.workflowDefinition.findMany({
+    where: {
+      triggerType: CRM_CONTACT_TYPE_TRIGGER,
+      config: { path: ['isDefault'], equals: true },
+      workspace: { slug: { not: keepSlug } },
+    },
+    select: {
+      id: true,
+      name: true,
+      workspace: { select: { slug: true, name: true } },
+    },
+    orderBy: [{ workspace: { slug: 'asc' } }, { name: 'asc' }],
+  });
+
+  console.log(
+    `\n📊 Found ${candidates.length} starter automation(s) to remove (outside "${keepSlug}"):`,
+  );
+  for (const c of candidates) {
+    console.log(`   • [${c.workspace.slug}] ${c.name} (${c.id})`);
+  }
+
+  if (candidates.length === 0) {
+    console.log('\n✅ Nothing to clean up.');
+    return;
+  }
+
+  if (!shouldDelete) {
+    console.log(
+      `\nℹ️  Dry run — no rows deleted. Re-run with --delete to remove the ${candidates.length} automation(s) above.`,
+    );
+    return;
+  }
+
+  console.log(`\n🗑️  Deleting ${candidates.length} starter automation(s)...`);
+  const result = await db.workflowDefinition.deleteMany({
+    where: { id: { in: candidates.map((c) => c.id) } },
+  });
+  console.log(`✅ Deleted ${result.count} automation(s) (steps/runs cascaded).`);
+}
+
+cleanupStarterAutomations()
+  .then(() => {
+    console.log('\n✅ Done.');
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error('\n❌ Cleanup failed:', error);
+    process.exit(1);
+  })
+  .finally(() => {
+    void db.$disconnect();
+  });

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/automations/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/automations/page.tsx
@@ -1,25 +1,24 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import {
   Title,
   Text,
   Button,
-  Card,
   Badge,
   Group,
   Stack,
   Loader,
-  Box,
   ThemeIcon,
-  Divider,
   Select,
   Modal,
   TextInput,
+  ActionIcon,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconBolt, IconPlus } from '@tabler/icons-react';
+import { modals } from '@mantine/modals';
+import { IconBolt, IconPlus, IconTrash } from '@tabler/icons-react';
 import { notifications } from '@mantine/notifications';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { api } from '~/trpc/react';
@@ -62,17 +61,29 @@ export default function CrmAutomationsPage() {
     { enabled },
   );
 
-  // Seed the two starter automations once if the workspace has none yet.
-  const ensureDefaults = api.crmAutomation.ensureDefaults.useMutation({
+  const remove = api.crmAutomation.remove.useMutation({
     onSuccess: () => void utils.crmAutomation.list.invalidate(),
+    onError: (error) =>
+      notifications.show({
+        title: 'Could not delete automation',
+        message: error.message,
+        color: 'red',
+      }),
   });
-  const ensuredRef = useRef(false);
-  useEffect(() => {
-    if (!workspaceId || ensuredRef.current) return;
-    ensuredRef.current = true;
-    ensureDefaults.mutate({ workspaceId });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspaceId]);
+
+  const confirmDelete = (id: string, name: string) =>
+    modals.openConfirmModal({
+      title: 'Delete automation',
+      children: (
+        <Text size="sm">
+          Delete <strong>{name}</strong>? This removes the automation and its run
+          history and can&apos;t be undone.
+        </Text>
+      ),
+      labels: { confirm: 'Delete', cancel: 'Cancel' },
+      confirmProps: { color: 'red' },
+      onConfirm: () => remove.mutate({ id }),
+    });
 
   const [createOpened, { open: openCreate, close: closeCreate }] =
     useDisclosure(false);
@@ -102,14 +113,17 @@ export default function CrmAutomationsPage() {
   const runs = runsQuery.data ?? [];
 
   return (
-    <Stack gap="lg" p="md">
-      <Group justify="space-between" align="flex-start">
-        <Box>
-          <Title order={2}>Automations</Title>
-          <Text c="dimmed" size="sm">
+    <div className="-m-6 flex h-full flex-col">
+      {/* Header bar */}
+      <div className="flex items-center justify-between border-b border-border-primary bg-background-primary px-4 py-3">
+        <div>
+          <Title order={3} className="text-text-primary">
+            Automations
+          </Title>
+          <Text size="sm" className="text-text-muted">
             Onboarding automations run when a contact&apos;s Customer type is set.
           </Text>
-        </Box>
+        </div>
         <Group gap="sm">
           <Select
             placeholder="Open an automation…"
@@ -125,37 +139,42 @@ export default function CrmAutomationsPage() {
             Create new automation
           </Button>
         </Group>
-      </Group>
+      </div>
 
-      {automationsQuery.isLoading ? (
-        <Loader />
-      ) : automations.length === 0 ? (
-        <Card withBorder padding="xl">
-          <Stack align="center" gap="sm">
+      {/* Body */}
+      <div className="flex-1 overflow-auto">
+        {automationsQuery.isLoading ? (
+          <div className="p-6">
+            <Loader />
+          </div>
+        ) : automations.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 px-4 py-16 text-center">
             <ThemeIcon size="xl" variant="light">
               <IconBolt />
             </ThemeIcon>
-            <Text fw={600}>No automations yet</Text>
-            <Text c="dimmed" size="sm" ta="center">
+            <Text fw={600} className="text-text-primary">
+              No automations yet
+            </Text>
+            <Text size="sm" className="max-w-sm text-text-muted">
               Create an automation, then add a contact with that Customer type to
               trigger one.
             </Text>
-          </Stack>
-        </Card>
-      ) : (
-        <Stack gap="sm">
-          {automations.map((automation) => (
-            <Card
-              key={automation.id}
-              withBorder
-              padding="md"
-              style={{ cursor: 'pointer' }}
-              onClick={() => router.push(`${pathname}/${automation.id}`)}
-            >
-              <Group justify="space-between" align="flex-start">
-                <Box>
+          </div>
+        ) : (
+          <div>
+            {automations.map((automation) => (
+              <div
+                key={automation.id}
+                role="button"
+                tabIndex={0}
+                className="flex cursor-pointer items-center justify-between gap-4 border-b border-border-primary px-4 py-3 transition-colors hover:bg-surface-hover"
+                onClick={() => router.push(`${pathname}/${automation.id}`)}
+              >
+                <div className="min-w-0">
                   <Group gap="xs">
-                    <Text fw={600}>{automation.name}</Text>
+                    <Text fw={600} className="text-text-primary">
+                      {automation.name}
+                    </Text>
                     <Badge variant="light">
                       {targetTypeOf(automation.config)}
                     </Badge>
@@ -166,74 +185,101 @@ export default function CrmAutomationsPage() {
                       {automation.isActive ? 'active' : 'inactive'}
                     </Badge>
                   </Group>
-                  <Text c="dimmed" size="sm" mt={4}>
+                  <Text size="sm" mt={4} className="truncate text-text-muted">
                     {automation.steps.length > 0
                       ? automation.steps.map((step) => step.label).join('  →  ')
                       : 'No steps yet'}
                   </Text>
-                </Box>
-                <Badge variant="outline">
-                  {automation._count.runs}{' '}
-                  {automation._count.runs === 1 ? 'run' : 'runs'}
-                </Badge>
-              </Group>
-            </Card>
-          ))}
-        </Stack>
-      )}
-
-      <Divider label="Recent runs" labelPosition="left" />
-
-      {runsQuery.isLoading ? (
-        <Loader />
-      ) : runs.length === 0 ? (
-        <Text c="dimmed" size="sm">
-          No runs yet. Add a contact with a matching Customer type to trigger one.
-        </Text>
-      ) : (
-        <Stack gap="xs">
-          {runs.map((run) => (
-            <Card key={run.id} withBorder padding="sm">
-              <Group justify="space-between" align="flex-start">
-                <Box>
-                  <Group gap="xs">
-                    <Text fw={500} size="sm">
-                      {run.definition.name}
-                    </Text>
-                    <Badge
-                      size="sm"
-                      color={statusColor(run.status)}
-                      variant="light"
-                    >
-                      {run.status}
-                    </Badge>
-                  </Group>
-                  <Text c="dimmed" size="xs" mt={2}>
-                    {new Date(run.startedAt).toLocaleString()}
-                  </Text>
-                </Box>
-                <Group gap={6}>
-                  {run.stepRuns.map((step) => (
-                    <Badge
-                      key={step.id}
-                      size="xs"
-                      color={statusColor(step.status)}
-                      variant="dot"
-                    >
-                      {step.status}
-                    </Badge>
-                  ))}
+                </div>
+                <Group gap="sm" wrap="nowrap">
+                  <Badge variant="outline">
+                    {automation._count.runs}{' '}
+                    {automation._count.runs === 1 ? 'run' : 'runs'}
+                  </Badge>
+                  <ActionIcon
+                    variant="subtle"
+                    color="red"
+                    aria-label={`Delete ${automation.name}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      confirmDelete(automation.id, automation.name);
+                    }}
+                  >
+                    <IconTrash size={16} />
+                  </ActionIcon>
                 </Group>
-              </Group>
-              {run.errorMessage ? (
-                <Text c="red" size="xs" mt={4}>
-                  {run.errorMessage}
-                </Text>
-              ) : null}
-            </Card>
-          ))}
-        </Stack>
-      )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Recent runs */}
+        <div className="border-b border-border-primary bg-background-primary px-4 py-2">
+          <Text
+            size="xs"
+            fw={600}
+            className="uppercase tracking-wider text-text-muted"
+          >
+            Recent runs
+          </Text>
+        </div>
+        {runsQuery.isLoading ? (
+          <div className="p-4">
+            <Loader />
+          </div>
+        ) : runs.length === 0 ? (
+          <Text size="sm" className="px-4 py-3 text-text-muted">
+            No runs yet. Add a contact with a matching Customer type to trigger
+            one.
+          </Text>
+        ) : (
+          <div>
+            {runs.map((run) => (
+              <div
+                key={run.id}
+                className="border-b border-border-primary px-4 py-3"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <Group gap="xs">
+                      <Text fw={500} size="sm" className="text-text-primary">
+                        {run.definition.name}
+                      </Text>
+                      <Badge
+                        size="sm"
+                        color={statusColor(run.status)}
+                        variant="light"
+                      >
+                        {run.status}
+                      </Badge>
+                    </Group>
+                    <Text size="xs" mt={2} className="text-text-muted">
+                      {new Date(run.startedAt).toLocaleString()}
+                    </Text>
+                  </div>
+                  <Group gap={6} wrap="nowrap">
+                    {run.stepRuns.map((step) => (
+                      <Badge
+                        key={step.id}
+                        size="xs"
+                        color={statusColor(step.status)}
+                        variant="dot"
+                      >
+                        {step.status}
+                      </Badge>
+                    ))}
+                  </Group>
+                </div>
+                {run.errorMessage ? (
+                  <Text size="xs" mt={4} c="red">
+                    {run.errorMessage}
+                  </Text>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
 
       <Modal
         opened={createOpened}
@@ -279,6 +325,6 @@ export default function CrmAutomationsPage() {
           </Group>
         </Stack>
       </Modal>
-    </Stack>
+    </div>
   );
 }

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/[id]/page.tsx
@@ -34,7 +34,6 @@ import {
   IconBrandBluesky,
   IconBuilding,
   IconPlus,
-  IconPhoneCall,
   IconCalendar,
   IconNote,
   IconStar,
@@ -126,18 +125,22 @@ function ActivityItem({
   action,
   date,
   subject,
+  icon,
+  href,
 }: {
   actor: string;
   action: string;
   date: Date;
   subject?: string;
+  icon?: React.ReactNode;
+  href?: string;
 }) {
   const initial = actor[0]?.toUpperCase() ?? '?';
 
-  return (
+  const body = (
     <div className="flex items-start gap-3 py-3">
       <Avatar size="sm" radius="xl" className="mt-0.5">
-        {initial}
+        {icon ?? initial}
       </Avatar>
       <div className="flex-1 min-w-0">
         <div className="flex items-baseline justify-between gap-2 flex-wrap">
@@ -161,6 +164,16 @@ function ActivityItem({
       </div>
     </div>
   );
+
+  if (href) {
+    return (
+      <Link href={href} className="block rounded-md hover:bg-surface-hover transition-colors">
+        {body}
+      </Link>
+    );
+  }
+
+  return body;
 }
 
 // Collapsible section component
@@ -583,6 +596,19 @@ export default function ContactDetailPage() {
     { enabled: !!contactId }
   );
 
+  // Get meetings associated with this contact
+  const { data: meetingsData } = api.crmContact.getMeetings.useQuery(
+    { contactId },
+    { enabled: !!contactId }
+  );
+  const meetings = meetingsData?.meetings ?? [];
+
+  // Get the unified activity timeline (interactions + meetings)
+  const { data: activityData } = api.crmContact.getActivity.useQuery(
+    { contactId },
+    { enabled: !!contactId }
+  );
+
   // Get all contacts for prev/next navigation
   const { data: allContacts } = api.crmContact.getAll.useQuery(
     { workspaceId: workspaceId! },
@@ -604,7 +630,7 @@ export default function ContactDetailPage() {
     };
   }, [allContacts, contactId]);
 
-  // Build activity items
+  // Build activity items from the merged interaction + meeting timeline
   const activityItems = useMemo(() => {
     if (!contact) return [];
     const items: Array<{
@@ -613,28 +639,42 @@ export default function ContactDetailPage() {
       action: string;
       date: Date;
       subject?: string;
+      icon?: React.ReactNode;
+      href?: string;
     }> = [];
 
     const fullName =
       [contact.firstName, contact.lastName].filter(Boolean).join(' ') || 'Unknown';
 
-    // Add interactions as activity
-    contact.interactions?.forEach((interaction) => {
+    activityData?.events.forEach((event) => {
+      if (event.kind === 'meeting') {
+        items.push({
+          id: `meeting-${event.id}`,
+          actor: fullName,
+          action: 'had a meeting',
+          date: new Date(event.occurredAt),
+          subject: event.title ?? event.summary ?? undefined,
+          icon: <IconCalendar size={16} />,
+          href: `/recording/${event.id}`,
+        });
+        return;
+      }
+
       items.push({
-        id: interaction.id,
+        id: event.id,
         actor: fullName,
         action:
-          interaction.type === 'EMAIL'
+          event.interactionType === 'EMAIL'
             ? 'sent an email'
-            : interaction.type === 'TELEGRAM'
+            : event.interactionType === 'TELEGRAM'
               ? 'sent a message'
-              : interaction.type === 'PHONE_CALL'
+              : event.interactionType === 'PHONE_CALL'
                 ? 'had a call'
-                : interaction.type === 'MEETING'
+                : event.interactionType === 'MEETING'
                   ? 'had a meeting'
                   : 'added a note',
-        date: new Date(interaction.createdAt),
-        subject: interaction.subject ?? interaction.notes ?? undefined,
+        date: new Date(event.occurredAt),
+        subject: event.subject ?? event.notes ?? undefined,
       });
     });
 
@@ -647,7 +687,7 @@ export default function ContactDetailPage() {
     });
 
     return items.sort((a, b) => b.date.getTime() - a.date.getTime());
-  }, [contact]);
+  }, [contact, activityData]);
 
   if (workspaceLoading || isLoading) {
     return (
@@ -790,14 +830,14 @@ export default function ContactDetailPage() {
               Telegram
             </Tabs.Tab>
             <Tabs.Tab
-              value="calls"
+              value="meetings"
               rightSection={
                 <Badge size="xs" variant="light">
-                  {contact.interactions?.filter((i) => i.type === 'PHONE_CALL').length ?? 0}
+                  {meetings.length}
                 </Badge>
               }
             >
-              Calls
+              Meetings
             </Tabs.Tab>
             <Tabs.Tab
               value="company"
@@ -959,6 +999,8 @@ export default function ContactDetailPage() {
                         action={item.action}
                         date={item.date}
                         subject={item.subject}
+                        icon={item.icon}
+                        href={item.href}
                       />
                     ))
                   ) : (
@@ -1057,6 +1099,8 @@ export default function ContactDetailPage() {
                         action={item.action}
                         date={item.date}
                         subject={item.subject}
+                        icon={item.icon}
+                        href={item.href}
                       />
                     ))
                   ) : (
@@ -1167,48 +1211,52 @@ export default function ContactDetailPage() {
             </div>
           )}
 
-          {activeTab === 'calls' && (
+          {activeTab === 'meetings' && (
             <div className="space-y-4">
               <Title order={4} className="text-text-primary">
-                Calls
+                Meetings
               </Title>
-              {contact.interactions?.filter((i) => i.type === 'PHONE_CALL').length ? (
+              {meetings.length ? (
                 <div className="rounded-lg border border-border-primary bg-surface-secondary divide-y divide-border-primary">
-                  {contact.interactions
-                    .filter((i) => i.type === 'PHONE_CALL')
-                    .map((call) => (
-                      <div key={call.id} className="p-4 flex items-start gap-3">
-                        <Avatar size="md" radius="xl">
-                          {getInitialFromName(contact.firstName ?? contact.lastName)}
-                        </Avatar>
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-baseline justify-between gap-2 mb-1">
-                            <Text size="sm" className="font-semibold text-text-primary">
-                              {call.subject ?? 'Call'}
-                            </Text>
+                  {meetings.map((meeting) => (
+                    <Link
+                      key={meeting.id}
+                      href={`/recording/${meeting.id}`}
+                      className="flex items-start gap-3 p-4 hover:bg-surface-hover transition-colors"
+                    >
+                      <Avatar size="md" radius="xl" color="grape">
+                        <IconCalendar size={18} />
+                      </Avatar>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-baseline justify-between gap-2 mb-1">
+                          <Text size="sm" className="font-semibold text-text-primary">
+                            {meeting.title ?? 'Untitled meeting'}
+                          </Text>
+                          {(meeting.meetingDate ?? meeting.createdAt) && (
                             <Text size="xs" className="text-text-muted shrink-0">
-                              {new Date(call.createdAt).toLocaleDateString('en-US', {
+                              {new Date(
+                                meeting.meetingDate ?? meeting.createdAt
+                              ).toLocaleDateString('en-US', {
                                 day: 'numeric',
                                 month: 'short',
+                                year: 'numeric',
                               })}
-                            </Text>
-                          </div>
-                          <Text size="sm" className="text-text-muted">
-                            {fullName}
-                          </Text>
-                          {call.notes && (
-                            <Text size="sm" className="text-text-muted mt-1 line-clamp-2">
-                              {call.notes}
                             </Text>
                           )}
                         </div>
+                        {meeting.summary && (
+                          <Text size="sm" className="text-text-muted line-clamp-2">
+                            {meeting.summary}
+                          </Text>
+                        )}
                       </div>
-                    ))}
+                    </Link>
+                  ))}
                 </div>
               ) : (
                 <div className="rounded-lg border border-border-primary bg-surface-secondary p-12 text-center">
-                  <IconPhoneCall size={40} className="text-text-muted mx-auto mb-3" />
-                  <Text size="sm" className="text-text-muted">No calls yet</Text>
+                  <IconCalendar size={40} className="text-text-muted mx-auto mb-3" />
+                  <Text size="sm" className="text-text-muted">No meetings yet</Text>
                 </div>
               )}
             </div>

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/[id]/page.tsx
@@ -596,18 +596,13 @@ export default function ContactDetailPage() {
     { enabled: !!contactId }
   );
 
-  // Get meetings associated with this contact
-  const { data: meetingsData } = api.crmContact.getMeetings.useQuery(
-    { contactId },
-    { enabled: !!contactId }
-  );
-  const meetings = meetingsData?.meetings ?? [];
-
-  // Get the unified activity timeline (interactions + meetings)
+  // Get the unified activity timeline (interactions + meetings); it also returns
+  // the full meeting list for the Meetings tab so we only load meetings once.
   const { data: activityData } = api.crmContact.getActivity.useQuery(
     { contactId },
     { enabled: !!contactId }
   );
+  const meetings = activityData?.meetings ?? [];
 
   // Get all contacts for prev/next navigation
   const { data: allContacts } = api.crmContact.getAll.useQuery(

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/lists/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/lists/page.tsx
@@ -6,12 +6,10 @@ import {
   Title,
   Text,
   Button,
-  Card,
   Badge,
   Group,
   Stack,
   Loader,
-  Box,
   ThemeIcon,
   Modal,
   TextInput,
@@ -55,51 +53,59 @@ export default function CrmListsPage() {
   const lists = listsQuery.data ?? [];
 
   return (
-    <Stack gap="lg" p="md">
-      <Group justify="space-between" align="flex-start">
-        <Box>
-          <Title order={2}>Lists</Title>
-          <Text c="dimmed" size="sm">
+    <div className="-m-6 flex h-full flex-col">
+      {/* Header bar */}
+      <div className="flex items-center justify-between border-b border-border-primary bg-background-primary px-4 py-3">
+        <div>
+          <Title order={3} className="text-text-primary">
+            Lists
+          </Title>
+          <Text size="sm" className="text-text-muted">
             Curated lists of contacts — the audience a Broadcast sends to.
           </Text>
-        </Box>
+        </div>
         <Button leftSection={<IconPlus size={16} />} onClick={openCreate}>
           Create list
         </Button>
-      </Group>
+      </div>
 
-      {listsQuery.isLoading ? (
-        <Loader />
-      ) : lists.length === 0 ? (
-        <Card withBorder padding="xl">
-          <Stack align="center" gap="sm">
+      {/* Body */}
+      <div className="flex-1 overflow-auto">
+        {listsQuery.isLoading ? (
+          <div className="p-6">
+            <Loader />
+          </div>
+        ) : lists.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 px-4 py-16 text-center">
             <ThemeIcon size="xl" variant="light">
               <IconListDetails />
             </ThemeIcon>
-            <Text fw={600}>No lists yet</Text>
-            <Text c="dimmed" size="sm" ta="center">
+            <Text fw={600} className="text-text-primary">
+              No lists yet
+            </Text>
+            <Text size="sm" className="max-w-sm text-text-muted">
               Create a list, add contacts to it, then point a Broadcast at it.
             </Text>
-          </Stack>
-        </Card>
-      ) : (
-        <Stack gap="sm">
-          {lists.map((list) => (
-            <Card
-              key={list.id}
-              withBorder
-              padding="md"
-              style={{ cursor: 'pointer' }}
-              onClick={() => router.push(`${pathname}/${list.id}`)}
-            >
-              <Group justify="space-between" align="center">
-                <Text fw={600}>{list.name}</Text>
+          </div>
+        ) : (
+          <div>
+            {lists.map((list) => (
+              <div
+                key={list.id}
+                role="button"
+                tabIndex={0}
+                className="flex cursor-pointer items-center justify-between gap-4 border-b border-border-primary px-4 py-3 transition-colors hover:bg-surface-hover"
+                onClick={() => router.push(`${pathname}/${list.id}`)}
+              >
+                <Text fw={600} className="text-text-primary">
+                  {list.name}
+                </Text>
                 <Badge variant="light">{list.memberType}</Badge>
-              </Group>
-            </Card>
-          ))}
-        </Stack>
-      )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
 
       <Modal opened={createOpened} onClose={closeCreate} title="Create list">
         <Stack gap="sm">
@@ -125,6 +131,6 @@ export default function CrmListsPage() {
           </Group>
         </Stack>
       </Modal>
-    </Stack>
+    </div>
   );
 }

--- a/src/app/_components/home/StatsSection.tsx
+++ b/src/app/_components/home/StatsSection.tsx
@@ -6,15 +6,15 @@ interface StatsSectionProps {
 
 const stats = [
   {
-    value: "50+",
+    value: "11",
     label: "Organizations",
   },
   {
-    value: "10k+",
+    value: "130+",
     label: "AI-Coordinated Actions",
   },
   {
-    value: "95%",
+    value: "44%",
     label: "Outcome Achievement",
   },
   {

--- a/src/server/api/routers/crmAutomation.ts
+++ b/src/server/api/routers/crmAutomation.ts
@@ -240,7 +240,7 @@ export const crmAutomationRouter = createTRPCRouter({
       return { id: definition.id, isActive: input.isActive };
     }),
 
-  /** Delete a user-created automation. Starter (`isDefault`) automations refuse. */
+  /** Delete an automation (including starter `isDefault` ones). */
   remove: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
@@ -249,13 +249,6 @@ export const crmAutomationRouter = createTRPCRouter({
         input.id,
         ctx.session.user.id,
       );
-      if (isDefaultConfig(definition.config)) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message:
-            "Starter automations can't be deleted — deactivate them instead.",
-        });
-      }
       await ctx.db.workflowDefinition.delete({ where: { id: definition.id } });
       return { id: definition.id };
     }),

--- a/src/server/api/routers/crmContact.ts
+++ b/src/server/api/routers/crmContact.ts
@@ -38,6 +38,11 @@ function decryptContactPII<T extends CrmContact>(
   };
 }
 
+// How close (in ms) a calendar MEETING interaction must be to a transcribed
+// session for the two to be treated as the same real-world meeting in the
+// activity timeline. See the dedupe note in `getActivity`.
+const MEETING_DEDUPE_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
 // A transcribed meeting linked to a contact, projected to the fields the CRM uses
 type ContactMeeting = {
   id: string;
@@ -812,54 +817,10 @@ export const crmContactRouter = createTRPCRouter({
       };
     }),
 
-  // Get meetings (transcription sessions) associated with a contact.
-  // A contact is linked to a meeting either explicitly (participant.contactId)
-  // or implicitly by matching the participant's email to the contact's email.
-  getMeetings: protectedProcedure
-    .input(
-      z.object({
-        contactId: z.string(),
-        limit: z.number().min(1).max(100).optional(),
-      }),
-    )
-    .query(async ({ ctx, input }) => {
-      const { contactId, limit = 50 } = input;
-
-      // Get the contact and verify access
-      const contact = await ctx.db.crmContact.findFirst({
-        where: {
-          id: contactId,
-          workspace: { members: { some: { userId: ctx.session.user.id } } },
-        },
-        select: { workspaceId: true, email: true },
-      });
-
-      if (!contact) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Contact not found or inaccessible",
-        });
-      }
-
-      // Decrypt the contact's email so we can match participants captured by email
-      let contactEmail: string | null = null;
-      try {
-        contactEmail = decryptBuffer(contact.email) ?? null;
-      } catch (e) {
-        console.error("PII decryption failed for contact", contactId, e);
-      }
-
-      const meetings = await loadContactMeetings(ctx.db, {
-        workspaceId: contact.workspaceId,
-        contactId,
-        contactEmail,
-      });
-
-      return { meetings: meetings.slice(0, limit) };
-    }),
-
   // Unified activity timeline for a contact: CRM interactions (emails, notes,
   // calls, etc.) and transcribed meetings, merged and sorted newest-first.
+  // Also returns the full meeting list (for a dedicated Meetings tab) so callers
+  // don't need a second round-trip — both views share one meeting load.
   getActivity: protectedProcedure
     .input(
       z.object({
@@ -906,8 +867,29 @@ export const crmContactRouter = createTRPCRouter({
         }),
       ]);
 
+      // Calendar-synced meetings (ContactSyncService writes them as MEETING-type
+      // interactions) and transcribed sessions can describe the same real-world
+      // meeting, but share no id. Drop a MEETING interaction when a transcribed
+      // session falls within a short window of it so the timeline shows it once.
+      // Heuristic: favour leaving a possible duplicate over hiding a real meeting.
+      const meetingTimesMs = meetings.map((m) =>
+        (m.meetingDate ?? m.createdAt).getTime(),
+      );
+      const isCoveredByTranscript = (whenMs: number) =>
+        meetingTimesMs.some(
+          (mt) => Math.abs(mt - whenMs) <= MEETING_DEDUPE_WINDOW_MS,
+        );
+
+      const dedupedInteractions = interactions.filter(
+        (i) =>
+          !(
+            i.type === "MEETING" &&
+            isCoveredByTranscript(i.occurredAt.getTime())
+          ),
+      );
+
       const events = [
-        ...interactions.map((i) => ({
+        ...dedupedInteractions.map((i) => ({
           kind: "interaction" as const,
           id: i.id,
           interactionType: i.type,
@@ -927,7 +909,7 @@ export const crmContactRouter = createTRPCRouter({
         })),
       ].sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime());
 
-      return { events: events.slice(0, limit) };
+      return { events: events.slice(0, limit), meetings };
     }),
 
   // Assign contact to organization

--- a/src/server/api/routers/crmContact.ts
+++ b/src/server/api/routers/crmContact.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { encryptString, decryptBuffer } from "~/server/utils/encryption";
-import type { Prisma, CrmContact } from "@prisma/client";
+import type { Prisma, CrmContact, PrismaClient } from "@prisma/client";
 import { ContactSyncService } from "~/server/services/ContactSyncService";
 import { ConnectionStrengthCalculator } from "~/server/services/ConnectionStrengthCalculator";
 import { GoogleTokenManager } from "~/server/services/GoogleTokenManager";
@@ -36,6 +36,67 @@ function decryptContactPII<T extends CrmContact>(
     github: decryptBuffer(contact.github) ?? null,
     bluesky: decryptBuffer(contact.bluesky) ?? null,
   };
+}
+
+// A transcribed meeting linked to a contact, projected to the fields the CRM uses
+type ContactMeeting = {
+  id: string;
+  title: string | null;
+  summary: string | null;
+  meetingDate: Date | null;
+  createdAt: Date;
+  durationSeconds: number | null;
+  participantCount: number | null;
+};
+
+// Load the transcription sessions a contact took part in. A contact is linked to
+// a session either explicitly (participant.contactId) or implicitly by matching
+// the participant's email to the contact's email. Deduped and sorted newest-first.
+async function loadContactMeetings(
+  db: PrismaClient,
+  params: { workspaceId: string; contactId: string; contactEmail: string | null },
+): Promise<ContactMeeting[]> {
+  const participantOr: Prisma.TranscriptionSessionParticipantWhereInput[] = [
+    { contactId: params.contactId },
+  ];
+  if (params.contactEmail) {
+    participantOr.push({
+      email: { equals: params.contactEmail, mode: "insensitive" },
+    });
+  }
+
+  const participants = await db.transcriptionSessionParticipant.findMany({
+    where: {
+      workspaceId: params.workspaceId,
+      OR: participantOr,
+    },
+    select: {
+      transcriptionSession: {
+        select: {
+          id: true,
+          title: true,
+          summary: true,
+          meetingDate: true,
+          createdAt: true,
+          durationSeconds: true,
+          participantCount: true,
+        },
+      },
+    },
+  });
+
+  const byId = new Map<string, ContactMeeting>();
+  for (const p of participants) {
+    if (p.transcriptionSession) {
+      byId.set(p.transcriptionSession.id, p.transcriptionSession);
+    }
+  }
+
+  return Array.from(byId.values()).sort((a, b) => {
+    const aDate = (a.meetingDate ?? a.createdAt).getTime();
+    const bDate = (b.meetingDate ?? b.createdAt).getTime();
+    return bDate - aDate;
+  });
 }
 
 // Input schemas
@@ -749,6 +810,124 @@ export const crmContactRouter = createTRPCRouter({
         interactions,
         nextCursor,
       };
+    }),
+
+  // Get meetings (transcription sessions) associated with a contact.
+  // A contact is linked to a meeting either explicitly (participant.contactId)
+  // or implicitly by matching the participant's email to the contact's email.
+  getMeetings: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string(),
+        limit: z.number().min(1).max(100).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const { contactId, limit = 50 } = input;
+
+      // Get the contact and verify access
+      const contact = await ctx.db.crmContact.findFirst({
+        where: {
+          id: contactId,
+          workspace: { members: { some: { userId: ctx.session.user.id } } },
+        },
+        select: { workspaceId: true, email: true },
+      });
+
+      if (!contact) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Contact not found or inaccessible",
+        });
+      }
+
+      // Decrypt the contact's email so we can match participants captured by email
+      let contactEmail: string | null = null;
+      try {
+        contactEmail = decryptBuffer(contact.email) ?? null;
+      } catch (e) {
+        console.error("PII decryption failed for contact", contactId, e);
+      }
+
+      const meetings = await loadContactMeetings(ctx.db, {
+        workspaceId: contact.workspaceId,
+        contactId,
+        contactEmail,
+      });
+
+      return { meetings: meetings.slice(0, limit) };
+    }),
+
+  // Unified activity timeline for a contact: CRM interactions (emails, notes,
+  // calls, etc.) and transcribed meetings, merged and sorted newest-first.
+  getActivity: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string(),
+        limit: z.number().min(1).max(200).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const { contactId, limit = 100 } = input;
+
+      // Combine existence + access in one query
+      const contact = await ctx.db.crmContact.findFirst({
+        where: {
+          id: contactId,
+          workspace: { members: { some: { userId: ctx.session.user.id } } },
+        },
+        select: { workspaceId: true, email: true },
+      });
+
+      if (!contact) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Contact not found or inaccessible",
+        });
+      }
+
+      let contactEmail: string | null = null;
+      try {
+        contactEmail = decryptBuffer(contact.email) ?? null;
+      } catch (e) {
+        console.error("PII decryption failed for contact", contactId, e);
+      }
+
+      const [interactions, meetings] = await Promise.all([
+        ctx.db.crmContactInteraction.findMany({
+          where: { contactId },
+          orderBy: { occurredAt: "desc" },
+          take: limit,
+        }),
+        loadContactMeetings(ctx.db, {
+          workspaceId: contact.workspaceId,
+          contactId,
+          contactEmail,
+        }),
+      ]);
+
+      const events = [
+        ...interactions.map((i) => ({
+          kind: "interaction" as const,
+          id: i.id,
+          interactionType: i.type,
+          direction: i.direction,
+          subject: i.subject,
+          notes: i.notes,
+          occurredAt: i.occurredAt,
+        })),
+        ...meetings.map((m) => ({
+          kind: "meeting" as const,
+          id: m.id,
+          title: m.title,
+          summary: m.summary,
+          durationSeconds: m.durationSeconds,
+          participantCount: m.participantCount,
+          occurredAt: m.meetingDate ?? m.createdAt,
+        })),
+      ].sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime());
+
+      return { events: events.slice(0, limit) };
     }),
 
   // Assign contact to organization


### PR DESCRIPTION
Moves a commit accidentally landed on local `main` onto this branch, plus two follow-up changes from the working copy.

## Commits

**fix(crm): scope starter automations to one workspace, add delete + restyle** (`30aad2b7`)
- Remove the on-mount `ensureDefaults` seed so starter automations ("Advisor onboarding", "Channel Partner onboarding") no longer propagate into every workspace on first Automations-page load.
- Allow deleting starter (`isDefault`) automations; add a per-row delete button (confirm modal + list invalidation).
- `scripts/cleanup-crm-starter-automations.ts` to remove leftover seeded starters from every workspace except a keep-workspace (dry-run by default, `--delete` to execute).
- Restyle Automations + Lists pages to match the Contacts page (edge-to-edge header, bordered hover rows, semantic tokens).

**feat(crm): show contact meetings and a unified activity timeline** (`7c0d024f`)
- `crmContact.getMeetings`: transcription sessions a contact joined, linked by `participant.contactId` or matching (decrypted) email; deduped, newest-first.
- `crmContact.getActivity`: merge interactions + meetings into one timeline.
- Contact page: replace the Calls tab with a Meetings tab (links to recordings); drive the activity timeline off `getActivity`.

**chore(home): update landing-page stat numbers** (`d8a5d4f4`)
- Replace placeholder marketing figures with current real numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added meeting history to contact profiles, with a new Meetings tab and linked meeting cards.
  * Introduced a unified activity timeline that combines interactions and meetings.
  * Added per-automation delete controls with confirmation for cleanup of starter automations.

* **Bug Fixes**
  * Contact activity and meeting lists now load more complete, deduplicated results.
  * Deletion now works for default/starter automations when confirmed.

* **Style**
  * Updated several CRM pages to a refreshed, more consistent layout and row presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->