### PR TITLE
feat(pages): resolve page links on public pages + publish linked pages

### DIFF
--- a/docs/adr/0038-page-public-publishing.md
+++ b/docs/adr/0038-page-public-publishing.md
@@ -36,3 +36,10 @@ Publishing also cuts across the ADR-0033 visibility model — a Page inheriting 
 - New public route group with its own root layout at `/p/[slugId]`; the first place the app serves authored workspace content unauthenticated.
 - `page.publish` / `page.unpublish` / `page.updatePublicSettings` / `page.duplicate` mutations.
 - Sub-pages (deferred by ADR-0033) remain compatible by construction: URLs are flat, publishing is per-page, so a tree adds navigation (breadcrumbs/child links rendered only when the target is itself published) without touching this scheme.
+
+## Amendment — linked-page resolution and batch publish (2026-07-06)
+
+The `/page` slash command created soft sub-pages (`pageLink` nodes), realising the deferred case above. Two additions, both preserving "publishing is an explicit per-page act":
+
+- **Render-time link resolution**: the public route resolves each `pageLink` target per request (the route is already `force-dynamic`). A **published** target renders as a link to its public URL with its live title; an unpublished/deleted target renders as plain title text (no page id or workspace path leaks). Publish order is irrelevant — links go live/dead the moment the target's publish state changes.
+- **Consent-preserving batch publish**: the share popover lists the transitively linked pages that are not yet public (workspace-scoped BFS over `pageLink` graphs, cycle-safe, capped at 50) and offers one action to publish them (`page.publishMany`, ids explicit, edit-gated per page). Nothing is ever published implicitly; **unpublish never cascades** — a linked page may be linked from elsewhere or shared directly.

--- a/src/app/(published)/p/[slugId]/page.tsx
+++ b/src/app/(published)/p/[slugId]/page.tsx
@@ -11,6 +11,10 @@ import {
   buildPublicPagePath,
   parsePublicPageParam,
 } from "~/lib/pages/public-url";
+import {
+  collectPageLinkIds,
+  type PublicPageLinkMap,
+} from "~/lib/pages/public-doc";
 import { renderPublicPageHtml } from "~/server/services/pages/public-html";
 import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
 import { PublicThemeToggle } from "./_components/PublicThemeToggle";
@@ -39,6 +43,33 @@ const getPublishedPage = cache(async (param: string) => {
   if (!page) return null;
   return { page, requestSlug: parsed.slug };
 });
