### PR TITLE
feat(forms): per-form applicant-account offer toggle + custom prompt

### DIFF
--- a/prisma/migrations/20260702100000_form_applicant_account_offer/migration.sql
+++ b/prisma/migrations/20260702100000_form_applicant_account_offer/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Form" ADD COLUMN     "applicantAccountPrompt" TEXT,
+ADD COLUMN     "offerApplicantAccount" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2834,6 +2834,12 @@ model Form {
   destinations        Json     @default("[]")
   isActive            Boolean  @default(false)
   confirmationMessage String?  @db.Text
+  // Applicant account offer (CONTEXT.md ### Forms): whether the success page
+  // shows the optional "create an Exponential account" CTA, and an optional
+  // per-form override of its prompt copy (null = the built-in default).
+  // Defaults preserve pre-existing behaviour (offer shown, default copy).
+  offerApplicantAccount  Boolean @default(true)
+  applicantAccountPrompt String? @db.Text
   createdById         String?
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt

--- a/src/app/(public)/f/[slug]/_components/PublicForm.tsx
+++ b/src/app/(public)/f/[slug]/_components/PublicForm.tsx
@@ -32,12 +32,16 @@ interface PublicField {
   placeholder?: string;
 }
 
+import { DEFAULT_APPLICANT_ACCOUNT_PROMPT } from '~/lib/forms/applicantAccountPrompt';
+
 interface PublicFormProps {
   slug: string;
   name: string;
   description: string | null;
   fields: PublicField[];
   confirmationMessage: string | null;
+  offerApplicantAccount: boolean;
+  applicantAccountPrompt: string | null;
 }
 
 export function PublicForm({
@@ -46,6 +50,8 @@ export function PublicForm({
   description,
   fields,
   confirmationMessage,
+  offerApplicantAccount,
+  applicantAccountPrompt,
 }: PublicFormProps) {
   const [values, setValues] = useState<Record<string, unknown>>({});
   const [honeypot, setHoneypot] = useState('');
@@ -186,7 +192,7 @@ export function PublicForm({
               {done}
             </Text>
 
-            {accountEmail && (
+            {offerApplicantAccount && accountEmail && (
               <>
                 <Divider w="100%" my="xs" />
                 {accountRequested ? (
@@ -197,8 +203,8 @@ export function PublicForm({
                 ) : (
                   <Stack align="center" gap="xs">
                     <Text size="sm" c="dimmed" ta="center">
-                      Want to apply faster next time and keep track of your
-                      applications? Create a free Exponential account.
+                      {applicantAccountPrompt ??
+                        DEFAULT_APPLICANT_ACCOUNT_PROMPT}
                     </Text>
                     <Button
                       variant="light"

--- a/src/app/(public)/f/[slug]/page.tsx
+++ b/src/app/(public)/f/[slug]/page.tsx
@@ -22,6 +22,8 @@ export default async function PublicFormPage({
       description={form.description}
       fields={parseFormFields(form.fields)}
       confirmationMessage={form.confirmationMessage}
+      offerApplicantAccount={form.offerApplicantAccount}
+      applicantAccountPrompt={form.applicantAccountPrompt}
     />
   );
 }

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
@@ -37,6 +37,7 @@ import { notifications } from '@mantine/notifications';
 import { api } from '~/trpc/react';
 import { slugify } from '~/utils/slugify';
 import { CRM_CUSTOMER_TYPE_OPTIONS } from '~/lib/crm/automationCatalog';
+import { DEFAULT_APPLICANT_ACCOUNT_PROMPT } from '~/lib/forms/applicantAccountPrompt';
 import { MarkdownInput } from '~/app/_components/shared/MarkdownInput';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 
@@ -106,6 +107,10 @@ export default function FormEditorPage() {
   const [description, setDescription] = useState('');
   const [isActive, setIsActive] = useState(false);
   const [confirmationMessage, setConfirmationMessage] = useState('');
+  // Applicant account offer (success page): toggle + optional custom prompt
+  // ('' = use the built-in default copy).
+  const [offerAccount, setOfferAccount] = useState(true);
+  const [accountPrompt, setAccountPrompt] = useState('');
   const [fields, setFields] = useState<EditorField[]>([]);
   const [crmEnabled, setCrmEnabled] = useState(false);
   const [customerType, setCustomerType] = useState<string | null>(null);
@@ -169,6 +174,8 @@ export default function FormEditorPage() {
     setDescription(data.description ?? '');
     setIsActive(data.isActive);
     setConfirmationMessage(data.confirmationMessage ?? '');
+    setOfferAccount(data.offerApplicantAccount);
+    setAccountPrompt(data.applicantAccountPrompt ?? '');
     setFields(
       asArray(data.fields).map((f) => {
         const field = f as Partial<EditorField>;
@@ -455,6 +462,8 @@ export default function FormEditorPage() {
       fields: cleanedFields,
       destinations,
       confirmationMessage: confirmationMessage.trim() || null,
+      offerApplicantAccount: offerAccount,
+      applicantAccountPrompt: accountPrompt.trim() || null,
     });
   };
 
@@ -942,6 +951,34 @@ export default function FormEditorPage() {
         autosize
         minRows={2}
       />
+
+      <Card withBorder padding="md">
+        <Stack gap="sm">
+          <Switch
+            label="Offer an Exponential account after submit"
+            description="Shows a create-account prompt and button on the success page. Only appears when the form collects an email."
+            checked={offerAccount}
+            onChange={(e) => {
+              setOfferAccount(e.currentTarget.checked);
+              touch();
+            }}
+          />
+          {offerAccount && (
+            <Textarea
+              label="Account prompt"
+              description="Leave empty to use the default text."
+              placeholder={DEFAULT_APPLICANT_ACCOUNT_PROMPT}
+              value={accountPrompt}
+              onChange={(e) => {
+                setAccountPrompt(e.currentTarget.value);
+                touch();
+              }}
+              autosize
+              minRows={2}
+            />
+          )}
+        </Stack>
+      </Card>
     </Stack>
   );
 }

--- a/src/lib/forms/applicantAccountPrompt.ts
+++ b/src/lib/forms/applicantAccountPrompt.ts
@@ -1,0 +1,9 @@
+/**
+ * Default applicant-account prompt (CONTEXT.md ### Forms — "Applicant
+ * account"), shown on a form's success page when the form has no per-form
+ * override (`Form.applicantAccountPrompt` null). Shared by the public
+ * renderer and the forms-admin editor so the placeholder copy cannot drift.
+ */
+export const DEFAULT_APPLICANT_ACCOUNT_PROMPT =
+  "Want to apply faster next time and keep track of your applications? " +
+  "Create a free Exponential account.";

--- a/src/server/api/routers/__tests__/formAccountOffer.test.ts
+++ b/src/server/api/routers/__tests__/formAccountOffer.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the applicant-account offer settings on `form.update` —
+ * `offerApplicantAccount` (success-page CTA toggle) and
+ * `applicantAccountPrompt` (per-form copy override; empty ⇒ null ⇒ built-in
+ * default). See CONTEXT.md ### Forms — "Applicant account".
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` instead of a real
+ * database, so they run in milliseconds and CANNOT touch any real DB.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(_opts?: any) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({
+    auth: () => null,
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = {
+  current: null,
+};
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) {
+    dbHolder.current = mockDeep<PrismaClient>();
+  }
+  return dbHolder.current;
+}
+
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+vi.mock("~/server/services/notifications/EmailNotificationService", () => ({
+  sendAssignmentNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/server/services/onboarding/syncOnboardingProgress", () => ({
+  completeOnboardingStep: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/lib/blob", () => ({
+  uploadToBlob: vi.fn().mockResolvedValue({ url: "blob://test" }),
+}));
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const callerId = "user-1";
+const workspaceId = "ws-1";
+const formId = "form-1";
+
+function stubForm(dbMock: DeepMockProxy<PrismaClient>) {
+  dbMock.form.findUnique.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { id: formId, workspaceId, slug: "test" } as any,
+  );
+}
+
+function stubMembership(dbMock: DeepMockProxy<PrismaClient>) {
+  dbMock.workspaceUser.findFirst.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { userId: callerId, workspaceId, role: "member" } as any,
+  );
+}
+
+describe("form.update — applicant account offer (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    stubForm(dbMock);
+    stubMembership(dbMock);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    dbMock.form.update.mockResolvedValue({ id: formId } as any);
+  });
+
+  it("persists disabling the offer and a custom prompt", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.form.update({
+      id: formId,
+      offerApplicantAccount: false,
+      applicantAccountPrompt: "Track your application status any time.",
+    });
+
+    expect(dbMock.form.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: formId },
+        data: expect.objectContaining({
+          offerApplicantAccount: false,
+          applicantAccountPrompt: "Track your application status any time.",
+        }),
+      }),
+    );
+  });
+
+  it("stores an empty/whitespace prompt as null (built-in default copy)", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.form.update({
+      id: formId,
+      applicantAccountPrompt: "   ",
+    });
+
+    expect(dbMock.form.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ applicantAccountPrompt: null }),
+      }),
+    );
+  });
+
+  it("leaves both untouched when omitted from the payload", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.form.update({ id: formId, name: "Renamed" });
+
+    expect(dbMock.form.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          offerApplicantAccount: undefined,
+          applicantAccountPrompt: undefined,
+        }),
+      }),
+    );
+  });
+});

--- a/src/server/api/routers/__tests__/formAccountOffer.test.ts
+++ b/src/server/api/routers/__tests__/formAccountOffer.test.ts
@@ -140,19 +140,22 @@ describe("form.update — applicant account offer (mocked)", () => {
     );
   });
 
-  it("stores an empty/whitespace prompt as null (built-in default copy)", async () => {
-    const caller = createMockCaller({ userId: callerId, db: dbMock });
-    await caller.form.update({
-      id: formId,
-      applicantAccountPrompt: "   ",
-    });
+  it.each(["   ", ""])(
+    "stores an empty/whitespace prompt (%j) as null (built-in default copy)",
+    async (emptyPrompt) => {
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.form.update({
+        id: formId,
+        applicantAccountPrompt: emptyPrompt,
+      });
 
-    expect(dbMock.form.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ applicantAccountPrompt: null }),
-      }),
-    );
-  });
+      expect(dbMock.form.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ applicantAccountPrompt: null }),
+        }),
+      );
+    },
+  );
 
   it("leaves both untouched when omitted from the payload", async () => {
     const caller = createMockCaller({ userId: callerId, db: dbMock });

--- a/src/server/api/routers/form.ts
+++ b/src/server/api/routers/form.ts
@@ -165,6 +165,8 @@ export const formRouter = createTRPCRouter({
         destinations: z.array(formDestinationSchema).optional(),
         isActive: z.boolean().optional(),
         confirmationMessage: z.string().max(2000).nullable().optional(),
+        offerApplicantAccount: z.boolean().optional(),
+        applicantAccountPrompt: z.string().max(500).nullable().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -331,6 +333,12 @@ export const formRouter = createTRPCRouter({
             input.confirmationMessage === undefined
               ? undefined
               : input.confirmationMessage,
+          offerApplicantAccount: input.offerApplicantAccount,
+          // Empty/whitespace override falls back to null (the built-in copy).
+          applicantAccountPrompt:
+            input.applicantAccountPrompt === undefined
+              ? undefined
+              : (input.applicantAccountPrompt?.trim() ?? "") || null,
         },
       });
       return { id: form.id };

--- a/src/server/api/routers/form.ts
+++ b/src/server/api/routers/form.ts
@@ -338,7 +338,9 @@ export const formRouter = createTRPCRouter({
           applicantAccountPrompt:
             input.applicantAccountPrompt === undefined
               ? undefined
-              : (input.applicantAccountPrompt?.trim() ?? "") || null,
+              : input.applicantAccountPrompt === null
+                ? null
+                : input.applicantAccountPrompt.trim() || null,
         },
       });
       return { id: form.id };


### PR DESCRIPTION
### **User description**
## Problem

The success page's **Applicant account** CTA (*"Want to apply faster next time and keep track of your applications? Create a free Exponential account."* + the create-account button) is hardcoded: it shows for every form that collects an email, with fixed copy. Form owners have no way to turn it off or reword it.

## Change

- **Schema (migration):** `Form.offerApplicantAccount Boolean @default(true)` and `Form.applicantAccountPrompt String? @db.Text`. Defaults preserve existing behaviour everywhere (offer shown, built-in copy). Migration `20260702100000_form_applicant_account_offer` generated **offline** via `prisma migrate diff` (datamodel→datamodel; no database touched locally).
- **Public success page** gates the CTA block on the toggle and renders the per-form prompt when set. The default copy is hoisted to a shared constant (`~/lib/forms/applicantAccountPrompt`) so the renderer and the editor placeholder cannot drift. The existing "only when the form collects an email" gate is unchanged.
- **Forms admin editor:** an *"Offer an Exponential account after submit"* switch + an *Account prompt* textarea (empty ⇒ default copy), placed with the other success-page setting (confirmation message), saved through `form.update`.
- **`form.update`** accepts both fields; an empty/whitespace prompt normalizes to `null`.

## Tests

`formAccountOffer.test.ts` (mocked Prisma, no DB): persists toggle + custom prompt; empty prompt ⇒ null; omitted fields untouched. `tsc --noEmit` clean; full unit suite green via pre-commit; integration tests exercise the migration via testcontainers.

Follow-up to #333/#334/#335, Feature `cmr2areh10012l204mhj6wi31`. Glossary: **Applicant account** (CONTEXT.md ### Forms).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add per-form applicant-account offer toggle (`offerApplicantAccount`) and custom prompt (`applicantAccountPrompt`) to forms

- Schema migration adds two new `Form` columns with defaults preserving existing behaviour

- Public success page gates the account CTA on the toggle and renders per-form prompt or built-in default

- Forms admin editor gains a switch + textarea for the new settings; unit tests cover all edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Schema["Prisma schema\n+ migration\n(offerApplicantAccount, applicantAccountPrompt)"] -- "new fields" --> FormUpdate["form.update\nmutation"]
  FormUpdate -- "persists toggle + prompt\n(empty → null)" --> DB["DB: Form table"]
  DB -- "hydrates" --> AdminEditor["Forms admin editor\n(Switch + Textarea)"]
  AdminEditor -- "save payload" --> FormUpdate
  DB -- "read on page load" --> PublicPage["Public form page\n(/f/[slug])"]
  PublicPage -- "passes props" --> PublicForm["PublicForm component"]
  PublicForm -- "offerApplicantAccount gate\n+ prompt ?? DEFAULT" --> SuccessPage["Success page\nAccount CTA"]
  SharedConst["DEFAULT_APPLICANT_ACCOUNT_PROMPT\n(~/lib/forms/applicantAccountPrompt)"] -- "shared constant" --> PublicForm
  SharedConst -- "placeholder" --> AdminEditor
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>PublicForm.tsx</strong><dd><code>Gate account CTA on toggle; render per-form or default prompt</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/336/files#diff-477d22ebaebb95d9f645f090403892e95bb1077f5f7ac500e1e0079843ef7c8e">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Pass offerApplicantAccount and applicantAccountPrompt to PublicForm</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/336/files#diff-1f7ea9aac7fe6bca7a300a0f3ef75190d5c3f57ea355d1e438a1f68c9413a992">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Add offer switch and prompt textarea to forms admin editor</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/336/files#diff-afb86c06ceed1e1769972469d1c7b4ff8df03d365653609f34115d996bb78ce4">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>applicantAccountPrompt.ts</strong><dd><code>New shared constant for default applicant account prompt copy</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/336/files#diff-f19ca3b0d44ef85dfa26271960bc7f8548caa8f20139d7f97b5d2771fa70efce">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>form.ts</strong><dd><code>Accept and persist offerApplicantAccount and applicantAccountPrompt in </code><br><code>form.update</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/336/files#diff-beb02a17929c976cb1c1e65e3c2413570a2a625b309c3a98616ecebf25856de8">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>schema.prisma</strong><dd><code>Add offerApplicantAccount and applicantAccountPrompt fields to Form </code><br><code>model</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/336/files#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>migration.sql</strong><dd><code>Migration adding two new columns to Form table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/336/files#diff-3f560e467ca9c62c5882f5e1ca1180b271d29c1580d6ef62d0526678e6bcaee3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>formAccountOffer.test.ts</strong><dd><code>Unit tests for applicant account offer toggle and prompt normalization</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/336/files#diff-bc57146eeb2dbcbab3b382fa1fa4efed727535ab8983330b531a2adbdf313220">+173/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

