### PR TITLE
chore: extract shared <KanbanBoard>; migrate Project tasks board

### DIFF
--- a/src/app/_components/KanbanBoard.tsx
+++ b/src/app/_components/KanbanBoard.tsx
@@ -1,26 +1,14 @@
 "use client";
 
-import { useState, useMemo } from "react";
-import {
-  DndContext,
-  DragOverlay,
-  PointerSensor,
-  KeyboardSensor,
-  useSensor,
-  useSensors,
-  closestCenter,
-} from "@dnd-kit/core";
-import type { DragEndEvent, DragStartEvent, DragOverEvent } from "@dnd-kit/core";
-import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { useMemo } from "react";
 import { Title, Paper } from "@mantine/core";
 import { api } from "~/trpc/react";
 import { notifications } from "@mantine/notifications";
-import { KanbanColumn } from "./KanbanColumn";
 import { TaskCard } from "./TaskCard";
-import styles from "./ProjectTasks.module.css";
+import { KanbanBoard as SharedKanbanBoard } from "./shared/kanban";
+import type { KanbanColumnDef, KanbanItem } from "./shared/kanban";
 
 type ActionStatus = "BACKLOG" | "TODO" | "IN_PROGRESS" | "IN_REVIEW" | "DONE" | "CANCELLED";
-type ColumnAccent = "slate" | "brand" | "amber" | "violet" | "green" | "red";
 
 interface Action {
   id: string;
@@ -46,13 +34,16 @@ interface Action {
   } | null;
 }
 
+// The item shape handed to the shared board: an Action tagged with its column.
+type BoardItem = Action & KanbanItem;
+
 interface KanbanBoardProps {
   projectId?: string;
   actions: Action[];
   onActionOpen?: (id: string) => void;
 }
 
