### PR TITLE
fix(forms): Active switch persists immediately via dedicated form.setActive

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
@@ -292,7 +292,7 @@ export default function FormEditorPage() {
         message: data.isActive
           ? `Now accepting submissions at /f/${data.slug}`
           : 'The public link is no longer live.',
-        color: 'green',
+        color: data.isActive ? 'green' : 'gray',
       });
       void utils.form.get.invalidate({ id });
       void utils.form.list.invalidate();

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
@@ -280,6 +280,31 @@ export default function FormEditorPage() {
       notifications.show({ title: 'Could not delete', message: error.message, color: 'red' }),
   });
 
+  // Activation persists immediately via its own mutation — never through the
+  // draft Save flow, where it could be silently lost to unrelated validation.
+  // Local `isActive` flips only on success, so the badge and the public
+  // /f/[slug] link never claim a liveness the database doesn't have.
+  const setActive = api.form.setActive.useMutation({
+    onSuccess: (data) => {
+      setIsActive(data.isActive);
+      notifications.show({
+        title: data.isActive ? 'Form is live' : 'Form deactivated',
+        message: data.isActive
+          ? `Now accepting submissions at /f/${data.slug}`
+          : 'The public link is no longer live.',
+        color: 'green',
+      });
+      void utils.form.get.invalidate({ id });
+      void utils.form.list.invalidate();
+    },
+    onError: (error) =>
+      notifications.show({
+        title: 'Could not update active state',
+        message: error.message,
+        color: 'red',
+      }),
+  });
+
   const touch = () => markDirty(true);
 
   const addField = () => {
@@ -393,13 +418,15 @@ export default function FormEditorPage() {
         },
       });
     }
+    // `isActive` is deliberately absent: activation persists immediately via
+    // the dedicated setActive mutation, never through the draft Save (which
+    // could clobber a just-toggled value with a stale one).
     save.mutate({
       id,
       name: name.trim() || 'Untitled form',
       description: description.trim() || null,
       fields: cleanedFields,
       destinations,
-      isActive,
       confirmationMessage: confirmationMessage.trim() || null,
     });
   };
