### PR TITLE
refactor: Collapse duplicate transcript-parse logic into the shared module

### DIFF
--- a/src/lib/meeting-view-model.ts
+++ b/src/lib/meeting-view-model.ts
@@ -1,6 +1,7 @@
 import type { RouterOutputs } from "~/trpc/react";
 import { getInitial } from "~/utils/avatarColors";
 import { parseFirefliesSummary, isEmptyFirefliesSummary } from "~/lib/fireflies-summary";
+import { parseTranscript } from "~/lib/transcript";
 import type { FirefliesSummary } from "~/server/services/FirefliesService";
 
 /**
@@ -52,42 +53,19 @@ export interface MeetingViewModel {
   questions: never[];
   hasVideo: boolean;
   captureCount: number;
-  /** Number of diarized transcript turns; 0 for plain-text / no transcript
-   *  (so the Transcript tab badge self-hides). Mirrors TranscriptTab parsing. */
+  /** Number of canonical transcript turns; 0 for an empty/absent transcript
+   *  (so the Transcript tab badge self-hides). */
   transcriptCount: number;
 }
 
-/** Count diarized transcript turns the way {@link TranscriptTab} renders them:
- *  prefer `sentencesJson`, fall back to a Fireflies-shaped `transcription`
- *  string. Plain text has no discrete turns → 0. */
+/** Count canonical transcript turns via the shared parser registry (ADR-0032).
+ *  One source of truth — the same normalization the renderer consumes. */
 function countTranscriptTurns(
   transcription: string | null,
   sentencesJson: unknown,
 ): number {
-  const countArray = (arr: unknown[]): number =>
-    arr.filter(
-      (s) => s && typeof s === "object" && typeof (s as { text?: unknown }).text === "string",
-    ).length;
-
-  if (Array.isArray(sentencesJson)) {
-    const n = countArray(sentencesJson);
-    if (n > 0) return n;
-  }
-  if (transcription) {
-    try {
-      const obj: unknown = JSON.parse(transcription);
-      if (
-        obj &&
-        typeof obj === "object" &&
-        Array.isArray((obj as { sentences?: unknown }).sentences)
-      ) {
-        return countArray((obj as { sentences: unknown[] }).sentences);
-      }
-    } catch {
-      /* not JSON — plain text, no discrete turns */
-    }
-  }
-  return 0;
+  // Turn count is independent of speaker flavor, so participants aren't needed.
+  return parseTranscript({ transcription, sentencesJson, participants: [] }).length;
 }
 
 function capitalise(value: string): string {

--- a/src/lib/transcript/__tests__/labelled-turns.test.ts
+++ b/src/lib/transcript/__tests__/labelled-turns.test.ts
@@ -41,6 +41,14 @@ describe("labelledTurnsParser", () => {
     expect(turns[2]?.text).toBe("Perfect. Here's where it breaks.");
   });
 
+  it("a [SCREENSHOT] at end of line does not merge the next turn", () => {
+    const raw = ["Me: done here. [SCREENSHOT]", "Them: my reply"].join("\n");
+    const turns = labelledTurnsParser.parse(input(raw));
+    expect(turns).toHaveLength(2);
+    expect(turns[0]).toMatchObject({ speaker: "Me", text: "done here." });
+    expect(turns[1]).toMatchObject({ speaker: "Them", text: "my reply" });
+  });
+
   it("rotates them/alt for 3+ distinct speakers, stable by first appearance", () => {
     const raw = [
       "Alice: one",

--- a/src/lib/transcript/labelled-turns.ts
+++ b/src/lib/transcript/labelled-turns.ts
@@ -1,4 +1,5 @@
 import { createFlavorAssigner, hostNamesOf } from "./flavor";
+import { stripScreenshots } from "./strip";
 import type { TranscriptParser, TranscriptTurn } from "./types";
 
 /**
@@ -30,10 +31,6 @@ const SPEAKER_RE = /^([A-Za-z][A-Za-z0-9 .'’-]{0,40}):\s*/;
 
 function isMetaLabel(label: string): boolean {
   return META_HEADER_KEYS.has(label.trim().toLowerCase());
-}
-
-function stripScreenshots(raw: string): string {
-  return raw.replace(/\s*\[SCREENSHOT\]\.?\s*/g, " ");
 }
 
 /**

--- a/src/lib/transcript/raw.ts
+++ b/src/lib/transcript/raw.ts
@@ -1,8 +1,5 @@
+import { stripScreenshots } from "./strip";
 import type { TranscriptParser } from "./types";
-
-function stripScreenshots(raw: string): string {
-  return raw.replace(/\s*\[SCREENSHOT\]\.?\s*/g, " ");
-}
 
 /**
  * Terminal fallback: a transcript we could not structure becomes one

--- a/src/lib/transcript/strip.ts
+++ b/src/lib/transcript/strip.ts
@@ -1,0 +1,8 @@
+/**
+ * Remove `[SCREENSHOT]` markers (optionally followed by a period) and the inline
+ * whitespace hugging them, collapsing to a single space. Newlines are preserved
+ * so a marker at the end of a line never merges two turns together.
+ */
+export function stripScreenshots(raw: string): string {
+  return raw.replace(/[^\S\n]*\[SCREENSHOT\]\.?[^\S\n]*/g, " ");
+}

--- a/src/server/services/meetings/__tests__/extractReadableTranscript.test.ts
+++ b/src/server/services/meetings/__tests__/extractReadableTranscript.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Behaviour tests for extractReadableTranscript after it was routed through the
+ * shared transcript parser (ADR-0032). Guards the summarizer-feed contract:
+ * Fireflies blobs stay byte-equivalent; Me:/Them: pastes drop header noise.
+ */
+
+import { describe, expect, it } from "vitest";
+import { extractReadableTranscript } from "../extractReadableTranscript";
+
+describe("extractReadableTranscript", () => {
+  it("formats a Fireflies { sentences } blob as speaker-prefixed lines", () => {
+    const blob = JSON.stringify({
+      sentences: [
+        { text: "Welcome.", speaker_name: "Alice", start_time: 0, end_time: 1 },
+        { text: "Thanks.", speaker_name: "Bob", start_time: 1, end_time: 2 },
+      ],
+    });
+    expect(extractReadableTranscript(blob)).toBe("Alice: Welcome.\nBob: Thanks.");
+  });
+
+  it("derives readable dialogue from a Me:/Them: paste, dropping the header block", () => {
+    const raw = [
+      "Meeting Title: Sync",
+      "Date: 04 Jun 2026",
+      "Transcript:",
+      "Me: Hello there. [SCREENSHOT]",
+      "Them: Hi!",
+    ].join("\n");
+    // Header lines and the [SCREENSHOT] marker are gone; only dialogue remains.
+    expect(extractReadableTranscript(raw)).toBe("Me: Hello there.\nThem: Hi!");
+  });
+
+  it("returns the prose for an unstructured transcript", () => {
+    expect(extractReadableTranscript("just a freeform note")).toBe("just a freeform note");
+  });
+
+  it("returns an empty string for null/empty input", () => {
+    expect(extractReadableTranscript(null)).toBe("");
+    expect(extractReadableTranscript("   ")).toBe("");
+  });
+});

--- a/src/server/services/meetings/extractReadableTranscript.ts
+++ b/src/server/services/meetings/extractReadableTranscript.ts
@@ -1,39 +1,24 @@
-import {
-  FirefliesService,
-  type FirefliesTranscript,
-} from "~/server/services/FirefliesService";
+import { parseTranscript, turnsToReadableText } from "~/lib/transcript";
 
 /**
  * Normalize a stored `transcription` field into readable plain text for the
- * summarizer. Fireflies sessions store a JSON `{ sentences: [...] }` blob;
- * device sessions store plain text. Returns "" when there's nothing to
+ * summarizer, via the shared transcript parser (ADR-0032). Fireflies `{ sentences }`
+ * blobs and device plain-text pastes both normalize to canonical turns, then
+ * serialize to speaker-prefixed lines. Returns "" when there's nothing to
  * summarize.
+ *
+ * For Fireflies blobs this is byte-equivalent to the previous
+ * `FirefliesService.formatTranscriptText` output; for `Me:`/`Them:` pastes it is
+ * intentionally cleaner — meeting header lines (`Meeting Title:`, `Date:`, …) and
+ * `[SCREENSHOT]` markers are dropped rather than fed to the summarizer.
  *
  * Shared by the transcription router's `generateSummary` mutation and the
  * auto-summarize cron sweep so both produce summaries from identical input.
  */
 export function extractReadableTranscript(raw: string | null): string {
-  if (!raw) return "";
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) return "";
-
-  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
-    try {
-      const parsed: unknown = JSON.parse(trimmed);
-      const sentences =
-        parsed && typeof parsed === "object" && "sentences" in parsed
-          ? (parsed as { sentences?: FirefliesTranscript["sentences"] })
-              .sentences
-          : undefined;
-      if (sentences?.length) {
-        return FirefliesService.formatTranscriptText(sentences);
-      }
-    } catch {
-      // Not JSON — fall through and treat the raw string as plain text.
-    }
-  }
-
-  return trimmed;
+  return turnsToReadableText(
+    parseTranscript({ transcription: raw, sentencesJson: null, participants: [] }),
+  );
 }
 
 /** Max transcript chars fed to the summarizer (cost/latency bound). */


