### PR TITLE
feat: create_deal Form destination (applicant → contact + hiring-board card)

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
@@ -34,6 +34,7 @@ import { api } from '~/trpc/react';
 import { slugify } from '~/utils/slugify';
 import { CRM_CUSTOMER_TYPE_OPTIONS } from '~/lib/crm/automationCatalog';
 import { MarkdownInput } from '~/app/_components/shared/MarkdownInput';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
 
 type FieldType = 'text' | 'email' | 'textarea' | 'select' | 'checkbox' | 'url';
 
@@ -91,7 +92,24 @@ export default function FormEditorPage() {
     lastName: null,
     company: null,
   });
+  // create_deal destination (ADR-0033): upsert applicant + drop a card on a pipeline.
+  const [dealEnabled, setDealEnabled] = useState(false);
+  const [dealPipelineId, setDealPipelineId] = useState<string | null>(null);
+  const [dealStageId, setDealStageId] = useState<string | null>(null);
+  const [dealCustomerType, setDealCustomerType] = useState<string | null>(null);
+  const [dealTitleTemplate, setDealTitleTemplate] = useState('');
+  const [dealFieldMap, setDealFieldMap] = useState<
+    Record<ContactSlot, string | null>
+  >({ email: null, firstName: null, lastName: null, company: null });
   const [dirty, setDirty] = useState(false);
+
+  const { workspaceId } = useWorkspace();
+  const { data: pipelines } = api.pipeline.list.useQuery(
+    { workspaceId: workspaceId! },
+    { enabled: !!workspaceId },
+  );
+  const dealStages =
+    pipelines?.find((p) => p.id === dealPipelineId)?.pipelineStages ?? [];
 
   useEffect(() => {
     const data = query.data;
@@ -132,6 +150,42 @@ export default function FormEditorPage() {
       });
     } else {
       setCrmEnabled(false);
+    }
+    const deal = asArray(data.destinations).find(
+      (d) => (d as { type?: string }).type === 'create_deal',
+    ) as { config?: Record<string, unknown> } | undefined;
+    if (deal?.config) {
+      setDealEnabled(true);
+      setDealPipelineId(
+        typeof deal.config.pipelineId === 'string'
+          ? deal.config.pipelineId
+          : null,
+      );
+      setDealStageId(
+        typeof deal.config.stageId === 'string' ? deal.config.stageId : null,
+      );
+      setDealCustomerType(
+        typeof deal.config.customerType === 'string'
+          ? deal.config.customerType
+          : null,
+      );
+      setDealTitleTemplate(
+        typeof deal.config.dealTitleTemplate === 'string'
+          ? deal.config.dealTitleTemplate
+          : '',
+      );
+      const dmap = (deal.config.contactFieldMap ?? {}) as Record<
+        string,
+        unknown
+      >;
+      setDealFieldMap({
+        email: typeof dmap.email === 'string' ? dmap.email : null,
+        firstName: typeof dmap.firstName === 'string' ? dmap.firstName : null,
+        lastName: typeof dmap.lastName === 'string' ? dmap.lastName : null,
+        company: typeof dmap.company === 'string' ? dmap.company : null,
+      });
+    } else {
+      setDealEnabled(false);
     }
     setDirty(false);
   }, [query.data]);
@@ -204,21 +258,39 @@ export default function FormEditorPage() {
       required: f.required,
       ...(f.type === 'select' ? { options: f.options } : {}),
     }));
