### PR TITLE
feat(forms): rename a form's public slug from the editor

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
@@ -29,6 +29,9 @@ import {
   IconArrowUp,
   IconArrowDown,
   IconExternalLink,
+  IconPencil,
+  IconCheck,
+  IconX,
 } from '@tabler/icons-react';
 import { notifications } from '@mantine/notifications';
 import { api } from '~/trpc/react';
@@ -305,6 +308,30 @@ export default function FormEditorPage() {
       }),
   });
 
+  // Inline slug rename (deferred in ADR-0029). `slugDraft === null` means not
+  // editing. The server normalizes with the same slugify used at create and
+  // rejects collisions; local `slug` flips only on success.
+  const [slugDraft, setSlugDraft] = useState<string | null>(null);
+  const updateSlug = api.form.updateSlug.useMutation({
+    onSuccess: (data) => {
+      setSlug(data.slug);
+      setSlugDraft(null);
+      notifications.show({
+        title: 'Public link updated',
+        message: `The form now lives at /f/${data.slug}. The old link no longer works.`,
+        color: 'green',
+      });
+      void utils.form.get.invalidate({ id });
+      void utils.form.list.invalidate();
+    },
+    onError: (error) =>
+      notifications.show({
+        title: 'Could not rename the link',
+        message: error.message,
+        color: 'red',
+      }),
+  });
+
   const touch = () => markDirty(true);
 
   const addField = () => {
@@ -446,22 +473,75 @@ export default function FormEditorPage() {
             <Badge color={isActive ? 'green' : 'gray'} variant="light">
               {isActive ? 'active' : 'inactive'}
             </Badge>
-            {isActive ? (
-              <Anchor
-                href={`/f/${slug}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                size="sm"
-              >
-                <Group gap={4} align="center">
-                  /f/{slug}
-                  <IconExternalLink size={14} />
-                </Group>
-              </Anchor>
+            {slugDraft !== null ? (
+              <Group gap={4} align="center">
+                <Text size="sm" c="dimmed">
+                  /f/
+                </Text>
+                <TextInput
+                  size="xs"
+                  value={slugDraft}
+                  onChange={(e) => setSlugDraft(e.currentTarget.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter')
+                      updateSlug.mutate({ id, slug: slugDraft });
+                    if (e.key === 'Escape') setSlugDraft(null);
+                  }}
+                  autoFocus
+                  aria-label="New public link slug"
+                />
+                <ActionIcon
+                  variant="subtle"
+                  color="green"
+                  size="sm"
+                  loading={updateSlug.isPending}
+                  onClick={() => updateSlug.mutate({ id, slug: slugDraft })}
+                  aria-label="Save new link"
+                >
+                  <IconCheck size={14} />
+                </ActionIcon>
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
+                  onClick={() => setSlugDraft(null)}
+                  aria-label="Cancel rename"
+                >
+                  <IconX size={14} />
+                </ActionIcon>
+                <Text c="dimmed" size="xs">
+                  renaming breaks the old link
+                </Text>
+              </Group>
             ) : (
-              <Text c="dimmed" size="sm">
-                /f/{slug} (activate to view live)
-              </Text>
+              <>
+                {isActive ? (
+                  <Anchor
+                    href={`/f/${slug}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    size="sm"
+                  >
+                    <Group gap={4} align="center">
+                      /f/{slug}
+                      <IconExternalLink size={14} />
+                    </Group>
+                  </Anchor>
+                ) : (
+                  <Text c="dimmed" size="sm">
+                    /f/{slug} (activate to view live)
+                  </Text>
+                )}
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  size="sm"
+                  onClick={() => setSlugDraft(slug)}
+                  aria-label="Rename public link"
+                >
+                  <IconPencil size={14} />
+                </ActionIcon>
+              </>
             )}
           </Group>
         </Box>

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
@@ -483,7 +483,7 @@ export default function FormEditorPage() {
                   value={slugDraft}
                   onChange={(e) => setSlugDraft(e.currentTarget.value)}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter')
+                    if (e.key === 'Enter' && !updateSlug.isPending)
                       updateSlug.mutate({ id, slug: slugDraft });
                     if (e.key === 'Escape') setSlugDraft(null);
                   }}

