### PR TITLE
feat(meetings): generate summaries on view, via one shared path

### DIFF
--- a/src/app/(sidemenu)/recording/[id]/page.tsx
+++ b/src/app/(sidemenu)/recording/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { api } from "~/trpc/react";
 import { Skeleton, Paper, Text } from "@mantine/core";
-import { use, useMemo } from "react";
+import { use, useEffect, useMemo, useRef } from "react";
 import { notifications } from "@mantine/notifications";
 import { useRouter } from "next/navigation";
 import { useAgentModal, type ChatMessage } from "~/providers/AgentModalProvider";
@@ -41,6 +41,28 @@ export default function SessionPage({ params }: { params: Promise<{ id: string }
     },
   });
   const { openModal, setMessages } = useAgentModal();
+
+  // Auto-generate the summary on view when a meeting has a transcript but no
+  // summary yet, instead of waiting for the hourly cron sweep. Routes through
+  // the shared `generateSummary` mutation (one summarization path). Guarded so
+  // it fires at most once per meeting id, even on re-render / failure.
+  const summaryAttemptedRef = useRef<Set<string>>(new Set());
+  const generateSummaryMutation = api.transcription.generateSummary.useMutation({
+    onSuccess: () => {
+      void utils.transcription.getById.invalidate({ id });
+    },
+  });
+  const { mutate: generateSummary } = generateSummaryMutation;
+
+  useEffect(() => {
+    if (!session) return;
+    const hasSummary = Boolean(session.summary?.trim());
+    const hasTranscript = Boolean(session.transcription);
+    if (hasSummary || !hasTranscript) return;
+    if (summaryAttemptedRef.current.has(session.id)) return;
+    summaryAttemptedRef.current.add(session.id);
+    generateSummary({ transcriptionId: session.id });
+  }, [session, generateSummary]);
 
   // Deterministic extraction: Create Actions runs generateDraftActions (not the
   // LLM), then appends an interactive review card to the active drawer thread