-    const destinations = crmEnabled
-      ? [
-          {
-            type: 'create_crm_contact',
-            config: {
-              customerType: customerType ?? '',
-              fieldMap: Object.fromEntries(
-                CONTACT_SLOTS.map((s) => [s.key, fieldMap[s.key]]).filter(
-                  ([, v]) => v,
-                ),
-              ),
-            },
-          },
-        ]
-      : [];
+    const destinations: { type: string; config: Record<string, unknown> }[] =
+      [];
+    if (crmEnabled) {
+      destinations.push({
+        type: 'create_crm_contact',
+        config: {
+          customerType: customerType ?? '',
+          fieldMap: Object.fromEntries(
+            CONTACT_SLOTS.map((s) => [s.key, fieldMap[s.key]]).filter(
+              ([, v]) => v,
+            ),
+          ),
+        },
+      });
+    }
+    if (dealEnabled) {
+      destinations.push({
+        type: 'create_deal',
+        config: {
+          pipelineId: dealPipelineId ?? '',
+          stageId: dealStageId ?? '',
+          customerType: dealCustomerType ?? '',
+          contactFieldMap: Object.fromEntries(
+            CONTACT_SLOTS.map((s) => [s.key, dealFieldMap[s.key]]).filter(
+              ([, v]) => v,
+            ),
+          ),
+          ...(dealTitleTemplate.trim()
+            ? { dealTitleTemplate: dealTitleTemplate.trim() }
+            : {}),
+        },
+      });
+    }
     save.mutate({
       id,
       name: name.trim() || 'Untitled form',
@@ -447,6 +519,102 @@ export default function FormEditorPage() {
                   value={fieldMap[slot.key]}
                   onChange={(value) => {
                     setFieldMap((prev) => ({ ...prev, [slot.key]: value }));
+                    touch();
+                  }}
+                  clearable
+                  w={200}
+                />
+              ))}
+            </Group>
+          </Stack>
+        )}
+      </Card>
+
+      <Card withBorder padding="md">
+        <Group justify="space-between" mb="sm">
+          <Box>
+            <Text fw={600}>When submitted → Add to pipeline (create deal)</Text>
+            <Text c="dimmed" size="xs">
+              Upserts the applicant as a contact (firing matching automations)
+              and drops a card on the chosen pipeline stage.
+            </Text>
+          </Box>
+          <Switch
+            checked={dealEnabled}
+            onChange={(e) => {
+              setDealEnabled(e.currentTarget.checked);
+              touch();
+            }}
+          />
+        </Group>
+        {dealEnabled && (
+          <Stack gap="sm">
+            <Group gap="sm" wrap="wrap" align="flex-end">
+              <Select
+                label="Pipeline"
+                placeholder="Select a pipeline"
+                data={(pipelines ?? []).map((p) => ({
+                  value: p.id,
+                  label: p.name,
+                }))}
+                value={dealPipelineId}
+                onChange={(value) => {
+                  setDealPipelineId(value);
+                  // Stage belongs to a pipeline — reset it when the pipeline changes.
+                  setDealStageId(null);
+                  touch();
+                }}
+                w={220}
+              />
+              <Select
+                label="Stage"
+                placeholder={
+                  dealPipelineId ? 'Select a stage' : 'Pick a pipeline first'
+                }
+                data={dealStages.map((s) => ({ value: s.id, label: s.name }))}
+                value={dealStageId}
+                onChange={(value) => {
+                  setDealStageId(value);
+                  touch();
+                }}
+                disabled={!dealPipelineId}
+                w={220}
+              />
+              <Select
+                label="Customer type"
+                placeholder="e.g. Applicant"
+                data={CRM_CUSTOMER_TYPE_OPTIONS}
+                value={dealCustomerType}
+                onChange={(value) => {
+                  setDealCustomerType(value);
+                  touch();
+                }}
+                searchable
+                w={220}
+              />
+            </Group>
+            <TextInput
+              label="Deal title template"
+              description="Optional. Use {fieldKey} tokens; defaults to the applicant's name, then email."
+              placeholder="e.g. {firstName} {lastName} — Frontend role"
+              value={dealTitleTemplate}
+              onChange={(e) => {
+                setDealTitleTemplate(e.currentTarget.value);
+                touch();
+              }}
+              w={420}
+            />
+            <Divider label="Map form fields → applicant" labelPosition="left" />
+            <Group gap="sm" wrap="wrap">
+              {CONTACT_SLOTS.map((slot) => (
+                <Select
+                  key={slot.key}
+                  label={`${slot.label}${slot.required ? ' *' : ''}`}
+                  placeholder="Select a field"
+                  data={fieldKeyOptions}
+                  value={dealFieldMap[slot.key]}
+                  onChange={(value) => {
+                    setDealFieldMap((prev) => ({ ...prev, [slot.key]: value }));
                     touch();
                   }}
                   clearable

--- a/src/server/api/routers/form.ts
+++ b/src/server/api/routers/form.ts
@@ -137,6 +137,67 @@ export const formRouter = createTRPCRouter({
               });
             }
           }
+          if (dest.type === "create_deal") {
+            const pipelineId =
+              typeof dest.config.pipelineId === "string"
+                ? dest.config.pipelineId
+                : "";
+            const stageId =
+              typeof dest.config.stageId === "string"
+                ? dest.config.stageId
+                : "";
+            if (!pipelineId || !stageId) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message: "Create deal requires a pipeline and a stage.",
+              });
+            }
+            if (
+              !(
+                typeof dest.config.customerType === "string" &&
+                dest.config.customerType.trim()
+              )
+            ) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message: "Create deal requires a Customer type for the applicant.",
+              });
+            }
+            // Same email-dedup requirement as create_crm_contact (the deal is
+            // linked to the upserted contact).
+            const fieldMap =
+              dest.config.contactFieldMap &&
+              typeof dest.config.contactFieldMap === "object"
+                ? (dest.config.contactFieldMap as Record<string, unknown>)
+                : {};
+            const emailKey =
+              typeof fieldMap.email === "string" ? fieldMap.email : "";
+            const emailField = effectiveFields.find((f) => f.key === emailKey);
+            if (!emailField || emailField.type !== "email") {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message:
+                  "Create deal requires an Email field mapped to the applicant's email.",
+              });
+            }
+            // The stage must belong to the chosen pipeline, which must be a
+            // pipeline Project in this workspace.
+            const stage = await ctx.db.pipelineStage.findFirst({
+              where: {
+                id: stageId,
+                projectId: pipelineId,
+                project: { workspaceId: form.workspaceId, type: "pipeline" },
+              },
+              select: { id: true },
+            });
+            if (!stage) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message:
+                  "Create deal: the selected stage does not belong to the chosen pipeline.",
+              });
+            }
+          }
         }
       }
 

