### PR TITLE
feat(crm): explicit "enrich now" trigger for existing contacts

### DIFF
--- a/src/server/api/routers/crmApi.ts
+++ b/src/server/api/routers/crmApi.ts
@@ -7,7 +7,10 @@ import { Prisma } from "@prisma/client";
 import type { CrmContact, PrismaClient } from "@prisma/client";
 import { getProjectAccess, hasProjectAccess } from "~/server/services/access";
 import { emailHashFor } from "~/server/services/crm/createCrmContact";
-import { dispatchContactEnrichment } from "~/server/services/crm/enrichment/dispatchContactEnrichment";
+import {
+  dispatchContactEnrichment,
+  enqueueContactEnrichment,
+} from "~/server/services/crm/enrichment/dispatchContactEnrichment";
 
 // ─── Helpers ────────────────────────────────────────────────────────
 
@@ -531,6 +534,36 @@ export const crmApiRouter = createTRPCRouter({
       });
 
       return interaction;
+    }),
+
+  // Explicitly enqueue a web-search enrichment job for an existing contact.
+  // Unlike the automatic path (which fires on create and is gated on the
+  // workspace's enableAutoEnrichContacts flag), this is a deliberate user
+  // action, so it forces the enqueue regardless of the flag. The
+  // enrich-pending-contacts cron drains the PENDING row into Mastra's
+  // enrichmentAgent. Idempotent: a contact with a job already PENDING/RUNNING is
+  // not re-queued (that in-flight job's id is returned instead).
+  contactEnrich: apiKeyMiddleware
+    .input(z.object({ contactId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const contact = await ctx.db.crmContact.findUnique({
+        where: { id: input.contactId },
+        select: { workspaceId: true },
+      });
+      if (!contact) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Contact not found" });
+      }
+      await verifyWorkspaceAccess(ctx.db, contact.workspaceId, ctx.userId);
+
+      return enqueueContactEnrichment(
+        ctx.db,
+        {
+          contactId: input.contactId,
+          workspaceId: contact.workspaceId,
+          createdById: ctx.userId,
+        },
+        { force: true },
+      );
     }),
 
   // ─── Organizations ──────────────────────────────────────────────

--- a/src/server/services/crm/enrichment/dispatchContactEnrichment.ts
+++ b/src/server/services/crm/enrichment/dispatchContactEnrichment.ts
@@ -1,61 +1,97 @@
 import { type PrismaClient } from "@prisma/client";
 
