### PR TITLE
feat(crm): redesign edit-contact as a drawer with image attachments

### DIFF
--- a/prisma/migrations/20260625122913_add_crm_contact_attachments/migration.sql
+++ b/prisma/migrations/20260625122913_add_crm_contact_attachments/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "CrmContactAttachment" (
+    "id" TEXT NOT NULL,
+    "contactId" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "fileName" TEXT NOT NULL,
+    "fileSize" INTEGER NOT NULL,
+    "contentType" TEXT NOT NULL,
+    "s3Key" TEXT NOT NULL,
+    "uploadedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CrmContactAttachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CrmContactAttachment_contactId_idx" ON "CrmContactAttachment"("contactId");
+
+-- CreateIndex
+CREATE INDEX "CrmContactAttachment_workspaceId_idx" ON "CrmContactAttachment"("workspaceId");
+
+-- AddForeignKey
+ALTER TABLE "CrmContactAttachment" ADD CONSTRAINT "CrmContactAttachment_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "CrmContact"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260625125227_crm_contact_screenshots/migration.sql
+++ b/prisma/migrations/20260625125227_crm_contact_screenshots/migration.sql
@@ -1,0 +1,36 @@
+/*
+  Warnings:
+
+  - You are about to drop the `CrmContactAttachment` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "CrmContactAttachment" DROP CONSTRAINT "CrmContactAttachment_contactId_fkey";
+
+-- DropTable
+DROP TABLE "CrmContactAttachment";
+
+-- CreateTable
+CREATE TABLE "CrmContactScreenshot" (
+    "id" TEXT NOT NULL,
+    "contactId" TEXT NOT NULL,
+    "screenshotId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CrmContactScreenshot_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CrmContactScreenshot_contactId_idx" ON "CrmContactScreenshot"("contactId");
+
+-- CreateIndex
+CREATE INDEX "CrmContactScreenshot_screenshotId_idx" ON "CrmContactScreenshot"("screenshotId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CrmContactScreenshot_contactId_screenshotId_key" ON "CrmContactScreenshot"("contactId", "screenshotId");
+
+-- AddForeignKey
+ALTER TABLE "CrmContactScreenshot" ADD CONSTRAINT "CrmContactScreenshot_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "CrmContact"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CrmContactScreenshot" ADD CONSTRAINT "CrmContactScreenshot_screenshotId_fkey" FOREIGN KEY ("screenshotId") REFERENCES "Screenshot"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1289,6 +1289,7 @@ model Screenshot {
   createdAt              DateTime              @default(now())
   transcriptionSession   TranscriptionSession? @relation(fields: [transcriptionSessionId], references: [id])
   actionScreenshots      ActionScreenshot[]
+  crmContactScreenshots  CrmContactScreenshot[]
 }
 
 model ActionScreenshot {
@@ -2571,6 +2572,7 @@ model CrmContact {
   communications              CrmCommunication[]
   deals                       Deal[]
   transcriptionParticipations TranscriptionSessionParticipant[]
+  screenshots                 CrmContactScreenshot[]
 
   @@index([workspaceId])
   @@index([organizationId])
@@ -2581,6 +2583,24 @@ model CrmContact {
   @@index([connectionScore])
   @@index([workspaceId, importSource])
   @@unique([workspaceId, emailHash])
+}
+
+// Join between a CRM contact and an uploaded image/screenshot. Mirrors
+// ActionScreenshot: the binary lives in Vercel Blob (see src/lib/blob.ts) and the
+// shared Screenshot row holds the URL. Pasting/dropping an image on the edit
+// drawer creates one of these on save.
+model CrmContactScreenshot {
+  id           String   @id @default(cuid())
+  contactId    String
+  screenshotId String
+  createdAt    DateTime @default(now())
+
+  contact    CrmContact @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  screenshot Screenshot @relation(fields: [screenshotId], references: [id], onDelete: Cascade)
+
+  @@unique([contactId, screenshotId])
+  @@index([contactId])
+  @@index([screenshotId])
 }
 
 model CrmOrganization {

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import {
   Title,
@@ -53,6 +53,7 @@ import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { api } from '~/trpc/react';
 import Link from 'next/link';
 import { notifications } from '@mantine/notifications';
+import { EditContactDrawer } from '~/app/_components/crm/EditContactDrawer';
 
 // Helper function to get relative time
 function getRelativeTime(date: Date): string {
@@ -348,228 +349,6 @@ function AddInteractionForm({
           </Button>
           <Button type="submit" loading={addInteraction.isPending}>
             Add Interaction
-          </Button>
-        </div>
-      </Stack>
-    </form>
-  );
-}
-
-interface ContactEditFormProps {
-  contact: {
-    id: string;
-    firstName: string | null;
-    lastName: string | null;
-    email: string | null;
-    phone: string | null;
-    linkedIn: string | null;
-    telegram: string | null;
-    twitter: string | null;
-    github: string | null;
-    bluesky: string | null;
-    about: string | null;
-    profileType: string | null;
-    organizationId: string | null;
-  };
-  workspaceId: string;
-  onSuccess: () => void;
-  onCancel: () => void;
-}
-
-function ContactEditForm({
-  contact,
-  workspaceId,
-  onSuccess,
-  onCancel,
-}: ContactEditFormProps) {
-  const [formData, setFormData] = useState({
-    firstName: '',
-    lastName: '',
-    email: '',
-    phone: '',
-    linkedIn: '',
-    telegram: '',
-    twitter: '',
-    github: '',
-    bluesky: '',
-    about: '',
-    profileType: '',
-    organizationId: '',
-  });
-
-  const utils = api.useUtils();
-
-  const { data: organizations } = api.crmOrganization.getAll.useQuery(
-    { workspaceId, limit: 100 },
-    { enabled: !!workspaceId },
-  );
-
-  const updateContact = api.crmContact.update.useMutation({
-    onSuccess: () => {
-      void utils.crmContact.getById.invalidate({ id: contact.id });
-      void utils.crmContact.getAll.invalidate();
-      notifications.show({
-        title: 'Success',
-        message: 'Contact updated successfully',
-        color: 'green',
-      });
-      onSuccess();
-    },
-    onError: (error) => {
-      notifications.show({
-        title: 'Error',
-        message: error.message,
-        color: 'red',
-      });
-    },
-  });
-
-  useEffect(() => {
-    setFormData({
-      firstName: contact.firstName ?? '',
-      lastName: contact.lastName ?? '',
-      email: contact.email ?? '',
-      phone: contact.phone ?? '',
-      linkedIn: contact.linkedIn ?? '',
-      telegram: contact.telegram ?? '',
-      twitter: contact.twitter ?? '',
-      github: contact.github ?? '',
-      bluesky: contact.bluesky ?? '',
-      about: contact.about ?? '',
-      profileType: contact.profileType ?? '',
-      organizationId: contact.organizationId ?? '',
-    });
-  }, [contact]);
-
-  const getOptionalValue = (value: string) => value.trim();
-
-  const getNullableEmail = (value: string) => {
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : null;
-  };
-
-  const handleSubmit = (event: React.FormEvent) => {
-    event.preventDefault();
-    updateContact.mutate({
-      id: contact.id,
-      firstName: formData.firstName.trim(),
-      lastName: formData.lastName.trim(),
-      email: getNullableEmail(formData.email),
-      phone: getOptionalValue(formData.phone),
-      linkedIn: getOptionalValue(formData.linkedIn),
-      telegram: getOptionalValue(formData.telegram),
-      twitter: getOptionalValue(formData.twitter),
-      github: getOptionalValue(formData.github),
-      bluesky: getOptionalValue(formData.bluesky),
-      about: formData.about.trim(),
-      profileType: formData.profileType.trim() || undefined,
-      organizationId: formData.organizationId.length > 0 ? formData.organizationId : null,
-    });
-  };
-
-  return (
-    <form onSubmit={handleSubmit}>
-      <Stack gap="md">
-        <div className="grid grid-cols-2 gap-3">
-          <TextInput
-            label="First Name"
-            value={formData.firstName}
-            onChange={(event) =>
-              setFormData({ ...formData, firstName: event.target.value })
-            }
-          />
-          <TextInput
-            label="Last Name"
-            value={formData.lastName}
-            onChange={(event) =>
-              setFormData({ ...formData, lastName: event.target.value })
-            }
-          />
-        </div>
-        <TextInput
-          label="Email"
-          type="email"
-          value={formData.email}
-          onChange={(event) => setFormData({ ...formData, email: event.target.value })}
-        />
-        <TextInput
-          label="Phone"
-          value={formData.phone}
-          onChange={(event) => setFormData({ ...formData, phone: event.target.value })}
-        />
-        <TextInput
-          label="LinkedIn URL"
-          value={formData.linkedIn}
-          onChange={(event) => setFormData({ ...formData, linkedIn: event.target.value })}
-        />
-        <TextInput
-          label="Telegram"
-          placeholder="@username"
-          value={formData.telegram}
-          onChange={(event) => setFormData({ ...formData, telegram: event.target.value })}
-        />
-        <TextInput
-          label="Twitter"
-          placeholder="@handle"
-          value={formData.twitter}
-          onChange={(event) => setFormData({ ...formData, twitter: event.target.value })}
-        />
-        <TextInput
-          label="GitHub"
-          placeholder="username"
-          value={formData.github}
-          onChange={(event) => setFormData({ ...formData, github: event.target.value })}
-        />
-        <TextInput
-          label="BlueSky"
-          placeholder="@handle.bsky.social"
-          value={formData.bluesky}
-          onChange={(event) => setFormData({ ...formData, bluesky: event.target.value })}
-        />
-        <Textarea
-          label="Description"
-          minRows={3}
-          value={formData.about}
-          onChange={(event) => setFormData({ ...formData, about: event.target.value })}
-        />
-        <Select
-          label="Profile Type"
-          placeholder="Select type"
-          data={[
-            { value: 'Developer', label: 'Developer' },
-            { value: 'Designer', label: 'Designer' },
-            { value: 'Founder', label: 'Founder' },
-            { value: 'Product Manager', label: 'Product Manager' },
-            { value: 'Investor', label: 'Investor' },
-            { value: 'Marketing', label: 'Marketing' },
-            { value: 'Sales', label: 'Sales' },
-            { value: 'Other', label: 'Other' },
-          ]}
-          value={formData.profileType}
-          onChange={(value) => setFormData({ ...formData, profileType: value ?? '' })}
-          clearable
-          searchable
-        />
-        <Select
-          label="Company"
-          placeholder="Select organization"
-          data={
-            organizations?.organizations.map((org) => ({
-              value: org.id,
-              label: org.name,
-            })) ?? []
-          }
-          value={formData.organizationId}
-          onChange={(value) => setFormData({ ...formData, organizationId: value ?? '' })}
-          clearable
-          searchable
-        />
-        <div className="flex justify-end gap-2 mt-2">
-          <Button variant="subtle" onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button type="submit" loading={updateContact.isPending}>
-            Save Changes
           </Button>
         </div>
       </Stack>
@@ -1601,16 +1380,15 @@ export default function ContactDetailPage() {
         />
       </Modal>
 
-      <Modal opened={editModalOpened} onClose={closeEditModal} title="Edit Contact" size="lg">
-        {contact && workspaceId ? (
-          <ContactEditForm
-            contact={contact}
-            workspaceId={workspaceId}
-            onSuccess={closeEditModal}
-            onCancel={closeEditModal}
-          />
-        ) : null}
-      </Modal>
+      {contact && workspaceId ? (
+        <EditContactDrawer
+          opened={editModalOpened}
+          onClose={closeEditModal}
+          contact={contact}
+          workspaceId={workspaceId}
+          onSaved={closeEditModal}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/app/_components/crm/EditContactDrawer.tsx
+++ b/src/app/_components/crm/EditContactDrawer.tsx
@@ -1,0 +1,582 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Drawer,
+  TextInput,
+  Select,
+  Chip,
+  Button,
+  ActionIcon,
+  Avatar,
+  FileButton,
+  Image,
+  Modal,
+  Tooltip,
+  Text,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import {
+  IconUser,
+  IconMail,
+  IconPhone,
+  IconShare3,
+  IconBrandLinkedin,
+  IconBrandTelegram,
+  IconBrandTwitter,
+  IconBrandGithub,
+  IconBrandBluesky,
+  IconFileText,
+  IconPhoto,
+  IconUpload,
+  IconX,
+  IconMaximize,
+  IconMinimize,
+} from '@tabler/icons-react';
+import { api } from '~/trpc/react';
+import { MarkdownInput } from '~/app/_components/shared/MarkdownInput';
+import type { PastedScreenshot } from '~/app/_components/ActionModalForm';
+
+const PROFILE_TYPES = [
+  'Developer',
+  'Designer',
+  'Founder',
+  'Product Manager',
+  'Investor',
+  'Marketing',
+  'Sales',
+  'Other',
+];
+
+export interface EditContactDrawerContact {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+  phone: string | null;
+  linkedIn: string | null;
+  telegram: string | null;
+  twitter: string | null;
+  github: string | null;
+  bluesky: string | null;
+  about: string | null;
+  profileType: string | null;
+  organizationId: string | null;
+}
+
+interface EditContactDrawerProps {
+  opened: boolean;
+  onClose: () => void;
+  contact: EditContactDrawerContact;
+  workspaceId: string;
+  /** Called after a successful save (e.g. to close the drawer). */
+  onSaved?: () => void;
+}
+
+/** Read an image File into a PastedScreenshot (base64 + preview data URL). */
+function readImageFile(file: File): Promise<PastedScreenshot> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const dataUrl = reader.result as string;
+      resolve({
+        id: `screenshot-${Date.now()}-${Math.round(file.size)}`,
+        base64: dataUrl.split(',')[1] ?? '',
+        previewUrl: dataUrl,
+      });
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read image'));
+    reader.readAsDataURL(file);
+  });
+}
+
+interface FormState {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  linkedIn: string;
+  telegram: string;
+  twitter: string;
+  github: string;
+  bluesky: string;
+  about: string;
+  profileType: string;
+  organizationId: string;
+}
+
+function toFormState(contact: EditContactDrawerContact): FormState {
+  return {
+    firstName: contact.firstName ?? '',
+    lastName: contact.lastName ?? '',
+    email: contact.email ?? '',
+    phone: contact.phone ?? '',
+    linkedIn: contact.linkedIn ?? '',
+    telegram: contact.telegram ?? '',
+    twitter: contact.twitter ?? '',
+    github: contact.github ?? '',
+    bluesky: contact.bluesky ?? '',
+    about: contact.about ?? '',
+    profileType: contact.profileType ?? '',
+    organizationId: contact.organizationId ?? '',
+  };
+}
+
+/** Uppercase section header with a leading icon and a trailing hairline rule. */
+function GroupLabel({
+  icon,
+  children,
+}: {
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mb-3 flex items-center gap-2">
+      <span className="text-text-faint">{icon}</span>
+      <span className="text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+        {children}
+      </span>
+      <span className="h-px flex-1 bg-border-subtle" />
+    </div>
+  );
+}
+
+export function EditContactDrawer({
+  opened,
+  onClose,
+  contact,
+  workspaceId,
+  onSaved,
+}: EditContactDrawerProps) {
+  const utils = api.useUtils();
+  const [form, setForm] = useState<FormState>(() => toFormState(contact));
+  const [wide, setWide] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
+  // Newly added images (paste/drop/click) held until Save, then uploaded.
+  const [pastedScreenshots, setPastedScreenshots] = useState<PastedScreenshot[]>([]);
+  const resetFileRef = useRef<() => void>(null);
+
+  // Re-seed the form + clear pending images each time the drawer opens.
+  useEffect(() => {
+    if (opened) {
+      setForm(toFormState(contact));
+      setPastedScreenshots([]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opened, contact.id]);
+
+  const set =
+    <K extends keyof FormState>(key: K) =>
+    (value: FormState[K]) =>
+      setForm((prev) => ({ ...prev, [key]: value }));
+
+  const { data: organizations } = api.crmOrganization.getAll.useQuery(
+    { workspaceId, limit: 100 },
+    { enabled: opened && !!workspaceId },
+  );
+
+  const { data: existingScreenshots } = api.crmContact.listScreenshots.useQuery(
+    { contactId: contact.id },
+    { enabled: opened && !!contact.id },
+  );
+
+  const updateContact = api.crmContact.update.useMutation();
+  const uploadImage = api.crmContact.uploadImage.useMutation();
+  const removeScreenshot = api.crmContact.removeScreenshot.useMutation({
+    onSuccess: () => {
+      void utils.crmContact.listScreenshots.invalidate({ contactId: contact.id });
+    },
+    onError: (error) => {
+      notifications.show({ title: 'Error', message: error.message, color: 'red' });
+    },
+  });
+
+  // Combined gallery: persisted images (from DB) + pending ones (this session).
+  const galleryImages = useMemo(
+    () => [
+      ...(existingScreenshots ?? []).map((s) => ({
+        id: s.id,
+        previewUrl: s.url,
+        persisted: true as const,
+      })),
+      ...pastedScreenshots.map((s) => ({
+        id: s.id,
+        previewUrl: s.previewUrl,
+        persisted: false as const,
+      })),
+    ],
+    [existingScreenshots, pastedScreenshots],
+  );
+
+  const addImageFiles = async (files: File[]) => {
+    const images = files.filter((f) => f.type.startsWith('image/'));
+    if (images.length === 0) return;
+    try {
+      const shots = await Promise.all(images.map(readImageFile));
+      setPastedScreenshots((prev) => [...prev, ...shots]);
+    } catch {
+      notifications.show({
+        title: 'Error',
+        message: 'Could not read that image',
+        color: 'red',
+      });
+    }
+  };
+
+  // Paste a screenshot into the description — same behaviour as EditActionModal.
+  const handleDescriptionPaste = (e: React.ClipboardEvent) => {
+    const items = e.clipboardData.items;
+    for (const item of items) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault();
+        const file = item.getAsFile();
+        if (!file) continue;
+        void addImageFiles([file]);
+        break; // only the first image
+      }
+    }
+  };
+
+  const removeImage = (id: string, persisted: boolean) => {
+    if (persisted) {
+      removeScreenshot.mutate({ contactId: contact.id, screenshotId: id });
+    } else {
+      setPastedScreenshots((prev) => prev.filter((s) => s.id !== id));
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      // Upload any pending images first (mirrors EditActionModal save flow).
+      for (const shot of pastedScreenshots) {
+        await uploadImage.mutateAsync({
+          contactId: contact.id,
+          base64Data: shot.base64,
+        });
+      }
+
+      const trimmedEmail = form.email.trim();
+      await updateContact.mutateAsync({
+        id: contact.id,
+        firstName: form.firstName.trim(),
+        lastName: form.lastName.trim(),
+        email: trimmedEmail.length > 0 ? trimmedEmail : null,
+        phone: form.phone.trim(),
+        linkedIn: form.linkedIn.trim(),
+        telegram: form.telegram.trim(),
+        twitter: form.twitter.trim(),
+        github: form.github.trim(),
+        bluesky: form.bluesky.trim(),
+        about: form.about.trim(),
+        profileType: form.profileType.trim() || undefined,
+        organizationId: form.organizationId.length > 0 ? form.organizationId : null,
+      });
+
+      setPastedScreenshots([]);
+      void utils.crmContact.getById.invalidate({ id: contact.id });
+      void utils.crmContact.getAll.invalidate();
+      void utils.crmContact.listScreenshots.invalidate({ contactId: contact.id });
+      notifications.show({
+        title: 'Saved',
+        message: 'Contact updated successfully',
+        color: 'green',
+      });
+      onSaved?.();
+    } catch (error) {
+      notifications.show({
+        title: 'Error',
+        message: error instanceof Error ? error.message : 'Failed to save contact',
+        color: 'red',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const fullName = `${form.firstName} ${form.lastName}`.trim() || 'New contact';
+  const initial = (form.firstName?.[0] ?? form.lastName?.[0] ?? '?').toUpperCase();
+
+  return (
+    <Drawer.Root
+      opened={opened}
+      onClose={onClose}
+      position="right"
+      size={wide ? 720 : 540}
+    >
+      <Drawer.Overlay />
+      <Drawer.Content style={{ display: 'flex', flexDirection: 'column' }}>
+        <Drawer.Header>
+          <div className="flex w-full items-center gap-3">
+            <Avatar radius="md" color="brand">
+              {initial}
+            </Avatar>
+            <div className="min-w-0 flex-1">
+              <div className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+                Edit contact
+              </div>
+              <div className="truncate text-base font-semibold text-text-primary">
+                {fullName}
+              </div>
+            </div>
+            <Tooltip label={wide ? 'Standard width' : 'Wide'} withArrow>
+              <ActionIcon
+                variant="subtle"
+                color="gray"
+                onClick={() => setWide((w) => !w)}
+                aria-label={wide ? 'Standard width' : 'Wide'}
+              >
+                {wide ? <IconMinimize size={18} /> : <IconMaximize size={18} />}
+              </ActionIcon>
+            </Tooltip>
+            <Drawer.CloseButton />
+          </div>
+        </Drawer.Header>
+
+        <Drawer.Body style={{ flex: 1, overflowY: 'auto' }}>
+          {/* Identity */}
+          <section className="mb-7">
+            <GroupLabel icon={<IconUser size={13} />}>Identity</GroupLabel>
+            <div className="grid grid-cols-2 gap-3">
+              <TextInput
+                label="First name"
+                value={form.firstName}
+                onChange={(e) => set('firstName')(e.currentTarget.value)}
+              />
+              <TextInput
+                label="Last name"
+                value={form.lastName}
+                onChange={(e) => set('lastName')(e.currentTarget.value)}
+              />
+            </div>
+            <Text size="sm" fw={500} mt="md" mb={6} c="dimmed">
+              Profile type
+            </Text>
+            <Chip.Group
+              multiple={false}
+              value={form.profileType}
+              onChange={(value) => set('profileType')(value)}
+            >
+              <div className="flex flex-wrap gap-2">
+                {PROFILE_TYPES.map((type) => (
+                  <Chip key={type} value={type} variant="outline" size="sm">
+                    {type}
+                  </Chip>
+                ))}
+              </div>
+            </Chip.Group>
+            <Select
+              mt="md"
+              label="Company"
+              placeholder="Select organization…"
+              data={
+                organizations?.organizations.map((org) => ({
+                  value: org.id,
+                  label: org.name,
+                })) ?? []
+              }
+              value={form.organizationId || null}
+              onChange={(value) => set('organizationId')(value ?? '')}
+              clearable
+              searchable
+            />
+          </section>
+
+          {/* Contact */}
+          <section className="mb-7">
+            <GroupLabel icon={<IconMail size={13} />}>Contact</GroupLabel>
+            <TextInput
+              label="Email"
+              type="email"
+              leftSection={<IconMail size={15} />}
+              value={form.email}
+              onChange={(e) => set('email')(e.currentTarget.value)}
+            />
+            <TextInput
+              mt="sm"
+              label="Phone"
+              leftSection={<IconPhone size={15} />}
+              placeholder="Add phone number"
+              value={form.phone}
+              onChange={(e) => set('phone')(e.currentTarget.value)}
+            />
+          </section>
+
+          {/* Social */}
+          <section className="mb-7">
+            <GroupLabel icon={<IconShare3 size={13} />}>Social</GroupLabel>
+            <TextInput
+              label="LinkedIn URL"
+              type="url"
+              leftSection={<IconBrandLinkedin size={15} />}
+              value={form.linkedIn}
+              onChange={(e) => set('linkedIn')(e.currentTarget.value)}
+            />
+            <TextInput
+              mt="sm"
+              label="Telegram"
+              leftSection={<IconBrandTelegram size={15} />}
+              placeholder="username"
+              value={form.telegram}
+              onChange={(e) => set('telegram')(e.currentTarget.value)}
+            />
+            <TextInput
+              mt="sm"
+              label="Twitter / X"
+              leftSection={<IconBrandTwitter size={15} />}
+              placeholder="handle"
+              value={form.twitter}
+              onChange={(e) => set('twitter')(e.currentTarget.value)}
+            />
+            <TextInput
+              mt="sm"
+              label="GitHub"
+              leftSection={<IconBrandGithub size={15} />}
+              placeholder="username"
+              value={form.github}
+              onChange={(e) => set('github')(e.currentTarget.value)}
+            />
+            <TextInput
+              mt="sm"
+              label="BlueSky"
+              leftSection={<IconBrandBluesky size={15} />}
+              placeholder="handle.bsky.social"
+              value={form.bluesky}
+              onChange={(e) => set('bluesky')(e.currentTarget.value)}
+            />
+          </section>
+
+          {/* Description — paste a screenshot here to attach it (like actions). */}
+          <section className="mb-7">
+            <GroupLabel icon={<IconFileText size={13} />}>Description</GroupLabel>
+            <MarkdownInput
+              value={form.about}
+              onChange={(value) => set('about')(value)}
+              onPaste={handleDescriptionPaste}
+              placeholder="Add notes, context, rates… or paste a screenshot to attach it."
+              minRows={4}
+            />
+          </section>
+
+          {/* Images */}
+          <section>
+            <GroupLabel icon={<IconPhoto size={13} />}>Images</GroupLabel>
+            <FileButton
+              multiple
+              accept="image/*"
+              resetRef={resetFileRef}
+              onChange={(files) => {
+                resetFileRef.current?.();
+                if (files.length) void addImageFiles(files);
+              }}
+            >
+              {(btnProps) => (
+                <div
+                  {...btnProps}
+                  role="button"
+                  tabIndex={0}
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    setDragOver(true);
+                  }}
+                  onDragLeave={() => setDragOver(false)}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    setDragOver(false);
+                    if (e.dataTransfer.files.length) {
+                      void addImageFiles(Array.from(e.dataTransfer.files));
+                    }
+                  }}
+                  className={`flex cursor-pointer items-center gap-3 rounded-md border border-dashed p-4 transition-colors ${
+                    dragOver
+                      ? 'border-border-focus bg-surface-secondary'
+                      : 'border-border-strong hover:border-border-focus hover:bg-surface-secondary'
+                  }`}
+                >
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-surface-secondary text-brand-primary">
+                    <IconUpload size={19} />
+                  </span>
+                  <div>
+                    <div className="text-sm font-medium text-text-primary">
+                      {dragOver ? 'Drop image to attach' : 'Add images for this person'}
+                    </div>
+                    <div className="text-xs text-text-muted">
+                      Click to browse, drag &amp; drop, or paste a screenshot above
+                    </div>
+                  </div>
+                </div>
+              )}
+            </FileButton>
+
+            {galleryImages.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {galleryImages.map((img) => (
+                  <div key={img.id} className="group relative">
+                    <span
+                      className="cursor-pointer"
+                      onClick={() => setLightboxUrl(img.previewUrl)}
+                    >
+                      <Image
+                        src={img.previewUrl}
+                        alt="Contact image"
+                        h={80}
+                        w="auto"
+                        radius="sm"
+                        className="border border-border-primary transition-colors hover:border-brand-primary"
+                      />
+                    </span>
+                    <ActionIcon
+                      size="xs"
+                      variant="filled"
+                      color="red"
+                      radius="xl"
+                      className="absolute -right-1 -top-1 opacity-0 transition-opacity group-hover:opacity-100"
+                      aria-label="Remove image"
+                      loading={
+                        img.persisted &&
+                        removeScreenshot.isPending &&
+                        removeScreenshot.variables?.screenshotId === img.id
+                      }
+                      onClick={() => removeImage(img.id, img.persisted)}
+                    >
+                      <IconX size={10} />
+                    </ActionIcon>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        </Drawer.Body>
+
+        {/* Footer */}
+        <div className="flex shrink-0 items-center gap-2 border-t border-border-subtle px-4 py-3">
+          <span className="text-xs text-text-muted">
+            Changes aren&apos;t saved until you confirm.
+          </span>
+          <span className="flex-1" />
+          <Button variant="subtle" color="gray" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSave()} loading={saving}>
+            Save changes
+          </Button>
+        </div>
+      </Drawer.Content>
+
+      <Modal
+        opened={!!lightboxUrl}
+        onClose={() => setLightboxUrl(null)}
+        size="auto"
+        centered
+        withCloseButton={false}
+        padding={0}
+      >
+        {lightboxUrl && (
+          <Image src={lightboxUrl} alt="Contact image" fit="contain" mah="80vh" />
+        )}
+      </Modal>
+    </Drawer.Root>
+  );
+}

--- a/src/app/_components/crm/EditContactDrawer.tsx
+++ b/src/app/_components/crm/EditContactDrawer.tsx
@@ -250,14 +250,8 @@ export function EditContactDrawer({
   const handleSave = async () => {
     setSaving(true);
     try {
-      // Upload any pending images first (mirrors EditActionModal save flow).
-      for (const shot of pastedScreenshots) {
-        await uploadImage.mutateAsync({
-          contactId: contact.id,
-          base64Data: shot.base64,
-        });
-      }
-
+      // Save the contact fields first; if this throws we never upload images,
+      // so there are no orphaned blobs to clean up.
       const trimmedEmail = form.email.trim();
       await updateContact.mutateAsync({
         id: contact.id,
@@ -275,10 +269,39 @@ export function EditContactDrawer({
         organizationId: form.organizationId.length > 0 ? form.organizationId : null,
       });
 
-      setPastedScreenshots([]);
       void utils.crmContact.getById.invalidate({ id: contact.id });
       void utils.crmContact.getAll.invalidate();
-      void utils.crmContact.listScreenshots.invalidate({ contactId: contact.id });
+
+      // Upload pending images in parallel. Drop each one from state as it
+      // succeeds so a retry never re-uploads an already-persisted image.
+      if (pastedScreenshots.length > 0) {
+        const pending = pastedScreenshots;
+        const results = await Promise.allSettled(
+          pending.map((shot) =>
+            uploadImage.mutateAsync({
+              contactId: contact.id,
+              base64Data: shot.base64,
+            }),
+          ),
+        );
+        const failedIds = pending
+          .filter((_, i) => results[i]?.status === 'rejected')
+          .map((s) => s.id);
+        setPastedScreenshots((prev) => prev.filter((s) => failedIds.includes(s.id)));
+        void utils.crmContact.listScreenshots.invalidate({ contactId: contact.id });
+
+        if (failedIds.length > 0) {
+          // Contact saved, but some images didn't upload — keep the drawer open
+          // so the user can retry just the failures.
+          notifications.show({
+            title: 'Some images failed',
+            message: `Contact saved, but ${failedIds.length} image(s) could not be uploaded. Try again.`,
+            color: 'orange',
+          });
+          return;
+        }
+      }
+
       notifications.show({
         title: 'Saved',
         message: 'Contact updated successfully',
@@ -469,7 +492,7 @@ export function EditContactDrawer({
               resetRef={resetFileRef}
               onChange={(files) => {
                 resetFileRef.current?.();
-                if (files.length) void addImageFiles(files);
+                if (files && files.length > 0) void addImageFiles(files);
               }}
             >
               {(btnProps) => (

--- a/src/server/api/routers/crmContact.ts
+++ b/src/server/api/routers/crmContact.ts
@@ -7,6 +7,33 @@ import { ContactSyncService } from "~/server/services/ContactSyncService";
 import { ConnectionStrengthCalculator } from "~/server/services/ConnectionStrengthCalculator";
 import { GoogleTokenManager } from "~/server/services/GoogleTokenManager";
 import { dispatchContactTypeAutomations } from "~/server/services/crm/automation/dispatchContactTypeAutomations";
+import { uploadToBlob, deleteFromBlob } from "~/lib/blob";
+
+// Verify the signed-in user belongs to the workspace that owns `contactId`.
+// Throws NOT_FOUND / FORBIDDEN otherwise.
+async function assertContactAccess(
+  db: PrismaClient,
+  userId: string,
+  contactId: string,
+): Promise<{ workspaceId: string }> {
+  const contact = await db.crmContact.findUnique({
+    where: { id: contactId },
+    select: { workspaceId: true },
+  });
+  if (!contact) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Contact not found" });
+  }
+  const access = await db.workspaceUser.findFirst({
+    where: { workspaceId: contact.workspaceId, userId },
+  });
+  if (!access) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You do not have access to this contact",
+    });
+  }
+  return { workspaceId: contact.workspaceId };
+}
 
 // Type for decrypted contact - replaces Bytes fields with string | null
 type DecryptedContact<T extends CrmContact> = Omit<
@@ -1282,5 +1309,95 @@ export const crmContactRouter = createTRPCRouter({
       });
 
       return { success: true, message: "Score recalculation started" };
+    }),
+
+  // ──────────────────────────────────────────────────────────────────
+  // Screenshots / images — Vercel Blob storage + shared Screenshot model,
+  // joined to the contact via CrmContactScreenshot. Mirrors action.uploadImage.
+  // ──────────────────────────────────────────────────────────────────
+
+  // List a contact's uploaded images (already-persisted blob URLs).
+  listScreenshots: protectedProcedure
+    .input(z.object({ contactId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      await assertContactAccess(ctx.db, ctx.session.user.id, input.contactId);
+
+      const rows = await ctx.db.crmContactScreenshot.findMany({
+        where: { contactId: input.contactId },
+        orderBy: { createdAt: "desc" },
+        include: { screenshot: true },
+      });
+
+      return rows.map((row) => ({
+        id: row.screenshotId,
+        url: row.screenshot.url,
+        createdAt: row.createdAt,
+      }));
+    }),
+
+  // Upload an image (base64) and associate it with a contact.
+  uploadImage: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string(),
+        base64Data: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertContactAccess(ctx.db, ctx.session.user.id, input.contactId);
+
+      const timestamp = new Date().toISOString().replace(/[/:]/g, "-");
+      const filename = `screenshots/contacts/${input.contactId}/${timestamp}.png`;
+      const blob = await uploadToBlob(input.base64Data, filename);
+
+      const screenshot = await ctx.db.screenshot.create({
+        data: {
+          url: blob.url,
+          timestamp: new Date().toISOString(),
+        },
+      });
+
+      await ctx.db.crmContactScreenshot.create({
+        data: {
+          contactId: input.contactId,
+          screenshotId: screenshot.id,
+        },
+      });
+
+      return { id: screenshot.id, url: blob.url };
+    }),
+
+  // Remove an image from a contact: delete the join, the Screenshot row, and the blob.
+  removeScreenshot: protectedProcedure
+    .input(z.object({ contactId: z.string(), screenshotId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await assertContactAccess(ctx.db, ctx.session.user.id, input.contactId);
+
+      const join = await ctx.db.crmContactScreenshot.findUnique({
+        where: {
+          contactId_screenshotId: {
+            contactId: input.contactId,
+            screenshotId: input.screenshotId,
+          },
+        },
+        include: { screenshot: true },
+      });
+      if (!join) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Image not found" });
+      }
+
+      const blobUrl = join.screenshot.url;
+      await ctx.db.crmContactScreenshot.delete({ where: { id: join.id } });
+      // Best-effort: drop the Screenshot row + blob if nothing else references it.
+      await ctx.db.screenshot
+        .delete({ where: { id: input.screenshotId } })
+        .catch(() => undefined);
+      if (blobUrl) {
+        await deleteFromBlob(blobUrl).catch((e) => {
+          console.error("Failed to delete blob for contact image", input.screenshotId, e);
+        });
+      }
+
+      return { success: true };
     }),
 });

--- a/src/server/api/routers/crmContact.ts
+++ b/src/server/api/routers/crmContact.ts
@@ -1388,14 +1388,31 @@ export const crmContactRouter = createTRPCRouter({
 
       const blobUrl = join.screenshot.url;
       await ctx.db.crmContactScreenshot.delete({ where: { id: join.id } });
-      // Best-effort: drop the Screenshot row + blob if nothing else references it.
-      await ctx.db.screenshot
-        .delete({ where: { id: input.screenshotId } })
-        .catch(() => undefined);
-      if (blobUrl) {
-        await deleteFromBlob(blobUrl).catch((e) => {
-          console.error("Failed to delete blob for contact image", input.screenshotId, e);
-        });
+
+      // Only drop the shared Screenshot row + blob when nothing else references
+      // it (another contact join or an action screenshot). Otherwise we'd orphan
+      // those references or delete a blob that is still in use.
+      const [actionRefs, contactRefs] = await Promise.all([
+        ctx.db.actionScreenshot.count({
+          where: { screenshotId: input.screenshotId },
+        }),
+        ctx.db.crmContactScreenshot.count({
+          where: { screenshotId: input.screenshotId },
+        }),
+      ]);
+      if (actionRefs + contactRefs === 0) {
+        await ctx.db.screenshot
+          .delete({ where: { id: input.screenshotId } })
+          .catch(() => undefined);
+        if (blobUrl) {
+          await deleteFromBlob(blobUrl).catch((e) => {
+            console.error(
+              "Failed to delete blob for contact image",
+              input.screenshotId,
+              e,
+            );
+          });
+        }
       }
 
       return { success: true };


### PR DESCRIPTION
## What

Replaces the edit-contact **Modal** on the contact detail page with a slide-out **Drawer** matching the new design, and adds image attachments by reusing the existing action-screenshot upload plumbing.

### Drawer
- Grouped sections — **Identity / Contact / Social / Description / Images** — with an avatar header and a standard/wide width toggle.
- Profile type → Mantine `Chip` group; Company → org `Select`; social fields with brand icons.
- Description uses the canonical `MarkdownInput` (Markdown, per ADR-0017).
- All colours via semantic tokens — no hardcoded hex.

### Image attachments (reuses, doesn't reinvent)
- New `CrmContactScreenshot` join (mirrors `ActionScreenshot`) against the shared `Screenshot` model; binaries go to **Vercel Blob** via the existing `uploadToBlob`.
- `crmContact.uploadImage` / `listScreenshots` / `removeScreenshot` mirror `action.uploadImage`.
- Reuses the `PastedScreenshot` type + paste handler from `ActionModalForm`:
  - **Paste a screenshot into the description** → attaches it (identical behaviour to `EditActionModal`).
  - **Drag an image** over the Images zone → live drag-over feedback.
  - **Click-to-upload** via `FileButton`.
  - Thumbnail grid with hover-remove + click-to-lightbox. Pending images upload **on Save**; saved images load via `listScreenshots` and remove immediately.

### Scope notes
- **Job title / Primary location** intentionally omitted (not on the `CrmContact` schema).
- Two migrations ship together: the first creates `CrmContactAttachment`, the second drops it and adds `CrmContactScreenshot`. An earlier S3-attachment approach was replaced by reusing the screenshot pattern; both migrations are kept so the `DROP` is valid on a fresh DB.

## Migrations
- `20260625122913_add_crm_contact_attachments`
- `20260625125227_crm_contact_screenshots`

## Test plan
- [ ] Edit a contact: all fields save; profile-type chips + company select work.
- [ ] Paste a screenshot into the description → thumbnail appears → Save → persists and reloads via `listScreenshots`.
- [ ] Drag an image onto the Images zone (drag-over feedback) and the click-upload button both attach.
- [ ] Remove a saved image; remove a pending (unsaved) image.
- [ ] Requires Vercel Blob env (`BLOB_READ_WRITE_TOKEN`), same as action screenshots.

`npm run check` clean; pre-commit (1078 unit tests, migration + hardcoded-colour checks) green.