--- a/src/server/services/forms/FormDestinationRegistry.ts
+++ b/src/server/services/forms/FormDestinationRegistry.ts
@@ -2,6 +2,7 @@ import { type PrismaClient } from "@prisma/client";
 
 import { type IFormDestination } from "./destinations/IFormDestination";
 import { CreateCrmContactDestination } from "./destinations/CreateCrmContactDestination";
+import { CreateDealDestination } from "./destinations/CreateDealDestination";
 
 /**
  * Registry of **Form destinations**, mirroring the automation `StepRegistry`.
@@ -38,5 +39,6 @@ export function createFormDestinationRegistry(
 ): FormDestinationRegistry {
   const registry = new FormDestinationRegistry();
   registry.register(new CreateCrmContactDestination(db));
+  registry.register(new CreateDealDestination(db));
   return registry;
 }

--- a/src/server/services/forms/destinations/CreateDealDestination.ts
+++ b/src/server/services/forms/destinations/CreateDealDestination.ts
@@ -1,0 +1,207 @@
+import { type PrismaClient } from "@prisma/client";
+
+import { createCrmContact } from "~/server/services/crm/createCrmContact";
+import {
+  type IFormDestination,
+  type FormDestinationContext,
+} from "./IFormDestination";
+
+interface ContactFieldMap {
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  company?: string;
+}
+
+/**
+ * `create_deal` — the public job-application destination (ADR-0033). In ONE
+ * handler it (a) upserts the applicant as a CRM contact via the shared
+ * `createCrmContact` — same `emailHash` dedup + `dispatchContactTypeAutomations`
+ * path as `create_crm_contact`, so an `Applicant`-typed Automation sends any
+ * acknowledgment (the form stays email-ignorant) — then (b) drops them onto a
+ * chosen `(pipeline, stage)` as a `Deal`, linked to that contact.
+ *
+ * Folding the contact upsert in here (rather than composing two destinations)
+ * is deliberate: destinations run independently and can't share a freshly
+ * created `contactId`.
+ *
+ * Idempotent on repeat submission: the contact dedupes by `emailHash`, and if
+ * an OPEN deal (a deal in an `active` stage) already exists for
+ * `(pipeline, contact)` we skip creating a second card. The `FormSubmission` is
+ * still always stored by the caller.
+ *
+ * Config: `{ pipelineId, stageId, customerType, contactFieldMap: { email,
+ * firstName, lastName, company }, dealTitleTemplate? }` where field-map values
+ * are form field keys. `dealTitleTemplate` supports `{fieldKey}` tokens drawn
+ * from the submission; it falls back to the applicant's name, then their email.
+ */
+export class CreateDealDestination implements IFormDestination {
+  type = "create_deal";
+  label = "Create deal (applicant → pipeline)";
+
+  constructor(private db: PrismaClient) {}
+
+  async run(
+    data: Record<string, unknown>,
+    config: Record<string, unknown>,
+    context: FormDestinationContext,
+  ): Promise<Record<string, unknown>> {
+    const pipelineId =
+      typeof config.pipelineId === "string" ? config.pipelineId : null;
+    const stageId =
+      typeof config.stageId === "string" ? config.stageId : null;
+    if (!pipelineId || !stageId) {
+      throw new Error("create_deal: pipelineId and stageId are required");
+    }
+
+    // A Deal's createdById is required — the form owner attributes the card.
+    if (!context.ownerId) {
+      throw new Error("create_deal: form has no owner to attribute the deal to");
+    }
+
+    const customerType =
+      typeof config.customerType === "string" ? config.customerType : null;
+    const fieldMap =
+      config.contactFieldMap && typeof config.contactFieldMap === "object"
+        ? (config.contactFieldMap as ContactFieldMap)
+        : {};
+
+    const pick = (key?: string): string | null => {
+      if (!key) return null;
+      const value = data[key];
+      return typeof value === "string" && value.trim() ? value.trim() : null;
+    };
+
+    // Email is the contact dedup key (same reasoning as create_crm_contact).
+    const email = pick(fieldMap.email);
+    if (!email) {
+      throw new Error("create_deal: submission has no email to dedupe on");
+    }
+
+    // Guard the target before any writes: the stage must belong to the named
+    // pipeline, which must be a pipeline Project in this workspace. Stops a
+    // misconfigured form dropping a card onto another workspace's board.
+    const stage = await this.db.pipelineStage.findFirst({
+      where: {
+        id: stageId,
+        projectId: pipelineId,
+        project: { workspaceId: context.workspaceId, type: "pipeline" },
+      },
+      select: { id: true },
+    });
+    if (!stage) {
+      throw new Error(
+        "create_deal: stage not found in the configured pipeline for this workspace",
+      );
+    }
+
+    // (a) Upsert the applicant — fires contact-type automations via the shared path.
+    const contact = await createCrmContact(this.db, {
+      workspaceId: context.workspaceId,
+      email,
+      firstName: pick(fieldMap.firstName),
+      lastName: pick(fieldMap.lastName),
+      company: pick(fieldMap.company),
+      profileType: customerType,
+      createdById: context.ownerId,
+      importSource: "FORM",
+      triggeredById: context.ownerId,
+    });
+
+    // (b) Idempotent: skip a second OPEN card for the same applicant on this
+    // pipeline. "Open" = sitting in an active (non-won/lost) stage.
+    const existingOpen = await this.db.deal.findFirst({
+      where: {
+        projectId: pipelineId,
+        contactId: contact.contactId,
+        stage: { type: "active" },
+      },
+      select: { id: true },
+    });
+    if (existingOpen) {
+      return {
+        contactId: contact.contactId,
+        contactCreated: contact.created,
+        automationFired: contact.fired,
+        dealId: existingOpen.id,
+        dealCreated: false,
+      };
+    }
+
+    const title = this.renderTitle(config.dealTitleTemplate, data, fieldMap, {
+      pick,
+      email,
+    });
+
+    const lastDeal = await this.db.deal.findFirst({
+      where: { projectId: pipelineId, stageId },
+      orderBy: { stageOrder: "desc" },
+      select: { stageOrder: true },
+    });
+    const stageOrder = (lastDeal?.stageOrder ?? -1) + 1;
+
+    const deal = await this.db.deal.create({
+      data: {
+        projectId: pipelineId,
+        stageId,
+        title,
+        // Sales fields (value/probability/currency) left at defaults — the Deal
+        // is overloaded as a candidate card here (ADR-0033), like profileType.
+        contactId: contact.contactId,
+        workspaceId: context.workspaceId,
+        createdById: context.ownerId,
+        stageOrder,
+      },
+      select: { id: true },
+    });
+
+    await this.db.dealActivity.create({
+      data: {
+        dealId: deal.id,
+        userId: context.ownerId,
+        type: "CREATED",
+        content: `Deal "${title}" created from a form submission`,
+        metadata: { stageId, source: "form", formId: context.formId },
+      },
+    });
+
+    return {
+      contactId: contact.contactId,
+      contactCreated: contact.created,
+      automationFired: contact.fired,
+      dealId: deal.id,
+      dealCreated: true,
+    };
+  }
+
+  /** Build the card title: template tokens → applicant name → email. */
+  private renderTitle(
+    templateRaw: unknown,
+    data: Record<string, unknown>,
+    fieldMap: ContactFieldMap,
+    deps: { pick: (key?: string) => string | null; email: string },
+  ): string {
+    const template =
+      typeof templateRaw === "string" && templateRaw.trim()
+        ? templateRaw.trim()
+        : null;
+
+    if (template) {
+      const rendered = template
+        .replace(/\{(\w+)\}/g, (_match, key: string) => {
+          const value = data[key];
+          return typeof value === "string" && value.trim()
+            ? value.trim()
+            : "";
+        })
+        .trim();
+      if (rendered) return rendered;
+    }
+
+    const name = [deps.pick(fieldMap.firstName), deps.pick(fieldMap.lastName)]
+      .filter(Boolean)
+      .join(" ")
+      .trim();
+    return name || deps.email;
+  }
+}

