### PR TITLE
fix(editor): serialize autosaves so a tab cannot conflict with itself

### DIFF
--- a/src/app/_components/shared/RichDocEditor.tsx
+++ b/src/app/_components/shared/RichDocEditor.tsx
@@ -11,6 +11,7 @@ import { notifications } from "@mantine/notifications";
 import { buildPrdExtensions } from "~/lib/prd/extensions";
 import { SlashCommand, type SlashCommandItem } from "~/lib/prd/slash-command";
 import { markdownToDoc, EMPTY_DOC, isDocEmpty } from "~/lib/prd/codec";
+import { createSaveQueue } from "~/lib/prd/save-queue";
 import { PageLinkWithView } from "./PageLinkView";
 import "@mantine/tiptap/styles.css";
 
@@ -201,12 +202,20 @@ export function RichDocEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialDoc, initialMarkdown]);
 
-  // Latest save fn behind a ref so the editor's onUpdate closure never goes stale.
-  const saveRef = useRef<(editor: Editor) => Promise<void>>(() =>
-    Promise.resolve(),
-  );
-  saveRef.current = (editor: Editor) => {
+  // Serialized JSON of the last content persisted (or loaded), so no-op
+  // triggers like a plain blur don't fire a save at all.
+  const lastSavedRef = useRef<string | null>(null);
+
+  // Latest save fn behind a ref so the queue's closure never goes stale. It
+  // reads the editor, content and version base at execution time, and never
+  // rejects (the conflict modal handles the error) — the queue relies on that.
+  const saveRef = useRef<() => Promise<void>>(() => Promise.resolve());
+  saveRef.current = () => {
+    const editor = editorRef.current;
+    if (!editor || editor.isDestroyed) return Promise.resolve();
     const json = editor.getJSON();
+    const serialized = JSON.stringify(json);
+    if (serialized === lastSavedRef.current) return Promise.resolve();
     const markdown = (
       editor.storage.markdown as { getMarkdown: () => string }
     ).getMarkdown();
@@ -215,6 +224,7 @@ export function RichDocEditor({
         if (res && typeof res.docVersion === "number") {
           versionRef.current = res.docVersion;
         }
+        lastSavedRef.current = serialized;
       })
       .catch((err: { data?: { code?: string } }) => {
         if (err?.data?.code === "CONFLICT" && !conflictShown.current) {
@@ -237,9 +247,16 @@ export function RichDocEditor({
       });
   };
 
+  // All triggers (typing debounce, blur, flush) funnel through one queue so
+  // saves never overlap — an overlapping save would reuse the base version of
+  // the one in flight and trip the server's stale-write guard as a phantom
+  // conflict from this same tab.
+  const saveQueueRef = useRef(createSaveQueue(() => saveRef.current()));
+  const requestSave = () => void saveQueueRef.current.request();
+
   const flushSave = async () => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    if (editorRef.current) await saveRef.current(editorRef.current);
+    await saveQueueRef.current.request();
   };
   const editorRef = useRef<Editor | null>(null);
 
@@ -257,16 +274,16 @@ export function RichDocEditor({
     ],
     content: doc ?? "",
     immediatelyRender: false,
-    onUpdate: ({ editor: e }) => {
+    onUpdate: () => {
       onDocUpdate?.();
       if (!editable) return;
       if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => void saveRef.current(e), 1000);
+      debounceRef.current = setTimeout(requestSave, 1000);
     },
-    onBlur: ({ editor: e }) => {
+    onBlur: () => {
       if (!editable) return;
       if (debounceRef.current) clearTimeout(debounceRef.current);
-      void saveRef.current(e);
+      requestSave();
     },
     editorProps: {
       attributes: {
@@ -292,10 +309,14 @@ export function RichDocEditor({
   }, [editor]);
 
   // Load the resolved doc into the editor exactly once (never clobber edits).
+  // The dirty baseline is read back from the editor (not from `doc`) because
+  // Tiptap normalizes content on load — comparing against the raw input would
+  // make an unedited document look dirty.
   useEffect(() => {
     if (editor && doc && !contentLoaded.current) {
       contentLoaded.current = true;
       editor.commands.setContent(doc);
+      lastSavedRef.current = JSON.stringify(editor.getJSON());
     }
   }, [editor, doc]);
 

--- a/src/lib/prd/__tests__/save-queue.test.ts
+++ b/src/lib/prd/__tests__/save-queue.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { createSaveQueue } from "../save-queue";
+
+/** A run whose completion the test controls. */
+function controllableRun() {
+  const resolvers: Array<() => void> = [];
+  const events: string[] = [];
+  let running = 0;
+  let maxConcurrent = 0;
+  let calls = 0;
+  const run = () => {
+    calls += 1;
+    running += 1;
+    maxConcurrent = Math.max(maxConcurrent, running);
+    events.push(`start ${calls}`);
+    const n = calls;
+    return new Promise<void>((resolve) => {
+      resolvers.push(() => {
+        running -= 1;
+        events.push(`end ${n}`);
+        resolve();
+      });
+    });
+  };
+  const finishNext = async () => {
+    resolvers.shift()?.();
+    // Let the chained .then continuations flush.
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+  return {
+    run,
+    finishNext,
+    events,
+    get calls() {
+      return calls;
+    },
+    get maxConcurrent() {
+      return maxConcurrent;
+    },
+  };
+}
+
+describe("createSaveQueue", () => {
+  it("never runs two saves concurrently", async () => {
+    const ctl = controllableRun();
+    const queue = createSaveQueue(ctl.run);
+
+    void queue.request();
+    await Promise.resolve(); // first run starts
+    void queue.request(); // requested while the first is in flight
+
+    // Second request waits for the first, even though the first is in flight.
+    expect(ctl.calls).toBe(1);
+    await ctl.finishNext();
+    expect(ctl.calls).toBe(2);
+    await ctl.finishNext();
+    expect(ctl.maxConcurrent).toBe(1);
+    expect(ctl.events).toEqual(["start 1", "end 1", "start 2", "end 2"]);
+  });
+
+  it("coalesces requests made while a run is queued", async () => {
+    const ctl = controllableRun();
+    const queue = createSaveQueue(ctl.run);
+
+    void queue.request(); // starts running
+    await Promise.resolve();
+    void queue.request(); // queued behind it
+    void queue.request(); // coalesces into the queued run
+    void queue.request(); // coalesces too
+
+    await ctl.finishNext();
+    await ctl.finishNext();
+    await queue.flush();
+    expect(ctl.calls).toBe(2);
+  });
+
+  it("flush resolves only after all queued runs settle", async () => {
+    const ctl = controllableRun();
+    const queue = createSaveQueue(ctl.run);
+
+    void queue.request();
+    await Promise.resolve();
+    void queue.request();
+
+    let flushed = false;
+    void queue.flush().then(() => {
+      flushed = true;
+    });
+
+    await ctl.finishNext();
+    expect(flushed).toBe(false); // second run still in flight
+    await ctl.finishNext();
+    await Promise.resolve();
+    expect(flushed).toBe(true);
+  });
+
+  it("a slow in-flight run holds back a later request", async () => {
+    const ctl = controllableRun();
+    const queue = createSaveQueue(ctl.run);
+
+    void queue.request();
+    await Promise.resolve();
+    void queue.request();
+
+    // First run stays pending across several ticks — the second must not start.
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(ctl.calls).toBe(1);
+
+    await ctl.finishNext();
+    expect(ctl.calls).toBe(2);
+    await ctl.finishNext();
+  });
+
+  it("keeps accepting requests after previous runs complete", async () => {
+    const ctl = controllableRun();
+    const queue = createSaveQueue(ctl.run);
+
+    void queue.request();
+    await ctl.finishNext();
+    expect(ctl.calls).toBe(1);
+
+    void queue.request();
+    await ctl.finishNext();
+    expect(ctl.calls).toBe(2);
+  });
+});

--- a/src/lib/prd/save-queue.ts
+++ b/src/lib/prd/save-queue.ts
@@ -1,0 +1,40 @@
+/**
+ * Save queue — serializes autosaves so a tab can never race itself (ADR-0024).
+ *
+ * The rich-doc editor fires saves from several triggers (typing debounce, blur,
+ * explicit flush). Without serialization, two overlapping requests both carry
+ * the `docVersion` read before either landed, and the server's stale-write
+ * guard rejects the second as a CONFLICT — a phantom "someone else edited"
+ * dialog with only one tab open.
+ *
+ * `request()` runs `run` after every previously queued run has settled, so it
+ * reads fresh state (current doc, current version) when it actually executes.
+ * Requests made while a run is already queued coalesce into that single
+ * trailing run. `flush()` resolves once everything queued so far has settled.
+ *
+ * `run` must never reject — the editor's save fn catches its own errors (the
+ * conflict modal handles them). A rejection would poison the chain.
+ */
+export interface SaveQueue {
+  /** Queue a run after any in-flight one; coalesces with an already-queued run. */
+  request: () => Promise<void>;
+  /** Resolves once all runs queued so far have settled. */
+  flush: () => Promise<void>;
+}
+
+export function createSaveQueue(run: () => Promise<void>): SaveQueue {
+  let chain: Promise<void> = Promise.resolve();
+  let queued = false;
+
+  const request = (): Promise<void> => {
+    if (queued) return chain;
+    queued = true;
+    chain = chain.then(() => {
+      queued = false;
+      return run();
+    });
+    return chain;
+  };
+
+  return { request, flush: () => chain };
+}


### PR DESCRIPTION
### **User description**
## What

- Fixes the intermittent spurious **"This page changed / Someone else saved a newer version"** dialog that appeared with only one tab open.
- Root cause: autosaves fired from three uncoordinated triggers (typing debounce, blur, `flushSave`), each capturing `baseVersion` at call time. A save still in flight plus a second trigger sent two writes with the same base version, and the server's stale-write guard correctly rejected the second as `CONFLICT` — blaming a phantom "someone else".
- Fix: route all triggers through a serializing save queue (`src/lib/prd/save-queue.ts`) that reads fresh content + version when each save actually executes, and skip saves when the doc is unchanged since the last persisted state (a plain blur no longer hits the network).
- Applies to both Knowledge Pages and the Feature PRD editor (shared `RichDocEditor` engine). Real cross-tab conflicts still show the dialog.
- Adds unit tests for the queue (no-concurrency, coalescing, flush ordering).

## Why

Editing a page intermittently raised the conflict-reload dialog "for no reason", risking lost work if the user picked Reload.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Introduces a serializing save queue to prevent phantom conflict dialogs

- Routes all save triggers (debounce, blur, flush) through `SaveQueue` to avoid overlapping writes

- Adds `lastSavedRef` to skip no-op saves when content is unchanged since last persist

- Adds unit tests for the new `save-queue` module covering concurrency, coalescing, and flush


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Typing debounce"]
  B["Blur event"]
  C["flushSave()"]
  D["SaveQueue\n(save-queue.ts)"]
  E["saveRef.current()\n(reads fresh state)"]
  F["onSave API call\n(with current version)"]
  G["lastSavedRef\n(skip no-op saves)"]

  A -- "requestSave()" --> D
  B -- "requestSave()" --> D
  C -- "queue.request()" --> D
  D -- "serialized execution" --> E
  E -- "check unchanged" --> G
  E -- "changed content" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>save-queue.ts</strong><dd><code>New serializing save queue to prevent concurrent autosaves</code></dd></summary>
<hr>

src/lib/prd/save-queue.ts

<ul><li>New module implementing a serializing <code>SaveQueue</code> interface<br> <li> <code>request()</code> queues a run after any in-flight one, coalescing multiple <br>pending requests into one<br> <li> <code>flush()</code> resolves once all queued runs have settled<br> <li> Documents that <code>run</code> must never reject to avoid poisoning the chain</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/345/files#diff-ed08dd56393437830e4122be8767ccce673f6093208a20142910392c0c1c9727">+40/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RichDocEditor.tsx</strong><dd><code>Route all editor save triggers through serializing queue</code>&nbsp; </dd></summary>
<hr>

src/app/_components/shared/RichDocEditor.tsx

<ul><li>Imports and instantiates <code>createSaveQueue</code>, routing all save triggers <br>through it<br> <li> Adds <code>lastSavedRef</code> to track last persisted content and skip unchanged <br>saves<br> <li> Changes <code>saveRef.current</code> to read editor state at execution time (not at <br>call time)<br> <li> Updates <code>onUpdate</code>, <code>onBlur</code>, and <code>flushSave</code> to use the queue via <br><code>requestSave()</code><br> <li> Sets <code>lastSavedRef</code> baseline after initial content load using normalized <br>editor JSON</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/345/files#diff-94ac9cac79aa08ce267f273a39bca6d43488b86f079813d3132a5a8770c18913">+31/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>save-queue.test.ts</strong><dd><code>Unit tests for save queue concurrency and coalescing behavior</code></dd></summary>
<hr>

src/lib/prd/__tests__/save-queue.test.ts

<ul><li>New test file with 5 unit tests for <code>createSaveQueue</code><br> <li> Tests cover: no concurrency, coalescing, flush ordering, slow <br>in-flight blocking, and re-use after completion<br> <li> Uses a <code>controllableRun</code> helper to manually resolve async runs and <br>inspect event ordering</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/345/files#diff-e700c7f3af39fc0bf68d63e592b5073b4b7bf579d558008ac87f8187a8863f7b">+127/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

