### PR TITLE
feat: Product Roadmap — horizontal drag to change Feature status

### DIFF
--- a/src/app/_components/products/ProductRoadmapBoard.tsx
+++ b/src/app/_components/products/ProductRoadmapBoard.tsx
@@ -1,7 +1,20 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDroppable,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import {
   Badge,
   Card,
@@ -18,7 +31,7 @@ import { api } from '~/trpc/react';
 import type { RouterOutputs } from '~/trpc/react';
 import { EmptyState } from '~/app/_components/EmptyState';
 import { getAvatarColor, getInitial } from '~/utils/avatarColors';
-import { FEATURE_STATUSES } from '~/lib/feature-statuses';
+import { FEATURE_STATUSES, type FeatureStatus } from '~/lib/feature-statuses';
 
 type RoadmapFeature =
   RouterOutputs['product']['feature']['listForWorkspace'][number];
@@ -28,6 +41,37 @@ type GroupBy = 'objective' | 'none';
 
 /** Lane key for the Unaligned swimlane (features with no `goalId`). */
 const UNALIGNED_KEY = '__unaligned__';
+/** Lane key used by the flat (ungrouped) board. */
+const FLAT_LANE_KEY = '__flat__';
+/** Separator joining a lane key + status into a unique droppable cell id. */
+const CELL_SEP = '::';
+
+const STATUS_VALUES = new Set<string>(FEATURE_STATUSES.map((s) => s.value));
+
+/**
+ * A droppable cell id encodes both its lane and its status (`lane::STATUS`) so
+ * every (Objective × status) cell is unique across swimlanes — dnd-kit requires
+ * unique droppable ids. Horizontal status drag only reads the status half.
+ */
+function cellId(laneKey: string, status: string) {
+  return `${laneKey}${CELL_SEP}${status}`;
+}
+
+/**
+ * Resolve the target {@link FeatureStatus} of a drop. `over` may be a cell
+ * (`lane::STATUS`) or another card (its feature id) when dropped onto a card —
+ * in which case we look up that feature's status.
+ */
+function resolveTargetStatus(
+  overId: string,
+  featuresById: Map<string, RoadmapFeature>,
+): FeatureStatus | null {
+  if (overId.includes(CELL_SEP)) {
+    const status = overId.slice(overId.lastIndexOf(CELL_SEP) + CELL_SEP.length);
+    return STATUS_VALUES.has(status) ? (status as FeatureStatus) : null;
+  }
+  return featuresById.get(overId)?.status ?? null;
+}
 
 // ---------------------------------------------------------------------------
 // Product badge — small colored chip identifying the card's owning Product.
@@ -56,12 +100,27 @@ function ProductBadge({ product }: { product: RoadmapProduct }) {
   );
 }
 
+function FeatureCardBody({ feature }: { feature: RoadmapFeature }) {
+  return (
+    <>
+      <Text size="sm" fw={500} className="text-text-primary" lineClamp={2}>
+        {feature.name}
+      </Text>
+      <Group mt="xs" gap="xs" justify="space-between" wrap="nowrap">
+        <ProductBadge product={feature.product} />
+      </Group>
+    </>
+  );
+}
+
+const FEATURE_CARD_CLASS =
+  'border border-border-primary bg-surface-secondary hover:border-border-focus transition-colors';
+
 // ---------------------------------------------------------------------------
-// Feature card (read-only in this slice — status changes happen on the
-// feature detail surface; drag arrives in a later slice).
+// Read-only card — a plain Link (viewers / guests get this).
 // ---------------------------------------------------------------------------
 
