### PR TITLE
feat(pages): /page slash command creates and links a sub-page

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx
@@ -125,6 +125,9 @@ function PageEditorContent({
         body={page.body ?? null}
         docVersion={page.docVersion}
         editable={page.canEdit}
+        workspaceId={page.workspaceId}
+        workspaceSlug={workspaceSlug}
+        projectId={page.projectId}
       />
     </div>
   );

--- a/src/app/_components/pages/PageDocument.tsx
+++ b/src/app/_components/pages/PageDocument.tsx
@@ -1,8 +1,16 @@
 "use client";
 
+import { useMemo, useRef } from "react";
+import { useRouter } from "next/navigation";
 import type { JSONContent } from "@tiptap/core";
+import { notifications } from "@mantine/notifications";
+import { IconFileText } from "@tabler/icons-react";
 import { api } from "~/trpc/react";
-import { RichDocEditor } from "~/app/_components/shared/RichDocEditor";
+import {
+  RichDocEditor,
+  type RichDocEditorHandle,
+} from "~/app/_components/shared/RichDocEditor";
+import type { SlashCommandItem } from "~/lib/prd/slash-command";
 
 interface PageDocumentProps {
   pageId: string;
@@ -12,6 +20,11 @@ interface PageDocumentProps {
   body: string | null;
   docVersion?: number;
   editable?: boolean;
+  /** Placement of the page — the `/page` command creates the new page in the
+   * same workspace/project so it inherits identical visibility. */
+  workspaceId: string;
+  workspaceSlug: string;
+  projectId?: string | null;
 }
 
 /**
@@ -19,6 +32,10 @@ interface PageDocumentProps {
  * engine wired to the Page `bodyDoc`/`body`/`docVersion` storage. Anchored
  * comments are intentionally OUT of scope for Pages v1, so no comment layer is
  * passed — the engine renders just the document surface.
+ *
+ * Adds the Pages-only `/page` slash command: creates a sibling page (same
+ * workspace + project), drops a `pageLink` block at the cursor, flushes the
+ * autosave so the link survives navigation, and opens the new page.
  */
 export function PageDocument({
   pageId,
@@ -26,10 +43,67 @@ export function PageDocument({
   body,
   docVersion = 0,
   editable = false,
+  workspaceId,
+  workspaceSlug,
+  projectId,
 }: PageDocumentProps) {
+  const router = useRouter();
+  const utils = api.useUtils();
   const initBodyDoc = api.page.initBodyDoc.useMutation();
   const updatePage = api.page.update.useMutation();
   const uploadImage = api.page.uploadImage.useMutation();
+  const createPage = api.page.create.useMutation();
+  const createPageMutate = createPage.mutate;
+
+  const handleRef = useRef<RichDocEditorHandle | null>(null);
+
+  const slashExtras = useMemo<SlashCommandItem[]>(
+    () => [
+      {
+        title: "Page",
+        description: "Create a new page, linked here",
+        icon: IconFileText,
+        run: ({ editor, range }) => {
+          editor.chain().focus().deleteRange(range).run();
+          createPageMutate(
+            { workspaceId, projectId },
+            {
+              onSuccess: (page) => {
+                if (editor.isDestroyed) return;
+                editor
+                  .chain()
+                  .focus()
+                  .insertContent({
+                    type: "pageLink",
+                    attrs: {
+                      pageId: page.id,
+                      title: page.title,
+                      href: `/w/${workspaceSlug}/pages/${page.id}`,
+                    },
+                  })
+                  .run();
+                // Persist the link now — navigating away unmounts the editor
+                // before the debounced autosave would fire — and mark this
+                // page's cached doc stale so back-navigation refetches it.
+                handleRef.current?.flushSave();
+                void utils.page.get.invalidate({ id: pageId });
+                void utils.page.list.invalidate();
+                router.push(`/w/${workspaceSlug}/pages/${page.id}`);
+              },
+              onError: () => {
+                notifications.show({
+                  title: "Could not create page",
+                  message: "Please try again.",
+                  color: "red",
+                });
+              },
+            },
+          );
+        },
+      },
+    ],
+    [createPageMutate, workspaceId, projectId, workspaceSlug, pageId, router, utils],
+  );
 
   return (
     <RichDocEditor
@@ -55,6 +129,10 @@ export function PageDocument({
       uploadImage={(base64Data) =>
         uploadImage.mutateAsync({ id: pageId, base64Data })
       }
+      slashExtras={slashExtras}
+      onReady={(handle) => {
+        handleRef.current = handle;
+      }}
     />
   );
 }

--- a/src/app/_components/pages/PageDocument.tsx
+++ b/src/app/_components/pages/PageDocument.tsx
@@ -68,7 +68,7 @@ export function PageDocument({
           createPageMutate(
             { workspaceId, projectId },
             {
-              onSuccess: (page) => {
+              onSuccess: async (page) => {
                 if (editor.isDestroyed) return;
                 editor
                   .chain()
@@ -82,11 +82,12 @@ export function PageDocument({
                     },
                   })
                   .run();
-                // Persist the link now — navigating away unmounts the editor
-                // before the debounced autosave would fire — and mark this
-                // page's cached doc stale so back-navigation refetches it.
-                handleRef.current?.flushSave();
-                void utils.page.get.invalidate({ id: pageId });
+                // Persist the link before navigating — the unmount would drop
+                // the debounced autosave — and only then mark this page's
+                // cached doc stale, so back-navigation can't refetch the
+                // pre-link doc while the save is still in flight.
+                await handleRef.current?.flushSave();
+                await utils.page.get.invalidate({ id: pageId });
                 void utils.page.list.invalidate();
                 router.push(`/w/${workspaceSlug}/pages/${page.id}`);
               },

--- a/src/app/_components/pages/PageDocument.tsx
+++ b/src/app/_components/pages/PageDocument.tsx
@@ -68,7 +68,7 @@ export function PageDocument({
           createPageMutate(
             { workspaceId, projectId },
             {
-              onSuccess: async (page) => {
+              onSuccess: (page) => {
                 if (editor.isDestroyed) return;
                 editor
                   .chain()
@@ -86,10 +86,12 @@ export function PageDocument({
                 // the debounced autosave — and only then mark this page's
                 // cached doc stale, so back-navigation can't refetch the
                 // pre-link doc while the save is still in flight.
-                await handleRef.current?.flushSave();
-                await utils.page.get.invalidate({ id: pageId });
-                void utils.page.list.invalidate();
-                router.push(`/w/${workspaceSlug}/pages/${page.id}`);
+                void (async () => {
+                  await handleRef.current?.flushSave();
+                  await utils.page.get.invalidate({ id: pageId });
+                  void utils.page.list.invalidate();
+                  router.push(`/w/${workspaceSlug}/pages/${page.id}`);
+                })();
               },
               onError: () => {
                 notifications.show({

--- a/src/app/_components/prd/PrdDocument.tsx
+++ b/src/app/_components/prd/PrdDocument.tsx
@@ -67,7 +67,7 @@ export function PrdDocument({
   enableComments = false,
 }: PrdDocumentProps) {
   const [editor, setEditor] = useState<Editor | null>(null);
-  const flushSaveRef = useRef<() => void>(() => undefined);
+  const flushSaveRef = useRef<() => Promise<void>>(() => Promise.resolve());
 
   // Bumped on every doc change so thread reconciliation re-reads the live marks.
   const [docTick, setDocTick] = useState(0);
@@ -182,7 +182,7 @@ export function PrdDocument({
     // fire two concurrent saves with the same baseVersion (which can race into a
     // spurious stale-write conflict). Persist the mark right away instead so the
     // thread is anchored on reload.
-    flushSaveRef.current();
+    void flushSaveRef.current();
     setPending({ threadId, quotedText });
     setActiveThreadId(threadId);
     setAnchorPos(anchor);

--- a/src/app/_components/shared/PageLinkView.tsx
+++ b/src/app/_components/shared/PageLinkView.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import {
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+  type NodeViewProps,
+} from "@tiptap/react";
+import { IconFileText } from "@tabler/icons-react";
+import { api } from "~/trpc/react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import { PageLink } from "~/lib/prd/page-link";
+
+/**
+ * Interactive node view for the {@link PageLink} block: a clickable link to
+ * another Knowledge Page showing its **live** title. The title comes from the
+ * already-cached `page.list` query (one shared query for every link in the
+ * doc), which `PageTitle` invalidates on rename — so renaming a page updates
+ * every link to it without touching the documents that link there. The `title`
+ * attr is only a snapshot fallback (page deleted / no access / loading); while
+ * the doc is editable we sync the live title back into the attr so the
+ * Markdown projection and public render stay current.
+ */
+function PageLinkView({ node, editor, updateAttributes }: NodeViewProps) {
+  const pageId = node.attrs.pageId as string | null;
+  const cachedTitle = (node.attrs.title as string | null) ?? "Untitled";
+  const { workspace, workspaceId } = useWorkspace();
+
+  const { data: pages } = api.page.list.useQuery(
+    { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId },
+  );
+  const livePage = pages?.find((p) => p.id === pageId);
+  const liveTitle = livePage?.title;
+  const title = liveTitle ?? cachedTitle;
+
+  useEffect(() => {
+    if (editor.isEditable && liveTitle && liveTitle !== cachedTitle) {
+      updateAttributes({ title: liveTitle });
+    }
+  }, [editor.isEditable, liveTitle, cachedTitle, updateAttributes]);
+
+  const href =
+    workspace && pageId
+      ? `/w/${workspace.slug}/pages/${pageId}`
+      : ((node.attrs.href as string | null) ?? "#");
+
+  return (
+    <NodeViewWrapper data-type="page-link" className="page-link-block my-1">
+      <Link
+        href={href}
+        contentEditable={false}
+        draggable={false}
+        className="inline-flex max-w-full items-center gap-2 rounded-md px-1 py-0.5 no-underline hover:bg-surface-hover"
+      >
+        <IconFileText size={18} className="shrink-0 text-text-muted" />
+        <span className="truncate font-medium text-text-primary underline decoration-border-primary underline-offset-2">
+          {title}
+        </span>
+      </Link>
+    </NodeViewWrapper>
+  );
+}
+
+/** The {@link PageLink} node with the interactive React view attached — what
+ * the live editor uses in place of the headless base node. */
+export const PageLinkWithView = PageLink.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(PageLinkView);
+  },
+});

--- a/src/app/_components/shared/RichDocEditor.tsx
+++ b/src/app/_components/shared/RichDocEditor.tsx
@@ -9,8 +9,9 @@ import { Text } from "@mantine/core";
 import { modals } from "@mantine/modals";
 import { notifications } from "@mantine/notifications";
 import { buildPrdExtensions } from "~/lib/prd/extensions";
-import { SlashCommand } from "~/lib/prd/slash-command";
+import { SlashCommand, type SlashCommandItem } from "~/lib/prd/slash-command";
 import { markdownToDoc, EMPTY_DOC, isDocEmpty } from "~/lib/prd/codec";
+import { PageLinkWithView } from "./PageLinkView";
 import "@mantine/tiptap/styles.css";
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
@@ -52,6 +53,8 @@ export interface RichDocEditorProps {
   // ───────── optional host layer (e.g. Feature comments) ─────────
   /** Extra Tiptap extensions layered on top of the shared set. */
   extraExtensions?: Extensions;
+  /** Extra `/` slash-menu commands appended after the built-in blocks. */
+  slashExtras?: SlashCommandItem[];
   /** Extra bubble-menu controls (rendered after the formatting group). */
   bubbleExtras?: React.ReactNode;
   /** Fires on every doc change, so a host can re-read live marks. */
@@ -90,6 +93,7 @@ export function RichDocEditor({
   onInitDoc,
   uploadImage,
   extraExtensions,
+  slashExtras,
   bubbleExtras,
   onDocUpdate,
   onReady,
@@ -238,8 +242,13 @@ export function RichDocEditor({
   const editor = useEditor({
     editable,
     extensions: [
-      ...buildPrdExtensions(placeholder ? { placeholder } : {}),
-      ...(editable ? [SlashCommand] : []),
+      ...buildPrdExtensions({
+        ...(placeholder ? { placeholder } : {}),
+        pageLink: PageLinkWithView,
+      }),
+      ...(editable
+        ? [SlashCommand.configure({ extraCommands: slashExtras ?? [] })]
+        : []),
       ...(extraExtensions ?? []),
     ],
     content: doc ?? "",

--- a/src/app/_components/shared/RichDocEditor.tsx
+++ b/src/app/_components/shared/RichDocEditor.tsx
@@ -19,8 +19,10 @@ const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 /** Imperative handle the comment layer (or any host) needs from the engine. */
 export interface RichDocEditorHandle {
   editor: Editor | null;
-  /** Cancel any pending debounced autosave and persist immediately. */
-  flushSave: () => void;
+  /** Cancel any pending debounced autosave and persist immediately. Resolves
+   * once the save has settled, so a host can await it before navigating away
+   * (a rejected save resolves too — the conflict modal handles the error). */
+  flushSave: () => Promise<void>;
 }
 
 export interface RichDocEditorProps {
@@ -200,13 +202,15 @@ export function RichDocEditor({
   }, [initialDoc, initialMarkdown]);
 
   // Latest save fn behind a ref so the editor's onUpdate closure never goes stale.
-  const saveRef = useRef<(editor: Editor) => void>(() => undefined);
+  const saveRef = useRef<(editor: Editor) => Promise<void>>(() =>
+    Promise.resolve(),
+  );
   saveRef.current = (editor: Editor) => {
     const json = editor.getJSON();
     const markdown = (
       editor.storage.markdown as { getMarkdown: () => string }
     ).getMarkdown();
-    void onSave({ doc: json, markdown, baseVersion: versionRef.current })
+    return onSave({ doc: json, markdown, baseVersion: versionRef.current })
       .then((res) => {
         if (res && typeof res.docVersion === "number") {
           versionRef.current = res.docVersion;
@@ -233,9 +237,9 @@ export function RichDocEditor({
       });
   };
 
-  const flushSave = () => {
+  const flushSave = async () => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    if (editorRef.current) saveRef.current(editorRef.current);
+    if (editorRef.current) await saveRef.current(editorRef.current);
   };
   const editorRef = useRef<Editor | null>(null);
 
@@ -257,12 +261,12 @@ export function RichDocEditor({
       onDocUpdate?.();
       if (!editable) return;
       if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => saveRef.current(e), 1000);
+      debounceRef.current = setTimeout(() => void saveRef.current(e), 1000);
     },
     onBlur: ({ editor: e }) => {
       if (!editable) return;
       if (debounceRef.current) clearTimeout(debounceRef.current);
-      saveRef.current(e);
+      void saveRef.current(e);
     },
     editorProps: {
       attributes: {

--- a/src/lib/pages/__tests__/public-doc.test.ts
+++ b/src/lib/pages/__tests__/public-doc.test.ts
@@ -99,6 +99,29 @@ describe("sanitizeDocForPublic", () => {
     expect(listItem.content![0]!.content![0]!.marks).toEqual([]);
   });
 
+  it("strips page ids and internal hrefs from page links, keeping the title", () => {
+    const input = doc([
+      {
+        type: "pageLink",
+        attrs: {
+          pageId: "clx123",
+          title: "Design notes",
+          href: "/w/acme/pages/clx123",
+        },
+      },
+      { type: "pageLink" },
+    ]);
+    const out = sanitizeDocForPublic(input);
+    expect(out.content![0]).toEqual({
+      type: "pageLink",
+      attrs: { title: "Design notes" },
+    });
+    expect(out.content![1]).toEqual({
+      type: "pageLink",
+      attrs: { title: "Untitled" },
+    });
+  });
+
   it("does not mutate the input document", () => {
     const input = doc([
       { type: "image", attrs: { src: "data:image/png;base64,AAAA" } },

--- a/src/lib/pages/public-doc.ts
+++ b/src/lib/pages/public-doc.ts
@@ -9,6 +9,8 @@ import type { JSONContent } from "@tiptap/core";
  *  - `image` nodes keep only http(s) srcs (drops `data:`/`javascript:`)
  *  - `comment` marks are internal collaboration artifacts and are stripped,
  *    matching the Markdown projection, which also drops them (ADR-0024)
+ *  - `pageLink` nodes keep only the cached title — the target page id and
+ *    internal workspace path are private and must not leak into public HTML
  *
  * Pure and isomorphic — unit-testable without a DOM.
  */
@@ -22,6 +24,14 @@ function isSafeLinkMark(mark: { attrs?: Record<string, unknown> }): boolean {
 }
 
 function sanitizeNode(node: JSONContent): JSONContent | null {
+  if (node.type === "pageLink") {
+    const title = node.attrs?.title;
+    return {
+      type: "pageLink",
+      attrs: { title: typeof title === "string" && title ? title : "Untitled" },
+    };
+  }
+
   if (node.type === "image") {
     const src = node.attrs?.src as unknown;
     if (typeof src !== "string" || !SAFE_IMAGE_SRC.test(src.trim())) {

--- a/src/lib/prd/__tests__/codec.test.ts
+++ b/src/lib/prd/__tests__/codec.test.ts
@@ -110,6 +110,40 @@ describe("PRD document codec", () => {
     });
   });
 
+  describe("page links project to plain Markdown links", () => {
+    it("serialises a pageLink node as [title](href)", () => {
+      const doc: JSONContent = {
+        type: "doc",
+        content: [
+          {
+            type: "pageLink",
+            attrs: {
+              pageId: "clx123",
+              title: "Design notes",
+              href: "/w/acme/pages/clx123",
+            },
+          },
+        ],
+      };
+      expect(docToMarkdown(doc)).toBe("[Design notes](/w/acme/pages/clx123)");
+    });
+
+    it("escapes brackets in the cached title and tolerates missing attrs", () => {
+      const doc: JSONContent = {
+        type: "doc",
+        content: [
+          { type: "pageLink", attrs: { pageId: "clx1", title: "A [draft]" } },
+        ],
+      };
+      expect(docToMarkdown(doc)).toBe("[A \\[draft\\]]()");
+      const bare: JSONContent = {
+        type: "doc",
+        content: [{ type: "pageLink" }],
+      };
+      expect(docToMarkdown(bare)).toBe("[Untitled]()");
+    });
+  });
+
   describe("comment marks drop from the Markdown projection", () => {
     it("keeps the text but emits no comment mark/span/threadId", () => {
       const doc: JSONContent = {

--- a/src/lib/prd/__tests__/codec.test.ts
+++ b/src/lib/prd/__tests__/codec.test.ts
@@ -136,6 +136,16 @@ describe("PRD document codec", () => {
         ],
       };
       expect(docToMarkdown(doc)).toBe("[A \\[draft\\]]()");
+      const hostileHref: JSONContent = {
+        type: "doc",
+        content: [
+          {
+            type: "pageLink",
+            attrs: { pageId: "clx2", title: "T", href: "/w/a(b)/pages/x" },
+          },
+        ],
+      };
+      expect(docToMarkdown(hostileHref)).toBe("[T](/w/a\\(b\\)/pages/x)");
       const bare: JSONContent = {
         type: "doc",
         content: [{ type: "pageLink" }],

--- a/src/lib/prd/extensions.ts
+++ b/src/lib/prd/extensions.ts
@@ -1,4 +1,4 @@
-import type { Extensions } from "@tiptap/core";
+import type { AnyExtension, Extensions } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -7,6 +7,7 @@ import TaskItem from "@tiptap/extension-task-item";
 import Image from "@tiptap/extension-image";
 import { Markdown } from "tiptap-markdown";
 import { CommentMark } from "./comment-mark";
+import { PageLink } from "./page-link";
 
 /**
  * The schema for the **PRD body** — the single scoped exception to ADR-0017
@@ -31,7 +32,16 @@ export const PRD_DEFAULT_PLACEHOLDER =
   "Write the PRD… select text to format or comment, or type / for blocks.";
 
 export function buildPrdExtensions(
-  options: { placeholder?: string } = {},
+  options: {
+    placeholder?: string;
+    /**
+     * Override for the {@link PageLink} node — the interactive editor passes
+     * `PageLinkWithView` (same schema + a React node view resolving the live
+     * page title); the headless codec and the server-side public render use
+     * the plain base node.
+     */
+    pageLink?: AnyExtension;
+  } = {},
 ): Extensions {
   return [
     StarterKit.configure({
@@ -54,6 +64,7 @@ export function buildPrdExtensions(
       HTMLAttributes: { class: "prd-image rounded-md max-w-full" },
     }),
     CommentMark,
+    options.pageLink ?? PageLink,
     Placeholder.configure({
       placeholder: options.placeholder ?? PRD_DEFAULT_PLACEHOLDER,
     }),

--- a/src/lib/prd/page-link.ts
+++ b/src/lib/prd/page-link.ts
@@ -78,7 +78,11 @@ export const PageLink = Node.create({
             ((node.attrs.title as string | null) ?? "Untitled") || "Untitled";
           const href = (node.attrs.href as string | null) ?? "";
           const safeTitle = title.replace(/([[\]])/g, "\\$1");
-          state.write(`[${safeTitle}](${href})`);
+          // Escape the same destination characters prosemirror-markdown
+          // escapes for link marks, so a hostile href can't break out of the
+          // link syntax and corrupt the projection.
+          const safeHref = href.replace(/[()"\\]/g, "\\$&");
+          state.write(`[${safeTitle}](${safeHref})`);
           state.closeBlock(node);
         },
         parse: {},

--- a/src/lib/prd/page-link.ts
+++ b/src/lib/prd/page-link.ts
@@ -1,0 +1,88 @@
+import { Node, mergeAttributes } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { MarkdownSerializerState } from "@tiptap/pm/markdown";
+
+/**
+ * Block atom that links to another Knowledge Page from inside a document — the
+ * `/page` slash command inserts one after creating the target page (Notion-style
+ * sub-pages, minus real nesting: the target is an ordinary workspace Page).
+ *
+ * The node carries the target `pageId` plus a **cached** `title`/`href`
+ * snapshot. The interactive editor swaps in a React node view
+ * (`PageLinkWithView`) that resolves the live title, so renames show up
+ * immediately; this base definition is what the headless codec and the public
+ * static render use. `renderHTML` deliberately emits a non-navigable `<div>`
+ * (no `href`) so a published page never links into the authenticated app.
+ *
+ * Markdown projection: a plain link `[title](href)`. There is no parse rule —
+ * a Markdown-source rewrite (e.g. the Zoe agent) degrades the node to a
+ * regular link mark, which still navigates to the page in-app.
+ */
+export const PageLink = Node.create({
+  name: "pageLink",
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      pageId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-page-id"),
+        renderHTML: (attributes) => {
+          const pageId = attributes.pageId as string | null;
+          return pageId ? { "data-page-id": pageId } : {};
+        },
+      },
+      title: {
+        default: "Untitled",
+        parseHTML: (element) => element.getAttribute("data-title"),
+        renderHTML: (attributes) => {
+          const title = attributes.title as string | null;
+          return title ? { "data-title": title } : {};
+        },
+      },
+      href: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-href"),
+        renderHTML: (attributes) => {
+          const href = attributes.href as string | null;
+          return href ? { "data-href": href } : {};
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="page-link"]' }];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, {
+        "data-type": "page-link",
+        class: "page-link-block",
+      }),
+      String((node.attrs.title as string | null) ?? "Untitled"),
+    ];
+  },
+
+  /** tiptap-markdown spec: project the node as a plain Markdown link. */
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state: MarkdownSerializerState, node: ProseMirrorNode) {
+          const title =
+            ((node.attrs.title as string | null) ?? "Untitled") || "Untitled";
+          const href = (node.attrs.href as string | null) ?? "";
+          const safeTitle = title.replace(/([[\]])/g, "\\$1");
+          state.write(`[${safeTitle}](${href})`);
+          state.closeBlock(node);
+        },
+        parse: {},
+      },
+    };
+  },
+});

--- a/src/lib/prd/slash-command.tsx
+++ b/src/lib/prd/slash-command.tsx
@@ -26,9 +26,11 @@ import tippy, { type Instance, type GetReferenceClientRect } from "tippy.js";
 /**
  * `/` slash-command block menu for the PRD editor (ADR-0024 Tier B). Built on
  * `@tiptap/suggestion`: typing `/` opens a keyboard-navigable list that inserts
- * structural blocks (headings, lists, task lists, code block, quote).
+ * structural blocks (headings, lists, task lists, code block, quote). Hosts can
+ * append context-dependent commands (e.g. the Pages editor's "Page" command)
+ * via the `extraCommands` option.
  */
-interface SlashCommandItem {
+export interface SlashCommandItem {
   title: string;
   description: string;
   icon: TablerIcon;
@@ -166,13 +168,9 @@ const SlashCommandList = forwardRef<SlashCommandListRef, SlashCommandListProps>(
   },
 );
 
-const suggestion: Omit<SuggestionOptions<SlashCommandItem>, "editor"> = {
+const suggestion: Omit<SuggestionOptions<SlashCommandItem>, "editor" | "items"> = {
   char: "/",
   startOfLine: false,
-  items: ({ query }) =>
-    COMMANDS.filter((item) =>
-      item.title.toLowerCase().startsWith(query.toLowerCase()),
-    ),
   command: ({ editor, range, props }) => props.run({ editor, range }),
   render: () => {
     let component: ReactRenderer<SlashCommandListRef, SlashCommandListProps>;
@@ -226,9 +224,26 @@ const suggestion: Omit<SuggestionOptions<SlashCommandItem>, "editor"> = {
   },
 };
 
-export const SlashCommand = Extension.create({
+export interface SlashCommandOptions {
+  /** Host-injected commands appended after the built-in block commands. */
+  extraCommands: SlashCommandItem[];
+}
+
+export const SlashCommand = Extension.create<SlashCommandOptions>({
   name: "slashCommand",
+  addOptions() {
+    return { extraCommands: [] };
+  },
   addProseMirrorPlugins() {
-    return [Suggestion({ editor: this.editor, ...suggestion })];
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...suggestion,
+        items: ({ query }) =>
+          [...COMMANDS, ...this.options.extraCommands].filter((item) =>
+            item.title.toLowerCase().startsWith(query.toLowerCase()),
+          ),
+      }),
+    ];
   },
 });


### PR DESCRIPTION
### **User description**
## What

Typing `/` in a Knowledge Page body now offers a **Page** command (filterable as `/page`). Selecting it:

1. creates a new page in the same workspace/project (inheriting identical visibility),
2. inserts a `pageLink` block at the cursor,
3. flushes the autosave (so the link survives the navigation unmount), and
4. opens the new page.

Navigating back shows the link with a file icon and the target page's title.

## How the title stays live

The `pageLink` node stores only the target `pageId` plus a cached `title`/`href` snapshot. A React node view resolves the display title from the shared `page.list` query — the same query `PageTitle` already invalidates on rename — so one cached query serves every link in a document and renames propagate to all links without rewriting the linking documents. While a doc is editable, the live title is synced back into the node attr so the Markdown projection and public render stay current.

## Off-island + public behavior

- **Markdown projection** (`body`, read by CLI/agents): the node serialises as a plain `[title](/w/{slug}/pages/{id})` link. There is no parse rule — a Markdown-source rewrite (e.g. Zoe) degrades it to a regular link mark, which still navigates in-app.
- **Published pages** (ADR-0038): `sanitizeDocForPublic` strips `pageId` and the internal workspace path from page links; the public HTML shows just the title text, so internal URLs/ids never leak.
- The node lives in the shared PRD schema (`buildPrdExtensions`), with an override point so the live editor attaches the React view while the headless codec and server-side `generateHTML` use the plain base node (keeps the server bundle free of client imports).

## Changes

- `src/lib/prd/page-link.ts` (new) — base `pageLink` block node: schema, static HTML render, Markdown serialisation
- `src/lib/prd/slash-command.tsx` — slash menu accepts host-injected `extraCommands`
- `src/lib/prd/extensions.ts` — registers the node; optional node-view override
- `src/app/_components/shared/PageLinkView.tsx` (new) — interactive node view with live title + navigation
- `src/app/_components/shared/RichDocEditor.tsx` — `slashExtras` prop; uses the view-enabled node
- `src/app/_components/pages/PageDocument.tsx` — the `/page` command: create → insert → flush save → invalidate caches → navigate
- `src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx` — passes workspace/project placement down
- `src/lib/pages/public-doc.ts` — public sanitizer handling for `pageLink`

## Tests

- `codec.test.ts`: Markdown projection of `pageLink` (happy path, bracket escaping, missing attrs)
- `public-doc.test.ts`: public sanitization strips id/href, keeps title
- Full unit suite green (1251 tests); typecheck and ESLint clean

## Notes

- New pages are titled **"Untitled"**, matching the existing "New page" button.
- No DB changes — safe for main per the fast-track criteria.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds `/page` slash command to Knowledge Page editor creating linked sub-pages

- Introduces new `pageLink` TipTap node with Markdown serialization and public sanitization

- `flushSave` now returns a `Promise<void>` ensuring save completes before navigation

- Adds `SlashCommandItem` export and `extraCommands` option for host-injected commands


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PageDocument\n(host)"] -- "slashExtras + onReady" --> B["RichDocEditor"]
  B -- "buildPrdExtensions\n(pageLink override)" --> C["PageLinkWithView\n(React node view)"]
  C -- "page.list query" --> D["Live title resolution"]
  B -- "SlashCommand.configure\n(extraCommands)" --> E["SlashCommand extension"]
  E -- "/page selected" --> F["createPage mutation"]
  F -- "insertContent pageLink" --> G["pageLink node"]
  G -- "flushSave (awaited)" --> H["Navigate to new page"]
  G -- "Markdown serialization" --> I["[title](href)"]
  G -- "sanitizeDocForPublic" --> J["title only (no pageId/href)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>page-link.ts</strong><dd><code>New pageLink block node with Markdown serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/343/files#diff-94119179092d410fa0aa1596920ee27e263807f9ede48067f1c6fa61b4a1719a">+92/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PageLinkView.tsx</strong><dd><code>React node view resolving live page title</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/343/files#diff-a4f054452bc17097d18c6cb103a6d0413d6408615cf8ed187d32967ec0295398">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PageDocument.tsx</strong><dd><code>Wire /page slash command and flushSave handle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/343/files#diff-381f79c00467608f97330626d377b83d5ae351da580b4673a46edc2af783f1af">+82/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Pass workspaceId, workspaceSlug, projectId to PageDocument</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/343/files#diff-6b79b72a995acbd10cc157f1131181cd7ed46fc478f1fd996884e2c162db08b2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RichDocEditor.tsx</strong><dd><code>flushSave returns Promise; add slashExtras and PageLinkWithView</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/343/files#diff-94ac9cac79aa08ce267f273a39bca6d43488b86f079813d3132a5a8770c18913">+24/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>extensions.ts</strong><dd><code>Add pageLink node with override option to buildPrdExtensions</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/343/files#diff-df9e8e0d34ac894a019436e84fc03a982819ea60173d72157688eb406a309dc8">+13/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>slash-command.tsx</strong><dd><code>Export SlashCommandItem and add extraCommands option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/343/files#diff-acdef4f8d766b21f181571a45e27e07b8527191f38b36f90e682ea9c15246a6e">+24/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>public-doc.ts</strong><dd><code>Strip pageId and internal href from pageLink in public render</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/343/files#diff-64d759dc1f727883c8edd8f63a004f8f1f145b831eeb35e116d75a036cf4e0d4">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>PrdDocument.tsx</strong><dd><code>Update flushSaveRef type to Promise-returning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/343/files#diff-fb26fc25e3f6039b3fcca439dad29a1ebe61368c3ea825b772515b3acae5dd35">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>public-doc.test.ts</strong><dd><code>Tests for pageLink sanitization in public doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/343/files#diff-17f4aa034ebdbb5efd00ae1ff6e130fe9048ad7bb627a89d746270d47dda885c">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codec.test.ts</strong><dd><code>Tests for pageLink Markdown serialization and edge cases</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/343/files#diff-2ba7b1a5c15e6ebf19a9cb4982363f8a5e224c3c6f44bbc3c6caf5d4bfd7e690">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

