### PR TITLE
fix(forms): preserve typed line breaks on public form description

### DIFF
--- a/src/app/(public)/f/[slug]/_components/PublicForm.tsx
+++ b/src/app/(public)/f/[slug]/_components/PublicForm.tsx
@@ -220,7 +220,11 @@ export function PublicForm({
         <Stack gap="xs" mb="md">
           <Title order={2}>{name}</Title>
           {description && (
-            <MarkdownRenderer content={description} variant="prose" />
+            <MarkdownRenderer
+              content={description}
+              variant="prose"
+              softBreaks
+            />
           )}
         </Stack>
         {restored && (

--- a/src/app/_components/shared/MarkdownRenderer.tsx
+++ b/src/app/_components/shared/MarkdownRenderer.tsx
@@ -337,6 +337,13 @@ interface MarkdownRendererProps {
   content: string;
   /** Spacing preset. Defaults to long-form "prose". */
   variant?: MarkdownVariant;
+  /**
+   * Preserve single (typed) newlines as line breaks, even in the `prose`
+   * variant. Use for prose authored in a textarea (e.g. the public form
+   * description) so it matches the `MarkdownInput` compact preview. The
+   * `compact` variant always preserves soft breaks regardless of this flag.
+   */
+  softBreaks?: boolean;
   /** Names that should render as mention badges (compact surfaces). */
   mentionNames?: string[];
   /** Owner-only image delete handler (compact surfaces, e.g. comments). */
@@ -347,6 +354,7 @@ interface MarkdownRendererProps {
 export function MarkdownRenderer({
   content,
   variant = "prose",
+  softBreaks,
   mentionNames,
   onDeleteImage,
   className,
@@ -366,8 +374,10 @@ export function MarkdownRenderer({
   }
 
   const remarkPlugins: PluggableList = [remarkGfm];
-  // Compact surfaces are textarea-authored: preserve typed line breaks.
-  if (variant === "compact") remarkPlugins.push(remarkSoftBreaks);
+  // Textarea-authored content preserves typed line breaks: always for the
+  // compact variant, opt-in via `softBreaks` for prose surfaces.
+  if (variant === "compact" || softBreaks)
+    remarkPlugins.push(remarkSoftBreaks);
   if (mentionNames && mentionNames.length > 0) {
     remarkPlugins.push([remarkMentions, mentionNames]);
   }


### PR DESCRIPTION
### **User description**
## Problem

The public form page (`/f/<slug>`) rendered its description differently from the live preview in the CRM form editor. Authored line breaks — e.g. **Engagement:**, **Location:**, **Rate:**, **Reports to:** each on their own line — collapsed into a single run-on paragraph on the published page.

| Editor preview | Public page (before) |
|---|---|
| Each field on its own line | All fields merged into one paragraph |

## Root cause

`MarkdownRenderer` only applies the `remarkSoftBreaks` plugin (which turns single typed newlines into line breaks) for `variant="compact"`. The editor's `MarkdownInput` preview uses `compact`, but the public form uses `variant="prose"` — so on the public page single newlines collapsed into spaces per standard Markdown.

## Fix

- Add an opt-in `softBreaks` prop to `MarkdownRenderer` that applies `remarkSoftBreaks` even in the `prose` variant.
- Pass `softBreaks` from `PublicForm`. The description is textarea-authored, so preserving typed line breaks matches what the author sees in the editor preview — while keeping the larger prose styling.

Other prose surfaces (docs, blog) are unaffected — they don't set the flag, so standard Markdown newline behavior is preserved.

## Testing

Type-only addition of an optional prop, validated by CI (lint/typecheck/build). Manual check: open `/f/data_engineer` and confirm the description lines render on separate lines matching the editor preview.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix line breaks collapsing on public form description page

- Add opt-in `softBreaks` prop to `MarkdownRenderer` component

- Pass `softBreaks` to `MarkdownRenderer` in `PublicForm` for textarea-authored content


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PublicForm\n(variant='prose')"] -- "softBreaks prop added" --> B["MarkdownRenderer"]
  B -- "variant === 'compact'\nOR softBreaks === true" --> C["remarkSoftBreaks plugin applied"]
  C -- "single newlines preserved" --> D["Correct line breaks rendered"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PublicForm.tsx</strong><dd><code>Pass softBreaks to MarkdownRenderer in PublicForm</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(public)/f/[slug]/_components/PublicForm.tsx

<ul><li>Added <code>softBreaks</code> prop to the <code>MarkdownRenderer</code> usage for the form <br>description<br> <li> Ensures textarea-authored line breaks are preserved on the public form <br>page</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/322/files#diff-477d22ebaebb95d9f645f090403892e95bb1077f5f7ac500e1e0079843ef7c8e">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MarkdownRenderer.tsx</strong><dd><code>Add opt-in softBreaks prop to MarkdownRenderer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/shared/MarkdownRenderer.tsx

<ul><li>Added optional <code>softBreaks</code> boolean prop to <code>MarkdownRendererProps</code> <br>interface with JSDoc comment<br> <li> Updated plugin logic to apply <code>remarkSoftBreaks</code> when <code>variant === </code><br><code>'compact'</code> OR <code>softBreaks</code> is true<br> <li> Destructures <code>softBreaks</code> in the component function signature</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/322/files#diff-982e749a9dbc62ab3830f8aee144ad608878d098da2db51270cb62d38c11d90a">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

