### PR TITLE
feat(crm): organization API surface + event-driven contact enrichment

### DIFF
--- a/prisma/migrations/20260701093131_add_contact_enrichment/migration.sql
+++ b/prisma/migrations/20260701093131_add_contact_enrichment/migration.sql
@@ -1,0 +1,36 @@
+-- AlterTable
+ALTER TABLE "Workspace" ADD COLUMN     "enableAutoEnrichContacts" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "CrmContactEnrichment" (
+    "id" TEXT NOT NULL,
+    "contactId" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "error" TEXT,
+    "metadata" JSONB,
+    "createdById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "startedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "CrmContactEnrichment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CrmContactEnrichment_contactId_idx" ON "CrmContactEnrichment"("contactId");
+
+-- CreateIndex
+CREATE INDEX "CrmContactEnrichment_workspaceId_idx" ON "CrmContactEnrichment"("workspaceId");
+
+-- CreateIndex
+CREATE INDEX "CrmContactEnrichment_status_idx" ON "CrmContactEnrichment"("status");
+
+-- CreateIndex
+CREATE INDEX "CrmContactEnrichment_createdAt_idx" ON "CrmContactEnrichment"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "CrmContactEnrichment" ADD CONSTRAINT "CrmContactEnrichment_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "CrmContact"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CrmContactEnrichment" ADD CONSTRAINT "CrmContactEnrichment_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -309,6 +309,9 @@ model Workspace {
   enableDailyPlanBanner    Boolean    @default(true)
   enableWeeklyReviewBanner Boolean    @default(true)
   enableEmailNotifications Boolean    @default(true)
+  // When on, creating a CRM contact enqueues an async web-search enrichment job
+  // (drained by the enrich-pending-contacts cron → Mastra enrichmentAgent).
+  enableAutoEnrichContacts Boolean    @default(false)
 
   // Notion integration defaults: { defaultIntegrationId, defaultDatabaseId, fieldMappings, syncDirection, syncFrequency }
   notionDefaultConfig Json?
@@ -335,6 +338,7 @@ model Workspace {
   crmCommunications       CrmCommunication[]
   crmTemplates            CrmCommunicationTemplate[]
   crmImportBatches        ContactImportBatch[]
+  crmEnrichments          CrmContactEnrichment[]
   // Forms relations
   forms                   Form[]
   // Plugin and OKR relations
@@ -2610,6 +2614,7 @@ model CrmContact {
   deals                       Deal[]
   transcriptionParticipations TranscriptionSessionParticipant[]
   screenshots                 CrmContactScreenshot[]
+  enrichments                 CrmContactEnrichment[]
 
   @@index([workspaceId])
   @@index([organizationId])
@@ -2620,6 +2625,33 @@ model CrmContact {
   @@index([connectionScore])
   @@index([workspaceId, importSource])
   @@unique([workspaceId, emailHash])
+}
+
+// Async enrichment job for a CRM contact. Written (status PENDING) by
+// dispatchContactEnrichment when a contact is created in a workspace with
+// enableAutoEnrichContacts on; drained by the enrich-pending-contacts cron,
+// which hands the contact to Mastra's enrichmentAgent (web search + write-back).
+// Mirrors ContactImportBatch's role as a durable status/audit record for
+// serverless fire-and-forget work.
+model CrmContactEnrichment {
+  id          String    @id @default(cuid())
+  contactId   String
+  workspaceId String
+  status      String    @default("PENDING") // PENDING, RUNNING, COMPLETED, FAILED
+  error       String?   @db.Text
+  metadata    Json? // agent summary, fields written, tool uses
+  createdById String?
+  createdAt   DateTime  @default(now())
+  startedAt   DateTime?
+  completedAt DateTime?
+
+  contact   CrmContact @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  workspace Workspace  @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@index([contactId])
+  @@index([workspaceId])
+  @@index([status])
+  @@index([createdAt])
 }
 
 // Join between a CRM contact and an uploaded image/screenshot. Mirrors

--- a/src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx
@@ -43,6 +43,7 @@ import {
   IconClock,
   IconPlus,
   IconShieldExclamation,
+  IconSparkles,
   type Icon as TablerIcon,
 } from '@tabler/icons-react';
 import { useRouter } from 'next/navigation';
@@ -154,6 +155,7 @@ export default function WorkspaceSettingsPage() {
   const dailyPlanBannerEnabled = workspaceData?.enableDailyPlanBanner ?? true;
   const weeklyReviewBannerEnabled = workspaceData?.enableWeeklyReviewBanner ?? true;
   const emailNotificationsEnabled = workspaceData?.enableEmailNotifications ?? true;
+  const autoEnrichContactsEnabled = workspaceData?.enableAutoEnrichContacts ?? false;
   const currentHomeLayout = validateHomeLayout(workspaceData?.homeLayout);
 
   const featureSuccess = (message: string) => () => {
@@ -218,6 +220,13 @@ export default function WorkspaceSettingsPage() {
       emailNotificationsEnabled
         ? 'Email notifications have been disabled'
         : 'Email notifications have been enabled'
+    ),
+  });
+  const updateAutoEnrichContactsMutation = api.workspace.update.useMutation({
+    onSuccess: featureSuccess(
+      autoEnrichContactsEnabled
+        ? 'Contact auto-enrichment has been disabled'
+        : 'Contact auto-enrichment has been enabled'
     ),
   });
 
@@ -1046,6 +1055,21 @@ export default function WorkspaceSettingsPage() {
                 updateEmailNotificationsMutation.mutate({
                   workspaceId,
                   enableEmailNotifications: checked,
+                });
+              }}
+            />
+            <FeatureRow
+              icon={IconSparkles}
+              tag="CRM"
+              title="Auto-enrich Contacts"
+              description="When a contact is created, run a background web search to fill in missing details (email, LinkedIn, Twitter, bio, organization)."
+              enabled={autoEnrichContactsEnabled}
+              disabled={!canEdit || updateAutoEnrichContactsMutation.isPending}
+              onToggle={(checked) => {
+                if (!workspaceId) return;
+                updateAutoEnrichContactsMutation.mutate({
+                  workspaceId,
+                  enableAutoEnrichContacts: checked,
                 });
               }}
             />

--- a/src/app/api/cron/enrich-pending-contacts/route.ts
+++ b/src/app/api/cron/enrich-pending-contacts/route.ts
@@ -1,0 +1,40 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { headers } from "next/headers";
+
+import { db } from "~/server/db";
+import { runPendingEnrichments } from "~/server/services/crm/enrichment/runPendingEnrichments";
+
+/**
+ * Cron endpoint: drains PENDING CRM contact enrichment jobs (created when a
+ * contact is added in a workspace with `enableAutoEnrichContacts` on) and hands
+ * each contact to Mastra's `enrichmentAgent` for web-search + write-back.
+ *
+ * A durable queue drained by cron — rather than a fire-and-forget fetch from the
+ * create mutation — is deliberate: Vercel serverless can freeze a function after
+ * it returns, orphaning un-awaited async work. Registered in vercel.json.
+ * Auth is the shared CRON_SECRET, matching the other cron routes.
+ */
+export async function GET(_request: NextRequest) {
+  try {
+    const headersList = await headers();
+    const authHeader = headersList.get("authorization");
+    const cronSecret = process.env.CRON_SECRET;
+
+    if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const result = await runPendingEnrichments(db, new Date());
+    if (result.failed.length > 0) {
+      console.error("[Cron] contact enrichments failed:", result.failed);
+    }
+
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    console.error("[Cron] enrich-pending-contacts failed:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/cron/enrich-pending-contacts/route.ts
+++ b/src/app/api/cron/enrich-pending-contacts/route.ts
@@ -12,7 +12,11 @@ import { runPendingEnrichments } from "~/server/services/crm/enrichment/runPendi
  * A durable queue drained by cron — rather than a fire-and-forget fetch from the
  * create mutation — is deliberate: Vercel serverless can freeze a function after
  * it returns, orphaning un-awaited async work. Registered in vercel.json.
- * Auth is the shared CRON_SECRET, matching the other cron routes.
+ *
+ * Auth is the shared CRON_SECRET. Because this endpoint has real external side
+ * effects (it triggers Mastra agent runs and paid web searches), it fails
+ * closed: a missing CRON_SECRET denies every request rather than leaving the
+ * sweep open to anonymous callers.
  */
 export async function GET(_request: NextRequest) {
   try {
@@ -20,7 +24,7 @@ export async function GET(_request: NextRequest) {
     const authHeader = headersList.get("authorization");
     const cronSecret = process.env.CRON_SECRET;
 
-    if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 

--- a/src/server/api/routers/crmApi.ts
+++ b/src/server/api/routers/crmApi.ts
@@ -7,6 +7,7 @@ import { Prisma } from "@prisma/client";
 import type { CrmContact, PrismaClient } from "@prisma/client";
 import { getProjectAccess, hasProjectAccess } from "~/server/services/access";
 import { emailHashFor } from "~/server/services/crm/createCrmContact";
+import { dispatchContactEnrichment } from "~/server/services/crm/enrichment/dispatchContactEnrichment";
 
 // ─── Helpers ────────────────────────────────────────────────────────
 
@@ -110,9 +111,55 @@ async function getPipelineForWorkspace(
   return pipeline;
 }
 
+// Find an existing organization by name (case-insensitive, workspace-scoped)
+// or create it. Lets callers link a contact to an org by name in one call
+// without a separate lookup — the CLI/SDK's `organizationName` convenience.
+async function resolveOrganizationByName(
+  db: PrismaClient,
+  workspaceId: string,
+  userId: string,
+  name: string,
+): Promise<string> {
+  const trimmed = name.trim();
+  const existing = await db.crmOrganization.findFirst({
+    where: { workspaceId, name: { equals: trimmed, mode: "insensitive" } },
+    select: { id: true },
+  });
+  if (existing) return existing.id;
+
+  const created = await db.crmOrganization.create({
+    data: { workspaceId, name: trimmed, createdById: userId },
+    select: { id: true },
+  });
+  return created.id;
+}
+
 // ─── Input Schemas ──────────────────────────────────────────────────
 
 const piiFields = ["email", "phone", "linkedIn", "telegram", "twitter", "github", "bluesky"] as const;
+
+const organizationSizeEnum = z.enum([
+  "1-10", "11-50", "51-200", "201-500", "501-1000", "1000+",
+]);
+
+const organizationCreateInput = z.object({
+  workspaceId: z.string(),
+  name: z.string().min(1),
+  websiteUrl: z.string().url().optional().nullable(),
+  logoUrl: z.string().url().optional().nullable(),
+  description: z.string().optional(),
+  industry: z.string().optional(),
+  size: organizationSizeEnum.optional(),
+});
+
+const organizationInclude = {
+  createdBy: {
+    select: { id: true, name: true, email: true, image: true },
+  },
+  _count: {
+    select: { contacts: true },
+  },
+} as const;
 
 const contactCreateInput = z.object({
   workspaceId: z.string(),
@@ -130,6 +177,9 @@ const contactCreateInput = z.object({
   skills: z.array(z.string()).optional(),
   tags: z.array(z.string()).optional(),
   organizationId: z.string().optional(),
+  // Link (or find-or-create) an organization by name. Ignored when
+  // organizationId is supplied — the explicit id always wins.
+  organizationName: z.string().optional(),
 });
 
 const contactUpdateInput = z.object({
@@ -148,6 +198,9 @@ const contactUpdateInput = z.object({
   skills: z.array(z.string()).optional(),
   tags: z.array(z.string()).optional(),
   organizationId: z.string().optional().nullable(),
+  // Link (or find-or-create) an organization by name. Ignored when
+  // organizationId is supplied — the explicit id always wins.
+  organizationName: z.string().optional(),
 });
 
 // ─── Router ─────────────────────────────────────────────────────────
@@ -260,7 +313,7 @@ export const crmApiRouter = createTRPCRouter({
   contactCreate: apiKeyMiddleware
     .input(contactCreateInput)
     .mutation(async ({ ctx, input }) => {
-      const { workspaceId, ...contactData } = input;
+      const { workspaceId, organizationName, ...contactData } = input;
       await verifyWorkspaceAccess(ctx.db, workspaceId, ctx.userId);
 
       if (contactData.organizationId) {
@@ -274,6 +327,14 @@ export const crmApiRouter = createTRPCRouter({
             message: "Organization must belong to the same workspace",
           });
         }
+      } else if (organizationName?.trim()) {
+        // No explicit id — find-or-create the org by name in this workspace.
+        contactData.organizationId = await resolveOrganizationByName(
+          ctx.db,
+          workspaceId,
+          ctx.userId,
+          organizationName,
+        );
       }
 
       const contactInclude = {
@@ -324,6 +385,12 @@ export const crmApiRouter = createTRPCRouter({
           data: dbData as Parameters<typeof ctx.db.crmContact.create>[0]["data"],
           include: contactInclude,
         });
+        // Opt-in async enrichment (no-op unless the workspace enabled it).
+        await dispatchContactEnrichment(ctx.db, {
+          contactId: contact.id,
+          workspaceId,
+          createdById: ctx.userId,
+        });
         return { ...safeDecryptContact(contact), wasExisting: false };
       } catch (err) {
         // Concurrent double-submit: between the dedupe lookup above and this
@@ -348,7 +415,7 @@ export const crmApiRouter = createTRPCRouter({
   contactUpdate: apiKeyMiddleware
     .input(contactUpdateInput)
     .mutation(async ({ ctx, input }) => {
-      const { id, ...updateData } = input;
+      const { id, organizationName, ...updateData } = input;
 
       const existing = await ctx.db.crmContact.findUnique({
         where: { id },
@@ -368,7 +435,17 @@ export const crmApiRouter = createTRPCRouter({
       if (updateData.profileType !== undefined) dbUpdate.profileType = updateData.profileType;
       if (updateData.skills !== undefined) dbUpdate.skills = updateData.skills;
       if (updateData.tags !== undefined) dbUpdate.tags = updateData.tags;
-      if (updateData.organizationId !== undefined) dbUpdate.organizationId = updateData.organizationId;
+      if (updateData.organizationId !== undefined) {
+        dbUpdate.organizationId = updateData.organizationId;
+      } else if (organizationName?.trim()) {
+        // No explicit id — find-or-create the org by name in this workspace.
+        dbUpdate.organizationId = await resolveOrganizationByName(
+          ctx.db,
+          existing.workspaceId,
+          ctx.userId,
+          organizationName,
+        );
+      }
 
       // PII fields - encrypt or null
       for (const field of piiFields) {
@@ -454,6 +531,89 @@ export const crmApiRouter = createTRPCRouter({
       });
 
       return interaction;
+    }),
+
+  // ─── Organizations ──────────────────────────────────────────────
+
+  organizationList: apiKeyMiddleware
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        search: z.string().optional(),
+        industry: z.string().optional(),
+        limit: z.number().min(1).max(100).optional(),
+        cursor: z.string().optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const { workspaceId, search, industry, limit = 50, cursor } = input;
+      await verifyWorkspaceAccess(ctx.db, workspaceId, ctx.userId);
+
+      const organizations = await ctx.db.crmOrganization.findMany({
+        where: {
+          workspaceId,
+          ...(search
+            ? {
+                OR: [
+                  { name: { contains: search, mode: "insensitive" } },
+                  { description: { contains: search, mode: "insensitive" } },
+                ],
+              }
+            : {}),
+          ...(industry ? { industry } : {}),
+        },
+        include: organizationInclude,
+        orderBy: { name: "asc" },
+        take: limit + 1,
+        ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      });
+
+      let nextCursor: string | undefined;
+      if (organizations.length > limit) {
+        organizations.pop();
+        nextCursor = organizations[organizations.length - 1]?.id;
+      }
+
+      return { organizations, nextCursor };
+    }),
+
+  organizationGet: apiKeyMiddleware
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const organization = await ctx.db.crmOrganization.findFirst({
+        where: {
+          id: input.id,
+          workspace: { members: { some: { userId: ctx.userId } } },
+        },
+        include: organizationInclude,
+      });
+
+      if (!organization) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Organization not found or inaccessible",
+        });
+      }
+
+      return organization;
+    }),
+
+  organizationCreate: apiKeyMiddleware
+    .input(organizationCreateInput)
+    .mutation(async ({ ctx, input }) => {
+      const { workspaceId, ...organizationData } = input;
+      await verifyWorkspaceAccess(ctx.db, workspaceId, ctx.userId);
+
+      const organization = await ctx.db.crmOrganization.create({
+        data: {
+          ...organizationData,
+          workspaceId,
+          createdById: ctx.userId,
+        },
+        include: organizationInclude,
+      });
+
+      return organization;
     }),
 
   // ─── Pipeline ───────────────────────────────────────────────────

--- a/src/server/api/routers/crmContact.ts
+++ b/src/server/api/routers/crmContact.ts
@@ -7,6 +7,7 @@ import { ContactSyncService } from "~/server/services/ContactSyncService";
 import { ConnectionStrengthCalculator } from "~/server/services/ConnectionStrengthCalculator";
 import { GoogleTokenManager } from "~/server/services/GoogleTokenManager";
 import { dispatchContactTypeAutomations } from "~/server/services/crm/automation/dispatchContactTypeAutomations";
+import { dispatchContactEnrichment } from "~/server/services/crm/enrichment/dispatchContactEnrichment";
 import { uploadToBlob, deleteFromBlob } from "~/lib/blob";
 
 // Verify the signed-in user belongs to the workspace that owns `contactId`.
@@ -470,6 +471,14 @@ export const crmContactRouter = createTRPCRouter({
           e,
         );
       }
+
+      // Opt-in async enrichment: enqueue a web-search job when the workspace
+      // has it enabled. Never let this break creation.
+      await dispatchContactEnrichment(ctx.db, {
+        contactId: contact.id,
+        workspaceId,
+        createdById: ctx.session.user.id,
+      });
 
       // Decrypt fields for the response
       try {

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -347,6 +347,7 @@ export const workspaceRouter = createTRPCRouter({
         enableDailyPlanBanner: z.boolean().optional(),
         enableWeeklyReviewBanner: z.boolean().optional(),
         enableEmailNotifications: z.boolean().optional(),
+        enableAutoEnrichContacts: z.boolean().optional(),
         homeLayout: z.enum(["command", "activity", "coaching"]).optional(),
       })
     )
@@ -381,6 +382,7 @@ export const workspaceRouter = createTRPCRouter({
           enableDailyPlanBanner: input.enableDailyPlanBanner,
           enableWeeklyReviewBanner: input.enableWeeklyReviewBanner,
           enableEmailNotifications: input.enableEmailNotifications,
+          enableAutoEnrichContacts: input.enableAutoEnrichContacts,
           homeLayout: input.homeLayout,
         },
       });

--- a/src/server/services/crm/enrichment/dispatchContactEnrichment.ts
+++ b/src/server/services/crm/enrichment/dispatchContactEnrichment.ts
@@ -1,0 +1,67 @@
+import { type PrismaClient } from "@prisma/client";
+
+/**
+ * Event-driven, opt-in CRM contact enrichment dispatcher. Wired into the two
+ * contact create paths (`crmContact.create` and `crmApi.contactCreate`).
+ *
+ * When a workspace has `enableAutoEnrichContacts` on, this writes a durable
+ * `CrmContactEnrichment` row (status PENDING) — a fast, awaited DB write and
+ * nothing more. The heavy work (web search + write-back) runs later, out of
+ * band: the `enrich-pending-contacts` cron drains PENDING rows and hands each
+ * contact to Mastra's `enrichmentAgent`. The row is the "event" and the audit
+ * trail, mirroring how `ContactImportBatch` backs the Gmail/Calendar import.
+ *
+ * A durable queue row (rather than a fire-and-forget fetch from the mutation)
+ * is deliberate: Vercel serverless can freeze a function after it returns its
+ * response, orphaning un-awaited async work.
+ *
+ * Idempotent: a contact that already has a non-FAILED enrichment is skipped, so
+ * dedupe-hit re-creates never pile up duplicate jobs. Failures are swallowed —
+ * enrichment must never break contact creation.
+ */
+export interface DispatchEnrichmentInput {
+  contactId: string;
+  workspaceId: string;
+  createdById?: string;
+}
+
+export async function dispatchContactEnrichment(
+  db: PrismaClient,
+  input: DispatchEnrichmentInput,
+): Promise<{ enqueued: boolean }> {
+  try {
+    const workspace = await db.workspace.findUnique({
+      where: { id: input.workspaceId },
+      select: { enableAutoEnrichContacts: true },
+    });
+    if (!workspace?.enableAutoEnrichContacts) return { enqueued: false };
+
+    // Idempotency: don't stack jobs for a contact already queued/enriched.
+    // Only a FAILED prior attempt should be re-queued (by an explicit retry).
+    const existing = await db.crmContactEnrichment.findFirst({
+      where: {
+        contactId: input.contactId,
+        status: { in: ["PENDING", "RUNNING", "COMPLETED"] },
+      },
+      select: { id: true },
+    });
+    if (existing) return { enqueued: false };
+
+    await db.crmContactEnrichment.create({
+      data: {
+        contactId: input.contactId,
+        workspaceId: input.workspaceId,
+        status: "PENDING",
+        createdById: input.createdById,
+      },
+    });
+    return { enqueued: true };
+  } catch (err) {
+    console.error(
+      "[crmEnrichment] failed to enqueue enrichment for contact",
+      input.contactId,
+      err,
+    );
+    return { enqueued: false };
+  }
+}

--- a/src/server/services/crm/enrichment/runPendingEnrichments.ts
+++ b/src/server/services/crm/enrichment/runPendingEnrichments.ts
@@ -1,0 +1,163 @@
+import { type PrismaClient } from "@prisma/client";
+
+import { decryptBuffer } from "~/server/utils/encryption";
+import { generateAgentJWT } from "~/server/utils/jwt";
+
+const MASTRA_API_URL = process.env.MASTRA_API_URL;
+
+// How many contacts a single cron sweep will hand to the enrichment agent.
+// Bounded so one invocation stays well inside the serverless time budget; the
+// remainder is picked up on the next sweep.
+const BATCH_SIZE = 10;
+
+export interface RunEnrichmentsResult {
+  claimed: number;
+  completed: string[];
+  failed: { id: string; error: string }[];
+}
+
+/**
+ * Drains PENDING `CrmContactEnrichment` rows and hands each contact to Mastra's
+ * `enrichmentAgent`, which web-searches the person and writes the results back
+ * to the contact itself (via its CRM update tool, through exponential's
+ * encrypted update path). This runner only claims work, triggers the agent, and
+ * records status — it never touches contact PII directly.
+ *
+ * Claiming is atomic per row (updateMany filtered on status=PENDING) so
+ * overlapping cron sweeps never double-process the same job.
+ */
+export async function runPendingEnrichments(
+  db: PrismaClient,
+  now: Date,
+): Promise<RunEnrichmentsResult> {
+  const result: RunEnrichmentsResult = { claimed: 0, completed: [], failed: [] };
+
+  if (!MASTRA_API_URL) {
+    console.error(
+      "[crmEnrichment] MASTRA_API_URL not set; skipping enrichment sweep",
+    );
+    return result;
+  }
+
+  const pending = await db.crmContactEnrichment.findMany({
+    where: { status: "PENDING" },
+    orderBy: { createdAt: "asc" },
+    take: BATCH_SIZE,
+    select: { id: true },
+  });
+
+  for (const { id } of pending) {
+    // Atomic claim: only the sweep that flips PENDING→RUNNING owns this row.
+    const claim = await db.crmContactEnrichment.updateMany({
+      where: { id, status: "PENDING" },
+      data: { status: "RUNNING", startedAt: now },
+    });
+    if (claim.count !== 1) continue;
+    result.claimed += 1;
+
+    try {
+      await enrichOne(db, id);
+      await db.crmContactEnrichment.update({
+        where: { id },
+        data: { status: "COMPLETED", completedAt: new Date() },
+      });
+      result.completed.push(id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      await db.crmContactEnrichment.update({
+        where: { id },
+        data: { status: "FAILED", error: message, completedAt: new Date() },
+      });
+      result.failed.push({ id, error: message });
+    }
+  }
+
+  return result;
+}
+
+async function enrichOne(db: PrismaClient, enrichmentId: string): Promise<void> {
+  const enrichment = await db.crmContactEnrichment.findUniqueOrThrow({
+    where: { id: enrichmentId },
+    include: {
+      contact: { include: { organization: { select: { name: true } } } },
+    },
+  });
+  const contact = enrichment.contact;
+
+  // Load the job's creator to authenticate the agent's CRM write-back as a
+  // real workspace member (the tools authorize via this JWT).
+  const creator = enrichment.createdById
+    ? await db.user.findUnique({
+        where: { id: enrichment.createdById },
+        select: { id: true, email: true, name: true, image: true },
+      })
+    : null;
+  if (!creator) {
+    throw new Error("Enrichment job has no resolvable creator to authorize");
+  }
+
+  const agentJWT = generateAgentJWT(
+    { id: creator.id, email: creator.email, name: creator.name, image: creator.image },
+    30,
+  );
+
+  const name = [contact.firstName, contact.lastName].filter(Boolean).join(" ").trim();
+  const existingEmail = safeDecrypt(contact.email);
+  const known: string[] = [];
+  if (contact.about) known.push(`Bio: ${contact.about}`);
+  if (contact.organization?.name) known.push(`Organization: ${contact.organization.name}`);
+  if (contact.tags?.length) known.push(`Tags: ${contact.tags.join(", ")}`);
+  if (existingEmail) known.push(`Email: ${existingEmail}`);
+
+  const prompt = [
+    `Enrich the CRM contact with id "${contact.id}" (workspace "${contact.workspaceId}").`,
+    name ? `Name: ${name}.` : "Name unknown.",
+    known.length ? `Already known:\n${known.join("\n")}` : "No other details known.",
+    "",
+    "Web-search this person, then update the contact (contactId above) with any",
+    "new details you can verify: email, LinkedIn, Twitter/X, a concise bio (about),",
+    "and their current organization. Only fill fields that are currently empty —",
+    "never overwrite an existing value. Link the organization by name if found.",
+  ].join("\n");
+
+  const res = await fetch(`${MASTRA_API_URL}/api/agents/enrichmentAgent/generate`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${agentJWT}`,
+    },
+    body: JSON.stringify({
+      messages: [{ role: "user", content: prompt }],
+      requestContext: {
+        authToken: agentJWT,
+        userId: creator.id,
+        userEmail: creator.email,
+        workspaceId: contact.workspaceId,
+        todoAppBaseUrl:
+          process.env.TODO_APP_BASE_URL ??
+          process.env.NEXTAUTH_URL ??
+          "http://localhost:3000",
+      },
+    }),
+  });
+
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`Mastra enrichmentAgent failed (${res.status}): ${text.slice(0, 500)}`);
+  }
+
+  // Record the agent's summary for the audit trail; the agent has already
+  // written any fields back to the contact via its CRM tools.
+  await db.crmContactEnrichment.update({
+    where: { id: enrichmentId },
+    data: { metadata: { agentResponse: text.slice(0, 2000) } },
+  });
+}
+
+function safeDecrypt(value: Buffer | Uint8Array | null): string | null {
+  try {
+    return decryptBuffer(value) ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/server/services/crm/enrichment/runPendingEnrichments.ts
+++ b/src/server/services/crm/enrichment/runPendingEnrichments.ts
@@ -1,6 +1,5 @@
 import { type PrismaClient } from "@prisma/client";
 
-import { decryptBuffer } from "~/server/utils/encryption";
 import { generateAgentJWT } from "~/server/utils/jwt";
 
 const MASTRA_API_URL = process.env.MASTRA_API_URL;
@@ -102,12 +101,27 @@ async function enrichOne(db: PrismaClient, enrichmentId: string): Promise<void> 
   );
 
   const name = [contact.firstName, contact.lastName].filter(Boolean).join(" ").trim();
-  const existingEmail = safeDecrypt(contact.email);
+
+  // Tell the agent which contactable fields are ALREADY populated by name only —
+  // presence, never the decrypted value. This keeps the "only fill empty fields"
+  // guidance actionable without decrypting PII into the prompt (and thus into the
+  // external agent request / model context). Presence is a plain null-check on
+  // the encrypted columns; no decryption needed.
+  const alreadySet: string[] = [];
+  if (contact.email != null) alreadySet.push("email");
+  if (contact.phone != null) alreadySet.push("phone");
+  if (contact.linkedIn != null) alreadySet.push("LinkedIn");
+  if (contact.twitter != null) alreadySet.push("Twitter");
+  if (contact.github != null) alreadySet.push("GitHub");
+  if (contact.bluesky != null) alreadySet.push("Bluesky");
+
   const known: string[] = [];
   if (contact.about) known.push(`Bio: ${contact.about}`);
   if (contact.organization?.name) known.push(`Organization: ${contact.organization.name}`);
   if (contact.tags?.length) known.push(`Tags: ${contact.tags.join(", ")}`);
-  if (existingEmail) known.push(`Email: ${existingEmail}`);
+  if (alreadySet.length) {
+    known.push(`Already-populated fields (do NOT overwrite): ${alreadySet.join(", ")}`);
+  }
 
   const prompt = [
     `Enrich the CRM contact with id "${contact.id}" (workspace "${contact.workspaceId}").`,
@@ -141,23 +155,17 @@ async function enrichOne(db: PrismaClient, enrichmentId: string): Promise<void> 
     }),
   });
 
-  const text = await res.text();
   if (!res.ok) {
-    throw new Error(`Mastra enrichmentAgent failed (${res.status}): ${text.slice(0, 500)}`);
+    const errText = await res.text();
+    throw new Error(
+      `Mastra enrichmentAgent failed (${res.status}): ${errText.slice(0, 500)}`,
+    );
   }
 
-  // Record the agent's summary for the audit trail; the agent has already
-  // written any fields back to the contact via its CRM tools.
-  await db.crmContactEnrichment.update({
-    where: { id: enrichmentId },
-    data: { metadata: { agentResponse: text.slice(0, 2000) } },
-  });
-}
-
-function safeDecrypt(value: Buffer | Uint8Array | null): string | null {
-  try {
-    return decryptBuffer(value) ?? null;
-  } catch {
-    return null;
-  }
+  // Deliberately do NOT persist the agent's free-text response: it can echo
+  // back PII it found/confirmed (e.g. the contact's email), and metadata is a
+  // plaintext JSONB column — storing it there would undercut the encryption-at-
+  // rest guarantee for contact PII. The enrichment result is already reflected
+  // on the contact record itself (the source of truth), and this job's
+  // status/timestamps provide the audit trail.
 }

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,10 @@
     {
       "path": "/api/cron/run-scheduled-automations",
       "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/enrich-pending-contacts",
+      "schedule": "*/10 * * * *"
     }
   ]
 }


### PR DESCRIPTION
### **User description**
## What & why

Closes two CRM capability gaps and adds opt-in contact enrichment.

### 1. Organizations creatable outside the web UI
`CrmOrganization` + `crmOrganizationRouter` existed but were session-only. The SDK/CLI/agents go through the API-key `crmApiRouter`, which had contacts + deals but **no organization procedures** — so orgs (e.g. "Columbia IRI", "ICPAC", "KNMI") couldn't be created or linked programmatically.

- Adds `crmApi.organizationList` / `organizationGet` / `organizationCreate` (API-key auth, same workspace-access checks as contacts).
- Adds a find-or-create-by-name helper and optional `organizationName` on `contactCreate` / `contactUpdate`, so a contact can be linked to an org by name in one call (explicit `organizationId` still wins).

*(Companion PRs expose this through `exponential-sdk` and `exponential-cli`.)*

### 2. Event-driven, opt-in contact enrichment
When a contact is created in a workspace with enrichment enabled, a background web-search fills in missing details (email, LinkedIn, Twitter, bio, org).

- `enableAutoEnrichContacts` workspace flag + settings toggle (owner/admin-gated).
- `CrmContactEnrichment` durable job model (mirrors `ContactImportBatch`).
- `dispatchContactEnrichment` fires on **both** create paths (`crmContact.create` + `crmApi.contactCreate`), writing a PENDING job — a fast awaited DB write that never blocks/breaks creation.
- `enrich-pending-contacts` Vercel cron (every 10 min, `CRON_SECRET`-guarded) drains PENDING jobs and hands each contact to Mastra's `enrichmentAgent`, which web-searches and writes results back via the existing CRM tools (encrypted update path).

**Why a cron-drained queue, not fire-and-forget:** Vercel serverless can freeze a function after it returns its response, orphaning un-awaited async work. A durable PENDING row + cron drainer matches the existing cron+batch pattern.

## Migration
`20260701093131_add_contact_enrichment` — adds `Workspace.enableAutoEnrichContacts` + the `CrmContactEnrichment` table. Additive only.

## Deploy dependencies (post-merge)
- Mastra gateway deployed with the new `enrichmentAgent` (companion PR in `../mastra`), plus `SERPER_API_KEY` (web search) and `MASTRA_API_URL` / `CRON_SECRET`.

## Verification
- `tsc --noEmit` and targeted `eslint` clean on all changed files.
- `prisma validate` passes; migration is self-contained and additive.
- No hardcoded colors in the settings toggle.


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Adds organization CRUD endpoints (`organizationList`, `organizationGet`, `organizationCreate`) to the API-key CRM router

- Adds find-or-create-by-name helper and `organizationName` field to `contactCreate`/`contactUpdate` for one-call org linking

- Introduces opt-in, event-driven contact enrichment: `enableAutoEnrichContacts` workspace flag, durable `CrmContactEnrichment` job model, and `dispatchContactEnrichment` dispatcher

- Adds `enrich-pending-contacts` Vercel cron (every 10 min) that drains PENDING jobs via Mastra's `enrichmentAgent` with PII-safe prompting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Contact Create\n(crmContact / crmApi)"] -- "dispatchContactEnrichment" --> B["CrmContactEnrichment\n(PENDING row)"]
  B -- "drained by cron\n(every 10 min)" --> C["enrich-pending-contacts\nroute.ts"]
  C -- "PENDING → RUNNING" --> D["runPendingEnrichments"]
  D -- "agent call" --> E["Mastra enrichmentAgent\n(web search + write-back)"]
  E -- "COMPLETED / FAILED" --> B
  F["crmApiRouter\norganizationList/Get/Create"] -- "API-key auth" --> G["CrmOrganization"]
  H["organizationName input"] -- "resolveOrganizationByName" --> G
  G -- "linked to" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>page.tsx</strong><dd><code>Add auto-enrich contacts toggle to workspace settings UI</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/323/files#diff-0ac5e4711f55c32c32d6519fc8c97fef283b6baff89a3712fee47cbc4ddc65f7">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>route.ts</strong><dd><code>New cron endpoint draining PENDING enrichment jobs securely</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/323/files#diff-0f613907ab197cd0bf2ae68c3d41cdf25b037611fd7501773f60f4fcd973b557">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>crmApi.ts</strong><dd><code>Add organization endpoints and enrichment dispatch to CRM API router</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/323/files#diff-5a0e60d29e34a8b4a14c8286db30121f20477f6f47479aa3b31553831ff6f0b4">+163/-3</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>crmContact.ts</strong><dd><code>Dispatch contact enrichment on session-based contact creation</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/323/files#diff-4365e036b2514a8aa3f9962c34aadb646c4e6e06b1223a39744976340d8b07a9">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>workspace.ts</strong><dd><code>Expose enableAutoEnrichContacts in workspace update mutation</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/323/files#diff-b94d59060e1c78a6a505a0a58d90bb366e921cdd053126776199f6abcee0f846">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dispatchContactEnrichment.ts</strong><dd><code>New idempotent enrichment dispatcher writing PENDING job rows</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/323/files#diff-1ba8ee470fa28fe7ccadf813172b238c1ef1dbc66029245ab4ffeec8c9d35d92">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runPendingEnrichments.ts</strong><dd><code>New service draining enrichment jobs via Mastra agent calls</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/323/files#diff-ce5b10e133a232bb461286622ddd4e3a4edea801f4fd04e626eac86adab45f23">+171/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>migration.sql</strong><dd><code>Migration adding enableAutoEnrichContacts column and </code><br><code>CrmContactEnrichment table</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/323/files#diff-6c1e936ac203aa3e177abf41358da25278060272666d50630aab7dd529b2a445">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.prisma</strong><dd><code>Add CrmContactEnrichment model and workspace enrichment flag</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/323/files#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565c">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vercel.json</strong><dd><code>Register enrich-pending-contacts cron job every 10 minutes</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/323/files#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

