### PR TITLE
feat(tickets): user-friendly /tickets/<number> URLs

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
@@ -523,15 +523,29 @@ function LinkedActionsSection({
 export default function TicketDetailPage() {
   const router = useRouter();
   const params = useParams();
-  const ticketId = params.ticketId as string;
+  const routeParam = params.ticketId as string;
   const productSlug = params.productSlug as string;
-  const { workspace, workspaceId } = useWorkspace();
+  const { workspace, workspaceId, isLoading: isWorkspaceLoading } =
+    useWorkspace();
   const utils = api.useUtils();
 
-  const { data: ticket, isLoading } = api.product.ticket.getById.useQuery(
-    { id: ticketId },
-    { enabled: !!ticketId },
-  );
+  // Resolve the URL segment (sequential number, Linear-style `PLAT-29`, CUID,
+  // or fun shortId) to the canonical ticket CUID. Everything below keys off
+  // this CUID, so all mutations/invalidations are unaffected by the URL form.
+  const { data: resolved, isLoading: isResolving } =
+    api.product.ticket.resolveId.useQuery(
+      { workspaceId: workspaceId ?? "", productSlug, identifier: routeParam },
+      { enabled: !!workspaceId && !!routeParam, retry: false },
+    );
+  const ticketId = resolved?.id ?? "";
+
+  const { data: ticket, isLoading: isTicketLoading } =
+    api.product.ticket.getById.useQuery(
+      { id: ticketId },
+      { enabled: !!ticketId },
+    );
+  const isLoading =
+    isWorkspaceLoading || isResolving || (!!ticketId && isTicketLoading);
 
   // Data for selectors
   const members = workspace?.members ?? [];
@@ -582,6 +596,19 @@ export default function TicketDetailPage() {
       setTitleValue(ticket.title);
     }
   }, [ticket]);
+
+  // Canonicalise the address bar to the clean number form (`/tickets/29`) when
+  // the ticket was reached via CUID or a Linear-style id. Legacy tickets with
+  // no number (0) keep their CUID URL.
+  useEffect(() => {
+    if (!ticket || !workspace || ticket.number <= 0) return;
+    const canonical = String(ticket.number);
+    if (routeParam !== canonical) {
+      router.replace(
+        `/w/${workspace.slug}/products/${productSlug}/tickets/${canonical}`,
+      );
+    }
+  }, [ticket, workspace, routeParam, productSlug, router]);
 
   const updateTicket = api.product.ticket.update.useMutation({
     onSuccess: async () => {

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/new/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/new/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@mantine/core";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
+import { ticketUrlId } from "~/lib/fun-ids";
 
 const TYPE_OPTIONS = [
   { value: "BUG", label: "Bug" },
@@ -101,7 +102,7 @@ export default function NewTicketPage() {
       }
       if (workspace) {
         router.push(
-          `/w/${workspace.slug}/products/${productSlug}/tickets/${ticket.id}`,
+          `/w/${workspace.slug}/products/${productSlug}/tickets/${ticketUrlId(ticket)}`,
         );
       }
     },

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
@@ -43,7 +43,7 @@ import { api } from "~/trpc/react";
 import { EmptyState } from "~/app/_components/EmptyState";
 import { CreateTicketModal } from "~/app/_components/product/CreateTicketModal";
 import { EditTicketModal } from "~/app/_components/product/EditTicketModal";
-import { generateLinearId } from "~/lib/fun-ids";
+import { generateLinearId, ticketUrlId } from "~/lib/fun-ids";
 import { TicketKanbanBoard } from "~/app/_components/product/TicketKanbanBoard";
 import { PriorityIcon, PRIORITY_LABELS as PRIORITY_LABEL_MAP } from "~/app/_components/product/PriorityIcon";
 import { BlockedIndicator } from "~/app/_components/product/TicketDependenciesSection";
@@ -411,7 +411,7 @@ export default function TicketsBacklogPage() {
     <div
       key={ticket.id}
       className="flex items-center gap-3 px-3 py-2 hover:bg-surface-hover transition-colors cursor-pointer border-b border-border-primary"
-      onClick={() => router.push(`${basePath}/${ticket.id}`)}
+      onClick={() => router.push(`${basePath}/${ticketUrlId(ticket)}`)}
     >
       <Text size="xs" className="text-text-muted font-mono w-14 shrink-0" lineClamp={1}>
         {product?.funTicketIds && ticket.shortId ? ticket.shortId : (ticket.number > 0 && product ? generateLinearId(product.name, ticket.number) : null)}
@@ -482,7 +482,7 @@ export default function TicketsBacklogPage() {
     <Table.Tr
       key={ticket.id}
       className="cursor-pointer hover:bg-surface-hover transition-colors"
-      onClick={() => router.push(`${basePath}/${ticket.id}`)}
+      onClick={() => router.push(`${basePath}/${ticketUrlId(ticket)}`)}
     >
       {vc.has("id") && (
         <Table.Td style={{ width: 70 }}>

--- a/src/app/_components/product/graph/TicketDrawer.tsx
+++ b/src/app/_components/product/graph/TicketDrawer.tsx
@@ -19,6 +19,7 @@ import {
 } from "@tabler/icons-react";
 import { api } from "~/trpc/react";
 import { STATUS_COLORS, STATUS_LABELS } from "~/lib/ticket-statuses";
+import { ticketUrlId } from "~/lib/fun-ids";
 
 interface Props {
   ticketId: string | null;
@@ -107,7 +108,7 @@ export function TicketDrawer({ ticketId, basePath, onClose }: Props) {
 
           <Button
             component={Link}
-            href={`${basePath}/tickets/${ticket.id}`}
+            href={`${basePath}/tickets/${ticketUrlId(ticket)}`}
             rightSection={<IconExternalLink size={14} />}
             variant="filled"
             fullWidth
@@ -132,6 +133,7 @@ function StatusPill({ status }: { status: string }) {
 
 interface MinimalLinkedTicket {
   id: string;
+  number: number;
   title: string;
   status: string;
 }
@@ -177,7 +179,7 @@ function DependencyList({
               <Text
                 size="xs"
                 component={Link}
-                href={`${basePath}/tickets/${t.id}`}
+                href={`${basePath}/tickets/${ticketUrlId(t)}`}
                 className="text-text-primary flex-1 min-w-0 hover:text-blue-400 transition-colors"
                 lineClamp={1}
               >

--- a/src/lib/__tests__/fun-ids.test.ts
+++ b/src/lib/__tests__/fun-ids.test.ts
@@ -28,6 +28,17 @@ describe("parseTicketUrlId", () => {
     expect(parseTicketUrlId("")).toBeNull();
     expect(parseTicketUrlId("abc")).toBeNull();
   });
+
+  it("rejects non-positive numbers (legacy number=0 tickets use their CUID)", () => {
+    expect(parseTicketUrlId("0")).toBeNull();
+    expect(parseTicketUrlId("PLAT-0")).toBeNull();
+    expect(parseTicketUrlId("00")).toBeNull();
+  });
+
+  it("parses large numbers", () => {
+    expect(parseTicketUrlId("999999")).toBe(999999);
+    expect(parseTicketUrlId("PLAT-1000000")).toBe(1000000);
+  });
 });
 
 describe("ticketUrlId", () => {

--- a/src/lib/__tests__/fun-ids.test.ts
+++ b/src/lib/__tests__/fun-ids.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { parseTicketUrlId, ticketUrlId } from "../fun-ids";
+
+describe("parseTicketUrlId", () => {
+  it("parses a bare number", () => {
+    expect(parseTicketUrlId("29")).toBe(29);
+  });
+
+  it("parses a Linear-style id", () => {
+    expect(parseTicketUrlId("PLAT-29")).toBe(29);
+    expect(parseTicketUrlId("plat-29")).toBe(29);
+    expect(parseTicketUrlId("ATP-14")).toBe(14);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(parseTicketUrlId("  29  ")).toBe(29);
+  });
+
+  it("returns null for a CUID", () => {
+    expect(parseTicketUrlId("cmqf3vv1i0001l804zxzlhg8c")).toBeNull();
+  });
+
+  it("returns null for a fun shortId", () => {
+    expect(parseTicketUrlId("swift.falcon")).toBeNull();
+  });
+
+  it("returns null for empty / non-numeric input", () => {
+    expect(parseTicketUrlId("")).toBeNull();
+    expect(parseTicketUrlId("abc")).toBeNull();
+  });
+});
+
+describe("ticketUrlId", () => {
+  it("prefers the sequential number when present", () => {
+    expect(ticketUrlId({ id: "cmabc", number: 29 })).toBe("29");
+  });
+
+  it("falls back to the CUID for legacy tickets with number 0", () => {
+    expect(ticketUrlId({ id: "cmabc", number: 0 })).toBe("cmabc");
+  });
+
+  it("round-trips with parseTicketUrlId for numbered tickets", () => {
+    const id = ticketUrlId({ id: "cmabc", number: 42 });
+    expect(parseTicketUrlId(id)).toBe(42);
+  });
+});

--- a/src/lib/fun-ids.ts
+++ b/src/lib/fun-ids.ts
@@ -111,3 +111,25 @@ export function generateLinearId(productName: string, number: number): string {
     .slice(0, 4) || "T";
   return `${prefix}-${number}`;
 }
+
+/**
+ * The canonical, user-friendly identifier to put in a ticket URL.
+ * Prefers the per-product sequential number (e.g. `/tickets/29`) and falls
+ * back to the CUID for legacy tickets that never got a number (number === 0).
+ * The ticket detail route resolves all three forms (number, CUID, Linear-style
+ * `PLAT-29`), so existing links keep working — this just picks the clean one.
+ */
+export function ticketUrlId(ticket: { id: string; number: number }): string {
+  return ticket.number > 0 ? String(ticket.number) : ticket.id;
+}
+
+/**
+ * Parse a ticket URL segment into a sequential-number lookup key. Accepts a
+ * bare number (`29`) or a Linear-style id (`PLAT-29`, case-insensitive).
+ * Returns the number when the segment encodes one, otherwise null — in which
+ * case the raw segment should be treated as a CUID / fun shortId.
+ */
+export function parseTicketUrlId(segment: string): number | null {
+  const match = /^(?:[a-z][a-z0-9]*-)?(\d+)$/i.exec(segment.trim());
+  return match ? parseInt(match[1]!, 10) : null;
+}

--- a/src/lib/fun-ids.ts
+++ b/src/lib/fun-ids.ts
@@ -126,10 +126,17 @@ export function ticketUrlId(ticket: { id: string; number: number }): string {
 /**
  * Parse a ticket URL segment into a sequential-number lookup key. Accepts a
  * bare number (`29`) or a Linear-style id (`PLAT-29`, case-insensitive).
- * Returns the number when the segment encodes one, otherwise null — in which
- * case the raw segment should be treated as a CUID / fun shortId.
+ * Returns the number when the segment encodes a *positive* one, otherwise null
+ * — in which case the raw segment should be treated as a CUID / fun shortId.
+ *
+ * `0` is rejected on purpose: `Ticket.number` defaults to 0 for legacy tickets
+ * that never got a sequential number, and those are addressed only by their
+ * CUID (see `ticketUrlId`). Treating `/tickets/0` as a number lookup would let
+ * an unintended legacy ticket resolve, so we fall through to the CUID branch.
  */
 export function parseTicketUrlId(segment: string): number | null {
   const match = /^(?:[a-z][a-z0-9]*-)?(\d+)$/i.exec(segment.trim());
-  return match ? parseInt(match[1]!, 10) : null;
+  if (!match) return null;
+  const parsed = parseInt(match[1]!, 10);
+  return parsed > 0 ? parsed : null;
 }

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -11,6 +11,7 @@ import {
 } from "~/lib/ticket-statuses";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 import { uploadToBlob } from "~/lib/blob";
+import { parseTicketUrlId } from "~/lib/fun-ids";
 
 const ticketTypeEnum = z.enum([
   "BUG",
@@ -262,6 +263,62 @@ export const ticketRouter = createTRPCRouter({
 
       const { depsOut: _depsOut, depsIn: _depsIn, ...rest } = ticket;
       return { ...rest, dependsOn, requiredFor, openBlockerCount, isBlocked };
+    }),
+
+  /**
+   * Resolve a ticket URL segment to its canonical CUID, scoped to a product.
+   * Accepts the user-friendly sequential number (`29`), a Linear-style id
+   * (`PLAT-29`), a CUID, or a fun shortId. Powers `/tickets/29` URLs: the
+   * detail page feeds the returned `id` into `getById`. The `number` is
+   * returned too so the page can canonicalise the address bar.
+   */
+  resolveId: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        productSlug: z.string(),
+        identifier: z.string().min(1),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      await assertWorkspaceMember(
+        ctx.db,
+        ctx.session.user.id,
+        input.workspaceId,
+      );
+
+      const product = await ctx.db.product.findUnique({
+        where: {
+          workspaceId_slug: {
+            workspaceId: input.workspaceId,
+            slug: input.productSlug,
+          },
+        },
+        select: { id: true },
+      });
+      if (!product) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Product not found" });
+      }
+
+      const number = parseTicketUrlId(input.identifier);
+      const ticket =
+        number !== null
+          ? await ctx.db.ticket.findUnique({
+              where: { productId_number: { productId: product.id, number } },
+              select: { id: true, number: true },
+            })
+          : await ctx.db.ticket.findFirst({
+              where: {
+                productId: product.id,
+                OR: [{ id: input.identifier }, { shortId: input.identifier }],
+              },
+              select: { id: true, number: true },
+            });
+
+      if (!ticket) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Ticket not found" });
+      }
+      return ticket;
     }),
 
   create: protectedProcedure

--- a/src/server/services/sentry/SentryBugService.ts
+++ b/src/server/services/sentry/SentryBugService.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 import { createTicketWithNumber } from "~/plugins/product/server/services/createTicket";
+import { ticketUrlId } from "~/lib/fun-ids";
 import { buildBugBody, type SentryBug } from "./sentryPayload";
 import { notifyZulipOfSentryBug } from "./sentryZulip";
 
@@ -144,7 +145,7 @@ export async function ingestSentryBug(
   // Announce the new bug in Zulip (best-effort) with a deep link to the ticket.
   // Only on creation — recurring errors that dedup above do not re-notify.
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://www.exponential.im";
-  const ticketUrl = `${baseUrl}/w/${product.workspace.slug}/products/${product.slug}/tickets/${ticket.id}`;
+  const ticketUrl = `${baseUrl}/w/${product.workspace.slug}/products/${product.slug}/tickets/${ticketUrlId(ticket)}`;
   await notifyZulipOfSentryBug(db, {
     workspaceId: product.workspaceId,
     authorId: errol.id,

--- a/src/server/services/sentry/__tests__/SentryBugService.test.ts
+++ b/src/server/services/sentry/__tests__/SentryBugService.test.ts
@@ -14,7 +14,9 @@ vi.hoisted(() => {
 });
 
 vi.mock("~/plugins/product/server/services/createTicket", () => ({
-  createTicketWithNumber: vi.fn(() => Promise.resolve({ id: "ticket-1" })),
+  createTicketWithNumber: vi.fn(() =>
+    Promise.resolve({ id: "ticket-1", number: 7 }),
+  ),
 }));
 
 // Zulip notify is exercised in its own test; here we just assert it's invoked
@@ -163,7 +165,7 @@ describe("ingestSentryBug", () => {
         title: "Boom",
         sentryUrl: "https://sentry.io/issues/42",
         ticketUrl:
-          "https://app.example/w/syntrofi/products/exponential/tickets/ticket-1",
+          "https://app.example/w/syntrofi/products/exponential/tickets/7",
       }),
     );
   });


### PR DESCRIPTION
## Problem

Ticket detail URLs only resolved the CUID form, so the readable URL 404'd while the CUID worked:

- ❌ `…/products/platform/tickets/29`
- ✅ `…/products/platform/tickets/cmqf3vv1i0001l804zxzlhg8c`

The per-product sequential `number` already exists on every ticket (`@@unique([productId, number])`) — it just wasn't wired to routing.

## Approach

Because the URL already scopes the product in its path, a bare `number` is unambiguous, so `/tickets/29` is the clean canonical form. The route now accepts **all** forms and canonicalises to the number.

- **`ticket.resolveId`** (new) — resolves a URL segment (sequential number, Linear-style `PLAT-29`, CUID, or fun shortId) to the canonical CUID, scoped to the product via `assertWorkspaceMember`. `getById` is left untouched — it stays the by-CUID lookup used across the app (drawer, edit modal, dependencies, etc.).
- **Detail page** resolves the segment → feeds the CUID into `getById`, so every existing mutation/invalidation keeps working unchanged. After load it `router.replace`s to the clean `/tickets/<number>` form (legacy tickets with `number === 0` keep their CUID URL).
- **Number-based links** generated everywhere tickets are linked: backlog list rows, ticket drawer (open + related), create redirect, and Sentry bug Zulip notifications.
- **Helpers + tests**: `ticketUrlId` / `parseTicketUrlId` in `fun-ids.ts` with unit tests.

## Compatibility

- No schema change, **no migration**.
- Every existing CUID link and Linear-style id keeps resolving, then redirects to the canonical number URL.

## Verification

- `npx tsc --noEmit` — clean (0 errors)
- `vitest run src/lib/__tests__/fun-ids.test.ts` — 9 passing
- Source files lint clean