### PR TITLE
fix(pages): fill full available width instead of narrow centered container

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { Container, Skeleton, Text, TextInput } from '@mantine/core';
+import { Skeleton, Text, TextInput } from '@mantine/core';
 import type { JSONContent } from '@tiptap/core';
 import { api } from '~/trpc/react';
 import { PageDocument } from '~/app/_components/pages/PageDocument';
@@ -77,27 +77,27 @@ function PageEditorContent({ pageId }: { pageId: string }) {
 
   if (isLoading) {
     return (
-      <Container size="md" className="py-8">
+      <div className="w-full px-6 py-8">
         <Skeleton height={36} width={320} mb="xl" />
         <Skeleton height={400} />
-      </Container>
+      </div>
     );
   }
 
   if (error || !page) {
     return (
-      <Container size="md" className="py-8">
+      <div className="w-full px-6 py-8">
         <Text className="text-text-secondary">
           {error?.data?.code === 'FORBIDDEN'
             ? "You don't have access to this page."
             : 'Page not found.'}
         </Text>
-      </Container>
+      </div>
     );
   }
 
   return (
-    <Container size="md" className="py-8">
+    <div className="w-full px-6 py-8">
       <div className="mb-4">
         <PageTitle pageId={page.id} initialTitle={page.title} editable={page.canEdit} />
       </div>
@@ -108,7 +108,7 @@ function PageEditorContent({ pageId }: { pageId: string }) {
         docVersion={page.docVersion}
         editable={page.canEdit}
       />
-    </Container>
+    </div>
   );
 }
 

--- a/src/app/(sidemenu)/w/[workspaceSlug]/pages/_components/PagesListContent.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/pages/_components/PagesListContent.tsx
@@ -6,7 +6,6 @@ import { useRouter } from 'next/navigation';
 import {
   Badge,
   Button,
-  Container,
   Group,
   Skeleton,
   Text,
@@ -49,7 +48,7 @@ export function PagesListContent({ workspaceId, workspaceSlug }: PagesListConten
   }, [pages, search]);
 
   return (
-    <Container size="lg" className="py-8">
+    <div className="w-full px-6 py-8">
       <Group justify="space-between" align="center" mb="lg">
         <Group gap="xs" align="center">
           <IconFileText size={22} className="text-text-secondary" />
@@ -115,6 +114,6 @@ export function PagesListContent({ workspaceId, workspaceSlug }: PagesListConten
           ))}
         </div>
       )}
-    </Container>
+    </div>
   );
 }

--- a/src/app/(sidemenu)/w/[workspaceSlug]/pages/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/pages/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Suspense } from 'react';
-import { Container, Skeleton, Text } from '@mantine/core';
+import { Skeleton, Text } from '@mantine/core';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { PagesListContent } from './_components/PagesListContent';
 
@@ -10,18 +10,18 @@ function WorkspacePagesContent() {
 
   if (isLoading) {
     return (
-      <Container size="lg" className="py-8">
+      <div className="w-full px-6 py-8">
         <Skeleton height={40} width={200} mb="lg" />
         <Skeleton height={300} />
-      </Container>
+      </div>
     );
   }
 
   if (!workspace || !workspaceId || !workspaceSlug) {
     return (
-      <Container size="lg" className="py-8">
+      <div className="w-full px-6 py-8">
         <Text className="text-text-secondary">Workspace not found</Text>
-      </Container>
+      </div>
     );
   }
 


### PR DESCRIPTION
### **User description**
## What

- Replace Mantine `<Container size="md">` in the page detail/editor view (and its loading/error states) with full-width wrappers
- Same for the Pages list route states (`size="lg"`) and `PagesListContent`

## Why

Page content rendered as a narrow centered column; pages should always fill the full width of the available screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace Mantine `Container` with full-width `div` in pages views

- Fixes narrow centered layout in page detail/editor and list views

- Loading and error states also updated to use full-width wrappers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mantine Container\n(size='md'/'lg')"] -- "replaced with" --> B["div\n(w-full px-6 py-8)"]
  B -- "affects" --> C["Page Detail/Editor View"]
  B -- "affects" --> D["Pages List View"]
  B -- "affects" --> E["Loading & Error States"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Replace Container with full-width div in page editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx

<ul><li>Removed <code>Container</code> import from <code>@mantine/core</code><br> <li> Replaced <code><Container size="md"></code> with <code><div className="w-full px-6 py-8"></code> <br>in loading, error, and main content states</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/340/files#diff-6b79b72a995acbd10cc157f1131181cd7ed46fc478f1fd996884e2c162db08b2">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PagesListContent.tsx</strong><dd><code>Replace Container with full-width div in pages list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/pages/_components/PagesListContent.tsx

<ul><li>Removed <code>Container</code> import from <code>@mantine/core</code><br> <li> Replaced <code><Container size="lg"></code> with <code><div className="w-full px-6 py-8"></code> <br>as the root wrapper</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/340/files#diff-e4d0a69c872899dc7c591d5b13f99700f92aff404f83467ff67fb0d13846778d">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Replace Container with full-width div in pages route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/pages/page.tsx

<ul><li>Removed <code>Container</code> import from <code>@mantine/core</code><br> <li> Replaced <code><Container size="lg"></code> with <code><div className="w-full px-6 py-8"></code> <br>in loading and error states</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/340/files#diff-a041e2fec395c797dacf65a1e7ceb3d75a3b3484373cca0c37a74242066d5a2f">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

