### PR TITLE
feat: persist public form answers as a localStorage draft

### DIFF
--- a/src/app/(public)/f/[slug]/_components/PublicForm.tsx
+++ b/src/app/(public)/f/[slug]/_components/PublicForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Container,
   Card,
@@ -13,9 +13,13 @@ import {
   Checkbox,
   Button,
   ThemeIcon,
+  Alert,
+  Group,
+  Anchor,
 } from '@mantine/core';
 import { IconCircleCheck } from '@tabler/icons-react';
 import { MarkdownRenderer } from '~/app/_components/shared/MarkdownRenderer';
+import { loadDraft, saveDraft, clearDraft } from './formDraft';
 
 interface PublicField {
   key: string;
@@ -47,9 +51,41 @@ export function PublicForm({
   const [generalError, setGeneralError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [done, setDone] = useState<string | null>(null);
+  // Form draft (CONTEXT.md ### Forms): restore in-progress answers from
+  // localStorage on load, then persist them debounced as the applicant types.
+  const [restored, setRestored] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
 
   const setValue = (key: string, value: unknown) =>
     setValues((prev) => ({ ...prev, [key]: value }));
+
+  // Restore once on mount (client-only — runs after hydration to avoid a
+  // server/client mismatch). `hydrated` gates the save effect so its first
+  // pass — which still sees the initial empty values — never overwrites the
+  // draft we're about to load.
+  useEffect(() => {
+    const draft = loadDraft(slug);
+    if (draft) {
+      setValues(draft);
+      setRestored(true);
+    }
+    setHydrated(true);
+  }, [slug]);
+
+  // Persist answers debounced; honeypot lives in its own state and is never
+  // included in `values`, so it's never written to the draft.
+  useEffect(() => {
+    if (!hydrated) return;
+    const timer = setTimeout(() => saveDraft(slug, values), 500);
+    return () => clearTimeout(timer);
+  }, [values, slug, hydrated]);
+
+  const handleClearDraft = () => {
+    clearDraft(slug);
+    setValues({});
+    setErrors({});
+    setRestored(false);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -69,6 +105,8 @@ export function PublicForm({
         confirmationMessage?: string | null;
       };
       if (res.ok && body.ok) {
+        clearDraft(slug);
+        setRestored(false);
         setDone(
           body.confirmationMessage ??
             confirmationMessage ??
@@ -113,6 +151,27 @@ export function PublicForm({
             <MarkdownRenderer content={description} variant="prose" />
           )}
         </Stack>
+        {restored && (
+          <Alert
+            variant="light"
+            color="blue"
+            withCloseButton
+            onClose={() => setRestored(false)}
+            mb="md"
+          >
+            <Group justify="space-between" align="center" gap="xs" wrap="nowrap">
+              <Text size="sm">Restored your saved answers on this device.</Text>
+              <Anchor
+                component="button"
+                type="button"
+                size="sm"
+                onClick={handleClearDraft}
+              >
+                Clear
+              </Anchor>
+            </Group>
+          </Alert>
+        )}
         <form onSubmit={handleSubmit}>
           <Stack gap="md">
             {fields.map((field) => {

--- a/src/app/(public)/f/[slug]/_components/__tests__/formDraft.test.ts
+++ b/src/app/(public)/f/[slug]/_components/__tests__/formDraft.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearDraft, loadDraft, saveDraft } from '../formDraft';
+
+const SLUG = 'data_engineer';
+const KEY = `expo:form-draft:${SLUG}`;
+
+describe('formDraft', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('round-trips saved answers', () => {
+    saveDraft(SLUG, { name: 'Ada', email: 'ada@example.com' });
+    expect(loadDraft(SLUG)).toEqual({ name: 'Ada', email: 'ada@example.com' });
+  });
+
+  it('returns null when there is no draft', () => {
+    expect(loadDraft(SLUG)).toBeNull();
+  });
+
+  it('does not persist empty answers, and clears any existing draft', () => {
+    saveDraft(SLUG, { name: 'Ada' });
+    saveDraft(SLUG, { name: '', agree: false });
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+    expect(loadDraft(SLUG)).toBeNull();
+  });
+
+  it('ignores and clears a draft older than the 7-day TTL', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    saveDraft(SLUG, { name: 'Ada' });
+
+    // 8 days later — past the TTL.
+    vi.setSystemTime(new Date('2026-01-09T00:00:00Z'));
+    expect(loadDraft(SLUG)).toBeNull();
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('restores a draft still within the TTL', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    saveDraft(SLUG, { name: 'Ada' });
+
+    vi.setSystemTime(new Date('2026-01-06T00:00:00Z')); // 5 days later
+    expect(loadDraft(SLUG)).toEqual({ name: 'Ada' });
+  });
+
+  it('clears a draft on demand', () => {
+    saveDraft(SLUG, { name: 'Ada' });
+    clearDraft(SLUG);
+    expect(loadDraft(SLUG)).toBeNull();
+  });
+
+  it('discards a malformed entry', () => {
+    window.localStorage.setItem(KEY, 'not json');
+    expect(loadDraft(SLUG)).toBeNull();
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+});

--- a/src/app/(public)/f/[slug]/_components/formDraft.ts
+++ b/src/app/(public)/f/[slug]/_components/formDraft.ts
@@ -1,0 +1,85 @@
+/**
+ * Client-only persistence for a public form's in-progress answers — the **Form
+ * draft** (CONTEXT.md ### Forms). Stored in `localStorage` under
+ * `expo:form-draft:{slug}` as `{ values, savedAt }`, so a refresh or closed tab
+ * never loses work. Never sent to the server — the careful server PII posture
+ * (ADR-0029) is unchanged; the draft inverts it locally, on the applicant's own
+ * device only. Self-expires after a 7-day TTL.
+ */
+
+const KEY_PREFIX = 'expo:form-draft:';
+const TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+interface StoredDraft {
+  values: Record<string, unknown>;
+  savedAt: number;
+}
+
+function keyFor(slug: string): string {
+  return `${KEY_PREFIX}${slug}`;
+}
+
+function hasContent(values: Record<string, unknown>): boolean {
+  return Object.values(values).some((v) => v !== '' && v !== false && v != null);
+}
+
+/**
+ * Returns the saved answers for a slug, or `null` when there is nothing useful
+ * to restore (missing, malformed, empty, or older than the TTL). Expired or
+ * malformed entries are cleared as a side effect.
+ */
+export function loadDraft(slug: string): Record<string, unknown> | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(keyFor(slug));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<StoredDraft> | null;
+    const values = parsed?.values;
+    const savedAt = parsed?.savedAt;
+    if (
+      typeof savedAt !== 'number' ||
+      typeof values !== 'object' ||
+      values === null
+    ) {
+      clearDraft(slug);
+      return null;
+    }
+    if (Date.now() - savedAt > TTL_MS) {
+      clearDraft(slug);
+      return null;
+    }
+    return hasContent(values) ? values : null;
+  } catch {
+    // Corrupt/unreadable entry — drop it so it doesn't linger.
+    clearDraft(slug);
+    return null;
+  }
+}
+
+/**
+ * Persists the current answers. Writing empty answers clears the draft instead,
+ * so a wiped form doesn't leave a stale entry behind. Best-effort: a full or
+ * unavailable `localStorage` is swallowed.
+ */
+export function saveDraft(slug: string, values: Record<string, unknown>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (!hasContent(values)) {
+      clearDraft(slug);
+      return;
+    }
+    const payload: StoredDraft = { values, savedAt: Date.now() };
+    window.localStorage.setItem(keyFor(slug), JSON.stringify(payload));
+  } catch {
+    // localStorage unavailable or over quota — the draft is best-effort.
+  }
+}
+
+export function clearDraft(slug: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(keyFor(slug));
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## What

Adds a client-only **Form draft** to the public form so a refresh or closed tab never loses an applicant's work (CONTEXT.md ### Forms). Answers are saved to `localStorage` under `expo:form-draft:{slug}` (as `{ values, savedAt }`), debounced as the applicant types. On return the fields are silently restored and a dismissible "Restored your saved answers · Clear" banner appears — the Clear action is the shared-machine escape hatch. The draft is cleared on successful submit and self-expires after a 7-day TTL.

Nothing leaves the browser — the careful server PII posture (ADR-0029) is unchanged. The honeypot is never persisted.

## Acceptance criteria

- [x] Typing writes a debounced draft under `expo:form-draft:{slug}`; honeypot never persisted
- [x] Reopening silently restores saved answers and shows a dismissible "Restored · Clear" banner
- [x] "Clear" wipes the draft and empties the fields
- [x] Successful submit clears the draft
- [x] Drafts older than 7 days are ignored and not restored
- [x] No data leaves the browser; no hardcoded colors

## Tests

- New unit suite for the storage helper (`formDraft.test.ts`): roundtrip, empty-clears, 7-day TTL expiry/within-TTL, on-demand clear, malformed-entry discard.

---

Ships: outer.carp