### PR TITLE
chore: migrate Tickets board onto shared <KanbanBoard>

### DIFF
--- a/src/app/_components/product/TicketKanbanBoard.tsx
+++ b/src/app/_components/product/TicketKanbanBoard.tsx
@@ -1,25 +1,17 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
-import {
-  DndContext,
-  DragOverlay,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-  type DragStartEvent,
-} from "@dnd-kit/core";
-import { useDroppable } from "@dnd-kit/core";
+import { useMemo } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Badge, Card, Group, Paper, Stack, Text } from "@mantine/core";
+import { Badge, Card, Group, Text } from "@mantine/core";
 import { useRouter } from "next/navigation";
 import { api } from "~/trpc/react";
 import { BOARD_COLUMNS, type TicketStatus } from "~/lib/ticket-statuses";
 import { PriorityIcon } from "~/app/_components/product/PriorityIcon";
 import { BlockedIndicator } from "~/app/_components/product/TicketDependenciesSection";
 import { generateLinearId } from "~/lib/fun-ids";
+import { KanbanBoard as SharedKanbanBoard } from "~/app/_components/shared/kanban";
+import type { ColumnAccent, KanbanColumnDef, KanbanItem } from "~/app/_components/shared/kanban";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -40,10 +32,37 @@ interface TicketItem {
   isBlocked: boolean;
 }
 
+type BoardItem = TicketItem & KanbanItem;
+
 const TYPE_COLORS: Record<string, string> = { BUG: "red", FEATURE: "blue", CHORE: "gray", IMPROVEMENT: "teal", SPIKE: "violet", RESEARCH: "yellow" };
 
+// Map the centralised ticket-status Mantine colours (~/lib/ticket-statuses) onto
+// the shared board's accent vocabulary (ADR-0037).
+function mapStatusColorToAccent(color: string): ColumnAccent {
+  switch (color) {
+    case "blue":
+    case "indigo":
+      return "brand";
+    case "grape":
+    case "violet":
+      return "violet";
+    case "orange":
+    case "yellow":
+      return "amber";
+    case "green":
+    case "teal":
+      return "green";
+    case "red":
+      return "red";
+    case "gray":
+    case "dark":
+    default:
+      return "slate";
+  }
+}
+
 // ---------------------------------------------------------------------------