+
+/**
+ * Resolve the `pageLink` targets of a doc that are themselves published, so
+ * the render can link them to their public URLs with their live titles.
+ * Resolution happens per request — the route is `force-dynamic` — so links go
+ * live/dead the moment a target is published/unpublished, regardless of the
+ * order the pages were published in.
+ */
+async function resolvePublishedPageLinks(
+  bodyDoc: JSONContent,
+): Promise<PublicPageLinkMap> {
+  const ids = collectPageLinkIds(bodyDoc);
+  if (ids.length === 0) return new Map();
+  const targets = await db.knowledgePage.findMany({
+    where: { id: { in: ids }, isPublic: true, publicId: { not: null } },
+    select: { id: true, title: true, publicId: true, publicSlug: true },
+  });
+  return new Map(
+    targets.map((t) => [
+      t.id,
+      {
+        title: t.title,
+        href: buildPublicPagePath(t.publicSlug ?? "untitled", t.publicId!),
+      },
+    ]),
+  );
+}
 
 /** Plain-text excerpt of the Markdown projection for meta descriptions. */
 function excerpt(markdown: string | null): string | undefined {
@@ -102,7 +133,10 @@ export default async function PublishedPage({
   }
 
   const html = page.bodyDoc
-    ? renderPublicPageHtml(page.bodyDoc as JSONContent)
+    ? renderPublicPageHtml(
+        page.bodyDoc as JSONContent,
+        await resolvePublishedPageLinks(page.bodyDoc as JSONContent),
+      )
     : null;
 
   const updatedAt = new Intl.DateTimeFormat("en", {

--- a/src/app/_components/layout/WorkspaceTopbar.module.css
+++ b/src/app/_components/layout/WorkspaceTopbar.module.css
@@ -24,3 +24,16 @@
 .crumbSep {
   color: var(--color-text-muted);
 }
+
+.crumbLink {
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.crumbLink:hover {
+  color: var(--color-text-primary);
+}

--- a/src/app/_components/layout/WorkspaceTopbar.tsx
+++ b/src/app/_components/layout/WorkspaceTopbar.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { IconFolder } from '@tabler/icons-react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { api } from '~/trpc/react';
 import styles from './WorkspaceTopbar.module.css';
 
 const PAGE_LABELS: Record<string, string> = {
@@ -34,9 +36,27 @@ function getCurrentPageLabel(pathname: string, workspaceSlug: string): string {
   return PAGE_LABELS[segment] ?? segment.charAt(0).toUpperCase() + segment.slice(1);
 }
 
+/** Extract the page id when on a page-detail route (`/w/{slug}/pages/{id}`). */
+function getPageDetailId(pathname: string, workspaceSlug: string): string | null {
+  const prefix = `/w/${workspaceSlug}/`;
+  if (!pathname.startsWith(prefix)) return null;
+  const parts = pathname.slice(prefix.length).split('/');
+  return parts[0] === 'pages' && parts[1] ? parts[1] : null;
+}
+
 export function WorkspaceTopbar() {
   const { workspace, workspaceSlug } = useWorkspace();
   const pathname = usePathname();
+
+  const pageDetailId = workspaceSlug
+    ? getPageDetailId(pathname, workspaceSlug)
+    : null;
+
+  // Reverse-lookup the linking ("parent") page, only on a page-detail route.
+  const { data: parent } = api.page.parentCrumb.useQuery(
+    { id: pageDetailId ?? '' },
+    { enabled: !!pageDetailId },
+  );
 
   if (!workspace || !workspaceSlug) return null;
 
@@ -50,7 +70,24 @@ export function WorkspaceTopbar() {
         {pageLabel && (
           <>
             <span className={styles.crumbSep}>/</span>
-            <span>{pageLabel}</span>
+            {pageDetailId ? (
+              <Link href={`/w/${workspaceSlug}/pages`} className={styles.crumbLink}>
+                {pageLabel}
+              </Link>
+            ) : (
+              <span>{pageLabel}</span>
+            )}
+          </>
+        )}
+        {parent && (
+          <>
+            <span className={styles.crumbSep}>/</span>
+            <Link
+              href={`/w/${workspaceSlug}/pages/${parent.id}`}
+              className={styles.crumbLink}
+            >
+              {parent.title}
+            </Link>
           </>
         )}
       </div>

--- a/src/app/_components/pages/PageShareMenu.tsx
+++ b/src/app/_components/pages/PageShareMenu.tsx
@@ -7,6 +7,7 @@ import {
   Anchor,
   Button,
   CopyButton,
+  Divider,
   Group,
   Menu,
   Popover,
@@ -73,6 +74,20 @@ export function PageShareMenu({
   const updateSettings = api.page.updatePublicSettings.useMutation({
     onSettled,
     onError: (e) => onError(e, "Could not update public settings"),
+  });
+  // Linked pages that aren't public yet — their links render as plain text on
+  // the public page. Listed here so publishing them stays an explicit act.
+  const linkedUnpublished = api.page.linkedUnpublished.useQuery(
+    { id: pageId },
+    { enabled: canEdit && isPublic },
+  );
+  const linkedPages = linkedUnpublished.data ?? [];
+  const publishMany = api.page.publishMany.useMutation({
+    onSettled: () => {
+      void utils.page.linkedUnpublished.invalidate({ id: pageId });
+      void onSettled();
+    },
+    onError: (e) => onError(e, "Could not publish linked pages"),
   });
   const duplicate = api.page.duplicate.useMutation({
     onSuccess: (copy) => {
@@ -196,6 +211,44 @@ export function PageShareMenu({
                       })
                     }
                   />
+                  {linkedPages.length > 0 ? (
+                    <>
+                      <Divider />
+                      <Stack gap={6}>
+                        <Text size="sm" fw={500}>
+                          Linked pages not yet public
+                        </Text>
+                        <Text size="xs" className="text-text-muted">
+                          Links to these pages show as plain text on the
+                          public page until they are published too.
+                        </Text>
+                        {linkedPages.map((linked) => (
+                          <Text
+                            key={linked.id}
+                            size="xs"
+                            className="truncate text-text-secondary"
+                          >
+                            • {linked.title}
+                          </Text>
+                        ))}
+                        <Button
+                          size="xs"
+                          variant="light"
+                          loading={publishMany.isPending}
+                          onClick={() =>
+                            publishMany.mutate({
+                              ids: linkedPages.map((l) => l.id),
+                            })
+                          }
+                        >
+                          Publish{" "}
+                          {linkedPages.length === 1
+                            ? "1 linked page"
+                            : `${linkedPages.length} linked pages`}
+                        </Button>
+                      </Stack>
+                    </>
+                  ) : null}
                 </>
               ) : null}
             </Stack>

--- a/src/lib/pages/__tests__/public-doc.test.ts
+++ b/src/lib/pages/__tests__/public-doc.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { JSONContent } from "@tiptap/core";
 
-import { sanitizeDocForPublic } from "../public-doc";
+import { collectPageLinkIds, sanitizeDocForPublic } from "../public-doc";
 
 function doc(content: JSONContent[]): JSONContent {
   return { type: "doc", content };
@@ -122,6 +122,39 @@ describe("sanitizeDocForPublic", () => {
     });
   });
 
+  it("links page links whose target is published, with the live title", () => {
+    const input = doc([
+      {
+        type: "pageLink",
+        attrs: { pageId: "clx1", title: "Old title", href: "/w/acme/pages/clx1" },
+      },
+      {
+        type: "pageLink",
+        attrs: { pageId: "clx2", title: "Private", href: "/w/acme/pages/clx2" },
+      },
+    ]);
+    const out = sanitizeDocForPublic(
+      input,
+      new Map([["clx1", { title: "Live title", href: "/p/live-title-ab12cd34" }]]),
+    );
+    // Published target → paragraph linking to the public URL.
+    expect(out.content![0]).toEqual({
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Live title",
+          marks: [{ type: "link", attrs: { href: "/p/live-title-ab12cd34" } }],
+        },
+      ],
+    });
+    // Unpublished target → title-only node, no id/href leak.
+    expect(out.content![1]).toEqual({
+      type: "pageLink",
+      attrs: { title: "Private" },
+    });
+  });
+
   it("does not mutate the input document", () => {
     const input = doc([
       { type: "image", attrs: { src: "data:image/png;base64,AAAA" } },
@@ -129,5 +162,26 @@ describe("sanitizeDocForPublic", () => {
     const snapshot = JSON.parse(JSON.stringify(input)) as JSONContent;
     sanitizeDocForPublic(input);
     expect(input).toEqual(snapshot);
+  });
+});
+
+describe("collectPageLinkIds", () => {
+  it("collects distinct ids in document order, including nested nodes", () => {
+    const input = doc([
+      { type: "pageLink", attrs: { pageId: "b", title: "B" } },
+      {
+        type: "blockquote",
+        content: [{ type: "pageLink", attrs: { pageId: "a", title: "A" } }],
+      },
+      { type: "pageLink", attrs: { pageId: "b", title: "B again" } },
+      { type: "pageLink" },
+      { type: "paragraph", content: [{ type: "text", text: "no links" }] },
+    ]);
+    expect(collectPageLinkIds(input)).toEqual(["b", "a"]);
+  });
+
+  it("returns empty for empty or missing docs", () => {
+    expect(collectPageLinkIds(null)).toEqual([]);
+    expect(collectPageLinkIds(doc([]))).toEqual([]);
   });
 });

--- a/src/lib/pages/__tests__/public-doc.test.ts
+++ b/src/lib/pages/__tests__/public-doc.test.ts
@@ -155,6 +155,24 @@ describe("sanitizeDocForPublic", () => {
     });
   });
 
+  it("falls back to title-only when a resolved href is not app-relative", () => {
+    const input = doc([
+      {
+        type: "pageLink",
+        attrs: { pageId: "clx1", title: "Cached", href: "/w/acme/pages/clx1" },
+      },
+    ]);
+    const out = sanitizeDocForPublic(
+      input,
+      // A target whose href is somehow unsafe must never reach the HTML.
+      new Map([["clx1", { title: "Live", href: "javascript:alert(1)" }]]),
+    );
+    expect(out.content![0]).toEqual({
+      type: "pageLink",
+      attrs: { title: "Cached" },
+    });
+  });
+
   it("does not mutate the input document", () => {
     const input = doc([
       { type: "image", attrs: { src: "data:image/png;base64,AAAA" } },

--- a/src/lib/pages/public-doc.ts
+++ b/src/lib/pages/public-doc.ts
@@ -42,10 +42,12 @@ function sanitizeNode(
     const pageId = node.attrs?.pageId;
     const target =
       typeof pageId === "string" ? pageLinks.get(pageId) : undefined;
-    if (target) {
-      // The target is published — link to its public URL with the live title.
-      // Constructed here from trusted values, so it bypasses SAFE_LINK_HREF
-      // (the public path is app-relative, not http(s)).
+    // A published target with a safe app-relative href becomes a real link to
+    // its public URL with its live title. The href is built from trusted
+    // values (buildPublicPagePath always emits `/p/…`), but this is a public
+    // HTML render, so we still refuse anything that isn't an app-relative path
+    // — defense-in-depth against a `javascript:`/`data:` href slipping in.
+    if (target && target.href.startsWith("/")) {
       return {
         type: "paragraph",
         content: [
@@ -57,6 +59,8 @@ function sanitizeNode(
         ],
       };
     }
+    // Otherwise (unpublished / unknown / unsafe href): title-only text, with no
+    // page id or internal workspace path leaked.
     const title = node.attrs?.title;
     return {
       type: "pageLink",

--- a/src/lib/pages/public-doc.ts
+++ b/src/lib/pages/public-doc.ts
@@ -9,8 +9,11 @@ import type { JSONContent } from "@tiptap/core";
  *  - `image` nodes keep only http(s) srcs (drops `data:`/`javascript:`)
  *  - `comment` marks are internal collaboration artifacts and are stripped,
  *    matching the Markdown projection, which also drops them (ADR-0024)
- *  - `pageLink` nodes keep only the cached title — the target page id and
- *    internal workspace path are private and must not leak into public HTML
+ *  - `pageLink` nodes resolve through the caller-supplied map of **published**
+ *    targets: a published target becomes a plain paragraph linking to its
+ *    public URL (live title); an unpublished/unknown target keeps only the
+ *    cached title — the page id and internal workspace path are private and
+ *    must not leak into public HTML
  *
  * Pure and isomorphic — unit-testable without a DOM.
  */
@@ -18,13 +21,42 @@ import type { JSONContent } from "@tiptap/core";
 const SAFE_LINK_HREF = /^(?:https?:|mailto:)/i;
 const SAFE_IMAGE_SRC = /^https?:/i;
 
+/** A published pageLink target: its live title and public path (`/p/…`). */
+export interface PublicPageLinkTarget {
+  title: string;
+  href: string;
+}
+
+export type PublicPageLinkMap = ReadonlyMap<string, PublicPageLinkTarget>;
+
 function isSafeLinkMark(mark: { attrs?: Record<string, unknown> }): boolean {
   const href = mark.attrs?.href;
   return typeof href === "string" && SAFE_LINK_HREF.test(href.trim());
 }
 
-function sanitizeNode(node: JSONContent): JSONContent | null {
+function sanitizeNode(
+  node: JSONContent,
+  pageLinks: PublicPageLinkMap,
+): JSONContent | null {
   if (node.type === "pageLink") {
+    const pageId = node.attrs?.pageId;
+    const target =
+      typeof pageId === "string" ? pageLinks.get(pageId) : undefined;
+    if (target) {
+      // The target is published — link to its public URL with the live title.
+      // Constructed here from trusted values, so it bypasses SAFE_LINK_HREF
+      // (the public path is app-relative, not http(s)).
+      return {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: target.title || "Untitled",
+            marks: [{ type: "link", attrs: { href: target.href } }],
+          },
+        ],
+      };
+    }
     const title = node.attrs?.title;
     return {
       type: "pageLink",
@@ -46,7 +78,7 @@ function sanitizeNode(node: JSONContent): JSONContent | null {
   });
 
   const content = node.content
-    ?.map(sanitizeNode)
+    ?.map((child) => sanitizeNode(child, pageLinks))
     .filter((child): child is JSONContent => child !== null);
 
   return {
@@ -56,6 +88,35 @@ function sanitizeNode(node: JSONContent): JSONContent | null {
   };
 }
 
-export function sanitizeDocForPublic(doc: JSONContent): JSONContent {
-  return sanitizeNode(doc) ?? { type: "doc", content: [] };
+const NO_LINKS: PublicPageLinkMap = new Map();
+
+export function sanitizeDocForPublic(
+  doc: JSONContent,
+  pageLinks: PublicPageLinkMap = NO_LINKS,
+): JSONContent {
+  return sanitizeNode(doc, pageLinks) ?? { type: "doc", content: [] };
+}
+
+/**
+ * Collect the distinct page ids referenced by `pageLink` nodes in a document,
+ * in document order. Pure; used by the public render (to resolve published
+ * targets) and by the publish flow (to walk the linked-page graph).
+ */
+export function collectPageLinkIds(
+  doc: JSONContent | null | undefined,
+): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  const walk = (node: JSONContent) => {
+    if (node.type === "pageLink") {
+      const pageId = node.attrs?.pageId;
+      if (typeof pageId === "string" && pageId && !seen.has(pageId)) {
+        seen.add(pageId);
+        ids.push(pageId);
+      }
+    }
+    node.content?.forEach(walk);
+  };
+  if (doc) walk(doc);
+  return ids;
 }

--- a/src/server/api/routers/page.ts
+++ b/src/server/api/routers/page.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { randomInt } from "crypto";
+import type { JSONContent } from "@tiptap/core";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { Prisma, type PrismaClient } from "@prisma/client";
@@ -8,6 +9,7 @@ import {
   PUBLIC_ID_LENGTH,
   slugifyPageTitle,
 } from "~/lib/pages/public-url";
+import { collectPageLinkIds } from "~/lib/pages/public-doc";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 import { checkStaleWrite } from "~/lib/prd/stale-write";
 import { uploadToBlob } from "~/lib/blob";
@@ -136,6 +138,123 @@ function generatePublicId(): string {
     id += PUBLIC_ID_ALPHABET[randomInt(PUBLIC_ID_ALPHABET.length)];
   }
   return id;
+}
+
+/**
+ * The publish core (ADR-0038), shared by `publish` and `publishMany`. Callers
+ * must have already enforced edit access. First publish mints the immutable
+ * `publicId` and derives `publicSlug` from the title; republish reuses both,
+ * reviving old links.
+ */
+async function publishPage(db: PrismaClient, id: string) {
+  const existing = await db.knowledgePage.findUniqueOrThrow({
+    where: { id },
+    select: { title: true, publicId: true, publicSlug: true },
+  });
+
+  const publicSlug = existing.publicSlug ?? slugifyPageTitle(existing.title);
+
+  if (existing.publicId) {
+    return db.knowledgePage.update({
+      where: { id },
+      data: { isPublic: true, publicSlug, publishedAt: new Date() },
+      select: PUBLIC_SETTINGS_SELECT,
+    });
+  }
+
+  // Mint the id here rather than in the schema default so it only exists
+  // for pages that have actually been published. Retry on the (36^8)
+  // collision rather than pre-checking. `publicId: null` in the where
+  // guards against a concurrent first publish: the loser of that race
+  // must reuse the winner's id, never overwrite an id that may already
+  // have been shared.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      return await db.knowledgePage.update({
+        where: { id, AND: [{ publicId: null }] },
+        data: {
+          isPublic: true,
+          publicId: generatePublicId(),
+          publicSlug,
+          publishedAt: new Date(),
+        },
+        select: PUBLIC_SETTINGS_SELECT,
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        // P2002: minted id collided with another page's — remint.
+        if (error.code === "P2002") continue;
+        // P2025: a concurrent publish minted first — keep its id.
+        if (error.code === "P2025") {
+          return db.knowledgePage.update({
+            where: { id },
+            data: { isPublic: true, publishedAt: new Date() },
+            select: PUBLIC_SETTINGS_SELECT,
+          });
+        }
+      }
+      throw error;
+    }
+  }
+  throw new TRPCError({
+    code: "INTERNAL_SERVER_ERROR",
+    message: "Could not allocate a public URL. Please try again.",
+  });
+}
+
+/** Cap on the pageLink graph walk — keeps a pathological/cyclic doc bounded. */
+const LINKED_PAGES_LIMIT = 50;
+
+/**
+ * Walk the `pageLink` graph from a root page (BFS, cycle-safe, capped at
+ * {@link LINKED_PAGES_LIMIT}), returning the distinct reachable pages.
+ * Constrained to the root's workspace: `/page` only ever creates same-workspace
+ * links, and a pasted cross-workspace id must not leak another workspace's
+ * titles through this query.
+ */
+async function collectLinkedPages(
+  db: PrismaClient,
+  root: { id: string; workspaceId: string },
+  rootDoc: JSONContent | null,
+) {
+  const visited = new Set<string>([root.id]);
+  const linked: {
+    id: string;
+    title: string;
+    isPublic: boolean;
+    createdById: string;
+    projectId: string | null;
+    workspaceId: string;
+  }[] = [];
+  let frontier = collectPageLinkIds(rootDoc).filter((id) => !visited.has(id));
+
+  while (frontier.length > 0 && visited.size <= LINKED_PAGES_LIMIT) {
+    frontier.forEach((id) => visited.add(id));
+    const pages = await db.knowledgePage.findMany({
+      where: { id: { in: frontier }, workspaceId: root.workspaceId },
+      select: {
+        id: true,
+        title: true,
+        isPublic: true,
+        bodyDoc: true,
+        createdById: true,
+        projectId: true,
+        workspaceId: true,
+      },
+    });
+    const next: string[] = [];
+    for (const page of pages) {
+      const { bodyDoc, ...rest } = page;
+      linked.push(rest);
+      next.push(
+        ...collectPageLinkIds(bodyDoc as JSONContent | null).filter(
+          (id) => !visited.has(id),
+        ),
+      );
+    }
+    frontier = [...new Set(next)];
+  }
+  return linked;
 }
 
 export const pageRouter = createTRPCRouter({
@@ -433,61 +552,70 @@ export const pageRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const page = await loadPageForAccess(ctx.db, input.id);
       await ensurePageAccess(ctx.db, ctx.session.user.id, page, "edit");
+      return publishPage(ctx.db, input.id);
+    }),
 
-      const existing = await ctx.db.knowledgePage.findUniqueOrThrow({
+  /**
+   * The pages this page links to (via `pageLink` nodes, transitively) that are
+   * not yet published and that the caller could publish. The share popover
+   * lists them so publishing a sub-tree stays an explicit, visible act —
+   * ADR-0038's "publishing never follows from visibility rules" holds; this
+   * only extends the consent surface.
+   */
+  linkedUnpublished: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const page = await loadPageForAccess(ctx.db, input.id);
+      await ensurePageAccess(ctx.db, userId, page, "view");
+
+      const root = await ctx.db.knowledgePage.findUniqueOrThrow({
         where: { id: input.id },
-        select: { title: true, publicId: true, publicSlug: true },
+        select: { bodyDoc: true },
       });
+      const linked = await collectLinkedPages(
+        ctx.db,
+        page,
+        root.bodyDoc as JSONContent | null,
+      );
 
-      const publicSlug =
-        existing.publicSlug ?? slugifyPageTitle(existing.title);
-
-      if (existing.publicId) {
-        return ctx.db.knowledgePage.update({
-          where: { id: input.id },
-          data: { isPublic: true, publicSlug, publishedAt: new Date() },
-          select: PUBLIC_SETTINGS_SELECT,
-        });
-      }
-
-      // Mint the id here rather than in the schema default so it only exists
-      // for pages that have actually been published. Retry on the (36^8)
-      // collision rather than pre-checking. `publicId: null` in the where
-      // guards against a concurrent first publish: the loser of that race
-      // must reuse the winner's id, never overwrite an id that may already
-      // have been shared.
-      for (let attempt = 0; attempt < 5; attempt++) {
-        try {
-          return await ctx.db.knowledgePage.update({
-            where: { id: input.id, AND: [{ publicId: null }] },
-            data: {
-              isPublic: true,
-              publicId: generatePublicId(),
-              publicSlug,
-              publishedAt: new Date(),
-            },
-            select: PUBLIC_SETTINGS_SELECT,
-          });
-        } catch (error) {
-          if (error instanceof Prisma.PrismaClientKnownRequestError) {
-            // P2002: minted id collided with another page's — remint.
-            if (error.code === "P2002") continue;
-            // P2025: a concurrent publish minted first — keep its id.
-            if (error.code === "P2025") {
-              return ctx.db.knowledgePage.update({
-                where: { id: input.id },
-                data: { isPublic: true, publishedAt: new Date() },
-                select: PUBLIC_SETTINGS_SELECT,
-              });
-            }
-          }
-          throw error;
+      const publishable: { id: string; title: string }[] = [];
+      for (const candidate of linked) {
+        if (candidate.isPublic) continue;
+        const access = await getKnowledgePageAccess(ctx.db, userId, candidate);
+        if (canEditKnowledgePage(access)) {
+          publishable.push({ id: candidate.id, title: candidate.title });
         }
       }
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Could not allocate a public URL. Please try again.",
-      });
+      return publishable;
+    }),
+
+  /**
+   * Publish several pages at once — the share popover's "publish linked pages"
+   * action (typically the ids returned by `linkedUnpublished`). Each page is
+   * gated by the same edit check as `publish`; ids are explicit so the server
+   * never publishes anything the user didn't see listed.
+   */
+  publishMany: protectedProcedure
+    .input(
+      z.object({
+        ids: z.array(z.string()).min(1).max(LINKED_PAGES_LIMIT),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const ids = [...new Set(input.ids)];
+      // Gate every page before publishing any, so a mid-list FORBIDDEN can't
+      // leave a half-published batch.
+      for (const id of ids) {
+        const page = await loadPageForAccess(ctx.db, id);
+        await ensurePageAccess(ctx.db, userId, page, "edit");
+      }
+      const results = [];
+      for (const id of ids) {
+        results.push(await publishPage(ctx.db, id));
+      }
+      return results;
     }),
 
   /** Unpublish → the public URL 404s immediately. `publicId`/`publicSlug` are

--- a/src/server/api/routers/page.ts
+++ b/src/server/api/routers/page.ts
@@ -346,11 +346,16 @@ export const pageRouter = createTRPCRouter({
       const page = await loadPageForAccess(ctx.db, input.id);
       await ensurePageAccess(ctx.db, userId, page, "view");
 
+      // Escape LIKE wildcards (`%` `_` `\`) so a pathological id can't broaden
+      // the pre-filter into a full-workspace scan. Postgres LIKE treats `\` as
+      // the escape char by default, so `\%`/`\_`/`\\` match those literals.
+      // (Titles still can't leak: every candidate is view-gated below.)
+      const likePattern = `%${input.id.replace(/[\\%_]/g, "\\$&")}%`;
       const rows = await ctx.db.$queryRaw<{ id: string }[]>`
         SELECT "id" FROM "KnowledgePage"
         WHERE "workspaceId" = ${page.workspaceId}
           AND "id" <> ${input.id}
-          AND "bodyDoc"::text LIKE ${`%${input.id}%`}
+          AND "bodyDoc"::text LIKE ${likePattern}
         ORDER BY "updatedAt" DESC
         LIMIT 20
       `;
@@ -659,8 +664,15 @@ export const pageRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
       const ids = [...new Set(input.ids)];
-      // Gate every page before publishing any, so a mid-list FORBIDDEN can't
-      // leave a half-published batch.
+      // Pre-flight: require edit access on *every* page before publishing any,
+      // so "you can't publish X" rejects the whole request up front instead of
+      // after publishing some of the batch. This is not a transaction —
+      // publishPage's mint-collision retry must survive a unique violation,
+      // which would abort a Postgres tx — so a rare failure mid-loop leaves a
+      // partial batch. That's safe: publishing is idempotent, so the caller can
+      // simply retry. (The permission window between check and publish is
+      // sub-second and low-impact: at worst a page the user could edit moments
+      // ago gets published.)
       for (const id of ids) {
         const page = await loadPageForAccess(ctx.db, id);
         await ensurePageAccess(ctx.db, userId, page, "edit");

--- a/src/server/api/routers/page.ts
+++ b/src/server/api/routers/page.ts
@@ -329,6 +329,60 @@ export const pageRouter = createTRPCRouter({
       return { ...page, canEdit: canEditKnowledgePage(access) };
     }),
 
+  /**
+   * The "parent" of a page for breadcrumbs: a page whose body links to this
+   * one via a `pageLink` node. Sub-pages are soft — there is no stored parent
+   * pointer (ADR-0033/0038) — so this is a reverse lookup: scan same-workspace
+   * pages whose serialized `bodyDoc` mentions this id (cheap `::text` LIKE
+   * pre-filter), then confirm with {@link collectPageLinkIds} to reject
+   * incidental text matches, and gate on the caller's view access. A page can
+   * have several linkers; the newest-edited viewable one wins. Returns null
+   * when the page is top-level or has no viewable linker.
+   */
+  parentCrumb: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const page = await loadPageForAccess(ctx.db, input.id);
+      await ensurePageAccess(ctx.db, userId, page, "view");
+
+      const rows = await ctx.db.$queryRaw<{ id: string }[]>`
+        SELECT "id" FROM "KnowledgePage"
+        WHERE "workspaceId" = ${page.workspaceId}
+          AND "id" <> ${input.id}
+          AND "bodyDoc"::text LIKE ${`%${input.id}%`}
+        ORDER BY "updatedAt" DESC
+        LIMIT 20
+      `;
+      if (rows.length === 0) return null;
+
+      const candidates = await ctx.db.knowledgePage.findMany({
+        where: { id: { in: rows.map((r) => r.id) } },
+        select: {
+          id: true,
+          title: true,
+          bodyDoc: true,
+          createdById: true,
+          projectId: true,
+          workspaceId: true,
+        },
+      });
+      const byId = new Map(candidates.map((c) => [c.id, c]));
+
+      // Preserve the raw query's newest-edited-first order.
+      for (const { id } of rows) {
+        const candidate = byId.get(id);
+        if (!candidate) continue;
+        const links = collectPageLinkIds(candidate.bodyDoc as JSONContent | null);
+        if (!links.includes(input.id)) continue;
+        const access = await getKnowledgePageAccess(ctx.db, userId, candidate);
+        if (canViewKnowledgePage(access)) {
+          return { id: candidate.id, title: candidate.title };
+        }
+      }
+      return null;
+    }),
+
   create: protectedProcedure
     .input(
       z.object({

--- a/src/server/services/pages/public-html.ts
+++ b/src/server/services/pages/public-html.ts
@@ -4,14 +4,25 @@ import { generateHTML } from "@tiptap/html";
 import type { JSONContent } from "@tiptap/core";
 
 import { buildPrdExtensions } from "~/lib/prd/extensions";
-import { sanitizeDocForPublic } from "~/lib/pages/public-doc";
+import {
+  sanitizeDocForPublic,
+  type PublicPageLinkMap,
+} from "~/lib/pages/public-doc";
 
 /**
  * Render a Page's canonical ProseMirror `bodyDoc` to static HTML for the
  * unauthenticated `/p/[slugId]` route (ADR-0038). Runs the public sanitization
- * pass first, then serializes through the same shared extension schema the
- * editor uses, so the public render and the editor agree on every node type.
+ * pass first — including resolving `pageLink` nodes against the supplied map
+ * of published targets — then serializes through the same shared extension
+ * schema the editor uses, so the public render and the editor agree on every
+ * node type.
  */
-export function renderPublicPageHtml(bodyDoc: JSONContent): string {
-  return generateHTML(sanitizeDocForPublic(bodyDoc), buildPrdExtensions());
+export function renderPublicPageHtml(
+  bodyDoc: JSONContent,
+  pageLinks?: PublicPageLinkMap,
+): string {
+  return generateHTML(
+    sanitizeDocForPublic(bodyDoc, pageLinks),
+    buildPrdExtensions(),
+  );
 }


### PR DESCRIPTION
### **User description**
## Problem

A published page (e.g. `/p/balcony-railing-removal-…`) that links to a sub-page created with the `/page` command showed the link as dead plain text, with no way to make the sub-page reachable from the public site.

## What this does

**1. Render-time link resolution (order-independent).**
The `/p/[slugId]` route now resolves every `pageLink` target per request (the route is already `force-dynamic`, one extra indexed query):

- Target **published** → renders as a real link to the target's public URL (`/p/{slug}-{publicId}`), with its **live** title.
- Target unpublished/deleted → today's behavior: plain title text, no page id or internal workspace path leaked.

Because resolution is per-request, publish order is irrelevant: publish a sub-page at any time and every published page linking to it starts linking immediately — no republish needed. Unpublishing a sub-page instantly degrades its links back to plain text.

**2. "Publish linked pages" in the share popover (consent-preserving).**
The share popover now lists the transitively linked pages that aren't public yet (workspace-scoped BFS over the `pageLink` graph, cycle-safe, capped at 50, filtered to pages the caller can edit) with a one-click **Publish N linked pages** action:

- New `page.linkedUnpublished` query + `page.publishMany` mutation (explicit ids; every page edit-gated **before** any publish, so a mid-list FORBIDDEN can't leave a half-published batch).
- The existing publish core is extracted into a shared `publishPage` helper — `publish` behavior is unchanged (including the publicId mint/collision/race handling).
- **Unpublish never cascades** — a linked page may be linked from other published pages or shared directly.

## ADR

ADR-0038 said *"publishing is an explicit per-page act; it never follows from visibility rules"* and anticipated sub-page navigation "rendered only when the target is itself published". This implements exactly that; an amendment section documents both additions. Nothing is ever published implicitly.

## Tests

- `public-doc.test.ts`: published-target resolution (live title + public href), unpublished-target stripping, `collectPageLinkIds` (nested, dedupe, order, empty docs).
- Typecheck + ESLint clean; unit suite green.

## Notes

- No DB changes.
- The N+1 access checks in `linkedUnpublished` are bounded by the 50-page graph cap; fine at current scale.


___

### **PR Type**
Enhancement, tests


___

### **Description**
- Resolve `pageLink` targets at render-time on public pages, linking published sub-pages

- Add `page.linkedUnpublished` query and `page.publishMany` mutation for batch publishing

- Show parent page breadcrumb in topbar on page-detail routes via `page.parentCrumb`

- Extract shared `publishPage` helper and add `collectPageLinkIds` utility with tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Public page route\n/p/[slugId]"]
  B["resolvePublishedPageLinks()"]
  C["collectPageLinkIds()"]
  D["sanitizeDocForPublic()\n+ PublicPageLinkMap"]
  E["renderPublicPageHtml()"]
  F["page.linkedUnpublished\nquery"]
  G["page.publishMany\nmutation"]
  H["PageShareMenu\n(share popover)"]
  I["page.parentCrumb\nquery"]
  J["WorkspaceTopbar\n(breadcrumb)"]
  K["publishPage()\nshared helper"]

  A -- "fetch published targets" --> B
  B -- "collect ids" --> C
  B -- "resolve map" --> D
  D --> E
  H -- "list unpublished" --> F
  F -- "BFS via" --> C
  H -- "batch publish" --> G
  G -- "per-page" --> K
  J -- "reverse lookup" --> I
  I -- "confirm via" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>public-doc.ts</strong><dd><code>Add PublicPageLinkMap support and collectPageLinkIds utility</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/346/files#diff-64d759dc1f727883c8edd8f63a004f8f1f145b831eeb35e116d75a036cf4e0d4">+71/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.ts</strong><dd><code>Add parentCrumb, linkedUnpublished, publishMany; extract publishPage </code><br><code>helper</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/346/files#diff-417f180698c610991876ae407a7d19f5f60eb699f3e815dc47afecc6971a6b30">+242/-48</a></td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Resolve published pageLink targets per request on public route</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/346/files#diff-4f26c8af11e87fbc5369d3d633ae9caa1b378237be0f184791f9f816da09d28a">+35/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>public-html.ts</strong><dd><code>Pass PublicPageLinkMap through to sanitizeDocForPublic</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/346/files#diff-701deb4d80beb340efeacd4e95b511382164d65fa8351cf09a75457a6c123e6b">+16/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PageShareMenu.tsx</strong><dd><code>Show linked unpublished pages and batch publish action in share </code><br><code>popover</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/346/files#diff-60ee54c276474d7e0ee7bc12befe4026df8749bdfe1a5b3832e39ca89d98f7de">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WorkspaceTopbar.tsx</strong><dd><code>Show parent page breadcrumb on page-detail routes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/346/files#diff-0a3f487ebf1dec7561a7040706f2d2946ef04831b491257afd67d3982e7af848">+38/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>public-doc.test.ts</strong><dd><code>Add tests for pageLink resolution and collectPageLinkIds</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/346/files#diff-17f4aa034ebdbb5efd00ae1ff6e130fe9048ad7bb627a89d746270d47dda885c">+73/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>WorkspaceTopbar.module.css</strong><dd><code>Add crumbLink styles for linked breadcrumb items</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/346/files#diff-501873cc092689ba177f70a73db57f18484c8dcea8ac01b52fc14033a4517d66">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0038-page-public-publishing.md</strong><dd><code>Document linked-page resolution and batch publish amendment</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/346/files#diff-bcaa05a63db41bb8678982c352051e7bfad89d745433e2000f68beec49835152">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

