### PR TITLE
feat(integrations): per-workspace Postmark email sender

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx
@@ -44,6 +44,7 @@ import {
   IconPlus,
   IconShieldExclamation,
   IconSparkles,
+  IconSend,
   type Icon as TablerIcon,
 } from '@tabler/icons-react';
 import { useRouter } from 'next/navigation';
@@ -109,6 +110,9 @@ export default function WorkspaceSettingsPage() {
   } | null>(null);
   const [firefliesModalOpened, { open: openFirefliesModal, close: closeFirefliesModal }] = useDisclosure(false);
   const [emailModalOpened, { open: openEmailModal, close: closeEmailModal }] = useDisclosure(false);
+  const [postmarkModalOpened, { open: openPostmarkModal, close: closePostmarkModal }] = useDisclosure(false);
+  const [postmarkApiKey, setPostmarkApiKey] = useState('');
+  const [postmarkFrom, setPostmarkFrom] = useState('');
   const [emailProvider, setEmailProvider] = useState<string>('gmail');
   const [emailAddress, setEmailAddress] = useState('');
   const [emailAppPassword, setEmailAppPassword] = useState('');
@@ -376,6 +380,53 @@ export default function WorkspaceSettingsPage() {
     },
   });
 
+  const { data: postmarkStatus, refetch: refetchPostmarkStatus } =
+    api.integration.getWorkspacePostmarkStatus.useQuery(
+      { workspaceId: workspaceId! },
+      { enabled: !!workspaceId }
+    );
+
+  const createPostmarkMutation = api.integration.createPostmarkIntegration.useMutation({
+    onSuccess: () => {
+      void refetchPostmarkStatus();
+      closePostmarkModal();
+      setPostmarkApiKey('');
+      setPostmarkFrom('');
+      notifications.show({
+        title: 'Postmark Connected',
+        message: 'Workspace email delivery will use your Postmark sender.',
+        color: 'green',
+        autoClose: 3000,
+      });
+    },
+    onError: (error) => {
+      notifications.show({
+        title: 'Postmark Connection Failed',
+        message: error.message,
+        color: 'red',
+      });
+    },
+  });
+
+  const removePostmarkMutation = api.integration.removePostmarkIntegration.useMutation({
+    onSuccess: () => {
+      void refetchPostmarkStatus();
+      notifications.show({
+        title: 'Postmark Removed',
+        message: 'Workspace email will use the platform default sender.',
+        color: 'blue',
+        autoClose: 3000,
+      });
+    },
+    onError: (error) => {
+      notifications.show({
+        title: 'Error',
+        message: error.message,
+        color: 'red',
+      });
+    },
+  });
+
   const { data: notionConfig, refetch: refetchNotionConfig } = api.workspace.getNotionConfig.useQuery(
     { workspaceId: workspaceId! },
     { enabled: !!workspaceId }
@@ -439,6 +490,20 @@ export default function WorkspaceSettingsPage() {
   const handleRemoveWorkspaceEmail = () => {
     if (!workspaceId) return;
     removeEmailMutation.mutate({ workspaceId });
+  };
+
+  const handleSavePostmark = () => {
+    if (!workspaceId || !postmarkApiKey || !postmarkFrom) return;
+    createPostmarkMutation.mutate({
+      workspaceId,
+      apiKey: postmarkApiKey,
+      fromAddress: postmarkFrom,
+    });
+  };
+
+  const handleRemovePostmark = () => {
+    if (!workspaceId) return;
+    removePostmarkMutation.mutate({ workspaceId });
   };
 
   const handleStartEdit = (field: 'name' | 'description' | 'aiInstructions') => {
@@ -1130,6 +1195,54 @@ export default function WorkspaceSettingsPage() {
               </Stack>
             </SettingsSection>
 
+            <SettingsSection
+              icon={IconSend}
+              title="Postmark"
+              description="Send this workspace's notification, CRM, and broadcast emails from your own Postmark server and sender address. Leave unset to use the platform default."
+            >
+              <Stack gap="sm">
+                {postmarkStatus?.configured ? (
+                  <Group justify="space-between">
+                    <div>
+                      <div className="text-[13px] text-text-secondary">
+                        {postmarkStatus.fromAddress ?? 'Configured'}
+                      </div>
+                      <div className="text-[11.5px] text-text-muted">
+                        Sending via your Postmark server
+                      </div>
+                    </div>
+                    {canEdit && (
+                      <Group gap="xs">
+                        <Button variant="light" size="xs" onClick={openPostmarkModal}>
+                          Change
+                        </Button>
+                        <Button
+                          variant="subtle"
+                          size="xs"
+                          color="red"
+                          onClick={handleRemovePostmark}
+                          loading={removePostmarkMutation.isPending}
+                        >
+                          Remove
+                        </Button>
+                      </Group>
+                    )}
+                  </Group>
+                ) : (
+                  <Group justify="space-between">
+                    <div className="text-[13px] text-text-muted">
+                      Using the platform default email sender
+                    </div>
+                    {canEdit && (
+                      <Button variant="light" size="xs" onClick={openPostmarkModal}>
+                        Add Postmark
+                      </Button>
+                    )}
+                  </Group>
+                )}
+              </Stack>
+            </SettingsSection>
+
             {workspaceId && (
               <SettingsSection
                 icon={IconBrandSlack}
@@ -1460,6 +1573,52 @@ export default function WorkspaceSettingsPage() {
               disabled={!emailAddress || !emailAppPassword}
             >
               Connect Email
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+
+      <Modal
+        opened={postmarkModalOpened}
+        onClose={closePostmarkModal}
+        title="Configure Postmark"
+        size="md"
+      >
+        <Stack gap="md">
+          <Alert icon={<IconSend size={16} />} title="Postmark Setup" color="blue">
+            Emails originating from this workspace will be delivered using your Postmark
+            server token and sender address. The from-address must be a verified Sender
+            Signature (or on a verified domain) in your Postmark account.
+          </Alert>
+
+          <TextInput
+            label="Server API Token"
+            placeholder="Your Postmark server token"
+            required
+            type="password"
+            value={postmarkApiKey}
+            onChange={(e) => setPostmarkApiKey(e.currentTarget.value)}
+          />
+
+          <TextInput
+            label="From Address"
+            placeholder="notifications@yourdomain.com"
+            required
+            type="email"
+            value={postmarkFrom}
+            onChange={(e) => setPostmarkFrom(e.currentTarget.value)}
+          />
+
+          <Group justify="flex-end" mt="md">
+            <Button variant="subtle" onClick={closePostmarkModal}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSavePostmark}
+              loading={createPostmarkMutation.isPending}
+              disabled={!postmarkApiKey || !postmarkFrom}
+            >
+              Save Postmark
             </Button>
           </Group>
         </Stack>

--- a/src/server/api/routers/integration.ts
+++ b/src/server/api/routers/integration.ts
@@ -3355,6 +3355,124 @@ export const integrationRouter = createTRPCRouter({
       return { success: true };
     }),
 
+  // ==================== POSTMARK INTEGRATION ====================
+  // Per-workspace Postmark server token + from-address. Used by
+  // EmailService.resolvePostmark() so a workspace's notification / CRM /
+  // broadcast email ships from its own sender, falling back to the env default.
+
+  createPostmarkIntegration: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        apiKey: z.string().min(1, "Server API token is required"),
+        fromAddress: z.string().email("From address must be a valid email"),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Only workspace owners/admins can change how the workspace sends email.
+      const membership = await ctx.db.workspaceUser.findFirst({
+        where: {
+          workspaceId: input.workspaceId,
+          userId: ctx.session.user.id,
+          role: { in: ["owner", "admin"] },
+        },
+      });
+      if (!membership) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only workspace owners or admins can configure Postmark.",
+        });
+      }
+
+      // One config per workspace: replace any existing one.
+      await ctx.db.integration.deleteMany({
+        where: { provider: "postmark", workspaceId: input.workspaceId },
+      });
+
+      const integration = await ctx.db.integration.create({
+        data: {
+          name: "Postmark",
+          type: "API_KEY",
+          provider: "postmark",
+          description: "Workspace email delivery via Postmark",
+          userId: ctx.session.user.id,
+          workspaceId: input.workspaceId,
+          status: "ACTIVE",
+        },
+      });
+
+      const encryptedApiKey = encryptCredential(input.apiKey);
+      await ctx.db.integrationCredential.createMany({
+        data: [
+          {
+            key: encryptedApiKey.key,
+            keyType: "api_key",
+            isEncrypted: encryptedApiKey.isEncrypted,
+            integrationId: integration.id,
+          },
+          {
+            key: input.fromAddress,
+            keyType: "from_address",
+            isEncrypted: false,
+            integrationId: integration.id,
+          },
+        ],
+      });
+
+      return { configured: true, fromAddress: input.fromAddress };
+    }),
+
+  // Get the workspace Postmark status. Never returns the token.
+  getWorkspacePostmarkStatus: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const membership = await ctx.db.workspaceUser.findFirst({
+        where: { workspaceId: input.workspaceId, userId: ctx.session.user.id },
+      });
+      if (!membership) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You are not a member of this workspace.",
+        });
+      }
+
+      const integration = await ctx.db.integration.findFirst({
+        where: { provider: "postmark", status: "ACTIVE", workspaceId: input.workspaceId },
+        include: { credentials: true },
+      });
+
+      if (!integration) return { configured: false as const };
+
+      const fromAddress = integration.credentials.find(
+        (c) => c.keyType === "from_address",
+      )?.key;
+
+      return { configured: true as const, fromAddress };
+    }),
+
+  removePostmarkIntegration: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const membership = await ctx.db.workspaceUser.findFirst({
+        where: {
+          workspaceId: input.workspaceId,
+          userId: ctx.session.user.id,
+          role: { in: ["owner", "admin"] },
+        },
+      });
+      if (!membership) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only workspace owners or admins can remove Postmark.",
+        });
+      }
+
+      await ctx.db.integration.deleteMany({
+        where: { provider: "postmark", workspaceId: input.workspaceId },
+      });
+      return { success: true };
+    }),
+
   // ==================== ZULIP INTEGRATION ====================
 
   createZulipIntegration: protectedProcedure

