### PR TITLE
feat: Shared partitionActions() + action.getTodaysActions endpoint

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -136,6 +136,16 @@ _Avoid_: Auto-close, auto-merge (it promotes a ticket on *someone else's* merge,
 - **Meetings** now emit `WorkspaceActivityEvent` rows via `recordActivity` (entityType `meeting`: `created`, then `summarized` once the auto-summary lands) — the internal-data write-path of ADR-0001, so a meeting appears in the workspace feed, the **Aggregated activity feed**, and the **Weekly work digest** from one write.
 - **Commit activity** _(decided, not yet built — [ADR-0022](docs/adr/0022-github-activity-ingestion-webhook-poll-persisted.md))_: commits are **persisted** to `GitHubActivity` via the webhook `push` event + the per-install App-token poll (not the retired PAT cron of ADR-0019), per-commit stored but **rendered grouped**, reaching the **Aggregated activity feed** and the digest. Attributing a commit to *you* still needs the **GitHub identity claim** (`User.githubLogin`), which remains unbuilt — so "mine" filtering is the gating dependency for commits in the **Weekly work digest**.
 
+### Daily planning
+
+**Today's actions**:
+The set of a user's **Actions** that the `/today` page renders — the canonical "what's on my plate today". **ACTIVE** actions, owned by the user (created-by-me-with-no-assignees **or** assigned-to-me — same ownership as `action.getAll`), drawn across **all workspaces** (the `/today` route is deliberately *not* workspace-scoped). Partitioned by `useActionPartition` into **overdue** (`scheduledStart` before today), **today** (`scheduledStart` today, **or** no schedule and `dueDate` today), and **inbox** (no schedule, no due date, no project). The key semantic: an action is "on my plate today" if it is **scheduled-or-due** today — *scheduled today counts even with no due date* (this is why a 2:24 PM-scheduled "Pay Malte" belongs here). When **Zoe** is asked to act on "today"/"these"/"those" actions, she must resolve against *this* set via a tool, never a name search — the partition logic is being extracted from the client hook to a pure server-shared function so the page, the tRPC endpoint, and Zoe's tool agree by construction (one-source-of-truth, as with [ADR-0007](docs/adr/0007-deterministic-action-extraction.md) and the **Weekly plan digest**). See [ADR-0034](docs/adr/0034-todays-actions-shared-partition.md).
+_Avoid_: Today's plan (reserved — that's the narrower voice **Daily brief**), today's tasks, my day.
+
+**Daily brief**:
+The short, **speakable** morning summary built by `generateBriefingData` and surfaced by voice's `get_todays_plan` **coarse tool** and the web morning briefing. **Narrower than Today's actions on purpose**: it counts only **due-today** (`dueDate` in `[startOfDay, endOfDay]`) and **overdue-by-`dueDate`** actions plus low-progress projects — it does **not** include scheduled-today or inbox actions. So the **Daily brief** and **Today's actions** can legitimately disagree on what "today" contains (the brief omits a scheduled-but-not-due "Pay Malte"). This divergence is **known and accepted for now**; converging voice onto the **Today's actions** definition is deferred, not done. See [ADR-0034](docs/adr/0034-todays-actions-shared-partition.md).
+_Avoid_: Treating the brief as the source of truth for `/today`; "today's plan" for the `/today` list.
+
 ### Weekly planning
 
 **Weekly plan**:

