### PR TITLE
feat(pages): favourite knowledge pages from the page header

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx
@@ -8,6 +8,7 @@ import { api } from '~/trpc/react';
 import { PageDocument } from '~/app/_components/pages/PageDocument';
 import { PageShareMenu } from '~/app/_components/pages/PageShareMenu';
 import { PageSubpages } from '~/app/_components/pages/PageSubpages';
+import { FavoriteButton } from '~/app/_components/shared/FavoriteButton';
 import type { RichDocEditorHandle } from '~/app/_components/shared/RichDocEditor';
 
 /** Inline-editable page title; saves on blur/Enter when changed (metadata-only
@@ -26,6 +27,9 @@ function PageTitle({
   const updateTitle = api.page.update.useMutation({
     onSuccess: () => {
       void utils.page.list.invalidate();
+      // Favourite titles are resolved live from the page, so a rename should
+      // show up in the sidebar immediately.
+      void utils.favorite.list.invalidate();
     },
   });
 
@@ -140,15 +144,23 @@ function PageEditorContent({
         <div className="min-w-0 flex-1">
           <PageTitle pageId={page.id} initialTitle={page.title} editable={page.canEdit} />
         </div>
-        <PageShareMenu
-          pageId={page.id}
-          workspaceSlug={workspaceSlug}
-          isPublic={page.isPublic}
-          publicId={page.publicId}
-          publicSlug={page.publicSlug}
-          publicSeoIndexed={page.publicSeoIndexed}
-          canEdit={page.canEdit}
-        />
+        <div className="flex items-center gap-2">
+          <FavoriteButton
+            entityType="page"
+            entityId={`pages/${page.id}`}
+            label={page.title}
+            workspaceId={page.workspaceId}
+          />
+          <PageShareMenu
+            pageId={page.id}
+            workspaceSlug={workspaceSlug}
+            isPublic={page.isPublic}
+            publicId={page.publicId}
+            publicSlug={page.publicSlug}
+            publicSeoIndexed={page.publicSeoIndexed}
+            canEdit={page.canEdit}
+          />
+        </div>
       </div>
       <PageDocument
         pageId={page.id}

--- a/src/server/api/routers/__tests__/favorite.test.ts
+++ b/src/server/api/routers/__tests__/favorite.test.ts
@@ -230,6 +230,67 @@ describe("favorite router (mocked)", () => {
         },
       ]);
     });
+
+    it("resolves knowledge-page rows (`pages/{id}`) to the live page title, skipping deleted pages", async () => {
+      dbMock.favorite.findMany.mockResolvedValue([
+        {
+          id: "fav-kp",
+          entityType: "page",
+          entityId: "pages/ckpage111",
+          label: "Old snapshot title",
+          icon: null,
+          workspaceId: WORKSPACE_ID,
+        },
+        {
+          id: "fav-kp-deleted",
+          entityType: "page",
+          entityId: "pages/ckpage999",
+          label: "Deleted page",
+          icon: null,
+          workspaceId: WORKSPACE_ID,
+        },
+        {
+          id: "fav-static",
+          entityType: "page",
+          entityId: PAGE_PATH,
+          label: "Acme · Features",
+          icon: "features",
+          workspaceId: WORKSPACE_ID,
+        },
+      ] as never);
+      dbMock.goal.findMany.mockResolvedValue([] as never);
+      dbMock.keyResult.findMany.mockResolvedValue([] as never);
+      // Only ckpage111 still exists, and it has been renamed since favouriting.
+      dbMock.knowledgePage.findMany.mockResolvedValue([
+        { id: "ckpage111", title: "Renamed page" },
+      ] as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      const items = await caller.favorite.list({ workspaceId: WORKSPACE_ID });
+
+      expect(dbMock.knowledgePage.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ["ckpage111", "ckpage999"] } },
+        select: { id: true, title: true },
+      });
+      expect(items).toEqual([
+        {
+          id: "fav-kp",
+          entityType: "page",
+          entityId: "pages/ckpage111",
+          title: "Renamed page",
+          icon: null,
+          workspaceId: WORKSPACE_ID,
+        },
+        {
+          id: "fav-static",
+          entityType: "page",
+          entityId: PAGE_PATH,
+          title: "Acme · Features",
+          icon: "features",
+          workspaceId: WORKSPACE_ID,
+        },
+      ]);
+    });
   });
 
   describe("isFavorite", () => {

--- a/src/server/api/routers/favorite.ts
+++ b/src/server/api/routers/favorite.ts
@@ -12,6 +12,12 @@ import { getWorkspaceMembership } from "~/server/services/access";
 const entityTypeEnum = z.enum(["objective", "keyResult", "page"]);
 type EntityType = z.infer<typeof entityTypeEnum>;
 
+// Knowledge pages live at `pages/{id}`; their titles are resolved live in
+// `list` so renames show up in the sidebar (and favourites of deleted pages
+// are skipped). Other page paths (e.g. product sections) are static routes
+// and keep their snapshot label.
+const KNOWLEDGE_PAGE_PATH = /^pages\/([a-z0-9]+)$/;
+
 /**
  * Verify the user may favourite this entity and return the entity's
  * workspaceId (captured on the Favorite row for workspace-scoped surfaces).
@@ -57,8 +63,9 @@ interface FavoriteListItem {
 export const favoriteRouter = createTRPCRouter({
   // The current user's favourites, optionally scoped to a workspace (the
   // sidebar passes the active workspace). Entity titles are resolved per type;
-  // page titles come from the snapshot label. Favourites whose target no longer
-  // exists are skipped (stale rows) — pages, being plain paths, never go stale.
+  // knowledge-page titles are resolved live from the path's page id, other
+  // page paths use the snapshot label. Favourites whose target no longer
+  // exists are skipped (stale rows) — static page paths never go stale.
   list: protectedProcedure
     .input(z.object({ workspaceId: z.string().nullish() }).optional())
     .query(async ({ ctx, input }): Promise<FavoriteListItem[]> => {
@@ -78,8 +85,12 @@ export const favoriteRouter = createTRPCRouter({
       const keyResultIds = favorites
         .filter((f) => f.entityType === "keyResult")
         .map((f) => f.entityId);
+      const knowledgePageIds = favorites
+        .filter((f) => f.entityType === "page")
+        .map((f) => KNOWLEDGE_PAGE_PATH.exec(f.entityId)?.[1])
+        .filter((id): id is string => id !== undefined);
 
-      const [goals, keyResults] = await Promise.all([
+      const [goals, keyResults, knowledgePages] = await Promise.all([
         objectiveIds.length
           ? ctx.db.goal.findMany({
               where: { id: { in: objectiveIds } },
@@ -92,10 +103,17 @@ export const favoriteRouter = createTRPCRouter({
               select: { id: true, title: true },
             })
           : Promise.resolve([]),
+        knowledgePageIds.length
+          ? ctx.db.knowledgePage.findMany({
+              where: { id: { in: knowledgePageIds } },
+              select: { id: true, title: true },
+            })
+          : Promise.resolve([]),
       ]);
 
       const goalTitle = new Map(goals.map((g) => [String(g.id), g.title]));
       const krTitle = new Map(keyResults.map((k) => [k.id, k.title]));
+      const pageTitle = new Map(knowledgePages.map((p) => [p.id, p.title]));
 
       const items: FavoriteListItem[] = [];
       for (const f of favorites) {
@@ -106,8 +124,14 @@ export const favoriteRouter = createTRPCRouter({
         } else if (entityType === "keyResult") {
           title = krTitle.get(f.entityId);
         } else {
-          // page — snapshot label, falling back to the path if somehow unset
-          title = f.label ?? f.entityId;
+          const pageId = KNOWLEDGE_PAGE_PATH.exec(f.entityId)?.[1];
+          if (pageId) {
+            // knowledge page — live title; undefined means the page was deleted
+            title = pageTitle.get(pageId);
+          } else {
+            // static page path — snapshot label, falling back to the path
+            title = f.label ?? f.entityId;
+          }
         }
         if (!title) continue; // entity target deleted — skip stale favourite
         items.push({

--- a/src/server/api/routers/favorite.ts
+++ b/src/server/api/routers/favorite.ts
@@ -15,8 +15,11 @@ type EntityType = z.infer<typeof entityTypeEnum>;
 // Knowledge pages live at `pages/{id}`; their titles are resolved live in
 // `list` so renames show up in the sidebar (and favourites of deleted pages
 // are skipped). Other page paths (e.g. product sections) are static routes
-// and keep their snapshot label.
-const KNOWLEDGE_PAGE_PATH = /^pages\/([a-z0-9]+)$/;
+// and keep their snapshot label. The id charset is kept broad (cuid today,
+// but cuid2/nanoid/uuid ids also match) so a future id-format change won't
+// silently downgrade page favourites to their snapshot label. No `g`/`y`
+// flag: `.match()` on the shared instance stays stateless across rows.
+const KNOWLEDGE_PAGE_PATH = /^pages\/([a-zA-Z0-9_-]+)$/;
 
 /**
  * Verify the user may favourite this entity and return the entity's
@@ -87,7 +90,7 @@ export const favoriteRouter = createTRPCRouter({
         .map((f) => f.entityId);
       const knowledgePageIds = favorites
         .filter((f) => f.entityType === "page")
-        .map((f) => KNOWLEDGE_PAGE_PATH.exec(f.entityId)?.[1])
+        .map((f) => f.entityId.match(KNOWLEDGE_PAGE_PATH)?.[1])
         .filter((id): id is string => id !== undefined);
 
       const [goals, keyResults, knowledgePages] = await Promise.all([
@@ -124,7 +127,7 @@ export const favoriteRouter = createTRPCRouter({
         } else if (entityType === "keyResult") {
           title = krTitle.get(f.entityId);
         } else {
-          const pageId = KNOWLEDGE_PAGE_PATH.exec(f.entityId)?.[1];
+          const pageId = f.entityId.match(KNOWLEDGE_PAGE_PATH)?.[1];
           if (pageId) {
             // knowledge page — live title; undefined means the page was deleted
             title = pageTitle.get(pageId);


### PR DESCRIPTION
### **User description**
## Summary
- Adds a star (`FavoriteButton`) to the knowledge-page detail header at `/w/{slug}/pages/{id}`, so pages can be pinned to the **Favourites** section in the left sidebar — same UX as favouriting product pages and OKRs.
- Reuses the existing polymorphic `page` favourite kind with `entityId = pages/{id}`, which the sidebar already resolves to `/w/{slug}/pages/{id}`. No schema or migration changes.
- `favorite.list` now resolves knowledge-page titles **live** from the page id in the stored path, so renaming a page updates its sidebar label, and favourites pointing at deleted pages are hidden. Static page paths (product sections) keep their snapshot label as before.
- Renaming a page from the title input also invalidates `favorite.list`, so the sidebar label refreshes immediately.

## Testing
- New unit test: `favorite.list` resolves `pages/{id}` rows to the live title, skips deleted pages, and leaves static-path page favourites on their snapshot label.
- All 1282 unit tests pass; `tsc --noEmit` and ESLint clean on changed files.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `FavoriteButton` to knowledge-page detail header for sidebar pinning

- `favorite.list` resolves knowledge-page titles live from page id, hiding deleted pages

- Page rename invalidates `favorite.list` so sidebar label updates immediately

- New unit tests cover live title resolution and deleted-page filtering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Knowledge Page Header"] -- "FavoriteButton added" --> B["Favorite Row\n(entityId = pages/{id})"]
  B -- "favorite.list query" --> C["KNOWLEDGE_PAGE_PATH regex\nmatches pages/{id}"]
  C -- "live lookup" --> D["knowledgePage.findMany"]
  D -- "title resolved" --> E["Sidebar Favourites"]
  C -- "no match (static path)" --> F["Snapshot label used"]
  G["PageTitle rename"] -- "invalidates" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add FavoriteButton to knowledge-page detail header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx

<ul><li>Imports and renders <code>FavoriteButton</code> in the page detail header alongside <br><code>PageShareMenu</code><br> <li> Wraps header actions in a flex container to accommodate the new button<br> <li> Invalidates <code>favorite.list</code> on page title update so sidebar label <br>refreshes immediately</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/351/files#diff-6b79b72a995acbd10cc157f1131181cd7ed46fc478f1fd996884e2c162db08b2">+21/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>favorite.ts</strong><dd><code>Resolve knowledge-page favourite titles live in favorite.list</code></dd></summary>
<hr>

src/server/api/routers/favorite.ts

<ul><li>Introduces <code>KNOWLEDGE_PAGE_PATH</code> regex (<code>/^pages\/([a-zA-Z0-9_-]+)$/</code>) to <br>identify knowledge-page favourites<br> <li> Extracts page ids from matching favourites and fetches live titles via <br><code>knowledgePage.findMany</code><br> <li> Builds a <code>pageTitle</code> map; uses live title for knowledge pages, snapshot <br>label for static paths<br> <li> Favourites pointing at deleted knowledge pages are silently skipped</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/351/files#diff-e720167f111a92c5c294b3f4e8780bb32f08797da5ed9c13414a15680605f535">+32/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>favorite.test.ts</strong><dd><code>Unit tests for live knowledge-page title resolution in favorites</code></dd></summary>
<hr>

src/server/api/routers/__tests__/favorite.test.ts

<ul><li>Adds test case verifying <code>pages/{id}</code> favourites resolve to live page <br>title<br> <li> Asserts deleted knowledge pages are excluded from the returned list<br> <li> Confirms static page-path favourites retain their snapshot label <br>unchanged<br> <li> Validates correct <code>knowledgePage.findMany</code> call arguments</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/351/files#diff-82090567005956f5f2c7fde1b0eccf079067c5b1c4b9a3c2c5e46eca1b9bcee7">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