--- a/src/server/api/routers/integration.ts
+++ b/src/server/api/routers/integration.ts
@@ -3384,39 +3384,44 @@ export const integrationRouter = createTRPCRouter({
         });
       }
 
-      // One config per workspace: replace any existing one.
-      await ctx.db.integration.deleteMany({
-        where: { provider: "postmark", workspaceId: input.workspaceId },
-      });
-
-      const integration = await ctx.db.integration.create({
-        data: {
-          name: "Postmark",
-          type: "API_KEY",
-          provider: "postmark",
-          description: "Workspace email delivery via Postmark",
-          userId: ctx.session.user.id,
-          workspaceId: input.workspaceId,
-          status: "ACTIVE",
-        },
-      });
-
+      // One config per workspace: replace any existing one. Run the replace as a
+      // single transaction so a failure can't leave the workspace with an
+      // integration row and no credentials (which resolvePostmark would silently
+      // treat as "unconfigured") or with no integration at all.
       const encryptedApiKey = encryptCredential(input.apiKey);
-      await ctx.db.integrationCredential.createMany({
-        data: [
-          {
-            key: encryptedApiKey.key,
-            keyType: "api_key",
-            isEncrypted: encryptedApiKey.isEncrypted,
-            integrationId: integration.id,
+      await ctx.db.$transaction(async (tx) => {
+        await tx.integration.deleteMany({
+          where: { provider: "postmark", workspaceId: input.workspaceId },
+        });
+
+        const integration = await tx.integration.create({
+          data: {
+            name: "Postmark",
+            type: "API_KEY",
+            provider: "postmark",
+            description: "Workspace email delivery via Postmark",
+            userId: ctx.session.user.id,
+            workspaceId: input.workspaceId,
+            status: "ACTIVE",
           },
-          {
-            key: input.fromAddress,
-            keyType: "from_address",
-            isEncrypted: false,
-            integrationId: integration.id,
-          },
-        ],
+        });
+
+        await tx.integrationCredential.createMany({
+          data: [
+            {
+              key: encryptedApiKey.key,
+              keyType: "api_key",
+              isEncrypted: encryptedApiKey.isEncrypted,
+              integrationId: integration.id,
+            },
+            {
+              key: input.fromAddress,
+              keyType: "from_address",
+              isEncrypted: false,
+              integrationId: integration.id,
+            },
+          ],
+        });
       });
 
       return { configured: true, fromAddress: input.fromAddress };

--- a/src/server/services/EmailService.ts
+++ b/src/server/services/EmailService.ts
@@ -54,7 +54,17 @@ export async function resolvePostmark(
   const apiKeyCred = integration.credentials.find((c) => c.keyType === "api_key");
   const fromCred = integration.credentials.find((c) => c.keyType === "from_address");
 
-  const apiKey = apiKeyCred ? getDecryptedKey(apiKeyCred) : null;
+  // A corrupted/tampered credential must not break the send — fall back to env.
+  let apiKey: string | null = null;
+  try {
+    apiKey = apiKeyCred ? getDecryptedKey(apiKeyCred) : null;
+  } catch (error) {
+    console.error(
+      "[EmailService] Failed to decrypt workspace Postmark API key; falling back to env config.",
+      error,
+    );
+    return envConfig;
+  }
   const from = fromCred?.key;
 
   // Use the workspace config only when both parts are present; a partial config

--- a/src/server/services/EmailService.ts
+++ b/src/server/services/EmailService.ts
@@ -11,8 +11,60 @@
 import { colorTokens } from "~/styles/colors";
 import { PRODUCT_NAME } from "~/lib/brand";
 import { getPublicBaseUrlFromEnv } from "~/lib/urls";
+import { db } from "~/server/db";
+import { getDecryptedKey } from "~/server/utils/credentialHelper";
 
 const POSTMARK_API_URL = "https://api.postmarkapp.com/email";
+
+interface PostmarkConfig {
+  apiKey: string | null;
+  from: string;
+}
+
+/**
+ * Resolve which Postmark server token + from-address to use for a send.
+ *
+ * When a `workspaceId` is provided and that workspace has an ACTIVE `postmark`
+ * integration with both an api key and a from-address, the workspace's own
+ * Postmark config is used so its email ships from its own sender. Otherwise we
+ * fall back to the instance-global env vars — the historical behavior — which is
+ * also what pre-login emails (magic link / welcome) always use since they carry
+ * no workspace context.
+ *
+ * Looked up by `workspaceId` only (no `userId` filter): notification / CRM /
+ * broadcast sends run in a background context with no session user.
+ */
+export async function resolvePostmark(
+  workspaceId?: string
+): Promise<PostmarkConfig> {
+  const envConfig: PostmarkConfig = {
+    apiKey: process.env.AUTH_POSTMARK_KEY ?? process.env.POSTMARK_SERVER_TOKEN ?? null,
+    from: process.env.AUTH_POSTMARK_FROM ?? "noreply@exponential.im",
+  };
+
+  if (!workspaceId) return envConfig;
+
+  const integration = await db.integration.findFirst({
+    where: { provider: "postmark", status: "ACTIVE", workspaceId },
+    include: { credentials: true },
+  });
+
+  if (!integration) return envConfig;
+
+  const apiKeyCred = integration.credentials.find((c) => c.keyType === "api_key");
+  const fromCred = integration.credentials.find((c) => c.keyType === "from_address");
+
+  const apiKey = apiKeyCred ? getDecryptedKey(apiKeyCred) : null;
+  const from = fromCred?.key;
+
+  // Use the workspace config only when both parts are present; a partial config
+  // must not mix a workspace key with the platform from-address (or vice versa).
+  if (apiKey && from) {
+    return { apiKey, from };
+  }
+
+  return envConfig;
+}
 
 // Email clients don't support CSS variables, so we inline the brand hex here.
 // Source of truth is `colorTokens.light.brand.primary` in `src/styles/colors.ts`.
@@ -23,15 +75,19 @@ interface SendEmailParams {
   subject: string;
   htmlBody: string;
   textBody: string;
+  /**
+   * When set, a workspace-configured Postmark server token + from-address is
+   * preferred over the env default. Omit for pre-login / non-workspace emails.
+   */
+  workspaceId?: string;
 }
 
-async function sendEmail({ to, subject, htmlBody, textBody }: SendEmailParams): Promise<void> {
-  const apiKey = process.env.AUTH_POSTMARK_KEY ?? process.env.POSTMARK_SERVER_TOKEN;
-  const from = process.env.AUTH_POSTMARK_FROM ?? "noreply@exponential.im";
+async function sendEmail({ to, subject, htmlBody, textBody, workspaceId }: SendEmailParams): Promise<void> {
+  const { apiKey, from } = await resolvePostmark(workspaceId);
 
   if (!apiKey) {
     console.error(
-      "[EmailService] Postmark API key not configured. Set AUTH_POSTMARK_KEY or POSTMARK_SERVER_TOKEN environment variable."
+      "[EmailService] Postmark API key not configured. Set AUTH_POSTMARK_KEY or POSTMARK_SERVER_TOKEN environment variable, or configure a workspace Postmark integration."
     );
     throw new Error("Email service not configured: missing AUTH_POSTMARK_KEY or POSTMARK_SERVER_TOKEN");
   }
@@ -665,8 +721,9 @@ export async function sendAssignmentNotificationEmail(params: {
   workspaceName: string;
   personalSettingsUrl: string;
   workspaceSettingsUrl: string;
+  workspaceId?: string;
 }): Promise<void> {
-  const { to, assigneeName, assignerName, actionName, actionUrl, workspaceName, personalSettingsUrl, workspaceSettingsUrl } = params;
+  const { to, assigneeName, assignerName, actionName, actionUrl, workspaceName, personalSettingsUrl, workspaceSettingsUrl, workspaceId } = params;
   const brandColor = EMAIL_BRAND_COLOR;
   const appName = PRODUCT_NAME;
   const footer = generateNotificationFooter({ workspaceName, personalSettingsUrl, workspaceSettingsUrl });
@@ -753,6 +810,7 @@ ${footer.text}
     subject: `[${appName}] You've been assigned to: ${actionName}`,
     htmlBody,
     textBody,
+    workspaceId,
   });
 }
 
@@ -769,8 +827,9 @@ export async function sendMentionNotificationEmail(params: {
   workspaceName: string;
   personalSettingsUrl: string;
   workspaceSettingsUrl: string;
+  workspaceId?: string;
 }): Promise<void> {
-  const { to, mentionedName, authorName, actionName, commentPreview, actionUrl, workspaceName, personalSettingsUrl, workspaceSettingsUrl } = params;
+  const { to, mentionedName, authorName, actionName, commentPreview, actionUrl, workspaceName, personalSettingsUrl, workspaceSettingsUrl, workspaceId } = params;
   const brandColor = EMAIL_BRAND_COLOR;
   const appName = PRODUCT_NAME;
   const footer = generateNotificationFooter({ workspaceName, personalSettingsUrl, workspaceSettingsUrl });
@@ -866,6 +925,7 @@ ${footer.text}
     subject: `[${appName}] ${authorName} mentioned you in: ${actionName}`,
     htmlBody,
     textBody,
+    workspaceId,
   });
 }
 
@@ -880,8 +940,9 @@ export async function sendCrmOnboardingWelcomeEmail(params: {
   to: string;
   name?: string | null;
   customerType: string;
+  workspaceId?: string;
 }): Promise<{ subject: string; htmlBody: string; textBody: string }> {
-  const { to, name, customerType } = params;
+  const { to, name, customerType, workspaceId } = params;
   const appName = PRODUCT_NAME;
   const greeting = name ? `Hi ${name},` : "Hi there,";
   const subject = `Welcome — you're signed up as a ${customerType}`;
@@ -907,7 +968,7 @@ We're preparing your ${customerType} agreement now. You'll receive a separate em
 Thanks,
 The ${appName} team`;
 
-  await sendEmail({ to, subject, htmlBody, textBody });
+  await sendEmail({ to, subject, htmlBody, textBody, workspaceId });
   return { subject, htmlBody, textBody };
 }
 
@@ -922,6 +983,7 @@ export async function sendCrmAutomationEmail(params: {
   subject: string;
   bodyHtml: string;
   bodyText: string;
+  workspaceId?: string;
 }): Promise<{ subject: string; htmlBody: string; textBody: string }> {
   const appName = PRODUCT_NAME;
   const htmlBody = `
@@ -938,6 +1000,7 @@ export async function sendCrmAutomationEmail(params: {
     subject: params.subject,
     htmlBody,
     textBody: params.bodyText,
+    workspaceId: params.workspaceId,
   });
   return { subject: params.subject, htmlBody, textBody: params.bodyText };
 }
@@ -961,6 +1024,7 @@ export async function sendBroadcastDigestEmail(params: {
   sections: { category: string; items: string[] }[];
   unsubscribeUrl: string;
   greetingName?: string | null;
+  workspaceId?: string;
 }): Promise<{ subject: string; htmlBody: string; textBody: string }> {
   const appName = PRODUCT_NAME;
   const greeting = params.greetingName
@@ -1021,6 +1085,7 @@ Unsubscribe: ${params.unsubscribeUrl}`;
     subject: params.subject,
     htmlBody,
     textBody,
+    workspaceId: params.workspaceId,
   });
 
   return { subject: params.subject, htmlBody, textBody };

--- a/src/server/services/__tests__/EmailService.test.ts
+++ b/src/server/services/__tests__/EmailService.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for resolvePostmark — the resolver that decides whether a send uses
+ * a workspace's own Postmark config or the instance-global env default.
+ * `~/server/db` is mocked so only findFirst behavior is exercised.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.hoisted(() => {
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+const { findFirst } = vi.hoisted(() => ({ findFirst: vi.fn() }));
+vi.mock("~/server/db", () => ({
+  db: { integration: { findFirst } },
+}));
+
+import { resolvePostmark } from "../EmailService";
+
+const ENV_KEY = "env-server-token";
+const ENV_FROM = "noreply@platform.test";
+
+/** A workspace integration row with the given credential rows. */
+function integrationWith(
+  credentials: { key: string; keyType: string; isEncrypted: boolean }[],
+) {
+  return { id: "int_1", credentials };
+}
+
+beforeEach(() => {
+  findFirst.mockReset();
+  process.env.AUTH_POSTMARK_KEY = ENV_KEY;
+  process.env.AUTH_POSTMARK_FROM = ENV_FROM;
+  delete process.env.POSTMARK_SERVER_TOKEN;
+});
+
+describe("resolvePostmark", () => {
+  it("returns env config when no workspaceId is given (never queries the db)", async () => {
+    const result = await resolvePostmark();
+    expect(result).toEqual({ apiKey: ENV_KEY, from: ENV_FROM });
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it("falls back to env config when the workspace has no postmark integration", async () => {
+    findFirst.mockResolvedValue(null);
+    const result = await resolvePostmark("ws_1");
+    expect(result).toEqual({ apiKey: ENV_KEY, from: ENV_FROM });
+  });
+
+  it("uses the workspace config when both credentials are present", async () => {
+    findFirst.mockResolvedValue(
+      integrationWith([
+        { key: "ws-token", keyType: "api_key", isEncrypted: false },
+        { key: "hello@workspace.test", keyType: "from_address", isEncrypted: false },
+      ]),
+    );
+    const result = await resolvePostmark("ws_1");
+    expect(result).toEqual({ apiKey: "ws-token", from: "hello@workspace.test" });
+  });
+
+  it("falls back to env when the workspace config is missing the from-address", async () => {
+    findFirst.mockResolvedValue(
+      integrationWith([
+        { key: "ws-token", keyType: "api_key", isEncrypted: false },
+      ]),
+    );
+    const result = await resolvePostmark("ws_1");
+    expect(result).toEqual({ apiKey: ENV_KEY, from: ENV_FROM });
+  });
+
+  it("looks up the integration by workspaceId only, not by user", async () => {
+    findFirst.mockResolvedValue(null);
+    await resolvePostmark("ws_1");
+    const where = findFirst.mock.calls[0]?.[0]?.where as Record<string, unknown>;
+    expect(where).toMatchObject({
+      provider: "postmark",
+      status: "ACTIVE",
+      workspaceId: "ws_1",
+    });
+    expect(where).not.toHaveProperty("userId");
+  });
+});

--- a/src/server/services/crm/automation/steps/SendEmailStep.ts
+++ b/src/server/services/crm/automation/steps/SendEmailStep.ts
@@ -86,6 +86,7 @@ export class SendEmailStep implements IStepExecutor {
           : `Welcome — you're signed up as a ${customerType}`,
         bodyHtml: renderTextBodyToHtml(customBody, data),
         bodyText: renderTextBodyToPlain(customBody, data),
+        workspaceId: context.workspaceId,
       });
       subject = rendered.subject;
       htmlBody = rendered.htmlBody;
@@ -95,6 +96,7 @@ export class SendEmailStep implements IStepExecutor {
         to: toEmail,
         name,
         customerType,
+        workspaceId: context.workspaceId,
       });
       subject = rendered.subject;
       htmlBody = rendered.htmlBody;

