### PR TITLE
feat: Render Me:/Them: turns on /recording/[id] via the parser

### DIFF
--- a/src/app/_components/meeting/TranscriptTab.tsx
+++ b/src/app/_components/meeting/TranscriptTab.tsx
@@ -4,17 +4,9 @@ import { useMemo, useState } from "react";
 import { IconSearch, IconUsers } from "@tabler/icons-react";
 import { MpAvatar } from "./MpAvatar";
 import { getInitial } from "~/utils/avatarColors";
-import type {
-  MeetingChapter,
-  MeetingParticipant,
-  ParticipantFlavor,
-} from "~/lib/meeting-view-model";
-
-interface Sentence {
-  text: string;
-  speakerName: string | null;
-  startTime: number;
-}
+import { parseTranscript } from "~/lib/transcript";
+import type { TranscriptTurn } from "~/lib/transcript";
+import type { MeetingChapter, MeetingParticipant } from "~/lib/meeting-view-model";
 
 interface TranscriptTabProps {
   transcription: string | null;
@@ -27,42 +19,6 @@ function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60);
   const s = Math.floor(seconds % 60);
   return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
-}
-
-/** Parse the best available diarized transcript. Prefers `sentencesJson`,
- *  falls back to a Fireflies-shaped `transcription` string, else null. */
-function parseSentences(transcription: string | null, sentencesJson: unknown): Sentence[] | null {
-  const fromArray = (arr: unknown[]): Sentence[] | null => {
-    const rows = arr
-      .map((s) => {
-        if (!s || typeof s !== "object") return null;
-        const obj = s as Record<string, unknown>;
-        const text = typeof obj.text === "string" ? obj.text : null;
-        if (text === null) return null;
-        const speakerName =
-          typeof obj.speaker_name === "string" ? obj.speaker_name : null;
-        const startTime = typeof obj.start_time === "number" ? obj.start_time : 0;
-        return { text, speakerName, startTime };
-      })
-      .filter((r): r is Sentence => r !== null);
-    return rows.length > 0 ? rows : null;
-  };
-
-  if (Array.isArray(sentencesJson)) {
-    const parsed = fromArray(sentencesJson);
-    if (parsed) return parsed;
-  }
-  if (transcription) {
-    try {
-      const obj: unknown = JSON.parse(transcription);
-      if (obj && typeof obj === "object" && Array.isArray((obj as { sentences?: unknown }).sentences)) {
-        return fromArray((obj as { sentences: unknown[] }).sentences);
-      }
-    } catch {
-      /* not JSON — plain text */
-    }
-  }
-  return null;
 }
 
 function withHighlight(text: string, query: string) {
@@ -94,38 +50,31 @@ export function TranscriptTab({
   const [query, setQuery] = useState("");
   const [onlyMe, setOnlyMe] = useState(false);
 
-  const sentences = useMemo(
-    () => parseSentences(transcription, sentencesJson),
-    [transcription, sentencesJson],
+  // Normalize via the canonical parser (ADR-0032): flavor and timestamps are
+  // resolved in the parser, so this component is purely presentational.
+  const turns = useMemo<TranscriptTurn[]>(
+    () =>
+      parseTranscript({
+        transcription,
+        sentencesJson,
+        participants: participants.map((p) => ({
+          name: p.name,
+          isHost: p.isHost,
+        })),
+      }),
+    [transcription, sentencesJson, participants],
   );
 
-  // speaker name → identity flavor (match participants first, then rotate)
-  const flavorBySpeaker = useMemo(() => {
-    const map = new Map<string, ParticipantFlavor>();
-    for (const p of participants) map.set(p.name, p.flavor);
-    if (sentences) {
-      let rotation = 0;
-      const rotated: ParticipantFlavor[] = ["them", "alt"];
-      for (const s of sentences) {
-        const name = s.speakerName ?? "";
-        if (!name || map.has(name)) continue;
-        map.set(name, rotated[rotation % rotated.length]!);
-        rotation += 1;
-      }
-    }
-    return map;
-  }, [participants, sentences]);
+  const hasMe = useMemo(() => turns.some((t) => t.flavor === "me"), [turns]);
 
-  const hostNames = useMemo(
-    () => new Set(participants.filter((p) => p.flavor === "me").map((p) => p.name)),
-    [participants],
-  );
+  if (turns.length === 0) {
+    return <div className="mp-empty">No transcript available yet.</div>;
+  }
 
-  // Plain-text fallback: no diarization data.
-  if (!sentences) {
-    if (!transcription) {
-      return <div className="mp-empty">No transcript available yet.</div>;
-    }
+  // Speaker-less fallback: a single unstructured block. Render it plainly (no
+  // avatar/name, newlines preserved) with search, as before.
+  const isPlainFallback = turns.length === 1 && turns[0]!.speaker === null;
+  if (isPlainFallback) {
     return (
       <div>
         <div className="mp-tr__toolbar">
@@ -139,19 +88,20 @@ export function TranscriptTab({
           </div>
         </div>
         <p className="mp-turn__text" style={{ whiteSpace: "pre-wrap" }}>
-          {withHighlight(transcription, query)}
+          {withHighlight(turns[0]!.text, query)}
         </p>
       </div>
     );
   }
 
-  const filtered = sentences.filter((s) => {
-    if (onlyMe && !(s.speakerName && hostNames.has(s.speakerName))) return false;
-    if (query && !s.text.toLowerCase().includes(query.toLowerCase())) return false;
+  const filtered = turns.filter((t) => {
+    if (onlyMe && t.flavor !== "me") return false;
+    if (query && !t.text.toLowerCase().includes(query.toLowerCase())) return false;
     return true;
   });
 
-  // interleave chapter markers by start time (only when not filtering)
+  // interleave chapter markers by start time (only when not filtering, and only
+  // for timestamped transcripts — plain-text pastes have no times or chapters)
   const sortedChapters = [...chapters].sort((a, b) => a.startTime - b.startTime);
   const showChapters = !query && !onlyMe && sortedChapters.length > 0;
   let nextChapter = 0;
@@ -167,7 +117,7 @@ export function TranscriptTab({
             onChange={(e) => setQuery(e.currentTarget.value)}
           />
         </div>
-        {hostNames.size > 0 && (
+        {hasMe && (
           <button
             className={`mp-tr__filter ${onlyMe ? "on" : ""}`}
             onClick={() => setOnlyMe((v) => !v)}
@@ -180,12 +130,12 @@ export function TranscriptTab({
       {filtered.length === 0 ? (
         <div className="mp-empty">No matching transcript lines.</div>
       ) : (
-        filtered.map((s, i) => {
+        filtered.map((turn, i) => {
           const chapterMarkers: React.ReactNode[] = [];
-          if (showChapters) {
+          if (showChapters && turn.startTime !== null) {
             while (
               nextChapter < sortedChapters.length &&
-              s.startTime >= sortedChapters[nextChapter]!.startTime
+              turn.startTime >= sortedChapters[nextChapter]!.startTime
             ) {
               const ch = sortedChapters[nextChapter]!;
               chapterMarkers.push(
@@ -199,14 +149,16 @@ export function TranscriptTab({
             }
           }
 
-          const name = s.speakerName ?? "";
-          const flavor = flavorBySpeaker.get(name) ?? "them";
+          const name = turn.speaker ?? "";
+          const flavor = turn.flavor ?? "them";
           return (
             <div key={`row-${i}`}>
               {chapterMarkers}
               <div className="mp-turn">
                 <div className="mp-turn__gutter">
-                  <span className="mp-turn__time">{formatTime(s.startTime)}</span>
+                  {turn.startTime !== null && (
+                    <span className="mp-turn__time">{formatTime(turn.startTime)}</span>
+                  )}
                   {name && (
                     <MpAvatar
                       initial={getInitial(name)}
@@ -216,8 +168,10 @@ export function TranscriptTab({
                   )}
                 </div>
                 <div>
-                  {name && <div className={`mp-turn__name mp-turn__name--${flavor}`}>{name}</div>}
-                  <p className="mp-turn__text">{withHighlight(s.text, query)}</p>
+                  {name && (
+                    <div className={`mp-turn__name mp-turn__name--${flavor}`}>{name}</div>
+                  )}
+                  <p className="mp-turn__text">{withHighlight(turn.text, query)}</p>
                 </div>
               </div>
             </div>

--- a/src/app/_components/meeting/__tests__/TranscriptTab.test.tsx
+++ b/src/app/_components/meeting/__tests__/TranscriptTab.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Render tests for TranscriptTab. Asserts external behaviour: it consumes the
+ * canonical parser (ADR-0032) so a device `Me:`/`Them:` paste renders as
+ * speaker-attributed turns, the time gutter hides for timeless transcripts, and
+ * the speaker-less fallback renders a plain block.
+ */
+
+import { describe, expect, test } from "vitest";
+import { render, screen } from "~/test/test-utils";
+import { TranscriptTab } from "../TranscriptTab";
+import type { MeetingParticipant } from "~/lib/meeting-view-model";
+
+const noParticipants: MeetingParticipant[] = [];
+
+const MELISSA = [
+  "Meeting Title: Sync with Melissa",
+  "Date: 04 Jun 2026",
+  "Transcript:",
+  "Me: Hey Melissa.",
+  "Them: Hi there!",
+  "Me: Let's get started.",
+].join("\n");
+
+describe("TranscriptTab", () => {
+  test("renders Me:/Them: paste as alternating speaker turns", () => {
+    const { container } = render(
+      <TranscriptTab
+        transcription={MELISSA}
+        sentencesJson={null}
+        chapters={[]}
+        participants={noParticipants}
+      />,
+    );
+
+    const names = Array.from(container.querySelectorAll(".mp-turn__name")).map(
+      (n) => n.textContent,
+    );
+    expect(names).toEqual(["Me", "Them", "Me"]);
+    // me/them identity tone is applied from the parser's flavor.
+    expect(container.querySelector(".mp-turn__name--me")).not.toBeNull();
+    expect(container.querySelector(".mp-turn__name--them")).not.toBeNull();
+  });
+
+  test("hides the time gutter when every turn is timeless", () => {
+    const { container } = render(
+      <TranscriptTab
+        transcription={MELISSA}
+        sentencesJson={null}
+        chapters={[]}
+        participants={noParticipants}
+      />,
+    );
+    expect(container.querySelector(".mp-turn__time")).toBeNull();
+  });
+
+  test("never renders a header line as a speaker", () => {
+    render(
+      <TranscriptTab
+        transcription={MELISSA}
+        sentencesJson={null}
+        chapters={[]}
+        participants={noParticipants}
+      />,
+    );
+    expect(screen.queryByText("Meeting Title")).toBeNull();
+    expect(screen.queryByText("Date")).toBeNull();
+  });
+
+  test("shows times for Fireflies turns", () => {
+    const { container } = render(
+      <TranscriptTab
+        transcription={null}
+        sentencesJson={[
+          { text: "Welcome.", speaker_name: "Alice", start_time: 0, end_time: 2 },
+          { text: "Hello.", speaker_name: "Bob", start_time: 65, end_time: 67 },
+        ]}
+        chapters={[]}
+        participants={noParticipants}
+      />,
+    );
+    const times = Array.from(container.querySelectorAll(".mp-turn__time")).map(
+      (n) => n.textContent,
+    );
+    expect(times).toEqual(["00:00", "01:05"]);
+  });
+
+  test("renders an unrecognised transcript as a plain speaker-less block", () => {
+    const { container } = render(
+      <TranscriptTab
+        transcription={"a freeform note with no speaker labels"}
+        sentencesJson={null}
+        chapters={[]}
+        participants={noParticipants}
+      />,
+    );
+    expect(container.querySelector(".mp-turn__name")).toBeNull();
+    expect(container.querySelector(".mp-turn__avatar")).toBeNull();
+    expect(screen.getByText("a freeform note with no speaker labels")).toBeTruthy();
+  });
+
+  test("shows the empty state when there is no transcript", () => {
+    render(
+      <TranscriptTab
+        transcription={null}
+        sentencesJson={null}
+        chapters={[]}
+        participants={noParticipants}
+      />,
+    );
+    expect(screen.getByText("No transcript available yet.")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

Make the meeting detail page (`/recording/[id]`) render every transcript — including the device `Me:`/`Them:` paste — as speaker-attributed turns, by feeding it the parser from micro.tuna (#286).

- `TranscriptTab` consumes `parseTranscript(input)` (`TranscriptTurn[]`) instead of its own Fireflies-only `parseSentences`. Flavor and timestamps are resolved in the parser, so the component is now purely presentational (ADR-0032).
- Each turn shows the speaker with the correct identity tone (`me`/`them`/`alt`) and avatar; `Me`/host → `me`, others → `them`/`alt`.
- The time gutter is hidden when a turn's `startTime` is null (plain-text pastes), shown for Fireflies turns.
- The speaker-less fallback renders as a plain block (no avatar/name, newlines preserved), with search.
- Existing Fireflies rendering (names, timestamps, search, "Only me", chapters) is preserved.
- Header lines never become Speakers; the Participants panel is untouched.

Scope is the detail page only (`TranscriptTab`). `MeetingDetail`'s props are unchanged. The meetings-list migration and single-renderer consolidation are smoky.ridge (#3).

> Note on flavor: identity tone for non-host speakers now rotates `them`/`alt` by first appearance in the transcript (parser-resolved, per ADR-0032) rather than by participant index. This is the intended move of flavor resolution out of the renderer; it can shift the avatar/name *colour* of non-host Fireflies speakers, but names, times, ordering, search, "Only me", and chapters are unchanged.

## Acceptance criteria

- [x] Opening `/recording/[id]` for a `Me:`/`Them:` transcript shows alternating me/them turns, not a raw pre-wrapped blob.
- [x] No time gutter renders when all turns are timeless; Fireflies turns still show times.
- [x] Fireflies meetings render with names, timestamps, search, Only me, chapters.
- [x] An unrecognised transcript renders a plain speaker-less block (no invented speaker).
- [x] No header line appears as a speaker or Participant.

Covered by 6 happy-dom render tests in `TranscriptTab.test.tsx`.

---

Ships: rusty.nebula