### PR TITLE
feat(forms): checkbox groups, field placeholders, submit label + footnote

### DIFF
--- a/prisma/migrations/20260702120000_form_submit_label_and_footnote/migration.sql
+++ b/prisma/migrations/20260702120000_form_submit_label_and_footnote/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Form" ADD COLUMN     "footnote" TEXT,
+ADD COLUMN     "submitLabel" TEXT;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2840,6 +2840,11 @@ model Form {
   // Defaults preserve pre-existing behaviour (offer shown, default copy).
   offerApplicantAccount  Boolean @default(true)
   applicantAccountPrompt String? @db.Text
+  // Public renderer copy overrides: the submit button label (null = "Submit")
+  // and a small dimmed note rendered under the button (null = nothing) —
+  // e.g. "We'll only use your email for updates and follow-ups."
+  submitLabel String?
+  footnote    String? @db.Text
   createdById         String?
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt

--- a/src/app/(public)/f/[slug]/_components/PublicForm.tsx
+++ b/src/app/(public)/f/[slug]/_components/PublicForm.tsx
@@ -26,7 +26,14 @@ import { loadDraft, saveDraft, clearDraft } from './formDraft';
 interface PublicField {
   key: string;
   label: string;
-  type: 'text' | 'email' | 'textarea' | 'select' | 'checkbox' | 'url';
+  type:
+    | 'text'
+    | 'email'
+    | 'textarea'
+    | 'select'
+    | 'checkbox'
+    | 'checkbox_group'
+    | 'url';
   required: boolean;
   options?: string[];
   placeholder?: string;
@@ -42,6 +49,8 @@ interface PublicFormProps {
   confirmationMessage: string | null;
   offerApplicantAccount: boolean;
   applicantAccountPrompt: string | null;
+  submitLabel: string | null;
+  footnote: string | null;
 }
 
 export function PublicForm({
@@ -52,6 +61,8 @@ export function PublicForm({
   confirmationMessage,
   offerApplicantAccount,
   applicantAccountPrompt,
+  submitLabel,
+  footnote,
 }: PublicFormProps) {
   const [values, setValues] = useState<Record<string, unknown>>({});
   const [honeypot, setHoneypot] = useState('');
@@ -315,6 +326,29 @@ export function PublicForm({
                   />
                 );
               }
+              if (field.type === 'checkbox_group') {
+                // "Check all that apply" — value is an array of the selected
+                // option strings.
+                const selected = Array.isArray(values[field.key])
+                  ? (values[field.key] as string[])
+                  : [];
+                return (
+                  <Checkbox.Group
+                    key={field.key}
+                    label={field.label}
+                    required={field.required}
+                    error={errors[field.key]}
+                    value={selected}
+                    onChange={(v) => setValue(field.key, v)}
+                  >
+                    <Stack gap="xs" mt="xs">
+                      {(field.options ?? []).map((opt) => (
+                        <Checkbox key={opt} value={opt} label={opt} />
+                      ))}
+                    </Stack>
+                  </Checkbox.Group>
+                );
+              }
               return (
                 <TextInput
                   {...common}
@@ -351,8 +385,14 @@ export function PublicForm({
             )}
 
             <Button type="submit" loading={submitting}>
-              Submit
+              {submitLabel ?? 'Submit'}
             </Button>
+
+            {footnote && (
+              <Text size="sm" c="dimmed" ta="center">
+                {footnote}
+              </Text>
+            )}
           </Stack>
         </form>
       </Card>

--- a/src/app/(public)/f/[slug]/page.tsx
+++ b/src/app/(public)/f/[slug]/page.tsx
@@ -24,6 +24,8 @@ export default async function PublicFormPage({
       confirmationMessage={form.confirmationMessage}
       offerApplicantAccount={form.offerApplicantAccount}
       applicantAccountPrompt={form.applicantAccountPrompt}
+      submitLabel={form.submitLabel}
+      footnote={form.footnote}
     />
   );
 }

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/forms/[formId]/page.tsx
@@ -41,7 +41,17 @@ import { DEFAULT_APPLICANT_ACCOUNT_PROMPT } from '~/lib/forms/applicantAccountPr
 import { MarkdownInput } from '~/app/_components/shared/MarkdownInput';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 
-type FieldType = 'text' | 'email' | 'textarea' | 'select' | 'checkbox' | 'url';
+type FieldType =
+  | 'text'
+  | 'email'
+  | 'textarea'
+  | 'select'
+  | 'checkbox'
+  | 'checkbox_group'
+  | 'url';
+
+/** Field types that render a free-text input and so can carry a placeholder. */
+const PLACEHOLDER_TYPES: FieldType[] = ['text', 'email', 'textarea', 'url'];
 
 interface EditorField {
   key: string;
@@ -49,6 +59,7 @@ interface EditorField {
   type: FieldType;
   required: boolean;
   options: string[];
+  placeholder: string;
 }
 
 const FIELD_TYPE_OPTIONS = [
@@ -57,6 +68,7 @@ const FIELD_TYPE_OPTIONS = [
   { value: 'textarea', label: 'Long text' },
   { value: 'select', label: 'Dropdown' },
   { value: 'checkbox', label: 'Checkbox' },
+  { value: 'checkbox_group', label: 'Checkboxes (multi)' },
   { value: 'url', label: 'URL / link' },
 ];
 
@@ -111,6 +123,9 @@ export default function FormEditorPage() {
   // ('' = use the built-in default copy).
   const [offerAccount, setOfferAccount] = useState(true);
   const [accountPrompt, setAccountPrompt] = useState('');
+  // Public renderer copy overrides ('' = use the defaults).
+  const [submitLabel, setSubmitLabel] = useState('');
+  const [footnote, setFootnote] = useState('');
   const [fields, setFields] = useState<EditorField[]>([]);
   const [crmEnabled, setCrmEnabled] = useState(false);
   const [customerType, setCustomerType] = useState<string | null>(null);
@@ -176,6 +191,8 @@ export default function FormEditorPage() {
     setConfirmationMessage(data.confirmationMessage ?? '');
     setOfferAccount(data.offerApplicantAccount);
     setAccountPrompt(data.applicantAccountPrompt ?? '');
+    setSubmitLabel(data.submitLabel ?? '');
+    setFootnote(data.footnote ?? '');
     setFields(
       asArray(data.fields).map((f) => {
         const field = f as Partial<EditorField>;
@@ -185,6 +202,7 @@ export default function FormEditorPage() {
           type: field.type ?? 'text',
           required: field.required ?? false,
           options: Array.isArray(field.options) ? field.options : [],
+          placeholder: field.placeholder ?? '',
         };
       }),
     );
@@ -344,7 +362,14 @@ export default function FormEditorPage() {
   const addField = () => {
     setFields((prev) => [
       ...prev,
-      { key: '', label: '', type: 'text', required: false, options: [] },
+      {
+        key: '',
+        label: '',
+        type: 'text',
+        required: false,
+        options: [],
+        placeholder: '',
+      },
     ]);
     touch();
   };
@@ -385,7 +410,12 @@ export default function FormEditorPage() {
       label: f.label.trim() || f.key,
       type: f.type,
       required: f.required,
-      ...(f.type === 'select' ? { options: f.options } : {}),
+      ...(f.type === 'select' || f.type === 'checkbox_group'
+        ? { options: f.options }
+        : {}),
+      ...(PLACEHOLDER_TYPES.includes(f.type) && f.placeholder.trim()
+        ? { placeholder: f.placeholder.trim() }
+        : {}),
     }));
     const destinations: { type: string; config: Record<string, unknown> }[] =
       [];
@@ -464,6 +494,8 @@ export default function FormEditorPage() {
       confirmationMessage: confirmationMessage.trim() || null,
       offerApplicantAccount: offerAccount,
       applicantAccountPrompt: accountPrompt.trim() || null,
+      submitLabel: submitLabel.trim() || null,
+      footnote: footnote.trim() || null,
     });
   };
 
@@ -669,12 +701,23 @@ export default function FormEditorPage() {
                     updateField(index, { required: e.currentTarget.checked })
                   }
                 />
-                {field.type === 'select' && (
+                {(field.type === 'select' ||
+                  field.type === 'checkbox_group') && (
                   <TagsInput
                     label="Options"
                     value={field.options}
                     onChange={(value) => updateField(index, { options: value })}
                     w={220}
+                  />
+                )}
+                {PLACEHOLDER_TYPES.includes(field.type) && (
+                  <TextInput
+                    label="Placeholder"
+                    value={field.placeholder}
+                    onChange={(e) =>
+                      updateField(index, { placeholder: e.currentTarget.value })
+                    }
+                    w={180}
                   />
                 )}
                 <Group gap={2}>
@@ -951,6 +994,29 @@ export default function FormEditorPage() {
         autosize
         minRows={2}
       />
+
+      <Group grow align="flex-start">
+        <TextInput
+          label="Submit button label"
+          description="Leave empty for “Submit”."
+          placeholder="Submit"
+          value={submitLabel}
+          onChange={(e) => {
+            setSubmitLabel(e.currentTarget.value);
+            touch();
+          }}
+        />
+        <TextInput
+          label="Footnote"
+          description="Small note under the submit button."
+          placeholder="We’ll only use your email for updates and follow-ups."
+          value={footnote}
+          onChange={(e) => {
+            setFootnote(e.currentTarget.value);
+            touch();
+          }}
+        />
+      </Group>
 
       <Card withBorder padding="md">
         <Stack gap="sm">

--- a/src/server/api/routers/__tests__/formAccountOffer.test.ts
+++ b/src/server/api/routers/__tests__/formAccountOffer.test.ts
@@ -157,6 +157,24 @@ describe("form.update — applicant account offer (mocked)", () => {
     },
   );
 
+  it("persists submit-label and footnote overrides, normalizing empty to null", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.form.update({
+      id: formId,
+      submitLabel: "Count me in",
+      footnote: "   ",
+    });
+
+    expect(dbMock.form.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          submitLabel: "Count me in",
+          footnote: null,
+        }),
+      }),
+    );
+  });
+
   it("leaves both untouched when omitted from the payload", async () => {
     const caller = createMockCaller({ userId: callerId, db: dbMock });
     await caller.form.update({ id: formId, name: "Renamed" });

--- a/src/server/api/routers/__tests__/formAccountOffer.test.ts
+++ b/src/server/api/routers/__tests__/formAccountOffer.test.ts
@@ -175,7 +175,7 @@ describe("form.update — applicant account offer (mocked)", () => {
     );
   });
 
-  it("leaves both untouched when omitted from the payload", async () => {
+  it("leaves all copy fields untouched when omitted from the payload", async () => {
     const caller = createMockCaller({ userId: callerId, db: dbMock });
     await caller.form.update({ id: formId, name: "Renamed" });
 
@@ -184,6 +184,8 @@ describe("form.update — applicant account offer (mocked)", () => {
         data: expect.objectContaining({
           offerApplicantAccount: undefined,
           applicantAccountPrompt: undefined,
+          submitLabel: undefined,
+          footnote: undefined,
         }),
       }),
     );

--- a/src/server/api/routers/form.ts
+++ b/src/server/api/routers/form.ts
@@ -167,6 +167,8 @@ export const formRouter = createTRPCRouter({
         confirmationMessage: z.string().max(2000).nullable().optional(),
         offerApplicantAccount: z.boolean().optional(),
         applicantAccountPrompt: z.string().max(500).nullable().optional(),
+        submitLabel: z.string().max(100).nullable().optional(),
+        footnote: z.string().max(500).nullable().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -341,6 +343,20 @@ export const formRouter = createTRPCRouter({
               : input.applicantAccountPrompt === null
                 ? null
                 : input.applicantAccountPrompt.trim() || null,
+          // Renderer copy overrides — empty/whitespace falls back to null
+          // (the built-in default).
+          submitLabel:
+            input.submitLabel === undefined
+              ? undefined
+              : input.submitLabel === null
+                ? null
+                : input.submitLabel.trim() || null,
+          footnote:
+            input.footnote === undefined
+              ? undefined
+              : input.footnote === null
+                ? null
+                : input.footnote.trim() || null,
         },
       });
       return { id: form.id };

--- a/src/server/services/forms/__tests__/formSchema.test.ts
+++ b/src/server/services/forms/__tests__/formSchema.test.ts
@@ -90,3 +90,54 @@ describe("validateSubmission", () => {
     if (!result.ok) expect(result.errors.first_name).toMatch(/too long/i);
   });
 });
+
+describe("validateSubmission — checkbox_group", () => {
+  const groupFields: FormField[] = [
+    {
+      key: "help",
+      label: "How would you like to help?",
+      type: "checkbox_group",
+      required: true,
+      options: ["Keep me in the loop", "I'd like to test", "Something else"],
+    },
+  ];
+
+  it("accepts a subset of options and dedupes/trims selections", () => {
+    const result = validateSubmission(groupFields, {
+      help: ["Keep me in the loop", " I'd like to test ", "Keep me in the loop"],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok)
+      expect(result.clean.help).toEqual([
+        "Keep me in the loop",
+        "I'd like to test",
+      ]);
+  });
+
+  it("tolerates a lone string as a single selection", () => {
+    const result = validateSubmission(groupFields, { help: "Something else" });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.clean.help).toEqual(["Something else"]);
+  });
+
+  it("rejects a selection not in the options", () => {
+    const result = validateSubmission(groupFields, {
+      help: ["Keep me in the loop", "injected"],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.help).toMatch(/invalid option/i);
+  });
+
+  it("requires at least one selection when required", () => {
+    const result = validateSubmission(groupFields, { help: [] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errors.help).toMatch(/required/i);
+  });
+
+  it("accepts an empty selection when optional", () => {
+    const optional: FormField[] = [{ ...groupFields[0]!, required: false }];
+    const result = validateSubmission(optional, {});
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.clean.help).toEqual([]);
+  });
+});

--- a/src/server/services/forms/formSchema.ts
+++ b/src/server/services/forms/formSchema.ts
@@ -14,6 +14,7 @@ export const FORM_FIELD_TYPES = [
   "textarea",
   "select",
   "checkbox",
+  "checkbox_group",
   "url",
 ] as const;
 export type FormFieldType = (typeof FORM_FIELD_TYPES)[number];
@@ -78,6 +79,34 @@ export function validateSubmission(
         errors[field.key] = `${field.label} is required`;
       } else {
         clean[field.key] = value;
+      }
+      continue;
+    }
+
+    if (field.type === "checkbox_group") {
+      // "Check all that apply": value is an array of selected option strings
+      // (a lone string is tolerated). Every selection must be a defined
+      // option; required means at least one selection.
+      const rawArr = Array.isArray(raw)
+        ? raw
+        : typeof raw === "string" && raw
+          ? [raw]
+          : [];
+      const selections = [
+        ...new Set(
+          rawArr
+            .filter((v): v is string => typeof v === "string")
+            .map((v) => v.trim())
+            .filter(Boolean),
+        ),
+      ];
+      const invalid = selections.filter((s) => !field.options?.includes(s));
+      if (invalid.length > 0) {
+        errors[field.key] = `${field.label} contains an invalid option`;
+      } else if (field.required && selections.length === 0) {
+        errors[field.key] = `${field.label} is required`;
+      } else {
+        clean[field.key] = selections;
       }
       continue;
     }


### PR DESCRIPTION
### **User description**
## Problem

The form builder couldn't reproduce a real intake form (the "Help us build Clear" shape): no multi-select **"check all that apply"** field, no way to author field **placeholders** (the model/renderer supported them, the editor didn't), a hardcoded **"Submit"** button, and no **footnote** under the button ("We'll only use your email…").

## Change

- **`checkbox_group` field type** — renders a `Checkbox.Group` of options on the public form; validates as an array of selections (every selection must be a defined option; `required` = at least one; deduped/trimmed; a lone string tolerated). Pure JSON — no migration. The editor's options editor now serves both *Dropdown* and *Checkboxes (multi)*.
- **Placeholder authoring** — the field editor exposes `placeholder` for text/email/textarea/url.
- **`Form.submitLabel` + `Form.footnote`** *(migration `20260702120000_form_submit_label_and_footnote`, generated offline via `prisma migrate diff` — no DB touched locally)* — button label defaults to "Submit"; footnote renders as a small dimmed note under the button. Both editable beside the confirmation message; empty ⇒ null ⇒ defaults.

## Tests

`formSchema.test.ts`: 5 new `checkbox_group` cases (subset+dedupe/trim, lone string, invalid option, required-empty, optional-empty). `formAccountOffer.test.ts`: submit-label/footnote persistence + empty⇒null. Full forms sweep 57/57; `tsc --noEmit` clean.

Follow-up to #333–#336, Feature `cmr2areh10012l204mhj6wi31`.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `checkbox_group` field type for multi-select "check all that apply" inputs

- Add `submitLabel` and `footnote` fields to `Form` model with schema migration

- Expose `placeholder` authoring in field editor for text/email/textarea/url types

- Extend tests for `checkbox_group` validation and `submitLabel`/`footnote` persistence


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Schema["Prisma schema\n+ migration\n(submitLabel, footnote)"] -- "new fields" --> FormUpdate["form.update\nmutation"]
  FormUpdate -- "persists label + footnote\n(empty → null)" --> DB["DB: Form table"]
  DB -- "hydrates" --> AdminEditor["Forms admin editor\n(submitLabel, footnote inputs)"]
  AdminEditor -- "save payload" --> FormUpdate
  DB -- "read on page load" --> PublicPage["Public form page\n(/f/[slug])"]
  PublicPage -- "passes props" --> PublicForm["PublicForm component"]
  PublicForm -- "renders checkbox_group\n+ submitLabel + footnote" --> Renderer["Public form renderer"]
  FieldEditor["Field editor\n(placeholder + checkbox_group)"] -- "options + placeholder" --> AdminEditor
  FormSchema["formSchema.ts\ncheckbox_group validation"] -- "validates selections" --> PublicForm
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>PublicForm.tsx</strong><dd><code>Add checkbox_group renderer, submitLabel, and footnote support</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/337/files#diff-477d22ebaebb95d9f645f090403892e95bb1077f5f7ac500e1e0079843ef7c8e">+42/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Pass submitLabel and footnote props to PublicForm</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/337/files#diff-1f7ea9aac7fe6bca7a300a0f3ef75190d5c3f57ea355d1e438a1f68c9413a992">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Add checkbox_group type, placeholder editor, submitLabel and footnote </code><br><code>inputs</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/337/files#diff-afb86c06ceed1e1769972469d1c7b4ff8df03d365653609f34115d996bb78ce4">+70/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>form.ts</strong><dd><code>Accept and normalize submitLabel and footnote in form.update</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/337/files#diff-beb02a17929c976cb1c1e65e3c2413570a2a625b309c3a98616ecebf25856de8">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>formSchema.ts</strong><dd><code>Add checkbox_group field type and validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/337/files#diff-5bf45b39ad4bc58927b7b49030e1b61496f0468d4c6aab7f810895a87de43962">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>formAccountOffer.test.ts</strong><dd><code>Add tests for submitLabel/footnote persistence and omission behaviour</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/337/files#diff-bc57146eeb2dbcbab3b382fa1fa4efed727535ab8983330b531a2adbdf313220">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>formSchema.test.ts</strong><dd><code>Add checkbox_group validation test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/337/files#diff-a4189cd0aa25e1888bb869bc3543602dbd462efaed2bc9542fd68cea6bc805ff">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>migration.sql</strong><dd><code>Migration adding submitLabel and footnote columns to Form table</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/337/files#diff-8b1691107ed43afbbb7777f9cb27c2ba7c35fb5ac5d0d1e2e78df3d98e4dbd0b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.prisma</strong><dd><code>Add submitLabel and footnote fields to Form model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/337/files#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