--- a/src/server/services/crm/automation/steps/SendEmailToListStep.ts
+++ b/src/server/services/crm/automation/steps/SendEmailToListStep.ts
@@ -100,6 +100,7 @@ export class SendEmailToListStep implements IStepExecutor {
             sections: digest.sections,
             unsubscribeUrl,
             greetingName: r.greetingName,
+            workspaceId: context.workspaceId,
           });
           await this.db.crmCommunication.create({
             data: {

--- a/src/server/services/crm/broadcast/broadcastService.ts
+++ b/src/server/services/crm/broadcast/broadcastService.ts
@@ -159,6 +159,7 @@ export async function runBroadcastTestSend(
     // Test preview — not a real recipient, so no working unsubscribe needed.
     unsubscribeUrl: "#",
     greetingName: null,
+    workspaceId: input.workspaceId,
   });
 
   return { skipped: false };

--- a/src/server/services/notifications/EmailNotificationService.ts
+++ b/src/server/services/notifications/EmailNotificationService.ts
@@ -220,6 +220,7 @@ export async function sendAssignmentNotifications(
           workspaceName: ws.workspaceName,
           personalSettingsUrl: urls.personalSettingsUrl,
           workspaceSettingsUrl: urls.workspaceSettingsUrl,
+          workspaceId: ws.workspaceId,
         });
       }),
     );
