### PR TITLE
feat: let the AI set project start and end dates (#228)

### DIFF
--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -3896,11 +3896,13 @@ export const mastraRouter = createTRPCRouter({
       status: z.enum(['ACTIVE', 'ON_HOLD', 'COMPLETED', 'CANCELLED']).optional().default('ACTIVE'),
       priority: z.enum(['HIGH', 'MEDIUM', 'LOW', 'NONE']).optional().default('MEDIUM'),
       workspaceId: z.string().optional(),
+      startDate: z.string().optional(), // ISO string
+      endDate: z.string().optional(), // ISO string
     }))
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
-      console.log(`🏗️ [tRPC createProject] RECEIVED: name="${input.name}", status=${input.status}, priority=${input.priority}, userId=${userId}`);
+      console.log(`🏗️ [tRPC createProject] RECEIVED: name="${input.name}", status=${input.status}, priority=${input.priority}, startDate=${input.startDate ?? "none"}, endDate=${input.endDate ?? "none"}, userId=${userId}`);
 
       // Generate a unique slug
       const baseSlug = slugify(input.name);
@@ -3921,6 +3923,8 @@ export const mastraRouter = createTRPCRouter({
           slug,
           createdById: userId,
           workspaceId: input.workspaceId ?? null,
+          startDate: input.startDate ? new Date(input.startDate) : null,
+          endDate: input.endDate ? new Date(input.endDate) : null,
         },
       });
 
@@ -3934,6 +3938,75 @@ export const mastraRouter = createTRPCRouter({
           status: project.status,
           priority: project.priority,
           slug: project.slug,
+        },
+      };
+    }),
+
+  // Update an existing project's core fields on behalf of the agent. Only the
+  // provided fields change. Access is gated by the same project-access path the
+  // human `project.updateDates` / `mastra.updateAction` use (ADR-0016 — reuse
+  // the human authorization path, the agent JWT never enters the LLM context).
+  // Dates arrive as ISO strings (the `dueDate` convention) and are parsed here.
+  updateProject: protectedProcedure
+    .input(z.object({
+      projectId: z.string(),
+      name: z.string().min(1).optional(),
+      description: z.string().nullable().optional(),
+      status: z.enum(['ACTIVE', 'ON_HOLD', 'COMPLETED', 'CANCELLED']).optional(),
+      priority: z.enum(['HIGH', 'MEDIUM', 'LOW', 'NONE']).optional(),
+      startDate: z.string().nullable().optional(), // ISO string, null to clear
+      endDate: z.string().nullable().optional(), // ISO string, null to clear
+    }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      console.log(`✏️ [tRPC updateProject] RECEIVED: projectId=${input.projectId}, userId=${userId}, changes=${JSON.stringify(input)}`);
+
+      const existing = await ctx.db.project.findUnique({
+        where: { id: input.projectId },
+        select: { id: true },
+      });
+      if (!existing) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Project not found' });
+      }
+
+      const access = await getProjectAccess(ctx.db, userId, input.projectId);
+      if (!hasProjectAccess(access)) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'You do not have access to this project',
+        });
+      }
+
+      const updateData: Record<string, unknown> = {};
+      if (input.name !== undefined) updateData.name = input.name;
+      if (input.description !== undefined) updateData.description = input.description;
+      if (input.status !== undefined) updateData.status = input.status;
+      if (input.priority !== undefined) updateData.priority = input.priority;
+      if (input.startDate !== undefined) {
+        updateData.startDate = input.startDate ? new Date(input.startDate) : null;
+      }
+      if (input.endDate !== undefined) {
+        updateData.endDate = input.endDate ? new Date(input.endDate) : null;
+      }
+
+      const project = await ctx.db.project.update({
+        where: { id: input.projectId },
+        data: updateData,
+      });
+
+      console.log(`✅ [tRPC updateProject] UPDATED: id=${project.id}, name="${project.name}"`);
+
+      return {
+        project: {
+          id: project.id,
+          name: project.name,
+          description: project.description,
+          status: project.status,
+          priority: project.priority,
+          slug: project.slug,
+          startDate: project.startDate ? project.startDate.toISOString() : null,
+          endDate: project.endDate ? project.endDate.toISOString() : null,
         },
       };
     }),

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -34,6 +34,21 @@ import { NotionAgentService } from "~/server/services/notionAgentService";
 // OpenAI client for embeddings
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
+// Parse an ISO date string supplied by an agent tool into a Date. Empty/nullish
+// values clear the field (return null); a malformed string throws BAD_REQUEST
+// rather than silently persisting an `Invalid Date` to the DB.
+function parseAgentDate(value: string | null | undefined, field: string): Date | null {
+  if (value == null || value === "") return null;
+  const parsed = new Date(value);
+  if (isNaN(parsed.getTime())) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `Invalid ${field}: expected an ISO date string (e.g. "2026-09-19T12:00:00Z")`,
+    });
+  }
+  return parsed;
+}
+
 // Get Mastra API URL from environment variable
 const MASTRA_API_URL = process.env.MASTRA_API_URL;
 