--- a/docs/adr/0034-todays-actions-shared-partition.md
+++ b/docs/adr/0034-todays-actions-shared-partition.md
@@ -1,0 +1,37 @@
+# Today's actions — a shared partition, distinct from the Daily brief
+
+## Status
+
+Accepted — 2026-06-29
+
+## Context
+
+A user on `/today` asked Zoe (in the chat drawer) to "mark the Malte ones done". Zoe **deflected** — "do you remember which project, or should I search your Notion workspace directly?" — which violates her contract on two axes ([CONTEXT.md](../../CONTEXT.md) "Thread score"): **Grounded** (call a tool for facts/actions, never fabricate or ask) and **No deflection** (the router persona's "never tell the user to check their own list"). By the **Failure lane** taxonomy this is primarily a `code_bug`: a tool Zoe needed was missing, with an `agent_behaviour` tail (the deflection).
+
+The root cause is **discovery, not completion**. `action.update` already authorizes by action id via the central access service (`getActionAccess` + `canEditAction`), so completing an action works cross-workspace once Zoe has its id. But Zoe-the-brain's mastra toolset had **no way to list the user's actions for "today"**: she has `get-project-actions` (needs a project), `get-action-items` (meeting-scoped), and `get-today-calendar-events` (calendar, not actions). `/today` is deliberately **not** workspace-scoped and spans all workspaces, so a loose "Pay Malte" action was unreachable.
+
+The obvious DRY fix — reuse `generateBriefingData` (which already backs voice's `get_todays_plan` coarse tool and is cross-workspace) — is a **trap**. That service defines "today" as `dueDate ∈ [todayStart, todayEnd]` (due-only), whereas `/today` (`useActionPartition`) defines it as **scheduled-or-due**: `scheduledStart` today, or no schedule and `dueDate` today, plus overdue and inbox. "Pay Malte" was **scheduled** (2:24 PM), not due — so a briefing-backed tool would have reproduced the exact bug.
+
+## Decision
+
+Give Zoe a dedicated **Today's actions** read tool whose definition is provably identical to what `/today` renders.
+
+- **Extract the partition to a pure, server-shared function** (`partitionActions()` in `~/lib/actions/`). `useActionPartition` (client) and a new `action.getTodaysActions` tRPC procedure (server) both call it, so "what counts as today" agrees by construction — the one-source-of-truth pattern of [ADR-0007](0007-deterministic-action-extraction.md) and the **Weekly plan digest** extraction.
+- **`action.getTodaysActions`** returns the three pre-partitioned groups (`overdue` / `today` / `inbox`), cross-workspace by default (optional `workspaceId` filter), each row carrying `{ id, name, status, scheduledStart, dueDate, projectName, workspaceName }`, capped defensively (~50/group) with total counts.
+- **`get-todays-actions` mastra tool** calls it via `authenticatedTrpcCall`. Its **description is the behaviour driver**: fire on "today's actions / what's on my plate / these / those / them", return ids for completion, and **never ask which project or workspace**. No `zoe-agent.ts` instruction edit up front — revisit only if eval shows the description is insufficient.
+- **Completion is unchanged** — Zoe calls the existing `update-action` (→ `action.update`, id-authorized) per returned id.
+- **Capture an EvalCase** ([ADR-0013](0013-eval-replay-frozen-prefix.md)) from this Thread: frozen prefix "mark the Malte ones done", expectation "must call `get-todays-actions`, must not deflect" — so the fix is proven and the deflection is regression-guarded.
+
+## Considered alternatives
+
+- **Inline the on-screen list into ManyChat's page context.** Rejected — violates the established counts-only/fetch-via-tool convention (meetings/goals/projects), taxes ~1k+ tokens on every turn, goes stale mid-conversation, and only works while the user is physically on `/today` (not from the home drawer or "what's on my plate" anywhere). It also treats the symptom (awareness) not the cause (a missing tool).
+- **Reuse `generateBriefingData` / voice's `get_todays_plan`.** Rejected — its **due-only** definition is narrower than `/today` and would still miss scheduled-but-not-due actions like "Pay Malte".
+- **Converge voice onto the scheduled-or-due definition now.** Deferred — out of scope for this fix; the divergence is documented and convergence is a later, separate decision.
+- **Edit `zoe-agent.ts` instructions to force tool use.** Deferred behind the tool description; the idiomatic Mastra mechanism is the tool's own description, and we measure via eval before adding prompt weight.
+
+## Consequences
+
+- New `partitionActions()` in `~/lib/actions/`; `useActionPartition` refactored to consume it (behaviour unchanged).
+- New `action.getTodaysActions` tRPC procedure + a `get-todays-actions` tool in `../mastra`.
+- **Two coexisting "today" definitions** are accepted for now: **Today's actions** (scheduled-or-due, the `/today` set and Zoe's chat tool) vs. the **Daily brief** (due-only, voice + morning briefing). Both are documented as canonical terms in CONTEXT.md; convergence of voice is explicitly deferred.
+- A new EvalCase enters the regression suite guarding grounding/no-deflection for this class.

--- a/src/app/_components/actions/hooks/useActionPartition.ts
+++ b/src/app/_components/actions/hooks/useActionPartition.ts
@@ -1,111 +1,22 @@
 import { useMemo } from "react";
-import { sortByPriority } from "~/lib/actions/priority";
+import {
+  partitionActions,
+  type ActionPartition,
+  type PartitionableAction,
+} from "~/lib/actions/partition";
 
-export interface ActionPartition<T> {
-  overdue: T[];
-  todays: T[];
-  upcoming: T[];
-  inbox: T[];
-  completed: T[];
-}
+export type { ActionPartition, PartitionableAction };
 
 interface UseActionPartitionOptions {
   today: Date;
-}
-
-interface PartitionableAction {
-  id: string;
-  status: string;
-  priority?: string | null;
-  scheduledStart?: Date | string | null;
-  dueDate?: Date | string | null;
-  projectId?: string | null;
-  completedAt?: Date | string | null;
-}
-
-function startOfDay(d: Date): Date {
-  const out = new Date(d);
-  out.setHours(0, 0, 0, 0);
-  return out;
-}
-
-function addDays(base: Date, n: number): Date {
-  const out = new Date(base);
-  out.setDate(out.getDate() + n);
-  return out;
 }
 
 export function useActionPartition<T extends PartitionableAction>(
   actions: T[],
   options: UseActionPartitionOptions,
 ): ActionPartition<T> {
-  return useMemo(() => {
-    const today = startOfDay(options.today);
-    const tomorrow = addDays(today, 1);
-
-    const overdue: T[] = [];
-    const todays: T[] = [];
-    const upcoming: T[] = [];
-    const inbox: T[] = [];
-    const completed: T[] = [];
-
-    for (const a of actions) {
-      if (a.status === "COMPLETED") {
-        completed.push(a);
-        continue;
-      }
-      if (a.status !== "ACTIVE") continue;
-
-      const scheduled = a.scheduledStart ? new Date(a.scheduledStart) : null;
-      const scheduledDay = scheduled ? startOfDay(scheduled) : null;
-      const due = a.dueDate ? new Date(a.dueDate) : null;
-      const dueDay = due ? startOfDay(due) : null;
-
-      if (scheduledDay && scheduledDay.getTime() < today.getTime()) {
-        overdue.push(a);
-        continue;
-      }
-
-      if (
-        scheduledDay &&
-        scheduledDay.getTime() === today.getTime() &&
-        scheduled &&
-        scheduled < tomorrow
-      ) {
-        todays.push(a);
-        continue;
-      }
-
-      if (!scheduled && dueDay && dueDay.getTime() === today.getTime()) {
-        todays.push(a);
-        continue;
-      }
-
-      if (scheduledDay && scheduledDay.getTime() > tomorrow.getTime()) {
-        upcoming.push(a);
-        continue;
-      }
-
-      if (!a.dueDate && !a.scheduledStart && !a.projectId) {
-        inbox.push(a);
-        continue;
-      }
-    }
-
-    overdue.sort(sortByPriority);
-    todays.sort(sortByPriority);
-    upcoming.sort(sortByPriority);
-    inbox.sort(sortByPriority);
-
-    completed.sort((a, b) => {
-      const aAt = a.completedAt;
-      const bAt = b.completedAt;
-      if (!aAt && !bAt) return a.id.localeCompare(b.id);
-      if (!aAt) return 1;
-      if (!bAt) return -1;
-      return new Date(bAt).getTime() - new Date(aAt).getTime();
-    });
-
-    return { overdue, todays, upcoming, inbox, completed };
-  }, [actions, options.today]);
+  return useMemo(
+    () => partitionActions(actions, { today: options.today }),
+    [actions, options.today],
+  );
 }

--- a/src/lib/actions/__tests__/partition.test.ts
+++ b/src/lib/actions/__tests__/partition.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { partitionActions, type PartitionableAction } from "../partition";
+
+// A fixed "today" so the suite is deterministic regardless of the wall clock.
+const TODAY = new Date("2026-06-29T09:00:00.000Z");
+
+function at(day: string, time = "12:00:00.000Z"): Date {
+  return new Date(`${day}T${time}`);
+}
+
+function action(overrides: Partial<PartitionableAction> = {}): PartitionableAction {
+  return {
+    id: Math.random().toString(36).slice(2),
+    status: "ACTIVE",
+    priority: "Quick",
+    scheduledStart: null,
+    dueDate: null,
+    projectId: null,
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+describe("partitionActions", () => {
+  it("buckets a scheduled-today action with NO due date into `todays` (the Pay Malte shape)", () => {
+    const malte = action({
+      id: "malte",
+      scheduledStart: at("2026-06-29", "14:24:00.000Z"), // 2:24 PM today, no dueDate
+      dueDate: null,
+    });
+
+    const { todays, overdue, inbox, upcoming } = partitionActions([malte], {
+      today: TODAY,
+    });
+
+    expect(todays.map((a) => a.id)).toEqual(["malte"]);
+    expect(overdue).toHaveLength(0);
+    expect(inbox).toHaveLength(0);
+    expect(upcoming).toHaveLength(0);
+  });
+
+  it("buckets a due-today action with no schedule into `todays`", () => {
+    const a = action({ id: "due-today", dueDate: at("2026-06-29") });
+    const { todays } = partitionActions([a], { today: TODAY });
+    expect(todays.map((x) => x.id)).toEqual(["due-today"]);
+  });
+
+  it("buckets a scheduled-before-today action into `overdue`", () => {
+    const a = action({ id: "past", scheduledStart: at("2026-06-27") });
+    const { overdue, todays } = partitionActions([a], { today: TODAY });
+    expect(overdue.map((x) => x.id)).toEqual(["past"]);
+    expect(todays).toHaveLength(0);
+  });
+
+  it("buckets a scheduled-after-tomorrow action into `upcoming`", () => {
+    const a = action({ id: "future", scheduledStart: at("2026-07-05") });
+    const { upcoming, todays } = partitionActions([a], { today: TODAY });
+    expect(upcoming.map((x) => x.id)).toEqual(["future"]);
+    expect(todays).toHaveLength(0);
+  });
+
+  it("buckets a no-schedule/no-due/no-project action into `inbox`", () => {
+    const a = action({ id: "loose" });
+    const { inbox } = partitionActions([a], { today: TODAY });
+    expect(inbox.map((x) => x.id)).toEqual(["loose"]);
+  });
+
+  it("does NOT put a no-schedule/no-due action that has a project into inbox", () => {
+    const a = action({ id: "projected", projectId: "proj-1" });
+    const { inbox, todays, overdue, upcoming } = partitionActions([a], {
+      today: TODAY,
+    });
+    expect(inbox).toHaveLength(0);
+    expect(todays).toHaveLength(0);
+    expect(overdue).toHaveLength(0);
+    expect(upcoming).toHaveLength(0);
+  });
+
+  it("scheduled-today wins over a due date on another day (scheduled-or-due boundary)", () => {
+    // Scheduled today but due far in the future: still `todays`, because
+    // scheduled-today is evaluated before the due-date fallback.
+    const a = action({
+      id: "sched-wins",
+      scheduledStart: at("2026-06-29", "08:00:00.000Z"),
+      dueDate: at("2026-07-20"),
+    });
+    const { todays, upcoming } = partitionActions([a], { today: TODAY });
+    expect(todays.map((x) => x.id)).toEqual(["sched-wins"]);
+    expect(upcoming).toHaveLength(0);
+  });
+
+  it("keeps a due-today action that is also scheduled today in `todays` (no double-count)", () => {
+    const a = action({
+      id: "both",
+      scheduledStart: at("2026-06-29", "10:00:00.000Z"),
+      dueDate: at("2026-06-29"),
+    });
+    const { todays } = partitionActions([a], { today: TODAY });
+    expect(todays.map((x) => x.id)).toEqual(["both"]);
+  });
+
+  it("routes COMPLETED to `completed` and drops non-ACTIVE statuses", () => {
+    const done = action({
+      id: "done",
+      status: "COMPLETED",
+      completedAt: at("2026-06-29", "08:00:00.000Z"),
+    });
+    const deleted = action({ id: "gone", status: "DELETED" });
+    const draft = action({ id: "draft", status: "DRAFT" });
+
+    const { completed, todays, overdue, inbox, upcoming } = partitionActions(
+      [done, deleted, draft],
+      { today: TODAY },
+    );
+
+    expect(completed.map((x) => x.id)).toEqual(["done"]);
+    expect([...todays, ...overdue, ...inbox, ...upcoming]).toHaveLength(0);
+  });
+
+  it("sorts each active bucket by priority then id", () => {
+    const a = action({ id: "b", priority: "Quick", scheduledStart: at("2026-06-29", "09:00:00.000Z") });
+    const b = action({ id: "a", priority: "1st Priority", scheduledStart: at("2026-06-29", "10:00:00.000Z") });
+    const c = action({ id: "c", priority: "Quick", scheduledStart: at("2026-06-29", "11:00:00.000Z") });
+
+    const { todays } = partitionActions([a, b, c], { today: TODAY });
+    // Highest priority ("1st Priority") first, then "Quick" ties broken by id.
+    expect(todays.map((x) => x.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not read the wall clock — same input + same `today` is stable", () => {
+    const set = [
+      action({ id: "x", scheduledStart: at("2026-06-29", "14:24:00.000Z") }),
+      action({ id: "y", dueDate: at("2026-06-29") }),
+      action({ id: "z" }),
+    ];
+    const first = partitionActions(set, { today: TODAY });
+    const second = partitionActions(set, { today: TODAY });
+    expect(first.todays.map((a) => a.id)).toEqual(second.todays.map((a) => a.id));
+    expect(first.inbox.map((a) => a.id)).toEqual(second.inbox.map((a) => a.id));
+  });
+});

--- a/src/lib/actions/partition.ts
+++ b/src/lib/actions/partition.ts
@@ -1,0 +1,129 @@
+import { sortByPriority } from "~/lib/actions/priority";
+
+export interface ActionPartition<T> {
+  overdue: T[];
+  todays: T[];
+  upcoming: T[];
+  inbox: T[];
+  completed: T[];
+}
+
+export interface PartitionableAction {
+  id: string;
+  status: string;
+  priority?: string | null;
+  scheduledStart?: Date | string | null;
+  dueDate?: Date | string | null;
+  projectId?: string | null;
+  completedAt?: Date | string | null;
+}
+
+export interface PartitionActionsOptions {
+  today: Date;
+}
+
+function startOfDay(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+function addDays(base: Date, n: number): Date {
+  const out = new Date(base);
+  out.setDate(out.getDate() + n);
+  return out;
+}
+
+/**
+ * Pure, server-shared partition of a user's actions into the `/today` buckets —
+ * the single source of truth for "what counts as today" (ADR-0034).
+ *
+ * Both the client hook `useActionPartition` and the `action.getTodaysActions`
+ * tRPC procedure call this, so the page and Zoe's tool agree by construction.
+ *
+ * The "today" definition here is **scheduled-or-due** (the `/today` set), which
+ * is deliberately wider than the due-only **Daily brief** (`generateBriefingData`):
+ *   - `overdue`   — `scheduledStart` before today
+ *   - `todays`    — `scheduledStart` today, OR no schedule and `dueDate` today
+ *                   (a scheduled-today action with no due date still counts —
+ *                   the "Pay Malte" shape)
+ *   - `upcoming`  — `scheduledStart` after tomorrow
+ *   - `inbox`     — no schedule, no due date, no project
+ *   - `completed` — status COMPLETED
+ *
+ * Only `ACTIVE` (and `COMPLETED`) actions are bucketed; any other status is
+ * dropped. The function is pure: it does not read the clock — callers pass
+ * `today` explicitly so the result is deterministic and testable.
+ */
+export function partitionActions<T extends PartitionableAction>(
+  actions: T[],
+  options: PartitionActionsOptions,
+): ActionPartition<T> {
+  const today = startOfDay(options.today);
+  const tomorrow = addDays(today, 1);
+
+  const overdue: T[] = [];
+  const todays: T[] = [];
+  const upcoming: T[] = [];
+  const inbox: T[] = [];
+  const completed: T[] = [];
+
+  for (const a of actions) {
+    if (a.status === "COMPLETED") {
+      completed.push(a);
+      continue;
+    }
+    if (a.status !== "ACTIVE") continue;
+
+    const scheduled = a.scheduledStart ? new Date(a.scheduledStart) : null;
+    const scheduledDay = scheduled ? startOfDay(scheduled) : null;
+    const due = a.dueDate ? new Date(a.dueDate) : null;
+    const dueDay = due ? startOfDay(due) : null;
+
+    if (scheduledDay && scheduledDay.getTime() < today.getTime()) {
+      overdue.push(a);
+      continue;
+    }
+
+    if (
+      scheduledDay &&
+      scheduledDay.getTime() === today.getTime() &&
+      scheduled &&
+      scheduled < tomorrow
+    ) {
+      todays.push(a);
+      continue;
+    }
+
+    if (!scheduled && dueDay && dueDay.getTime() === today.getTime()) {
+      todays.push(a);
+      continue;
+    }
+
+    if (scheduledDay && scheduledDay.getTime() > tomorrow.getTime()) {
+      upcoming.push(a);
+      continue;
+    }
+
+    if (!a.dueDate && !a.scheduledStart && !a.projectId) {
+      inbox.push(a);
+      continue;
+    }
+  }
+
+  overdue.sort(sortByPriority);
+  todays.sort(sortByPriority);
+  upcoming.sort(sortByPriority);
+  inbox.sort(sortByPriority);
+
+  completed.sort((a, b) => {
+    const aAt = a.completedAt;
+    const bAt = b.completedAt;
+    if (!aAt && !bAt) return a.id.localeCompare(b.id);
+    if (!aAt) return 1;
+    if (!bAt) return -1;
+    return new Date(bAt).getTime() - new Date(aAt).getTime();
+  });
+
+  return { overdue, todays, upcoming, inbox, completed };
+}

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -24,6 +24,7 @@ import {
   PROJECT_ACTIVITY_TYPES,
 } from "~/server/services/projectActivity";
 import { recordActivity } from "~/server/services/activity/recordActivity";
+import { partitionActions } from "~/lib/actions/partition";
 
 
 export const actionRouter = createTRPCRouter({
@@ -976,6 +977,92 @@ export const actionRouter = createTRPCRouter({
           },
         },
       });
+    }),
+
+  // Today's actions (ADR-0034): the cross-workspace, scheduled-or-due set the
+  // /today page renders, exposed for Zoe's `get-todays-actions` tool. Uses the
+  // same `partitionActions()` source of truth as the client hook, so "what
+  // counts as today" agrees by construction. Distinct from the due-only
+  // Daily brief (`generateBriefingData`).
+  getTodaysActions: protectedProcedure
+    .input(
+      z
+        .object({
+          workspaceId: z.string().optional(),
+        })
+        .optional(),
+    )
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      // Same ownership as action.getAll: created-by-me-with-no-assignees OR
+      // assigned-to-me. Cross-workspace by default; optional workspaceId filter
+      // matches either the action's own workspace or its project's workspace
+      // (so project-less actions are still scoped correctly).
+      const actions = await ctx.db.action.findMany({
+        where: {
+          AND: [
+            {
+              OR: [
+                { createdById: userId, assignees: { none: {} } },
+                { assignees: { some: { userId } } },
+              ],
+            },
+            ...(input?.workspaceId
+              ? [
+                  {
+                    OR: [
+                      { workspaceId: input.workspaceId },
+                      { project: { workspaceId: input.workspaceId } },
+                    ],
+                  },
+                ]
+              : []),
+          ],
+          status: "ACTIVE",
+        },
+        select: {
+          id: true,
+          name: true,
+          status: true,
+          priority: true,
+          scheduledStart: true,
+          dueDate: true,
+          projectId: true,
+          completedAt: true,
+          project: {
+            select: {
+              name: true,
+              workspace: { select: { name: true } },
+            },
+          },
+          workspace: { select: { name: true } },
+        },
+      });
+
+      const partition = partitionActions(actions, { today: new Date() });
+
+      const PER_GROUP_CAP = 50;
+      const toRow = (a: (typeof actions)[number]) => ({
+        id: a.id,
+        name: a.name,
+        status: a.status,
+        scheduledStart: a.scheduledStart,
+        dueDate: a.dueDate,
+        projectName: a.project?.name ?? null,
+        workspaceName: a.workspace?.name ?? a.project?.workspace?.name ?? null,
+      });
+
+      const toGroup = (group: (typeof actions)) => ({
+        count: group.length,
+        actions: group.slice(0, PER_GROUP_CAP).map(toRow),
+      });
+
+      return {
+        overdue: toGroup(partition.overdue),
+        today: toGroup(partition.todays),
+        inbox: toGroup(partition.inbox),
+      };
     }),
 
   getByDateRange: protectedProcedure


### PR DESCRIPTION
### **User description**
## What

Make the "what counts as today" definition one shared, server-callable thing, and expose it as a cross-workspace tRPC endpoint that returns **Today's actions** with ids — so the `/today` page and (next slice) Zoe's tool agree by construction. Per [ADR-0034](docs/adr/0034-todays-actions-shared-partition.md).

- Extract the bucketing from the client hook `useActionPartition` into a pure `partitionActions(actions, { today })` in `~/lib/actions/partition.ts`. Semantics unchanged and **scheduled-or-due** (the `/today` definition, **not** the due-only Daily brief).
- `useActionPartition` now delegates to it (behaviour identical).
- New `action.getTodaysActions` tRPC procedure: same ownership as `action.getAll`, cross-workspace by default with optional `workspaceId` filter, ACTIVE actions, runs `partitionActions()` server-side, returns `overdue` / `today` / `inbox` groups — each row `{ id, name, status, scheduledStart, dueDate, projectName, workspaceName }`, capped 50/group with counts.
- Documents the **Today's actions** vs **Daily brief** terms in CONTEXT.md.

Note: the page-context experiment the ticket asks to remove (`today` case in `formatPageContextData`, `useRegisterPageContext`/`todayPageContext` in `TodayLayout`) was never committed to `main` — it lived only as an uncommitted local draft — so this branch is already clean of it.

## Acceptance criteria

- [x] `partitionActions()` is a pure function in `~/lib/actions/`, unit-tested across the buckets (overdue / today / inbox), incl. the scheduled-today-no-due-date case (the "Pay Malte" shape) and the scheduled-or-due boundary.
- [x] `useActionPartition` delegates to `partitionActions()`; `/today` renders identically.
- [x] `action.getTodaysActions` returns the three groups across all the user's workspaces when no `workspaceId` is passed, each row carrying id + name + status + scheduledStart + dueDate + projectName + workspaceName, capped ~50/group with counts.
- [x] A scheduled-today action with no due date (the "Pay Malte" shape) appears in the `today` group.
- [x] The page-context experiment is absent; `npm run check` (typecheck + lint) passes; 1193 unit tests pass.

---

Ships: flat.squid


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Extract bucketing logic from `useActionPartition` into pure shared `partitionActions()` function

- Add new `action.getTodaysActions` tRPC endpoint returning overdue/today/inbox groups cross-workspace

- Add unit tests for `partitionActions()` covering all bucket scenarios and edge cases

- Document "Today's actions" vs "Daily brief" distinction in CONTEXT.md and ADR-0034


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["useActionPartition (hook)"] -- "delegates to" --> P["partitionActions()\n~/lib/actions/partition.ts"]
  B["action.getTodaysActions\n(tRPC procedure)"] -- "calls" --> P
  P -- "returns" --> C["overdue / todays / upcoming / inbox / completed"]
  B -- "returns to caller" --> D["overdue / today / inbox\n(capped 50/group with counts)"]
  E["partition.test.ts"] -- "unit tests" --> P
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useActionPartition.ts</strong><dd><code>Refactor hook to delegate to shared partitionActions()</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/actions/hooks/useActionPartition.ts

<ul><li>Removed all inline bucketing logic (date helpers, loop, sorting)<br> <li> Now imports and delegates to <code>partitionActions()</code> from <br><code>~/lib/actions/partition</code><br> <li> Re-exports <code>ActionPartition</code> and <code>PartitionableAction</code> types for consumers<br> <li> Hook behaviour is unchanged; implementation is now a thin <code>useMemo</code> <br>wrapper</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/314/files#diff-002a7c028a3e2764429ccc3581ff9aeef7d10f2eb2ec651e9671165a8c5931ec">+10/-99</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>partition.ts</strong><dd><code>New pure shared partitionActions() function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/actions/partition.ts

<ul><li>New pure function <code>partitionActions()</code> extracted from the client hook<br> <li> Exports <code>ActionPartition</code>, <code>PartitionableAction</code>, and <br><code>PartitionActionsOptions</code> interfaces<br> <li> Contains all bucketing logic: overdue, todays, upcoming, inbox, <br>completed with priority sorting<br> <li> Documented as single source of truth per ADR-0034; does not read the <br>clock (caller passes <code>today</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/314/files#diff-e5521fa3900ec832c7cfe62b2fddb56b86fd920941be52cb96620b199d937121">+129/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>action.ts</strong><dd><code>Add getTodaysActions tRPC endpoint using shared partition</code></dd></summary>
<hr>

src/server/api/routers/action.ts

<ul><li>Imports <code>partitionActions</code> from <code>~/lib/actions/partition</code><br> <li> Adds new <code>getTodaysActions</code> tRPC protected procedure<br> <li> Queries ACTIVE actions cross-workspace with optional <code>workspaceId</code> <br>filter using same ownership rules as <code>getAll</code><br> <li> Returns overdue/today/inbox groups, each capped at 50 rows with total <br>count</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/314/files#diff-5b198a3cc9e3495e32e4dcdf28771f225d15998a0c3ab9de63ef7f12941d1dbb">+87/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>partition.test.ts</strong><dd><code>Unit tests for partitionActions() across all buckets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/actions/__tests__/partition.test.ts

<ul><li>New test file with 10 unit tests for <code>partitionActions()</code><br> <li> Covers all buckets: overdue, todays (scheduled and due-date variants), <br>upcoming, inbox, completed<br> <li> Tests edge cases: "Pay Malte" shape, scheduled-or-due boundary, no <br>double-count, non-ACTIVE statuses<br> <li> Verifies priority sorting and determinism (no wall-clock dependency)</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/314/files#diff-b06a6d01433a48830e17b6133dd49ae4bab5a69edd20292862310f8bef48f85f">+141/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONTEXT.md</strong><dd><code>Document Today's actions vs Daily brief terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CONTEXT.md

<ul><li>Adds "Daily planning" section defining canonical terms<br> <li> Documents "Today's actions" (scheduled-or-due, <code>/today</code> set) vs "Daily <br>brief" (due-only, voice/briefing)<br> <li> Clarifies ownership, cross-workspace scope, and Zoe's resolution <br>contract<br> <li> Notes known divergence between the two definitions and defers <br>convergence</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/314/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>0034-todays-actions-shared-partition.md</strong><dd><code>ADR-0034: Today's actions shared partition decision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/adr/0034-todays-actions-shared-partition.md

<ul><li>New ADR documenting the root cause (missing tool causing Zoe <br>deflection)<br> <li> Records decision to extract <code>partitionActions()</code> and add <br><code>getTodaysActions</code> endpoint<br> <li> Documents rejected alternatives (briefing reuse, page context <br>injection, instruction edits)<br> <li> Notes accepted coexistence of two "today" definitions with deferred <br>convergence</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/314/files#diff-9d5c9c274ec1ecd06ecdfdeb80b913a426cd55f7564ddbbf5b15bcd2515c3350">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