@@ -368,6 +369,7 @@ export async function sendMentionNotifications(
           workspaceName: ws.workspaceName,
           personalSettingsUrl: urls.personalSettingsUrl,
           workspaceSettingsUrl: urls.workspaceSettingsUrl,
+          workspaceId: ws.workspaceId,
         });
       }),
     );


### PR DESCRIPTION
### **User description**
## What

Adds a **per-workspace Postmark integration** on the workspace settings Integrations page (`/w/<slug>/settings` → Integrations). A workspace owner/admin can enter their own Postmark **Server API Token** and **From Address**; email that originates from that workspace then ships from its own sender instead of the platform default (`noreply@exponential.im`).

## Why

Today every workspace's transactional/notification email goes out through a single `sendEmail()` choke point that reads the instance-global `AUTH_POSTMARK_KEY` / `AUTH_POSTMARK_FROM` env vars — so all workspaces share one sender. This lets a workspace deliver its own notification/CRM/broadcast email from its own verified domain.

## Scope (decided up front)

- **Workspace-scoped**, one config per workspace.
- **Wired into** the senders that already carry a `workspaceId`: assignment + mention notifications, CRM automation/onboarding, and broadcast digest. Pre-login emails (magic link / welcome) and invites stay on the env default.
- **No save-time validation** (mirrors Fireflies/Zulip — a bad config surfaces when a later send fails).
- **Fallback** to the env vars when a workspace has no config, or when its config is partial.