-const KANBAN_COLUMNS: { id: ActionStatus; title: string; accent: ColumnAccent }[] = [
+const KANBAN_COLUMNS: (KanbanColumnDef & { id: ActionStatus })[] = [
   { id: "BACKLOG", title: "Backlog", accent: "slate" },
   { id: "TODO", title: "Todo", accent: "brand" },
   { id: "IN_PROGRESS", title: "In Progress", accent: "amber" },
@@ -69,56 +60,33 @@ const priorityOrder: Record<string, number> = {
   'Remember': 9, 'Watch': 10
 };
 
-export function KanbanBoard({ projectId, actions, onActionOpen }: KanbanBoardProps) {
-  const [activeTask, setActiveTask] = useState<Action | null>(null);
-  const [optimisticUpdates, setOptimisticUpdates] = useState<Record<string, ActionStatus>>({});
-  const [dragOverTaskId, setDragOverTaskId] = useState<string | null>(null);
+// Resolve an action to its board column (unset status defaults to TODO).
+const columnFor = (action: Action): ActionStatus => action.kanbanStatus ?? "TODO";
 
+export function KanbanBoard({ projectId, actions, onActionOpen }: KanbanBoardProps) {
   const utils = api.useUtils();
 
-  // Mutation for updating kanban status with ordering
+  // Mutation for updating kanban status with ordering. The shared board owns the
+  // optimistic column move + rollback; here we keep the tRPC cache snapshot for
+  // rollback and the invalidate that reconciles ordering.
   const updateKanbanStatusMutation = api.action.updateKanbanStatusWithOrder.useMutation({
-    onMutate: async ({ actionId, kanbanStatus }) => {
-      // Cancel outgoing refetches
-      await utils.action.getProjectActions.cancel({ projectId: projectId! });
-
-      // Snapshot the previous value
-      const previousActions = utils.action.getProjectActions.getData({ projectId: projectId! });
-
-      // Only set if not already set by handleDragEnd (avoid duplicate render)
-      setOptimisticUpdates(prev => {
-        if (prev[actionId] === kanbanStatus) return prev;
-        return { ...prev, [actionId]: kanbanStatus };
-      });
-
-      return { previousActions, actionId, originalStatus: previousActions?.find((a: any) => a.id === actionId)?.kanbanStatus };
+    onMutate: async () => {
+      if (!projectId) return { previousActions: undefined };
+      await utils.action.getProjectActions.cancel({ projectId });
+      const previousActions = utils.action.getProjectActions.getData({ projectId });
+      return { previousActions };
     },
-    onSuccess: (_, { actionId: _actionId }) => {
-      // Clear optimistic update on success
-      // setOptimisticUpdates(prev => {
-      //   const newUpdates = { ...prev };
-      //   delete newUpdates[actionId];
-      //   return newUpdates;
-      // });
+    onSuccess: () => {
       notifications.show({
         title: "Status Updated",
         message: "Task status has been updated successfully",
         color: "green",
       });
     },
-    onError: (error, { actionId }, context) => {
-      // Rollback optimistic update on error
-      setOptimisticUpdates(prev => {
-        const newUpdates = { ...prev };
-        delete newUpdates[actionId];
-        return newUpdates;
-      });
-      
-      // Restore previous data if available
+    onError: (error, _vars, context) => {
       if (context?.previousActions && projectId) {
         utils.action.getProjectActions.setData({ projectId }, context.previousActions);
       }
-      
       notifications.show({
         title: "Update Failed",
         message: error.message || "Failed to update task status",
@@ -126,257 +94,85 @@ export function KanbanBoard({ projectId, actions, onActionOpen }: KanbanBoardPro
       });
     },
     onSettled: () => {
-      // Always refetch after error or success to ensure consistency
       if (projectId) {
         void utils.action.getProjectActions.invalidate({ projectId });
       }
     },
   });
 
-  // Apply optimistic updates to actions
-  const actionsWithOptimisticUpdates = useMemo(() => {
-    return actions.map(action => ({
-      ...action,
-      kanbanStatus: optimisticUpdates[action.id] ?? action.kanbanStatus
-    }));
-  }, [actions, optimisticUpdates]);
-
-  // Filter actions that have kanban status or assign default status
-  const kanbanActions = actionsWithOptimisticUpdates.filter(action =>
-    action.projectId && (action.kanbanStatus || action.kanbanStatus === null)
+  // Only project actions belong on the board.
+  const boardActions = useMemo(
+    () => actions.filter((action) => action.projectId),
+    [actions],
   );
 
-  // Group actions by status and sort by priority (with manual kanbanOrder override)
-  const actionsByStatus = useMemo(() => {
-    return KANBAN_COLUMNS.reduce((acc, column) => {
-      const columnActions = kanbanActions.filter(
-        action => action.kanbanStatus === column.id ||
-        (column.id === "TODO" && !action.kanbanStatus) // Default to TODO if no status
-      );
+  // Group by column and sort within each: manual kanbanOrder → scheduledStart →
+  // priority → id. Flatten in column order so the shared board's per-column
+  // display order matches this (its drop index maps back onto these lists).
+  const items = useMemo<BoardItem[]>(() => {
+    const flattened: BoardItem[] = [];
+    for (const column of KANBAN_COLUMNS) {
+      const columnActions = boardActions
+        .filter((action) => columnFor(action) === column.id)
+        .sort((a, b) => {
+          const aOrder = a.kanbanOrder;
+          const bOrder = b.kanbanOrder;
+          if (aOrder != null && bOrder != null) return aOrder - bOrder;
+          if (aOrder != null) return -1;
+          if (bOrder != null) return 1;
 
-      // Sort by kanbanOrder (manual positioning), then scheduledStart, then priority, then ID
-      acc[column.id] = columnActions.sort((a, b) => {
-        const aOrder = a.kanbanOrder;
-        const bOrder = b.kanbanOrder;
+          const aStart = a.scheduledStart ? new Date(a.scheduledStart).getTime() : Infinity;
+          const bStart = b.scheduledStart ? new Date(b.scheduledStart).getTime() : Infinity;
+          if (aStart !== bStart) return aStart - bStart;
 
-        // 1. Manual positioning takes precedence (if BOTH have kanbanOrder)
-        if (aOrder != null && bOrder != null) {
-          return aOrder - bOrder;
-        }
-        if (aOrder != null) return -1;
-        if (bOrder != null) return 1;
+          const priorityDiff = (priorityOrder[a.priority] ?? 999) - (priorityOrder[b.priority] ?? 999);
+          if (priorityDiff !== 0) return priorityDiff;
 
-        // 2. Sort by scheduledStart (ascending - earliest first, null/undefined at end)
-        const aScheduledStart = a.scheduledStart ? new Date(a.scheduledStart).getTime() : Infinity;
-        const bScheduledStart = b.scheduledStart ? new Date(b.scheduledStart).getTime() : Infinity;
-        if (aScheduledStart !== bScheduledStart) {
-          return aScheduledStart - bScheduledStart;
-        }
+          return a.id.localeCompare(b.id);
+        });
 
-        // 3. Sort by priority (1st Priority first)
-        const priorityDiff = (priorityOrder[a.priority] ?? 999) - (priorityOrder[b.priority] ?? 999);
-        if (priorityDiff !== 0) return priorityDiff;
-
-        // 4. Tiebreaker: by ID
-        return a.id.localeCompare(b.id);
-      });
-
-      return acc;
-    }, {} as Record<ActionStatus, Action[]>);
-  }, [kanbanActions]);
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 8,
-      },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    })
-  );
-
-  const handleDragStart = (event: DragStartEvent) => {
-    const task = kanbanActions.find(action => action.id === event.active.id);
-    setActiveTask(task || null);
-    setDragOverTaskId(null);
-  };
-
-  const handleDragOver = (event: DragOverEvent) => {
-    const { over } = event;
-    
-    if (over) {
-      const overId = over.id as string;
-      const isColumn = KANBAN_COLUMNS.some(col => col.id === overId);
-      
-      if (!isColumn) {
-        // Dragging over a task
-        setDragOverTaskId(overId);
-      } else {
-        setDragOverTaskId(null);
+      for (const action of columnActions) {
+        flattened.push({ ...action, columnId: column.id });
       }
-    } else {
-      setDragOverTaskId(null);
     }
-  };
+    return flattened;
+  }, [boardActions]);
 
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-    setDragOverTaskId(null);
+  // Translate the shared board's (itemId, toColumnId, toIndex) into the existing
+  // status+order mutation. The card sitting at toIndex is the drop target
+  // ("insert above"); a column-end drop has no target and just changes status.
+  const handleMove = (itemId: string, toColumnId: string, toIndex: number) => {
+    const targetColumnItems = items.filter((item) => item.columnId === toColumnId);
+    const target = targetColumnItems[toIndex];
+    const droppedOnTaskId = target && target.id !== itemId ? target.id : undefined;
 
-    if (!over) {
-      setActiveTask(null);
-      return;
-    }
-
-    const taskId = active.id as string;
-    const overId = over.id as string;
-
-    // Find the task being moved
-    const task = kanbanActions.find(action => action.id === taskId);
-    if (!task) {
-      setActiveTask(null);
-      return;
-    }
-
-    // Prevent concurrent updates for the same task
-    if (updateKanbanStatusMutation.isPending) {
-      setActiveTask(null);
-      return;
-    }
-
-    // Determine the new status and whether we're dropping on a column or task
-    const isColumn = KANBAN_COLUMNS.some(col => col.id === overId);
-    let newStatus: ActionStatus;
-    let droppedOnTaskId: string | undefined;
-
-    if (isColumn) {
-      newStatus = overId as ActionStatus;
-    } else {
-      // Dropped on another task - use that task's status
-      const targetTask = kanbanActions.find(action => action.id === overId);
-      if (!targetTask) {
-        setActiveTask(null);
-        return;
-      }
-      newStatus = targetTask.kanbanStatus ?? "TODO";
-      droppedOnTaskId = overId;
-    }
-
-    const currentStatus = optimisticUpdates[taskId] ?? task.kanbanStatus ?? "TODO";
-
-    // If status hasn't changed and not reordering within column, do nothing
-    if (currentStatus === newStatus && !droppedOnTaskId) {
-      setActiveTask(null);
-      return;
-    }
-
-    // CRITICAL: Apply optimistic update BEFORE clearing activeTask
-    // This ensures the card is in its new position when DragOverlay disappears
-    setOptimisticUpdates(prev => ({ ...prev, [taskId]: newStatus }));
-
-    // NOW clear activeTask (DragOverlay disappears, but card is already in new position)
-    setActiveTask(null);
-
-    // Fire the mutation
-    updateKanbanStatusMutation.mutate({
-      actionId: taskId,
-      kanbanStatus: newStatus,
+    return updateKanbanStatusMutation.mutateAsync({
+      actionId: itemId,
+      kanbanStatus: toColumnId as ActionStatus,
       ...(droppedOnTaskId ? { droppedOnTaskId } : {}),
     });
   };
 
-  const handleDragCancel = () => {
-    setActiveTask(null);
-    setDragOverTaskId(null);
-  };
-
-  if (!kanbanActions.length) {
-    return (
-      <Paper className="p-8 text-center">
-        <Title order={3} c="dimmed">
-          No project tasks found
-        </Title>
-        <p className="text-text-secondary mt-2">
-          Add tasks to a project to see them in the Kanban board.
-        </p>
-      </Paper>
-    );
-  }
-
   return (
-    <div className="w-full" role="application" aria-label="Kanban board">
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragStart={handleDragStart}
-        onDragOver={handleDragOver}
-        onDragEnd={handleDragEnd}
-        onDragCancel={handleDragCancel}
-        accessibility={{
-          announcements: {
-            onDragStart({ active }) {
-              const activeTask = kanbanActions.find(task => task.id === active.id);
-              return `Started dragging task: ${activeTask?.name || active.id}`;
-            },
-            onDragOver({ active, over }) {
-              const activeTask = kanbanActions.find(task => task.id === active.id);
-              if (over) {
-                const isColumn = KANBAN_COLUMNS.some(col => col.id === over.id);
-                if (isColumn) {
-                  const column = KANBAN_COLUMNS.find(col => col.id === over.id);
-                  return `${activeTask?.name || active.id} is over ${column?.title} column`;
-                } else {
-                  const targetTask = kanbanActions.find(task => task.id === over.id);
-                  return `${activeTask?.name || active.id} is over task: ${targetTask?.name || over.id}`;
-                }
-              }
-              return `${activeTask?.name || active.id} is no longer over a droppable area`;
-            },
-            onDragEnd({ active, over }) {
-              const activeTask = kanbanActions.find(task => task.id === active.id);
-              if (over) {
-                const isColumn = KANBAN_COLUMNS.some(col => col.id === over.id);
-                if (isColumn) {
-                  const column = KANBAN_COLUMNS.find(col => col.id === over.id);
-                  return `${activeTask?.name || active.id} was moved to ${column?.title} column`;
-                } else {
-                  const targetTask = kanbanActions.find(task => task.id === over.id);
-                  return `${activeTask?.name || active.id} was placed above ${targetTask?.name || over.id}`;
-                }
-              }
-              return `${activeTask?.name || active.id} was dropped`;
-            },
-            onDragCancel({ active }) {
-              const activeTask = kanbanActions.find(task => task.id === active.id);
-              return `Dragging ${activeTask?.name || active.id} was cancelled`;
-            },
-          },
-        }}
-      >
-        <div className={styles.kboard}>
-          {KANBAN_COLUMNS.map((column) => (
-            <KanbanColumn
-              key={column.id}
-              id={column.id}
-              title={column.title}
-              accent={column.accent}
-              tasks={actionsByStatus[column.id] || []}
-              dragOverTaskId={dragOverTaskId}
-              onActionOpen={onActionOpen}
-            />
-          ))}
-        </div>
-
-        <DragOverlay>
-          {activeTask && (
-            <TaskCard
-              task={activeTask}
-              isDragging
-            />
-          )}
-        </DragOverlay>
-      </DndContext>
-    </div>
+    <SharedKanbanBoard<BoardItem>
+      columns={KANBAN_COLUMNS}
+      items={items}
+      onMove={handleMove}
+      getItemLabel={(item) => item.name}
+      bleed
+      renderCard={(item, { isOverlay }) => (
+        <TaskCard task={item} isDragging={isOverlay} onActionOpen={onActionOpen} />
+      )}
+      emptyState={
+        <Paper className="p-8 text-center">
+          <Title order={3} c="dimmed">
+            No project tasks found
+          </Title>
+          <p className="text-text-secondary mt-2">
+            Add tasks to a project to see them in the Kanban board.
+          </p>
+        </Paper>
+      }
+    />
   );
 }

--- a/src/app/_components/ProjectTasks.module.css
+++ b/src/app/_components/ProjectTasks.module.css
@@ -155,6 +155,11 @@
 }
 
 /* ── Kanban board ─────────────────────────────────────── */
+/* TRANSITIONAL (ADR-0037): the canonical `.kboard` / `.kcol*` accent vocabulary
+   now lives in src/app/_components/shared/kanban/Kanban.module.css. The copy
+   below is still consumed by the not-yet-migrated boards via the legacy
+   KanbanColumn.tsx (Actions board). It is removed once those boards migrate
+   onto <KanbanBoard> (tickets A2–A4). Do not add new consumers. */
 
 .kboard {
   display: flex;

--- a/src/app/_components/shared/kanban/Kanban.module.css
+++ b/src/app/_components/shared/kanban/Kanban.module.css
@@ -1,0 +1,176 @@
+/* Shared Kanban board presentation (ADR-0037).
+   Owns the board/column chrome and the `.kcol*` accent vocabulary that
+   graduated out of the Project-scoped ProjectTasks.module.css.
+   All colours reference CSS variables from globals.css.
+   Alpha-only rgba() values (shadows, tints, glows) are allowed. */
+
+/* ── Kanban board ─────────────────────────────────────── */
+
+.kboard {
+  display: flex;
+  gap: 14px;
+  overflow-x: auto;
+  padding-bottom: 12px;
+  align-items: flex-start;
+}
+
+/* Opt-in horizontal bleed for shells with 32px side padding (Project tasks tab).
+   Consumers pass this via the board `className` prop so the generic board
+   stays free of any page-shell assumption. */
+.kboardBleed {
+  margin: 0 -32px;
+  padding-left: 32px;
+  padding-right: 32px;
+  scroll-padding-left: 32px;
+}
+
+.kboard::-webkit-scrollbar {
+  height: 8px;
+}
+
+.kboard::-webkit-scrollbar-thumb {
+  background: var(--color-border-strong);
+  border-radius: 4px;
+}
+
+.kboard::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* Per-column accent tokens (slate default, overridden by accent modifier) */
+.kcol {
+  --col-accent: var(--color-text-muted);
+  --col-tint: rgba(148, 163, 184, 0.10);
+  --col-glow: rgba(148, 163, 184, 0.18);
+
+  flex: 0 0 296px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  min-height: 480px;
+  overflow: hidden;
+  position: relative;
+  transition: background 120ms, border-color 120ms;
+}
+
+.kcol::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: var(--col-accent);
+  opacity: 0.9;
+}
+
+.kcolOver {
+  background: var(--color-bg-elevated);
+  border-color: var(--col-accent);
+}
+
+/* Accent variants */
+.kcolSlate {
+  --col-accent: var(--accent-neutral);
+  --col-tint: rgba(111, 127, 152, 0.10);
+  --col-glow: rgba(111, 127, 152, 0.20);
+}
+.kcolBrand {
+  --col-accent: var(--brand-400);
+  --col-tint: rgba(78, 137, 255, 0.10);
+  --col-glow: rgba(78, 137, 255, 0.22);
+}
+.kcolAmber {
+  --col-accent: var(--accent-okr);
+  --col-tint: rgba(245, 185, 74, 0.10);
+  --col-glow: rgba(245, 185, 74, 0.22);
+}
+.kcolViolet {
+  --col-accent: var(--accent-meetings);
+  --col-tint: rgba(167, 139, 250, 0.10);
+  --col-glow: rgba(167, 139, 250, 0.22);
+}
+.kcolGreen {
+  --col-accent: var(--accent-crm);
+  --col-tint: rgba(74, 222, 140, 0.10);
+  --col-glow: rgba(74, 222, 140, 0.22);
+}
+.kcolRed {
+  --col-accent: var(--accent-due);
+  --col-tint: rgba(248, 113, 113, 0.10);
+  --col-glow: rgba(248, 113, 113, 0.22);
+}
+
+.kcolHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 11px 14px 10px;
+  background: linear-gradient(180deg, var(--col-tint), transparent);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.kcolHeadLeft {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.kcolHeadRight {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.kcolDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--col-accent);
+  box-shadow: 0 0 0 3px var(--col-glow);
+}
+
+.kcolLabel {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  letter-spacing: 0.005em;
+}
+
+.kcolCount {
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 10px;
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.kcolBody {
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-height: 80px;
+}
+
+.kcolEmpty {
+  margin: 8px;
+  padding: 36px 10px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--color-text-faint);
+  border: 1.5px dashed var(--color-border-subtle);
+  border-radius: 8px;
+}
+
+/* Drop indicator between cards */
+.kcolDropIndicator {
+  height: 3px;
+  background: var(--col-accent);
+  border-radius: 2px;
+  margin: 0 2px 4px;
+  opacity: 0.75;
+}

--- a/src/app/_components/shared/kanban/KanbanBoard.tsx
+++ b/src/app/_components/shared/kanban/KanbanBoard.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+} from "@dnd-kit/core";
+import type { DragEndEvent, DragStartEvent, DragOverEvent } from "@dnd-kit/core";
+import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { KanbanColumn } from "./KanbanColumn";
+import type { KanbanBoardProps, KanbanItem } from "./types";
+import styles from "./Kanban.module.css";
+
+/**
+ * Presentation-only, data-agnostic Kanban board (ADR-0037).
+ *
+ * Owns: dnd-kit wiring (DndContext, sensors, collision, DragOverlay), droppable
+ * columns, the between-card drop indicator, a11y announcements, and the shared
+ * optimistic-move state machine (a card jumps columns immediately on drop and
+ * reverts if `onMove` rejects; intra-column ordering settles when the consumer
+ * refetches, matching every existing board's behaviour).
+ *
+ * Knows nothing about Actions / Deals / Insights / tRPC. Each board supplies its
+ * columns, pre-sorted items, a bespoke `renderCard`, and an `onMove` mutation.
+ *
+ * Card contract: each bespoke card owns its own
+ * `useSortable({ id: item.id })` — the board provides the surrounding
+ * DndContext + SortableContext; the card provides the draggable node.
+ */
+export function KanbanBoard<T extends KanbanItem>({
+  columns,
+  items,
+  renderCard,
+  onMove,
+  getItemLabel,
+  emptyState,
+  columnEmptyState,
+  bleed = false,
+  className,
+}: KanbanBoardProps<T>) {
+  // Pending column overrides: itemId -> optimistic columnId.
+  const [optimistic, setOptimistic] = useState<Record<string, string>>({});
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [dragOverItemId, setDragOverItemId] = useState<string | null>(null);
+  const isMovingRef = useRef(false);
+
+  const columnIds = useMemo(() => new Set(columns.map((c) => c.id)), [columns]);
+  const itemById = useMemo(() => {
+    const map = new Map<string, T>();
+    for (const item of items) map.set(item.id, item);
+    return map;
+  }, [items]);
+
+  const label = useCallback(
+    (id: string) => {
+      const item = itemById.get(id);
+      return item && getItemLabel ? getItemLabel(item) : id;
+    },
+    [itemById, getItemLabel],
+  );
+
+  // Effective column for an item, applying any pending optimistic override.
+  const effectiveColumn = useCallback(
+    (item: T) => optimistic[item.id] ?? item.columnId,
+    [optimistic],
+  );
+
+  // Prune overrides the server has caught up with (keeps `optimistic` bounded).
+  useEffect(() => {
+    setOptimistic((prev) => {
+      const next: Record<string, string> = {};
+      let changed = false;
+      for (const [id, colId] of Object.entries(prev)) {
+        const item = itemById.get(id);
+        if (item && item.columnId === colId) {
+          changed = true; // server agrees — drop the override
+        } else {
+          next[id] = colId;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [itemById]);
+
+  // Group item ids per column, in input (display) order, applying overrides.
+  const itemIdsByColumn = useMemo(() => {
+    const groups: Record<string, string[]> = {};
+    for (const col of columns) groups[col.id] = [];
+    for (const item of items) {
+      const colId = effectiveColumn(item);
+      groups[colId]?.push(item.id);
+    }
+    return groups;
+  }, [columns, items, effectiveColumn]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
+    setDragOverItemId(null);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    const overId = event.over?.id as string | undefined;
+    setDragOverItemId(overId && !columnIds.has(overId) ? overId : null);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    setDragOverItemId(null);
+    setActiveId(null);
+
+    if (!over) return;
+
+    const itemId = active.id as string;
+    const dragged = itemById.get(itemId);
+    if (!dragged) return;
+
+    // Ignore drops while a previous move is still settling (matches prior boards).
+    if (isMovingRef.current) return;
+
+    const overId = over.id as string;
+    const droppedOnColumn = columnIds.has(overId);
+
+    // Resolve the target column: a column drop uses the column id; a card drop
+    // uses that card's (effective) column.
+    let toColumnId: string;
+    if (droppedOnColumn) {
+      toColumnId = overId;
+    } else {
+      const overItem = itemById.get(overId);
+      if (!overItem) return;
+      toColumnId = effectiveColumn(overItem);
+    }
+
+    // Insertion index within the target column's display list. Dropping on a
+    // column appends; dropping on a card targets that card's slot.
+    const targetIds = itemIdsByColumn[toColumnId] ?? [];
+    const toIndex = droppedOnColumn
+      ? targetIds.length
+      : Math.max(0, targetIds.indexOf(overId));
+
+    const currentColumnId = effectiveColumn(dragged);
+
+    // No-op: same column and not targeting a specific card (nothing to reorder).
+    if (currentColumnId === toColumnId && droppedOnColumn) return;
+
+    // Apply the optimistic column move up-front, then fire the injected mutation.
+    setOptimistic((prev) => ({ ...prev, [itemId]: toColumnId }));
+    isMovingRef.current = true;
+
+    void Promise.resolve(onMove(itemId, toColumnId, toIndex))
+      .catch(() => {
+        // Revert the optimistic move; the consumer's onError restores its cache.
+        setOptimistic((prev) => {
+          const next = { ...prev };
+          delete next[itemId];
+          return next;
+        });
+      })
+      .finally(() => {
+        isMovingRef.current = false;
+      });
+  };
+
+  const handleDragCancel = () => {
+    setActiveId(null);
+    setDragOverItemId(null);
+  };
+
+  if (items.length === 0 && emptyState) {
+    return <>{emptyState}</>;
+  }
+
+  const activeItem = activeId ? itemById.get(activeId) : null;
+  const boardClassName = [styles.kboard, bleed ? styles.kboardBleed : "", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className="w-full" role="application" aria-label="Kanban board">
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+        accessibility={{
+          announcements: {
+            onDragStart({ active }) {
+              return `Started dragging ${label(active.id as string)}`;
+            },
+            onDragOver({ active, over }) {
+              if (!over) return `${label(active.id as string)} is no longer over a droppable area`;
+              const overId = over.id as string;
+              if (columnIds.has(overId)) {
+                const col = columns.find((c) => c.id === overId);
+                return `${label(active.id as string)} is over ${col?.title ?? overId} column`;
+              }
+              return `${label(active.id as string)} is over ${label(overId)}`;
+            },
+            onDragEnd({ active, over }) {
+              if (!over) return `${label(active.id as string)} was dropped`;
+              const overId = over.id as string;
+              if (columnIds.has(overId)) {
+                const col = columns.find((c) => c.id === overId);
+                return `${label(active.id as string)} was moved to ${col?.title ?? overId} column`;
+              }
+              return `${label(active.id as string)} was placed near ${label(overId)}`;
+            },
+            onDragCancel({ active }) {
+              return `Dragging ${label(active.id as string)} was cancelled`;
+            },
+          },
+        }}
+      >
+        <div className={boardClassName}>
+          {columns.map((column) => (
+            <KanbanColumn
+              key={column.id}
+              id={column.id}
+              title={column.title}
+              accent={column.accent}
+              itemIds={itemIdsByColumn[column.id] ?? []}
+              dragOverItemId={dragOverItemId}
+              columnEmptyState={columnEmptyState}
+            >
+              {(itemId) => {
+                const item = itemById.get(itemId);
+                return item ? renderCard(item, { isOverlay: false }) : null;
+              }}
+            </KanbanColumn>
+          ))}
+        </div>
+
+        <DragOverlay>
+          {activeItem ? renderCard(activeItem, { isOverlay: true }) : null}
+        </DragOverlay>
+      </DndContext>
+    </div>
+  );
+}

--- a/src/app/_components/shared/kanban/KanbanCard.tsx
+++ b/src/app/_components/shared/kanban/KanbanCard.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import type { ReactNode } from "react";
+import styles from "./Kanban.module.css";
+
+interface KanbanCardProps {
+  /** Shown above the card when another card is being dragged over this one. */
+  showDropIndicator: boolean;
+  children: ReactNode;
+}
+
+/**
+ * Internal positional wrapper for a single card slot. It renders the between-card
+ * drop indicator and the bespoke card content. The card itself owns its
+ * `useSortable` wiring (see `KanbanBoard` docs), so this wrapper stays presentational.
+ */
+export function KanbanCard({ showDropIndicator, children }: KanbanCardProps) {
+  return (
+    <div>
+      {showDropIndicator && (
+        <div className={styles.kcolDropIndicator} aria-hidden="true" />
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/app/_components/shared/kanban/KanbanColumn.tsx
+++ b/src/app/_components/shared/kanban/KanbanColumn.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { KanbanCard } from "./KanbanCard";
+import type { ColumnAccent } from "./types";
+import styles from "./Kanban.module.css";
+
+const ACCENT_CLASS: Record<ColumnAccent, string> = {
+  slate: styles.kcolSlate!,
+  brand: styles.kcolBrand!,
+  amber: styles.kcolAmber!,
+  violet: styles.kcolViolet!,
+  green: styles.kcolGreen!,
+  red: styles.kcolRed!,
+};
+
+interface KanbanColumnProps {
+  id: string;
+  title: string;
+  accent: ColumnAccent;
+  /** Ids of the items in this column, in display order (for SortableContext). */
+  itemIds: string[];
+  /** The card being dragged over (for the drop indicator), or null. */
+  dragOverItemId: string | null;
+  /** Rendered per item, in order. */
+  children: (itemId: string) => ReactNode;
+  columnEmptyState?: ReactNode;
+}
+
+/**
+ * Internal droppable column. Data-agnostic: it knows column chrome, droppable
+ * wiring, and the sortable context, but nothing about what a card contains.
+ */
+export function KanbanColumn({
+  id,
+  title,
+  accent,
+  itemIds,
+  dragOverItemId,
+  children,
+  columnEmptyState,
+}: KanbanColumnProps) {
+  const { setNodeRef, isOver } = useDroppable({ id });
+
+  const classes = [styles.kcol, ACCENT_CLASS[accent], isOver ? styles.kcolOver : ""]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={classes}
+      role="region"
+      aria-label={`${title} column with ${itemIds.length} item${itemIds.length !== 1 ? "s" : ""}`}
+    >
+      <div className={styles.kcolHead}>
+        <div className={styles.kcolHeadLeft}>
+          <span className={styles.kcolDot} aria-hidden="true" />
+          <span className={styles.kcolLabel}>{title}</span>
+          <span className={styles.kcolCount}>{itemIds.length}</span>
+        </div>
+      </div>
+
+      <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+        <div className={styles.kcolBody}>
+          {itemIds.map((itemId) => (
+            <KanbanCard key={itemId} showDropIndicator={dragOverItemId === itemId}>
+              {children(itemId)}
+            </KanbanCard>
+          ))}
+          {itemIds.length === 0 && (
+            <div
+              className={styles.kcolEmpty}
+              role="region"
+              aria-label={`Empty ${title.toLowerCase()} column. Drop items here to change their status.`}
+            >
+              {columnEmptyState ?? "Drop items here"}
+            </div>
+          )}
+        </div>
+      </SortableContext>
+    </div>
+  );
+}

--- a/src/app/_components/shared/kanban/index.ts
+++ b/src/app/_components/shared/kanban/index.ts
@@ -1,0 +1,8 @@
+export { KanbanBoard } from "./KanbanBoard";
+export type {
+  KanbanBoardProps,
+  KanbanColumnDef,
+  KanbanItem,
+  ColumnAccent,
+  RenderCardOptions,
+} from "./types";

--- a/src/app/_components/shared/kanban/types.ts
+++ b/src/app/_components/shared/kanban/types.ts
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+
+/**
+ * The fixed accent vocabulary the shared board understands (ADR-0037).
+ * Boards with a fixed enum map their statuses to an accent; DB-driven boards
+ * (CRM pipeline) map their stage colour onto the nearest accent token.
+ */
+export type ColumnAccent = "slate" | "brand" | "amber" | "violet" | "green" | "red";
+
+/** A column on the board. `id` is matched against `KanbanItem.columnId`. */
+export interface KanbanColumnDef {
+  id: string;
+  title: string;
+  accent: ColumnAccent;
+}
+
+/**
+ * The minimum shape the board needs from each item. Consumers pass their own
+ * richer objects (which extend this) and receive them back in `renderCard`.
+ * `items` are expected to arrive already sorted in display order per column;
+ * the board preserves that order and only repositions an item while a move is
+ * optimistically in flight.
+ */
+export interface KanbanItem {
+  id: string;
+  columnId: string;
+}
+
+export interface RenderCardOptions {
+  /** True when the card is being rendered inside the drag overlay. */
+  isOverlay: boolean;
+}
+
+export interface KanbanBoardProps<T extends KanbanItem> {
+  columns: KanbanColumnDef[];
+  items: T[];
+  /**
+   * Render one card. The card owns its own `useSortable({ id: item.id })`
+   * wiring (the board provides the surrounding DndContext, droppable columns,
+   * and SortableContext). `isOverlay` is true only for the drag overlay copy.
+   */
+  renderCard: (item: T, opts: RenderCardOptions) => ReactNode;
+  /**
+   * Fired when a card is dropped in a new position. The board applies the move
+   * optimistically and reverts if the returned promise rejects. Each board
+   * supplies its own tRPC mutation + cache invalidation here.
+   */
+  onMove: (itemId: string, toColumnId: string, toIndex: number) => void | Promise<unknown>;
+  /** Accessible label for a11y drag announcements. Defaults to the item id. */
+  getItemLabel?: (item: T) => string;
+  /** Rendered instead of the board when there are no items. */
+  emptyState?: ReactNode;
+  /** Rendered inside a column body when that column has no items. */
+  columnEmptyState?: ReactNode;
+  /**
+   * Bleed the board through a 32px-padded page shell so columns scroll
+   * edge-to-edge (matches the Project tasks tab). Off by default.
+   */
+  bleed?: boolean;
+  /** Merged onto the scrolling board container. */
+  className?: string;
+}


### PR DESCRIPTION
### **User description**
## What

Implements **ADR-0037** — extract one presentation-only `<KanbanBoard>` and prove it by migrating the **Project tasks** board onto it with zero behavioural change.

New shared component under `src/app/_components/shared/kanban/`:
- `KanbanBoard.tsx` — owns dnd-kit wiring (DndContext, sensors, collision, DragOverlay), droppable columns, the between-card drop indicator, a11y announcements, and the **shared optimistic-move machine** (a card jumps columns on drop and reverts if `onMove` rejects; intra-column ordering settles on refetch — matching the existing board exactly).
- `KanbanColumn.tsx` / `KanbanCard.tsx` — internals.
- `Kanban.module.css` — the `.kcol*` accent vocabulary (slate/brand/amber/violet/green/red) graduated out of `ProjectTasks.module.css`.

Data-agnostic contract (the only integration points):
- `columns: { id, title, accent }[]`
- `items: (T & { id, columnId })[]` (pre-sorted per column by the consumer)
- `renderCard(item, { isOverlay }) => ReactNode` — bespoke cards; each card owns its own `useSortable`
- `onMove(itemId, toColumnId, toIndex) => Promise<unknown>` — each board injects its own tRPC mutation + invalidation

The Project board (`src/app/_components/KanbanBoard.tsx`) is now a thin consumer: same public API (`{ projectId, actions, onActionOpen }`), same sort logic, same `action.updateKanbanStatusWithOrder` mutation. `TaskCard` is unchanged.

## Incremental-safety note

The Actions board (`WorkspaceKanbanBoard`) still shares the legacy `KanbanColumn`/`TaskCard`/`ProjectTasks.module.css .kcol*`. To keep that board working with no behavioural change, this PR leaves a **transitional copy** of the `.kcol*` block in `ProjectTasks.module.css` (marked with a comment). It is removed when the remaining boards migrate (tickets A2–A4). The shared component owns the canonical accent vocabulary.

The decorative (non-functional) column `+`/`⋯` header buttons were dropped from the shared column chrome.

## Acceptance criteria

- [x] `<KanbanBoard>` (+ internal `KanbanColumn`/`KanbanCard`) exists in a shared path with the documented props
- [x] `.kcol*` accent tokens owned by the shared component (canonical); Project module keeps a transitional copy for unmigrated boards
- [x] Project tasks board renders via `<KanbanBoard>` and behaves identically (drag across statuses, optimistic update, rollback on error, ordering preserved)
- [x] No entity-specific props leak into `<KanbanBoard>`
- [x] Typecheck + ESLint clean (via `tsc`/`eslint`; the `npm run` scripts OOM at 4GB on this repo), 1200 unit tests pass, no hardcoded colours

---

Ships: Clear #22

Part of epic *Insights unification + Kanban consolidation*.


___

### **PR Type**
Enhancement


___

### **Description**
- Extract a reusable, data-agnostic `<KanbanBoard>` shared component under `src/app/_components/shared/kanban/`

- Shared board owns dnd-kit wiring, optimistic move state machine, a11y announcements, and column accent vocabulary

- Migrate Project tasks board (`KanbanBoard.tsx`) to thin consumer of the shared component with no behavioral change

- Transitional CSS copy retained in `ProjectTasks.module.css` for not-yet-migrated boards (Actions board)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["KanbanBoard.tsx\n(Project tasks consumer)"] -- "uses" --> B["shared/kanban/KanbanBoard.tsx\n(data-agnostic, dnd-kit wiring)"]
  B -- "renders columns via" --> C["shared/kanban/KanbanColumn.tsx\n(droppable, SortableContext)"]
  C -- "renders cards via" --> D["shared/kanban/KanbanCard.tsx\n(drop indicator wrapper)"]
  B -- "styles from" --> E["shared/kanban/Kanban.module.css\n(.kcol* accent vocabulary)"]
  B -- "typed by" --> F["shared/kanban/types.ts\n(KanbanItem, KanbanColumnDef, etc.)"]
  G["ProjectTasks.module.css\n(transitional .kcol* copy)"] -- "still used by" --> H["Legacy Actions board\n(not yet migrated)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>KanbanBoard.tsx</strong><dd><code>Refactor Project tasks board to thin shared-board consumer</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/328/files#diff-26e98b355d99ac5d4535c1a957721c8572e6629280c6d607146c0d7944c70d90">+86/-290</a></td>

</tr>

<tr>
  <td><strong>KanbanBoard.tsx</strong><dd><code>New data-agnostic shared KanbanBoard with optimistic moves</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/328/files#diff-a8b1e8b5fe110f6901bf6c0527560c9752a8cc926331ff19d433eb76cbbcae35">+251/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>KanbanColumn.tsx</strong><dd><code>New shared droppable KanbanColumn with accent and sortable context</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/328/files#diff-3ff5848513923d3c0665d87d1d8f7d88338a1e8b35b89696f69c8ffc5d624a6c">+86/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>KanbanCard.tsx</strong><dd><code>New shared KanbanCard wrapper with drop indicator support</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/328/files#diff-69baad84841fa17f027fe1bee69f9497126491dc86c4f987c1674b250c0b2d32">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Define shared Kanban types: KanbanItem, KanbanColumnDef, props</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/328/files#diff-675120a4c0e7413bc4abd9d3ffae1395fbcff690466fc3e958e2ccde3702e407">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export shared kanban components and types from barrel file</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/328/files#diff-f20c8bcb96e78b8e523f67667a72a19f2ccd64d2c55efe498958c06516f92cf6">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Kanban.module.css</strong><dd><code>New shared CSS module with board layout and accent vocabulary</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/328/files#diff-8919f95b3d324d0fa4eef36f7d6bc3c4b730aa656bfc4df7440a00d1a40c00c3">+176/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ProjectTasks.module.css</strong><dd><code>Add transitional comment marking legacy .kcol* accent block</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/328/files#diff-521265cfe9424056b0913ca76b42f1b5cdb2d7d8e5f0edb5389947b0e24a9aab">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

