### PR TITLE
feat: time-trap on the public form intake

### DIFF
--- a/src/app/(public)/f/[slug]/_components/PublicForm.tsx
+++ b/src/app/(public)/f/[slug]/_components/PublicForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Container,
   Card,
@@ -57,6 +57,12 @@ export function PublicForm({
   // localStorage on load, then persist them debounced as the applicant types.
   const [restored, setRestored] = useState(false);
   const [hydrated, setHydrated] = useState(false);
+  // Time-trap (ADR-0034): record when the form was presented so the intake can
+  // reject implausibly fast (bot) submissions.
+  const renderedAtRef = useRef<number | null>(null);
+  useEffect(() => {
+    renderedAtRef.current = Date.now();
+  }, []);
   // Applicant account CTA (CONTEXT.md ### Forms): an optional, success-page-only
   // offer to create an Exponential account via a magic link to the email the
   // applicant already submitted. Captured at submit so it survives the values
@@ -125,10 +131,13 @@ export function PublicForm({
     setGeneralError(null);
     setErrors({});
     try {
+      const elapsedMs = renderedAtRef.current
+        ? Date.now() - renderedAtRef.current
+        : 0;
       const res = await fetch(`/api/forms/${slug}/submit`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ data: values, honeypot }),
+        body: JSON.stringify({ data: values, honeypot, elapsedMs }),
       });
       const body = (await res.json()) as {
         ok: boolean;

--- a/src/app/api/forms/[slug]/submit/route.ts
+++ b/src/app/api/forms/[slug]/submit/route.ts
@@ -8,6 +8,7 @@ import {
 } from "~/server/services/forms/formSchema";
 import { runFormDestinations } from "~/server/services/forms/runDestinations";
 import { emailHashFor } from "~/server/services/crm/createCrmContact";
+import { isTooFastSubmission } from "~/server/services/forms/timeTrap";
 
 /**
  * Public **Forms intake** (ADR-0029): POST /api/forms/[slug]/submit. Validates
@@ -70,9 +71,13 @@ export async function POST(
     );
   }
 
-  let body: { data?: unknown; honeypot?: unknown };
+  let body: { data?: unknown; honeypot?: unknown; elapsedMs?: unknown };
   try {
-    body = (await request.json()) as { data?: unknown; honeypot?: unknown };
+    body = (await request.json()) as {
+      data?: unknown;
+      honeypot?: unknown;
+      elapsedMs?: unknown;
+    };
   } catch {
     return NextResponse.json(
       { ok: false, error: "Invalid request body" },
@@ -104,6 +109,23 @@ export async function POST(
         formId: form.id,
         data: {},
         metadata: { ip, honeypotTripped: true } as Prisma.InputJsonValue,
+      },
+    });
+    return NextResponse.json({ ok: true });
+  }
+
+  // Time-trap (ADR-0034): reject implausibly fast fills like a honeypot hit —
+  // record, skip destinations, fake success so bots learn nothing.
+  if (isTooFastSubmission(body.elapsedMs)) {
+    await db.formSubmission.create({
+      data: {
+        formId: form.id,
+        data: {},
+        metadata: {
+          ip,
+          timeTrapped: true,
+          elapsedMs: typeof body.elapsedMs === "number" ? body.elapsedMs : null,
+        } as Prisma.InputJsonValue,
       },
     });
     return NextResponse.json({ ok: true });

--- a/src/server/services/forms/__tests__/timeTrap.test.ts
+++ b/src/server/services/forms/__tests__/timeTrap.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MIN_FILL_MS,
+  fillDurationMs,
+  isTooFastSubmission,
+} from '../timeTrap';
+
+describe('timeTrap', () => {
+  describe('fillDurationMs', () => {
+    it('passes through a valid non-negative number', () => {
+      expect(fillDurationMs(4200)).toBe(4200);
+      expect(fillDurationMs(0)).toBe(0);
+    });
+
+    it('coerces missing or malformed values to 0', () => {
+      expect(fillDurationMs(undefined)).toBe(0);
+      expect(fillDurationMs(null)).toBe(0);
+      expect(fillDurationMs('4200')).toBe(0);
+      expect(fillDurationMs(-100)).toBe(0);
+      expect(fillDurationMs(Number.NaN)).toBe(0);
+      expect(fillDurationMs(Infinity)).toBe(0);
+    });
+  });
+
+  describe('isTooFastSubmission', () => {
+    it('rejects sub-threshold fills', () => {
+      expect(isTooFastSubmission(0)).toBe(true);
+      expect(isTooFastSubmission(MIN_FILL_MS - 1)).toBe(true);
+    });
+
+    it('accepts fills at or beyond the threshold', () => {
+      expect(isTooFastSubmission(MIN_FILL_MS)).toBe(false);
+      expect(isTooFastSubmission(10_000)).toBe(false);
+    });
+
+    it('treats missing/malformed timing as too fast', () => {
+      expect(isTooFastSubmission(undefined)).toBe(true);
+      expect(isTooFastSubmission('soon')).toBe(true);
+    });
+
+    it('honours a custom threshold', () => {
+      expect(isTooFastSubmission(1500, 1000)).toBe(false);
+      expect(isTooFastSubmission(800, 1000)).toBe(true);
+    });
+  });
+});

--- a/src/server/services/forms/timeTrap.ts
+++ b/src/server/services/forms/timeTrap.ts
@@ -1,0 +1,31 @@
+/**
+ * Time-trap (ADR-0034): a human takes a few seconds to fill a form; a bot
+ * submits near-instantly. The public form reports how long it was on screen
+ * (`elapsedMs`); the intake rejects implausibly fast fills like a honeypot hit.
+ *
+ * Pure so the decision is unit-testable independently of the route.
+ */
+
+/** Minimum plausible fill time. Conservative and tunable. */
+export const MIN_FILL_MS = 3000;
+
+/** Coerces an untrusted `elapsedMs` from the request body to a safe number. */
+export function fillDurationMs(elapsedMs: unknown): number {
+  return typeof elapsedMs === 'number' &&
+    Number.isFinite(elapsedMs) &&
+    elapsedMs >= 0
+    ? elapsedMs
+    : 0;
+}
+
+/**
+ * True when a submission arrived too fast to be a genuine human fill. A missing
+ * or malformed duration coerces to 0 and is therefore treated as too fast — the
+ * only legitimate caller (the public form) always sends a real value.
+ */
+export function isTooFastSubmission(
+  elapsedMs: unknown,
+  minMs: number = MIN_FILL_MS,
+): boolean {
+  return fillDurationMs(elapsedMs) < minMs;
+}


### PR DESCRIPTION
### **User description**
## What

Adds a **time-trap** to the public Forms intake — layer 2 of the privacy-first spam stack (ADR-0034). The public form records when it was presented and reports the elapsed fill duration (`elapsedMs`) with the submission. The intake rejects implausibly fast (sub-3s) fills as likely bots, mirroring the honeypot path: record the attempt, skip destinations, return a fake success so bots learn nothing.

The threshold is a single tunable constant (`MIN_FILL_MS`), and the decision is a pure, unit-tested predicate (`timeTrap.ts`) so it's verifiable without the route. Honeypot behaviour is unchanged; legitimate (slower) submissions are unaffected.

## Acceptance criteria

- [x] Public form sends a signal letting the server compute fill duration (render → submit)
- [x] Intake rejects submissions faster than the ~3s threshold without running destinations
- [x] Threshold is a single tunable constant
- [x] Honeypot behaviour unchanged; legitimate (slower) submissions unaffected
- [x] Unit coverage for the time-trap decision (`timeTrap.test.ts`)

---

Ships: mint.forge


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add time-trap spam protection to public form intake (ADR-0034)

- Public form tracks render time and sends `elapsedMs` on submit

- Intake rejects sub-3s fills like honeypot: record, skip destinations, fake success

- Pure `timeTrap.ts` module with full unit test coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PublicForm (client)"] -- "records renderedAt on mount" --> B["useRef timestamp"]
  B -- "computes elapsedMs on submit" --> C["POST /api/forms/[slug]/submit"]
  C -- "elapsedMs < 3000ms" --> D["isTooFastSubmission()"]
  D -- "true (bot)" --> E["Record timeTrapped submission\nReturn fake ok:true"]
  D -- "false (human)" --> F["Normal validation & destinations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PublicForm.tsx</strong><dd><code>Track form render time and send elapsedMs on submit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(public)/f/[slug]/_components/PublicForm.tsx

<ul><li>Import <code>useRef</code> alongside existing hooks<br> <li> Add <code>renderedAtRef</code> to capture form render timestamp via <code>useEffect</code><br> <li> Compute <code>elapsedMs</code> from render time at submit and include it in the <br>POST body</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/313/files#diff-477d22ebaebb95d9f645f090403892e95bb1077f5f7ac500e1e0079843ef7c8e">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Reject implausibly fast submissions in forms intake</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/forms/[slug]/submit/route.ts

<ul><li>Import <code>isTooFastSubmission</code> from new <code>timeTrap</code> module<br> <li> Extend request body type to include <code>elapsedMs?: unknown</code><br> <li> Add time-trap check after honeypot: record submission with <br><code>timeTrapped: true</code> metadata and return fake success for too-fast fills</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/313/files#diff-cdefe0bf3eee445a53d5c283323eb43faae0e4d57c588fa7388e26fe1ceb7cfc">+24/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>timeTrap.ts</strong><dd><code>Pure time-trap decision module with tunable threshold</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/forms/timeTrap.ts

<ul><li>Export <code>MIN_FILL_MS</code> constant (3000ms) as tunable threshold<br> <li> Export <code>fillDurationMs</code> to safely coerce untrusted <code>elapsedMs</code> values<br> <li> Export <code>isTooFastSubmission</code> predicate with optional custom threshold <br>parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/313/files#diff-91231360b05ff105cd015a8db4bc221ded6761a22b3614b0f0ee08e489daeff9">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>timeTrap.test.ts</strong><dd><code>Full unit test coverage for time-trap predicates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/forms/__tests__/timeTrap.test.ts

<ul><li>Unit tests for <code>fillDurationMs</code> covering valid numbers and <br>malformed/missing values<br> <li> Unit tests for <code>isTooFastSubmission</code> covering sub-threshold, <br>at-threshold, missing, and custom threshold cases</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/313/files#diff-b4657d40207c693baae23bad38bc18f7d9f5cd7e9895b2106e1997552160ab2b">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

