### PR TITLE
feat: Product Roadmap — vertical drag to re-align a Feature's Objective

### DIFF
--- a/src/app/_components/products/ProductRoadmapBoard.tsx
+++ b/src/app/_components/products/ProductRoadmapBoard.tsx
@@ -7,9 +7,12 @@ import {
   DndContext,
   DragOverlay,
   PointerSensor,
+  pointerWithin,
+  rectIntersection,
   useSensor,
   useSensors,
   useDroppable,
+  type CollisionDetection,
   type DragEndEvent,
   type DragStartEvent,
 } from '@dnd-kit/core';
@@ -53,8 +56,39 @@ const UNALIGNED_KEY = '__unaligned__';
 const FLAT_LANE_KEY = '__flat__';
 /** Separator joining a lane key + status into a unique droppable cell id. */
 const CELL_SEP = '::';
+/** Prefix marking a droppable as a swimlane *header* (the re-align drop zone). */
+const LANE_HEADER_PREFIX = 'lane-header';
 
 const STATUS_VALUES = new Set<string>(FEATURE_STATUSES.map((s) => s.value));
+
+/** Droppable id for a swimlane's header (the Objective re-align drop zone). */
+function laneHeaderId(laneKey: string) {
+  return `${LANE_HEADER_PREFIX}${CELL_SEP}${laneKey}`;
+}
+
+/** If `overId` is a lane header, return its lane key; otherwise null. */
+function parseLaneHeader(overId: string): string | null {
+  const head = `${LANE_HEADER_PREFIX}${CELL_SEP}`;
+  return overId.startsWith(head) ? overId.slice(head.length) : null;
+}
+
+/**
+ * The target `goalId` for a re-align drop onto a lane header. A lane's key *is*
+ * its Objective's id (or the Unaligned sentinel), so the goalId is derived
+ * directly — dropping onto Unaligned clears alignment (`null`).
+ */
+function laneKeyToGoalId(laneKey: string): number | null {
+  return laneKey === UNALIGNED_KEY ? null : Number(laneKey);
+}
+
+/**
+ * Prefer the droppable under the pointer (so the narrow lane *header* is a
+ * reliable target) and fall back to rectangle overlap for column cells.
+ */
+const collisionDetection: CollisionDetection = (args) => {
+  const pointer = pointerWithin(args);
+  return pointer.length > 0 ? pointer : rectIntersection(args);
+};
 
 /**
  * A droppable cell id encodes both its lane and its status (`lane::STATUS`) so
@@ -322,6 +356,7 @@ function FlatBoard({
 interface Lane {
   key: string;
   title: string;
+  goalId: number | null;
   isUnaligned: boolean;
   features: RoadmapFeature[];
 }
@@ -338,6 +373,7 @@ function buildLanes(features: RoadmapFeature[]): Lane[] {
         aligned.set(key, {
           key,
           title: f.goal.title,
+          goalId: f.goal.id,
           isUnaligned: false,
           features: [f],
         });
@@ -352,11 +388,46 @@ function buildLanes(features: RoadmapFeature[]): Lane[] {
     ordered.push({
       key: UNALIGNED_KEY,
       title: 'Unaligned',
+      goalId: null,
       isUnaligned: true,
       features: unaligned,
     });
   }
   return ordered;
+}
+
+/**
+ * A swimlane's label gutter, doubling as the droppable re-align target. Dropping
+ * a card here re-aligns it to this lane's Objective (or clears alignment for the
+ * Unaligned lane). The header is the *only* re-align drop zone — a status
+ * (column) drag never re-homes the OKR (ADR-0035).
+ */
+function LaneHeader({ lane, canEdit }: { lane: Lane; canEdit: boolean }) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: laneHeaderId(lane.key),
+    disabled: !canEdit,
+  });
+  return (
+    <div
+      ref={setNodeRef}
+      className={`w-48 min-w-48 shrink-0 rounded-md pt-1 transition-all duration-200 ${
+        isOver ? 'ring-2 ring-blue-400 ring-opacity-50 bg-surface-hover' : ''
+      }`}
+    >
+      <Text
+        size="sm"
+        fw={600}
+        className={lane.isUnaligned ? 'text-text-muted italic' : 'text-text-primary'}
+        lineClamp={2}
+      >
+        {lane.title}
+      </Text>
+      <Text size="xs" className="text-text-muted">
+        {lane.features.length}{' '}
+        {lane.features.length === 1 ? 'feature' : 'features'}
+      </Text>
+    </div>
+  );
 }
 
 function SwimlaneBoard({
@@ -391,20 +462,7 @@ function SwimlaneBoard({
             const buckets = bucketByStatus(lane.features);
             return (
               <div key={lane.key} className="flex gap-3">
-                <div className="w-48 min-w-48 shrink-0 pt-1">
-                  <Text
-                    size="sm"
-                    fw={600}
-                    className={lane.isUnaligned ? 'text-text-muted italic' : 'text-text-primary'}
-                    lineClamp={2}
-                  >
-                    {lane.title}
-                  </Text>
-                  <Text size="xs" className="text-text-muted">
-                    {lane.features.length}{' '}
-                    {lane.features.length === 1 ? 'feature' : 'features'}
-                  </Text>
-                </div>
+                <LaneHeader lane={lane} canEdit={canEdit} />
                 {columns.map((col) => {
                   const items = buckets[col.value] ?? [];
                   return (
@@ -447,6 +505,12 @@ export function ProductRoadmapBoard() {
   const [optimisticMoves, setOptimisticMoves] = useState<
     Record<string, FeatureStatus>
   >({});
+  // Optimistic Objective re-aligns: featureId → its new goal (or null when
+  // re-aligned into the Unaligned lane). Carries the full goal so the card
+  // jumps swimlanes immediately (lane grouping reads `goal`, not just goalId).
+  const [optimisticAligns, setOptimisticAligns] = useState<
+    Record<string, RoadmapFeature['goal']>
+  >({});
 
   // A status drag writes `feature.update`, whose access check admits any
   // workspace member. Viewers/guests therefore get a read-only board — the
@@ -468,8 +532,14 @@ export function ProductRoadmapBoard() {
       });
     },
     onError: (_err, variables) => {
-      // Roll back the optimistic move.
+      // Roll back the optimistic move (status and/or re-align — a single drag
+      // triggers one of them, so clearing both for this feature is safe).
       setOptimisticMoves((prev) => {
+        const next = { ...prev };
+        delete next[variables.id];
+        return next;
+      });
+      setOptimisticAligns((prev) => {
         const next = { ...prev };
         delete next[variables.id];
         return next;
@@ -481,18 +551,39 @@ export function ProductRoadmapBoard() {
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
   );
 
-  // Apply optimistic status moves over the fetched data.
+  // Apply optimistic status moves + Objective re-aligns over the fetched data.
   const features = useMemo(() => {
     const base = data ?? [];
-    if (Object.keys(optimisticMoves).length === 0) return base;
-    return base.map((f) =>
-      optimisticMoves[f.id] ? { ...f, status: optimisticMoves[f.id]! } : f,
-    );
-  }, [data, optimisticMoves]);
+    if (
+      Object.keys(optimisticMoves).length === 0 &&
+      Object.keys(optimisticAligns).length === 0
+    ) {
+      return base;
+    }
+    return base.map((f) => {
+      let next = f;
+      if (optimisticMoves[f.id]) {
+        next = { ...next, status: optimisticMoves[f.id]! };
+      }
+      if (f.id in optimisticAligns) {
+        const goal = optimisticAligns[f.id] ?? null;
+        next = { ...next, goal, goalId: goal?.id ?? null };
+      }
+      return next;
+    });
+  }, [data, optimisticMoves, optimisticAligns]);
 
   const featuresById = useMemo(() => {
     const m = new Map<string, RoadmapFeature>();
     for (const f of features) m.set(f.id, f);
+    return m;
+  }, [features]);
+
+  // goalId → its lean goal, so a re-align onto a lane header can set the card's
+  // goal (for the optimistic lane jump) without an extra lookup.
+  const goalsById = useMemo(() => {
+    const m = new Map<number, NonNullable<RoadmapFeature['goal']>>();
+    for (const f of features) if (f.goal) m.set(f.goal.id, f.goal);
     return m;
   }, [features]);
 
@@ -532,16 +623,29 @@ export function ProductRoadmapBoard() {
       if (!over) return;
 
       const featureId = String(active.id);
-      const nextStatus = resolveTargetStatus(String(over.id), featuresById);
-      if (!nextStatus) return;
-
       const feature = featuresById.get(featureId);
-      if (!feature || feature.status === nextStatus) return;
+      if (!feature) return;
+      const overId = String(over.id);
 
+      // Re-align: dropped onto a swimlane header → change goalId (vertical).
+      const laneKey = parseLaneHeader(overId);
+      if (laneKey !== null) {
+        const nextGoalId = laneKeyToGoalId(laneKey);
+        if (feature.goalId === nextGoalId) return;
+        const nextGoal =
+          nextGoalId !== null ? (goalsById.get(nextGoalId) ?? null) : null;
+        setOptimisticAligns((prev) => ({ ...prev, [featureId]: nextGoal }));
+        updateFeature.mutate({ id: featureId, goalId: nextGoalId });
+        return;
+      }
+
+      // Status change: dropped onto a status column/cell (horizontal).
+      const nextStatus = resolveTargetStatus(overId, featuresById);
+      if (!nextStatus || feature.status === nextStatus) return;
       setOptimisticMoves((prev) => ({ ...prev, [featureId]: nextStatus }));
       updateFeature.mutate({ id: featureId, status: nextStatus });
     },
-    [canEdit, featuresById, updateFeature],
+    [canEdit, featuresById, goalsById, updateFeature],
   );
 
   const activeFeature = activeId ? featuresById.get(activeId) : null;
@@ -618,6 +722,7 @@ export function ProductRoadmapBoard() {
       {toolbar}
       <DndContext
         sensors={sensors}
+        collisionDetection={collisionDetection}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
       >


### PR DESCRIPTION
### **User description**
## What

Closes the governance loop on the **Product Roadmap** (ADR-0035). In swimlane mode, dropping a card onto a swimlane's **header** re-aligns the feature to that lane's Objective via `feature.update({ goalId })` — most importantly, dragging a card out of the **Unaligned** lane into an Objective lane aligns it in one gesture; dropping onto **Unaligned** clears alignment.

The lane header is the **only** re-align drop-zone (deliberate), so an ordinary horizontal status drag never silently re-homes a feature's OKR. Optimistic (the card jumps lanes immediately, updating both `goalId` and the `goal` relation) and access-gated identically to the status drag (viewers cannot re-align).

Collision detection switches to `pointerWithin` → `rectIntersection` so the narrow lane header is a reliable drop target.

Builds on #317 (swimlanes) + #318 (drag infra).

## Acceptance criteria

- [x] Dropping a card onto a swimlane's header re-aligns the feature (`feature.update({ goalId })`).
- [x] Dragging from Unaligned into an Objective lane sets that `goalId`; dragging into Unaligned clears it.
- [x] Re-align is gated to the lane-header drop-zone — a status (column) drag never changes `goalId`.
- [x] Optimistic update; access-gated identically to the status drag (viewers cannot re-align).

---

Refs: cold.koala


___

### **PR Type**
Enhancement


___

### **Description**
- Adds vertical drag-to-re-align Feature Objective in swimlane mode

- Lane headers become droppable re-align zones; dropping onto Unaligned clears `goalId`

- Optimistic lane-jump updates with rollback on error for `goalId` changes

- Switches collision detection to `pointerWithin` → `rectIntersection` for reliable narrow-header targeting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ProductRoadmapBoard"] -- "onDragEnd" --> B["parseLaneHeader(overId)"]
  B -- "lane header detected" --> C["laneKeyToGoalId(laneKey)"]
  C -- "nextGoalId" --> D["setOptimisticAligns"]
  D -- "immediate lane jump" --> E["SwimlaneBoard / buildLanes"]
  C -- "calls" --> F["feature.update({ goalId })"]
  F -- "on error" --> G["rollback optimisticAligns"]
  F -- "on success" --> H["invalidate listForWorkspace"]
  B -- "not a lane header" --> I["resolveTargetStatus (status drag)"]
  J["LaneHeader (useDroppable)"] -- "isOver highlight" --> E
  K["collisionDetection\n(pointerWithin → rectIntersection)"] -- "powers" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProductRoadmapBoard.tsx</strong><dd><code>Add vertical Objective re-align drag with optimistic lane-jump</code></dd></summary>
<hr>

src/app/_components/products/ProductRoadmapBoard.tsx

<ul><li>Adds <code>pointerWithin</code> + <code>rectIntersection</code> composite collision detection <br>for reliable lane-header targeting<br> <li> Introduces <code>LaneHeader</code> droppable component with visual drop highlight; <br>replaces inline lane label div<br> <li> Adds <code>laneHeaderId</code>, <code>parseLaneHeader</code>, <code>laneKeyToGoalId</code> helpers for <br>re-align drop-zone logic<br> <li> Adds <code>optimisticAligns</code> state with rollback; <code>handleDragEnd</code> now branches <br>on lane-header vs. status-cell drop<br> <li> Extends <code>Lane</code> interface and <code>buildLanes</code> to carry <code>goalId</code>; adds <code>goalsById</code> <br>memo for optimistic goal lookup</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/320/files#diff-129b5337c6e8708088d025e64b1a8c3bc1af809d521c707d02f94ec94e0e401b">+132/-27</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