### PR DESCRIPTION
## What

Retire the duplicate "is this Fireflies JSON or plain text?" logic, routing every consumer through the shared parser module from micro.tuna (#286) — ADR-0032.

- `meeting-view-model.countTranscriptTurns` is now `parseTranscript(input).length`.
- `extractReadableTranscript` (the summarizer feed) re-derives readable text via the shared `turnsToReadableText`, dropping its own JSON-sniffing.
- Removed the "Mirrors TranscriptTab parsing" comment; one source of truth remains.
- Also fixes a latent bug in the parser's `[SCREENSHOT]` stripping (it consumed newlines, merging the next turn when a marker sat at end of line) and factors the helper into one `strip.ts`.

## Behaviour notes

- **Fireflies**: turn counts and summarizer text are unchanged — `turnsToReadableText` is byte-equivalent to the old `FirefliesService.formatTranscriptText` output.
- **`Me:`/`Them:` pastes**: the Transcript-tab badge now reflects the real turn count (it self-hid before, when these rendered as a wall of text), matching the rendering shipped in rusty.nebula (#287). The summarizer feed is intentionally cleaner — header lines (`Meeting Title:`, `Date:`, …) and `[SCREENSHOT]` markers are dropped rather than fed in.
- The badge self-hide (`count === 0`) still works for an empty/absent transcript.

## Acceptance criteria

- [x] `countTranscriptTurns` delegates to `parseTranscript(input).length`; Fireflies counts unchanged, plain-text now reflects rendered turns, empty self-hides.
- [x] `extractReadableTranscript` derives from turns via `turnsToReadableText`; Fireflies byte-equivalent, plain-text intentionally cleaner.
- [x] No remaining duplicate Fireflies-JSON-sniffing or "must mirror" comments.
- [x] Round-trip tests cover `turnsToReadableText` (structured + plain-text) plus a new `extractReadableTranscript` behaviour suite.

---

Ships: epic.nebula

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transcript text is now normalized more consistently across the app, including cleaner handling of speaker-labeled dialogue, pasted transcripts, and structured transcript data.
  * `[SCREENSHOT]` markers and transcript header blocks are now removed more reliably before display or summarization.

* **Bug Fixes**
  * Fixed turn counting so line breaks and screenshot markers no longer cause adjacent transcript lines to merge incorrectly.
  * Improved readable transcript output for empty, whitespace-only, and unstructured inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->