### PR TITLE
feat(pages): KnowledgePage model + page.* CRUD router (lucky.shield)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -365,7 +365,7 @@ _Avoid_: Auth middleware (too generic), API-key auth (it's no longer only API ke
 > The CRM's full developer guide is `dev-docs/CRM_ARCHITECTURE.md`. The terms below are the **domain language** — especially the word boundaries this codebase keeps separate: **Pipeline** (deal board), **Workflow** (the internal engine's table names), **Automation** (the platform trigger→steps feature — no longer CRM-only, see [ADR-0029](docs/adr/0029-automation-platform-primitive.md)), **Broadcast** (a scheduled Automation that sends to a **List**), and **List** (the generic `Collection` membership primitive, [ADR-0030](docs/adr/0030-generic-collection-list-primitive.md)). They are not synonyms.
 
 **Pipeline** _(existing)_:
-The CRM deal board — a `Project` with `type: "pipeline"`, holding `Deal`s across configurable `PipelineStage`s (Lead → … → Won/Lost). One per workspace today. A *manual state machine* (a user drags deals between stages), **not** an automation engine. The schema supports many pipelines per workspace (stages and deals are per-Project), but the UI/`pipeline.get` assume one — **multi-pipeline is deferred**.
+The CRM deal board — a `Project` with `type: "pipeline"`, holding `Deal`s across **fully customizable** `PipelineStage`s (rename/recolor/reorder/add/remove via `/crm/pipeline/settings`; new pipelines seed the generic `DEFAULT_STAGES` then the user edits freely — no baked-in domain stages). A *manual state machine* (a user drags deals between stages), **not** an automation engine. The schema has always supported many pipelines per workspace (stages and deals are per-`Project`); the historical limit was that the UI/`pipeline.get`/`pipeline.create` assumed exactly one. **Multi-pipeline is now decided** ([ADR-0033](docs/adr/0033-multi-pipeline-and-form-deal-destination.md)) — a workspace may hold N named pipelines (e.g. a `Sales` and a `Hiring` pipeline) with a board switcher — but **not yet built**. A **`create_deal` Form destination** drops a public submission onto a chosen `(pipeline, stage)` as a `Deal` (the job-application use case; the `Deal` is overloaded as a candidate card, like `profileType`). _Build status: planned, not shipped._
 _Avoid_: Using "pipeline" for the **Workflow** engine or for an **Automation** — they are different concepts. The content/PM engine's `WorkflowPipelineRun` is an unrelated internal name.
 
 **Customer type**:
