### PR TITLE
feat: optional Applicant account CTA on the public form success page

### DIFF
--- a/src/app/(public)/f/[slug]/_components/PublicForm.tsx
+++ b/src/app/(public)/f/[slug]/_components/PublicForm.tsx
@@ -69,13 +69,6 @@ export function PublicForm({
   const setValue = (key: string, value: unknown) =>
     setValues((prev) => ({ ...prev, [key]: value }));
 
-  const emailForAccount = (): string => {
-    const emailField = fields.find((f) => f.type === 'email');
-    if (!emailField) return '';
-    const v = values[emailField.key];
-    return typeof v === 'string' ? v.trim() : '';
-  };
-
   const handleCreateAccount = async () => {
     if (!accountEmail) return;
     setAccountSubmitting(true);
@@ -146,7 +139,14 @@ export function PublicForm({
       if (res.ok && body.ok) {
         clearDraft(slug);
         setRestored(false);
-        setAccountEmail(emailForAccount());
+        // Capture the submitted email inline (from the values being submitted)
+        // for the optional account CTA on the success screen.
+        const emailField = fields.find((f) => f.type === 'email');
+        const submittedEmail =
+          emailField && typeof values[emailField.key] === 'string'
+            ? (values[emailField.key] as string).trim()
+            : '';
+        setAccountEmail(submittedEmail);
         setDone(
           body.confirmationMessage ??
             confirmationMessage ??

--- a/src/app/(public)/f/[slug]/_components/PublicForm.tsx
+++ b/src/app/(public)/f/[slug]/_components/PublicForm.tsx
@@ -16,8 +16,10 @@ import {
   Alert,
   Group,
   Anchor,
+  Divider,
 } from '@mantine/core';
-import { IconCircleCheck } from '@tabler/icons-react';
+import { IconCircleCheck, IconUserPlus } from '@tabler/icons-react';
+import { signIn } from 'next-auth/react';
 import { MarkdownRenderer } from '~/app/_components/shared/MarkdownRenderer';
 import { loadDraft, saveDraft, clearDraft } from './formDraft';
 
@@ -55,9 +57,46 @@ export function PublicForm({
   // localStorage on load, then persist them debounced as the applicant types.
   const [restored, setRestored] = useState(false);
   const [hydrated, setHydrated] = useState(false);
+  // Applicant account CTA (CONTEXT.md ### Forms): an optional, success-page-only
+  // offer to create an Exponential account via a magic link to the email the
+  // applicant already submitted. Captured at submit so it survives the values
+  // state. No link to the CrmContact the submission created (v1).
+  const [accountEmail, setAccountEmail] = useState('');
+  const [accountRequested, setAccountRequested] = useState(false);
+  const [accountSubmitting, setAccountSubmitting] = useState(false);
+  const [accountError, setAccountError] = useState<string | null>(null);
 
   const setValue = (key: string, value: unknown) =>
     setValues((prev) => ({ ...prev, [key]: value }));
+
+  const emailForAccount = (): string => {
+    const emailField = fields.find((f) => f.type === 'email');
+    if (!emailField) return '';
+    const v = values[emailField.key];
+    return typeof v === 'string' ? v.trim() : '';
+  };
+
+  const handleCreateAccount = async () => {
+    if (!accountEmail) return;
+    setAccountSubmitting(true);
+    setAccountError(null);
+    try {
+      const res = await signIn('postmark', {
+        email: accountEmail,
+        redirect: false,
+        callbackUrl: '/',
+      });
+      if (res?.error) {
+        setAccountError('Could not start account setup. Please try again.');
+      } else {
+        setAccountRequested(true);
+      }
+    } catch {
+      setAccountError('Could not start account setup. Please try again.');
+    } finally {
+      setAccountSubmitting(false);
+    }
+  };
 
   // Restore once on mount (client-only — runs after hydration to avoid a
   // server/client mismatch). `hydrated` gates the save effect so its first
@@ -107,6 +146,7 @@ export function PublicForm({
       if (res.ok && body.ok) {
         clearDraft(slug);
         setRestored(false);
+        setAccountEmail(emailForAccount());
         setDone(
           body.confirmationMessage ??
             confirmationMessage ??
@@ -136,6 +176,38 @@ export function PublicForm({
             <Text c="dimmed" ta="center">
               {done}
             </Text>
+
+            {accountEmail && (
+              <>
+                <Divider w="100%" my="xs" />
+                {accountRequested ? (
+                  <Text size="sm" c="dimmed" ta="center">
+                    Check your inbox at <strong>{accountEmail}</strong> to finish
+                    setting up your account.
+                  </Text>
+                ) : (
+                  <Stack align="center" gap="xs">
+                    <Text size="sm" c="dimmed" ta="center">
+                      Want to apply faster next time and keep track of your
+                      applications? Create a free Exponential account.
+                    </Text>
+                    <Button
+                      variant="light"
+                      leftSection={<IconUserPlus size={16} />}
+                      loading={accountSubmitting}
+                      onClick={() => void handleCreateAccount()}
+                    >
+                      Create my account
+                    </Button>
+                    {accountError && (
+                      <Text c="red" size="sm">
+                        {accountError}
+                      </Text>
+                    )}
+                  </Stack>
+                )}
+              </>
+            )}
           </Stack>
         </Card>
       </Container>


### PR DESCRIPTION
### **User description**
## What

After a successful public-form submission, the success page now shows an optional, **non-blocking** call-to-action to create a free Exponential account (the **Applicant account**, CONTEXT.md ### Forms). It uses a Postmark magic link sent to the email the applicant already entered — no password, no new auth surface (reuses the existing NextAuth Postmark provider). After the request, a "check your inbox" state is shown.

The CTA is **hidden** when the form has no email field (nothing to send to). The submit button is never forked or blocked — the offer lives only on the success screen, so it can't hurt submission conversion. v1 creates **no link** between the new `User` and the `CrmContact` the submission created.

## Acceptance criteria

- [x] After successful submit, the success state shows an optional account CTA using the applicant's submitted email
- [x] Clicking it triggers the Postmark magic-link sign-in flow (reuses existing NextAuth config)
- [x] CTA is hidden when the form has no `email` field
- [x] Declining costs nothing — submission is already complete; CTA is non-blocking
- [x] No new entity linkage between User and CrmContact; no hardcoded colors

---

Ships: rainy.jaguar


___

### **PR Type**
Enhancement


___

### **Description**
- Add optional applicant account CTA on public form success page

- CTA triggers Postmark magic-link sign-in via NextAuth, no password needed

- CTA hidden when form has no email field; non-blocking to submission flow

- Shows "check your inbox" state after account creation request


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Form Submission"] -- "success" --> B["Success Screen"]
  B -- "has email field" --> C["Account CTA shown"]
  B -- "no email field" --> D["CTA hidden"]
  C -- "user clicks 'Create my account'" --> E["signIn('postmark') called"]
  E -- "success" --> F["Check inbox message shown"]
  E -- "error" --> G["Error message shown"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PublicForm.tsx</strong><dd><code>Add optional applicant account CTA on success screen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(public)/f/[slug]/_components/PublicForm.tsx

<ul><li>Added <code>accountEmail</code>, <code>accountRequested</code>, <code>accountSubmitting</code>, and <br><code>accountError</code> state variables for the account CTA flow<br> <li> Added <code>handleCreateAccount</code> async function that calls NextAuth <br><code>signIn('postmark')</code> with the submitted email<br> <li> Captures submitted email inline after successful form submission by <br>finding the email field in <code>fields</code><br> <li> Renders optional account CTA section on success screen, with a <br>divider, prompt text, button, and "check your inbox" state; hidden <br>when no email was submitted</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/312/files#diff-477d22ebaebb95d9f645f090403892e95bb1077f5f7ac500e1e0079843ef7c8e">+73/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

