### PR TITLE
fix(meetings): anchor transcript "me" to the meeting owner so the panel and turns agree

### DIFF
--- a/src/lib/__tests__/meeting-view-model.test.ts
+++ b/src/lib/__tests__/meeting-view-model.test.ts
@@ -44,6 +44,32 @@ describe("assignParticipantFlavors", () => {
     expect(flavors).toEqual(["me", "them", "alt", "them"]);
   });
 
+  it("marks exactly one me when a userId-linked and an email-duplicate row both match", () => {
+    // A manually-added row and the user-linked row share the owner's email.
+    // The userId match must win and only one participant becomes "me".
+    const flavors = assignParticipantFlavors(
+      [
+        { userId: null, email: "james@x.com", isHost: false },
+        { userId: "u_james", email: "james@x.com", isHost: false },
+      ],
+      { userId: "u_james", email: "james@x.com" },
+    );
+    expect(flavors).toEqual(["them", "me"]);
+    expect(flavors.filter((f) => f === "me")).toHaveLength(1);
+  });
+
+  it("marks at most one me when the owner matches by email only", () => {
+    const flavors = assignParticipantFlavors(
+      [
+        { userId: null, email: "james@x.com", isHost: false },
+        { userId: null, email: "james@x.com", isHost: false },
+      ],
+      { userId: null, email: "james@x.com" },
+    );
+    expect(flavors.filter((f) => f === "me")).toHaveLength(1);
+    expect(flavors).toEqual(["me", "them"]);
+  });
+
   it("ignores a stray isHost flag once the owner is identified", () => {
     const flavors = assignParticipantFlavors(
       [

--- a/src/lib/__tests__/meeting-view-model.test.ts
+++ b/src/lib/__tests__/meeting-view-model.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for assignParticipantFlavors — the owner-anchored identity-tone
+ * resolver that keeps the participants panel and the transcript in agreement on
+ * who is "me" (ADR-0032 identity tone, resolved from the meeting owner).
+ */
+
+import { describe, expect, it } from "vitest";
+import { assignParticipantFlavors } from "../meeting-view-model";
+
+describe("assignParticipantFlavors", () => {
+  it("marks the owner-by-userId as me and rotates the rest by order", () => {
+    // The James/Melissa interview: owner James is a participant linked by userId.
+    const flavors = assignParticipantFlavors(
+      [
+        { userId: "u_james", email: "james@x.com", isHost: false },
+        { userId: null, email: "melissa@x.com", isHost: false },
+      ],
+      { userId: "u_james", email: "james@x.com" },
+    );
+    expect(flavors).toEqual(["me", "them"]);
+  });
+
+  it("matches the owner by email (case-insensitive) when userId is absent", () => {
+    const flavors = assignParticipantFlavors(
+      [
+        { userId: null, email: "Melissa@X.com", isHost: false },
+        { userId: null, email: "JAMES@x.com", isHost: false },
+      ],
+      { userId: null, email: "james@x.com" },
+    );
+    expect(flavors).toEqual(["them", "me"]);
+  });
+
+  it("rotates a third+ participant them/alt by appearance", () => {
+    const flavors = assignParticipantFlavors(
+      [
+        { userId: "u_owner", email: null, isHost: false },
+        { userId: "u_a", email: null, isHost: false },
+        { userId: "u_b", email: null, isHost: false },
+        { userId: "u_c", email: null, isHost: false },
+      ],
+      { userId: "u_owner", email: null },
+    );
+    expect(flavors).toEqual(["me", "them", "alt", "them"]);
+  });
+
+  it("ignores a stray isHost flag once the owner is identified", () => {
+    const flavors = assignParticipantFlavors(
+      [
+        { userId: "u_host", email: null, isHost: true },
+        { userId: "u_owner", email: null, isHost: false },
+      ],
+      { userId: "u_owner", email: null },
+    );
+    // Only the owner is "me"; the DB host flag does not override it.
+    expect(flavors).toEqual(["them", "me"]);
+  });
+
+  it("falls back to the isHost flag when no participant matches the owner", () => {
+    const flavors = assignParticipantFlavors(
+      [
+        { userId: "u_a", email: "a@x.com", isHost: false },
+        { userId: "u_b", email: "b@x.com", isHost: true },
+      ],
+      { userId: "u_ghost", email: "ghost@x.com" },
+    );
+    expect(flavors).toEqual(["them", "me"]);
+  });
+
+  it("assigns no me when there is neither an owner match nor a host", () => {
+    const flavors = assignParticipantFlavors(
+      [
+        { userId: "u_a", email: null, isHost: false },
+        { userId: "u_b", email: null, isHost: false },
+      ],
+      { userId: null, email: null },
+    );
+    expect(flavors).toEqual(["them", "alt"]);
+  });
+});

--- a/src/lib/meeting-view-model.ts
+++ b/src/lib/meeting-view-model.ts
@@ -120,6 +120,43 @@ function extractTalkTime(analyticsJson: unknown): Map<string, string> {
   return result;
 }
 
+/** Identity of the meeting owner/recorder — the "me" side of the conversation. */
+export interface MeetingOwnerIdentity {
+  userId: string | null;
+  email: string | null;
+}
+
+/**
+ * Resolve each participant's identity tone (flavor). The participant who is the
+ * meeting **owner** (the recorder, whose perspective a device `Me:`/`Them:`
+ * transcript is written from) is `"me"`; everyone else rotates `them`/`alt` by
+ * order — mirroring the transcript parser's rotation so the participants panel
+ * and the transcript agree on colour.
+ *
+ * The owner is matched by `userId` first, then by `email`. Only when no
+ * participant matches the owner do we fall back to the DB `isHost` flag (legacy
+ * meetings where the owner isn't linked as a participant).
+ */
+export function assignParticipantFlavors<
+  T extends { userId?: string | null; email?: string | null; isHost?: boolean | null },
+>(participants: T[], owner: MeetingOwnerIdentity): ParticipantFlavor[] {
+  const matchesOwner = (p: T): boolean =>
+    (owner.userId !== null && p.userId != null && p.userId === owner.userId) ||
+    (owner.email !== null &&
+      p.email != null &&
+      p.email.toLowerCase() === owner.email.toLowerCase());
+
+  const ownerIsParticipant = participants.some(matchesOwner);
+  const isMe = (p: T): boolean =>
+    ownerIsParticipant ? matchesOwner(p) : Boolean(p.isHost);
+
+  const rotatable: ParticipantFlavor[] = ["them", "alt"];
+  let rotation = 0;
+  return participants.map((p) =>
+    isMe(p) ? "me" : rotatable[rotation++ % rotatable.length]!,
+  );
+}
+
 /**
  * Map a `TranscriptionSession` (+ parsed Fireflies summary/analytics) into the
  * view model the meeting-detail UI consumes. Derives meeting type, summary
@@ -140,23 +177,24 @@ export function buildMeetingViewModel(session: MeetingSession): MeetingViewModel
 
   const talkTime = extractTalkTime(session.analyticsJson);
 
+  const flavors = assignParticipantFlavors(session.participants, {
+    userId: session.userId ?? null,
+    email: session.user?.email ?? null,
+  });
+
   const participants: MeetingParticipant[] = session.participants.map((p, index) => {
     const name = p.name ?? p.email ?? "Unknown";
-    const isHost = Boolean(p.isHost);
-    const flavor: ParticipantFlavor = isHost
-      ? "me"
-      : index % 2 === 0
-        ? "them"
-        : "alt";
+    const flavor = flavors[index]!;
+    const isMe = flavor === "me";
     const speakerKey = p.speakerLabel ?? p.name ?? "";
     return {
       id: p.id,
       name,
       initial: getInitial(p.name, p.email),
-      role: isHost ? "Host" : "",
+      role: isMe ? "Host" : "",
       talk: talkTime.get(speakerKey) ?? talkTime.get(name) ?? null,
       flavor,
-      isHost,
+      isHost: isMe,
     };
   });
 

--- a/src/lib/meeting-view-model.ts
+++ b/src/lib/meeting-view-model.ts
@@ -133,27 +133,37 @@ export interface MeetingOwnerIdentity {
  * order — mirroring the transcript parser's rotation so the participants panel
  * and the transcript agree on colour.
  *
- * The owner is matched by `userId` first, then by `email`. Only when no
- * participant matches the owner do we fall back to the DB `isHost` flag (legacy
- * meetings where the owner isn't linked as a participant).
+ * Exactly one participant is ever `"me"`: the owner is matched by `userId`
+ * first, then by `email`, then we fall back to the first DB-flagged host (legacy
+ * meetings where the owner isn't linked as a participant). Resolving to a single
+ * index avoids marking two rows `"me"` when, say, a user-linked participant and
+ * a manually-added participant share an email.
  */
 export function assignParticipantFlavors<
   T extends { userId?: string | null; email?: string | null; isHost?: boolean | null },
 >(participants: T[], owner: MeetingOwnerIdentity): ParticipantFlavor[] {
-  const matchesOwner = (p: T): boolean =>
-    (owner.userId !== null && p.userId != null && p.userId === owner.userId) ||
-    (owner.email !== null &&
-      p.email != null &&
-      p.email.toLowerCase() === owner.email.toLowerCase());
-
-  const ownerIsParticipant = participants.some(matchesOwner);
-  const isMe = (p: T): boolean =>
-    ownerIsParticipant ? matchesOwner(p) : Boolean(p.isHost);
+  const { userId: ownerUserId, email: ownerEmail } = owner;
+  const byUserId =
+    ownerUserId !== null
+      ? participants.findIndex((p) => p.userId != null && p.userId === ownerUserId)
+      : -1;
+  const byEmail =
+    ownerEmail !== null
+      ? participants.findIndex(
+          (p) => p.email != null && p.email.toLowerCase() === ownerEmail.toLowerCase(),
+        )
+      : -1;
+  const meIndex =
+    byUserId >= 0
+      ? byUserId
+      : byEmail >= 0
+        ? byEmail
+        : participants.findIndex((p) => Boolean(p.isHost));
 
   const rotatable: ParticipantFlavor[] = ["them", "alt"];
   let rotation = 0;
-  return participants.map((p) =>
-    isMe(p) ? "me" : rotatable[rotation++ % rotatable.length]!,
+  return participants.map((_p, index) =>
+    index === meIndex ? "me" : rotatable[rotation++ % rotatable.length]!,
   );
 }
 

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -559,6 +559,14 @@ export const transcriptionRouter = createTRPCRouter({
               contactId: true,
             },
           },
+          // Meeting owner/recorder — the "me" side a device Me:/Them: transcript
+          // is written from. Used to resolve participant identity tone.
+          user: {
+            select: {
+              id: true,
+              email: true,
+            },
+          },
           actions: {
             orderBy: { createdAt: "asc" },
           },


### PR DESCRIPTION
## Problem

On `/recording/[id]`, the Participants panel and the transcript disagreed on identity colour. For a device `Me:`/`Them:` meeting with **no host flagged**:

- The panel coloured participants by the DB `isHost` flag, falling back to index rotation — so the recorder (James) showed as `them` (purple) and the other person (Melissa) as `alt` (green).
- The transcript coloured turns from the parser — `Me:` → `me` (blue), `Them:` → `them` (purple).

So "Me" (blue) in the transcript didn't match James (purple) in the panel, and nothing told the view model that the logged-in user / recorder **is** the "Me".

## Fix

Resolve identity tone from the **meeting owner** (`TranscriptionSession.userId` / the owner's email), since a device `Me:`/`Them:` transcript is written from the recorder's perspective. The participant matching the owner becomes `me`; everyone else rotates `them`/`alt` by order, mirroring the transcript parser. The panel's `me` (blue) now matches the transcript's "Me" (blue), and Melissa becomes `them` (purple) matching "Them".

**Why anchor to the owner, not the viewer:** the transcript's `Me:` always refers to the recorder, so anchoring "me" to the recorder keeps the panel and transcript consistent for *every* viewer — including shared meetings where a non-recorder opens it. Viewer-anchoring would re-break the colour match in that case. (In the common case of viewing your own meeting, owner == viewer.)

## Changes

- New pure `assignParticipantFlavors(participants, owner)` helper — owner match by `userId` then email (case-insensitive), with the `isHost` flag as a legacy fallback when no participant matches the owner. 6 unit tests.
- `buildMeetingViewModel` uses it; the owner participant renders as `me` in both the panel and the transcript.
- `transcription.getById` now selects the owner's `{ id, email }` for the match (migration-free).

The `Me:`/`Them:` **labels** in the transcript are unchanged (kept per request) — only the panel's identity colour is reconciled to them.

> Note: the visible effect depends on the owner being linkable to a participant row by `userId` or email; the email fallback covers manually-added / CRM-contact participants. If a specific meeting's owner participant has neither, it degrades to today's behaviour (no regression).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Participant labels now more accurately identify the meeting owner, including fallback matching by email when needed.
  * Meeting details now include the owner’s contact info for better participant context.

* **Bug Fixes**
  * Improved participant role assignment so only one person is marked as “me” and duplicates are handled more reliably.
  * Fixed fallback behavior when no direct owner match is available, reducing incorrect label rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->