### PR TITLE
feat(okr): toggle to show/hide the OKR overview hero cards

### DIFF
--- a/src/plugins/okr/client/components/OkrDashboard.tsx
+++ b/src/plugins/okr/client/components/OkrDashboard.tsx
@@ -26,6 +26,8 @@ import {
   IconHierarchy,
   IconSparkles,
   IconX,
+  IconLayoutDashboard,
+  IconLayoutDashboardFilled,
 } from "@tabler/icons-react";
 import { keepPreviousData } from "@tanstack/react-query";
 import { PeriodTabs } from "./PeriodTabs";
@@ -159,6 +161,7 @@ export function OkrDashboard({
     new Set(),
   );
   const [nudgeDismissed, setNudgeDismissed] = useState(false);
+  const [heroCardsVisible, setHeroCardsVisible] = useState(true);
 
   const [formData, setFormData] = useState({
     goalId: "",
@@ -632,6 +635,19 @@ export function OkrDashboard({
               )}
               <Button
                 variant="default"
+                leftSection={
+                  heroCardsVisible ? (
+                    <IconLayoutDashboardFilled size={14} />
+                  ) : (
+                    <IconLayoutDashboard size={14} />
+                  )
+                }
+                onClick={() => setHeroCardsVisible((v) => !v)}
+              >
+                {heroCardsVisible ? "Hide overview" : "Show overview"}
+              </Button>
+              <Button
+                variant="default"
                 leftSection={<IconHierarchy size={14} />}
                 disabled
               >
@@ -667,7 +683,7 @@ export function OkrDashboard({
         />
 
         {/* Hero cards */}
-        {visibleObjectives.length > 0 && (
+        {heroCardsVisible && visibleObjectives.length > 0 && (
           <OkrHeroCards
             objectives={visibleObjectives}
             period={effectivePeriod}


### PR DESCRIPTION
### **User description**
Adds a **Hide overview** / **Show overview** button to the OKR dashboard toolbar that collapses the hero-card strip (Quarter Progress, Key Results by Confidence, Check-ins This Week, Trajectory).

### Notes
- Toggle state is component-local (\`useState(true)\`) — it resets to shown on reload. Persisting the preference (localStorage) is a possible follow-up.
- No schema/migration changes; UI-only, 17-line change.


___

### **PR Type**
Enhancement


___

### **Description**
- Add toggle button to show/hide OKR dashboard hero cards

- Button uses filled/outline dashboard icons to reflect visibility state

- Hero cards strip conditionally renders based on `heroCardsVisible` state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  btn["Toggle Button\n(Hide/Show overview)"]
  state["heroCardsVisible\n(useState)"]
  cards["OkrHeroCards\n(hero card strip)"]
  btn -- "onClick toggles" --> state
  state -- "controls render" --> cards
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OkrDashboard.tsx</strong><dd><code>Add toggle button to show/hide OKR hero cards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/okr/client/components/OkrDashboard.tsx

<ul><li>Import <code>IconLayoutDashboard</code> and <code>IconLayoutDashboardFilled</code> icons from <br><code>@tabler/icons-react</code><br> <li> Add <code>heroCardsVisible</code> state variable initialized to <code>true</code><br> <li> Add a toggle button in the toolbar that switches between "Hide <br>overview" and "Show overview" with corresponding icons<br> <li> Conditionally render <code>OkrHeroCards</code> based on <code>heroCardsVisible</code> state</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/324/files#diff-889bca4ccc882e62c348d484ae792375ad5527a219cadd0ddbcf25d6b4346d0b">+17/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