-/**
- * Event-driven, opt-in CRM contact enrichment dispatcher. Wired into the two
- * contact create paths (`crmContact.create` and `crmApi.contactCreate`).
- *
- * When a workspace has `enableAutoEnrichContacts` on, this writes a durable
- * `CrmContactEnrichment` row (status PENDING) — a fast, awaited DB write and
- * nothing more. The heavy work (web search + write-back) runs later, out of
- * band: the `enrich-pending-contacts` cron drains PENDING rows and hands each
- * contact to Mastra's `enrichmentAgent`. The row is the "event" and the audit
- * trail, mirroring how `ContactImportBatch` backs the Gmail/Calendar import.
- *
- * A durable queue row (rather than a fire-and-forget fetch from the mutation)
- * is deliberate: Vercel serverless can freeze a function after it returns its
- * response, orphaning un-awaited async work.
- *
- * Idempotent: a contact that already has a non-FAILED enrichment is skipped, so
- * dedupe-hit re-creates never pile up duplicate jobs. Failures are swallowed —
- * enrichment must never break contact creation.
- */
-export interface DispatchEnrichmentInput {
+export interface EnqueueEnrichmentInput {
   contactId: string;
   workspaceId: string;
   createdById?: string;
 }
 
+export interface EnqueueEnrichmentResult {
+  enqueued: boolean;
+  /** The relevant enrichment row id — the newly created one, or the in-flight one that blocked it. */
+  enrichmentId?: string;
+  /** Why nothing was enqueued (only set when `enqueued` is false). */
+  reason?: "auto-enrich-disabled" | "already-in-flight";
+}
+
+/**
+ * Core enqueue: writes a PENDING `CrmContactEnrichment` row for a contact, to be
+ * drained later by the `enrich-pending-contacts` cron (which hands it to
+ * Mastra's `enrichmentAgent`). The row is a durable queue entry and audit
+ * record, mirroring how `ContactImportBatch` backs the Gmail/Calendar import. A
+ * durable row (rather than a fire-and-forget fetch) is deliberate: Vercel
+ * serverless can freeze a function after it returns, orphaning un-awaited work.
+ *
+ * Shared by two callers:
+ * - the auto path (`dispatchContactEnrichment`, fired on contact create) —
+ *   `force: false`, gated on the workspace's `enableAutoEnrichContacts` flag;
+ * - the explicit "enrich now" path (`crmApi.contactEnrich`) — `force: true`,
+ *   which bypasses the flag because the user asked for it directly.
+ *
+ * Idempotency: never stacks a second job while one is PENDING or RUNNING. The
+ * auto path additionally treats an already-COMPLETED contact as done (enrich
+ * once); the forced path allows re-enriching a contact whose last job COMPLETED
+ * or FAILED.
+ *
+ * Unlike `dispatchContactEnrichment`, this does NOT swallow errors — an explicit
+ * caller wants to know if the enqueue failed.
+ */
+export async function enqueueContactEnrichment(
+  db: PrismaClient,
+  input: EnqueueEnrichmentInput,
+  opts: { force?: boolean } = {},
+): Promise<EnqueueEnrichmentResult> {
+  const force = opts.force ?? false;
+
+  if (!force) {
+    const workspace = await db.workspace.findUnique({
+      where: { id: input.workspaceId },
+      select: { enableAutoEnrichContacts: true },
+    });
+    if (!workspace?.enableAutoEnrichContacts) {
+      return { enqueued: false, reason: "auto-enrich-disabled" };
+    }
+  }
+
+  // Never run two jobs for one contact at once. The auto path also treats a
+  // COMPLETED contact as done; the forced path lets the user re-enrich it.
+  const blockingStatuses = force
+    ? ["PENDING", "RUNNING"]
+    : ["PENDING", "RUNNING", "COMPLETED"];
+  const existing = await db.crmContactEnrichment.findFirst({
+    where: { contactId: input.contactId, status: { in: blockingStatuses } },
+    select: { id: true },
+  });
+  if (existing) {
+    return { enqueued: false, enrichmentId: existing.id, reason: "already-in-flight" };
+  }
+
+  const row = await db.crmContactEnrichment.create({
+    data: {
+      contactId: input.contactId,
+      workspaceId: input.workspaceId,
+      status: "PENDING",
+      createdById: input.createdById,
+    },
+    select: { id: true },
+  });
+  return { enqueued: true, enrichmentId: row.id };
+}
+
+export type DispatchEnrichmentInput = EnqueueEnrichmentInput;
+
+/**
+ * Auto path: fired on contact create from both create mutations. Flag-gated and
+ * error-swallowing — enrichment must never break contact creation. Thin wrapper
+ * over `enqueueContactEnrichment` with `force: false`.
+ */
 export async function dispatchContactEnrichment(
   db: PrismaClient,
   input: DispatchEnrichmentInput,
 ): Promise<{ enqueued: boolean }> {
   try {
-    const workspace = await db.workspace.findUnique({
-      where: { id: input.workspaceId },
-      select: { enableAutoEnrichContacts: true },
-    });
-    if (!workspace?.enableAutoEnrichContacts) return { enqueued: false };
-
-    // Idempotency: don't stack jobs for a contact already queued/enriched.
-    // Only a FAILED prior attempt should be re-queued (by an explicit retry).
-    const existing = await db.crmContactEnrichment.findFirst({
-      where: {
-        contactId: input.contactId,
-        status: { in: ["PENDING", "RUNNING", "COMPLETED"] },
-      },
-      select: { id: true },
-    });
-    if (existing) return { enqueued: false };
-
-    await db.crmContactEnrichment.create({
-      data: {
-        contactId: input.contactId,
-        workspaceId: input.workspaceId,
-        status: "PENDING",
-        createdById: input.createdById,
-      },
-    });
-    return { enqueued: true };
+    const result = await enqueueContactEnrichment(db, input, { force: false });
+    return { enqueued: result.enqueued };
   } catch (err) {
     console.error(
       "[crmEnrichment] failed to enqueue enrichment for contact",


### PR DESCRIPTION
### **User description**
## What & why

Follow-up to #323. Automatic enrichment only fires **on contact create** and is gated on the workspace `enableAutoEnrichContacts` flag — so contacts created before enrichment was enabled (or in a workspace with it off) can't be enriched. This adds an explicit, user-initiated trigger.

- **`crmApi.contactEnrich({ contactId })`** (API-key) — verifies workspace access, then force-enqueues a PENDING `CrmContactEnrichment` row regardless of the workspace flag (the user asked for it directly). The existing `enrich-pending-contacts` cron drains it into Mastra's `enrichmentAgent`.
- Refactors the enqueue into a shared **`enqueueContactEnrichment`** core:
  - auto path (`dispatchContactEnrichment`) → `force: false`, still flag-gated + error-swallowing (never breaks contact creation);
  - explicit path → `force: true`, surfaces errors to the caller.
- **Idempotent**: never stacks a job while one is PENDING/RUNNING. The auto path also treats an already-COMPLETED contact as done; the forced path allows re-enriching a contact whose last job COMPLETED/FAILED.

Companion PRs expose this via `exponential-sdk` (`contacts.enrich(id)`) and `exponential-cli` (`contacts enrich <id>`).

## No migration
Reuses the `CrmContactEnrichment` table from #323.

## Verification
`tsc --noEmit` and targeted `eslint` clean on both changed files.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `crmApi.contactEnrich` endpoint for explicit, user-initiated contact enrichment

- Refactors enqueue logic into shared `enqueueContactEnrichment` core with `force` option

- Auto path remains flag-gated and error-swallowing; explicit path bypasses flag and surfaces errors

- Idempotent: blocks duplicate jobs while PENDING/RUNNING; forced path allows re-enriching COMPLETED/FAILED contacts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["crmApi.contactEnrich\n(force: true)"] -- "calls" --> C["enqueueContactEnrichment"]
  B["dispatchContactEnrichment\n(force: false, auto path)"] -- "calls" --> C
  C -- "checks flag\n(force:false only)" --> D["Workspace.enableAutoEnrichContacts"]
  C -- "idempotency check" --> E["CrmContactEnrichment\n(PENDING/RUNNING/COMPLETED)"]
  C -- "writes PENDING row" --> F["CrmContactEnrichment"]
  F -- "drained by cron" --> G["enrich-pending-contacts\n→ Mastra enrichmentAgent"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crmApi.ts</strong><dd><code>Add explicit contactEnrich API endpoint with force enqueue</code></dd></summary>
<hr>

src/server/api/routers/crmApi.ts

<ul><li>Imports <code>enqueueContactEnrichment</code> alongside <code>dispatchContactEnrichment</code><br> <li> Adds new <code>contactEnrich</code> mutation that verifies workspace access and <br>calls <code>enqueueContactEnrichment</code> with <code>force: true</code><br> <li> Returns enrichment job id to the caller; idempotent for <br>PENDING/RUNNING jobs</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/325/files#diff-5a0e60d29e34a8b4a14c8286db30121f20477f6f47479aa3b31553831ff6f0b4">+34/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dispatchContactEnrichment.ts</strong><dd><code>Refactor enrichment dispatcher into shared force-aware core</code></dd></summary>
<hr>

src/server/services/crm/enrichment/dispatchContactEnrichment.ts

<ul><li>Extracts core enqueue logic into new <code>enqueueContactEnrichment</code> function <br>with <code>force</code> option<br> <li> Introduces <code>EnqueueEnrichmentResult</code> type with <code>enqueued</code>, <code>enrichmentId</code>, <br>and <code>reason</code> fields<br> <li> <code>dispatchContactEnrichment</code> becomes a thin, error-swallowing wrapper <br>calling <code>enqueueContactEnrichment</code> with <code>force: false</code><br> <li> Forced path blocks only PENDING/RUNNING jobs; auto path also blocks <br>COMPLETED contacts</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/325/files#diff-1ba8ee470fa28fe7ccadf813172b238c1ef1dbc66029245ab4ffeec8c9d35d92">+80/-44</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

