### PR TITLE
feat(today): split /today into Overdue, Today, and Completed sections

### DIFF
--- a/docs/adr/0034-todays-actions-shared-partition.md
+++ b/docs/adr/0034-todays-actions-shared-partition.md
@@ -35,3 +35,4 @@ Give Zoe a dedicated **Today's actions** read tool whose definition is provably 
 - New `action.getTodaysActions` tRPC procedure + a `get-todays-actions` tool in `../mastra`.
 - **Two coexisting "today" definitions** are accepted for now: **Today's actions** (scheduled-or-due, the `/today` set and Zoe's chat tool) vs. the **Daily brief** (due-only, voice + morning briefing). Both are documented as canonical terms in CONTEXT.md; convergence of voice is explicitly deferred.
 - A new EvalCase enters the regression suite guarding grounding/no-deflection for this class.
+- **2026-07-06** — the `overdue` bucket widened to include unscheduled actions with a past `dueDate` (previously only past `scheduledStart` counted, so a past-due, never-scheduled action fell through every bucket and vanished from `/today` and Zoe's tool). Schedule still wins: a past-due action scheduled today/future is not overdue. A `completedToday` bucket was added for the `/today` completed section.

--- a/src/app/_components/actions/ActionsList.tsx
+++ b/src/app/_components/actions/ActionsList.tsx
@@ -5,6 +5,7 @@ import {
   Accordion,
   ActionIcon,
   Badge,
+  Button,
   Group,
   Text,
 } from "@mantine/core";
@@ -13,6 +14,8 @@ import { api } from "~/trpc/react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { useDayRollover } from "~/hooks/useDayRollover";
 import type { Action } from "~/lib/actions/types";
+import { formatRelativeDueAge } from "~/lib/actions/dates";
+import { overdueAnchor } from "~/lib/actions/partition";
 import { EditActionModal } from "../EditActionModal";
 import { AssignActionModal } from "../AssignActionModal";
 import { InboxZeroCelebration } from "../InboxZeroCelebration";
@@ -49,6 +52,8 @@ interface ActionsListProps {
   onActionClose?: () => void;
   onTagClick?: (tagId: string) => void;
   workspaceProjects?: Array<{ id: string; name: string }>;
+  /** When set, shows a "Reschedule all → Today" button in the Overdue header. */
+  onRescheduleAllOverdue?: (actionIds: string[]) => void;
 }
 
 export function ActionsList({
@@ -61,6 +66,7 @@ export function ActionsList({
   onActionOpen,
   onActionClose,
   workspaceProjects,
+  onRescheduleAllOverdue,
 }: ActionsListProps) {
   const today = useDayRollover();
   const partition = useActionPartition(actions, { today });
@@ -196,7 +202,9 @@ export function ActionsList({
   // Sections
   const showOverdueSection =
     partition.overdue.length > 0 && lower !== "inbox";
-  const completedList = partition.completed;
+  // The today view celebrates today's progress only; other views keep history.
+  const completedList =
+    lower === "today" ? partition.completedToday : partition.completed;
   const showCompleted = completedSection !== "hidden" && completedList.length > 0;
 
   // Empty states
@@ -223,6 +231,14 @@ export function ActionsList({
       key={a.id}
       action={a}
       isOverdue={isOverdue}
+      overdueLabel={
+        isOverdue
+          ? (() => {
+              const anchor = overdueAnchor(a);
+              return anchor ? formatRelativeDueAge(anchor, today) : undefined;
+            })()
+          : undefined
+      }
       bulkMode={bulkMode}
       bulkSelected={selection.isSelected(a.id)}
       onBulkToggle={selection.toggle}
@@ -265,14 +281,31 @@ export function ActionsList({
       {showOverdueSection && (
         <Accordion defaultValue="overdue" radius="md" className="mb-4">
           <Accordion.Item value="overdue">
-            <Accordion.Control>
-              <Group gap="xs">
-                <Text fw={600}>Overdue</Text>
-                <Badge color="red" variant="light">
-                  {partition.overdue.length}
-                </Badge>
-              </Group>
-            </Accordion.Control>
+            {/* Button sits beside the Control (nested buttons are invalid HTML) */}
+            <Group wrap="nowrap" gap={0}>
+              <Accordion.Control>
+                <Group gap="xs">
+                  <Text fw={600}>Overdue</Text>
+                  <Badge color="red" variant="light">
+                    {partition.overdue.length}
+                  </Badge>
+                </Group>
+              </Accordion.Control>
+              {onRescheduleAllOverdue && !bulkMode && (
+                <Button
+                  size="compact-xs"
+                  variant="light"
+                  color="red"
+                  mr="sm"
+                  style={{ flexShrink: 0 }}
+                  onClick={() =>
+                    onRescheduleAllOverdue(partition.overdue.map((a) => a.id))
+                  }
+                >
+                  Reschedule all → Today
+                </Button>
+              )}
+            </Group>
             <Accordion.Panel>
               {partition.overdue.map((a) => renderRow(a, true))}
             </Accordion.Panel>

--- a/src/app/_components/actions/TodayLayout.tsx
+++ b/src/app/_components/actions/TodayLayout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Text } from "@mantine/core";
 import { api, type RouterOutputs } from "~/trpc/react";
@@ -192,6 +192,18 @@ export function TodayLayout({ tagIds }: TodayLayoutProps) {
     for (const s of activeSuggestions) handleAcceptSuggestion(s);
   };
 
+  // "Now", not midnight — see TodayDesktopShell.handleRescheduleAllOverdue.
+  const handleRescheduleAllOverdue = useCallback(
+    (ids: string[]) =>
+      bulkReschedule({
+        actionIds: ids,
+        dueDate: new Date(),
+        label: "Today",
+        fromOverdue: true,
+      }),
+    [bulkReschedule],
+  );
+
   const handleActionOpen = (id: string) => {
     if (detailedEnabled && workspace?.slug) {
       router.push(`/w/${workspace.slug}/actions/${id}`);
@@ -250,14 +262,7 @@ export function TodayLayout({ tagIds }: TodayLayoutProps) {
               deepLinkActionId={actionIdFromUrl}
               onActionOpen={handleActionOpen}
               onActionClose={clearActionId}
-              onRescheduleAllOverdue={(ids) =>
-                bulkReschedule({
-                  actionIds: ids,
-                  dueDate: new Date(),
-                  label: "Today",
-                  fromOverdue: true,
-                })
-              }
+              onRescheduleAllOverdue={handleRescheduleAllOverdue}
             />
           )}
         </div>

--- a/src/app/_components/actions/TodayLayout.tsx
+++ b/src/app/_components/actions/TodayLayout.tsx
@@ -250,6 +250,14 @@ export function TodayLayout({ tagIds }: TodayLayoutProps) {
               deepLinkActionId={actionIdFromUrl}
               onActionOpen={handleActionOpen}
               onActionClose={clearActionId}
+              onRescheduleAllOverdue={(ids) =>
+                bulkReschedule({
+                  actionIds: ids,
+                  dueDate: new Date(),
+                  label: "Today",
+                  fromOverdue: true,
+                })
+              }
             />
           )}
         </div>

--- a/src/app/_components/actions/components/ActionRow.tsx
+++ b/src/app/_components/actions/components/ActionRow.tsx
@@ -21,6 +21,8 @@ import styles from "./ActionRow.module.css";
 interface ActionRowProps {
   action: Action;
   isOverdue?: boolean;
+  /** Relative age shown on overdue rows, e.g. "due 3d ago". Replaces the bare clock time. */
+  overdueLabel?: string;
   bulkMode?: boolean;
   bulkSelected?: boolean;
   onBulkToggle?: (id: string) => void;
@@ -37,6 +39,7 @@ interface ActionRowProps {
 export function ActionRow({
   action,
   isOverdue = false,
+  overdueLabel,
   bulkMode = false,
   bulkSelected = false,
   onBulkToggle,
@@ -111,7 +114,12 @@ export function ActionRow({
           <ActiveTimerIndicator actionId={action.id} className="ml-2 align-middle" />
         </div>
         <div className={styles.meta}>
-          {isOverdue && timeSource ? (
+          {isOverdue && overdueLabel ? (
+            <span className={`${styles.chip} ${styles.chipOverdue}`}>
+              <IconCalendar size={10} />
+              {overdueLabel}
+            </span>
+          ) : isOverdue && timeSource ? (
             <span className={`${styles.chip} ${styles.chipOverdue}`}>
               <IconClock size={10} />
               {formatClockTime(timeSource)}

--- a/src/app/_components/today-redesign/TaskRow.tsx
+++ b/src/app/_components/today-redesign/TaskRow.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { IconCalendar, IconClock } from "@tabler/icons-react";
+import { IconAlertCircle, IconCalendar, IconClock } from "@tabler/icons-react";
 import type { Action } from "~/lib/actions/types";
 import { toVisualPriority } from "~/lib/actions/priority";
 import { formatAprDay, formatClockTime } from "~/lib/actions/dates";
@@ -15,6 +15,8 @@ import { TagChip, tagTone } from "./TagChip";
 interface TaskRowProps {
   action: Action;
   isOverdue?: boolean;
+  /** Relative age shown on overdue rows, e.g. "due 3d ago". Replaces the absolute due-date chip. */
+  overdueLabel?: string;
   focused?: boolean;
   bulkMode?: boolean;
   bulkSelected?: boolean;
@@ -28,6 +30,7 @@ interface TaskRowProps {
 export function TaskRow({
   action,
   isOverdue = false,
+  overdueLabel,
   focused = false,
   bulkMode = false,
   bulkSelected = false,
@@ -99,11 +102,18 @@ export function TaskRow({
           <HTMLContent html={action.name} compactUrls />
         </div>
         <div className="td-task__meta">
-          {due && (
-            <span className="td-task__meta-item">
-              <IconCalendar size={11} />
-              {formatAprDay(due)}
+          {isOverdue && overdueLabel ? (
+            <span className="td-task__meta-item td-task__meta-item--overdue">
+              <IconAlertCircle size={11} />
+              {overdueLabel}
             </span>
+          ) : (
+            due && (
+              <span className="td-task__meta-item">
+                <IconCalendar size={11} />
+                {formatAprDay(due)}
+              </span>
+            )
           )}
           {scheduled && (
             <span className="td-task__meta-item">
@@ -126,6 +136,22 @@ export function TaskRow({
         className="td-task__reschedule"
         onClick={(e) => e.stopPropagation()}
       >
+        {isOverdue && !bulkMode && onReschedule && (
+          <button
+            type="button"
+            className="td-task__quick"
+            onClick={(e) => {
+              e.stopPropagation();
+              onReschedule(action.id, {
+                id: "today",
+                label: "Today",
+                date: new Date(),
+              });
+            }}
+          >
+            Today
+          </button>
+        )}
         <button
           type="button"
           className="td-task__action"

--- a/src/app/_components/today-redesign/TodayDesktopShell.tsx
+++ b/src/app/_components/today-redesign/TodayDesktopShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Modal, MultiSelect } from "@mantine/core";
@@ -253,14 +253,18 @@ export function TodayDesktopShell({
     return [...overdue, ...todays];
   }, [partition.overdue, partition.todays]);
 
-  const handleRescheduleAllOverdue = () => {
+  // "Now", not the midnight `today` from useDayRollover: bulkReschedule also
+  // sets scheduledStart, and a midnight date would render the rescheduled
+  // items as 12:00 AM blocks on the agenda rail (ReschedulePopover's "Today"
+  // quick option makes the same choice).
+  const handleRescheduleAllOverdue = useCallback(() => {
     bulkReschedule({
       actionIds: partition.overdue.map((a) => a.id),
       dueDate: new Date(),
       label: "Today",
       fromOverdue: true,
     });
-  };
+  }, [bulkReschedule, partition.overdue]);
 
   // ---- Bulk selection -----------------------------------------------------
   const selection = useBulkSelection(

--- a/src/app/_components/today-redesign/TodayDesktopShell.tsx
+++ b/src/app/_components/today-redesign/TodayDesktopShell.tsx
@@ -5,13 +5,14 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Modal, MultiSelect } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { IconHash, IconSearch } from "@tabler/icons-react";
+import { IconChevronRight, IconHash, IconSearch } from "@tabler/icons-react";
 import { api, type RouterOutputs } from "~/trpc/react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { useActionDeepLink } from "~/hooks/useActionDeepLink";
 import { useDetailedActionsEnabled } from "~/hooks/useDetailedActionsEnabled";
 import { useDayRollover } from "~/hooks/useDayRollover";
-import { hourFloat } from "~/lib/actions/dates";
+import { formatRelativeDueAge, hourFloat } from "~/lib/actions/dates";
+import { overdueAnchor } from "~/lib/actions/partition";
 import type { Action } from "~/lib/actions/types";
 import { CreateActionModal } from "../CreateActionModal";
 import { EditActionModal } from "../EditActionModal";
@@ -59,6 +60,13 @@ export function TodayDesktopShell({
     useDisclosure(false);
   const [tagPickerOpen, setTagPickerOpen] = useState(false);
   const [bulkMode, setBulkMode] = useState(false);
+  const [overdueOpen, setOverdueOpen] = useState(true);
+  const [completedOpen, setCompletedOpen] = useState(false);
+  // Bulk "select all" operates on overdue + today rows; never let a collapsed
+  // section hide rows that selection would silently include.
+  useEffect(() => {
+    if (bulkMode) setOverdueOpen(true);
+  }, [bulkMode]);
   const [zoeOpen, setZoeOpen] = useState(true);
   const [dismissedSuggestions, setDismissedSuggestions] = useState<Set<string>>(
     new Set(),
@@ -238,12 +246,21 @@ export function TodayDesktopShell({
     return `${DOW[d.getDay()]} · ${MON[d.getMonth()]} ${d.getDate()}`;
   }, []);
 
-  // ---- Rendered task list (active todays + overdue, completed at bottom) ---
+  // ---- Rendered task list (bulk selection scope: overdue + todays) --------
   const renderedActions = useMemo(() => {
     const overdue = partition.overdue;
     const todays = partition.todays;
     return [...overdue, ...todays];
   }, [partition.overdue, partition.todays]);
+
+  const handleRescheduleAllOverdue = () => {
+    bulkReschedule({
+      actionIds: partition.overdue.map((a) => a.id),
+      dueDate: new Date(),
+      label: "Today",
+      fromOverdue: true,
+    });
+  };
 
   // ---- Bulk selection -----------------------------------------------------
   const selection = useBulkSelection(
@@ -413,27 +430,132 @@ export function TodayDesktopShell({
               <div className="td-tasklist__rows">
                 {actionsQuery.isLoading ? (
                   <div className="td-tasklist__empty">Loading…</div>
-                ) : renderedActions.length === 0 ? (
+                ) : renderedActions.length === 0 &&
+                  partition.completedToday.length === 0 ? (
                   <div className="td-tasklist__empty">Nothing scheduled. Enjoy the calm.</div>
                 ) : (
-                  renderedActions.map((a) => (
-                    <TaskRow
-                      key={a.id}
-                      action={a as unknown as Action}
-                      isOverdue={partition.overdue.some((o) => o.id === a.id)}
-                      bulkMode={bulkMode}
-                      bulkSelected={selection.isSelected(a.id)}
-                      onBulkToggle={selection.toggle}
-                      onComplete={handleComplete}
-                      onOpen={handleOpen}
-                      onReschedule={handleReschedule}
-                      onTagClick={(tagId) => {
-                        if (!selectedTagIds.includes(tagId)) {
-                          onSelectedTagIdsChange([...selectedTagIds, tagId]);
-                        }
-                      }}
-                    />
-                  ))
+                  <>
+                    {hasOverdue && (
+                      <div className="td-section td-section--overdue">
+                        <button
+                          type="button"
+                          className="td-section__toggle"
+                          aria-expanded={overdueOpen}
+                          onClick={() => setOverdueOpen((v) => !v)}
+                        >
+                          <IconChevronRight
+                            size={12}
+                            className={
+                              overdueOpen
+                                ? "td-section__chev td-section__chev--open"
+                                : "td-section__chev"
+                            }
+                          />
+                          Overdue
+                          <span className="td-section__count td-section__count--overdue">
+                            {partition.overdue.length}
+                          </span>
+                        </button>
+                        {!bulkMode && (
+                          <button
+                            type="button"
+                            className="td-section__action"
+                            onClick={handleRescheduleAllOverdue}
+                          >
+                            Reschedule all → Today
+                          </button>
+                        )}
+                      </div>
+                    )}
+                    {overdueOpen &&
+                      partition.overdue.map((a) => {
+                        const anchor = overdueAnchor(a);
+                        return (
+                          <TaskRow
+                            key={a.id}
+                            action={a as unknown as Action}
+                            isOverdue
+                            overdueLabel={
+                              anchor
+                                ? formatRelativeDueAge(anchor, today)
+                                : undefined
+                            }
+                            bulkMode={bulkMode}
+                            bulkSelected={selection.isSelected(a.id)}
+                            onBulkToggle={selection.toggle}
+                            onComplete={handleComplete}
+                            onOpen={handleOpen}
+                            onReschedule={handleReschedule}
+                            onTagClick={(tagId) => {
+                              if (!selectedTagIds.includes(tagId)) {
+                                onSelectedTagIdsChange([...selectedTagIds, tagId]);
+                              }
+                            }}
+                          />
+                        );
+                      })}
+
+                    {hasOverdue && partition.todays.length > 0 && (
+                      <div className="td-section">
+                        Today
+                        <span className="td-section__count">
+                          {partition.todays.length}
+                        </span>
+                      </div>
+                    )}
+                    {partition.todays.map((a) => (
+                      <TaskRow
+                        key={a.id}
+                        action={a as unknown as Action}
+                        bulkMode={bulkMode}
+                        bulkSelected={selection.isSelected(a.id)}
+                        onBulkToggle={selection.toggle}
+                        onComplete={handleComplete}
+                        onOpen={handleOpen}
+                        onReschedule={handleReschedule}
+                        onTagClick={(tagId) => {
+                          if (!selectedTagIds.includes(tagId)) {
+                            onSelectedTagIdsChange([...selectedTagIds, tagId]);
+                          }
+                        }}
+                      />
+                    ))}
+
+                    {partition.completedToday.length > 0 && (
+                      <>
+                        <div className="td-section">
+                          <button
+                            type="button"
+                            className="td-section__toggle"
+                            aria-expanded={completedOpen}
+                            onClick={() => setCompletedOpen((v) => !v)}
+                          >
+                            <IconChevronRight
+                              size={12}
+                              className={
+                                completedOpen
+                                  ? "td-section__chev td-section__chev--open"
+                                  : "td-section__chev"
+                              }
+                            />
+                            Completed
+                            <span className="td-section__count">
+                              {partition.completedToday.length}
+                            </span>
+                          </button>
+                        </div>
+                        {completedOpen &&
+                          partition.completedToday.map((a) => (
+                            <TaskRow
+                              key={a.id}
+                              action={a as unknown as Action}
+                              onComplete={handleComplete}
+                              onOpen={handleOpen}
+                            />
+                          ))}
+                      </>
+                    )}
+                  </>
                 )}
               </div>
 

--- a/src/app/_components/today-redesign/today-desktop.css
+++ b/src/app/_components/today-redesign/today-desktop.css
@@ -222,6 +222,67 @@
   font-weight: 500;
 }
 
+/* ============================================================
+   List sections (Overdue / Today / Completed)
+   ============================================================ */
+.td-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px 6px;
+  font-size: 10.5px;
+  color: var(--td-faint);
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  font-weight: 500;
+}
+
+/* `.td ` prefix wins over the `.td button` reset. */
+.td .td-section__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+}
+.td-section--overdue .td-section__toggle { color: var(--td-prio-urgent); }
+
+.td-section__chev { transition: transform 120ms; flex-shrink: 0; }
+.td-section__chev--open { transform: rotate(90deg); }
+
+.td-section__count {
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--td-surface-2);
+  color: var(--td-muted);
+  font-size: 10px;
+  letter-spacing: 0;
+}
+.td-section__count--overdue {
+  background: var(--td-prio-urgent-10);
+  color: var(--td-prio-urgent);
+}
+
+.td .td-section__action {
+  margin-left: auto;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--td-prio-urgent-dim);
+  color: var(--td-prio-urgent);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+  text-transform: none;
+  cursor: pointer;
+}
+.td .td-section__action:hover { background: var(--td-prio-urgent-10); }
+
 .td-task {
   display: grid;
   grid-template-columns: 20px 1fr auto;
@@ -340,10 +401,30 @@
   flex-shrink: 0;
 }
 
+.td-task__meta-item--overdue { color: var(--td-prio-urgent); }
+
 .td-task__reschedule {
   position: relative;
   display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
+
+/* Hover-revealed one-click "Today" triage on overdue rows. */
+.td .td-task__quick {
+  display: none;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: transparent;
+  border: 1px solid var(--td-prio-urgent-dim);
+  color: var(--td-prio-urgent);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.td-task:hover .td-task__quick { display: inline-flex; }
+.td .td-task__quick:hover { background: var(--td-prio-urgent-10); }
 
 .td-task__action {
   width: 28px;

--- a/src/lib/actions/__tests__/dates.test.ts
+++ b/src/lib/actions/__tests__/dates.test.ts
@@ -27,8 +27,12 @@ describe("formatRelativeDueAge", () => {
     ).toBe("due yesterday");
   });
 
-  it("clamps to at least one day", () => {
-    expect(formatRelativeDueAge(today, today)).toBe("due yesterday");
+  it("defensively clamps a same-calendar-day anchor to 'due yesterday'", () => {
+    // Callers only pass anchors strictly before today, so a same-day anchor
+    // is out of contract; the clamp guarantees we never render "due 0d ago".
+    expect(formatRelativeDueAge(localDay(2026, 6, 29, 8), today)).toBe(
+      "due yesterday",
+    );
   });
 
   it("rounds correctly across a DST-length day", () => {

--- a/src/lib/actions/__tests__/dates.test.ts
+++ b/src/lib/actions/__tests__/dates.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { formatRelativeDueAge } from "../dates";
+
+// Local-time dates on purpose: the util mirrors the partition's local-day math.
+function localDay(y: number, m: number, d: number, h = 12): Date {
+  return new Date(y, m - 1, d, h, 0, 0, 0);
+}
+
+describe("formatRelativeDueAge", () => {
+  const today = localDay(2026, 6, 29);
+
+  it("says 'due yesterday' for a one-day-old anchor", () => {
+    expect(formatRelativeDueAge(localDay(2026, 6, 28), today)).toBe(
+      "due yesterday",
+    );
+  });
+
+  it("counts whole days for older anchors", () => {
+    expect(formatRelativeDueAge(localDay(2026, 6, 24), today)).toBe(
+      "due 5d ago",
+    );
+  });
+
+  it("ignores time-of-day — compares calendar days only", () => {
+    expect(
+      formatRelativeDueAge(localDay(2026, 6, 28, 23), localDay(2026, 6, 29, 1)),
+    ).toBe("due yesterday");
+  });
+
+  it("clamps to at least one day", () => {
+    expect(formatRelativeDueAge(today, today)).toBe("due yesterday");
+  });
+
+  it("rounds correctly across a DST-length day", () => {
+    // Late March in most northern-hemisphere zones has a 23-hour day; the
+    // day-normalized diff + Math.round keeps this at exactly 7 days.
+    expect(formatRelativeDueAge(localDay(2026, 3, 22), localDay(2026, 3, 29))).toBe(
+      "due 7d ago",
+    );
+  });
+});

--- a/src/lib/actions/__tests__/partition.test.ts
+++ b/src/lib/actions/__tests__/partition.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { partitionActions, type PartitionableAction } from "../partition";
+import {
+  overdueAnchor,
+  partitionActions,
+  type PartitionableAction,
+} from "../partition";
 
 // A fixed "today" so the suite is deterministic regardless of the wall clock.
 const TODAY = new Date("2026-06-29T09:00:00.000Z");
@@ -127,6 +131,86 @@ describe("partitionActions", () => {
     expect(todays.map((x) => x.id)).toEqual(["a", "b", "c"]);
   });
 
+  it("buckets an unscheduled past-due action into `overdue` (regression: used to vanish)", () => {
+    const bare = action({ id: "bare", dueDate: at("2026-06-28") });
+    const projected = action({
+      id: "projected",
+      dueDate: at("2026-06-25"),
+      projectId: "proj-1",
+    });
+
+    const { overdue, todays, inbox, upcoming } = partitionActions(
+      [bare, projected],
+      { today: TODAY },
+    );
+
+    expect(overdue.map((x) => x.id).sort()).toEqual(["bare", "projected"]);
+    expect([...todays, ...inbox, ...upcoming]).toHaveLength(0);
+  });
+
+  it("does NOT put an unscheduled past-due/no-project action into `inbox`", () => {
+    const a = action({ id: "late-loose", dueDate: at("2026-06-20") });
+    const { overdue, inbox } = partitionActions([a], { today: TODAY });
+    expect(overdue.map((x) => x.id)).toEqual(["late-loose"]);
+    expect(inbox).toHaveLength(0);
+  });
+
+  it("schedule wins over a past due date: scheduled today → `todays`", () => {
+    const a = action({
+      id: "rescued",
+      scheduledStart: at("2026-06-29", "10:00:00.000Z"),
+      dueDate: at("2026-06-25"),
+    });
+    const { todays, overdue } = partitionActions([a], { today: TODAY });
+    expect(todays.map((x) => x.id)).toEqual(["rescued"]);
+    expect(overdue).toHaveLength(0);
+  });
+
+  it("schedule wins over a past due date: scheduled future → `upcoming`", () => {
+    const a = action({
+      id: "deferred",
+      scheduledStart: at("2026-07-05"),
+      dueDate: at("2026-06-25"),
+    });
+    const { upcoming, overdue } = partitionActions([a], { today: TODAY });
+    expect(upcoming.map((x) => x.id)).toEqual(["deferred"]);
+    expect(overdue).toHaveLength(0);
+  });
+
+  it("sorts `overdue` by priority first, then oldest anchor, then id", () => {
+    const oldQuick = action({ id: "z-old", priority: "Quick", dueDate: at("2026-06-20") });
+    const newQuick = action({ id: "a-new", priority: "Quick", dueDate: at("2026-06-28") });
+    const newP1 = action({ id: "p1", priority: "1st Priority", scheduledStart: at("2026-06-28") });
+
+    const { overdue } = partitionActions([newQuick, oldQuick, newP1], {
+      today: TODAY,
+    });
+    // Priority beats age; within equal priority the oldest debt surfaces first.
+    expect(overdue.map((x) => x.id)).toEqual(["p1", "z-old", "a-new"]);
+  });
+
+  it("fills `completedToday` with today's completions only; `completed` keeps history", () => {
+    const thisMorning = action({
+      id: "fresh",
+      status: "COMPLETED",
+      completedAt: at("2026-06-29"),
+    });
+    const yesterday = action({
+      id: "stale",
+      status: "COMPLETED",
+      completedAt: at("2026-06-28"),
+    });
+    const unknown = action({ id: "unknown", status: "COMPLETED", completedAt: null });
+
+    const { completed, completedToday } = partitionActions(
+      [thisMorning, yesterday, unknown],
+      { today: TODAY },
+    );
+
+    expect(completedToday.map((x) => x.id)).toEqual(["fresh"]);
+    expect(completed.map((x) => x.id).sort()).toEqual(["fresh", "stale", "unknown"]);
+  });
+
   it("does not read the wall clock — same input + same `today` is stable", () => {
     const set = [
       action({ id: "x", scheduledStart: at("2026-06-29", "14:24:00.000Z") }),
@@ -137,5 +221,30 @@ describe("partitionActions", () => {
     const second = partitionActions(set, { today: TODAY });
     expect(first.todays.map((a) => a.id)).toEqual(second.todays.map((a) => a.id));
     expect(first.inbox.map((a) => a.id)).toEqual(second.inbox.map((a) => a.id));
+  });
+});
+
+describe("overdueAnchor", () => {
+  it("uses the scheduled day when a schedule exists (even with a due date)", () => {
+    const anchor = overdueAnchor({
+      scheduledStart: at("2026-06-26"),
+      dueDate: at("2026-06-20"),
+    });
+    expect(anchor?.getDate()).toBe(new Date(at("2026-06-26")).getDate());
+  });
+
+  it("falls back to the due day when unscheduled", () => {
+    const anchor = overdueAnchor({ scheduledStart: null, dueDate: at("2026-06-20") });
+    expect(anchor?.getDate()).toBe(new Date(at("2026-06-20")).getDate());
+  });
+
+  it("returns null when neither date exists", () => {
+    expect(overdueAnchor({ scheduledStart: null, dueDate: null })).toBeNull();
+  });
+
+  it("normalizes to local start of day", () => {
+    const anchor = overdueAnchor({ scheduledStart: at("2026-06-26"), dueDate: null });
+    expect(anchor?.getHours()).toBe(0);
+    expect(anchor?.getMinutes()).toBe(0);
   });
 });

--- a/src/lib/actions/dates.ts
+++ b/src/lib/actions/dates.ts
@@ -47,6 +47,19 @@ export function formatHourMinute12(h: number): string {
   return `${disp}:${String(min).padStart(2, "0")} ${suffix}`;
 }
 
+// Relative age of an overdue item, e.g. "due yesterday" / "due 5d ago".
+// Day-normalized before diffing so DST 23/25-hour days round correctly;
+// clamps to 1 day since callers only pass anchors strictly before today.
+export function formatRelativeDueAge(anchor: Date, today: Date): string {
+  const MS_DAY = 86_400_000;
+  const a = new Date(anchor);
+  a.setHours(0, 0, 0, 0);
+  const t = new Date(today);
+  t.setHours(0, 0, 0, 0);
+  const days = Math.max(1, Math.round((t.getTime() - a.getTime()) / MS_DAY));
+  return days === 1 ? "due yesterday" : `due ${days}d ago`;
+}
+
 export function addDays(base: Date, n: number): Date {
   const d = new Date(base);
   d.setDate(d.getDate() + n);

--- a/src/lib/actions/partition.ts
+++ b/src/lib/actions/partition.ts
@@ -1,4 +1,4 @@
-import { sortByPriority } from "~/lib/actions/priority";
+import { comparePriorityRank, sortByPriority } from "~/lib/actions/priority";
 
 export interface ActionPartition<T> {
   overdue: T[];
@@ -6,6 +6,8 @@ export interface ActionPartition<T> {
   upcoming: T[];
   inbox: T[];
   completed: T[];
+  /** Subset of `completed` with `completedAt` within [today, tomorrow). */
+  completedToday: T[];
 }
 
 export interface PartitionableAction {
@@ -35,6 +37,20 @@ function addDays(base: Date, n: number): Date {
 }
 
 /**
+ * The calendar day that makes (or would make) an action late: the
+ * `scheduledStart` day when a schedule exists, else the `dueDate` day.
+ * Null when the action has neither. Mirrors the overdue rule's
+ * schedule-wins precedence so sort order and age labels agree.
+ */
+export function overdueAnchor(
+  a: Pick<PartitionableAction, "scheduledStart" | "dueDate">,
+): Date | null {
+  if (a.scheduledStart) return startOfDay(new Date(a.scheduledStart));
+  if (a.dueDate) return startOfDay(new Date(a.dueDate));
+  return null;
+}
+
+/**
  * Pure, server-shared partition of a user's actions into the `/today` buckets —
  * the single source of truth for "what counts as today" (ADR-0034).
  *
@@ -43,13 +59,16 @@ function addDays(base: Date, n: number): Date {
  *
  * The "today" definition here is **scheduled-or-due** (the `/today` set), which
  * is deliberately wider than the due-only **Daily brief** (`generateBriefingData`):
- *   - `overdue`   — `scheduledStart` before today
+ *   - `overdue`   — `scheduledStart` before today, OR no schedule and
+ *                   `dueDate` before today (schedule wins: a past-due action
+ *                   scheduled today/future is NOT overdue)
  *   - `todays`    — `scheduledStart` today, OR no schedule and `dueDate` today
  *                   (a scheduled-today action with no due date still counts —
  *                   the "Pay Malte" shape)
  *   - `upcoming`  — `scheduledStart` after tomorrow
  *   - `inbox`     — no schedule, no due date, no project
  *   - `completed` — status COMPLETED
+ *   - `completedToday` — subset of `completed` finished within [today, tomorrow)
  *
  * Only `ACTIVE` (and `COMPLETED`) actions are bucketed; any other status is
  * dropped. The function is pure: it does not read the clock — callers pass
@@ -80,7 +99,12 @@ export function partitionActions<T extends PartitionableAction>(
     const due = a.dueDate ? new Date(a.dueDate) : null;
     const dueDay = due ? startOfDay(due) : null;
 
-    if (scheduledDay && scheduledDay.getTime() < today.getTime()) {
+    const isOverdue =
+      (scheduledDay !== null && scheduledDay.getTime() < today.getTime()) ||
+      (scheduledDay === null &&
+        dueDay !== null &&
+        dueDay.getTime() < today.getTime());
+    if (isOverdue) {
       overdue.push(a);
       continue;
     }
@@ -111,7 +135,15 @@ export function partitionActions<T extends PartitionableAction>(
     }
   }
 
-  overdue.sort(sortByPriority);
+  // Overdue: priority first, then oldest debt first, then id.
+  overdue.sort((a, b) => {
+    const rank = comparePriorityRank(a, b);
+    if (rank !== 0) return rank;
+    const aAnchor = overdueAnchor(a)?.getTime() ?? Number.MAX_SAFE_INTEGER;
+    const bAnchor = overdueAnchor(b)?.getTime() ?? Number.MAX_SAFE_INTEGER;
+    if (aAnchor !== bAnchor) return aAnchor - bAnchor;
+    return a.id.localeCompare(b.id);
+  });
   todays.sort(sortByPriority);
   upcoming.sort(sortByPriority);
   inbox.sort(sortByPriority);
@@ -125,5 +157,11 @@ export function partitionActions<T extends PartitionableAction>(
     return new Date(bAt).getTime() - new Date(aAt).getTime();
   });
 
-  return { overdue, todays, upcoming, inbox, completed };
+  const completedToday = completed.filter((a) => {
+    if (!a.completedAt) return false;
+    const t = new Date(a.completedAt).getTime();
+    return t >= today.getTime() && t < tomorrow.getTime();
+  });
+
+  return { overdue, todays, upcoming, inbox, completed, completedToday };
 }

--- a/src/lib/actions/priority.ts
+++ b/src/lib/actions/priority.ts
@@ -18,14 +18,23 @@ export const PRIORITY_ORDER: Record<Priority, number> = {
   "Someday Maybe": 11,
 };
 
+// Rank comparison only — no tiebreaker. Callers compose their own.
+export function comparePriorityRank(
+  a: { priority?: string | null },
+  b: { priority?: string | null },
+): number {
+  const aRank = PRIORITY_ORDER[a.priority as Priority] ?? 999;
+  const bRank = PRIORITY_ORDER[b.priority as Priority] ?? 999;
+  return aRank - bRank;
+}
+
 // Stable sort: priority rank, then id tiebreaker.
 export function sortByPriority(
   a: { priority?: string | null; id: string },
   b: { priority?: string | null; id: string },
 ): number {
-  const aRank = PRIORITY_ORDER[a.priority as Priority] ?? 999;
-  const bRank = PRIORITY_ORDER[b.priority as Priority] ?? 999;
-  if (aRank !== bRank) return aRank - bRank;
+  const rank = comparePriorityRank(a, b);
+  if (rank !== 0) return rank;
   return a.id.localeCompare(b.id);
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -966,6 +966,7 @@
      red→orange→yellow→green→blue scale used in priorityCheckboxBorderVar. */
   --td-prio-urgent:     #E47A6F;
   --td-prio-urgent-dim: rgba(228, 122, 111, 0.55);
+  --td-prio-urgent-10:  rgba(228, 122, 111, 0.10);
 
   --td-prio-p1:         #E47A6F;
   --td-prio-p1-dim:     rgba(228, 122, 111, 0.55);


### PR DESCRIPTION
### **User description**
## Problem

The /today list rendered overdue and today's actions as one undifferentiated flat list (overdue rows only got a red accent), so users couldn't distinguish "what I must do today" from "what I've slipped on." Worse, `partitionActions` defined overdue as *past `scheduledStart` only* — an action due yesterday that was never time-blocked fell through every bucket and **didn't appear on /today at all**.

## Changes

**Partition (shared source of truth, ADR-0034 — also powers Zoe's `get-todays-actions`):**
- Overdue = past `scheduledStart`, OR unscheduled with a past `dueDate`. Schedule wins: a past-due action rescheduled to today/future is not nagged as overdue.
- Overdue sorted by priority, then oldest-debt-first (`overdueAnchor`), then id.
- New `completedToday` bucket; `completed` keeps full history for other views.

**Desktop (`TodayDesktopShell`):**
- Collapsible red **Overdue (n)** section with a **Reschedule all → Today** button (reuses `bulkReschedule` — sets `scheduledStart`, never pulls future due dates earlier, fires `markProcessedOverdue`).
- Overdue rows show relative age ("due 3d ago") and a hover **Today** one-click reschedule.
- **Today (n)** section, then a collapsed **Completed (n)** showing only today's completions (desktop previously showed none).
- Bulk mode auto-expands Overdue so select-all can't silently include hidden rows; the header button hides while bulk mode is active.

**Mobile (`ActionsList` / `ActionRow` / `TodayLayout`):** same semantics — reschedule-all button beside the Overdue accordion control, relative ages, completed-today filter on the today view. The new `onRescheduleAllOverdue` prop is optional, so the other six `ActionsList` consumers are untouched.

## Behavior changes to be aware of

- **Other `ActionsList` views (project pages, etc.):** unscheduled past-due items now surface in their existing Overdue accordion instead of the main list — intended, they were previously easy to lose.
- **Zoe's `get-todays-actions`:** the overdue group now includes due-date-overdue items. Response shape unchanged (verified against `todaysActionRowSchema` in ../mastra).
- **First load:** users with a backlog of old unscheduled past-due actions will see them all in Overdue at once — honest, and the reschedule-all button is the escape hatch.

## Testing

- ~15 new unit tests: the vanishing past-due regression, schedule-wins precedence, overdue sort, `completedToday` filtering, `formatRelativeDueAge` (incl. DST-length day).
- Full unit suite passes (1266 tests), `tsc` clean, eslint clean on changed files.
- New color token `--td-prio-urgent-10` lives in the allowlisted `globals.css` scoped block; feature CSS uses `var()` only.

## Follow-up (out of scope)

Per-row `handleReschedule` sets `dueDate` unconditionally (can pull a future due date earlier), unlike `bulkReschedule` — pre-existing inconsistency worth its own ticket.

No migrations — fast-track eligible.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Split `/today` into collapsible Overdue, Today, and Completed sections on desktop and mobile

- Fixed bug where unscheduled past-due actions vanished from `/today` (overdue now includes no-schedule + past `dueDate`)

- Added `completedToday` bucket, relative age labels ("due 3d ago"), and "Reschedule all → Today" bulk action

- Added regression tests for partition logic and `formatRelativeDueAge` utility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["partitionActions()"] -- "widened overdue rule" --> B["overdue bucket"]
  A -- "new bucket" --> C["completedToday bucket"]
  B -- "overdueAnchor()" --> D["formatRelativeDueAge()"]
  D -- "relative age label" --> E["TaskRow / ActionRow"]
  B -- "ids" --> F["handleRescheduleAllOverdue()"]
  F -- "bulkReschedule" --> G["TodayDesktopShell / TodayLayout"]
  C -- "today only" --> H["Completed section (collapsed)"]
  B -- "collapsible section" --> I["Overdue section (red)"]
  A -- "unchanged" --> J["Today section"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>partition.ts</strong><dd><code>Widen overdue rule, add completedToday bucket and overdueAnchor helper</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-e5521fa3900ec832c7cfe62b2fddb56b86fd920941be52cb96620b199d937121">+43/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>priority.ts</strong><dd><code>Extract comparePriorityRank for composable sort ordering</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-78b2765c1ffbe58200568e8bed97953c35332a4eacec7f0b36cae9ccd5103f2b">+12/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dates.ts</strong><dd><code>Add formatRelativeDueAge utility for overdue age labels</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-4afaf1a7cee6286498ee9e58baf618808de3fe9de2be3ec2db820550e9c6fc32">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TodayDesktopShell.tsx</strong><dd><code>Add collapsible Overdue/Today/Completed sections with reschedule-all</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-00486f261f8e0fa50280355f8c7d48001ae5e904fdd67d21ce7ba20060bec597">+149/-23</a></td>

</tr>

<tr>
  <td><strong>TaskRow.tsx</strong><dd><code>Show relative age and hover Today quick-reschedule on overdue rows</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-0c5b98153957c60a3d9c518f75ad63fbe874d5e0741018e0349b65f6a1f91ffe">+31/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>today-desktop.css</strong><dd><code>Add section header, overdue count badge, and quick-reschedule button </code><br><code>styles</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-45f4d56a944c3cacf41abd758375ac279636bccf7bd58d4d3d52ed7eabbf093d">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ActionsList.tsx</strong><dd><code>Add Reschedule-all button in Overdue header and completedToday filter</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-421c3045e20e6c8cad751d595980fd1ce1e98e8feb588cbdfd382e05d991903f">+42/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TodayLayout.tsx</strong><dd><code>Wire handleRescheduleAllOverdue into mobile ActionsList</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-ffdca587fa3ac939e4a439640e3c03dd4382f179fffeb9d85b63295aa06db50d">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ActionRow.tsx</strong><dd><code>Support overdueLabel prop to show relative age on overdue rows</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-c2bc2eff6e38933ed731df45c13cc1b526df6faf85818bec4ef7ece32ae966f3">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>partition.test.ts</strong><dd><code>Add regression tests for overdue, completedToday, and overdueAnchor</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-b06a6d01433a48830e17b6133dd49ae4bab5a69edd20292862310f8bef48f85f">+110/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dates.test.ts</strong><dd><code>Add test suite for formatRelativeDueAge including DST edge cases</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-8a224a6dcdd6063b2d53c67463ab7bb108e9fa4cf9310094eb8581ca05f2227e">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>globals.css</strong><dd><code>Add --td-prio-urgent-10 CSS variable for overdue tint backgrounds</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-dd438e7ca4da8a47a35709920a07b6fef918609c1daa40f6e9b794ddfd3e4996">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0034-todays-actions-shared-partition.md</strong><dd><code>Document overdue bucket widening and completedToday addition</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/344/files#diff-9d5c9c274ec1ecd06ecdfdeb80b913a426cd55f7564ddbbf5b15bcd2515c3350">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

