### PR TITLE
feat: Multi-pipeline per workspace (named pipelines + board switcher)

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/pipeline/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/pipeline/page.tsx
@@ -1,8 +1,18 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Group, Button, Text, Loader, Stack } from "@mantine/core";
+import {
+  Group,
+  Button,
+  Text,
+  Loader,
+  Stack,
+  Select,
+  Modal,
+  TextInput,
+} from "@mantine/core";
 import { IconPlus, IconSettings } from "@tabler/icons-react";
+import { notifications } from "@mantine/notifications";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
 import { DealKanbanBoard } from "~/app/_components/pipeline/DealKanbanBoard";
@@ -16,39 +26,62 @@ export default function PipelinePage() {
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
   const [selectedDealId, setSelectedDealId] = useState<string | null>(null);
+  const [selectedPipelineId, setSelectedPipelineId] = useState<string | null>(
+    null,
+  );
+  const [newPipelineOpen, setNewPipelineOpen] = useState(false);
+  const [newPipelineName, setNewPipelineName] = useState("");
 
   const utils = api.useUtils();
 
-  // Query for existing pipeline
+  // A workspace may hold N named pipelines (ADR-0033).
   const {
-    data: pipeline,
-    isLoading: pipelineLoading,
-    error: pipelineError,
-  } = api.pipeline.get.useQuery(
+    data: pipelines,
+    isLoading: pipelinesLoading,
+    error: pipelinesError,
+  } = api.pipeline.list.useQuery(
     { workspaceId: workspaceId! },
     { enabled: !!workspaceId },
   );
 
-  // Mutation to create pipeline if it doesn't exist
   const createPipelineMutation = api.pipeline.create.useMutation({
-    onSuccess: () => {
-      void utils.pipeline.get.invalidate({ workspaceId: workspaceId! });
+    onSuccess: (created) => {
+      setSelectedPipelineId(created.id);
+      void utils.pipeline.list.invalidate({ workspaceId: workspaceId! });
     },
   });
 
-  // Auto-create pipeline if none exists
+  // First-run convenience: seed a default pipeline when the workspace has none.
   useEffect(() => {
     if (
       workspaceId &&
-      !pipelineLoading &&
-      !pipeline &&
-      !pipelineError &&
+      !pipelinesLoading &&
+      !pipelinesError &&
+      pipelines?.length === 0 &&
       !createPipelineMutation.isPending &&
       !createPipelineMutation.isSuccess
     ) {
       createPipelineMutation.mutate({ workspaceId });
     }
-  }, [workspaceId, pipelineLoading, pipeline, pipelineError, createPipelineMutation]);
+  }, [
+    workspaceId,
+    pipelinesLoading,
+    pipelinesError,
+    pipelines,
+    createPipelineMutation,
+  ]);
+
+  // Keep a valid pipeline selected: default to the first when none is chosen or
+  // the chosen one disappears (e.g. after switching workspaces).
+  useEffect(() => {
+    if (!pipelines || pipelines.length === 0) return;
+    if (!selectedPipelineId || !pipelines.some((p) => p.id === selectedPipelineId)) {
+      setSelectedPipelineId(pipelines[0]!.id);
+    }
+  }, [pipelines, selectedPipelineId]);
+
+  const pipeline =
+    pipelines?.find((p) => p.id === selectedPipelineId) ?? pipelines?.[0];
 
   const { data: deals, isLoading: dealsLoading } =
     api.pipeline.getDeals.useQuery(
@@ -61,9 +94,34 @@ export default function PipelinePage() {
     { enabled: !!pipeline?.id },
   );
 
+  const handleCreatePipeline = () => {
+    const name = newPipelineName.trim();
+    if (!name || !workspaceId) return;
+    createPipelineMutation.mutate(
+      { workspaceId, name },
+      {
+        onSuccess: () => {
+          setNewPipelineOpen(false);
+          setNewPipelineName("");
+          notifications.show({
+            title: "Pipeline created",
+            message: `“${name}” is ready. Rename its stages in Settings.`,
+            color: "green",
+          });
+        },
+        onError: (error) =>
+          notifications.show({
+            title: "Could not create pipeline",
+            message: error.message,
+            color: "red",
+          }),
+      },
+    );
+  };
+
   if (!workspace) return null;
 
-  if (pipelineLoading || createPipelineMutation.isPending) {
+  if (pipelinesLoading || createPipelineMutation.isPending) {
     return (
       <div className="flex items-center justify-center py-20">
         <Loader />
@@ -93,9 +151,30 @@ export default function PipelinePage() {
     <Stack gap="md">
       {/* Header */}
       <Group justify="space-between">
-        <Text fw={600} size="xl">
-          Pipeline
-        </Text>
+        <Group gap="sm">
+          {pipelines && pipelines.length > 1 ? (
+            <Select
+              aria-label="Select pipeline"
+              data={pipelines.map((p) => ({ value: p.id, label: p.name }))}
+              value={pipeline.id}
+              onChange={(value) => value && setSelectedPipelineId(value)}
+              allowDeselect={false}
+              w={220}
+              size="md"
+            />
+          ) : (
+            <Text fw={600} size="xl">
+              {pipeline.name}
+            </Text>
+          )}
+          <Button
+            variant="subtle"
+            leftSection={<IconPlus size={16} />}
+            onClick={() => setNewPipelineOpen(true)}
+          >
+            New pipeline
+          </Button>
+        </Group>
         <Group gap="sm">
           <Button
             variant="light"
@@ -152,6 +231,41 @@ export default function PipelinePage() {
         opened={!!selectedDealId}
         onClose={() => setSelectedDealId(null)}
       />
+
+      <Modal
+        opened={newPipelineOpen}
+        onClose={() => setNewPipelineOpen(false)}
+        title="New pipeline"
+        centered
+      >
+        <Stack gap="md">
+          <TextInput
+            label="Name"
+            placeholder="e.g. Hiring"
+            data-autofocus
+            value={newPipelineName}
+            onChange={(e) => setNewPipelineName(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleCreatePipeline();
+            }}
+          />
+          <Text c="dimmed" size="xs">
+            Seeds the default stages — rename and reorder them in Settings.
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="default" onClick={() => setNewPipelineOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCreatePipeline}
+              loading={createPipelineMutation.isPending}
+              disabled={!newPipelineName.trim()}
+            >
+              Create
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </Stack>
   );
 }

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/pipeline/settings/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/pipeline/settings/page.tsx
@@ -1,48 +1,39 @@
 "use client";
 
-import { useEffect } from "react";
-import { Text, Loader, Stack, Paper } from "@mantine/core";
+import { useEffect, useState } from "react";
+import { Text, Loader, Stack, Paper, Group, Select } from "@mantine/core";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
 import { PipelineSettingsModal } from "~/app/_components/pipeline/PipelineSettingsModal";
 
 export default function PipelineSettingsPage() {
   const { workspace, workspaceId } = useWorkspace();
-
-  const utils = api.useUtils();
-
-  const {
-    data: pipeline,
-    isLoading: pipelineLoading,
-    error: pipelineError,
-  } = api.pipeline.get.useQuery(
-    { workspaceId: workspaceId! },
-    { enabled: !!workspaceId },
+  const [selectedPipelineId, setSelectedPipelineId] = useState<string | null>(
+    null,
   );
 
-  const createPipelineMutation = api.pipeline.create.useMutation({
-    onSuccess: () => {
-      void utils.pipeline.get.invalidate({ workspaceId: workspaceId! });
-    },
-  });
+  const { data: pipelines, isLoading: pipelinesLoading } =
+    api.pipeline.list.useQuery(
+      { workspaceId: workspaceId! },
+      { enabled: !!workspaceId },
+    );
 
-  // Auto-create pipeline if none exists
   useEffect(() => {
+    if (!pipelines || pipelines.length === 0) return;
     if (
-      workspaceId &&
-      !pipelineLoading &&
-      !pipeline &&
-      !pipelineError &&
-      !createPipelineMutation.isPending &&
-      !createPipelineMutation.isSuccess
+      !selectedPipelineId ||
+      !pipelines.some((p) => p.id === selectedPipelineId)
     ) {
-      createPipelineMutation.mutate({ workspaceId });
+      setSelectedPipelineId(pipelines[0]!.id);
     }
-  }, [workspaceId, pipelineLoading, pipeline, pipelineError, createPipelineMutation]);
+  }, [pipelines, selectedPipelineId]);
+
+  const pipeline =
+    pipelines?.find((p) => p.id === selectedPipelineId) ?? pipelines?.[0];
 
   if (!workspace) return null;
 
-  if (pipelineLoading || createPipelineMutation.isPending) {
+  if (pipelinesLoading) {
     return (
       <div className="flex items-center justify-center py-20">
         <Loader />
@@ -55,11 +46,24 @@ export default function PipelineSettingsPage() {
   // Render inline settings (not as a modal)
   return (
     <Stack gap="md">
-      <Text fw={600} size="xl">
-        Pipeline Settings
-      </Text>
+      <Group justify="space-between">
+        <Text fw={600} size="xl">
+          Pipeline Settings
+        </Text>
+        {pipelines && pipelines.length > 1 && (
+          <Select
+            aria-label="Select pipeline"
+            data={pipelines.map((p) => ({ value: p.id, label: p.name }))}
+            value={pipeline.id}
+            onChange={(value) => value && setSelectedPipelineId(value)}
+            allowDeselect={false}
+            w={220}
+          />
+        )}
+      </Group>
       <Paper p="lg" radius="md" withBorder>
         <PipelineSettingsModal
+          key={pipeline.id}
           opened={true}
           onClose={() => {
             window.history.back();

--- a/src/app/_components/pipeline/PipelineSettingsModal.tsx
+++ b/src/app/_components/pipeline/PipelineSettingsModal.tsx
@@ -77,6 +77,7 @@ export function PipelineSettingsModal({
       setNewStageName("");
       void utils.pipeline.getStages.invalidate({ projectId });
       void utils.pipeline.get.invalidate();
+      void utils.pipeline.list.invalidate();
       notifications.show({
         title: "Stage added",
         message: "New pipeline stage created",
@@ -96,6 +97,7 @@ export function PipelineSettingsModal({
     onSuccess: () => {
       void utils.pipeline.getStages.invalidate({ projectId });
       void utils.pipeline.get.invalidate();
+      void utils.pipeline.list.invalidate();
     },
   });
 
@@ -103,6 +105,7 @@ export function PipelineSettingsModal({
     onSuccess: () => {
       void utils.pipeline.getStages.invalidate({ projectId });
       void utils.pipeline.get.invalidate();
+      void utils.pipeline.list.invalidate();
       void utils.pipeline.getDeals.invalidate({ projectId });
       notifications.show({
         title: "Stage deleted",

--- a/src/server/api/routers/crmApi.ts
+++ b/src/server/api/routers/crmApi.ts
@@ -74,14 +74,26 @@ async function getPipelineForWorkspace(
   db: PrismaClient,
   workspaceId: string,
   userId?: string,
+  pipelineId?: string,
 ) {
+  // A workspace may hold N pipelines (ADR-0033). Target a specific one when
+  // pipelineId is supplied; otherwise default to the oldest (the stable default
+  // the single-pipeline contract used to imply) so existing API callers keep
+  // working without choosing a pipeline.
   const pipeline = await db.project.findFirst({
-    where: { workspaceId, type: "pipeline" },
+    where: {
+      workspaceId,
+      type: "pipeline",
+      ...(pipelineId ? { id: pipelineId } : {}),
+    },
+    orderBy: { createdAt: "asc" },
   });
   if (!pipeline) {
     throw new TRPCError({
       code: "NOT_FOUND",
-      message: "No pipeline found for this workspace. Create one first via the UI.",
+      message: pipelineId
+        ? "Pipeline not found in this workspace."
+        : "No pipeline found for this workspace. Create one first via the UI.",
     });
   }
   // If a user is supplied, verify they have access to the pipeline project
@@ -446,16 +458,44 @@ export const crmApiRouter = createTRPCRouter({
 
   // ─── Pipeline ───────────────────────────────────────────────────
 
-  pipelineGet: apiKeyMiddleware
+  // List every pipeline in a workspace (multi-pipeline, ADR-0033) so API
+  // callers can discover ids before targeting one with pipelineId.
+  pipelineList: apiKeyMiddleware
     .input(z.object({ workspaceId: z.string() }))
     .query(async ({ ctx, input }) => {
       await verifyWorkspaceAccess(ctx.db, input.workspaceId, ctx.userId);
 
-      const pipeline = await ctx.db.project.findFirst({
+      const pipelines = await ctx.db.project.findMany({
         where: { workspaceId: input.workspaceId, type: "pipeline" },
+        include: { pipelineStages: { orderBy: { order: "asc" } } },
+        orderBy: { createdAt: "asc" },
+      });
+
+      const visible: typeof pipelines = [];
+      for (const pipeline of pipelines) {
+        const access = await getProjectAccess(ctx.db, ctx.userId, pipeline.id);
+        if (hasProjectAccess(access)) visible.push(pipeline);
+      }
+      return visible;
+    }),
+
+  pipelineGet: apiKeyMiddleware
+    .input(
+      z.object({ workspaceId: z.string(), pipelineId: z.string().optional() }),
+    )
+    .query(async ({ ctx, input }) => {
+      await verifyWorkspaceAccess(ctx.db, input.workspaceId, ctx.userId);
+
+      const pipeline = await ctx.db.project.findFirst({
+        where: {
+          workspaceId: input.workspaceId,
+          type: "pipeline",
+          ...(input.pipelineId ? { id: input.pipelineId } : {}),
+        },
         include: {
           pipelineStages: { orderBy: { order: "asc" } },
         },
+        orderBy: { createdAt: "asc" },
       });
       if (!pipeline) return null;
       const access = await getProjectAccess(ctx.db, ctx.userId, pipeline.id);
@@ -464,10 +504,17 @@ export const crmApiRouter = createTRPCRouter({
     }),
 
   pipelineGetStages: apiKeyMiddleware
-    .input(z.object({ workspaceId: z.string() }))
+    .input(
+      z.object({ workspaceId: z.string(), pipelineId: z.string().optional() }),
+    )
     .query(async ({ ctx, input }) => {
       await verifyWorkspaceAccess(ctx.db, input.workspaceId, ctx.userId);
-      const pipeline = await getPipelineForWorkspace(ctx.db, input.workspaceId, ctx.userId);
+      const pipeline = await getPipelineForWorkspace(
+        ctx.db,
+        input.workspaceId,
+        ctx.userId,
+        input.pipelineId,
+      );
 
       return ctx.db.pipelineStage.findMany({
         where: { projectId: pipeline.id },
@@ -479,10 +526,17 @@ export const crmApiRouter = createTRPCRouter({
   // ─── Deals ──────────────────────────────────────────────────────
 
   dealList: apiKeyMiddleware
-    .input(z.object({ workspaceId: z.string() }))
+    .input(
+      z.object({ workspaceId: z.string(), pipelineId: z.string().optional() }),
+    )
     .query(async ({ ctx, input }) => {
       await verifyWorkspaceAccess(ctx.db, input.workspaceId, ctx.userId);
-      const pipeline = await getPipelineForWorkspace(ctx.db, input.workspaceId, ctx.userId);
+      const pipeline = await getPipelineForWorkspace(
+        ctx.db,
+        input.workspaceId,
+        ctx.userId,
+        input.pipelineId,
+      );
 
       return ctx.db.deal.findMany({
         where: { projectId: pipeline.id },
@@ -528,6 +582,7 @@ export const crmApiRouter = createTRPCRouter({
     .input(
       z.object({
         workspaceId: z.string(),
+        pipelineId: z.string().optional(),
         stageId: z.string(),
         title: z.string().min(1),
         description: z.string().optional(),
@@ -542,7 +597,12 @@ export const crmApiRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       await verifyWorkspaceAccess(ctx.db, input.workspaceId, ctx.userId);
-      const pipeline = await getPipelineForWorkspace(ctx.db, input.workspaceId, ctx.userId);
+      const pipeline = await getPipelineForWorkspace(
+        ctx.db,
+        input.workspaceId,
+        ctx.userId,
+        input.pipelineId,
+      );
 
       // Position at end of stage
       const lastDeal = await ctx.db.deal.findFirst({

--- a/src/server/api/routers/pipeline.ts
+++ b/src/server/api/routers/pipeline.ts
@@ -74,14 +74,18 @@ async function ensureStageAccess(
 export const pipelineRouter = createTRPCRouter({
   // ─── Pipeline (Project) management ──────────────────────────
 
-  get: protectedProcedure
+  // List every pipeline in a workspace (a workspace may hold N named
+  // pipelines — e.g. a Sales and a Hiring pipeline — see ADR-0033). Filtered
+  // to the pipelines the user can view; ordered oldest-first so the first
+  // entry is the stable default the single-pipeline `get` would have returned.
+  list: protectedProcedure
     .input(
       z.object({
         workspaceId: z.string(),
       }),
     )
     .query(async ({ ctx, input }) => {
-      const pipeline = await ctx.db.project.findFirst({
+      const pipelines = await ctx.db.project.findMany({
         where: {
           workspaceId: input.workspaceId,
           type: "pipeline",
@@ -91,6 +95,44 @@ export const pipelineRouter = createTRPCRouter({
             orderBy: { order: "asc" },
           },
         },
+        orderBy: { createdAt: "asc" },
+      });
+
+      const visible: typeof pipelines = [];
+      for (const pipeline of pipelines) {
+        const access = await getProjectAccess(
+          ctx.db,
+          ctx.session.user.id,
+          pipeline.id,
+        );
+        if (hasProjectAccess(access)) visible.push(pipeline);
+      }
+      return visible;
+    }),
+
+  get: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        // Target a specific pipeline. Omitted → the workspace's default
+        // (oldest) pipeline, preserving the historical single-pipeline contract
+        // for callers that don't yet know about multiple pipelines.
+        pipelineId: z.string().optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const pipeline = await ctx.db.project.findFirst({
+        where: {
+          workspaceId: input.workspaceId,
+          type: "pipeline",
+          ...(input.pipelineId ? { id: input.pipelineId } : {}),
+        },
+        include: {
+          pipelineStages: {
+            orderBy: { order: "asc" },
+          },
+        },
+        orderBy: { createdAt: "asc" },
       });
       if (!pipeline) return null;
       const access = await getProjectAccess(
@@ -106,6 +148,10 @@ export const pipelineRouter = createTRPCRouter({
     .input(
       z.object({
         workspaceId: z.string(),
+        // A workspace may hold many pipelines, so each create makes a distinct
+        // one. Names need not be unique. Defaults so the first-run auto-create
+        // path (which has no name to offer) still works.
+        name: z.string().min(1).max(120).default("Pipeline"),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -125,23 +171,10 @@ export const pipelineRouter = createTRPCRouter({
         });
       }
 
-      // Check if one already exists
-      const existing = await ctx.db.project.findFirst({
-        where: {
-          workspaceId: input.workspaceId,
-          type: "pipeline",
-        },
-        include: {
-          pipelineStages: {
-            orderBy: { order: "asc" },
-          },
-        },
-      });
-
-      if (existing) return existing;
-
-      // Create a new pipeline project with default stages
-      const baseSlug = slugify("Pipeline");
+      // Always create a new, distinct pipeline (multi-pipeline, ADR-0033) —
+      // no collapsing to an existing one. Each is seeded with the generic
+      // DEFAULT_STAGES; the user re-stages it via the stage editor.
+      const baseSlug = slugify(input.name) || "pipeline";
       let slug = baseSlug;
       let counter = 1;
       while (await ctx.db.project.findFirst({ where: { slug } })) {
@@ -151,7 +184,7 @@ export const pipelineRouter = createTRPCRouter({
 
       return ctx.db.project.create({
         data: {
-          name: "Pipeline",
+          name: input.name,
           slug,
           type: "pipeline",
           status: "ACTIVE",


### PR DESCRIPTION
## What

Lifts the "one pipeline per workspace" limit (ADR-0033) so a workspace can hold **N named pipelines** (e.g. a `Sales` and a `Hiring` pipeline). A Pipeline is a `Project` with `type: "pipeline"`; the schema already supported many (stages/deals are per-`Project`) — the cap lived in the router + UI.

### Router (`pipeline.ts`)
- New `pipeline.list` — all pipelines in a workspace, access-filtered, oldest-first.
- `pipeline.get` takes an optional `pipelineId`; without it returns the oldest (the stable default), so existing single-pipeline callers keep working.
- `pipeline.create` takes a `name` (default `"Pipeline"`), no longer collapses to the existing pipeline, and always seeds the generic `DEFAULT_STAGES` on a distinct new `Project`.

### API audit (`crmApi.ts`)
- `getPipelineForWorkspace` + `pipelineGet` / `pipelineGetStages` / `dealList` / `dealCreate` take an optional `pipelineId` and default deterministically to the oldest pipeline (no silent "wrong pipeline").
- New `pipelineList` so API/CLI callers can discover pipeline ids before targeting one.

### UI
- Board page (`/crm/pipeline`) lists pipelines, shows a **switcher** when there's more than one, and a **New pipeline** named-create modal. First run still auto-seeds a default pipeline.
- Settings page is pipeline-aware with the same switcher.
- `PipelineSettingsModal` stage edits now also invalidate `pipeline.list` so the board reflects stage changes.

No schema migration. Stages stay fully customizable — no hiring/domain stages baked in.

## Acceptance criteria

- [x] A workspace can create a second, independently-named pipeline; both persist and are listable.
- [x] `pipeline.create` no longer collapses to the existing pipeline; new pipelines seed `DEFAULT_STAGES`.
- [x] The board UI has a switcher to view each pipeline; stages of each are independently editable.
- [x] Every prior single-pipeline assumption is audited and updated (router `get`/`create`, `crmApi` pipeline/deal endpoints, board + settings pages, settings-modal cache invalidation).
- [x] No schema migration required.

---

Ships: gold.fern
Part of feature: Public job-application forms with hiring pipeline