@@ -443,6 +443,26 @@ _Avoid_: Action, hook (use "destination"); coupling the Form model to any one de
 The public `POST /api/forms/[slug]/submit` route: rate-limit → honeypot check → load active form → `validateSubmission` → store **Form submission** → run **Form destinations**. Unauthenticated; protected by a hidden honeypot field + per-IP/per-email **in-memory** rate limiting (a documented stopgap — [ADR-0030](docs/adr/0030-form-automation-execution-sync-then-qstash.md)). The chain end-to-end: **Intake → `create_crm_contact` → `createCrmContact` (emailHash dedup) → `dispatchContactTypeAutomations` → CRM Automation (`send_email`)**.
 _Avoid_: Webhook (that's inbound-from-a-provider), submit endpoint.
 
+### Knowledge
+
+The workspace's body of reference material — split by **origin**, unified by one search index. Two origins of content, plus the index that makes both findable:
+
+**Page**:
+A free-form, human- (or **Zoe**-) authored rich document that stands on its own — a spec, a doc, a wiki page — *not* scoped to a Product, Day, or Meeting. Its own first-class top-level area (`/w/[slug]/pages`), nav item alongside Goals/Projects/Knowledge. Stored as `KnowledgePage` with a **ProseMirror `bodyDoc` (Json)** canonical document plus a derived **Markdown `body` (String)** projection — the same dual-storage exception Features use ([ADR-0024](docs/adr/0024-prosemirror-json-for-rich-documents.md)), widened to Pages by [ADR-0033](docs/adr/0033-knowledge-pages.md). Workspace-scoped with an optional `projectId`; flat (no nesting in v1); visibility **mirrors Meeting visibility** (project-linked Pages inherit the Project's rules incl. restriction; project-less Pages are workspace-visible). The Markdown projection is embedded into the shared **Knowledge index** by default (per-Page "include in search" toggle), so Pages are RAG/agent context like Resources. _Planned — not yet in the schema._
+_Avoid_: Document (that's the **ingested-file** model — see below), Note (that's the daily-journal entity), Wiki, Doc.
+
+**Resource**:
+A piece of **ingested external content** saved for reference and search — a web page, PDF, bookmark, or pasted note — stored as `Resource` with cleaned `content` (String) + original `rawContent`. The *consumption* side of Knowledge (you save/clip it), as opposed to a **Page** (you author it). Optionally embedded into the Knowledge index on create.
+_Avoid_: Document, Page, attachment.
+
+**Document** (ingested file):
+The narrow ingestion-artefact model `Document` — an uploaded/synced **file** (`s3Key`, `mimeType`, `sourceType: drive_file | upload | url | email_attachment`, `ingestionStatus`). It is a *file record*, **not** authored prose; never use the bare word "Document" for a **Page**.
+_Avoid_: Using "Document" for authored prose (that is a **Page**).
+
+**Knowledge index**:
+The single polymorphic embedding store `KnowledgeChunk` (`sourceType` + `sourceId`, `vector(1536)` via `text-embedding-3-small`, chunked ~500 tokens) that powers semantic search and Zoe's RAG. `sourceType` unions all Knowledge origins: `transcription` (Meetings), `resource`, `document`, and `page` (new). One index, many origins — co-locating authored Pages here is the whole point of embedding them.
+_Avoid_: Vector store, embeddings table (use "Knowledge index" / `KnowledgeChunk`).
+
 ## Flagged ambiguities
 
 - **"Meeting type" is not yet stored.** The Meetings v2 redesign surfaces `All / 1:1s / Rituals` tabs, but no `meetingType` column exists on `TranscriptionSession`. v1 ships with: All = full list, 1:1s = derived live from `participantCount = 2`, Rituals = empty state until a recurrence classifier exists. When Rituals gets real, the resolution will be either calendar recurrence data or a `meetingType` enum field with mutually exclusive values `one_on_one | ritual | other`.
@@ -460,3 +480,5 @@ _Avoid_: Webhook (that's inbound-from-a-provider), submit endpoint.
 - **"Pyro" vs "Zoe" — assistant naming drift.** The canonical in-app assistant agent is **Zoe** (the brain behind the chat drawer and voice). The chat drawer UI currently renders the label "Pyro" for the same assistant. These are the same agent under two names; the divergence is presentation-only — drift to resolve (settle on one user-facing name), not changed here.
 
 - **CRM Automations — PoC scope vs target model.** The target is "both": a typed Contact (**Customer type**) as the relationship spine, with `Deal`s tracked against it. The **PoC deliberately builds only the onboarding Automation** (typed contact → welcome email + **Agreement** for signature) and rides entirely on Contacts + the **Workflow** engine — it does **not** touch the deal board. **Deferred, not designed:** (1) multiple **Pipelines** per workspace / per-Customer-type boards (schema supports it; UI/`pipeline.get` assume one); (2) engine **branching** (the Attio "Switch" node) — the engine is linear today; (3) deals-against-relationship; (4) the builder's deferred surface — non-contact triggers, AI-agent steps, editable message copy, per-node run overlay. **Now built (no longer deferred):** the linear visual **Automation builder** ([ADR-0028](docs/adr/0028-crm-automation-builder-linear.md)) — superseding item (2)'s old "builder deferred, seeded-only" note. Don't model the still-deferred items until the client confirms direction.
+
+- **"Document" was used for two different things — resolved.** The word collided: the `Document` model is an *ingested file* (`s3Key`, ingestion status), but the new free-form authoring surface was also called "Documents". Resolved (2026-06-25): the authored entity is a **Page** (`KnowledgePage`); the file-ingestion model keeps the name **Document**; "Document" never means authored prose. See the **Knowledge** section above and [ADR-0033](docs/adr/0033-knowledge-pages.md).

--- a/docs/adr/0024-prosemirror-json-for-rich-documents.md
+++ b/docs/adr/0024-prosemirror-json-for-rich-documents.md
@@ -1,0 +1,28 @@
+# ProseMirror JSON for rich, node-addressable documents
+
+## Status
+
+Accepted — 2026-06-18 (documented retroactively 2026-06-25; the schema already referenced "ADR-0024" before this file existed).
+
+## Context
+
+[ADR-0017](0017-markdown-canonical-content-format.md) made **Markdown the canonical stored format for authored prose** and explicitly rejected Tiptap/WYSIWYG-to-HTML. That holds for ordinary prose fields (descriptions, comments, updates, chat).
+
+The PRD/feature editor (`PrdDocument`) needs more than prose: a slash-command menu, task lists, image nodes, and — critically — **anchored comments**, which require addressing a stable position *inside* the document. A flat Markdown string has no stable node identity to anchor a comment to. So `Feature` stores a richer representation than a prose field can carry.
+
+## Decision
+
+For documents that need **node-addressable structure** (anchored comments, slash menu, block-level editing), store a **ProseMirror JSON document as the canonical value**, alongside a **derived Markdown projection** for portability:
+
+- `Feature.descriptionDoc: Json` — canonical ProseMirror document, what the editor reads/writes.
+- `Feature.description: String` — Markdown projection, **write-only/derived** (serialized client-side via `tiptap-markdown` on every save, never read back into the editor). Keeps the content greppable, diff-able, agent-readable, and embeddable — i.e. it still satisfies ADR-0017's *intent* on the read side.
+- `Feature.docVersion: Int` — optimistic-concurrency guard (compare-and-set on save).
+- Lazy one-time migration (`initDescriptionDoc`): legacy Markdown → ProseMirror JSON on first open, idempotent.
+
+This is a **scoped exception** to ADR-0017, not a reversal. ADR-0017 remains the default for prose; ProseMirror JSON is reserved for documents that genuinely need structure. The shared Tiptap extension set lives in `~/lib/prd/extensions` (`buildPrdExtensions`).
+
+## Consequences
+
+- A second sanctioned storage format exists for a deliberately narrow set of entities. New use of it must clear the same bar (real need for node addressing), and must keep the Markdown projection so the read side stays ADR-0017-compatible.
+- The projection is lossy on round-trip (comment marks drop) — accepted, because the JSON is canonical and the Markdown is only a projection.
+- Extended to **Pages** by [ADR-0033](0033-knowledge-pages.md), which reuses this exact pattern.

--- a/docs/adr/0033-knowledge-pages.md
+++ b/docs/adr/0033-knowledge-pages.md
@@ -1,0 +1,37 @@
+# Knowledge Pages — a first-class authored-document entity
+
+## Status
+
+Accepted — 2026-06-25
+
+## Context
+
+The app had no general place to **author** free-form documents. The existing surfaces are each scoped to something else: `Feature` (a Product's PRD body), `Note` (a daily-journal entry tied to a `Day`), `Resource` (ingested *external* content for RAG), and `Document` (an ingested *file* artefact — `s3Key`, ingestion status). None of them is "a doc I sit down and write."
+
+The `Feature` editor (`PrdDocument`) is the nicest authoring experience in the app, and [ADR-0024](0024-prosemirror-json-for-rich-documents.md) already sanctions its ProseMirror-JSON-plus-Markdown-projection storage. The `KnowledgeChunk` semantic-search index is polymorphic and its `sourceType` already anticipates a `document`/page origin.
+
+## Decision
+
+Introduce **Page** (`KnowledgePage`) as a first-class authored-document entity.
+
+- **Storage reuses the [ADR-0024](0024-prosemirror-json-for-rich-documents.md) pattern**: `bodyDoc: Json` (canonical ProseMirror) + `body: String` (derived Markdown projection) + `docVersion: Int`. This widens ADR-0024's exception from Features to Pages; ADR-0017 stays the default for ordinary prose.
+- **Scope**: `workspaceId` (required) + optional `projectId`. Flat in v1 — no nesting; a self-referencing `parentId` tree is deferred.
+- **Visibility mirrors Meeting visibility** (reuses the central access service, `src/server/services/access/`): a project-linked Page inherits its Project's visibility (restricted-project allowlist included); a project-less Page is workspace-visible and editable by non-viewers. No separate private/personal-page concept in v1.
+- **Search**: the Markdown projection is embedded into `KnowledgeChunk` as `sourceType: "page"`, **default-on**, re-embedded on save after a settle delay (fire-and-forget, like transcription embedding), with a per-Page "include in search" toggle. Pages thus become Zoe/RAG context like Resources and Meetings.
+- **UI**: a **top-level nav item** (`/w/[slug]/pages` list, `/w/[slug]/pages/[id]` editor) — its own destination, *not* a tab inside Knowledge Base — though it still feeds the shared Knowledge index, so it remains findable from Knowledge Base search.
+- **Editor v1**: formatting, slash menu, task lists, image paste, debounced autosave, optimistic concurrency. **Anchored comments/threads are deferred** (the `CommentMark` extension may stay in the shared set, but the thread UI stays off for Pages).
+- **Agent authoring**: Zoe can create/update Pages via a Mastra tool using draft-and-confirm, reusing the `page.create`/`page.update` tRPC through the `mastra.*` callback pattern ([ADR-0020](0020-agent-integration-callback-not-token.md), [ADR-0016](0016-agent-activity-writes-reuse-human-path.md)).
+
+## Considered alternatives
+
+- **Reuse the existing `Document` model.** Rejected — it's a file-ingestion artefact (`s3Key`, `ingestionStatus`) with the wrong shape and a name collision; authored prose is a different thing.
+- **Markdown-only via `MarkdownInput` (full ADR-0017 compliance).** Rejected — loses the rich editor (slash menu, structure) that motivated the feature; the ADR-0024 pattern already preserves agent-readability via the projection.
+- **A "Documents" tab inside Knowledge Base.** Considered and rejected in favour of a top-level nav item for prominence; search co-location is preserved regardless via the shared index.
+- **Nesting/folders in v1.** Deferred — `parentId` is cheap to add later and not worth the tree-nav UI now.
+
+## Consequences
+
+- New `KnowledgePage` model + `page.*` tRPC router + a `mastra.*` callback endpoint + a `../mastra` tool.
+- A new top-level nav entry in `WorkspaceTopNav`.
+- `KnowledgeChunk.sourceType` gains a live `"page"` producer; `KnowledgeService` learns to embed/re-embed a Page from its Markdown projection.
+- ADR-0024's exception now covers two entities; any third use must still clear the "needs node-addressable structure" bar.

--- a/prisma/migrations/20260625154445_add_knowledge_page/migration.sql
+++ b/prisma/migrations/20260625154445_add_knowledge_page/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "KnowledgePage" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL DEFAULT 'Untitled',
+    "bodyDoc" JSONB,
+    "body" TEXT,
+    "docVersion" INTEGER NOT NULL DEFAULT 0,
+    "includeInSearch" BOOLEAN NOT NULL DEFAULT true,
+    "workspaceId" TEXT NOT NULL,
+    "projectId" TEXT,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "KnowledgePage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "KnowledgePage_workspaceId_idx" ON "KnowledgePage"("workspaceId");
+
+-- CreateIndex
+CREATE INDEX "KnowledgePage_projectId_idx" ON "KnowledgePage"("projectId");
+
+-- CreateIndex
+CREATE INDEX "KnowledgePage_createdById_idx" ON "KnowledgePage"("createdById");
+
+-- AddForeignKey
+ALTER TABLE "KnowledgePage" ADD CONSTRAINT "KnowledgePage_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "KnowledgePage" ADD CONSTRAINT "KnowledgePage_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "KnowledgePage" ADD CONSTRAINT "KnowledgePage_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -142,6 +142,7 @@ model User {
   ownedWorkspaces             Workspace[]                 @relation("WorkspaceOwner")
   workspaceMemberships        WorkspaceUser[]
   resources                   Resource[]
+  knowledgePages              KnowledgePage[]
   workspaceInvitationsCreated WorkspaceInvitation[]       @relation("InvitationCreator")
   // CRM relations
   crmContactsCreated          CrmContact[]                @relation("CrmContactCreatedBy")
@@ -322,6 +323,7 @@ model Workspace {
   timeEntries             TimeEntry[]
   teams                   Team[]
   resources               Resource[]
+  knowledgePages          KnowledgePage[]
   invitations             WorkspaceInvitation[]
   views                   View[]
   lists                   List[]
@@ -902,6 +904,7 @@ model Project {
   memberCapacities      TeamMemberWeeklyCapacity[] @relation("ProjectCapacities")
   lifeDomains           LifeDomain[]               @relation("ProjectLifeDomains")
   resources             Resource[]
+  knowledgePages        KnowledgePage[]
   recurringTasks        RecurringTask[]
   activities            ProjectActivity[]
   keyResults            KeyResultProject[] // Key results this project contributes to
@@ -2526,6 +2529,39 @@ model KnowledgeChunk {
   @@index([userId])
   @@index([projectId])
   @@index([workspaceId])
+}
+
+/// A free-form, human- or Zoe-authored rich document (ADR-0033) — a spec, doc,
+/// or wiki page that stands on its own, not scoped to a Product/Day/Meeting. Its
+/// own top-level area (/w/[slug]/pages). Storage reuses the Feature PRD
+/// dual-format (ADR-0024): `bodyDoc` is the canonical ProseMirror JSON the
+/// editor reads/writes; `body` is a derived, write-only Markdown projection
+/// (greppable, embeddable, agent-readable); `docVersion` powers the
+/// optimistic-concurrency stale-write guard. Workspace-scoped with an optional
+/// Project link (flat — no nesting in v1); visibility mirrors Meetings
+/// (project-linked inherits the Project's rules incl. restriction; project-less
+/// is workspace-visible). When `includeInSearch` is on, the Markdown projection
+/// feeds the shared Knowledge index as `KnowledgeChunk.sourceType = "page"`.
+model KnowledgePage {
+  id              String   @id @default(cuid())
+  title           String   @default("Untitled")
+  bodyDoc         Json?
+  body            String?
+  docVersion      Int      @default(0)
+  includeInSearch Boolean  @default(true)
+  workspaceId     String
+  projectId       String?
+  createdById     String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  project   Project?  @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  createdBy User      @relation(fields: [createdById], references: [id])
+
+  @@index([workspaceId])
+  @@index([projectId])
+  @@index([createdById])
 }
 
 // ============================================

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -83,6 +83,7 @@ import { favoriteRouter } from "~/server/api/routers/favorite";
 import { authRouter } from "./routers/auth";
 import { documentRouter } from "./routers/document";
 import { voiceRouter } from "./routers/voice";
+import { pageRouter } from "./routers/page";
 /**
  * This is the primary router for your server.
  *
@@ -168,6 +169,7 @@ export const appRouter = createTRPCRouter({
   auth: authRouter,
   document: documentRouter,
   voice: voiceRouter,
+  page: pageRouter,
   // Plugin system
   pluginConfig: pluginConfigRouter,
   okr: keyResultRouter,

--- a/src/server/api/routers/__tests__/page.integration.test.ts
+++ b/src/server/api/routers/__tests__/page.integration.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { getTestDb } from "~/test/test-db";
+import { createTestCaller } from "~/test/trpc-helpers";
+import {
+  createUser,
+  createWorkspace,
+  createProject,
+  addWorkspaceMember,
+  addProjectMember,
+} from "~/test/factories";
+
+async function createPage(
+  db: ReturnType<typeof getTestDb>,
+  args: {
+    createdById: string;
+    workspaceId: string;
+    projectId?: string | null;
+    title?: string;
+    includeInSearch?: boolean;
+  },
+) {
+  return db.knowledgePage.create({
+    data: {
+      createdById: args.createdById,
+      workspaceId: args.workspaceId,
+      projectId: args.projectId ?? null,
+      title: args.title ?? "A page",
+      body: "hello world",
+      includeInSearch: args.includeInSearch ?? true,
+    },
+  });
+}
+
+describe("page router", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  describe("get — visibility mirrors Meetings", () => {
+    it("workspace member can view a page on an unrestricted project", async () => {
+      const owner = await createUser(db);
+      const member = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-get-open" });
+      await addWorkspaceMember(db, ws.id, member.id, "member");
+      const project = await createProject(db, {
+        createdById: owner.id,
+        workspaceId: ws.id,
+        isRestricted: false,
+      });
+      const page = await createPage(db, {
+        createdById: owner.id,
+        workspaceId: ws.id,
+        projectId: project.id,
+      });
+
+      const caller = createTestCaller(member.id);
+      const result = await caller.page.get({ id: page.id });
+      expect(result.id).toBe(page.id);
+    });
+
+    it("denies a workspace member when the project is restricted", async () => {
+      const owner = await createUser(db);
+      const member = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-get-restricted" });
+      await addWorkspaceMember(db, ws.id, member.id, "member");
+      const project = await createProject(db, {
+        createdById: owner.id,
+        workspaceId: ws.id,
+        isRestricted: true,
+      });
+      const page = await createPage(db, {
+        createdById: owner.id,
+        workspaceId: ws.id,
+        projectId: project.id,
+      });
+
+      const caller = createTestCaller(member.id);
+      await expect(caller.page.get({ id: page.id })).rejects.toThrow(TRPCError);
+    });
+
+    it("allows a ProjectMember on a restricted project", async () => {
+      const owner = await createUser(db);
+      const projectMember = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-get-pm" });
+      await addWorkspaceMember(db, ws.id, projectMember.id, "member");
+      const project = await createProject(db, {
+        createdById: owner.id,
+        workspaceId: ws.id,
+        isRestricted: true,
+      });
+      await addProjectMember(db, project.id, projectMember.id, "viewer");
+      const page = await createPage(db, {
+        createdById: owner.id,
+        workspaceId: ws.id,
+        projectId: project.id,
+      });
+
+      const caller = createTestCaller(projectMember.id);
+      const result = await caller.page.get({ id: page.id });
+      expect(result.id).toBe(page.id);
+    });
+
+    it("workspace owner is the escape hatch for a restricted project", async () => {
+      const owner = await createUser(db);
+      const projectCreator = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-get-escape" });
+      await addWorkspaceMember(db, ws.id, projectCreator.id, "member");
+      const project = await createProject(db, {
+        createdById: projectCreator.id,
+        workspaceId: ws.id,
+        isRestricted: true,
+      });
+      const page = await createPage(db, {
+        createdById: projectCreator.id,
+        workspaceId: ws.id,
+        projectId: project.id,
+      });
+
+      const caller = createTestCaller(owner.id);
+      const result = await caller.page.get({ id: page.id });
+      expect(result.id).toBe(page.id);
+    });
+
+    it("project-less page is visible to any workspace member", async () => {
+      const owner = await createUser(db);
+      const member = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-get-projless" });
+      await addWorkspaceMember(db, ws.id, member.id, "viewer");
+      const page = await createPage(db, {
+        createdById: owner.id,
+        workspaceId: ws.id,
+        projectId: null,
+      });
+
+      const caller = createTestCaller(member.id);
+      const result = await caller.page.get({ id: page.id });
+      expect(result.id).toBe(page.id);
+    });
+
+    it("denies a non-member of the workspace on a project-less page", async () => {
+      const owner = await createUser(db);
+      const stranger = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-get-stranger" });
+      const page = await createPage(db, {
+        createdById: owner.id,
+        workspaceId: ws.id,
+        projectId: null,
+      });
+
+      const caller = createTestCaller(stranger.id);
+      await expect(caller.page.get({ id: page.id })).rejects.toThrow(TRPCError);
+    });
+  });
+
+  describe("list — scoped to visible pages", () => {
+    it("hides a restricted-project page from a non-member workspace member", async () => {
+      const owner = await createUser(db);
+      const member = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-list-hide" });
+      await addWorkspaceMember(db, ws.id, member.id, "member");
+      const restricted = await createProject(db, {
+        createdById: owner.id,
+        workspaceId: ws.id,
+        isRestricted: true,
+        name: "Restricted",
+      });
+      await createPage(db, {
+        createdById: owner.id,
+        workspaceId: ws.id,
+        projectId: restricted.id,
+        title: "Hidden page",
+      });
+      await createPage(db, {
+        createdById: owner.id,
+        workspaceId: ws.id,
+        projectId: null,
+        title: "Open page",
+      });
+
+      const caller = createTestCaller(member.id);
+      const list = await caller.page.list({ workspaceId: ws.id });
+      const titles = list.map((p) => p.title);
+      expect(titles).toContain("Open page");
+      expect(titles).not.toContain("Hidden page");
+    });
+
+    it("filters by title search", async () => {
+      const owner = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-list-search" });
+      await createPage(db, { createdById: owner.id, workspaceId: ws.id, title: "Roadmap" });
+      await createPage(db, { createdById: owner.id, workspaceId: ws.id, title: "Onboarding" });
+
+      const caller = createTestCaller(owner.id);
+      const list = await caller.page.list({ workspaceId: ws.id, search: "road" });
+      expect(list.map((p) => p.title)).toEqual(["Roadmap"]);
+    });
+  });
+
+  describe("create — placement gating", () => {
+    it("a non-viewer workspace member can create a project-less page", async () => {
+      const owner = await createUser(db);
+      const member = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-create-ok" });
+      await addWorkspaceMember(db, ws.id, member.id, "member");
+
+      const caller = createTestCaller(member.id);
+      const page = await caller.page.create({ workspaceId: ws.id, title: "Notes" });
+      expect(page.title).toBe("Notes");
+      expect(page.createdById).toBe(member.id);
+    });
+
+    it("a viewer cannot create a page", async () => {
+      const owner = await createUser(db);
+      const viewer = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-create-viewer" });
+      await addWorkspaceMember(db, ws.id, viewer.id, "viewer");
+
+      const caller = createTestCaller(viewer.id);
+      await expect(
+        caller.page.create({ workspaceId: ws.id, title: "Nope" }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it("cannot create a page on a restricted project without edit access", async () => {
+      const owner = await createUser(db);
+      const member = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-create-restricted" });
+      await addWorkspaceMember(db, ws.id, member.id, "member");
+      const project = await createProject(db, {
+        createdById: owner.id,
+        workspaceId: ws.id,
+        isRestricted: true,
+      });
+
+      const caller = createTestCaller(member.id);
+      await expect(
+        caller.page.create({ workspaceId: ws.id, projectId: project.id, title: "X" }),
+      ).rejects.toThrow(TRPCError);
+    });
+  });
+
+  describe("update — optimistic concurrency", () => {
+    it("rejects a stale body save (docVersion conflict)", async () => {
+      const owner = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-update-stale" });
+      const page = await createPage(db, { createdById: owner.id, workspaceId: ws.id });
+
+      const caller = createTestCaller(owner.id);
+      // First save from base 0 succeeds and bumps to 1.
+      const first = await caller.page.update({
+        id: page.id,
+        baseVersion: 0,
+        bodyDoc: { type: "doc", content: [] },
+        body: "v1",
+      });
+      expect(first).toMatchObject({ docVersion: 1 });
+
+      // A second save still claiming base 0 is stale.
+      await expect(
+        caller.page.update({
+          id: page.id,
+          baseVersion: 0,
+          bodyDoc: { type: "doc", content: [] },
+          body: "v2",
+        }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it("a viewer cannot edit a project-less page", async () => {
+      const owner = await createUser(db);
+      const viewer = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: owner.id, slug: "pg-update-viewer" });
+      await addWorkspaceMember(db, ws.id, viewer.id, "viewer");
+      const page = await createPage(db, { createdById: owner.id, workspaceId: ws.id });
+
+      const caller = createTestCaller(viewer.id);
+      await expect(
+        caller.page.update({ id: page.id, title: "hijack" }),
+      ).rejects.toThrow(TRPCError);
+    });
+  });
+});

--- a/src/server/api/routers/page.ts
+++ b/src/server/api/routers/page.ts
@@ -1,0 +1,314 @@
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { TRPCError } from "@trpc/server";
+import type { Prisma, PrismaClient } from "@prisma/client";
+import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
+import { checkStaleWrite } from "~/lib/prd/stale-write";
+import {
+  getKnowledgePageAccess,
+  canViewKnowledgePage,
+  canEditKnowledgePage,
+  buildKnowledgePageAccessWhere,
+  getProjectAccess,
+  canEditProject,
+  getWorkspaceMembership,
+  hasMinimumWorkspaceRole,
+} from "~/server/services/access";
+
+/**
+ * Canonical ProseMirror document shape for a Page body (ADR-0024). Same loose
+ * shape the Feature PRD router uses — the editor owns the real schema; the
+ * server only stores it as JSON.
+ */
+const prosemirrorDoc = z.record(z.string(), z.unknown());
+
+/** A Page reduced to exactly what the access resolver needs. */
+const PAGE_ACCESS_SELECT = {
+  id: true,
+  createdById: true,
+  projectId: true,
+  workspaceId: true,
+  docVersion: true,
+} satisfies Prisma.KnowledgePageSelect;
+
+async function loadPageForAccess(db: PrismaClient, id: string) {
+  const page = await db.knowledgePage.findUnique({
+    where: { id },
+    select: PAGE_ACCESS_SELECT,
+  });
+  if (!page) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Page not found" });
+  }
+  return page;
+}
+
+async function ensurePageAccess(
+  db: PrismaClient,
+  userId: string,
+  page: { createdById: string; projectId: string | null; workspaceId: string },
+  permission: "view" | "edit",
+): Promise<void> {
+  const access = await getKnowledgePageAccess(db, userId, page);
+  const allowed =
+    permission === "view"
+      ? canViewKnowledgePage(access)
+      : canEditKnowledgePage(access);
+  if (!allowed) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message:
+        permission === "view"
+          ? "You don't have access to this page"
+          : "You don't have permission to edit this page",
+    });
+  }
+}
+
+/**
+ * Gate Page creation / project re-assignment against the target scope, since no
+ * row exists yet to feed the resolver. A project-linked Page requires edit
+ * access to that project (restriction respected) and the project must live in
+ * the same workspace (a project-linked Page always inherits the project's
+ * workspace — mirrors the Meeting coherence rule). A project-less Page requires
+ * a non-viewer workspace role.
+ */
+async function assertCanPlacePage(
+  db: PrismaClient,
+  userId: string,
+  workspaceId: string,
+  projectId: string | null | undefined,
+): Promise<void> {
+  if (projectId) {
+    const project = await db.project.findUnique({
+      where: { id: projectId },
+      select: { workspaceId: true },
+    });
+    if (!project) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Project not found" });
+    }
+    if (project.workspaceId !== workspaceId) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "The project belongs to a different workspace",
+      });
+    }
+    const access = await getProjectAccess(db, userId, projectId);
+    if (!canEditProject(access)) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "You don't have permission to add a page to this project",
+      });
+    }
+    return;
+  }
+
+  const membership = await getWorkspaceMembership(db, userId, workspaceId);
+  if (!membership || !hasMinimumWorkspaceRole(membership.role, "member")) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You need member access to this workspace to create a page",
+    });
+  }
+}
+
+export const pageRouter = createTRPCRouter({
+  /**
+   * List the Pages a user can see in a workspace (visibility per ADR-0033 /
+   * `buildKnowledgePageAccessWhere`), newest-edited first. Optional `projectId`
+   * filter and case-insensitive title `search`.
+   */
+  list: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        projectId: z.string().optional(),
+        search: z.string().optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const filters: Prisma.KnowledgePageWhereInput[] = [
+        buildKnowledgePageAccessWhere(userId),
+        { workspaceId: input.workspaceId },
+      ];
+      if (input.projectId) {
+        filters.push({ projectId: input.projectId });
+      }
+      if (input.search?.trim()) {
+        filters.push({
+          title: { contains: input.search.trim(), mode: "insensitive" },
+        });
+      }
+
+      return ctx.db.knowledgePage.findMany({
+        where: { AND: filters },
+        orderBy: { updatedAt: "desc" },
+        select: {
+          id: true,
+          title: true,
+          projectId: true,
+          includeInSearch: true,
+          updatedAt: true,
+          createdAt: true,
+          project: { select: { id: true, name: true } },
+        },
+      });
+    }),
+
+  get: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const page = await ctx.db.knowledgePage.findUnique({
+        where: { id: input.id },
+        include: {
+          project: { select: { id: true, name: true, slug: true } },
+          createdBy: { select: { id: true, name: true, image: true } },
+        },
+      });
+      if (!page) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Page not found" });
+      }
+      await ensurePageAccess(ctx.db, ctx.session.user.id, page, "view");
+      return page;
+    }),
+
+  create: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        projectId: z.string().nullish(),
+        title: boundedText("Title", TEXT_LIMITS.LABEL).optional(),
+        body: boundedText("Body", TEXT_LIMITS.LARGE).optional(),
+        bodyDoc: prosemirrorDoc.optional(),
+        includeInSearch: z.boolean().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      await assertCanPlacePage(
+        ctx.db,
+        userId,
+        input.workspaceId,
+        input.projectId,
+      );
+
+      return ctx.db.knowledgePage.create({
+        data: {
+          workspaceId: input.workspaceId,
+          projectId: input.projectId ?? null,
+          title: input.title?.trim() ? input.title.trim() : "Untitled",
+          body: input.body,
+          bodyDoc: input.bodyDoc as Prisma.InputJsonValue | undefined,
+          includeInSearch: input.includeInSearch ?? true,
+          createdById: userId,
+        },
+      });
+    }),
+
+  /**
+   * Update a Page. The body-save path (ADR-0024) carries `bodyDoc` (canonical
+   * ProseMirror) plus its derived Markdown `body`, guarded by an
+   * optimistic-concurrency compare-and-set on `docVersion`; metadata-only
+   * updates (title, project link, search toggle) skip the version dance.
+   */
+  update: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        title: boundedText("Title", TEXT_LIMITS.LABEL, { min: 1 }).optional(),
+        projectId: z.string().nullish(),
+        includeInSearch: z.boolean().optional(),
+        bodyDoc: prosemirrorDoc.optional(),
+        body: boundedText("Body", TEXT_LIMITS.LARGE).optional(),
+        baseVersion: z.number().int().min(0).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const page = await loadPageForAccess(ctx.db, input.id);
+      await ensurePageAccess(ctx.db, userId, page, "edit");
+
+      const { id, bodyDoc, body, baseVersion, projectId, ...rest } = input;
+
+      // Re-assigning the project changes visibility + workspace coherence, so
+      // re-run placement gating for the new target (null = detach to workspace).
+      const projectIdProvided = projectId !== undefined;
+      if (projectIdProvided) {
+        await assertCanPlacePage(
+          ctx.db,
+          userId,
+          page.workspaceId,
+          projectId,
+        );
+      }
+
+      const data: Prisma.KnowledgePageUpdateInput = {
+        ...rest,
+        ...(projectIdProvided
+          ? {
+              project: projectId
+                ? { connect: { id: projectId } }
+                : { disconnect: true },
+            }
+          : {}),
+        ...(body !== undefined ? { body } : {}),
+      };
+
+      // Body autosave path: optimistic-concurrency guard + atomic version bump.
+      if (bodyDoc !== undefined) {
+        if (baseVersion === undefined) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "baseVersion is required when saving the page body",
+          });
+        }
+        const decision = checkStaleWrite({
+          storedVersion: page.docVersion,
+          baseVersion,
+        });
+        if (!decision.accept) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              decision.reason === "stale"
+                ? "This page was updated in another tab or by another member. Reload to get the latest version."
+                : "Stale document version — reload and try again.",
+          });
+        }
+        // The WHERE on docVersion closes the read→write race so two concurrent
+        // saves can't both bump from the same base.
+        const res = await ctx.db.knowledgePage.updateMany({
+          where: { id, docVersion: baseVersion },
+          data: {
+            ...rest,
+            ...(projectIdProvided ? { projectId: projectId ?? null } : {}),
+            ...(body !== undefined ? { body } : {}),
+            bodyDoc: bodyDoc as Prisma.InputJsonValue,
+            docVersion: { increment: 1 },
+          },
+        });
+        if (res.count === 0) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "This page was updated concurrently. Reload to get the latest version.",
+          });
+        }
+        return { id, docVersion: decision.nextVersion };
+      }
+
+      return ctx.db.knowledgePage.update({
+        where: { id },
+        data,
+      });
+    }),
+
+  delete: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const page = await loadPageForAccess(ctx.db, input.id);
+      await ensurePageAccess(ctx.db, ctx.session.user.id, page, "edit");
+      await ctx.db.knowledgePage.delete({ where: { id: input.id } });
+      return { success: true };
+    }),
+});