@@ -3923,8 +3938,8 @@ export const mastraRouter = createTRPCRouter({
           slug,
           createdById: userId,
           workspaceId: input.workspaceId ?? null,
-          startDate: input.startDate ? new Date(input.startDate) : null,
-          endDate: input.endDate ? new Date(input.endDate) : null,
+          startDate: parseAgentDate(input.startDate, "startDate"),
+          endDate: parseAgentDate(input.endDate, "endDate"),
         },
       });
 
@@ -3984,10 +3999,10 @@ export const mastraRouter = createTRPCRouter({
       if (input.status !== undefined) updateData.status = input.status;
       if (input.priority !== undefined) updateData.priority = input.priority;
       if (input.startDate !== undefined) {
-        updateData.startDate = input.startDate ? new Date(input.startDate) : null;
+        updateData.startDate = parseAgentDate(input.startDate, "startDate");
       }
       if (input.endDate !== undefined) {
-        updateData.endDate = input.endDate ? new Date(input.endDate) : null;
+        updateData.endDate = parseAgentDate(input.endDate, "endDate");
       }
 
       const project = await ctx.db.project.update({

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -3953,6 +3953,8 @@ export const mastraRouter = createTRPCRouter({
           status: project.status,
           priority: project.priority,
           slug: project.slug,
+          startDate: project.startDate ? project.startDate.toISOString() : null,
+          endDate: project.endDate ? project.endDate.toISOString() : null,
         },
       };
     }),


### PR DESCRIPTION
### **User description**
## What

Ticket #228 asked for project start/end date fields the AI can set, for time-boxed projects like "Sailing in Croatia Sep 19–26".

The premise was outdated: `Project.startDate`/`endDate`, the tRPC mutations (`project.create`/`update`/`updateDates`), the `CreateProjectModal` date pickers, and the draggable `ProjectTimelineView` **already exist**. The only gap was the **AI/Mastra path**, which this PR fills.

### Changes (this repo)
- **`mastra.createProject`**: now accepts `startDate`/`endDate` as ISO strings, parsed with `new Date()` into the create.
- **`mastra.updateProject`** (new): the first agent-facing project-update endpoint. Takes `projectId` + optional `name`/`description`/`status`/`priority`/`startDate`/`endDate`; only provided fields change. Authorization reuses `getProjectAccess`/`hasProjectAccess` — the same path `project.updateDates` and `mastra.updateAction` use (ADR-0016).

### Companion PR (mastra repo)
The agent tools + registrations live in the separate `../mastra` repo and ship in a companion PR: `createProjectTool` gains the date params, a new `updateProjectTool` is added, both registered across the three agents. Dates are documented as noon-UTC ISO to dodge timezone off-by-one (matching the `dueDate` convention).

### Decisions (from grilling)
- No migration, no UI work — already shipped.
- Dates as ISO `z.string()` → `new Date()`, consistent with the existing `dueDate` AI convention.
- No date-ordering validation (the human path has none — stayed consistent).
- No ADR / no CONTEXT.md change — project dates are self-explanatory and easily reversible.

## Verification
- `tsc --noEmit`: clean
- Unit tests: 1170 passing
- `eslint` on changed file: clean

---

Ships: dark.trout

[View in Exponential](https://www.exponential.im/w/syntrofi/products/exponential/tickets/228)


___

### **PR Type**
Enhancement


___

### **Description**
- New `mastra.updateProject` tRPC mutation for agent-facing project updates

- `mastra.createProject` now accepts `startDate`/`endDate` ISO string fields

- Shared `parseAgentDate` helper validates ISO dates, throws `BAD_REQUEST` on malformed input

- `createProject` response now includes `startDate`/`endDate` fields


___

### Diagram Walkthrough


```mermaid
flowchart LR
  agent["Agent Tool"]
  parseAgentDate["parseAgentDate()\nvalidates ISO string"]
  createProject["mastra.createProject\n+ startDate/endDate"]
  updateProject["mastra.updateProject\n(new endpoint)"]
  db["Prisma DB\nProject model"]

  agent -- "ISO date strings" --> parseAgentDate
  parseAgentDate -- "Date | null" --> createProject
  parseAgentDate -- "Date | null" --> updateProject
  createProject -- "create with dates" --> db
  updateProject -- "partial update" --> db
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mastra.ts</strong><dd><code>Add AI-facing project date fields and update endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/mastra.ts

<ul><li>Added <code>parseAgentDate</code> helper that validates ISO date strings and throws <br><code>BAD_REQUEST</code> on malformed input<br> <li> Extended <code>mastra.createProject</code> input schema with optional <br><code>startDate</code>/<code>endDate</code> ISO string fields and wires them through <br><code>parseAgentDate</code> to Prisma; response now includes these date fields<br> <li> Added new <code>mastra.updateProject</code> mutation supporting partial updates to <br><code>name</code>, <code>description</code>, <code>status</code>, <code>priority</code>, <code>startDate</code>, and <code>endDate</code>, gated by <br><code>getProjectAccess</code>/<code>hasProjectAccess</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/311/files#diff-afd76ed5d04839b106766464d541d99c9b1d0e8b28477ea826c7dcf52db960bb">+91/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

