### PR TITLE
feat: Product Roadmap — Objective swimlanes + Unaligned lane + group-by toggle

### DIFF
--- a/src/app/_components/products/ProductRoadmapBoard.tsx
+++ b/src/app/_components/products/ProductRoadmapBoard.tsx
@@ -1,8 +1,17 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Badge, Card, Group, Paper, Skeleton, Stack, Text } from '@mantine/core';
+import {
+  Badge,
+  Card,
+  Group,
+  Paper,
+  SegmentedControl,
+  Skeleton,
+  Stack,
+  Text,
+} from '@mantine/core';
 import { IconRoute } from '@tabler/icons-react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { api } from '~/trpc/react';
@@ -14,6 +23,11 @@ import { FEATURE_STATUSES } from '~/lib/feature-statuses';
 type RoadmapFeature =
   RouterOutputs['product']['feature']['listForWorkspace'][number];
 type RoadmapProduct = RoadmapFeature['product'];
+
+type GroupBy = 'objective' | 'none';
+
+/** Lane key for the Unaligned swimlane (features with no `goalId`). */
+const UNALIGNED_KEY = '__unaligned__';
 
 // ---------------------------------------------------------------------------
 // Product badge — small colored chip identifying the card's owning Product.
@@ -63,12 +77,7 @@ function FeatureCard({
       padding="sm"
       radius="sm"
     >
-      <Text
-        size="sm"
-        fw={500}
-        className="text-text-primary"
-        lineClamp={2}
-      >
+      <Text size="sm" fw={500} className="text-text-primary" lineClamp={2}>
         {feature.name}
       </Text>
       <Group mt="xs" gap="xs" justify="space-between" wrap="nowrap">
@@ -79,48 +88,201 @@ function FeatureCard({
 }
 
 // ---------------------------------------------------------------------------
-// Column
+// Helpers — bucket a feature list into status columns.
 // ---------------------------------------------------------------------------
 
-function BoardColumn({
-  label,
-  color,
+function bucketByStatus(features: RoadmapFeature[]) {
+  const map: Record<string, RoadmapFeature[]> = {};
+  for (const col of FEATURE_STATUSES) map[col.value] = [];
+  for (const f of features) (map[f.status] ??= []).push(f);
+  return map;
+}
+
+function StatusBadge({ label, color }: { label: string; color: string }) {
+  return (
+    <Badge
+      size="sm"
+      variant="filled"
+      color={color}
+      styles={{ label: { color: 'var(--mantine-color-dark-9)' } }}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Flat (group-by: none) — one row of status columns.
+// ---------------------------------------------------------------------------
+
+function FlatBoard({
   features,
   prefix,
 }: {
-  label: string;
-  color: string;
   features: RoadmapFeature[];
   prefix: string;
 }) {
+  const columns = useMemo(() => bucketByStatus(features), [features]);
   return (
-    <Paper className="min-w-64 w-64 shrink-0" p="sm" radius="md" withBorder>
-      <Group justify="space-between" mb="sm">
-        <Badge
-          size="sm"
-          variant="filled"
-          color={color}
-          styles={{ label: { color: 'var(--mantine-color-dark-9)' } }}
-        >
-          {label}
-        </Badge>
-        <Text size="xs" fw={600} className="text-text-muted">
-          {features.length}
-        </Text>
-      </Group>
-      <Stack gap="xs">
-        {features.map((feature) => (
-          <FeatureCard key={feature.id} feature={feature} prefix={prefix} />
-        ))}
-        {features.length === 0 && (
-          <div className="flex h-16 items-center justify-center rounded-md border-2 border-dashed border-border-secondary">
-            <Text size="xs" className="text-text-muted">
-              No features
-            </Text>
-          </div>
-        )}
-      </Stack>
-    </Paper>
+    <div className="flex w-full min-w-0 gap-3 overflow-x-auto px-8 pt-4 pb-4">
+      {FEATURE_STATUSES.map((col) => {
+        const items = columns[col.value] ?? [];
+        return (
+          <Paper
+            key={col.value}
+            className="w-64 min-w-64 shrink-0"
+            p="sm"
+            radius="md"
+            withBorder
+          >
+            <Group justify="space-between" mb="sm">
+              <StatusBadge label={col.label} color={col.color} />
+              <Text size="xs" fw={600} className="text-text-muted">
+                {items.length}
+              </Text>
+            </Group>
+            <Stack gap="xs">
+              {items.map((f) => (
+                <FeatureCard key={f.id} feature={f} prefix={prefix} />
+              ))}
+              {items.length === 0 && (
+                <div className="flex h-16 items-center justify-center rounded-md border-2 border-dashed border-border-secondary">
+                  <Text size="xs" className="text-text-muted">
+                    No features
+                  </Text>
+                </div>
+              )}
+            </Stack>
+          </Paper>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Swimlanes (group-by: Objective) — one lane per Objective + an Unaligned lane.
+// A shared header row of status labels sits above the lanes; every row uses the
+// same fixed column widths so the (Objective × status) grid stays aligned.
+// ---------------------------------------------------------------------------
+
+interface Lane {
+  key: string;
+  title: string;
+  isUnaligned: boolean;
+  features: RoadmapFeature[];
+}
+
+function SwimlaneBoard({
+  features,
+  prefix,
+}: {
+  features: RoadmapFeature[];
+  prefix: string;
+}) {
+  const lanes = useMemo<Lane[]>(() => {
+    const aligned = new Map<string, Lane>();
+    const unaligned: RoadmapFeature[] = [];
+    for (const f of features) {
+      if (f.goal) {
+        const key = String(f.goal.id);
+        const lane = aligned.get(key);
+        if (lane) lane.features.push(f);
+        else
+          aligned.set(key, {
+            key,
+            title: f.goal.title,
+            isUnaligned: false,
+            features: [f],
+          });
+      } else {
+        unaligned.push(f);
+      }
+    }
+    const ordered = Array.from(aligned.values()).sort((a, b) =>
+      a.title.localeCompare(b.title),
+    );
+    if (unaligned.length > 0) {
+      ordered.push({
+        key: UNALIGNED_KEY,
+        title: 'Unaligned',
+        isUnaligned: true,
+        features: unaligned,
+      });
+    }
+    return ordered;
+  }, [features]);
+
+  return (
+    <div className="w-full overflow-x-auto px-8 pt-4 pb-4">
+      <div className="min-w-max">
+        {/* Header row: lane-label gutter + status column labels */}
+        <div className="flex gap-3">
+          <div className="w-48 min-w-48 shrink-0" />
+          {FEATURE_STATUSES.map((col) => (
+            <div key={col.value} className="w-64 min-w-64 shrink-0 pb-1">
+              <Group justify="space-between">
+                <StatusBadge label={col.label} color={col.color} />
+              </Group>
+            </div>
+          ))}
+        </div>
+
+        {/* Lanes */}
+        <Stack gap="sm" mt="xs">
+          {lanes.map((lane) => {
+            const columns = bucketByStatus(lane.features);
+            return (
+              <div key={lane.key} className="flex gap-3">
+                <div className="w-48 min-w-48 shrink-0 pt-1">
+                  <Text
+                    size="sm"
+                    fw={600}
+                    className={
+                      lane.isUnaligned
+                        ? 'text-text-muted italic'
+                        : 'text-text-primary'
+                    }
+                    lineClamp={2}
+                  >
+                    {lane.title}
+                  </Text>
+                  <Text size="xs" className="text-text-muted">
+                    {lane.features.length}{' '}
+                    {lane.features.length === 1 ? 'feature' : 'features'}
+                  </Text>
+                </div>
+                {FEATURE_STATUSES.map((col) => {
+                  const items = columns[col.value] ?? [];
+                  return (
+                    <Paper
+                      key={col.value}
+                      className="w-64 min-w-64 shrink-0"
+                      p="xs"
+                      radius="md"
+                      withBorder
+                    >
+                      <Stack gap="xs">
+                        {items.map((f) => (
+                          <FeatureCard key={f.id} feature={f} prefix={prefix} />
+                        ))}
+                        {items.length === 0 && (
+                          <div className="flex h-12 items-center justify-center rounded-md border-2 border-dashed border-border-secondary">
+                            <Text size="xs" className="text-text-muted">
+                              —
+                            </Text>
+                          </div>
+                        )}
+                      </Stack>
+                    </Paper>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </Stack>
+      </div>
+    </div>
   );
 }
 
@@ -131,6 +293,7 @@ function BoardColumn({
 export function ProductRoadmapBoard() {
   const { workspace, workspaceId } = useWorkspace();
   const prefix = workspace?.slug ? `/w/${workspace.slug}` : '';
+  const [groupBy, setGroupBy] = useState<GroupBy>('objective');
 
   const { data: features, isLoading } =
     api.product.feature.listForWorkspace.useQuery(
@@ -138,22 +301,44 @@ export function ProductRoadmapBoard() {
       { enabled: !!workspaceId },
     );
 
-  const columnFeatures = useMemo(() => {
-    const map: Record<string, RoadmapFeature[]> = {};
-    for (const col of FEATURE_STATUSES) map[col.value] = [];
-    for (const f of features ?? []) {
-      (map[f.status] ??= []).push(f);
-    }
-    return map;
-  }, [features]);
+  const toolbar = (
+    <div className="flex items-center gap-2 px-8 pt-4">
+      <Text size="xs" className="text-text-muted">
+        Group by
+      </Text>
+      <SegmentedControl
+        size="xs"
+        value={groupBy}
+        onChange={(v) => setGroupBy(v as GroupBy)}
+        data={[
+          { value: 'objective', label: 'Objective' },
+          { value: 'none', label: 'None' },
+        ]}
+        styles={{
+          root: {
+            backgroundColor: 'var(--color-surface-secondary)',
+            border: '1px solid var(--color-border-primary)',
+          },
+        }}
+      />
+    </div>
+  );
 
   if (isLoading) {
     return (
-      <div className="flex gap-3 overflow-x-auto px-8 pt-6 pb-4">
-        {FEATURE_STATUSES.map((col) => (
-          <Skeleton key={col.value} height={320} className="min-w-64 w-64 shrink-0" radius="md" />
-        ))}
-      </div>
+      <>
+        {toolbar}
+        <div className="flex gap-3 overflow-x-auto px-8 pt-4 pb-4">
+          {FEATURE_STATUSES.map((col) => (
+            <Skeleton
+              key={col.value}
+              height={320}
+              className="w-64 min-w-64 shrink-0"
+              radius="md"
+            />
+          ))}
+        </div>
+      </>
     );
   }
 
@@ -169,16 +354,13 @@ export function ProductRoadmapBoard() {
   }
 
   return (
-    <div className="flex gap-3 overflow-x-auto px-8 pt-6 pb-4 w-full min-w-0">
-      {FEATURE_STATUSES.map((col) => (
-        <BoardColumn
-          key={col.value}
-          label={col.label}
-          color={col.color}
-          features={columnFeatures[col.value] ?? []}
-          prefix={prefix}
-        />
-      ))}
-    </div>
+    <>
+      {toolbar}
+      {groupBy === 'objective' ? (
+        <SwimlaneBoard features={features} prefix={prefix} />
+      ) : (
+        <FlatBoard features={features} prefix={prefix} />
+      )}
+    </>
   );
 }

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -319,6 +319,9 @@ export const featureRouter = createTRPCRouter({
               color: true,
             },
           },
+          // Lean Objective for the Product Roadmap's swimlane grouping
+          // (ADR-0035) — id + title only, no Key results / nested graph.
+          goal: { select: { id: true, title: true } },
         },
       });
     }),


### PR DESCRIPTION
### **User description**
## What

The OKR bridge for the **Product Roadmap** (ADR-0035). Groups the cross-product Feature board into **swimlane rows by Objective** (`Feature.goalId` → `Goal`). Features with no `goalId` collect in a dedicated **"Unaligned"** lane (a governance signal: work serving no OKR). A **"group by: Objective / none"** toggle collapses back to the flat status Kanban from `inner.toad`; defaults to grouped-by-Objective.

The `feature.listForWorkspace` query now also returns each feature's lean Objective (`id` + `title`) so swimlanes render without an extra fetch.

Builds on #316 (cross-product board + workspace query).

## Acceptance criteria

- [x] Board defaults to swimlanes, one row per Objective the workspace's features align to.
- [x] An "Unaligned" lane collects features with no `goalId`.
- [x] A "group by: Objective / none" toggle switches between swimlanes and the flat status Kanban.
- [x] Each swimlane shows the status columns; cards land in the correct (Objective × status) cell.
- [x] The query returns each feature's Objective (lean: id + title) — no per-card extra fetch.

---

Refs: cool.clover


___

### **PR Type**
Enhancement


___

### **Description**
- Adds Objective swimlane grouping to the Product Roadmap board
  - One lane per Objective + dedicated "Unaligned" lane for features with no `goalId`
  - "Group by: Objective / None" toggle to switch between swimlane and flat Kanban views

- Extends `feature.listForWorkspace` query to return lean Objective (`id` + `title`) per feature

- Refactors `ProductRoadmapBoard` into `FlatBoard` and `SwimlaneBoard` sub-components

- Adds shared `StatusBadge` component and `bucketByStatus` helper for column bucketing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ProductRoadmapBoard"] -- "group by toggle" --> B["SegmentedControl\n(Objective / None)"]
  B -- "objective" --> C["SwimlaneBoard"]
  B -- "none" --> D["FlatBoard"]
  C -- "groups features by" --> E["Lane (per Objective)"]
  E -- "includes" --> F["Unaligned Lane\n(no goalId)"]
  C -- "uses" --> G["bucketByStatus"]
  D -- "uses" --> G
  G -- "renders" --> H["FeatureCard + ProductBadge"]
  I["feature.listForWorkspace\n(tRPC)"] -- "now returns" --> J["goal: id + title"]
  J -- "powers" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProductRoadmapBoard.tsx</strong><dd><code>Add Objective swimlanes and group-by toggle to roadmap board</code></dd></summary>
<hr>

src/app/_components/products/ProductRoadmapBoard.tsx

<ul><li>Adds <code>useState</code> for <code>groupBy</code> toggle (<code>'objective'</code> | <code>'none'</code>), defaulting to <br><code>'objective'</code><br> <li> Introduces <code>SwimlaneBoard</code> component grouping features into <br>per-Objective lanes with an "Unaligned" lane for features with no <br><code>goalId</code><br> <li> Refactors flat Kanban into <code>FlatBoard</code> component; extracts <br><code>bucketByStatus</code> helper and <code>StatusBadge</code> component<br> <li> Adds <code>SegmentedControl</code> toolbar to switch between swimlane and flat <br>views; updates loading skeleton to include toolbar</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/317/files#diff-129b5337c6e8708088d025e64b1a8c3bc1af809d521c707d02f94ec94e0e401b">+247/-65</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>feature.ts</strong><dd><code>Return lean Objective in listForWorkspace query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/routers/feature.ts

<ul><li>Extends <code>listForWorkspace</code> query to include <code>goal</code> relation (<code>id</code> + <code>title</code>) <br>for each feature<br> <li> Enables swimlane grouping in <code>ProductRoadmapBoard</code> without additional <br>fetches</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/317/files#diff-bff1a29f77efa7f846d655a0106c96302d007305d09f09ecb53ab204ef97d03d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