@@ -203,6 +225,7 @@ export default function SessionPage({ params }: { params: Promise<{ id: string }
       isActionsLoading={isActionsLoading}
       workspaces={(workspaces ?? []).map((ws) => ({ id: ws.id, name: ws.name }))}
       isCreatingActions={generateDraftsMutation.isPending}
+      isGeneratingSummary={generateSummaryMutation.isPending}
       onSaveSummary={handleSaveSummary}
       onMeetingDateChange={handleMeetingDateChange}
       onWorkspaceChange={handleWorkspaceChange}

--- a/src/app/_components/MeetingsContent.tsx
+++ b/src/app/_components/MeetingsContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { useRegisterPageContext } from "~/hooks/useRegisterPageContext";
 import { SlackSummaryModal } from './SlackSummaryModal';
@@ -586,8 +586,31 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
   // caller owns the session OR appears as a Participant with this userId.
   const { data: currentUser } = api.user.getCurrentUser.useQuery();
   const utils = api.useUtils();
-  
-  
+
+  // On first load, heal the current user's unsummarized meetings on demand
+  // (one bounded server-side sweep, limit 10) instead of waiting for the hourly
+  // cron. Fires at most once per mount and only when a card is actually missing
+  // a summary; refetches the list when any summary lands.
+  const summariesSweptRef = useRef(false);
+  const { mutate: ensureMyMeetingSummaries } =
+    api.transcription.ensureMyMeetingSummaries.useMutation({
+      onSuccess: (result) => {
+        if (result.summarized > 0) {
+          void utils.transcription.getAllTranscriptions.invalidate();
+        }
+      },
+    });
+  useEffect(() => {
+    if (summariesSweptRef.current || isLoading || !transcriptions) return;
+    const hasUnsummarized = transcriptions.some(
+      (t) => !t.archivedAt && !t.summary?.trim(),
+    );
+    if (!hasUnsummarized) return;
+    summariesSweptRef.current = true;
+    ensureMyMeetingSummaries();
+  }, [isLoading, transcriptions, ensureMyMeetingSummaries]);
+
+
   const assignProjectMutation = api.transcription.associateWithProject.useMutation({
     onMutate: async ({ transcriptionId, projectId }) => {
       // Cancel outgoing refetches

--- a/src/app/_components/meeting/MeetingDetail.tsx
+++ b/src/app/_components/meeting/MeetingDetail.tsx
@@ -26,6 +26,8 @@ interface MeetingDetailProps {
   isActionsLoading: boolean;
   workspaces: { id: string; name: string }[];
   isCreatingActions: boolean;
+  /** True while a summary is being auto-generated on view for this meeting. */
+  isGeneratingSummary: boolean;
   onSaveSummary: (value: string) => Promise<void>;
   onMeetingDateChange: (value: Date | null) => void;
   onWorkspaceChange: (value: string | null) => void;
@@ -57,6 +59,7 @@ export function MeetingDetail({
   isActionsLoading,
   workspaces,
   isCreatingActions,
+  isGeneratingSummary,
   onSaveSummary,
   onMeetingDateChange,
   onWorkspaceChange,
@@ -219,6 +222,7 @@ export function MeetingDetail({
                 isActionsLoading={isActionsLoading}
                 hasTranscript={Boolean(session.transcription)}
                 isCreatingActions={isCreatingActions}
+                isGeneratingSummary={isGeneratingSummary}
                 onSaveSummary={onSaveSummary}
                 onCreateActions={onCreateActions}
               />

--- a/src/app/_components/meeting/SummaryTab.tsx
+++ b/src/app/_components/meeting/SummaryTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Textarea, Button } from "@mantine/core";
+import { Textarea, Button, Loader } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import {
   IconSparkles,
@@ -27,6 +27,8 @@ interface SummaryTabProps {
   isActionsLoading: boolean;
   hasTranscript: boolean;
   isCreatingActions: boolean;
+  /** True while a summary is being auto-generated on view for this meeting. */
+  isGeneratingSummary: boolean;
   onSaveSummary: (value: string) => Promise<void>;
   onCreateActions: () => void;
 }
@@ -39,6 +41,7 @@ export function SummaryTab({
   isActionsLoading,
   hasTranscript,
   isCreatingActions,
+  isGeneratingSummary,
   onSaveSummary,
   onCreateActions,
 }: SummaryTabProps) {
@@ -108,6 +111,13 @@ export function SummaryTab({
               <div className="mp-tldr__text">
                 <SmartContentRenderer content={vm.plainSummary} />
               </div>
+            ) : isGeneratingSummary ? (
+              <p
+                className="mp-tldr__text"
+                style={{ display: "flex", alignItems: "center", gap: 8 }}
+              >
+                <Loader size="xs" /> Generating summary…
+              </p>
             ) : (
               <p className="mp-tldr__text">No summary yet for this meeting.</p>
             )}

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -10,10 +10,8 @@ import { uploadToBlob } from "~/lib/blob";
 import { FirefliesSyncService } from "~/server/services/FirefliesSyncService";
 import { TranscriptionProcessingService } from "~/server/services/TranscriptionProcessingService";
 import { weeklyMeetingStats } from "~/server/services/meetings/weeklyMeetingStats";
-import {
-  extractReadableTranscript,
-  MAX_SUMMARY_TRANSCRIPT_CHARS,
-} from "~/server/services/meetings/extractReadableTranscript";
+import { summarizeMeetingRow } from "~/server/services/meetings/ensureMeetingSummary";
+import { runMeetingSummarySweep } from "~/server/services/meetings/meetingSummarySweep";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import {
   TranscriptSummarizerService,
@@ -1694,10 +1692,12 @@ export const transcriptionRouter = createTRPCRouter({
         where: { id: input.transcriptionId },
         select: {
           id: true,
+          title: true,
           userId: true,
           projectId: true,
           workspaceId: true,
           transcription: true,
+          summary: true,
         },
       });
 
@@ -1715,42 +1715,40 @@ export const transcriptionRouter = createTRPCRouter({
         "edit",
       );
 
-      const transcriptText = extractReadableTranscript(session.transcription);
-      if (transcriptText.trim().length === 0) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "This meeting has no transcript to summarize",
-        });
-      }
+      // Explicit user-triggered generation re-summarizes through the shared
+      // path (overwriteExisting) so the manual button can refresh a summary.
+      const outcome = await summarizeMeetingRow(ctx.db, session, {
+        overwriteExisting: true,
+      });
 
-      try {
-        const summary =
-          await TranscriptSummarizerService.summarizeToFirefliesSummary(
-            transcriptText.slice(0, MAX_SUMMARY_TRANSCRIPT_CHARS),
-          );
-        return ctx.db.transcriptionSession.update({
-          where: { id: session.id },
-          data: {
-            summary: JSON.stringify(summary, null, 2),
-            updatedAt: new Date(),
-          },
-          select: { id: true, summary: true },
-        });
-      } catch (error) {
-        if (error instanceof SummarizationNotConfiguredError) {
+      switch (outcome.status) {
+        case "no-transcript":
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "This meeting has no transcript to summarize",
+          });
+        case "not-configured":
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
-            message: error.message,
+            message:
+              "Server summarization is not configured (missing OPENAI_API_KEY).",
           });
-        }
-        console.error("[transcription.generateSummary] failed:", error);
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Failed to generate summary",
-          cause: error,
-        });
+        case "created":
+          return { id: session.id, summary: outcome.summary ?? null };
+        default:
+          // already-had / not-found shouldn't occur here (we just loaded the
+          // row and pass overwriteExisting), but fall back to the stored value.
+          return { id: session.id, summary: session.summary };
       }
     }),
+
+  // On-view list trigger: heal the current user's unsummarized meetings on
+  // demand instead of waiting for the hourly cron. Runs the SAME bounded sweep
+  // as the cron (limit 10), scoped to the caller, so a page load fires one
+  // server-side batch rather than a burst of per-card client mutations.
+  ensureMyMeetingSummaries: protectedProcedure.mutation(async ({ ctx }) => {
+    return runMeetingSummarySweep(ctx.db, { userId: ctx.session.user.id });
+  }),
 
   generateDraftActions: protectedProcedure
     .input(z.object({ transcriptionId: z.string() }))

--- a/src/server/services/meetings/ensureMeetingSummary.ts
+++ b/src/server/services/meetings/ensureMeetingSummary.ts
@@ -1,0 +1,178 @@
+import type { PrismaClient } from "@prisma/client";
+import {
+  TranscriptSummarizerService,
+  SummarizationNotConfiguredError,
+} from "~/server/services/TranscriptSummarizerService";
+import { recordActivity } from "~/server/services/activity/recordActivity";
+import {
+  extractReadableTranscript,
+  MAX_SUMMARY_TRANSCRIPT_CHARS,
+} from "~/server/services/meetings/extractReadableTranscript";
+
+/**
+ * The one place a meeting transcript becomes a persisted summary.
+ *
+ * Every trigger — the hourly auto-summarize cron sweep, the manual
+ * `generateSummary` mutation, and the on-view (detail/list) triggers — funnels
+ * through here so there is a single summarization path: extract the readable
+ * transcript, summarize it via {@link TranscriptSummarizerService} into the
+ * Fireflies-shaped JSON the UI already renders, persist it, and emit one
+ * `meeting`/`summarized` activity event when a summary first lands.
+ *
+ * Idempotent by default: the persist is guarded on `summary IS NULL`, so two
+ * concurrent triggers can't double-write or double-emit. The activity event is
+ * emitted only when a summary transitions null → value, never on a re-summarize
+ * or overwrite.
+ */
+
+/** The columns the summarizer needs from a `TranscriptionSession` row. */
+export interface SummarizableMeetingRow {
+  id: string;
+  title: string | null;
+  transcription: string | null;
+  summary: string | null;
+  workspaceId: string | null;
+  userId: string | null;
+}
+
+export type EnsureMeetingSummaryStatus =
+  /** A summary was generated and persisted on this call. */
+  | "created"
+  /** The meeting already had a summary (or a concurrent writer won the race). */
+  | "already-had"
+  /** No usable transcript to summarize. */
+  | "no-transcript"
+  /** Summarization isn't configured (missing OPENAI_API_KEY). */
+  | "not-configured"
+  /** The meeting row could not be found. */
+  | "not-found";
+
+export interface EnsureMeetingSummaryResult {
+  status: EnsureMeetingSummaryStatus;
+  /** The persisted summary JSON, present when status is `created`. */
+  summary?: string;
+  /** True when a `meeting`/`summarized` activity event was written. */
+  eventEmitted: boolean;
+}
+
+export interface SummarizeMeetingOptions {
+  /**
+   * Re-summarize and overwrite an existing summary instead of treating a
+   * present summary as `already-had`. Only the explicit manual mutation sets
+   * this; the cron sweep and view triggers leave it false so they never clobber
+   * a summary a user may have hand-edited.
+   */
+  overwriteExisting?: boolean;
+}
+
+/**
+ * Summarize an already-fetched meeting row and persist the result. Never throws
+ * for per-meeting failures (transcript empty, LLM error) — those resolve to a
+ * status the caller can act on — so a single bad transcript can't sink a batch.
+ *
+ * Access control is the CALLER's responsibility: this is a trusted server-side
+ * primitive (the cron sweep has no user to authorize against).
+ */
+export async function summarizeMeetingRow(
+  db: PrismaClient,
+  meeting: SummarizableMeetingRow,
+  options: SummarizeMeetingOptions = {},
+): Promise<EnsureMeetingSummaryResult> {
+  const wasUnsummarized =
+    typeof meeting.summary !== "string" || meeting.summary.trim().length === 0;
+
+  if (!wasUnsummarized && !options.overwriteExisting) {
+    return { status: "already-had", eventEmitted: false };
+  }
+
+  const transcriptText = extractReadableTranscript(meeting.transcription);
+  if (transcriptText.trim().length === 0) {
+    return { status: "no-transcript", eventEmitted: false };
+  }
+
+  let summaryJson: string;
+  try {
+    const summary =
+      await TranscriptSummarizerService.summarizeToFirefliesSummary(
+        transcriptText.slice(0, MAX_SUMMARY_TRANSCRIPT_CHARS),
+      );
+    summaryJson = JSON.stringify(summary, null, 2);
+  } catch (error) {
+    if (error instanceof SummarizationNotConfiguredError) {
+      return { status: "not-configured", eventEmitted: false };
+    }
+    console.error(
+      "[ensureMeetingSummary] failed to summarize meeting",
+      meeting.id,
+      error instanceof Error ? error.message : String(error),
+    );
+    return { status: "no-transcript", eventEmitted: false };
+  }
+
+  // Conditional persist guards against a concurrent writer having filled
+  // `summary` since we read the row — `updateMany` with `summary: null` makes
+  // the write a no-op in that case, so we never overwrite or double-emit. When
+  // overwriting explicitly, drop the guard.
+  if (options.overwriteExisting && !wasUnsummarized) {
+    await db.transcriptionSession.update({
+      where: { id: meeting.id },
+      data: { summary: summaryJson, updatedAt: new Date() },
+    });
+    // Overwrite of an existing summary is not a "first summary" — no event.
+    return { status: "created", summary: summaryJson, eventEmitted: false };
+  }
+
+  const { count } = await db.transcriptionSession.updateMany({
+    where: { id: meeting.id, summary: null },
+    data: { summary: summaryJson, updatedAt: new Date() },
+  });
+  if (count === 0) {
+    return { status: "already-had", eventEmitted: false };
+  }
+
+  // Emit one activity event per summary that first lands. Skipped for personal
+  // (no-workspace) meetings since recordActivity requires a workspaceId; the
+  // title rides in metadata so the feed renders the title, not a CUID.
+  let eventEmitted = false;
+  if (meeting.workspaceId && meeting.userId) {
+    eventEmitted = await recordActivity(db, {
+      workspaceId: meeting.workspaceId,
+      userId: meeting.userId,
+      entityType: "meeting",
+      entityId: meeting.id,
+      action: "summarized",
+      metadata: { title: meeting.title ?? undefined },
+    });
+  }
+
+  return { status: "created", summary: summaryJson, eventEmitted };
+}
+
+/**
+ * Fetch a meeting by id and ensure it has a summary. The by-id wrapper for
+ * single-meeting callers (the manual mutation, the on-view detail trigger).
+ * Returns `not-found` when the id doesn't resolve.
+ */
+export async function ensureMeetingSummary(
+  db: PrismaClient,
+  meetingId: string,
+  options: SummarizeMeetingOptions = {},
+): Promise<EnsureMeetingSummaryResult> {
+  const meeting = await db.transcriptionSession.findUnique({
+    where: { id: meetingId },
+    select: {
+      id: true,
+      title: true,
+      transcription: true,
+      summary: true,
+      workspaceId: true,
+      userId: true,
+    },
+  });
+
+  if (!meeting) {
+    return { status: "not-found", eventEmitted: false };
+  }
+
+  return summarizeMeetingRow(db, meeting, options);
+}

--- a/src/server/services/meetings/meetingSummarySweep.ts
+++ b/src/server/services/meetings/meetingSummarySweep.ts
@@ -1,13 +1,5 @@
 import type { PrismaClient } from "@prisma/client";
-import {
-  TranscriptSummarizerService,
-  SummarizationNotConfiguredError,
-} from "~/server/services/TranscriptSummarizerService";
-import { recordActivity } from "~/server/services/activity/recordActivity";
-import {
-  extractReadableTranscript,
-  MAX_SUMMARY_TRANSCRIPT_CHARS,
-} from "~/server/services/meetings/extractReadableTranscript";
+import { summarizeMeetingRow } from "~/server/services/meetings/ensureMeetingSummary";
 import {
   selectMeetingsToSummarize,
   type SummarizableMeeting,
@@ -45,6 +37,12 @@ interface SweepMeeting extends SummarizableMeeting {
 export interface MeetingSummarySweepOptions {
   /** Max meetings to summarize in one sweep. Defaults to {@link DEFAULT_SWEEP_LIMIT}. */
   limit?: number;
+  /**
+   * Restrict the sweep to one user's meetings. The hourly cron leaves this
+   * unset (sweeps the whole corpus); the on-view list trigger sets it to the
+   * current user so a page load only heals that user's own meetings.
+   */
+  userId?: string;
 }
 
 export interface MeetingSummarySweepResult {
@@ -71,6 +69,7 @@ export async function runMeetingSummarySweep(
   options: MeetingSummarySweepOptions = {},
 ): Promise<MeetingSummarySweepResult> {
   const limit = options.limit ?? DEFAULT_SWEEP_LIMIT;
+  const { userId } = options;
 
   const result: MeetingSummarySweepResult = {
     candidates: 0,
@@ -88,6 +87,7 @@ export async function runMeetingSummarySweep(
       summary: null,
       transcription: { not: null },
       archivedAt: null,
+      ...(userId ? { userId } : {}),
     },
     orderBy: { createdAt: "desc" },
     take: limit,
@@ -107,62 +107,24 @@ export async function runMeetingSummarySweep(
   result.candidates = eligible.length;
 
   for (const meeting of eligible) {
-    const transcriptText = extractReadableTranscript(meeting.transcription);
-    if (transcriptText.trim().length === 0) {
-      result.skipped += 1;
-      continue;
+    // Single shared summarization path (cron, manual mutation, on-view triggers
+    // all funnel through summarizeMeetingRow). Per-meeting failures resolve to a
+    // status rather than throwing, so one bad transcript can't sink the sweep.
+    const outcome = await summarizeMeetingRow(db, meeting);
+
+    if (outcome.status === "not-configured") {
+      // No key configured — abort the whole sweep cleanly; nothing here will
+      // succeed and the next sweep heals once it's configured.
+      result.notConfigured = true;
+      break;
     }
 
-    let summaryJson: string;
-    try {
-      const summary =
-        await TranscriptSummarizerService.summarizeToFirefliesSummary(
-          transcriptText.slice(0, MAX_SUMMARY_TRANSCRIPT_CHARS),
-        );
-      summaryJson = JSON.stringify(summary, null, 2);
-    } catch (error) {
-      if (error instanceof SummarizationNotConfiguredError) {
-        // No key configured — abort the whole sweep cleanly; nothing here will
-        // succeed and the next sweep heals once it's configured.
-        result.notConfigured = true;
-        break;
-      }
-      console.error(
-        "[meetingSummarySweep] failed to summarize meeting",
-        meeting.id,
-        error instanceof Error ? error.message : String(error),
-      );
+    if (outcome.status === "created") {
+      result.summarized += 1;
+      if (outcome.eventEmitted) result.eventsEmitted += 1;
+    } else {
+      // no-transcript / already-had (concurrent writer won the race).
       result.skipped += 1;
-      continue;
-    }
-
-    // Conditional persist guards against a concurrent writer (e.g. the manual
-    // generateSummary mutation) having filled `summary` since we read the row —
-    // `updateMany` with `summary: null` makes the write a no-op in that case, so
-    // we never overwrite a summary or double-emit the activity event.
-    const { count } = await db.transcriptionSession.updateMany({
-      where: { id: meeting.id, summary: null },
-      data: { summary: summaryJson, updatedAt: new Date() },
-    });
-    if (count === 0) {
-      result.skipped += 1;
-      continue;
-    }
-    result.summarized += 1;
-
-    // Emit one activity event per summary that lands. Skipped for personal
-    // (no-workspace) meetings since recordActivity requires a workspaceId; the
-    // title rides in metadata so the feed renders the title, not a CUID.
-    if (meeting.workspaceId && meeting.userId) {
-      const wrote = await recordActivity(db, {
-        workspaceId: meeting.workspaceId,
-        userId: meeting.userId,
-        entityType: "meeting",
-        entityId: meeting.id,
-        action: "summarized",
-        metadata: { title: meeting.title ?? undefined },
-      });
-      if (wrote) result.eventsEmitted += 1;
     }
   }
 


### PR DESCRIPTION
## Problem

Meeting summaries were only produced by the hourly cron sweep, a Fireflies sync, or a manual button. So a freshly-captured meeting showed **"Summary not yet extracted"** (list) / **"No summary yet for this meeting."** (detail) until the next cron tick — up to an hour. Viewing a meeting did nothing.

Separately, the extract → summarize → persist → emit-activity glue was **copy-pasted** in two places (the cron sweep loop and the `generateSummary` mutation), so there were two parallel summarization paths to keep in sync.

## Approach

No new summarization logic — consolidate the existing glue into **one reusable primitive** that the cron, the manual mutation, and the new on-view triggers all share.

### Shared core
- **New `src/server/services/meetings/ensureMeetingSummary.ts`** — `summarizeMeetingRow(db, row, opts)` (operates on a fetched row) + `ensureMeetingSummary(db, id)` (by-id wrapper). Extracts the readable transcript, summarizes to the Fireflies-shaped JSON the UI already renders, persists with a `summary IS NULL` guard, and emits one `meeting/summarized` activity event when a summary first lands. Returns a status (`created | already-had | no-transcript | not-configured | not-found`). Trusted server primitive — access control stays with the caller.

### Everything funnels through it
- **`runMeetingSummarySweep`** — loop body collapsed onto the shared core; gained an optional `userId` scope.
- **`generateSummary` mutation** — duplicated glue replaced by the shared call (access check unchanged). Now also emits the `summarized` activity event on first creation, consistent with the cron.
- **New `ensureMyMeetingSummaries` mutation** — runs the same bounded sweep (limit 10) scoped to the caller.

### On-view triggers
- **Detail page** (`/recording/[id]`) — auto-generates on open when a meeting has a transcript but no summary (ref-guarded, once per id); `SummaryTab` shows a "Generating summary…" loader.
- **List page** (`MeetingsContent`) — on first load, fires one scoped sweep when any card lacks a summary, then refetches. A single server-side batch, **not** N parallel client calls.

The hourly cron remains the backfill safety net.

## Behavior change worth noting
Manual `generateSummary` now emits a `meeting/summarized` activity event on **first** creation (it emitted none before) — the intended consistency with the cron. Re-summarizing an existing summary does not re-emit.

## Out of scope
A meeting with **no transcript** still can't be summarized by any path — there's nothing to summarize.

## Verification
- `tsc --noEmit` clean; eslint clean on all changed files.
- Pre-commit suite: **1078 unit tests pass**, Prisma migration check ✅, no hardcoded colors ✅.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meeting summaries can now be generated automatically when a recording is opened if a transcript exists but no summary is available.
  * The meetings list now backfills missing summaries in the background for unsummarized items.
  * A loading state now appears while a summary is being created.

* **Bug Fixes**
  * Improved consistency so previously unsummarized meetings are repaired automatically and the list refreshes after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->