### PR TITLE
feat: Product Roadmap tab — cross-product Feature board (flat status Kanban)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -167,7 +167,7 @@ _Avoid_: Review session (only in code), wizard state (it is no longer client-onl
 ### Product
 
 **Product**:
-A unit of work delivery owned by a workspace — has its own backlog, features, cycles, retros. Stored as `Product`. Routes live under `/w/[slug]/products/[productSlug]`. A Product also **owns zero or more Projects** (`Project.productId`, nullable) — so a Product spans two parallel work hierarchies: Feature→Ticket (product-management work) and Project→Action (delivery work). The product list and a Products & Projects view live as sibling routes (`/products`, `/products-grid`, `/products-projects`).
+A unit of work delivery owned by a workspace — has its own backlog, features, cycles, retros. Stored as `Product`. Routes live under `/w/[slug]/products/[productSlug]`. A Product also **owns zero or more Projects** (`Project.productId`, nullable) — so a Product spans two parallel work hierarchies: Feature→Ticket (product-management work) and Project→Action (delivery work). The product list, a Products & Projects view, and the cross-product **Product Roadmap** live as sibling routes (`/products`, `/products-grid`, `/products-projects`, `/products-roadmap`).
 _Avoid_: App, service, module.
 
 **Unassigned project**:
@@ -189,6 +189,10 @@ _Avoid_: Bot, service account (use "Errol" or "the Errol system user").
 **Feature**:
 A coherent slice of product capability inside a Product, stored as `Feature`. Has `status` (`IDEA`, `DEFINED`, `IN_PROGRESS`, `SHIPPED`, `ARCHIVED`), optional `vision`, optional alignment to a Goal (`Feature.goalId`). Groups Tickets (`Ticket.featureId`).
 _Avoid_: Task, story, item, issue.
+
+**Product Roadmap**:
+A workspace-wide **view** — a tab in the products area (`/products-roadmap`, sibling to List/Grid/Products & Projects) — that lays every **Feature** across *all* the workspace's **Products** onto one Kanban. Columns are `Feature.status` (`IDEA → DEFINED → IN_PROGRESS → SHIPPED`; `ARCHIVED` is a hidden filter, not a column; `SHIPPED` is time-bounded, defaulting to the current **OKR** `period`). Rows are **swimlanes by Objective** — each Feature sits under the **Objective** it aligns to (`Feature.goalId`), with an **Unaligned** lane for Features serving no Objective (a deliberate governance signal). Cards drag horizontally to change status and vertically (into a lane *header*) to re-align Objective — both write `feature.update` and inherit its access check, so a viewer gets a read-only board. Grouping collapses to a flat status Kanban ("group by: Objective / none"). It is **status-grouped, deliberately not time-based**, and is a **derived view** — *no `Roadmap` table*, just `Feature` + `Goal` read together. Its purpose is to **bridge OKRs and per-Product delivery**: the one screen where you see, per Objective, what's an idea vs in-flight vs shipped across every product. Strictly distinct from the strategy-pipeline **Roadmap** below (that means scheduled *Projects with timing*). See [ADR-0035](docs/adr/0035-product-roadmap-derived-status-view.md).
+_Avoid_: Roadmap (overloaded — the pipeline state below is Projects-with-*timing*; this is Features-by-*status*); Gantt/timeline (this has no time axis); Board (loses the OKR-swimlane bridge that earns the name).
 
 **Objective**:
 A strategic outcome — what Exponential schemas call `Goal`. Use the word "Objective" in OKR conversation and UI affordances ("Aligned to objective: …"); the underlying table is `Goal` for historical reasons. An Objective can nest under a parent Objective (`Goal.parentGoalId`), be scoped to a `period` (e.g. `Q2-2026`), and have many **Key results**.
@@ -242,7 +246,7 @@ _Avoid_: Solution, initiative (use "approach"); modelling it as its own table (i
 
 **Roadmap / Backlog**:
 Where a confirmed Implementation **Approach (Project)** lands — **not a separate entity**. **Roadmap** = committed work *with timing* (a scheduled Project); **Backlog** = validated but not yet scheduled. There is no `Roadmap` table; a roadmap is a **view/state over Projects**. (The legacy static `/roadmap` marketing page is unrelated and not data-backed.)
-_Avoid_: Treating "Roadmap" as a database or as the dependency-graph view (which deliberately avoids the word — it carries timeline connotations).
+_Avoid_: Treating "Roadmap" as a database or as the dependency-graph view (which deliberately avoids the word — it carries timeline connotations). Also distinct from the **Product Roadmap** tab above — that is a status-grouped view over *Features*; this is a timing-state over *Projects*. Same word, different entity and axis.
 
 **Parked**:
 A cross-cutting state for **Problems, Hypotheses, and Approaches** alike — an item that didn't pass its gate is parked **with a reason** (insufficient evidence, out of scope, duplicate, …), never deleted. The record of what was considered and why it was passed over; revisited quarterly. Modelled as `parkedAt` + `parkReason` on each entity, not a status value (an item's lifecycle status and its parked-ness are independent).

--- a/docs/adr/0035-product-roadmap-derived-status-view.md
+++ b/docs/adr/0035-product-roadmap-derived-status-view.md
@@ -1,0 +1,87 @@
+# Product Roadmap is a derived cross-product status view, not a stored entity
+
+## Status
+
+Accepted — 2026-06-30. Sits alongside the **Roadmap / Backlog** glossary entry in
+[CONTEXT.md](../../CONTEXT.md) (the strategy-pipeline state over Projects) and reuses the
+`Feature.goalId` alignment edge from the **Product alignment chain**.
+
+## Context
+
+The products area shows one Product at a time (`/products`, `/products-grid`,
+`/products-projects`). There is **no view across all Products**, and the **OKR**s
+(`/goals?tab=okrs`) live in a parallel surface with no on-screen link to the Features that serve
+them. The gap the team feels: *"what is every product building, and which Objective does each
+thing serve?"* — answerable today only by opening each Product and cross-referencing the goals
+page by hand.
+
+Two framings were in tension:
+
+- The user's word for the fix is **"Product Roadmap."** But the glossary already reserves
+  **Roadmap** for *committed Projects with timing* (a view/state over `Project`, no table), and the
+  per-Product dependency-graph view **deliberately avoids the word** because it "carries timeline
+  connotations." A naive read would make the new screen a Gantt over Projects.
+- What the team actually wants first is **"a simple Kanban across all products, by Feature
+  status"** — which has *no time axis at all* and is over **Features**, not Projects.
+
+So the new artifact collides head-on with an existing, correct term. The pieces to build it already
+exist: `FeatureStatus` (`IDEA → DEFINED → IN_PROGRESS → SHIPPED → ARCHIVED`) gives columns,
+`Feature.goalId` gives the Objective bridge, `Product.icon`/`color` give card badges, and
+`feature.update` already mutates both `status` and `goalId` under an access check. The only missing
+server piece is a workspace-wide (all-Products) Feature fetch; `feature.list` is per-Product today.
+
+## Decision
+
+**Build the Product Roadmap as a derived read-side view — no new table — and keep it deliberately
+status-based, not time-based.** It is a *fourth tab* in the products area
+(`/products-roadmap`), composing `Feature` + `Goal` that already exist.
+
+1. **No `Roadmap`/`RoadmapItem` entity.** The board is a query over `Feature` joined to its `Goal`.
+   This reaffirms the existing "there is no Roadmap table" stance rather than overturning it. A
+   stored planning artifact (bets that exist before any Feature) is explicitly *not* built now; it
+   would earn its own ADR if a real need for objective-less, feature-less bets appears.
+2. **Columns are `Feature.status`.** Active columns are `IDEA / DEFINED / IN_PROGRESS / SHIPPED`.
+   `ARCHIVED` is a hidden filter, not a column. `SHIPPED` is **time-bounded** (default: the current
+   OKR `period`) so the board stays "in-flight + recently landed," not an archive. v1 bounds
+   `SHIPPED` by `Feature.updatedAt` (a coarse proxy); `FeatureScope.shippedAt` is the precise signal
+   for a later refinement.
+3. **Rows are swimlanes by Objective.** Each Feature sits under the Objective it aligns to
+   (`Feature.goalId`), with an **Unaligned** lane for `goalId = null` — itself a governance signal
+   ("we are building things that serve no OKR"). The swimlane grouping is what makes this the
+   **OKR ↔ per-Product-delivery bridge** and what earns the name "Roadmap" rather than "Board." It
+   collapses to a flat status Kanban via a "group by: Objective / none" toggle.
+4. **Full drag, reusing `feature.update`.** Horizontal drag changes `status`; vertical drag into a
+   lane *header* re-aligns `goalId` (drag an Unaligned card up into an Objective lane to align it).
+   Both inherit `feature.update`'s access check, so a viewer gets a read-only board for free. The
+   header-only drop-zone for re-alignment keeps a status drag from silently re-homing the OKR.
+5. **The word "Roadmap" is taken, and the glossary disambiguates the collision** rather than
+   redefining the old term. Two distinct entries now coexist: **Product Roadmap** (Features by
+   *status*, a tab) and **Roadmap** (Projects with *timing*, a pipeline state). Same word, different
+   entity and different axis — called out in both entries' `_Avoid_` lines.
+
+## Considered alternatives
+
+- **A new `Roadmap`/`RoadmapItem` table** you draw bets on before Projects/Features exist. Rejected
+  for v1: contradicts the standing "no Roadmap table" decision, adds a migration, and answers a need
+  (feature-less bets) no one has yet expressed. Revisit only with a concrete case.
+- **A time-based Gantt over Projects** (the literal glossary meaning of "Roadmap"). Rejected as the
+  *first* build: the team explicitly asked for a status Kanban over Features, and the Gantt machinery
+  (`ProjectTimelineView`, `OkrTimeline`) already exists to build a separate timeline view later if
+  wanted. Naming the status board "Roadmap" does not consume that future.
+- **A plain cross-product "Board" with no OKR grouping.** Rejected: indistinguishable from the
+  existing per-Product feature board scaled up, and drops the OKR-bridge half of the original ask.
+  The Objective swimlane is the reason the view is worth its own tab and its own name.
+- **Redefining the existing "Roadmap" term to mean this.** Rejected: "Roadmap = scheduled Projects"
+  is a load-bearing node in the strategy pipeline (`Problem → Hypothesis → Approach → Roadmap |
+  Backlog`); broadening it would blur that chain. Adding a distinct sibling term is cleaner than
+  overloading a correct one.
+
+## Consequences
+
+- One new workspace-wide Feature query (all Products, lean card fields + `goal` + `product`); watch
+  payload size. No schema migration.
+- One new route/page + a fourth entry in `ProductsViewTabs`. No change to existing product views.
+- Two near-homonym glossary terms now coexist by design; the `_Avoid_` cross-references carry the
+  burden of keeping "Product Roadmap" (status/Features) and "Roadmap" (timing/Projects) apart.
+- **Deferred, not rejected:** a precise `SHIPPED` window via `FeatureScope.shippedAt`, and a genuine
+  time-based roadmap view — both are additive on top of this and neither is foreclosed.

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products-roadmap/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products-roadmap/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { ProductsViewTabs } from '~/app/_components/products/ProductsViewTabs';
+import { ProductRoadmapBoard } from '~/app/_components/products/ProductRoadmapBoard';
+
+export default function ProductsRoadmapPage() {
+  return (
+    <div className="flex h-full flex-col text-text-primary">
+      <ProductsViewTabs />
+      <ProductRoadmapBoard />
+    </div>
+  );
+}

--- a/src/app/_components/products/ProductRoadmapBoard.tsx
+++ b/src/app/_components/products/ProductRoadmapBoard.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useMemo } from 'react';
+import Link from 'next/link';
+import { Badge, Card, Group, Paper, Skeleton, Stack, Text } from '@mantine/core';
+import { IconRoute } from '@tabler/icons-react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { api } from '~/trpc/react';
+import type { RouterOutputs } from '~/trpc/react';
+import { EmptyState } from '~/app/_components/EmptyState';
+import { getAvatarColor, getInitial } from '~/utils/avatarColors';
+import { FEATURE_STATUSES } from '~/lib/feature-statuses';
+
+type RoadmapFeature =
+  RouterOutputs['product']['feature']['listForWorkspace'][number];
+type RoadmapProduct = RoadmapFeature['product'];
+
+// ---------------------------------------------------------------------------
+// Product badge — small colored chip identifying the card's owning Product.
+// `Product.icon` / `Product.color` are free-text and often unset, so fall back
+// to a deterministic avatar color + the product's initial.
+// ---------------------------------------------------------------------------
+
+function ProductBadge({ product }: { product: RoadmapProduct }) {
+  const dotStyle = {
+    backgroundColor: product.color ?? getAvatarColor(product.id),
+  };
+
+  return (
+    <Group gap={6} wrap="nowrap" align="center" className="min-w-0">
+      <span
+        className="flex h-4 w-4 shrink-0 items-center justify-center rounded-sm text-[10px] leading-none"
+        style={dotStyle}
+        aria-hidden
+      >
+        {product.icon ?? getInitial(product.name)}
+      </span>
+      <Text size="xs" className="text-text-muted truncate">
+        {product.name}
+      </Text>
+    </Group>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Feature card (read-only in this slice — status changes happen on the
+// feature detail surface; drag arrives in a later slice).
+// ---------------------------------------------------------------------------
+
+function FeatureCard({
+  feature,
+  prefix,
+}: {
+  feature: RoadmapFeature;
+  prefix: string;
+}) {
+  const href = `${prefix}/products/${feature.product.slug}/features/${feature.id}`;
+  return (
+    <Card
+      component={Link}
+      href={href}
+      className="border border-border-primary bg-surface-secondary hover:border-border-focus transition-colors"
+      padding="sm"
+      radius="sm"
+    >
+      <Text
+        size="sm"
+        fw={500}
+        className="text-text-primary"
+        lineClamp={2}
+      >
+        {feature.name}
+      </Text>
+      <Group mt="xs" gap="xs" justify="space-between" wrap="nowrap">
+        <ProductBadge product={feature.product} />
+      </Group>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Column
+// ---------------------------------------------------------------------------
+
+function BoardColumn({
+  label,
+  color,
+  features,
+  prefix,
+}: {
+  label: string;
+  color: string;
+  features: RoadmapFeature[];
+  prefix: string;
+}) {
+  return (
+    <Paper className="min-w-64 w-64 shrink-0" p="sm" radius="md" withBorder>
+      <Group justify="space-between" mb="sm">
+        <Badge
+          size="sm"
+          variant="filled"
+          color={color}
+          styles={{ label: { color: 'var(--mantine-color-dark-9)' } }}
+        >
+          {label}
+        </Badge>
+        <Text size="xs" fw={600} className="text-text-muted">
+          {features.length}
+        </Text>
+      </Group>
+      <Stack gap="xs">
+        {features.map((feature) => (
+          <FeatureCard key={feature.id} feature={feature} prefix={prefix} />
+        ))}
+        {features.length === 0 && (
+          <div className="flex h-16 items-center justify-center rounded-md border-2 border-dashed border-border-secondary">
+            <Text size="xs" className="text-text-muted">
+              No features
+            </Text>
+          </div>
+        )}
+      </Stack>
+    </Paper>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Board
+// ---------------------------------------------------------------------------
+
+export function ProductRoadmapBoard() {
+  const { workspace, workspaceId } = useWorkspace();
+  const prefix = workspace?.slug ? `/w/${workspace.slug}` : '';
+
+  const { data: features, isLoading } =
+    api.product.feature.listForWorkspace.useQuery(
+      { workspaceId: workspaceId ?? '' },
+      { enabled: !!workspaceId },
+    );
+
+  const columnFeatures = useMemo(() => {
+    const map: Record<string, RoadmapFeature[]> = {};
+    for (const col of FEATURE_STATUSES) map[col.value] = [];
+    for (const f of features ?? []) {
+      (map[f.status] ??= []).push(f);
+    }
+    return map;
+  }, [features]);
+
+  if (isLoading) {
+    return (
+      <div className="flex gap-3 overflow-x-auto px-8 pt-6 pb-4">
+        {FEATURE_STATUSES.map((col) => (
+          <Skeleton key={col.value} height={320} className="min-w-64 w-64 shrink-0" radius="md" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!features || features.length === 0) {
+    return (
+      <div className="px-8 pt-6">
+        <EmptyState
+          icon={IconRoute}
+          message="No features across your products yet. Create features inside a product to see them on the roadmap."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-3 overflow-x-auto px-8 pt-6 pb-4 w-full min-w-0">
+      {FEATURE_STATUSES.map((col) => (
+        <BoardColumn
+          key={col.value}
+          label={col.label}
+          color={col.color}
+          features={columnFeatures[col.value] ?? []}
+          prefix={prefix}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/app/_components/products/ProductsViewTabs.tsx
+++ b/src/app/_components/products/ProductsViewTabs.tsx
@@ -4,7 +4,12 @@ import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { IconTable, IconLayoutGrid, IconLayoutList } from '@tabler/icons-react';
+import {
+  IconTable,
+  IconLayoutGrid,
+  IconLayoutList,
+  IconRoute,
+} from '@tabler/icons-react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import styles from './ProductsViewTabs.module.css';
 
@@ -16,6 +21,12 @@ const VIEW_TABS = [
     label: 'Products & Projects',
     icon: IconLayoutList,
     path: '/products-projects',
+  },
+  {
+    value: 'roadmap',
+    label: 'Product Roadmap',
+    icon: IconRoute,
+    path: '/products-roadmap',
   },
 ] as const;
 
@@ -34,6 +45,7 @@ export function ProductsViewTabs({ actions }: ProductsViewTabsProps) {
   const activeTab: ViewTabValue = useMemo(() => {
     if (pathname.endsWith('/products-grid')) return 'grid';
     if (pathname.endsWith('/products-projects')) return 'projects';
+    if (pathname.endsWith('/products-roadmap')) return 'roadmap';
     return 'list';
   }, [pathname]);
 

--- a/src/lib/feature-statuses.ts
+++ b/src/lib/feature-statuses.ts
@@ -1,0 +1,52 @@
+/**
+ * Feature status definitions — single source of truth for the Product Roadmap
+ * board's labels, colors, and column ordering. Mirrors `~/lib/ticket-statuses`
+ * but for the `FeatureStatus` enum (`IDEA → DEFINED → IN_PROGRESS → SHIPPED →
+ * ARCHIVED`). See ADR-0035.
+ */
+
+export type FeatureStatus =
+  | "IDEA"
+  | "DEFINED"
+  | "IN_PROGRESS"
+  | "SHIPPED"
+  | "ARCHIVED";
+
+export const FEATURE_STATUSES: Array<{
+  value: FeatureStatus;
+  label: string;
+  color: string;
+  order: number;
+}> = [
+  { value: "IDEA", label: "Idea", color: "gray", order: 0 },
+  { value: "DEFINED", label: "Defined", color: "blue", order: 1 },
+  { value: "IN_PROGRESS", label: "In progress", color: "yellow", order: 2 },
+  { value: "SHIPPED", label: "Shipped", color: "green", order: 3 },
+  { value: "ARCHIVED", label: "Archived", color: "dark", order: 4 },
+];
+
+export const FEATURE_STATUS_LABELS: Record<string, string> = Object.fromEntries(
+  FEATURE_STATUSES.map((s) => [s.value, s.label]),
+);
+
+export const FEATURE_STATUS_COLORS: Record<string, string> = Object.fromEntries(
+  FEATURE_STATUSES.map((s) => [s.value, s.color]),
+);
+
+export const FEATURE_STATUS_ORDER: Record<string, number> = Object.fromEntries(
+  FEATURE_STATUSES.map((s) => [s.value, s.order]),
+);
+
+/**
+ * The status the Product Roadmap deliberately hides from its columns:
+ * `ARCHIVED` is a filter toggle, not a lane (ADR-0035, slice #5).
+ */
+export const ARCHIVED_FEATURE_STATUS: FeatureStatus = "ARCHIVED";
+
+/**
+ * The active roadmap columns (everything except `ARCHIVED`), in board order.
+ * This is the default set of columns the board renders.
+ */
+export const ROADMAP_BOARD_COLUMNS = FEATURE_STATUSES.filter(
+  (s) => s.value !== ARCHIVED_FEATURE_STATUS,
+);

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -280,6 +280,49 @@ export const featureRouter = createTRPCRouter({
       });
     }),
 
+  /**
+   * Workspace-wide Feature fetch for the cross-product **Product Roadmap** board
+   * (ADR-0035). Unlike {@link list} (one Product), this returns every Feature
+   * across *all* of the workspace's Products, with only the lean card fields the
+   * board needs plus the parent `product` (icon/color/name for the card badge).
+   * No descriptions, no ticket graphs — keep the payload small.
+   *
+   * Access is gated at the workspace level (`assertWorkspaceMember`); every
+   * Feature returned belongs to a Product in that workspace, so the per-Product
+   * access check is unnecessary.
+   */
+  listForWorkspace: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      await assertWorkspaceMember(
+        ctx.db,
+        ctx.session.user.id,
+        input.workspaceId,
+      );
+
+      return ctx.db.feature.findMany({
+        where: { product: { workspaceId: input.workspaceId } },
+        orderBy: { updatedAt: "desc" },
+        select: {
+          id: true,
+          name: true,
+          status: true,
+          priority: true,
+          goalId: true,
+          updatedAt: true,
+          product: {
+            select: {
+              id: true,
+              name: true,
+              slug: true,
+              icon: true,
+              color: true,
+            },
+          },
+        },
+      });
+    }),
+
   getById: protectedProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {


### PR DESCRIPTION
### **User description**
## What

The tracer bullet for the **Product Roadmap** (ADR-0035). Adds a 4th tab to the products area (`ProductsViewTabs`) → a new route `/products-roadmap` rendering a **flat status Kanban** of **every Feature across all the workspace's Products**. Columns are `Feature.status` (IDEA / DEFINED / IN_PROGRESS / SHIPPED / ARCHIVED — full set for this slice; bounding comes in `teal.mango`). Each card shows a **product badge** (icon/color/name). Read-only in this slice.

Derived view — **no new table**. One new server piece: `feature.listForWorkspace`, a workspace-wide Feature fetch returning lean card fields + parent product (the per-product `feature.list` is unchanged).

Also carries the design of record: `docs/adr/0035-product-roadmap-derived-status-view.md` and the **Product Roadmap** glossary entry in `CONTEXT.md`.

## Acceptance criteria

- [x] A "Product Roadmap" tab appears in the products area tab bar, routing to `/products-roadmap`.
- [x] The page lists every Feature across all Products in the current workspace, grouped into status columns.
- [x] Each card shows its product badge (icon/color/name).
- [x] The data comes from a workspace-scoped query (`feature.listForWorkspace`) returning lean card fields + product.
- [x] Board is read-only (status changes still happen on the feature detail surface).

---

Refs: inner.toad


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Adds a new "Product Roadmap" tab (`/products-roadmap`) with a flat status Kanban board
  - Displays all Features across all workspace Products grouped by status columns
  - Each card shows a product badge (icon/color/name) and links to the feature detail

- Adds `feature.listForWorkspace` tRPC query for workspace-wide Feature fetching

- Introduces `src/lib/feature-statuses.ts` as single source of truth for Feature status definitions

- Adds ADR-0035 and updates `CONTEXT.md` with Product Roadmap glossary entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ProductsViewTabs"] -- "new 4th tab" --> B["/products-roadmap route"]
  B -- "renders" --> C["ProductRoadmapBoard"]
  C -- "queries" --> D["feature.listForWorkspace tRPC"]
  D -- "fetches from" --> E["Feature + Product (DB)"]
  C -- "uses" --> F["FEATURE_STATUSES (feature-statuses.ts)"]
  C -- "renders columns" --> G["BoardColumn (per status)"]
  G -- "renders cards" --> H["FeatureCard + ProductBadge"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>page.tsx</strong><dd><code>New route page for Product Roadmap tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/316/files#diff-754cb5d76226fc211c11acc1eecf5e9233a5e8ee26c2579882cb39df1a6b1040">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProductRoadmapBoard.tsx</strong><dd><code>New cross-product Kanban board component with feature cards</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/316/files#diff-129b5337c6e8708088d025e64b1a8c3bc1af809d521c707d02f94ec94e0e401b">+184/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ProductsViewTabs.tsx</strong><dd><code>Add Product Roadmap as fourth tab in products view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/316/files#diff-7b1b3556a8071a818b09d7c7e66eacfb361f910882f35358322c5835ed534ded">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>feature-statuses.ts</strong><dd><code>New feature status definitions and constants for roadmap board</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/316/files#diff-347e21e3b507db809a2ae8e95759d9193b0fa00b24119fe8bbf6a52a63259b1f">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>feature.ts</strong><dd><code>Add workspace-wide listForWorkspace tRPC query for features</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/316/files#diff-bff1a29f77efa7f846d655a0106c96302d007305d09f09ecb53ab204ef97d03d">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CONTEXT.md</strong><dd><code>Add Product Roadmap glossary entry and update related definitions</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/316/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0035-product-roadmap-derived-status-view.md</strong><dd><code>New ADR documenting Product Roadmap as derived status view</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/316/files#diff-2dba0a8829ee004dd46b9d80b9e811835e138e18e9d9e3e81080f61458e24a04">+87/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