-// TicketCard (draggable)
+// TicketCard (draggable) — unchanged; owns its own useSortable
 // ---------------------------------------------------------------------------
 
 function TicketCard({ ticket, basePath, isDragOverlay, funTicketIds, productName }: { ticket: TicketItem; basePath: string; isDragOverlay?: boolean; funTicketIds: boolean; productName: string }) {
@@ -110,48 +129,6 @@ function TicketCard({ ticket, basePath, isDragOverlay, funTicketIds, productName
 }
 
 // ---------------------------------------------------------------------------
-// Column (droppable)
-// ---------------------------------------------------------------------------
-
-function BoardColumn({ status, label, color, tickets, basePath, funTicketIds, productName }: {
-  status: string; label: string; color: string; tickets: TicketItem[]; basePath: string; funTicketIds: boolean; productName: string;
-}) {
-  const { setNodeRef, isOver } = useDroppable({ id: status });
-
-  return (
-    <Paper
-      ref={setNodeRef}
-      className={`min-w-64 w-64 shrink-0 transition-all duration-200 ${isOver ? "ring-2 ring-blue-400 ring-opacity-50 bg-surface-hover" : ""}`}
-      p="sm"
-      radius="md"
-      withBorder
-    >
-      <Group justify="space-between" mb="sm">
-        <Badge
-          size="sm"
-          variant="filled"
-          color={color}
-          styles={{ label: { color: "var(--mantine-color-dark-9)" } }}
-        >
-          {label}
-        </Badge>
-        <Text size="xs" fw={600} className="text-text-muted">{tickets.length}</Text>
-      </Group>
-      <Stack gap="xs">
-        {tickets.map((ticket) => (
-          <TicketCard key={ticket.id} ticket={ticket} basePath={basePath} funTicketIds={funTicketIds} productName={productName} />
-        ))}
-        {tickets.length === 0 && (
-          <div className="h-16 border-2 border-dashed border-border-secondary rounded-md flex items-center justify-center">
-            <Text size="xs" className="text-text-muted">Drop here</Text>
-          </div>
-        )}
-      </Stack>
-    </Paper>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Board
 // ---------------------------------------------------------------------------
 
@@ -163,89 +140,50 @@ interface TicketKanbanBoardProps {
   basePath: string;
 }
 
+const BOARD_STATUSES = new Set<string>(BOARD_COLUMNS.map((c) => c.value));
+
 export function TicketKanbanBoard({ tickets, productId, productName, funTicketIds, basePath }: TicketKanbanBoardProps) {
   const utils = api.useUtils();
-  const [activeId, setActiveId] = useState<string | null>(null);
-  const [optimisticMoves, setOptimisticMoves] = useState<Record<string, TicketStatus>>({});
 
   const updateTicket = api.product.ticket.update.useMutation({
     onSuccess: async () => {
       await utils.product.ticket.list.invalidate({ productId });
     },
-    onError: (_err, variables) => {
-      // Rollback optimistic move
-      setOptimisticMoves((prev) => {
-        const next = { ...prev };
-        delete next[variables.id];
-        return next;
-      });
-    },
   });
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  const columns = useMemo<KanbanColumnDef[]>(
+    () => BOARD_COLUMNS.map((c) => ({ id: c.value, title: c.label, accent: mapStatusColorToAccent(c.color) })),
+    [],
   );
 
-  // Apply optimistic moves
-  const effectiveTickets = useMemo(() =>
-    tickets.map((t) => optimisticMoves[t.id] ? { ...t, status: optimisticMoves[t.id]! } : t),
-    [tickets, optimisticMoves],
+  // Tag each ticket with its column; drop ARCHIVED (no column) so it stays excluded.
+  const items = useMemo<BoardItem[]>(
+    () =>
+      tickets
+        .filter((t) => BOARD_STATUSES.has(t.status))
+        .map((t) => ({ ...t, columnId: t.status })),
+    [tickets],
   );
 
-  const columnTickets = useMemo(() => {
-    const map: Record<string, TicketItem[]> = {};
-    for (const col of BOARD_COLUMNS) map[col.value] = [];
-    for (const t of effectiveTickets) {
-      (map[t.status] ??= []).push(t);
-    }
-    return map;
-  }, [effectiveTickets]);
-
-  const activeTicket = activeId ? effectiveTickets.find((t) => t.id === activeId) : null;
-
-  const handleDragStart = useCallback((event: DragStartEvent) => {
-    setActiveId(event.active.id as string);
-  }, []);
-
-  const handleDragEnd = useCallback((event: DragEndEvent) => {
-    setActiveId(null);
-    const { active, over } = event;
-    if (!over) return;
-
-    const ticketId = active.id as string;
-    const overId = String(over.id);
-    const overColumn = BOARD_COLUMNS.find((c) => c.value === overId);
-    const overTicket = effectiveTickets.find((t) => t.id === overId);
-    const nextStatus = overColumn?.value ?? overTicket?.status;
-    if (!nextStatus) return;
-
-    const ticket = effectiveTickets.find((t) => t.id === ticketId);
-    if (!ticket || ticket.status === nextStatus) return;
-
-    // Optimistic update
-    setOptimisticMoves((prev) => ({ ...prev, [ticketId]: nextStatus }));
-    updateTicket.mutate({ id: ticketId, status: nextStatus });
-  }, [effectiveTickets, updateTicket]);
+  const handleMove = (itemId: string, toColumnId: string) =>
+    updateTicket.mutateAsync({ id: itemId, status: toColumnId as TicketStatus });
 
   return (
-    <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
-      <div className="flex gap-3 overflow-x-auto pb-4 w-full min-w-0">
-        {BOARD_COLUMNS.map((col) => (
-          <BoardColumn
-            key={col.value}
-            status={col.value}
-            label={col.label}
-            color={col.color}
-            tickets={columnTickets[col.value] ?? []}
-            basePath={basePath}
-            funTicketIds={funTicketIds}
-            productName={productName}
-          />
-        ))}
-      </div>
-      <DragOverlay>
-        {activeTicket && <TicketCard ticket={activeTicket} basePath={basePath} isDragOverlay funTicketIds={funTicketIds} productName={productName} />}
-      </DragOverlay>
-    </DndContext>
+    <SharedKanbanBoard<BoardItem>
+      columns={columns}
+      items={items}
+      onMove={handleMove}
+      getItemLabel={(item) => item.title}
+      columnEmptyState="Drop here"
+      renderCard={(item, { isOverlay }) => (
+        <TicketCard
+          ticket={item}
+          basePath={basePath}
+          isDragOverlay={isOverlay}
+          funTicketIds={funTicketIds}
+          productName={productName}
+        />
+      )}
+    />
   );
 }


### PR DESCRIPTION
### **User description**
## What

Migrates the **Tickets** kanban (`TicketKanbanBoard`) onto the shared `<KanbanBoard>` (A1, #328). Columns from the centralised `BOARD_COLUMNS` (`~/lib/ticket-statuses`), each status colour mapped to a `.kcol` accent. `TicketCard` (blocked indicator, type/priority/feature) is unchanged and keeps its own `useSortable`; `product.ticket.update` is injected via `onMove` with the shared optimistic rollback.

## Acceptance criteria

- [x] Tickets board renders via `<KanbanBoard>`; ARCHIVED still excluded
- [x] TicketCard unchanged
- [x] Drag→status change + optimistic behaviour unchanged
- [x] Typecheck + ESLint clean; no hardcoded colours (accent mapping via CSS vars)

---

Ships: Clear #25

Part of epic *Insights unification + Kanban consolidation*.


___

### **PR Type**
Enhancement


___

### **Description**
- Migrate `TicketKanbanBoard` to use shared `<KanbanBoard>` component

- Remove inline dnd-kit wiring, `BoardColumn`, and optimistic state from `TicketKanbanBoard`

- Map ticket status colors to shared `.kcol` accent vocabulary via `mapStatusColorToAccent`

- `TicketCard` remains unchanged, injecting `onMove` via `product.ticket.update` mutation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TicketKanbanBoard.tsx\n(Tickets board consumer)"] -- "uses" --> B["shared/kanban/KanbanBoard.tsx\n(data-agnostic, dnd-kit wiring)"]
  A -- "maps colors via" --> C["mapStatusColorToAccent()\n(status color → ColumnAccent)"]
  A -- "columns from" --> D["BOARD_COLUMNS\n(~/lib/ticket-statuses)"]
  A -- "injects mutation via" --> E["onMove → product.ticket.update\n(tRPC mutation)"]
  B -- "renders" --> F["TicketCard\n(unchanged, owns useSortable)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TicketKanbanBoard.tsx</strong><dd><code>Refactor Tickets board to thin shared KanbanBoard consumer</code></dd></summary>
<hr>

src/app/_components/product/TicketKanbanBoard.tsx

<ul><li>Replaced inline dnd-kit board scaffolding (<code>DndContext</code>, <code>DragOverlay</code>, <br>sensors, optimistic state) with shared <code><KanbanBoard></code><br> <li> Removed <code>BoardColumn</code> component; column definitions now derived from <br><code>BOARD_COLUMNS</code> mapped to <code>KanbanColumnDef</code><br> <li> Added <code>mapStatusColorToAccent</code> to translate Mantine status colors to <br>shared accent vocabulary<br> <li> <code>TicketCard</code> is unchanged; <code>onMove</code> delegates to <br><code>product.ticket.update.mutateAsync</code> with shared optimistic rollback</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/330/files#diff-ea1611c7cec7a28f846a173b8c98e7c752cd01b2e6269c425f898a7b17afcc93">+62/-124</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

