### PR TITLE
ci: add PR-Agent (Qodo) automated review workflow

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -1,0 +1,34 @@
+name: PR Agent
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created]
+jobs:
+  pr_agent_job:
+    # Skip when the event was triggered by a bot (e.g. PR-Agent's own comments)
+    # to avoid an infinite review loop.
+    if: ${{ github.event.sender.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+    name: PR Agent review
+    steps:
+      - name: PR Agent action step
+        id: pragent
+        uses: qodo-ai/pr-agent@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC.KEY: ${{ secrets.ANTHROPIC_KEY }}
+          # Repo-level behaviour is version-controlled in .pr_agent.toml.
+          # Model selection is kept here so the secret/model live together.
+          config.model: "anthropic/claude-sonnet-4-6"
+          # Point the fallback at another Anthropic model so PR-Agent never
+          # falls back to OpenAI (which would require an OPENAI_API_KEY).
+          config.fallback_models: '["anthropic/claude-sonnet-4-6"]'
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "true"
+          github_action_config.auto_improve: "true"
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,32 @@
+# PR-Agent (Qodo) configuration — version-controlled review behaviour.
+# Full reference: https://qodo-merge-docs.qodo.ai/usage-guide/configuration_options/
+# Env-level settings (model + ANTHROPIC.KEY) live in .github/workflows/pr_agent.yml.
+
+[config]
+# Keep both the primary and fallback on Anthropic so PR-Agent never tries to
+# initialise an OpenAI client (which would require OPENAI_API_KEY).
+model = "anthropic/claude-sonnet-4-6"
+fallback_models = ["anthropic/claude-sonnet-4-6"]
+# Markdown rendering of the model's suggestions.
+publish_output = true
+
+[pr_reviewer]
+# Concise, focused review. Flip these on if you want more.
+require_score_review = false
+require_tests_review = true
+require_security_review = true
+num_max_findings = 4
+# Don't re-post the whole review on every push; update the existing comment.
+persistent_comment = true
+final_update_message = false
+
+[pr_description]
+# Auto-generate a structured description + walkthrough.
+publish_description_as_comment = false
+add_original_user_description = true
+generate_ai_title = false
+
+[pr_code_suggestions]
+# Improvement suggestions ("/improve"). Keep the volume sane.
+num_code_suggestions = 4
+commitable_code_suggestions = false


### PR DESCRIPTION
## What

Adds the [qodo-ai/pr-agent](https://github.com/qodo-ai/pr-agent) GitHub Action, wired to Claude (`anthropic/claude-sonnet-4-6`).

- **`.github/workflows/pr_agent.yml`** — runs auto **describe / review / improve** on `opened`, `reopened`, `ready_for_review`, and `synchronize` (every push to an open PR re-reviews). The `issue_comment` trigger enables manual `/review`, `/improve`, `/ask "…"` in any PR comment. A `sender.type != 'Bot'` guard prevents an infinite review loop on the bot's own comments.
- **`.pr_agent.toml`** — version-controlled review behaviour (findings cap, tests/security review on, persistent comment so pushes update one comment instead of spamming).

## Notes on the config (vs. the original draft)

- Action path is `qodo-ai/pr-agent@main` (canonical; `the-pr-agent/pr-agent` is an old org redirect).
- `anthropic/claude-sonnet-4-6` is a registered model in PR-Agent's token map, so no `custom_model_max_tokens` needed.
- `config.fallback_models` points at another Anthropic model on purpose — this is the documented fix for PR-Agent trying to init an OpenAI client (qodo-ai/pr-agent#1323). **No OpenAI key required.**

## ⚠️ Required before this works

Set the repo secret (the workflow reads `secrets.ANTHROPIC_KEY`):

```bash
gh secret set ANTHROPIC_KEY
```

Until that secret exists, the workflow will run but fail at the auth step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated PR review support for new pull requests and PR comments.
  * Configured review settings to use AI-generated feedback, with security and test-focused checks.
  * Enabled persistent review comments and limited suggestion volume for cleaner PR feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->