### PR TITLE
feat(meetings): place meetings into the right workspace (picker + Action re-home)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,7 +50,7 @@ _Avoid_: Private project (use "restricted"), team project (team ownership ≠ re
 - A **Meeting** has zero or more **Participants** (`TranscriptionSessionParticipant`).
 - A **Meeting** has zero or more **Speakers** (derived from transcript). The Participant and Speaker sets overlap but are not identical.
 - A **Meeting** belongs to at most one **Project** and at most one **Workspace**. A **project-linked Meeting always inherits the project's Workspace** — a meeting with a Project but no Workspace is an incoherent state. Workspace-less ("personal") Meetings are legal **only** when there is also no Project. `createManualTranscription` enforces this server-side (derives `workspaceId` from the project when not supplied), since **Participants require a Workspace** (`TranscriptionSessionParticipant.workspaceId` is non-null).
-- A **Meeting** produces zero or more **Actions** (extracted by Zoe).
+- A **Meeting** produces zero or more **Actions** (extracted by Zoe). An Action extracted from a Meeting **lives where the Meeting lives** — it inherits the Meeting's Project and Workspace at extraction, and **follows the Meeting on reassignment**: moving a Meeting to a new Project (and thus Workspace) re-homes its Actions' `projectId` *and* `workspaceId`. An Action from a Meeting never sits in a different Workspace than its Meeting.
 - A **Ritual** is a *kind of* **Meeting** — not a separate entity.
 
 ### Activity
@@ -424,7 +424,7 @@ _Avoid_: merging List/Pipeline/Automation into one "Collection with stages and a
 A **generic** public-intake subsystem (a mini-Typeform), deliberately **decoupled from the CRM** — the CRM is just one **destination** a form can be wired to ([ADR-0029](docs/adr/0029-generic-forms-subsystem.md)). First use case: a public job-application form whose submission creates a contact and fires the existing automation.
 
 **Form**:
-A workspace-owned public intake definition — `Form { workspaceId, name, slug, fields Json, destinations Json, isActive, confirmationMessage? }`. Rendered unauthenticated at **`/f/[slug]`**; authored in a minimal in-app admin under CRM (`/crm/forms`). Knows nothing about the CRM itself. The `slug` is **globally unique** (not per-workspace) — the public URL carries no workspace, so the lookup must be unambiguous; `uniqueFormSlug` dedupes across all workspaces.
+A workspace-owned public intake definition — `Form { workspaceId, name, slug, description? @db.Text, fields Json, destinations Json, isActive, confirmationMessage? }`. Rendered unauthenticated at **`/f/[slug]`**; authored in a minimal in-app admin under CRM (`/crm/forms`). Knows nothing about the CRM itself. The `slug` is **globally unique** (not per-workspace) — the public URL carries no workspace, so the lookup must be unambiguous; `uniqueFormSlug` dedupes across all workspaces. **`description` is canonical Markdown** (ADR-0017) — the rich body shown above the fields (a job-application form's *job description* is just this field), authored with the shared `<MarkdownInput/>` and rendered with `<MarkdownRenderer/>`; legacy plaintext values stay valid Markdown. A "job-application form" is **not a distinct entity** — it is a Form with a Markdown `description` + custom **Form fields** + a `create_crm_contact` **destination**; the form layer stays job-ignorant.
 _Avoid_: Survey, lead form (it's generic; CRM is one destination), CrmForm (it is **not** CRM-coupled — don't name it that).
 
 **Form field**:

--- a/src/app/(sidemenu)/recording/[id]/page.tsx
+++ b/src/app/(sidemenu)/recording/[id]/page.tsx
@@ -18,10 +18,28 @@ export default function SessionPage({ params }: { params: Promise<{ id: string }
       { transcriptionId: id },
       { enabled: Boolean(id) },
     );
-  const { data: workspaces } = api.workspace.list.useQuery();
+  const { data: assignableProjects = [] } = api.project.getAssignable.useQuery();
   const utils = api.useUtils();
   const router = useRouter();
   const updateDetailsMutation = api.transcription.updateDetails.useMutation();
+  const assignProjectMutation = api.transcription.assignProject.useMutation({
+    onSuccess: () => {
+      notifications.show({
+        title: "Saved",
+        message: "Meeting placement updated",
+        color: "green",
+      });
+      void utils.transcription.getById.invalidate({ id });
+      void utils.action.getByTranscription.invalidate({ transcriptionId: id });
+    },
+    onError: (error) => {
+      notifications.show({
+        title: "Error",
+        message: error.message || "Failed to update placement",
+        color: "red",
+      });
+    },
+  });
   const archiveMutation = api.transcription.archiveTranscription.useMutation({
     onSuccess: () => {
       notifications.show({
@@ -165,23 +183,11 @@ export default function SessionPage({ params }: { params: Promise<{ id: string }
     }
   }
 
-  async function handleWorkspaceChange(workspaceId: string | null) {
+  function handleProjectChange(projectId: string | null) {
     if (!session) return;
-    try {
-      await updateDetailsMutation.mutateAsync({ id: session.id, workspaceId });
-      notifications.show({
-        title: "Saved",
-        message: workspaceId ? "Meeting moved to workspace" : "Meeting removed from workspace",
-        color: "green",
-      });
-      void utils.transcription.getById.invalidate({ id });
-    } catch (error) {
-      notifications.show({
-        title: "Error",
-        message: error instanceof Error ? error.message : "Failed to update workspace",
-        color: "red",
-      });
-    }
+    // Routes through the placement service: sets the project, derives the
+    // workspace, and re-homes the meeting's Actions in one path.
+    assignProjectMutation.mutate({ transcriptionId: session.id, projectId });
   }
 
   // Register page context so the agent chat knows what recording is in view.
@@ -223,12 +229,12 @@ export default function SessionPage({ params }: { params: Promise<{ id: string }
       session={session}
       actions={transcriptActions}
       isActionsLoading={isActionsLoading}
-      workspaces={(workspaces ?? []).map((ws) => ({ id: ws.id, name: ws.name }))}
+      assignableProjects={assignableProjects}
       isCreatingActions={generateDraftsMutation.isPending}
       isGeneratingSummary={generateSummaryMutation.isPending}
       onSaveSummary={handleSaveSummary}
       onMeetingDateChange={handleMeetingDateChange}
-      onWorkspaceChange={handleWorkspaceChange}
+      onProjectChange={handleProjectChange}
       onCreateActions={handleCreateActions}
       onArchive={handleArchive}
     />

--- a/src/app/_components/MeetingsContent.tsx
+++ b/src/app/_components/MeetingsContent.tsx
@@ -53,6 +53,7 @@ import {
   IconCheckbox,
 } from "@tabler/icons-react";
 import { TranscriptView } from "./meeting/TranscriptView";
+import { MeetingProjectPicker } from "./meeting/MeetingProjectPicker";
 import { FirefliesWizardModal } from "./integrations/FirefliesWizardModal";
 import { parseFirefliesSummary } from "~/lib/fireflies-summary";
 import {
@@ -531,7 +532,6 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
   const [selectedIntegrationFilter, setSelectedIntegrationFilter] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTranscriptionIds, setSelectedTranscriptionIds] = useState<Set<string>>(new Set());
-  const [bulkProjectAssignment, setBulkProjectAssignment] = useState<string | null>(null);
   const [deleteModalOpened, setDeleteModalOpened] = useState(false);
   const shouldUseCachedTranscriptions = Boolean(workspaceId);
   const { data: transcriptions, isLoading } = api.transcription.getAllTranscriptions.useQuery(
@@ -565,6 +565,10 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
   useRegisterPageContext(meetingsPageContext, { clearOnUnmount: false });
 
   const { data: projects } = api.project.getAll.useQuery({});
+  // Cross-workspace, edit-scoped candidates for the placement picker (grouped
+  // by workspace). Distinct from `projects` above, which feeds the optimistic
+  // cache update and carries the full project shape.
+  const { data: assignableProjects = [] } = api.project.getAssignable.useQuery();
   const { data: workflows = [] } = api.workflow.list.useQuery();
   const { data: webhookLogsData, isLoading: isLoadingLogs, refetch: refetchLogs } = api.transcription.getWebhookLogs.useQuery(
     { workspaceId, limit: 50 },
@@ -611,7 +615,7 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
   }, [isLoading, transcriptions, ensureMyMeetingSummaries]);
 
 
-  const assignProjectMutation = api.transcription.associateWithProject.useMutation({
+  const assignProjectMutation = api.transcription.assignProject.useMutation({
     onMutate: async ({ transcriptionId, projectId }) => {
       // Cancel outgoing refetches
       await utils.transcription.getAllTranscriptions.cancel();
@@ -700,7 +704,6 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
       });
       // Clear selections and refresh data
       setSelectedTranscriptionIds(new Set());
-      setBulkProjectAssignment(null);
       void utils.transcription.getAllTranscriptions.invalidate();
     },
     onError: (error) => {
@@ -838,18 +841,10 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
   };
 
   const handleProjectAssignment = (transcriptionId: string, projectId: string | null) => {
-    if (projectId) {
-      assignProjectMutation.mutate({
-        transcriptionId,
-        projectId,
-        autoProcess: false
-      });
-    }
-  };
-
-  const getProjectsForMeeting = (sessionWorkspaceId: string | null | undefined) => {
-    if (!sessionWorkspaceId) return [];
-    return (projects ?? []).filter(p => p.workspaceId === sessionWorkspaceId);
+    // projectId may be null to clear placement (Personal / no project). The
+    // assignProject endpoint routes through the placement service, so workspace
+    // and the meeting's Actions are re-homed to match.
+    assignProjectMutation.mutate({ transcriptionId, projectId });
   };
 
   const handleSlackSummaryModal = (session: any) => {
@@ -913,12 +908,12 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
     setSelectedTranscriptionIds(new Set());
   };
 
-  const handleBulkProjectAssignment = async () => {
-    if (selectedTranscriptionIds.size === 0 || !bulkProjectAssignment) return;
-    
+  const handleBulkProjectAssignment = async (projectId: string | null) => {
+    if (selectedTranscriptionIds.size === 0) return;
+
     await bulkAssignProjectMutation.mutateAsync({
       transcriptionIds: Array.from(selectedTranscriptionIds),
-      projectId: bulkProjectAssignment === "none" ? null : bulkProjectAssignment,
+      projectId,
     });
   };
 
@@ -1219,6 +1214,25 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
                           Select all
                         </Button>
                       </Group>
+                      <Group gap="sm">
+                        {/* Placement: same searchable, workspace-grouped picker as the rows */}
+                        <MeetingProjectPicker
+                          projects={assignableProjects}
+                          value={null}
+                          onChange={(projectId) => void handleBulkProjectAssignment(projectId)}
+                        >
+                          {({ toggle }) => (
+                            <Button
+                              size="xs"
+                              variant="light"
+                              leftSection={<IconFolder size={14} />}
+                              onClick={toggle}
+                              loading={bulkAssignProjectMutation.isPending}
+                            >
+                              Assign to project
+                            </Button>
+                          )}
+                        </MeetingProjectPicker>
                       <Menu shadow="md">
                         <Menu.Target>
                           <Button size="xs" variant="filled" rightSection={<IconDotsVertical size={14} />}>
@@ -1226,27 +1240,6 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
                           </Button>
                         </Menu.Target>
                         <Menu.Dropdown>
-                          <Menu.Label>Project Assignment</Menu.Label>
-                          {projects?.map(project => (
-                            <Menu.Item
-                              key={project.id}
-                              leftSection={<IconFolder size={14} />}
-                              onClick={() => {
-                                setBulkProjectAssignment(project.id);
-                                void handleBulkProjectAssignment();
-                              }}
-                            >
-                              {project.name}
-                            </Menu.Item>
-                          ))}
-                          <Menu.Divider />
-                          <Menu.Item color="gray" onClick={() => {
-                            setBulkProjectAssignment("none");
-                            void handleBulkProjectAssignment();
-                          }}>
-                            Remove from Project
-                          </Menu.Item>
-                          <Menu.Divider />
                           <Menu.Item leftSection={<IconArchive size={14} />} onClick={() => void handleBulkArchive()}>
                             Archive Meetings
                           </Menu.Item>
@@ -1255,6 +1248,7 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
                           </Menu.Item>
                         </Menu.Dropdown>
                       </Menu>
+                      </Group>
                     </Group>
                   </Paper>
                 )}
@@ -1296,7 +1290,6 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
                       </div>
                       <div className="flex min-w-0 flex-col gap-3">
                         {group.meetings.map((session) => {
-                      const projectsForWorkspace = getProjectsForMeeting(session.workspaceId);
                       const vmSession: MeetingCardSession = {
                         id: session.id,
                         sessionId: session.sessionId,
@@ -1392,60 +1385,36 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
                             </div>
                           </div>
                           <div className="flex shrink-0 items-start gap-3">
-                            {/* Project tag — colored variants by project hash */}
-                            {vm.projectPill && tagClass ? (
-                              <div onClick={stopBubble}>
-                                <Menu shadow="md" width={240}>
-                                  <Menu.Target>
+                            {/* Project placement — searchable, grouped by workspace, across all editable workspaces */}
+                            <div onClick={stopBubble}>
+                              <MeetingProjectPicker
+                                projects={assignableProjects}
+                                value={session.projectId}
+                                onChange={(projectId) => handleProjectAssignment(session.id, projectId)}
+                              >
+                                {({ toggle }) =>
+                                  vm.projectPill && tagClass ? (
                                     <button
                                       type="button"
+                                      onClick={toggle}
                                       className={`inline-flex h-[22px] max-w-[180px] items-center gap-1.5 truncate rounded px-2 text-[11.5px] font-medium ${tagClass.bg} ${tagClass.text}`}
                                     >
                                       <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${tagClass.dot}`} />
                                       <span className="truncate">{vm.projectPill.name}</span>
                                     </button>
-                                  </Menu.Target>
-                                  <Menu.Dropdown>
-                                    <Menu.Label>Reassign project</Menu.Label>
-                                    {projectsForWorkspace.map((p) => (
-                                      <Menu.Item key={p.id} onClick={() => handleProjectAssignment(session.id, p.id)}>
-                                        {p.name}
-                                      </Menu.Item>
-                                    ))}
-                                    <Menu.Divider />
-                                    <Menu.Item color="gray" onClick={() => handleProjectAssignment(session.id, null)}>
-                                      Remove project
-                                    </Menu.Item>
-                                  </Menu.Dropdown>
-                                </Menu>
-                              </div>
-                            ) : (
-                              <div onClick={stopBubble}>
-                                <Menu shadow="md" width={240}>
-                                  <Menu.Target>
+                                  ) : (
                                     <button
                                       type="button"
+                                      onClick={toggle}
                                       className="inline-flex h-[22px] items-center gap-1 rounded border border-dashed border-border-strong px-2 text-[11.5px] text-text-muted hover:border-brand-400 hover:text-brand-400"
                                     >
                                       <IconFolder size={11} />
                                       <span>Assign to project</span>
                                     </button>
-                                  </Menu.Target>
-                                  <Menu.Dropdown>
-                                    <Menu.Label>Assign to project</Menu.Label>
-                                    {projectsForWorkspace.length === 0 ? (
-                                      <Menu.Item disabled>No projects in this workspace</Menu.Item>
-                                    ) : (
-                                      projectsForWorkspace.map((p) => (
-                                        <Menu.Item key={p.id} onClick={() => handleProjectAssignment(session.id, p.id)}>
-                                          {p.name}
-                                        </Menu.Item>
-                                      ))
-                                    )}
-                                  </Menu.Dropdown>
-                                </Menu>
-                              </div>
-                            )}
+                                  )
+                                }
+                              </MeetingProjectPicker>
+                            </div>
 
                             {/* Avatar stack — Participants (calendar invitees) */}
                             {vm.avatars.length > 0 && (

--- a/src/app/_components/meeting/ContextRail.tsx
+++ b/src/app/_components/meeting/ContextRail.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { Select } from "@mantine/core";
 import { DateTimePicker } from "@mantine/dates";
 import {
   IconPlayerPlay,
-  IconArrowRight,
   IconShare,
   IconFileExport,
   IconExternalLink,
@@ -15,6 +13,10 @@ import {
 } from "@tabler/icons-react";
 import { Loader } from "@mantine/core";
 import { MpAvatar } from "./MpAvatar";
+import {
+  MeetingProjectPicker,
+  type MeetingProjectOption,
+} from "./MeetingProjectPicker";
 import type { MeetingParticipant } from "~/lib/meeting-view-model";
 
 interface ContextRailProps {
@@ -30,9 +32,12 @@ interface ContextRailProps {
   updatedLabel: string;
   meetingDate: Date | null;
   onMeetingDateChange: (value: Date | null) => void;
-  workspaceId: string | null;
-  workspaces: { id: string; name: string }[];
-  onWorkspaceChange: (value: string | null) => void;
+  /** Current placement + candidates. Workspace is derived from the project. */
+  projectId: string | null;
+  assignableProjects: MeetingProjectOption[];
+  onProjectChange: (projectId: string | null) => void;
+  /** Read-only workspace label, derived from the placed project. */
+  workspaceName: string | null;
   onShare: () => void;
   onExportTranscript: () => void;
   canExport: boolean;
@@ -56,9 +61,10 @@ export function ContextRail({
   updatedLabel,
   meetingDate,
   onMeetingDateChange,
-  workspaceId,
-  workspaces,
-  onWorkspaceChange,
+  projectId,
+  assignableProjects,
+  onProjectChange,
+  workspaceName,
   onShare,
   onExportTranscript,
   canExport,
@@ -118,33 +124,47 @@ export function ContextRail({
         </div>
       )}
 
-      {project && (
-        <div className="mp-rail__section">
-          <div className="mp-rail__label">Linked</div>
-          {projectHref ? (
-            <Link href={projectHref} className="mp-linkrow">
+      <div className="mp-rail__section">
+        <div className="mp-rail__label">Linked</div>
+        {/* Project placement — searchable, grouped by workspace. Picking a
+            project sets the meeting's workspace (and re-homes its Actions). */}
+        <MeetingProjectPicker
+          projects={assignableProjects}
+          value={projectId}
+          onChange={onProjectChange}
+        >
+          {({ toggle }) => (
+            <button
+              type="button"
+              onClick={toggle}
+              className="mp-linkrow"
+              style={{ width: "100%", textAlign: "left", cursor: "pointer" }}
+            >
               <span className="mp-linkrow__glyph mp-linkrow__glyph--ritual">
-                {project.name.charAt(0).toUpperCase()}
+                {project ? project.name.charAt(0).toUpperCase() : "+"}
               </span>
               <div style={{ minWidth: 0 }}>
-                <div className="mp-linkrow__title">{project.name}</div>
-                <div className="mp-linkrow__sub">Project</div>
+                <div className="mp-linkrow__title">
+                  {project ? project.name : "Assign to project"}
+                </div>
+                <div className="mp-linkrow__sub">
+                  {project
+                    ? workspaceName ?? "Project"
+                    : "Sets the workspace too"}
+                </div>
               </div>
-              <IconArrowRight size={13} className="mp-linkrow__arrow" />
-            </Link>
-          ) : (
-            <div className="mp-linkrow">
-              <span className="mp-linkrow__glyph mp-linkrow__glyph--ritual">
-                {project.name.charAt(0).toUpperCase()}
-              </span>
-              <div style={{ minWidth: 0 }}>
-                <div className="mp-linkrow__title">{project.name}</div>
-                <div className="mp-linkrow__sub">Project</div>
-              </div>
-            </div>
+            </button>
           )}
-        </div>
-      )}
+        </MeetingProjectPicker>
+        {project && projectHref && (
+          <Link
+            href={projectHref}
+            className="mt-1.5 inline-flex items-center gap-1 text-[11px] text-text-muted hover:text-brand-400"
+          >
+            <IconExternalLink size={12} /> Open project
+          </Link>
+        )}
+      </div>
 
       {(hasVideo || sourceLabel) && (
         <div className="mp-rail__section">
@@ -184,6 +204,10 @@ export function ContextRail({
               {sessionId.length > 8 ? `…${sessionId.slice(-6)}` : sessionId}
             </span>
           </div>
+          <div className="mp-railkv__row">
+            <span className="mp-railkv__k">Workspace</span>
+            <span className="mp-railkv__v">{workspaceName ?? "Personal"}</span>
+          </div>
         </div>
         <div className="mp-rail__field">
           <DateTimePicker
@@ -196,20 +220,6 @@ export function ContextRail({
             popoverProps={{ withinPortal: true }}
           />
         </div>
-        {workspaces.length > 0 && (
-          <div className="mp-rail__field">
-            <Select
-              label="Workspace"
-              size="xs"
-              data={[
-                { value: "", label: "No workspace" },
-                ...workspaces.map((ws) => ({ value: ws.id, label: ws.name })),
-              ]}
-              value={workspaceId ?? ""}
-              onChange={(value) => onWorkspaceChange(value === "" ? null : value)}
-            />
-          </div>
-        )}
       </div>
 
       <div className="mp-rail__section">

--- a/src/app/_components/meeting/MeetingDetail.tsx
+++ b/src/app/_components/meeting/MeetingDetail.tsx
@@ -15,6 +15,7 @@ import {
 } from "./ParticipantPicker";
 import { buildMeetingViewModel } from "~/lib/meeting-view-model";
 import type { MeetingSession } from "~/lib/meeting-view-model";
+import type { MeetingProjectOption } from "./MeetingProjectPicker";
 import { api, type RouterOutputs } from "~/trpc/react";
 
 type TranscriptAction = RouterOutputs["action"]["getByTranscription"][number];
@@ -24,13 +25,15 @@ interface MeetingDetailProps {
   session: MeetingSession;
   actions: TranscriptAction[];
   isActionsLoading: boolean;
-  workspaces: { id: string; name: string }[];
+  /** Candidate projects for placement (edit-scoped, across workspaces). */
+  assignableProjects: MeetingProjectOption[];
   isCreatingActions: boolean;
   /** True while a summary is being auto-generated on view for this meeting. */
   isGeneratingSummary: boolean;
   onSaveSummary: (value: string) => Promise<void>;
   onMeetingDateChange: (value: Date | null) => void;
-  onWorkspaceChange: (value: string | null) => void;
+  /** Place the meeting onto a project (null clears placement). */
+  onProjectChange: (projectId: string | null) => void;
   onCreateActions: () => void;
   onArchive: () => void;
 }
@@ -57,12 +60,12 @@ export function MeetingDetail({
   session,
   actions,
   isActionsLoading,
-  workspaces,
+  assignableProjects,
   isCreatingActions,
   isGeneratingSummary,
   onSaveSummary,
   onMeetingDateChange,
-  onWorkspaceChange,
+  onProjectChange,
   onCreateActions,
   onArchive,
 }: MeetingDetailProps) {
@@ -261,9 +264,10 @@ export function MeetingDetail({
             updatedLabel={new Date(session.updatedAt).toLocaleString(undefined, timestampFmt)}
             meetingDate={meetingDateObj}
             onMeetingDateChange={onMeetingDateChange}
-            workspaceId={session.workspaceId ?? null}
-            workspaces={workspaces}
-            onWorkspaceChange={onWorkspaceChange}
+            projectId={session.projectId ?? null}
+            assignableProjects={assignableProjects}
+            onProjectChange={onProjectChange}
+            workspaceName={session.workspace?.name ?? null}
             onShare={handleShare}
             onExportTranscript={handleExportTranscript}
             canExport={Boolean(session.transcription)}

--- a/src/app/_components/meeting/MeetingProjectPicker.tsx
+++ b/src/app/_components/meeting/MeetingProjectPicker.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useMemo, useState, type ReactNode } from "react";
+import { Combobox, Text, useCombobox } from "@mantine/core";
+
+/** A project option, grouped by its workspace in the dropdown. */
+export interface MeetingProjectOption {
+  id: string;
+  name: string;
+  /** Null for personal (workspace-less) projects. */
+  workspaceId: string | null;
+  workspaceName: string | null;
+}
+
+const NONE_VALUE = "__none__";
+const PERSONAL_GROUP = "Personal";
+
+interface MeetingProjectPickerProps {
+  /** Candidate projects (already edit-scoped + sorted by the server). */
+  projects: MeetingProjectOption[];
+  /** Currently placed project id, or null for Personal / no project. */
+  value: string | null;
+  /** Called with the chosen project id, or null to clear placement. */
+  onChange: (projectId: string | null) => void;
+  /** Custom trigger — receives a `toggle` to open/close the dropdown. */
+  children: (args: { toggle: () => void }) => ReactNode;
+  /** Label for the clear-placement option. */
+  noneLabel?: string;
+  dropdownWidth?: number;
+}
+
+/**
+ * Searchable project picker for placing a meeting, grouped by workspace, with a
+ * "Personal / no project" option that clears placement. The caller owns
+ * persistence via `onChange` and renders its own trigger via `children` so the
+ * picker can be reused from the meetings list row, the bulk bar, and the
+ * meeting detail page.
+ */
+export function MeetingProjectPicker({
+  projects,
+  value,
+  onChange,
+  children,
+  noneLabel = "Personal / no project",
+  dropdownWidth = 260,
+}: MeetingProjectPickerProps) {
+  const combobox = useCombobox({
+    onDropdownClose: () => {
+      combobox.resetSelectedOption();
+      setSearch("");
+    },
+  });
+  const [search, setSearch] = useState("");
+
+  const groups = useMemo(() => {
+    const q = search.toLowerCase().trim();
+    const filtered = q
+      ? projects.filter((p) => p.name.toLowerCase().includes(q))
+      : projects;
+    // Preserve the server's sort order while bucketing by workspace.
+    const byGroup = new Map<string, MeetingProjectOption[]>();
+    for (const p of filtered) {
+      const key = p.workspaceName ?? PERSONAL_GROUP;
+      const bucket = byGroup.get(key);
+      if (bucket) bucket.push(p);
+      else byGroup.set(key, [p]);
+    }
+    return Array.from(byGroup.entries());
+  }, [projects, search]);
+
+  return (
+    <Combobox
+      store={combobox}
+      width={dropdownWidth}
+      position="bottom-end"
+      onOptionSubmit={(val) => {
+        onChange(val === NONE_VALUE ? null : val);
+        combobox.closeDropdown();
+      }}
+    >
+      <Combobox.Target>
+        <div onClick={() => combobox.toggleDropdown()}>
+          {children({ toggle: () => combobox.toggleDropdown() })}
+        </div>
+      </Combobox.Target>
+      <Combobox.Dropdown>
+        <Combobox.Search
+          value={search}
+          onChange={(e) => {
+            setSearch(e.currentTarget.value);
+            combobox.updateSelectedOptionIndex();
+          }}
+          placeholder="Search projects…"
+          size="xs"
+        />
+        <Combobox.Options mah={280} style={{ overflowY: "auto" }}>
+          <Combobox.Option value={NONE_VALUE} active={value === null}>
+            <Text size="xs" className="text-text-muted">
+              {noneLabel}
+            </Text>
+          </Combobox.Option>
+          {groups.map(([groupName, items]) => (
+            <Combobox.Group key={groupName} label={groupName}>
+              {items.map((p) => (
+                <Combobox.Option key={p.id} value={p.id} active={value === p.id}>
+                  <Text size="xs">{p.name}</Text>
+                </Combobox.Option>
+              ))}
+            </Combobox.Group>
+          ))}
+          {groups.length === 0 && (
+            <Combobox.Empty>
+              <Text size="xs" className="text-text-muted">
+                No matching projects
+              </Text>
+            </Combobox.Empty>
+          )}
+        </Combobox.Options>
+      </Combobox.Dropdown>
+    </Combobox>
+  );
+}

--- a/src/app/_components/meeting/__tests__/MeetingProjectPicker.test.tsx
+++ b/src/app/_components/meeting/__tests__/MeetingProjectPicker.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Component tests for MeetingProjectPicker. Asserts external behaviour: it
+ * groups options by workspace, filters on search, always offers the clear
+ * ("Personal / no project") option, and emits the selected project id (or null)
+ * to onChange.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "~/test/test-utils";
+import "@testing-library/jest-dom/vitest";
+
+import {
+  MeetingProjectPicker,
+  type MeetingProjectOption,
+} from "../MeetingProjectPicker";
+
+const PROJECTS: MeetingProjectOption[] = [
+  { id: "p1", name: "Alpha", workspaceId: "ws1", workspaceName: "Acme" },
+  { id: "p2", name: "Bravo", workspaceId: "ws1", workspaceName: "Acme" },
+  { id: "p3", name: "Charlie", workspaceId: "ws2", workspaceName: "Beta Co" },
+];
+
+function setup(value: string | null = null) {
+  const onChange = vi.fn();
+  render(
+    <MeetingProjectPicker projects={PROJECTS} value={value} onChange={onChange}>
+      {() => <button type="button">trigger</button>}
+    </MeetingProjectPicker>,
+  );
+  fireEvent.click(screen.getByText("trigger"));
+  return { onChange };
+}
+
+describe("MeetingProjectPicker", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("groups options by workspace and always offers the clear option", () => {
+    setup();
+    expect(screen.getByText("Personal / no project")).toBeInTheDocument();
+    // Group labels rendered for each workspace.
+    expect(screen.getByText("Acme")).toBeInTheDocument();
+    expect(screen.getByText("Beta Co")).toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Charlie")).toBeInTheDocument();
+  });
+
+  it("filters options as the user types", () => {
+    setup();
+    fireEvent.change(screen.getByPlaceholderText("Search projects…"), {
+      target: { value: "char" },
+    });
+    expect(screen.getByText("Charlie")).toBeInTheDocument();
+    expect(screen.queryByText("Alpha")).not.toBeInTheDocument();
+    // The Beta Co group survives (it holds the match); Acme is gone.
+    expect(screen.queryByText("Acme")).not.toBeInTheDocument();
+  });
+
+  it("emits the chosen project id", () => {
+    const { onChange } = setup();
+    fireEvent.click(screen.getByText("Bravo"));
+    expect(onChange).toHaveBeenCalledWith("p2");
+  });
+
+  it("emits null when the clear option is chosen", () => {
+    const { onChange } = setup("p1");
+    fireEvent.click(screen.getByText("Personal / no project"));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("shows an empty state when search matches nothing", () => {
+    setup();
+    fireEvent.change(screen.getByPlaceholderText("Search projects…"), {
+      target: { value: "zzz" },
+    });
+    expect(screen.getByText("No matching projects")).toBeInTheDocument();
+  });
+});

--- a/src/server/api/routers/project.ts
+++ b/src/server/api/routers/project.ts
@@ -15,6 +15,7 @@ import {
 } from "~/server/services/access";
 import { completeOnboardingStep } from "~/server/services/onboarding/syncOnboardingProgress";
 import { recordActivity } from "~/server/services/activity/recordActivity";
+import { getAssignableProjects } from "~/server/services/meetings/getAssignableProjects";
 import type { PrismaClient } from "@prisma/client";
 
 /**
@@ -75,6 +76,15 @@ export const projectRouter = createTRPCRouter({
         projects,
       };
     }),
+
+  /**
+   * Candidate projects for placing a meeting: every project the caller can
+   * edit, across all their workspaces, tagged with workspace for grouping in
+   * the placement picker. See `getAssignableProjects`.
+   */
+  getAssignable: protectedProcedure.query(({ ctx }) =>
+    getAssignableProjects(ctx.db, ctx.session.user.id),
+  ),
 
   getAll: protectedProcedure
     .input(z.object({

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -12,6 +12,7 @@ import { TranscriptionProcessingService } from "~/server/services/TranscriptionP
 import { weeklyMeetingStats } from "~/server/services/meetings/weeklyMeetingStats";
 import { summarizeMeetingRow } from "~/server/services/meetings/ensureMeetingSummary";
 import { runMeetingSummarySweep } from "~/server/services/meetings/meetingSummarySweep";
+import { assignMeetingPlacement } from "~/server/services/meetings/assignMeetingPlacement";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import {
   TranscriptSummarizerService,
@@ -19,7 +20,6 @@ import {
 } from "~/server/services/TranscriptSummarizerService";
 import {
   buildTranscriptionAccessWhere,
-  canEditProject,
   canEditTranscription,
   canViewTranscription,
   getProjectAccess,
@@ -1188,61 +1188,18 @@ export const transcriptionRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      // Verify the user can edit the source transcription.
-      const existing = await ctx.db.transcriptionSession.findUnique({
+      // Single placement path: resolves the project's workspace, enforces edit
+      // access on the meeting and the target project, and re-homes the meeting
+      // AND its Actions (projectId + workspaceId) together.
+      await assignMeetingPlacement(ctx.db, ctx.session.user.id, {
+        meetingIds: [input.transcriptionId],
+        projectId: input.projectId,
+        scope: "editable",
+      });
+
+      return ctx.db.transcriptionSession.findUniqueOrThrow({
         where: { id: input.transcriptionId },
-        select: { id: true, userId: true, projectId: true, workspaceId: true },
       });
-      if (!existing) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Transcription not found",
-        });
-      }
-      await ensureTranscriptionAccess(
-        ctx.db,
-        ctx.session.user.id,
-        existing,
-        "edit",
-      );
-
-      // Verify the user can edit the target project, and resolve its workspace.
-      let workspaceId: string | null = null;
-      if (input.projectId) {
-        const targetAccess = await getProjectAccess(
-          ctx.db,
-          ctx.session.user.id,
-          input.projectId,
-        );
-        if (!canEditProject(targetAccess)) {
-          throw new TRPCError({
-            code: "FORBIDDEN",
-            message: "You do not have edit access to the target project",
-          });
-        }
-        const project = await ctx.db.project.findUnique({
-          where: { id: input.projectId },
-          select: { workspaceId: true },
-        });
-        workspaceId = project?.workspaceId ?? null;
-      }
-
-      const session = await ctx.db.transcriptionSession.update({
-        where: { id: input.transcriptionId },
-        data: {
-          projectId: input.projectId,
-          workspaceId,
-          updatedAt: new Date(),
-        },
-      });
-
-      // Also update all associated actions to the same project
-      await ctx.db.action.updateMany({
-        where: { transcriptionSessionId: input.transcriptionId },
-        data: { projectId: input.projectId },
-      });
-
-      return session;
     }),
 
   bulkAssignProject: protectedProcedure
@@ -1253,51 +1210,17 @@ export const transcriptionRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      // Verify the user can edit the target project, and resolve its workspace.
-      let workspaceId: string | null = null;
-      if (input.projectId) {
-        const targetAccess = await getProjectAccess(
-          ctx.db,
-          ctx.session.user.id,
-          input.projectId,
-        );
-        if (!canEditProject(targetAccess)) {
-          throw new TRPCError({
-            code: "FORBIDDEN",
-            message: "You do not have edit access to the target project",
-          });
-        }
-        const project = await ctx.db.project.findUnique({
-          where: { id: input.projectId },
-          select: { workspaceId: true },
-        });
-        workspaceId = project?.workspaceId ?? null;
-      }
-
-      // Sources are scoped to user-owned transcriptions to keep bulk
-      // semantics narrow — broader source access can be added once the UI
-      // exposes shared transcriptions.
-      const result = await ctx.db.transcriptionSession.updateMany({
-        where: {
-          id: { in: input.transcriptionIds },
-          userId: ctx.session.user.id,
-        },
-        data: {
+      // Bulk placement: narrow "owner" scope (only the caller's own meetings are
+      // touched). Same service re-homes each meeting AND its Actions together.
+      const result = await assignMeetingPlacement(
+        ctx.db,
+        ctx.session.user.id,
+        {
+          meetingIds: input.transcriptionIds,
           projectId: input.projectId,
-          workspaceId,
-          updatedAt: new Date(),
+          scope: "owner",
         },
-      });
-
-      // Also update actions of the transcriptions we just touched. Mirror
-      // the source userId scope so we don't touch other users' actions.
-      await ctx.db.action.updateMany({
-        where: {
-          transcriptionSessionId: { in: input.transcriptionIds },
-          transcriptionSession: { userId: ctx.session.user.id },
-        },
-        data: { projectId: input.projectId },
-      });
+      );
 
       return { count: result.count };
     }),

--- a/src/server/services/TranscriptionProcessingService.ts
+++ b/src/server/services/TranscriptionProcessingService.ts
@@ -9,6 +9,7 @@ import {
   getProjectAccess,
   hasProjectAccess as userHasProjectAccess,
 } from './access';
+import { assignMeetingPlacement } from './meetings/assignMeetingPlacement';
 
 export interface ProcessTranscriptionResult {
   success: boolean;
@@ -509,36 +510,16 @@ export class TranscriptionProcessingService {
     autoProcess = true
   ): Promise<{ success: boolean; error?: string; processed?: ProcessTranscriptionResult }> {
     try {
-      // 1. Verify user has access to both transcription and project
-      const transcription = await db.transcriptionSession.findUnique({
-        where: { id: transcriptionId }
+      // 1. Place the meeting through the single placement service so the
+      //    meeting AND its extracted Actions are re-homed together (projectId +
+      //    workspaceId), and edit access on both the meeting and the target
+      //    project is enforced. Then optionally run extraction.
+      await assignMeetingPlacement(db, userId, {
+        meetingIds: [transcriptionId],
+        projectId,
+        scope: "editable",
       });
 
-      if (!transcription || transcription.userId !== userId) {
-        return { success: false, error: 'Transcription not found or access denied' };
-      }
-
-      const hasProjectAccess = await this.verifyUserAccess(userId, projectId);
-      if (!hasProjectAccess) {
-        return { success: false, error: 'Access denied to project' };
-      }
-
-      // Get the project's workspace to inherit
-      const project = await db.project.findUnique({
-        where: { id: projectId },
-        select: { workspaceId: true }
-      });
-
-      // 2. Update the transcription with the project and workspace
-      await db.transcriptionSession.update({
-        where: { id: transcriptionId },
-        data: {
-          projectId,
-          workspaceId: project?.workspaceId ?? null
-        }
-      });
-
-      // 3. Optionally process the transcription
       if (autoProcess) {
         const processed = await this.processTranscription(transcriptionId, userId);
         return { success: true, processed };

--- a/src/server/services/access/index.ts
+++ b/src/server/services/access/index.ts
@@ -79,6 +79,7 @@ export {
   canEditProject,
   canManageProjectMembers,
   buildProjectAccessWhere,
+  buildProjectEditWhere,
 } from "./resolvers/projectResolver";
 export {
   getActionAccess,

--- a/src/server/services/access/resolvers/projectResolver.ts
+++ b/src/server/services/access/resolvers/projectResolver.ts
@@ -198,3 +198,63 @@ export function buildProjectAccessWhere(
     ],
   };
 }
+
+/**
+ * Prisma WHERE clause for projects a user can **edit** (the DB-level mirror of
+ * {@link canEditProject}). Stricter than {@link buildProjectAccessWhere}:
+ * `isPublic` alone grants view but not edit, and a restricted project requires
+ * an editor+ project-member role (not mere viewer membership) or the workspace
+ * owner/admin escape hatch.
+ *
+ * Use for candidate lists where the next action requires edit rights — e.g.
+ * the projects a meeting can be placed onto.
+ */
+export function buildProjectEditWhere(
+  userId: string,
+): Prisma.ProjectWhereInput {
+  return {
+    OR: [
+      { createdById: userId },
+      // Unrestricted: any project/team/workspace membership grants edit.
+      {
+        AND: [
+          { isRestricted: false },
+          {
+            OR: [
+              { projectMembers: { some: { userId } } },
+              { team: { members: { some: { userId } } } },
+              { workspace: { members: { some: { userId } } } },
+              {
+                workspace: {
+                  teams: { some: { members: { some: { userId } } } },
+                },
+              },
+            ],
+          },
+        ],
+      },
+      // Restricted: editor+ project member, or workspace owner/admin escape hatch.
+      {
+        AND: [
+          { isRestricted: true },
+          {
+            OR: [
+              {
+                projectMembers: {
+                  some: { userId, role: { in: ["admin", "editor"] } },
+                },
+              },
+              {
+                workspace: {
+                  members: {
+                    some: { userId, role: { in: ["owner", "admin"] } },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/src/server/services/meetings/__tests__/assignMeetingPlacement.test.ts
+++ b/src/server/services/meetings/__tests__/assignMeetingPlacement.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for the `assignMeetingPlacement` deep module.
+ *
+ * Uses `mockDeep<PrismaClient>()` so tests run in milliseconds and never touch
+ * a real DB (per CLAUDE.md "Test database safety"). The access resolvers are
+ * mocked so each test controls access outcomes directly and asserts the
+ * service's own logic: project-authoritative workspace resolution, Action
+ * re-homing, the null-clear case, edit-access enforcement, and bulk scoping.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+
+import { assignMeetingPlacement } from "../assignMeetingPlacement";
+import {
+  getProjectAccess,
+  canEditProject,
+  getTranscriptionAccess,
+  canEditTranscription,
+} from "~/server/services/access";
+
+vi.mock("~/server/services/access", () => ({
+  getProjectAccess: vi.fn(),
+  canEditProject: vi.fn(),
+  getTranscriptionAccess: vi.fn(),
+  canEditTranscription: vi.fn(),
+}));
+
+const db = mockDeep<PrismaClient>();
+const USER = "user-1";
+
+/** Make $transaction run the array of (mocked) Prisma promises, as in prod. */
+function runTransactionsLikeProd(mock: DeepMockProxy<PrismaClient>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (mock.$transaction as any).mockImplementation((ops: unknown) =>
+    Promise.all(ops as Promise<unknown>[]),
+  );
+}
+
+beforeEach(() => {
+  mockReset(db);
+  vi.mocked(getProjectAccess).mockReset();
+  vi.mocked(canEditProject).mockReset();
+  vi.mocked(getTranscriptionAccess).mockReset();
+  vi.mocked(canEditTranscription).mockReset();
+  runTransactionsLikeProd(db);
+  // Default: updateMany reports one row touched.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (db.transcriptionSession.updateMany as any).mockResolvedValue({ count: 1 });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (db.action.updateMany as any).mockResolvedValue({ count: 0 });
+});
+
+describe("assignMeetingPlacement", () => {
+  it("derives the meeting's workspace from the target project (project-authoritative)", async () => {
+    vi.mocked(canEditProject).mockReturnValue(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.project.findUnique as any).mockResolvedValue({ workspaceId: "ws-A" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.transcriptionSession.findMany as any).mockResolvedValue([{ id: "m1" }]);
+
+    const result = await assignMeetingPlacement(db, USER, {
+      meetingIds: ["m1"],
+      projectId: "proj-1",
+      scope: "owner",
+    });
+
+    expect(result.workspaceId).toBe("ws-A");
+    expect(db.transcriptionSession.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ projectId: "proj-1", workspaceId: "ws-A" }),
+      }),
+    );
+  });
+
+  it("re-homes child Actions' projectId AND workspaceId to match the meeting", async () => {
+    vi.mocked(canEditProject).mockReturnValue(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.project.findUnique as any).mockResolvedValue({ workspaceId: "ws-A" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.transcriptionSession.findMany as any).mockResolvedValue([{ id: "m1" }]);
+
+    await assignMeetingPlacement(db, USER, {
+      meetingIds: ["m1"],
+      projectId: "proj-1",
+      scope: "owner",
+    });
+
+    expect(db.action.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          transcriptionSessionId: { in: ["m1"] },
+        }),
+        data: { projectId: "proj-1", workspaceId: "ws-A" },
+      }),
+    );
+  });
+
+  it("clears project AND workspace on the meeting and its Actions when projectId is null", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.transcriptionSession.findMany as any).mockResolvedValue([{ id: "m1" }]);
+
+    const result = await assignMeetingPlacement(db, USER, {
+      meetingIds: ["m1"],
+      projectId: null,
+      scope: "owner",
+    });
+
+    expect(result.workspaceId).toBeNull();
+    // No project access check is performed for a null target.
+    expect(getProjectAccess).not.toHaveBeenCalled();
+    expect(db.action.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { projectId: null, workspaceId: null },
+      }),
+    );
+  });
+
+  it("throws FORBIDDEN when the caller cannot edit the target project", async () => {
+    vi.mocked(canEditProject).mockReturnValue(false);
+
+    await expect(
+      assignMeetingPlacement(db, USER, {
+        meetingIds: ["m1"],
+        projectId: "proj-1",
+        scope: "editable",
+      }),
+    ).rejects.toThrow(TRPCError);
+    expect(db.transcriptionSession.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("throws FORBIDDEN (editable scope) when the caller cannot edit a requested meeting", async () => {
+    vi.mocked(canEditProject).mockReturnValue(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.project.findUnique as any).mockResolvedValue({ workspaceId: "ws-A" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.transcriptionSession.findMany as any).mockResolvedValue([
+      { id: "m1", userId: "someone-else", projectId: null, workspaceId: null },
+    ]);
+    vi.mocked(getTranscriptionAccess).mockResolvedValue({} as never);
+    vi.mocked(canEditTranscription).mockReturnValue(false);
+
+    await expect(
+      assignMeetingPlacement(db, USER, {
+        meetingIds: ["m1"],
+        projectId: "proj-1",
+        scope: "editable",
+      }),
+    ).rejects.toThrow(TRPCError);
+    expect(db.transcriptionSession.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("owner scope only places meetings the caller owns, and never touches others' actions", async () => {
+    vi.mocked(canEditProject).mockReturnValue(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.project.findUnique as any).mockResolvedValue({ workspaceId: "ws-A" });
+    // Caller requested m1, m2, m3 but only owns m1 and m3.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.transcriptionSession.findMany as any).mockResolvedValue([
+      { id: "m1" },
+      { id: "m3" },
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.transcriptionSession.updateMany as any).mockResolvedValue({ count: 2 });
+
+    const result = await assignMeetingPlacement(db, USER, {
+      meetingIds: ["m1", "m2", "m3"],
+      projectId: "proj-1",
+      scope: "owner",
+    });
+
+    expect(result.count).toBe(2);
+    // Ownership lookup scoped to the caller.
+    expect(db.transcriptionSession.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: ["m1", "m2", "m3"] }, userId: USER },
+      }),
+    );
+    // Only the owned ids are written; the action update mirrors the owner guard.
+    expect(db.transcriptionSession.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: ["m1", "m3"] }, userId: USER },
+      }),
+    );
+    expect(db.action.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          transcriptionSessionId: { in: ["m1", "m3"] },
+          transcriptionSession: { userId: USER },
+        }),
+      }),
+    );
+  });
+
+  it("is a no-op for an empty meeting set", async () => {
+    const result = await assignMeetingPlacement(db, USER, {
+      meetingIds: [],
+      projectId: "proj-1",
+      scope: "owner",
+    });
+
+    expect(result.count).toBe(0);
+    expect(getProjectAccess).not.toHaveBeenCalled();
+    expect(db.transcriptionSession.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/meetings/__tests__/getAssignableProjects.test.ts
+++ b/src/server/services/meetings/__tests__/getAssignableProjects.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for the `getAssignableProjects` candidate resolver.
+ *
+ * Mocked Prisma (per CLAUDE.md "Test database safety"). The DB-level edit
+ * filtering is exercised by `buildProjectEditWhere`'s own coverage and the
+ * router integration tests; here we assert the service's contract: it scopes by
+ * the edit where-clause, requests workspace data for grouping, and shapes each
+ * row as `{ id, name, workspaceId, workspaceName }` (workspace-less → null).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mockDeep, mockReset } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import { getAssignableProjects } from "../getAssignableProjects";
+import { buildProjectEditWhere } from "~/server/services/access";
+
+vi.mock("~/server/services/access", () => ({
+  buildProjectEditWhere: vi.fn(() => ({ __editWhere: true })),
+}));
+
+const db = mockDeep<PrismaClient>();
+const USER = "user-1";
+
+beforeEach(() => {
+  mockReset(db);
+  vi.mocked(buildProjectEditWhere).mockClear();
+});
+
+describe("getAssignableProjects", () => {
+  it("scopes the query to the caller's editable projects and groups by workspace", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.project.findMany as any).mockResolvedValue([
+      { id: "p1", name: "Alpha", workspaceId: "ws-1", workspace: { name: "Acme" } },
+      { id: "p2", name: "Beta", workspaceId: "ws-2", workspace: { name: "Beta Co" } },
+    ]);
+
+    const result = await getAssignableProjects(db, USER);
+
+    expect(buildProjectEditWhere).toHaveBeenCalledWith(USER);
+    expect(db.project.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { __editWhere: true },
+        orderBy: [{ workspace: { name: "asc" } }, { name: "asc" }],
+      }),
+    );
+    expect(result).toEqual([
+      { id: "p1", name: "Alpha", workspaceId: "ws-1", workspaceName: "Acme" },
+      { id: "p2", name: "Beta", workspaceId: "ws-2", workspaceName: "Beta Co" },
+    ]);
+  });
+
+  it("maps a personal (workspace-less) project to null workspace fields", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.project.findMany as any).mockResolvedValue([
+      { id: "p3", name: "Personal thing", workspaceId: null, workspace: null },
+    ]);
+
+    const result = await getAssignableProjects(db, USER);
+
+    expect(result).toEqual([
+      { id: "p3", name: "Personal thing", workspaceId: null, workspaceName: null },
+    ]);
+  });
+
+  it("returns an empty list when the caller can edit nothing", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.project.findMany as any).mockResolvedValue([]);
+
+    expect(await getAssignableProjects(db, USER)).toEqual([]);
+  });
+});

--- a/src/server/services/meetings/assignMeetingPlacement.ts
+++ b/src/server/services/meetings/assignMeetingPlacement.ts
@@ -1,0 +1,140 @@
+import type { PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+import {
+  getProjectAccess,
+  canEditProject,
+  getTranscriptionAccess,
+  canEditTranscription,
+} from "~/server/services/access";
+
+/**
+ * The single way a Meeting gets placed.
+ *
+ * Placing a Meeting onto a Project is **project-authoritative**: the Meeting's
+ * Workspace is derived from the chosen Project, never set independently. A null
+ * `projectId` clears both Project and Workspace (the "Personal / no project"
+ * case). In every case the Meeting's extracted Actions are re-homed with it:
+ * an Action from a Meeting never sits in a different Workspace than its Meeting
+ * (see CONTEXT.md). This module is the canonical home of that invariant —
+ * `assignProject`, `bulkAssignProject`, and the detail page's placement write
+ * all delegate here so there is exactly one placement path.
+ *
+ * Deep module: pure server logic, no tRPC procedure types and no React in the
+ * interface. Errors surface as `TRPCError` to preserve the existing FORBIDDEN /
+ * NOT_FOUND contract the routers already expose.
+ */
+export type MeetingPlacementScope = "owner" | "editable";
+
+export interface AssignMeetingPlacementInput {
+  /** Meetings (`TranscriptionSession` ids) to place. */
+  meetingIds: string[];
+  /** Target project, or null to clear placement to Personal / no project. */
+  projectId: string | null;
+  /**
+   * Access semantics for the set:
+   * - `"owner"` — only Meetings owned by `userId` are ever touched (the narrow
+   *   bulk semantics; silently skips Meetings the caller doesn't own).
+   * - `"editable"` — every requested Meeting must pass the canonical edit-access
+   *   resolver (ADR-0014) or the whole call fails FORBIDDEN (single-meeting
+   *   semantics, where a non-owner with project/workspace edit rights may place).
+   */
+  scope: MeetingPlacementScope;
+}
+
+export interface AssignMeetingPlacementResult {
+  /** Number of Meetings actually re-homed. */
+  count: number;
+  /** The placement applied — workspace resolved from the project. */
+  projectId: string | null;
+  workspaceId: string | null;
+}
+
+export async function assignMeetingPlacement(
+  db: PrismaClient,
+  userId: string,
+  input: AssignMeetingPlacementInput,
+): Promise<AssignMeetingPlacementResult> {
+  const { meetingIds, projectId, scope } = input;
+
+  if (meetingIds.length === 0) {
+    return { count: 0, projectId, workspaceId: null };
+  }
+
+  // 1. Resolve the target Workspace from the Project (project-authoritative).
+  //    Placing onto a Project requires edit access to that Project.
+  let workspaceId: string | null = null;
+  if (projectId) {
+    const projectAccess = await getProjectAccess(db, userId, projectId);
+    if (!canEditProject(projectAccess)) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "You do not have edit access to the target project",
+      });
+    }
+    const project = await db.project.findUnique({
+      where: { id: projectId },
+      select: { workspaceId: true },
+    });
+    if (!project) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Target project not found",
+      });
+    }
+    workspaceId = project.workspaceId ?? null;
+  }
+
+  // 2. Determine which of the requested Meetings the caller may place.
+  let placeableIds: string[];
+  if (scope === "owner") {
+    const owned = await db.transcriptionSession.findMany({
+      where: { id: { in: meetingIds }, userId },
+      select: { id: true },
+    });
+    placeableIds = owned.map((m) => m.id);
+  } else {
+    const sessions = await db.transcriptionSession.findMany({
+      where: { id: { in: meetingIds } },
+      select: { id: true, userId: true, projectId: true, workspaceId: true },
+    });
+    const byId = new Map(sessions.map((s) => [s.id, s]));
+    for (const id of meetingIds) {
+      const session = byId.get(id);
+      if (!session) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meeting not found" });
+      }
+      const access = await getTranscriptionAccess(db, userId, session);
+      if (!canEditTranscription(access)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You do not have edit access to this meeting",
+        });
+      }
+    }
+    placeableIds = meetingIds;
+  }
+
+  if (placeableIds.length === 0) {
+    return { count: 0, projectId, workspaceId };
+  }
+
+  // 3. Re-home the Meetings AND their extracted Actions atomically — projectId
+  //    and workspaceId always move together. The owner guard is repeated in the
+  //    where clauses as defense-in-depth for the bulk path.
+  const ownerGuard = scope === "owner" ? { userId } : {};
+  const [sessionResult] = await db.$transaction([
+    db.transcriptionSession.updateMany({
+      where: { id: { in: placeableIds }, ...ownerGuard },
+      data: { projectId, workspaceId, updatedAt: new Date() },
+    }),
+    db.action.updateMany({
+      where: {
+        transcriptionSessionId: { in: placeableIds },
+        ...(scope === "owner" ? { transcriptionSession: { userId } } : {}),
+      },
+      data: { projectId, workspaceId },
+    }),
+  ]);
+
+  return { count: sessionResult.count, projectId, workspaceId };
+}

--- a/src/server/services/meetings/getAssignableProjects.ts
+++ b/src/server/services/meetings/getAssignableProjects.ts
@@ -1,0 +1,46 @@
+import type { PrismaClient } from "@prisma/client";
+import { buildProjectEditWhere } from "~/server/services/access";
+
+/**
+ * A project a meeting can be placed onto, carrying its workspace for grouping
+ * in the placement picker.
+ */
+export interface AssignableProject {
+  id: string;
+  name: string;
+  /** Null for personal (workspace-less) projects. */
+  workspaceId: string | null;
+  workspaceName: string | null;
+}
+
+/**
+ * The candidate projects for placing a meeting: every project the caller can
+ * **edit**, across all their workspaces, each tagged with its workspace so the
+ * picker can group by workspace. Edit (not view) is the bar because placement
+ * itself requires edit access — see {@link buildProjectEditWhere}. Ordered by
+ * workspace name, then project name, for stable grouped rendering.
+ *
+ * Deep module: pure read-side query, no tRPC/React types in the interface.
+ */
+export async function getAssignableProjects(
+  db: PrismaClient,
+  userId: string,
+): Promise<AssignableProject[]> {
+  const projects = await db.project.findMany({
+    where: buildProjectEditWhere(userId),
+    select: {
+      id: true,
+      name: true,
+      workspaceId: true,
+      workspace: { select: { name: true } },
+    },
+    orderBy: [{ workspace: { name: "asc" } }, { name: "asc" }],
+  });
+
+  return projects.map((p) => ({
+    id: p.id,
+    name: p.name,
+    workspaceId: p.workspaceId,
+    workspaceName: p.workspace?.name ?? null,
+  }));
+}


### PR DESCRIPTION
## Meeting placement: triage incoming meetings into the right workspace

Feature `cmqtlg0760001ib04w9m3fqlc`. One PR for the tightly-coupled chain — tickets `solar.arrow`, `polar.sleet`, `retro.ox`.

### Problem
Fireflies meetings arrive workspace-less. They couldn't be routed: the per-row project picker was gated by the meeting's own (empty) workspace, so it offered nothing; the detail page had a workspace selector but no project picker; and reassigning a meeting re-homed its workspace but **stranded its extracted Actions** in the old workspace ("goals coming through for any workspace").

### What's in this PR
- **`assignMeetingPlacement`** — one project-authoritative placement service. `assignProject`, `bulkAssignProject`, and `associateWithProject` all delegate to it, so a meeting's `projectId`+`workspaceId` **and** its Actions' `projectId`+`workspaceId` move together in one transaction. (`solar.arrow` — the bug fix.)
- **`getAssignableProjects`** + **`buildProjectEditWhere`** — candidate projects the caller can *edit*, across all their workspaces, grouped by workspace.
- **`MeetingProjectPicker`** — searchable, workspace-grouped picker with a "Personal / no project" option. Reused by the inbox row, the bulk bar, and the detail page. (`polar.sleet`.)
- **Detail page** — `/recording/[id]` now places via the same picker; the divergent workspace-selector write is gone, workspace shown read-only as derived from the project. (`retro.ox`.)

### Design notes
- Project is authoritative for workspace; there is deliberately no standalone workspace assignment and no project-less "parked in a workspace" state (CONTEXT.md).
- Also fixes two latent issues found en route: the per-row "Remove project" was a silent no-op, and the bulk assign had a set-state-then-read race.

### Tests
15 new tests (placement service, candidate resolver, picker component); full unit suite green (1134 in pre-commit unit project). The one failing test in CI's integration project (`workspaceHomeStats` "Only Wed is today") is a pre-existing date-fragile test unrelated to this change.

Notification deep-link to `/recording/[id]` (`thick.mantis`) ships separately.