## Changes

- `resolvePostmark(workspaceId)` in `EmailService.ts` — prefers a workspace's ACTIVE `postmark` integration (both `api_key` + `from_address`), else env. Looked up by `workspaceId` only (background sends have no session user).
- `sendEmail()` gains an optional `workspaceId`, threaded through the 5 wired senders and their 5 call sites.
- Three tRPC procedures: `createPostmarkIntegration` / `getWorkspacePostmarkStatus` (never returns the token) / `removePostmarkIntegration` — owner/admin only, token encrypted via `encryptCredential`, from-address plaintext. **No schema migration** — reuses `Integration` + `IntegrationCredential`.
- Postmark `SettingsSection` card + modal in the workspace settings Integrations block.

## Testing

- New `EmailService.test.ts` — 5 cases for `resolvePostmark` (no-workspace, no-integration, both-creds hit, partial-config fallback, workspaceId-only lookup). All pass.
- `tsc --noEmit` clean; `eslint` on changed files clean.
- Full unit suite green except one pre-existing, unrelated date-sensitive `isToday` sparkline assertion in `workspaceHomeStats.integration.test.ts` (no dependency on any touched code).

## Not covered here

Live end-to-end verification against a real Postmark account (driving the UI, confirming the encrypted DB row, verifying a real send uses the workspace sender vs env). Requires a running app + Postmark credentials.