@@ -442,10 +469,10 @@ export default function FormEditorPage() {
           <Switch
             label="Active"
             checked={isActive}
-            onChange={(e) => {
-              setIsActive(e.currentTarget.checked);
-              touch();
-            }}
+            disabled={setActive.isPending}
+            onChange={(e) =>
+              setActive.mutate({ id, isActive: e.currentTarget.checked })
+            }
           />
           <Button
             variant="subtle"

--- a/src/server/api/routers/__tests__/formSetActive.test.ts
+++ b/src/server/api/routers/__tests__/formSetActive.test.ts
@@ -136,6 +136,7 @@ describe("form.setActive (mocked)", () => {
     expect(dbMock.form.update).toHaveBeenCalledWith({
       where: { id: formId },
       data: { isActive: true },
+      select: { id: true, isActive: true, slug: true },
     });
   });
 
@@ -154,6 +155,7 @@ describe("form.setActive (mocked)", () => {
     expect(dbMock.form.update).toHaveBeenCalledWith({
       where: { id: formId },
       data: { isActive: false },
+      select: { id: true, isActive: true, slug: true },
     });
   });
 

--- a/src/server/api/routers/__tests__/formSetActive.test.ts
+++ b/src/server/api/routers/__tests__/formSetActive.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for `form.setActive` — the dedicated activation mutation.
+ *
+ * Activation persists on its own, decoupled from the editor's draft Save flow:
+ * the public /f/[slug] page 404s on an inactive form, so a toggle that looks
+ * live but never persisted is a broken public link. These tests pin that the
+ * mutation writes ONLY `isActive`, and that access control matches the rest of
+ * the form router (workspace membership on the form's own workspace).
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` instead of a real
+ * database, so they run in milliseconds and CANNOT touch any real DB.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(_opts?: any) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({
+    auth: () => null,
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = {
+  current: null,
+};
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) {
+    dbHolder.current = mockDeep<PrismaClient>();
+  }
+  return dbHolder.current;
+}
+
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+vi.mock("~/server/services/notifications/EmailNotificationService", () => ({
+  sendAssignmentNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/server/services/onboarding/syncOnboardingProgress", () => ({
+  completeOnboardingStep: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/lib/blob", () => ({
+  uploadToBlob: vi.fn().mockResolvedValue({ url: "blob://test" }),
+}));
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const callerId = "user-1";
+const workspaceId = "ws-1";
+const formId = "form-1";
+
+function stubForm(dbMock: DeepMockProxy<PrismaClient>, exists = true) {
+  dbMock.form.findUnique.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    exists ? ({ id: formId, workspaceId, slug: "test" } as any) : null,
+  );
+}
+
+function stubMembership(dbMock: DeepMockProxy<PrismaClient>, isMember: boolean) {
+  dbMock.workspaceUser.findFirst.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    isMember ? ({ userId: callerId, workspaceId, role: "member" } as any) : null,
+  );
+}
+
+describe("form.setActive (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  it("persists activation, writing ONLY isActive", async () => {
+    stubForm(dbMock);
+    stubMembership(dbMock, true);
+    dbMock.form.update.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: formId, workspaceId, slug: "test", isActive: true } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const result = await caller.form.setActive({ id: formId, isActive: true });
+
+    expect(result.isActive).toBe(true);
+    expect(dbMock.form.update).toHaveBeenCalledWith({
+      where: { id: formId },
+      data: { isActive: true },
+    });
+  });
+
+  it("persists deactivation the same way", async () => {
+    stubForm(dbMock);
+    stubMembership(dbMock, true);
+    dbMock.form.update.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: formId, workspaceId, slug: "test", isActive: false } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const result = await caller.form.setActive({ id: formId, isActive: false });
+
+    expect(result.isActive).toBe(false);
+    expect(dbMock.form.update).toHaveBeenCalledWith({
+      where: { id: formId },
+      data: { isActive: false },
+    });
+  });
+
+  it("rejects with NOT_FOUND when the form does not exist", async () => {
+    stubForm(dbMock, false);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.form.setActive({ id: formId, isActive: true }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" } satisfies Partial<TRPCError>);
+    expect(dbMock.form.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects with FORBIDDEN for a non-member of the form's workspace", async () => {
+    stubForm(dbMock);
+    stubMembership(dbMock, false);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.form.setActive({ id: formId, isActive: true }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" } satisfies Partial<TRPCError>);
+    expect(dbMock.form.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/api/routers/form.ts
+++ b/src/server/api/routers/form.ts
@@ -93,6 +93,8 @@ export const formRouter = createTRPCRouter({
       return ctx.db.form.update({
         where: { id: input.id },
         data: { isActive: input.isActive },
+        // Only what the switch UI consumes — keeps the contract explicit.
+        select: { id: true, isActive: true, slug: true },
       });
     }),
 

--- a/src/server/api/routers/form.ts
+++ b/src/server/api/routers/form.ts
@@ -79,6 +79,23 @@ export const formRouter = createTRPCRouter({
       return { id: form.id };
     }),
 
+  /**
+   * Persist activation on its own, decoupled from the editor's draft Save
+   * flow. The Active switch must take effect immediately — it must never be
+   * silently lost because the rest of the draft failed validation or Save was
+   * never clicked (the public /f/[slug] page 404s on an inactive form, so a
+   * "live-looking" toggle that didn't persist is a broken public link).
+   */
+  setActive: protectedProcedure
+    .input(z.object({ id: z.string(), isActive: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      await loadFormForUser(ctx.db, input.id, ctx.session.user.id);
+      return ctx.db.form.update({
+        where: { id: input.id },
+        data: { isActive: input.isActive },
+      });
+    }),
+
   update: protectedProcedure
     .input(
       z.object({


### PR DESCRIPTION
### **User description**
## Problem

Activating a form in the editor looked live but wasn't: the **Active** switch only flipped local React state, and persistence rode on the draft **Save** flow — silently lost when Save was never clicked, or blocked by unrelated destination validation. The header badge and the public `/f/[slug]` link rendered from that unsaved state, so a user could click a live-looking link and get a 404 (the public page requires `isActive: true` in the DB).

Observed in production on `/f/test` (form `cmr38c8uf0001l504qfwlllsz`): badge showed active, DB row was inactive, public link 404'd; refresh showed inactive again.

## Fix

- New **`form.setActive`** mutation — workspace-membership-checked (same `loadFormForUser` gate as the rest of the router), writes **only** `isActive`.
- The Active switch calls it directly; local state flips **on success only**, so the badge/link never claim a liveness the database doesn't have. Success/error toasts make the outcome explicit.
- `isActive` removed from the draft Save payload — a stale draft can no longer clobber a just-toggled value.

## Tests

`formSetActive.test.ts` (mocked Prisma, no DB): persists activation + deactivation writing only `isActive`; NOT_FOUND on missing form; FORBIDDEN for non-members. `tsc --noEmit` clean; full unit suite green via pre-commit.

Follow-up to #333 / Feature `cmr2areh10012l204mhj6wi31`.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix Active switch persisting immediately via dedicated `form.setActive` mutation

- Decouple activation from draft Save flow to prevent silent loss of toggle state

- Remove `isActive` from Save payload to prevent stale draft clobbering toggled value

- Add unit tests for `form.setActive` covering activation, deactivation, NOT_FOUND, and FORBIDDEN cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Switch["Active Switch\n(UI)"] -- "onChange" --> SetActiveMutation["form.setActive\nmutation"]
  SetActiveMutation -- "writes ONLY isActive" --> DB["DB: form.isActive"]
  DB -- "success" --> LocalState["Local isActive state\n(flips on success only)"]
  LocalState -- "reflects" --> Badge["Header badge\n+ /f/[slug] link"]
  SaveFlow["Draft Save flow"] -- "no longer includes isActive" --> DB
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Active switch calls dedicated mutation, removed from Save payload</code></dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx

<ul><li>Added <code>setActive</code> mutation using <code>api.form.setActive.useMutation</code> with <br>success/error toast notifications<br> <li> Local <code>isActive</code> state now flips only on mutation success, not on switch <br>change<br> <li> Switch <code>onChange</code> now calls <code>setActive.mutate</code> directly instead of <br>updating local state<br> <li> Removed <code>isActive</code> from the draft Save payload to prevent stale value <br>clobbering</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/334/files#diff-afb86c06ceed1e1769972469d1c7b4ff8df03d365653609f34115d996bb78ce4">+32/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>form.ts</strong><dd><code>Add dedicated setActive mutation to form router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/form.ts

<ul><li>Added new <code>setActive</code> protected procedure to the form router<br> <li> Mutation writes only <code>isActive</code> field, decoupled from draft Save flow<br> <li> Uses <code>loadFormForUser</code> for workspace membership access control<br> <li> Returns only <code>{ id, isActive, slug }</code> to keep contract explicit</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/334/files#diff-beb02a17929c976cb1c1e65e3c2413570a2a625b309c3a98616ecebf25856de8">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>formSetActive.test.ts</strong><dd><code>Unit tests for form.setActive mutation with access control</code></dd></summary>
<hr>

src/server/api/routers/__tests__/formSetActive.test.ts

<ul><li>New test file for <code>form.setActive</code> mutation using mocked Prisma<br> <li> Tests cover: activation persists, deactivation persists, NOT_FOUND on <br>missing form, FORBIDDEN for non-members<br> <li> Verifies mutation writes ONLY <code>isActive</code> with explicit <code>select</code> contract</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/334/files#diff-76f7ef09c11bc2b675942371cf7fe149223f0d29122f27c0416340d47f3d5c19">+182/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