--- a/src/server/services/forms/destinations/__tests__/CreateDealDestination.test.ts
+++ b/src/server/services/forms/destinations/__tests__/CreateDealDestination.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for the `create_deal` Form destination (ADR-0033). Pins the
+ * behaviour the public intake relies on: it upserts the applicant via the
+ * shared `createCrmContact` (so contact-type automations fire), drops a Deal on
+ * the configured (pipeline, stage), and is idempotent on repeat submission —
+ * an existing OPEN deal for the same (pipeline, contact) is not duplicated.
+ *
+ * `createCrmContact` is mocked so no real contact/automation logic runs; we
+ * only assert the deal-side wiring and the guards.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+const createCrmContactMock = vi.fn();
+
+vi.mock("~/server/services/crm/createCrmContact", () => ({
+  createCrmContact: (...args: unknown[]) => createCrmContactMock(...args),
+}));
+
+import { CreateDealDestination } from "../CreateDealDestination";
+
+const db = mockDeep<PrismaClient>();
+
+const context = {
+  formId: "form-1",
+  workspaceId: "ws-1",
+  submissionId: "sub-1",
+  ownerId: "owner-1",
+};
+
+const config = {
+  pipelineId: "pipe-1",
+  stageId: "stage-1",
+  customerType: "Applicant",
+  contactFieldMap: {
+    email: "email",
+    firstName: "first",
+    lastName: "last",
+  },
+};
+
+const data = {
+  email: "jane@example.com",
+  first: "Jane",
+  last: "Doe",
+};
+
+function makeDestination(): {
+  dest: CreateDealDestination;
+  db: DeepMockProxy<PrismaClient>;
+} {
+  return { dest: new CreateDealDestination(db), db };
+}
+
+beforeEach(() => {
+  mockReset(db);
+  createCrmContactMock.mockReset();
+  createCrmContactMock.mockResolvedValue({
+    contactId: "contact-1",
+    created: true,
+    fired: true,
+  });
+  // Stage belongs to the pipeline in this workspace.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db.pipelineStage.findFirst.mockResolvedValue({ id: "stage-1" } as any);
+});
+
+describe("CreateDealDestination", () => {
+  it("upserts the contact via the shared path and creates a deal", async () => {
+    const { dest } = makeDestination();
+    db.deal.findFirst.mockResolvedValue(null); // no existing open deal
+    db.deal.findFirst.mockResolvedValueOnce(null); // open-deal check
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    db.deal.create.mockResolvedValue({ id: "deal-1" } as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    db.dealActivity.create.mockResolvedValue({} as any);
+
+    const result = await dest.run(data, config, context);
+
+    expect(createCrmContactMock).toHaveBeenCalledTimes(1);
+    expect(createCrmContactMock.mock.calls[0]?.[1]).toMatchObject({
+      workspaceId: "ws-1",
+      email: "jane@example.com",
+      profileType: "Applicant",
+    });
+    expect(db.deal.create).toHaveBeenCalledTimes(1);
+    const createArgs = db.deal.create.mock.calls[0]?.[0];
+    expect(createArgs?.data).toMatchObject({
+      projectId: "pipe-1",
+      stageId: "stage-1",
+      contactId: "contact-1",
+      workspaceId: "ws-1",
+      createdById: "owner-1",
+      title: "Jane Doe",
+    });
+    expect(result).toMatchObject({
+      contactId: "contact-1",
+      dealId: "deal-1",
+      dealCreated: true,
+    });
+  });
+
+  it("is idempotent — skips a second open deal for the same applicant", async () => {
+    const { dest } = makeDestination();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    db.deal.findFirst.mockResolvedValue({ id: "existing-deal" } as any);
+
+    const result = await dest.run(data, config, context);
+
+    expect(db.deal.create).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      dealId: "existing-deal",
+      dealCreated: false,
+    });
+    // The open-deal lookup is scoped to active stages only.
+    const where = db.deal.findFirst.mock.calls[0]?.[0]?.where;
+    expect(where).toMatchObject({
+      projectId: "pipe-1",
+      contactId: "contact-1",
+      stage: { type: "active" },
+    });
+  });
+
+  it("uses the dealTitleTemplate with {token} substitution when provided", async () => {
+    const { dest } = makeDestination();
+    db.deal.findFirst.mockResolvedValue(null);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    db.deal.create.mockResolvedValue({ id: "deal-2" } as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    db.dealActivity.create.mockResolvedValue({} as any);
+
+    await dest.run(
+      data,
+      { ...config, dealTitleTemplate: "{first} — Frontend" },
+      context,
+    );
+
+    expect(db.deal.create.mock.calls[0]?.[0]?.data).toMatchObject({
+      title: "Jane — Frontend",
+    });
+  });
+
+  it("throws when pipelineId or stageId is missing", async () => {
+    const { dest } = makeDestination();
+    await expect(
+      dest.run(data, { ...config, stageId: "" }, context),
+    ).rejects.toThrow(/pipelineId and stageId are required/);
+    expect(createCrmContactMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when no email is mapped to dedupe on", async () => {
+    const { dest } = makeDestination();
+    await expect(
+      dest.run(
+        { first: "Jane" },
+        { ...config, contactFieldMap: { firstName: "first" } },
+        context,
+      ),
+    ).rejects.toThrow(/no email to dedupe on/);
+  });
+
+  it("throws when the stage does not belong to the pipeline/workspace", async () => {
+    const { dest } = makeDestination();
+    db.pipelineStage.findFirst.mockResolvedValue(null);
+
+    await expect(dest.run(data, config, context)).rejects.toThrow(
+      /stage not found in the configured pipeline/,
+    );
+    // No contact upsert or deal write when the target is invalid.
+    expect(createCrmContactMock).not.toHaveBeenCalled();
+    expect(db.deal.create).not.toHaveBeenCalled();
+  });
+
+  it("throws when the form has no owner to attribute the deal", async () => {
+    const { dest } = makeDestination();
+    await expect(
+      dest.run(data, config, { ...context, ownerId: null }),
+    ).rejects.toThrow(/no owner to attribute/);
+  });
+});


### PR DESCRIPTION
## What

A new **`create_deal`** Form destination (ADR-0033), registered in the `FormDestinationRegistry` with no core change. On a public submission it does **both**, in one handler (so destinations stay independent — a deal-only handler couldn't see a contact another destination just made):

1. Upserts the applicant as a `CrmContact` via the **shared `createCrmContact`** (`emailHash` dedup, stamps `customerType`, fires `dispatchContactTypeAutomations` — same path as `create_crm_contact`, so an `Applicant`-typed Automation sends any acknowledgment; the form stays email-ignorant).
2. Creates a `Deal` linked to that contact in `(pipelineId, stageId)`. Sales fields (`value`/`probability`/`currency`) are left at defaults — the `Deal` is overloaded as a candidate card, like the `profileType` overload.

**Idempotent**: the contact dedupes by `emailHash`; if an **open** deal (in an `active` stage) already exists for `(pipeline, contact)`, a second card is skipped. The `FormSubmission` is still always stored, and destination failures are recorded on the submission `result` and never 500 the public intake (`runFormDestinations` catches per-destination).

**Targeting is validated** — the stage must belong to the chosen pipeline in the workspace, both at save time (`form.update`) and at run time.

**Authoring**: the form admin gets a pipeline + stage picker (via `pipeline.list` from the multi-pipeline slice), a customer-type select, a contact field map, and an optional `{token}` deal-title template.

Config: `{ pipelineId, stageId, customerType, contactFieldMap, dealTitleTemplate? }`.

## Tests

New unit test `CreateDealDestination.test.ts` (7 cases): contact-upsert path, deal creation, idempotency (open-deal skip, scoped to active stages), `{token}` title templating, and the guards (missing pipeline/stage, missing email, stage-not-in-pipeline, missing owner).

## Acceptance criteria

- [x] `create_deal` registered in `FormDestinationRegistry` and selectable/configurable in the form admin with a pipeline + stage picker.
- [x] A public submission creates (or dedupes) the applicant `CrmContact` AND a `Deal` in the chosen pipeline/stage, linked to that contact.
- [x] Shared `createCrmContact` path is used so contact-type automation dispatch fires (no email logic in the destination).
- [x] Re-submitting with the same email does not create a duplicate open `Deal`; the submission is still stored.
- [x] Destination failures are recorded on the `FormSubmission` result and never 500 the public intake.

## Blocked by

- #294 (gold.fern — multi-pipeline) — **merged**; this branch is cut from the updated `main`.

---

Ships: violet.vertex
Part of feature: Public job-application forms with hiring pipeline