-function FeatureCard({
+function ReadonlyFeatureCard({
   feature,
   prefix,
 }: {
@@ -70,20 +129,73 @@ function FeatureCard({
 }) {
   const href = `${prefix}/products/${feature.product.slug}/features/${feature.id}`;
   return (
+    <Card component={Link} href={href} className={FEATURE_CARD_CLASS} padding="sm" radius="sm">
+      <FeatureCardBody feature={feature} />
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Draggable card — horizontal drag changes status (members+). Click (when not
+// dragging) navigates to the feature detail.
+// ---------------------------------------------------------------------------
+
+function DraggableFeatureCard({
+  feature,
+  prefix,
+  isDragOverlay,
+}: {
+  feature: RoadmapFeature;
+  prefix: string;
+  isDragOverlay?: boolean;
+}) {
+  const router = useRouter();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: feature.id });
+
+  const style = isDragOverlay
+    ? undefined
+    : {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.4 : 1,
+      };
+
+  return (
     <Card
-      component={Link}
-      href={href}
-      className="border border-border-primary bg-surface-secondary hover:border-border-focus transition-colors"
+      ref={isDragOverlay ? undefined : setNodeRef}
+      style={style}
+      {...(isDragOverlay ? {} : { ...attributes, ...listeners })}
+      className={`${FEATURE_CARD_CLASS} cursor-grab active:cursor-grabbing`}
       padding="sm"
       radius="sm"
+      onClick={(e: React.MouseEvent) => {
+        if (!isDragging && !isDragOverlay) {
+          e.stopPropagation();
+          router.push(
+            `${prefix}/products/${feature.product.slug}/features/${feature.id}`,
+          );
+        }
+      }}
     >
-      <Text size="sm" fw={500} className="text-text-primary" lineClamp={2}>
-        {feature.name}
-      </Text>
-      <Group mt="xs" gap="xs" justify="space-between" wrap="nowrap">
-        <ProductBadge product={feature.product} />
-      </Group>
+      <FeatureCardBody feature={feature} />
     </Card>
+  );
+}
+
+function FeatureCard({
+  feature,
+  prefix,
+  canEdit,
+}: {
+  feature: RoadmapFeature;
+  prefix: string;
+  canEdit: boolean;
+}) {
+  return canEdit ? (
+    <DraggableFeatureCard feature={feature} prefix={prefix} />
+  ) : (
+    <ReadonlyFeatureCard feature={feature} prefix={prefix} />
   );
 }
 
@@ -111,6 +223,45 @@ function StatusBadge({ label, color }: { label: string; color: string }) {
   );
 }
 
+/**
+ * Droppable status cell. The cell is the drop target for horizontal status
+ * drag; its id encodes its lane so cells stay unique across swimlanes.
+ */
+function StatusCell({
+  laneKey,
+  status,
+  isEmpty,
+  emptyHint,
+  children,
+}: {
+  laneKey: string;
+  status: string;
+  isEmpty: boolean;
+  emptyHint: string;
+  children: React.ReactNode;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: cellId(laneKey, status) });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`rounded-md transition-all duration-200 ${
+        isOver ? 'ring-2 ring-blue-400 ring-opacity-50 bg-surface-hover' : ''
+      }`}
+    >
+      <Stack gap="xs" className="min-h-12">
+        {children}
+        {isEmpty && (
+          <div className="flex h-12 items-center justify-center rounded-md border-2 border-dashed border-border-secondary">
+            <Text size="xs" className="text-text-muted">
+              {emptyHint}
+            </Text>
+          </div>
+        )}
+      </Stack>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Flat (group-by: none) — one row of status columns.
 // ---------------------------------------------------------------------------
@@ -118,9 +269,11 @@ function StatusBadge({ label, color }: { label: string; color: string }) {
 function FlatBoard({
   features,
   prefix,
+  canEdit,
 }: {
   features: RoadmapFeature[];
   prefix: string;
+  canEdit: boolean;
 }) {
   const columns = useMemo(() => bucketByStatus(features), [features]);
   return (
@@ -128,31 +281,23 @@ function FlatBoard({
       {FEATURE_STATUSES.map((col) => {
         const items = columns[col.value] ?? [];
         return (
-          <Paper
-            key={col.value}
-            className="w-64 min-w-64 shrink-0"
-            p="sm"
-            radius="md"
-            withBorder
-          >
+          <Paper key={col.value} className="w-64 min-w-64 shrink-0" p="sm" radius="md" withBorder>
             <Group justify="space-between" mb="sm">
               <StatusBadge label={col.label} color={col.color} />
               <Text size="xs" fw={600} className="text-text-muted">
                 {items.length}
               </Text>
             </Group>
-            <Stack gap="xs">
+            <StatusCell
+              laneKey={FLAT_LANE_KEY}
+              status={col.value}
+              isEmpty={items.length === 0}
+              emptyHint="No features"
+            >
               {items.map((f) => (
-                <FeatureCard key={f.id} feature={f} prefix={prefix} />
+                <FeatureCard key={f.id} feature={f} prefix={prefix} canEdit={canEdit} />
               ))}
-              {items.length === 0 && (
-                <div className="flex h-16 items-center justify-center rounded-md border-2 border-dashed border-border-secondary">
-                  <Text size="xs" className="text-text-muted">
-                    No features
-                  </Text>
-                </div>
-              )}
-            </Stack>
+            </StatusCell>
           </Paper>
         );
       })}
@@ -162,8 +307,6 @@ function FlatBoard({
 
 // ---------------------------------------------------------------------------
 // Swimlanes (group-by: Objective) — one lane per Objective + an Unaligned lane.
-// A shared header row of status labels sits above the lanes; every row uses the
-// same fixed column widths so the (Objective × status) grid stays aligned.
 // ---------------------------------------------------------------------------
 
 interface Lane {
@@ -173,45 +316,49 @@ interface Lane {
   features: RoadmapFeature[];
 }
 
+function buildLanes(features: RoadmapFeature[]): Lane[] {
+  const aligned = new Map<string, Lane>();
+  const unaligned: RoadmapFeature[] = [];
+  for (const f of features) {
+    if (f.goal) {
+      const key = String(f.goal.id);
+      const lane = aligned.get(key);
+      if (lane) lane.features.push(f);
+      else
+        aligned.set(key, {
+          key,
+          title: f.goal.title,
+          isUnaligned: false,
+          features: [f],
+        });
+    } else {
+      unaligned.push(f);
+    }
+  }
+  const ordered = Array.from(aligned.values()).sort((a, b) =>
+    a.title.localeCompare(b.title),
+  );
+  if (unaligned.length > 0) {
+    ordered.push({
+      key: UNALIGNED_KEY,
+      title: 'Unaligned',
+      isUnaligned: true,
+      features: unaligned,
+    });
+  }
+  return ordered;
+}
+
 function SwimlaneBoard({
   features,
   prefix,
+  canEdit,
 }: {
   features: RoadmapFeature[];
   prefix: string;
+  canEdit: boolean;
 }) {
-  const lanes = useMemo<Lane[]>(() => {
-    const aligned = new Map<string, Lane>();
-    const unaligned: RoadmapFeature[] = [];
-    for (const f of features) {
-      if (f.goal) {
-        const key = String(f.goal.id);
-        const lane = aligned.get(key);
-        if (lane) lane.features.push(f);
-        else
-          aligned.set(key, {
-            key,
-            title: f.goal.title,
-            isUnaligned: false,
-            features: [f],
-          });
-      } else {
-        unaligned.push(f);
-      }
-    }
-    const ordered = Array.from(aligned.values()).sort((a, b) =>
-      a.title.localeCompare(b.title),
-    );
-    if (unaligned.length > 0) {
-      ordered.push({
-        key: UNALIGNED_KEY,
-        title: 'Unaligned',
-        isUnaligned: true,
-        features: unaligned,
-      });
-    }
-    return ordered;
-  }, [features]);
+  const lanes = useMemo(() => buildLanes(features), [features]);
 
   return (
     <div className="w-full overflow-x-auto px-8 pt-4 pb-4">
@@ -221,9 +368,7 @@ function SwimlaneBoard({
           <div className="w-48 min-w-48 shrink-0" />
           {FEATURE_STATUSES.map((col) => (
             <div key={col.value} className="w-64 min-w-64 shrink-0 pb-1">
-              <Group justify="space-between">
-                <StatusBadge label={col.label} color={col.color} />
-              </Group>
+              <StatusBadge label={col.label} color={col.color} />
             </div>
           ))}
         </div>
@@ -238,11 +383,7 @@ function SwimlaneBoard({
                   <Text
                     size="sm"
                     fw={600}
-                    className={
-                      lane.isUnaligned
-                        ? 'text-text-muted italic'
-                        : 'text-text-primary'
-                    }
+                    className={lane.isUnaligned ? 'text-text-muted italic' : 'text-text-primary'}
                     lineClamp={2}
                   >
                     {lane.title}
@@ -255,25 +396,17 @@ function SwimlaneBoard({
                 {FEATURE_STATUSES.map((col) => {
                   const items = columns[col.value] ?? [];
                   return (
-                    <Paper
-                      key={col.value}
-                      className="w-64 min-w-64 shrink-0"
-                      p="xs"
-                      radius="md"
-                      withBorder
-                    >
-                      <Stack gap="xs">
+                    <Paper key={col.value} className="w-64 min-w-64 shrink-0" p="xs" radius="md" withBorder>
+                      <StatusCell
+                        laneKey={lane.key}
+                        status={col.value}
+                        isEmpty={items.length === 0}
+                        emptyHint="—"
+                      >
                         {items.map((f) => (
-                          <FeatureCard key={f.id} feature={f} prefix={prefix} />
+                          <FeatureCard key={f.id} feature={f} prefix={prefix} canEdit={canEdit} />
                         ))}
-                        {items.length === 0 && (
-                          <div className="flex h-12 items-center justify-center rounded-md border-2 border-dashed border-border-secondary">
-                            <Text size="xs" className="text-text-muted">
-                              —
-                            </Text>
-                          </div>
-                        )}
-                      </Stack>
+                      </StatusCell>
                     </Paper>
                   );
                 })}
@@ -291,15 +424,87 @@ function SwimlaneBoard({
 // ---------------------------------------------------------------------------
 
 export function ProductRoadmapBoard() {
-  const { workspace, workspaceId } = useWorkspace();
+  const { workspace, workspaceId, userRole } = useWorkspace();
   const prefix = workspace?.slug ? `/w/${workspace.slug}` : '';
   const [groupBy, setGroupBy] = useState<GroupBy>('objective');
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [optimisticMoves, setOptimisticMoves] = useState<
+    Record<string, FeatureStatus>
+  >({});
 
-  const { data: features, isLoading } =
-    api.product.feature.listForWorkspace.useQuery(
-      { workspaceId: workspaceId ?? '' },
-      { enabled: !!workspaceId },
+  // A status drag writes `feature.update`, whose access check admits any
+  // workspace member. Viewers/guests therefore get a read-only board — the
+  // drag affordance is gated client-side on role (the server mutation is the
+  // backstop for non-members). See ADR-0035 and the PR note.
+  const canEdit =
+    userRole === 'owner' || userRole === 'admin' || userRole === 'member';
+
+  const { data, isLoading } = api.product.feature.listForWorkspace.useQuery(
+    { workspaceId: workspaceId ?? '' },
+    { enabled: !!workspaceId },
+  );
+
+  const utils = api.useUtils();
+  const updateFeature = api.product.feature.update.useMutation({
+    onSuccess: async () => {
+      await utils.product.feature.listForWorkspace.invalidate({
+        workspaceId: workspaceId ?? '',
+      });
+    },
+    onError: (_err, variables) => {
+      // Roll back the optimistic move.
+      setOptimisticMoves((prev) => {
+        const next = { ...prev };
+        delete next[variables.id];
+        return next;
+      });
+    },
+  });
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  // Apply optimistic status moves over the fetched data.
+  const features = useMemo(() => {
+    const base = data ?? [];
+    if (Object.keys(optimisticMoves).length === 0) return base;
+    return base.map((f) =>
+      optimisticMoves[f.id] ? { ...f, status: optimisticMoves[f.id]! } : f,
     );
+  }, [data, optimisticMoves]);
+
+  const featuresById = useMemo(() => {
+    const m = new Map<string, RoadmapFeature>();
+    for (const f of features) m.set(f.id, f);
+    return m;
+  }, [features]);
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(String(event.active.id));
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setActiveId(null);
+      if (!canEdit) return;
+      const { active, over } = event;
+      if (!over) return;
+
+      const featureId = String(active.id);
+      const nextStatus = resolveTargetStatus(String(over.id), featuresById);
+      if (!nextStatus) return;
+
+      const feature = featuresById.get(featureId);
+      if (!feature || feature.status === nextStatus) return;
+
+      setOptimisticMoves((prev) => ({ ...prev, [featureId]: nextStatus }));
+      updateFeature.mutate({ id: featureId, status: nextStatus });
+    },
+    [canEdit, featuresById, updateFeature],
+  );
+
+  const activeFeature = activeId ? featuresById.get(activeId) : null;
 
   const toolbar = (
     <div className="flex items-center gap-2 px-8 pt-4">
@@ -330,19 +535,14 @@ export function ProductRoadmapBoard() {
         {toolbar}
         <div className="flex gap-3 overflow-x-auto px-8 pt-4 pb-4">
           {FEATURE_STATUSES.map((col) => (
-            <Skeleton
-              key={col.value}
-              height={320}
-              className="w-64 min-w-64 shrink-0"
-              radius="md"
-            />
+            <Skeleton key={col.value} height={320} className="w-64 min-w-64 shrink-0" radius="md" />
           ))}
         </div>
       </>
     );
   }
 
-  if (!features || features.length === 0) {
+  if (features.length === 0) {
     return (
       <div className="px-8 pt-6">
         <EmptyState
@@ -356,11 +556,22 @@ export function ProductRoadmapBoard() {
   return (
     <>
       {toolbar}
-      {groupBy === 'objective' ? (
-        <SwimlaneBoard features={features} prefix={prefix} />
-      ) : (
-        <FlatBoard features={features} prefix={prefix} />
-      )}
+      <DndContext
+        sensors={sensors}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        {groupBy === 'objective' ? (
+          <SwimlaneBoard features={features} prefix={prefix} canEdit={canEdit} />
+        ) : (
+          <FlatBoard features={features} prefix={prefix} canEdit={canEdit} />
+        )}
+        <DragOverlay>
+          {activeFeature ? (
+            <DraggableFeatureCard feature={activeFeature} prefix={prefix} isDragOverlay />
+          ) : null}
+        </DragOverlay>
+      </DndContext>
     </>
   );
 }


### PR DESCRIPTION
### **User description**
## What

Makes the **Product Roadmap** board a control surface for status (ADR-0035). Dragging a card horizontally across status columns calls `feature.update({ status })` with an **optimistic update** that reverts on error. Works in both the flat and swimlane layouts.

Droppable cells carry composite `lane::STATUS` ids so each (Objective × status) cell stays unique across swimlanes; a status drag reads only the status half, so `goalId` (the swimlane) is unchanged — vertical re-alignment is `cold.koala`.

**Read-only for viewers/guests:** the drag affordance is gated client-side on `userRole` (owner/admin/member can drag), with `feature.update` as the server backstop. See the note below.

> **Access-check nuance** (also commented on the ticket): the AC says read-only-for-viewers is "enforced by the existing `feature.update` access check." In practice that check (`assertWorkspaceMember`) admits *any* workspace member, including viewers/guests — so it does not by itself make the board read-only for them. To honor the intent, drag is gated on `userRole`; tightening `feature.update` server-side was out of scope (it's shared with PRD editing).

Builds on #316 (board) and #317 (swimlanes).

## Acceptance criteria

- [x] Dragging a card to another status column updates `Feature.status` via `feature.update`.
- [x] The move is optimistic and reconciles on server response (reverts on error).
- [x] Users without edit access cannot drag (board is read-only for them) — no duplicated *server* permission logic (thin client role gate for the affordance; server mutation is the backstop).
- [x] Works in both flat and swimlane (grouped) layouts.

---

Refs: polar.cocoa


___

### **PR Type**
Enhancement


___

### **Description**
- Adds horizontal drag-to-change-status to the Product Roadmap board using `@dnd-kit`

- Implements optimistic updates with rollback on error for status changes via `feature.update`

- Gates drag affordance on `userRole` (owner/admin/member can drag; viewers/guests get read-only board)

- Refactors card components into `ReadonlyFeatureCard` and `DraggableFeatureCard`; adds droppable `StatusCell` with visual drop feedback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ProductRoadmapBoard"] -- "canEdit check\n(userRole)" --> B["DraggableFeatureCard"]
  A -- "read-only" --> C["ReadonlyFeatureCard"]
  A -- "wraps board in" --> D["DndContext (@dnd-kit)"]
  D -- "onDragEnd" --> E["resolveTargetStatus"]
  E -- "reads cell id\n(lane::STATUS)" --> F["StatusCell (useDroppable)"]
  E -- "calls" --> G["feature.update (tRPC)"]
  G -- "on success" --> H["invalidate listForWorkspace"]
  G -- "on error" --> I["rollback optimisticMoves"]
  D -- "shows" --> J["DragOverlay\n(DraggableFeatureCard)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProductRoadmapBoard.tsx</strong><dd><code>Add drag-to-change-status with optimistic updates and role gating</code></dd></summary>
<hr>

src/app/_components/products/ProductRoadmapBoard.tsx

<ul><li>Integrates <code>@dnd-kit</code> (<code>DndContext</code>, <code>DragOverlay</code>, <code>useSortable</code>, <br><code>useDroppable</code>) for horizontal status drag<br> <li> Adds <code>DraggableFeatureCard</code> and <code>ReadonlyFeatureCard</code> components; <br><code>FeatureCard</code> dispatches based on <code>canEdit</code><br> <li> Introduces <code>StatusCell</code> droppable component with composite <code>lane::STATUS</code> <br>id and visual drop highlight<br> <li> Adds optimistic status moves (<code>optimisticMoves</code> state) with rollback on <br>mutation error<br> <li> Gates drag on <code>userRole</code> (owner/admin/member); extracts <code>buildLanes</code> and <br><code>resolveTargetStatus</code> helpers</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/318/files#diff-129b5337c6e8708088d025e64b1a8c3bc1af809d521c707d02f94ec94e0e401b">+318/-107</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