--- a/src/server/services/access/index.ts
+++ b/src/server/services/access/index.ts
@@ -94,3 +94,10 @@ export {
   buildTranscriptionAccessWhere,
 } from "./resolvers/transcriptionResolver";
 export type { TranscriptionAccessInfo } from "./resolvers/transcriptionResolver";
+export {
+  getKnowledgePageAccess,
+  canViewKnowledgePage,
+  canEditKnowledgePage,
+  buildKnowledgePageAccessWhere,
+} from "./resolvers/knowledgePageResolver";
+export type { KnowledgePageAccessInfo } from "./resolvers/knowledgePageResolver";

--- a/src/server/services/access/resolvers/knowledgePageResolver.ts
+++ b/src/server/services/access/resolvers/knowledgePageResolver.ts
@@ -1,0 +1,116 @@
+/**
+ * KnowledgePage (Page) Access Resolver
+ *
+ * Single source of truth for Page visibility (ADR-0033), which deliberately
+ * mirrors Meeting visibility (see {@link ./transcriptionResolver}) minus the
+ * participant concept — a Page has no attendees. A user can view a Page when
+ * any of these hold:
+ * - They created it (page owner).
+ * - It is assigned to a project they can access (project access is
+ *   authoritative — a workspace member without project access is denied,
+ *   restricted-project allowlist included).
+ * - It has no project and they are a member of its workspace (any role may
+ *   view; edit requires a non-viewer role).
+ */
+
+import type { Prisma, PrismaClient } from "@prisma/client";
+import type { WorkspaceRole } from "../types";
+import {
+  getProjectAccess,
+  hasProjectAccess,
+  canEditProject,
+  buildProjectAccessWhere,
+} from "./projectResolver";
+import {
+  getWorkspaceMembership,
+  buildWorkspaceAccessWhere,
+} from "./workspaceResolver";
+
+export interface KnowledgePageAccessInfo {
+  isOwner: boolean;
+  /** Whether the page is assigned to a project. */
+  hasProject: boolean;
+  hasProjectAccess: boolean;
+  canEditProject: boolean;
+  /** Workspace role for project-less pages; null when not a member. */
+  workspaceRole: WorkspaceRole | null;
+}
+
+export async function getKnowledgePageAccess(
+  db: PrismaClient,
+  userId: string,
+  page: {
+    createdById: string;
+    projectId: string | null;
+    workspaceId: string;
+  },
+): Promise<KnowledgePageAccessInfo> {
+  const isOwner = page.createdById === userId;
+
+  let projectAccess = null;
+  if (page.projectId) {
+    projectAccess = await getProjectAccess(db, userId, page.projectId);
+  }
+
+  let workspaceRole: WorkspaceRole | null = null;
+  if (!page.projectId) {
+    const membership = await getWorkspaceMembership(
+      db,
+      userId,
+      page.workspaceId,
+    );
+    workspaceRole = membership?.role ?? null;
+  }
+
+  return {
+    isOwner,
+    hasProject: !!page.projectId,
+    hasProjectAccess: projectAccess ? hasProjectAccess(projectAccess) : false,
+    canEditProject: projectAccess ? canEditProject(projectAccess) : false,
+    workspaceRole,
+  };
+}
+
+/** Check if user can view this page. */
+export function canViewKnowledgePage(access: KnowledgePageAccessInfo): boolean {
+  if (access.isOwner) return true;
+  // Project access is authoritative for project-assigned pages.
+  if (access.hasProject) return access.hasProjectAccess;
+  // Project-less pages: any workspace member (any role) may view.
+  return access.workspaceRole !== null;
+}
+
+/** Check if user can edit this page. */
+export function canEditKnowledgePage(access: KnowledgePageAccessInfo): boolean {
+  if (access.isOwner) return true;
+  if (access.hasProject) return access.canEditProject;
+  // Project-less pages: workspace members may edit, except viewers
+  // (viewer is a read-only role).
+  return access.workspaceRole !== null && access.workspaceRole !== "viewer";
+}
+
+/**
+ * Prisma WHERE clause for pages a user can access.
+ *
+ * Use for every bulk read over Pages (list, search, embedding sweeps) so all
+ * surfaces show the same set. Mirrors `getKnowledgePageAccess` exactly.
+ */
+export function buildKnowledgePageAccessWhere(
+  userId: string,
+): Prisma.KnowledgePageWhereInput {
+  return {
+    OR: [
+      // Page owner
+      { createdById: userId },
+      // Project-assigned pages: project access is authoritative
+      { project: buildProjectAccessWhere(userId) },
+      // Project-less pages: workspace membership (direct or via team)
+      {
+        AND: [
+          { projectId: null },
+          { workspace: buildWorkspaceAccessWhere(userId) },
+        ],
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Ticket

[lucky.shield #213](https://www.exponential.im) — KnowledgePage model + `page.*` CRUD router. Parent feature: **Knowledge Pages** (ADR-0033). First of 5 slices; #2–#5 (nav, editor, embedding, Zoe) build on this.

## What this adds

Introduces **Page** (`KnowledgePage`) as a first-class authored-document entity (ADR-0033). Storage reuses the Feature PRD dual-format from ADR-0024: `bodyDoc` (canonical ProseMirror JSON) + `body` (derived, write-only Markdown projection) + `docVersion` (optimistic-concurrency guard).

- **Schema + migration** (`add_knowledge_page`): `KnowledgePage` with `workspaceId` (required), optional `projectId`, `title`, `bodyDoc Json?`, `body String?`, `docVersion`, `includeInSearch`, `createdById`, and indexes on `workspaceId`/`projectId`/`createdById`. Purely additive — one new table, three FKs.
- **Access resolver** (`knowledgePageResolver.ts`): visibility **mirrors Meetings** — a project-linked Page inherits the Project's rules (restricted-allowlist included); a project-less Page is workspace-visible and editable by non-viewers. No participant concept (Pages have no attendees), so it's the transcription resolver minus attendance. Exported through the central access `index.ts`.
- **`page.*` router**: `create` / `list` / `get` / `update` / `delete`, all gated through the centralized access service (no inline permission checks). `update` does an atomic `docVersion` compare-and-set on the body-save path; `create` and project re-assignment are gated by `assertCanPlacePage` (project-edit access, or non-viewer workspace role; enforces the project↔workspace coherence rule).
- Registered as `page` in the root router.

## Tests

`page.integration.test.ts` covers the visibility matrix (open project, restricted project, ProjectMember, workspace-owner escape hatch, project-less workspace visibility, non-member denial), list scoping + title search, create-placement gating (viewer denied, restricted-project denied), and the stale-write `docVersion` conflict.

`npm run check` passes; full unit suite (1127) green; migration + hardcoded-color pre-commit checks pass.

## Notes for review

- Migration was authored via `prisma migrate dev` against a throwaway scratch DB (the shared dev DB has unrelated CRM migrations applied but not yet in `main`, which would otherwise force a reset). The generated SQL is additive-only.
- ADR-0024's dual-format exception now covers a second entity (Pages); ADR-0033 records the decision. The CONTEXT.md Knowledge glossary is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Knowledge Pages for workspace documentation, with optional project linking, editing, and a top-level pages area.
  * Improved rich-text document handling for more structured content and collaborative editing.
  * Pages can now be included in shared search results for knowledge retrieval.

* **Bug Fixes**
  * Added stricter access rules for viewing, creating, and editing pages.
  * Prevented overwriting newer edits with stale saves by adding version-based conflict checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->