### PR TITLE
feat(notifications): deep-link new-meeting notification to /recording/[id]

### DIFF
--- a/src/hooks/useNotificationChecker.tsx
+++ b/src/hooks/useNotificationChecker.tsx
@@ -6,6 +6,7 @@ import { Anchor, Text } from '@mantine/core';
 import Link from 'next/link';
 import { api } from '~/trpc/react';
 import { useSession } from 'next-auth/react';
+import { notificationDeepLink } from '~/server/services/notifications/notificationDeepLink';
 
 /**
  * Hook to check for and display new notifications on page load
@@ -58,13 +59,12 @@ export function useNotificationChecker() {
         // Only track notifications that we actually show to avoid skipping unshown types
         shownNotificationIds.current.add(notification.id);
 
-        const metadata = (() => {
-          try { return JSON.parse(notification.metadata as string) as { transcriptionId?: string }; }
-          catch { return null; }
-        })();
-        const meetingHref = metadata?.transcriptionId
-          ? `/recording/${metadata.transcriptionId}`
-          : '/meetings';
+        // Single source of truth for the click destination — shared with the
+        // web-push payload (NotificationScheduler).
+        const meetingHref = notificationDeepLink({
+          type: notification.type,
+          metadata: notification.metadata,
+        });
 
         notifications.show({
           id: notification.id, // Use notification ID to prevent duplicate toasts

--- a/src/server/services/notifications/NotificationScheduler.ts
+++ b/src/server/services/notifications/NotificationScheduler.ts
@@ -4,6 +4,7 @@ import { WhatsAppNotificationService } from './WhatsAppNotificationService';
 import { ZulipNotificationService } from './ZulipNotificationService';
 import { NotificationTemplates } from './NotificationTemplates';
 import { sendPushToUser } from './WebPushService';
+import { notificationDeepLink } from './notificationDeepLink';
 import { addDays, setHours, setMinutes, startOfDay, startOfWeek } from 'date-fns';
 import { toZonedTime, fromZonedTime } from 'date-fns-tz';
 
@@ -143,7 +144,12 @@ export class NotificationScheduler {
             title: notification.title,
             body: notification.message,
             tag: notification.type ?? 'scheduled',
-            url: '/',
+            // Deep-link to the relevant entity (e.g. a new meeting opens
+            // /recording/[id]); the service worker reads this on click.
+            url: notificationDeepLink({
+              type: notification.type,
+              metadata: notification.metadata,
+            }),
           },
           db,
         );

--- a/src/server/services/notifications/__tests__/notificationDeepLink.test.ts
+++ b/src/server/services/notifications/__tests__/notificationDeepLink.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for `notificationDeepLink` — the single source of a notification's
+ * click destination, used by the web-push payload and in-app navigation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { notificationDeepLink } from "../notificationDeepLink";
+
+describe("notificationDeepLink", () => {
+  it("deep-links a transcription_completed notification to its meeting", () => {
+    expect(
+      notificationDeepLink({
+        type: "transcription_completed",
+        metadata: { transcriptionId: "trx-123" },
+      }),
+    ).toBe("/recording/trx-123");
+  });
+
+  it("parses metadata stored as a JSON string (the webhook's shape)", () => {
+    expect(
+      notificationDeepLink({
+        type: "transcription_completed",
+        metadata: JSON.stringify({ transcriptionId: "trx-456", actionItemCount: 2 }),
+      }),
+    ).toBe("/recording/trx-456");
+  });
+
+  it("falls back to the inbox when the transcription id is missing", () => {
+    expect(
+      notificationDeepLink({ type: "transcription_completed", metadata: {} }),
+    ).toBe("/meetings");
+    expect(
+      notificationDeepLink({ type: "transcription_completed", metadata: null }),
+    ).toBe("/meetings");
+    expect(
+      notificationDeepLink({ type: "transcription_completed", metadata: "not json" }),
+    ).toBe("/meetings");
+  });
+
+  it("returns the app root for notification types without a deep link", () => {
+    expect(
+      notificationDeepLink({ type: "daily_summary", metadata: null }),
+    ).toBe("/");
+  });
+});

--- a/src/server/services/notifications/notificationDeepLink.ts
+++ b/src/server/services/notifications/notificationDeepLink.ts
@@ -1,0 +1,47 @@
+/**
+ * Resolve the in-app destination a notification should open when clicked.
+ *
+ * Pure and side-effect-free so it can drive every delivery surface from one
+ * place: the web-push payload `url` (consumed by the service worker's
+ * `notificationclick` handler) and any in-app row navigation. Returns an
+ * app-relative path; unknown types fall back to "/".
+ *
+ * The `metadata` column is `Json?` but is written as a JSON *string* by some
+ * producers (e.g. the Fireflies webhook), so both shapes are tolerated.
+ */
+export interface DeepLinkableNotification {
+  type: string;
+  metadata: unknown;
+}
+
+export function notificationDeepLink(notification: DeepLinkableNotification): string {
+  const meta = parseMetadata(notification.metadata);
+
+  switch (notification.type) {
+    case "transcription_completed": {
+      const id = typeof meta?.transcriptionId === "string" ? meta.transcriptionId : null;
+      // Land on the meeting so the user can place it; fall back to the inbox.
+      return id ? `/recording/${id}` : "/meetings";
+    }
+    default:
+      return "/";
+  }
+}
+
+function parseMetadata(metadata: unknown): Record<string, unknown> | null {
+  if (!metadata) return null;
+  if (typeof metadata === "string") {
+    try {
+      const parsed: unknown = JSON.parse(metadata);
+      return typeof parsed === "object" && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof metadata === "object") {
+    return metadata as Record<string, unknown>;
+  }
+  return null;
+}


### PR DESCRIPTION
## Deep-link the new-meeting notification to /recording/[id]

Feature `cmqtlg0760001ib04w9m3fqlc`, ticket `thick.mantis`. Independent of the picker chain (PR #296) — branched off `main`.

### Problem
The `transcription_completed` web-push notification hardcoded `url: '/'`, so clicking a "new meeting ready" notification didn't bring the user to the meeting where they can place it.

### Change
- New pure `notificationDeepLink(notification)` resolver: `transcription_completed` → `/recording/[id]` from `metadata.transcriptionId` (falls back to `/meetings`), other types → `/`.
- `NotificationScheduler` web-push payload now uses it (the service worker already navigates to `data.url` on click — no SW change needed).
- The in-app toast already deep-linked inline; refactored it to use the same resolver as the single source of truth.

No schema change — reads the existing `metadata.transcriptionId` the webhook already stores.

### Tests
4 new unit tests for the resolver (meeting link, JSON-string metadata, missing-id fallback, non-deep-link type). Full unit suite green.