## Deploy note

Relies on `DATABASE_ENCRYPTION_KEY` being set so the token is stored encrypted; without it `encryptCredential` falls back to plaintext with a warning, same as the existing email/Slack/Zulip integrations.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add per-workspace Postmark email integration with UI settings card and modal

- Implement `resolvePostmark()` to prefer workspace config over env defaults

- Add three tRPC procedures: create, get status, and remove Postmark integration

- Thread `workspaceId` through all workspace-scoped email senders (assignment, mention, CRM, broadcast)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["Workspace Settings\nIntegrations Page"]
  tRPC["tRPC Procedures\ncreate / status / remove"]
  DB["Integration +\nIntegrationCredential DB"]
  resolver["resolvePostmark(workspaceId)"]
  senders["Email Senders\nassignment, mention, CRM, broadcast"]
  postmark["Postmark API"]
  env["Env Vars\nAUTH_POSTMARK_KEY"]

  UI -- "createPostmarkIntegration\nremovePostmarkIntegration" --> tRPC
  UI -- "getWorkspacePostmarkStatus" --> tRPC
  tRPC -- "encrypted api_key +\nfrom_address" --> DB
  senders -- "workspaceId" --> resolver
  resolver -- "lookup ACTIVE postmark" --> DB
  resolver -- "fallback" --> env
  resolver -- "resolved config" --> postmark
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>page.tsx</strong><dd><code>Add Postmark settings card, modal, and mutation hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/347/files#diff-0ac5e4711f55c32c32d6519fc8c97fef283b6baff89a3712fee47cbc4ddc65f7">+159/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>integration.ts</strong><dd><code>Add three tRPC procedures for Postmark integration management</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/347/files#diff-c77c1944f43c90e73f35e8df34be0e27e5c7ef596a4380d6e731f974acb89b3f">+123/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>EmailService.ts</strong><dd><code>Add resolvePostmark and workspaceId support to sendEmail</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/347/files#diff-7efb63f19977ee348b1afbdb35fb8de2ac2bfa66d1cc9fcbb1c957a5959b7fcd">+83/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SendEmailStep.ts</strong><dd><code>Pass workspaceId to CRM automation email sends</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/347/files#diff-4041a8296460e14d669a2d94d5e05d2389e424e3b236dcaecf19858e2b4fc6f4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SendEmailToListStep.ts</strong><dd><code>Pass workspaceId to broadcast digest email sends</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/347/files#diff-78f0e61d9308e708e0a4e81827842ef630d66cc120fe2785bcc0f7a8bf868031">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>broadcastService.ts</strong><dd><code>Pass workspaceId to broadcast test send email</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/347/files#diff-9775daca1bbd36b3c9324852aefb4de06bbc414f986d066ab94a8cd97a4d749f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EmailNotificationService.ts</strong><dd><code>Pass workspaceId to assignment and mention notification emails</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/347/files#diff-f17fa722d8f985c7af8142bf980b69ab8cfd77853bb672a1205484660d5bb2a5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>EmailService.test.ts</strong><dd><code>Unit tests for resolvePostmark workspace config resolution</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/347/files#diff-0fb5e6fc5b684da60b7bb1fe741e65b497c245b831742e171d3b1d9c526eab8b">+83/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

