### PR TITLE
feat: Render Form.description as Markdown (public job-description body)

### DIFF
--- a/src/app/(public)/f/[slug]/_components/PublicForm.tsx
+++ b/src/app/(public)/f/[slug]/_components/PublicForm.tsx
@@ -15,6 +15,7 @@ import {
   ThemeIcon,
 } from '@mantine/core';
 import { IconCircleCheck } from '@tabler/icons-react';
+import { MarkdownRenderer } from '~/app/_components/shared/MarkdownRenderer';
 
 interface PublicField {
   key: string;
@@ -109,9 +110,7 @@ export function PublicForm({
         <Stack gap="xs" mb="md">
           <Title order={2}>{name}</Title>
           {description && (
-            <Text c="dimmed" size="sm">
-              {description}
-            </Text>
+            <MarkdownRenderer content={description} variant="prose" />
           )}
         </Stack>
         <form onSubmit={handleSubmit}>

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
@@ -14,6 +14,7 @@ import {
   Card,
   TextInput,
   Textarea,
+  Input,
   Select,
   Switch,
   ActionIcon,
@@ -32,6 +33,7 @@ import { notifications } from '@mantine/notifications';
 import { api } from '~/trpc/react';
 import { slugify } from '~/utils/slugify';
 import { CRM_CUSTOMER_TYPE_OPTIONS } from '~/lib/crm/automationCatalog';
+import { MarkdownInput } from '~/app/_components/shared/MarkdownInput';
 
 type FieldType = 'text' | 'email' | 'textarea' | 'select' | 'checkbox' | 'url';
 
@@ -77,6 +79,7 @@ export default function FormEditorPage() {
 
   const [name, setName] = useState('');
   const [slug, setSlug] = useState('');
+  const [description, setDescription] = useState('');
   const [isActive, setIsActive] = useState(false);
   const [confirmationMessage, setConfirmationMessage] = useState('');
   const [fields, setFields] = useState<EditorField[]>([]);
@@ -95,6 +98,7 @@ export default function FormEditorPage() {
     if (!data) return;
     setName(data.name);
     setSlug(data.slug);
+    setDescription(data.description ?? '');
     setIsActive(data.isActive);
     setConfirmationMessage(data.confirmationMessage ?? '');
     setFields(
@@ -218,6 +222,7 @@ export default function FormEditorPage() {
     save.mutate({
       id,
       name: name.trim() || 'Untitled form',
+      description: description.trim() || null,
       fields: cleanedFields,
       destinations,
       isActive,
@@ -280,6 +285,24 @@ export default function FormEditorPage() {
           w={300}
         />
       </Group>
+
+      <Input.Wrapper
+        label="Description"
+        description="The job-description body shown above the fields on the public page. Supports Markdown (headings, lists, links, bold)."
+      >
+        <Box mt={4}>
+          <MarkdownInput
+            value={description}
+            onChange={(value) => {
+              setDescription(value);
+              touch();
+            }}
+            placeholder="Describe the role, responsibilities, and how to apply…"
+            minRows={4}
+            maxRows={16}
+          />
+        </Box>
+      </Input.Wrapper>
 
       <Card withBorder padding="md">
         <Group justify="space-between" mb="sm">

--- a/src/server/api/routers/form.ts
+++ b/src/server/api/routers/form.ts
@@ -84,6 +84,7 @@ export const formRouter = createTRPCRouter({
       z.object({
         id: z.string(),
         name: z.string().min(1).max(200).optional(),
+        description: z.string().max(20000).nullable().optional(),
         fields: z.array(formFieldSchema).optional(),
         destinations: z.array(formDestinationSchema).optional(),
         isActive: z.boolean().optional(),
@@ -143,6 +144,8 @@ export const formRouter = createTRPCRouter({
         where: { id: form.id },
         data: {
           name: input.name,
+          description:
+            input.description === undefined ? undefined : input.description,
           fields: input.fields as Prisma.InputJsonValue | undefined,
           destinations: input.destinations as Prisma.InputJsonValue | undefined,
           isActive: input.isActive,


### PR DESCRIPTION
## What

Wires the already-existing `Form.description` field (in the schema as `@db.Text`, previously half-wired: not editable in the admin, rendered as plain text) so it becomes the rich **job-description body** of a public form, stored and rendered as canonical Markdown per ADR-0017.

- **Authoring** (`/crm/forms/[id]`): `description` is now editable via the shared `<MarkdownInput/>`; `form.update` accepts it (zod, nullable/optional, max 20k).
- **Public render** (`/f/[slug]`): the plain `<Text>` is replaced with `<MarkdownRenderer content variant="prose" />`, rendered above the fields.

No Tiptap / `PrdDocument` introduced (ADR-0017). No DB migration — legacy plaintext descriptions remain valid Markdown.

## Acceptance criteria

- [x] `description` is editable in the form admin via `<MarkdownInput/>` and persists through `form.update`.
- [x] The public `/f/[slug]` page renders `description` as Markdown (headings, lists, links, bold) above the fields via `<MarkdownRenderer variant="prose">`.
- [x] No Tiptap/PrdDocument introduced; no DB migration needed.
- [x] Existing forms with plaintext descriptions still render correctly.

---

Ships: brisk.bell
Part of feature: Public job-application forms with hiring pipeline