### PR TITLE
fix(crm): avoid unique-constraint error when adding a pipeline stage

### DIFF
--- a/src/server/api/routers/pipeline.ts
+++ b/src/server/api/routers/pipeline.ts
@@ -254,25 +254,37 @@ export const pipelineRouter = createTRPCRouter({
     )
     .use(requireProjectAccess("edit"))
     .mutation(async ({ ctx, input }) => {
-      // Shift existing stages at or after the target order
-      await ctx.db.pipelineStage.updateMany({
+      // Fetch the stages that need to shift up to make room. We can't use a
+      // single `updateMany({ increment: 1 })` because the @@unique([projectId,
+      // order]) constraint is checked per-row (not deferred): shifting order
+      // 3→4 transiently collides with the existing order 4. Shift them inside a
+      // transaction, highest order first, so each row moves into a free slot.
+      const stagesToShift = await ctx.db.pipelineStage.findMany({
         where: {
           projectId: input.projectId,
           order: { gte: input.order },
         },
-        data: {
-          order: { increment: 1 },
-        },
+        orderBy: { order: "desc" },
+        select: { id: true, order: true },
       });
 
-      return ctx.db.pipelineStage.create({
-        data: {
-          projectId: input.projectId,
-          name: input.name,
-          color: input.color,
-          type: input.type,
-          order: input.order,
-        },
+      return ctx.db.$transaction(async (tx) => {
+        for (const stage of stagesToShift) {
+          await tx.pipelineStage.update({
+            where: { id: stage.id },
+            data: { order: stage.order + 1 },
+          });
+        }
+
+        return tx.pipelineStage.create({
+          data: {
+            projectId: input.projectId,
+            name: input.name,
+            color: input.color,
+            type: input.type,
+            order: input.order,
+          },
+        });
       });
     }),
 


### PR DESCRIPTION
## Problem

Clicking **Add** on the CRM **Pipeline Settings** modal failed with:

> Invalid \`prisma.pipelineStage.updateMany()\` invocation: Unique constraint failed on the fields: (\`projectId\`,\`order\`)

## Root cause

\`createStage\` shifted existing stages with a single \`updateMany({ order: { increment: 1 } })\`. Postgres enforces the \`@@unique([projectId, order])\` constraint **per-row** (not deferred), so incrementing a run of consecutive orders transiently collides: shifting \`3→4\` violates uniqueness while the old \`4\` still exists.

The Pipeline Settings modal inserts new active stages at \`order = activeStages.length\` — exactly where the won/lost terminal stages sit — so adding a stage broke on **any pipeline with terminal stages** (i.e. every default pipeline).

## Fix

Shift the affected stages inside a transaction, **highest order first**, so each row moves into a free slot before the new stage is created. This mirrors the safe two-phase pattern already used by \`reorderStages\`. No schema change, no migration.

## Testing

- \`npm run test\` — 1151 unit tests pass
- Typecheck clean on the changed file