--- a/src/server/api/routers/__tests__/formUpdateSlug.test.ts
+++ b/src/server/api/routers/__tests__/formUpdateSlug.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for `form.updateSlug` — public-link rename (deferred in
+ * ADR-0029, now built). Pins the contract: input is normalized with the same
+ * `slugify` used at create; collisions with another form are rejected
+ * (CONFLICT), never silently deduped; a same-slug rename is a no-op; and the
+ * mutation writes ONLY `slug`.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` instead of a real
+ * database, so they run in milliseconds and CANNOT touch any real DB.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(_opts?: any) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({
+    auth: () => null,
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = {
+  current: null,
+};
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) {
+    dbHolder.current = mockDeep<PrismaClient>();
+  }
+  return dbHolder.current;
+}
+
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+vi.mock("~/server/services/notifications/EmailNotificationService", () => ({
+  sendAssignmentNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/server/services/onboarding/syncOnboardingProgress", () => ({
+  completeOnboardingStep: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/lib/blob", () => ({
+  uploadToBlob: vi.fn().mockResolvedValue({ url: "blob://test" }),
+}));
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const callerId = "user-1";
+const workspaceId = "ws-1";
+const formId = "form-1";
+
+/**
+ * `updateSlug` hits `form.findUnique` twice with different shapes: by `id`
+ * (the access-checked load) and by `slug` (the collision probe). Route each
+ * to its own stub.
+ */
+function stubFormLookups(
+  dbMock: DeepMockProxy<PrismaClient>,
+  opts: { currentSlug?: string; clashId?: string | null } = {},
+) {
+  const { currentSlug = "test", clashId = null } = opts;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dbMock.form.findUnique.mockImplementation(((args: any) => {
+    if (args?.where?.id) {
+      return Promise.resolve({
+        id: formId,
+        workspaceId,
+        slug: currentSlug,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+    }
+    return Promise.resolve(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      clashId ? ({ id: clashId } as any) : null,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any);
+}
+
+function stubMembership(dbMock: DeepMockProxy<PrismaClient>, isMember: boolean) {
+  dbMock.workspaceUser.findFirst.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    isMember ? ({ userId: callerId, workspaceId, role: "member" } as any) : null,
+  );
+}
+
+describe("form.updateSlug (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  it("normalizes the requested slug and writes ONLY slug", async () => {
+    stubFormLookups(dbMock);
+    stubMembership(dbMock, true);
+    dbMock.form.update.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: formId, slug: "clear_feedback" } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const result = await caller.form.updateSlug({
+      id: formId,
+      slug: "Clear Feedback",
+    });
+
+    expect(result.slug).toBe("clear_feedback");
+    expect(dbMock.form.update).toHaveBeenCalledWith({
+      where: { id: formId },
+      data: { slug: "clear_feedback" },
+      select: { id: true, slug: true },
+    });
+  });
+
+  it("is a no-op when the normalized slug matches the current one", async () => {
+    stubFormLookups(dbMock, { currentSlug: "test" });
+    stubMembership(dbMock, true);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const result = await caller.form.updateSlug({ id: formId, slug: "Test" });
+
+    expect(result.slug).toBe("test");
+    expect(dbMock.form.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects with CONFLICT when another form already holds the slug", async () => {
+    stubFormLookups(dbMock, { clashId: "form-other" });
+    stubMembership(dbMock, true);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.form.updateSlug({ id: formId, slug: "taken" }),
+    ).rejects.toMatchObject({ code: "CONFLICT" } satisfies Partial<TRPCError>);
+    expect(dbMock.form.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects with BAD_REQUEST when the slug normalizes to nothing", async () => {
+    stubFormLookups(dbMock);
+    stubMembership(dbMock, true);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.form.updateSlug({ id: formId, slug: "!!!" }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    } satisfies Partial<TRPCError>);
+    expect(dbMock.form.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects with FORBIDDEN for a non-member of the form's workspace", async () => {
+    stubFormLookups(dbMock);
+    stubMembership(dbMock, false);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.form.updateSlug({ id: formId, slug: "renamed" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" } satisfies Partial<TRPCError>);
+    expect(dbMock.form.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/api/routers/form.ts
+++ b/src/server/api/routers/form.ts
@@ -4,6 +4,7 @@ import { type PrismaClient, type Prisma } from "@prisma/client";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { uniqueFormSlug } from "~/server/services/forms/formSlug";
+import { slugify } from "~/utils/slugify";
 import {
   formFieldSchema,
   formDestinationSchema,
@@ -95,6 +96,47 @@ export const formRouter = createTRPCRouter({
         data: { isActive: input.isActive },
         // Only what the switch UI consumes — keeps the contract explicit.
         select: { id: true, isActive: true, slug: true },
+      });
+    }),
+
+  /**
+   * Rename a form's public slug (deferred in ADR-0029, now needed: the slug is
+   * frozen from the form's *initial* name, so a "test" placeholder sticks).
+   * The requested slug is normalized with the same `slugify` used at create; a
+   * collision with another form is rejected (CONFLICT) rather than silently
+   * deduped — the caller asked for a specific URL, so surprising them with
+   * `test_2` is worse than an error. Renaming breaks the old /f/ URL (no
+   * redirect table in v1) and leaves historical `source = "form:<old-slug>"`
+   * insight provenance untouched — both accepted, surfaced in the editor UI.
+   */
+  updateSlug: protectedProcedure
+    .input(z.object({ id: z.string(), slug: z.string().min(1).max(100) }))
+    .mutation(async ({ ctx, input }) => {
+      const form = await loadFormForUser(ctx.db, input.id, ctx.session.user.id);
+      const desired = slugify(input.slug) || "";
+      if (!desired) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "The slug must contain at least one letter or number.",
+        });
+      }
+      if (desired === form.slug) {
+        return { id: form.id, slug: form.slug };
+      }
+      const clash = await ctx.db.form.findUnique({
+        where: { slug: desired },
+        select: { id: true },
+      });
+      if (clash && clash.id !== input.id) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `"/f/${desired}" is already taken by another form.`,
+        });
+      }
+      return ctx.db.form.update({
+        where: { id: input.id },
+        data: { slug: desired },
+        select: { id: true, slug: true },
       });
     }),
 

--- a/src/server/api/routers/form.ts
+++ b/src/server/api/routers/form.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { type PrismaClient, type Prisma } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
@@ -127,17 +127,32 @@ export const formRouter = createTRPCRouter({
         where: { slug: desired },
         select: { id: true },
       });
-      if (clash && clash.id !== input.id) {
+      if (clash && clash.id !== form.id) {
         throw new TRPCError({
           code: "CONFLICT",
           message: `"/f/${desired}" is already taken by another form.`,
         });
       }
-      return ctx.db.form.update({
-        where: { id: input.id },
-        data: { slug: desired },
-        select: { id: true, slug: true },
-      });
+      try {
+        return await ctx.db.form.update({
+          where: { id: input.id },
+          data: { slug: desired },
+          select: { id: true, slug: true },
+        });
+      } catch (err) {
+        // The probe→write pair is not atomic; the DB @unique constraint is the
+        // real guard. Translate a lost race into the same clean CONFLICT.
+        if (
+          err instanceof Prisma.PrismaClientKnownRequestError &&
+          err.code === "P2002"
+        ) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: `"/f/${desired}" is already taken by another form.`,
+          });
+        }
+        throw err;
+      }
     }),
 
   update: protectedProcedure


### PR DESCRIPTION
### **User description**
## Problem

A form's public slug is generated once from its **initial** name and then frozen — renaming the form later doesn't touch it (slug rename was explicitly deferred in ADR-0029). So a form created with a placeholder name keeps its placeholder URL forever: observed in production with `/f/test` (form `cmr38c8uf0001l504qfwlllsz`, since renamed "Clear Web App Feedback").

## Change

- **`form.updateSlug` mutation** — workspace-membership-checked (same `loadFormForUser` gate as the rest of the router). Normalizes input with the same `slugify` used at create; **rejects collisions with CONFLICT** (slugs are globally unique — the public URL carries no workspace) rather than silently deduping to `test_2`; no-ops on a same-slug rename; writes only `slug`.
- **Editor header**: a pencil affordance next to `/f/<slug>` opens an inline rename (Enter/✓ to save, Esc/✕ to cancel) with an explicit *"renaming breaks the old link"* note. Local state flips only on success (same posture as #334's Active switch).

## Accepted consequences (v1)

- **No redirect** from the old URL — the old `/f/…` link 404s after a rename (no redirect table; the inline warning says so).
- **Historical insight provenance is untouched** — insights stamped `source="form:<old-slug>"` keep the old slug; new submissions stamp the new one. The origin *filter* (`form:` prefix, ADR-0037) is unaffected; per-form grouping across a rename is the string-convention trade-off ADR-0037 already flagged, with the typed-FK escape hatch if it bites.

## Tests

`formUpdateSlug.test.ts` (mocked Prisma, no DB): normalize+persist writing only `slug`; same-slug no-op; CONFLICT on taken slug; BAD_REQUEST on empty normalization; FORBIDDEN for non-members. `tsc --noEmit` clean; full unit suite green via pre-commit.

Follow-up to #333/#334, Feature `cmr2areh10012l204mhj6wi31`.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `form.updateSlug` mutation to rename a form's public slug from the editor

- Inline slug rename UI with pencil affordance, Enter/Esc keyboard support, and old-link warning

- Collision detection rejects taken slugs with CONFLICT; same-slug rename is a no-op; DB unique constraint race handled via P2002 catch

- Unit tests covering normalize+persist, same-slug no-op, CONFLICT, BAD_REQUEST on empty normalization, and FORBIDDEN for non-members


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PencilIcon["Pencil icon\n(editor header)"] -- "onClick" --> SlugDraftState["slugDraft state\n(inline TextInput)"]
  SlugDraftState -- "Enter / ✓ button" --> UpdateSlugMutation["form.updateSlug\nmutation"]
  UpdateSlugMutation -- "slugify + collision probe" --> SlugCheck{"slug taken?"}
  SlugCheck -- "yes → CONFLICT" --> ErrorToast["Error toast"]
  SlugCheck -- "no → write only slug" --> DB["DB: form.slug"]
  DB -- "success" --> LocalSlugState["Local slug state\n(flips on success only)"]
  LocalSlugState -- "reflects" --> HeaderLink["/f/[slug] header link"]
  SlugDraftState -- "Esc / ✕ button" --> Cancel["Cancel (no write)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Inline slug rename UI with pencil affordance and keyboard support</code></dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx

<ul><li>Added <code>slugDraft</code> state to control inline slug rename mode (<code>null</code> = not <br>editing)<br> <li> Added <code>updateSlug</code> mutation with success/error toast notifications and <br>cache invalidation<br> <li> Replaced static <code>/f/<slug></code> display with conditional inline rename UI <br>(TextInput, confirm/cancel ActionIcons, keyboard shortcuts)<br> <li> Added pencil icon affordance to enter rename mode; local <code>slug</code> state <br>flips only on mutation success<br> <li> Imported <code>IconPencil</code>, <code>IconCheck</code>, <code>IconX</code> from <code>@tabler/icons-react</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/335/files#diff-afb86c06ceed1e1769972469d1c7b4ff8df03d365653609f34115d996bb78ce4">+95/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>form.ts</strong><dd><code>Add updateSlug mutation with collision detection and race hardening</code></dd></summary>
<hr>

src/server/api/routers/form.ts

<ul><li>Added <code>updateSlug</code> protected procedure to the form router<br> <li> Normalizes input with <code>slugify</code>; rejects empty result with BAD_REQUEST<br> <li> Probes for slug collision and rejects with CONFLICT; handles lost <br>probe→write race via P2002 catch<br> <li> Same-slug rename returns early as a no-op; writes only <code>slug</code> field<br> <li> Imported <code>Prisma</code> (non-type) and <code>slugify</code> utility</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/335/files#diff-beb02a17929c976cb1c1e65e3c2413570a2a625b309c3a98616ecebf25856de8">+58/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>formUpdateSlug.test.ts</strong><dd><code>Unit tests for form.updateSlug covering all edge cases</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/__tests__/formUpdateSlug.test.ts

<ul><li>New test file for <code>form.updateSlug</code> using <code>mockDeep<PrismaClient>()</code> (no real DB)<br> <li> Tests: normalize+persist writing only <code>slug</code>; same-slug no-op skips <br><code>form.update</code>; CONFLICT on taken slug; BAD_REQUEST on empty <br>normalization; FORBIDDEN for non-members<br> <li> Stubs <code>form.findUnique</code> to route by-id and by-slug lookups to separate <br>mock responses<br> <li> Full environment variable and module mock setup matching existing test <br>conventions</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/335/files#diff-04a3cd22d89600a7bee698a52f8a078481407e145ccd9510c2c2f8065c9200f7">+210/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

