### PR TITLE
refactor(graph): priority icon, points chip, and cycle filter

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -283,8 +283,8 @@ A Ticket is "blocked" when its `openBlockerCount > 0` — i.e. it has at least o
 ### Dependency graph
 
 **Dependency graph**:
-A per-Product visualisation surfaced on the product detail page that overlays two distinct edge types: ticket-dependency edges (blocking, peer, DAG) and alignment edges (`Ticket → Feature → Objective`, hierarchical). Purpose: trace "this Objective is at risk" down to the specific Tickets jamming progress. Edge types are visually distinguished — not collapsed into one. Key results appear as decoration on Objective nodes (status chip), not as graph nodes.
-_Avoid_: Roadmap (carries timeline connotations), tree (loses the cross-cutting blocking edges), org chart.
+A per-Product visualisation surfaced on the product detail page that overlays two distinct edge types: ticket-dependency edges (blocking, peer, DAG) and alignment edges (`Ticket → Feature → Objective`, hierarchical). Purpose: trace "this Objective is at risk" down to the specific Tickets jamming progress. Edge types are visually distinguished — not collapsed into one. Key results appear as decoration on Objective nodes (status chip), not as graph nodes. Ticket cards carry optional encodings that render **only when set** (priority icon, points chip) — an unprioritised, unestimated board pays zero pixels. A **cycle filter** (All / per-cycle / No cycle) restricts the canvas to one cycle's Tickets plus their **1-hop out-of-cycle direct blockers**, drawn dimmed with a cycle chip — deliberately not downstream dependents or transitive chains, so the filtered view answers exactly "what outside work is jamming this cycle?". Spatial clustering by cycle was deliberately rejected: the canvas is a left-to-right cascade where horizontal position encodes dependency rank, and cluster boxes would fight that axis (clustering belongs in static exports instead).
+_Avoid_: Roadmap (carries timeline connotations), tree (loses the cross-cutting blocking edges), org chart, swimlanes/cluster boxes (the rejected spatial grouping).
 
 ### Voice
 

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/graph/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/graph/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Group, Skeleton, Stack, Switch } from "@mantine/core";
+import { Group, Select, Skeleton, Stack, Switch } from "@mantine/core";
 import { IconAffiliate } from "@tabler/icons-react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
@@ -12,6 +12,14 @@ import {
   type GraphNodeClick,
 } from "~/app/_components/product/graph/DependencyGraphCanvas";
 import { TicketDrawer } from "~/app/_components/product/graph/TicketDrawer";
+import {
+  applyCycleFilter,
+  deriveCycleOptions,
+  hasUncycledTickets,
+  CYCLE_FILTER_ALL,
+  CYCLE_FILTER_NONE,
+  type CycleFilterValue,
+} from "~/app/_components/product/graph/cycleFilter";
 
 export default function ProductGraphPage() {
   const params = useParams();
@@ -19,6 +27,8 @@ export default function ProductGraphPage() {
   const productSlug = params.productSlug as string;
   const { workspace, workspaceId } = useWorkspace();
   const [showCompleted, setShowCompleted] = useState(false);
+  const [cycleFilter, setCycleFilter] =
+    useState<CycleFilterValue>(CYCLE_FILTER_ALL);
   const [drawerTicketId, setDrawerTicketId] = useState<string | null>(null);
 
   const { data: product, isLoading: isProductLoading } =
@@ -32,6 +42,51 @@ export default function ProductGraphPage() {
       { productId: product?.id ?? "", includeCompleted: showCompleted },
       { enabled: !!product?.id },
     );
+
+  const allTickets = graph?.tickets;
+  const allEdges = graph?.blockingEdges;
+  const allFeatures = graph?.features;
+
+  const cycleOptions = useMemo(
+    () => deriveCycleOptions(allTickets ?? []),
+    [allTickets],
+  );
+  const showNoCycleOption = useMemo(
+    () => hasUncycledTickets(allTickets ?? []),
+    [allTickets],
+  );
+  // Fall back to "All" when the selected cycle drops out of the data
+  // (e.g. after toggling "Show completed").
+  const effectiveFilter =
+    cycleFilter === CYCLE_FILTER_ALL ||
+    (cycleFilter === CYCLE_FILTER_NONE && showNoCycleOption) ||
+    cycleOptions.some((c) => c.id === cycleFilter)
+      ? cycleFilter
+      : CYCLE_FILTER_ALL;
+
+  const { tickets: visibleTickets, dimmedTicketIds } = useMemo(
+    () => applyCycleFilter(allTickets ?? [], allEdges ?? [], effectiveFilter),
+    [allTickets, allEdges, effectiveFilter],
+  );
+
+  // Features stay visible only while an in-cycle (non-dimmed) ticket needs
+  // them; blocking edges only when both endpoints are drawn.
+  const visibleFeatures = useMemo(() => {
+    if (effectiveFilter === CYCLE_FILTER_ALL) return allFeatures ?? [];
+    const neededFeatureIds = new Set(
+      visibleTickets
+        .filter((t) => !dimmedTicketIds.has(t.id) && t.featureId)
+        .map((t) => t.featureId),
+    );
+    return (allFeatures ?? []).filter((f) => neededFeatureIds.has(f.id));
+  }, [allFeatures, visibleTickets, dimmedTicketIds, effectiveFilter]);
+
+  const visibleEdges = useMemo(() => {
+    const ids = new Set(visibleTickets.map((t) => t.id));
+    return (allEdges ?? []).filter(
+      (e) => ids.has(e.fromTicketId) && ids.has(e.toTicketId),
+    );
+  }, [allEdges, visibleTickets]);
 
   if (!workspace) return null;
 
@@ -78,6 +133,23 @@ export default function ProductGraphPage() {
   return (
     <Stack gap="md">
       <Group justify="flex-end">
+        {cycleOptions.length > 0 && (
+          <Select
+            aria-label="Filter by cycle"
+            size="sm"
+            w={200}
+            allowDeselect={false}
+            value={effectiveFilter}
+            onChange={(value) => setCycleFilter(value ?? CYCLE_FILTER_ALL)}
+            data={[
+              { value: CYCLE_FILTER_ALL, label: "All cycles" },
+              ...cycleOptions.map((c) => ({ value: c.id, label: c.name })),
+              ...(showNoCycleOption
+                ? [{ value: CYCLE_FILTER_NONE, label: "No cycle" }]
+                : []),
+            ]}
+          />
+        )}
         <Switch
           label="Show completed"
           checked={showCompleted}
@@ -86,10 +158,11 @@ export default function ProductGraphPage() {
       </Group>
       {hasTickets ? (
         <DependencyGraphCanvas
-          tickets={graph!.tickets}
-          features={graph!.features}
+          tickets={visibleTickets}
+          features={visibleFeatures}
           objectives={graph!.objectives}
-          blockingEdges={graph!.blockingEdges}
+          blockingEdges={visibleEdges}
+          dimmedTicketIds={dimmedTicketIds}
           onNodeClick={handleNodeClick}
         />
       ) : (

--- a/src/app/_components/product/graph/DependencyGraphCanvas.tsx
+++ b/src/app/_components/product/graph/DependencyGraphCanvas.tsx
@@ -125,6 +125,14 @@ export function DependencyGraphCanvas({
     );
     const showUnaligned = orphanTickets.length > 0;
 
+    // Single source of truth for Ticket alignment edges — consumed by both
+    // the layout pass and the rendered flow edges so they can never diverge.
+    const ticketAlignmentPairs: Array<{ source: string; target: string }> = [];
+    for (const t of tickets) {
+      const source = alignmentSourceFor(t);
+      if (source) ticketAlignmentPairs.push({ source, target: t.id });
+    }
+
     // Objective ids that are reachable via at least one visible Feature.
     const reachableObjectiveIds = new Set<number>();
     for (const f of features) {
@@ -158,11 +166,8 @@ export function DependencyGraphCanvas({
         });
       }
     }
-    for (const t of tickets) {
-      const source = alignmentSourceFor(t);
-      if (source) {
-        layoutEdges.push({ source, target: t.id, kind: "alignment" });
-      }
+    for (const p of ticketAlignmentPairs) {
+      layoutEdges.push({ ...p, kind: "alignment" });
     }
     for (const e of blockingEdges) {
       layoutEdges.push({
@@ -239,13 +244,11 @@ export function DependencyGraphCanvas({
     }
 
     // Alignment edges: Feature → Ticket (or UnalignedContainer → orphan ticket).
-    for (const t of tickets) {
-      const source = alignmentSourceFor(t);
-      if (!source) continue;
+    for (const p of ticketAlignmentPairs) {
       flowEdges.push({
-        id: `alignment:${source}->${t.id}`,
-        source,
-        target: t.id,
+        id: `alignment:${p.source}->${p.target}`,
+        source: p.source,
+        target: p.target,
         type: "default",
         style: alignmentEdgeStyle,
         markerEnd: alignmentMarker,

--- a/src/app/_components/product/graph/DependencyGraphCanvas.tsx
+++ b/src/app/_components/product/graph/DependencyGraphCanvas.tsx
@@ -52,6 +52,12 @@ interface Props {
   features?: DependencyGraphFeature[];
   objectives?: DependencyGraphObjective[];
   blockingEdges?: DependencyGraphBlockingEdge[];
+  /**
+   * Tickets rendered dimmed with a cycle chip — out-of-cycle direct blockers
+   * surfaced by the cycle filter. They never join the Unaligned container and
+   * carry no alignment edge when their Feature is filtered out.
+   */
+  dimmedTicketIds?: ReadonlySet<string>;
   onNodeClick?: (event: GraphNodeClick) => void;
 }
 
@@ -84,6 +90,7 @@ export function DependencyGraphCanvas({
   features = [],
   objectives = [],
   blockingEdges = [],
+  dimmedTicketIds,
   onNodeClick,
 }: Props) {
   // Theme the xyflow chrome (Controls / Background) to the app's color scheme
@@ -103,7 +110,19 @@ export function DependencyGraphCanvas({
     }
   };
   const { nodes, edges } = useMemo(() => {
-    const orphanTickets = tickets.filter((t) => t.featureId === null);
+    const dimmed = dimmedTicketIds ?? new Set<string>();
+    const featureIds = new Set(features.map((f) => f.id));
+    // Resolve each ticket's alignment parent under the current filter: its
+    // Feature when visible, the Unaligned container for non-dimmed orphans,
+    // nothing for dimmed tickets whose Feature was filtered out.
+    const alignmentSourceFor = (t: DependencyGraphTicket): string | null => {
+      if (t.featureId && featureIds.has(t.featureId)) return t.featureId;
+      if (t.featureId || dimmed.has(t.id)) return null;
+      return UNALIGNED_NODE_ID;
+    };
+    const orphanTickets = tickets.filter(
+      (t) => t.featureId === null && !dimmed.has(t.id),
+    );
     const showUnaligned = orphanTickets.length > 0;
 
     // Objective ids that are reachable via at least one visible Feature.
@@ -140,18 +159,9 @@ export function DependencyGraphCanvas({
       }
     }
     for (const t of tickets) {
-      if (t.featureId) {
-        layoutEdges.push({
-          source: t.featureId,
-          target: t.id,
-          kind: "alignment",
-        });
-      } else if (showUnaligned) {
-        layoutEdges.push({
-          source: UNALIGNED_NODE_ID,
-          target: t.id,
-          kind: "alignment",
-        });
+      const source = alignmentSourceFor(t);
+      if (source) {
+        layoutEdges.push({ source, target: t.id, kind: "alignment" });
       }
     }
     for (const e of blockingEdges) {
@@ -179,9 +189,13 @@ export function DependencyGraphCanvas({
           status: t.status,
           shortId: t.shortId,
           number: t.number,
+          priority: t.priority,
+          points: t.points,
           assignee: t.assignee,
           openBlockerCount: t.openBlockerCount,
           isBlocked: t.isBlocked,
+          dimmed: dimmed.has(t.id),
+          cycleName: t.cycle?.name ?? null,
         };
         return { id: n.id, type: "ticket", position, data, draggable: false };
       }
@@ -226,7 +240,7 @@ export function DependencyGraphCanvas({
 
     // Alignment edges: Feature → Ticket (or UnalignedContainer → orphan ticket).
     for (const t of tickets) {
-      const source = t.featureId ?? (showUnaligned ? UNALIGNED_NODE_ID : null);
+      const source = alignmentSourceFor(t);
       if (!source) continue;
       flowEdges.push({
         id: `alignment:${source}->${t.id}`,
@@ -261,7 +275,7 @@ export function DependencyGraphCanvas({
     }
 
     return { nodes: flowNodes, edges: flowEdges };
-  }, [tickets, features, objectives, blockingEdges]);
+  }, [tickets, features, objectives, blockingEdges, dimmedTicketIds]);
 
   return (
     <div

--- a/src/app/_components/product/graph/__tests__/cycleFilter.test.ts
+++ b/src/app/_components/product/graph/__tests__/cycleFilter.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyCycleFilter,
+  deriveCycleOptions,
+  hasUncycledTickets,
+  CYCLE_FILTER_ALL,
+  CYCLE_FILTER_NONE,
+} from "../cycleFilter";
+import type {
+  DependencyGraphBlockingEdge,
+  DependencyGraphTicket,
+} from "~/plugins/product/server/services/DependencyGraphService";
+
+function ticket(
+  id: string,
+  cycle: { id: string; name: string } | null,
+): DependencyGraphTicket {
+  return {
+    id,
+    number: 1,
+    shortId: id,
+    title: `Ticket ${id}`,
+    status: "BACKLOG",
+    priority: null,
+    points: null,
+    featureId: null,
+    cycle,
+    assignee: null,
+    openBlockerCount: 0,
+    isBlocked: false,
+  };
+}
+
+const sprint11 = { id: "c11", name: "Sprint 11" };
+const sprint12 = { id: "c12", name: "Sprint 12" };
+
+describe("deriveCycleOptions", () => {
+  it("returns distinct cycles sorted by name", () => {
+    const tickets = [
+      ticket("a", sprint12),
+      ticket("b", sprint11),
+      ticket("c", sprint12),
+      ticket("d", null),
+    ];
+    expect(deriveCycleOptions(tickets)).toEqual([
+      { id: "c11", name: "Sprint 11" },
+      { id: "c12", name: "Sprint 12" },
+    ]);
+  });
+});
+
+describe("hasUncycledTickets", () => {
+  it("detects tickets without a cycle", () => {
+    expect(hasUncycledTickets([ticket("a", sprint11)])).toBe(false);
+    expect(hasUncycledTickets([ticket("a", sprint11), ticket("b", null)])).toBe(
+      true,
+    );
+  });
+});
+
+describe("applyCycleFilter", () => {
+  const tickets = [
+    ticket("a", sprint11),
+    ticket("b", sprint12),
+    ticket("c", sprint12),
+    ticket("d", null),
+  ];
+  // a blocks b; d blocks c; b blocks d.
+  const edges: DependencyGraphBlockingEdge[] = [
+    { fromTicketId: "a", toTicketId: "b" },
+    { fromTicketId: "d", toTicketId: "c" },
+    { fromTicketId: "b", toTicketId: "d" },
+  ];
+
+  it('passes everything through undimmed for "all"', () => {
+    const result = applyCycleFilter(tickets, edges, CYCLE_FILTER_ALL);
+    expect(result.tickets).toEqual(tickets);
+    expect(result.dimmedTicketIds.size).toBe(0);
+  });
+
+  it("keeps a cycle's tickets plus dimmed 1-hop out-of-cycle blockers", () => {
+    const result = applyCycleFilter(tickets, edges, "c12");
+    expect(result.tickets.map((t) => t.id)).toEqual(["a", "b", "c", "d"]);
+    expect(Array.from(result.dimmedTicketIds).sort()).toEqual(["a", "d"]);
+  });
+
+  it("does not pull in downstream dependents", () => {
+    // Sprint 11 contains only "a"; "b" depends on it but must stay hidden.
+    const result = applyCycleFilter(tickets, edges, "c11");
+    expect(result.tickets.map((t) => t.id)).toEqual(["a"]);
+    expect(result.dimmedTicketIds.size).toBe(0);
+  });
+
+  it("does not follow blocking chains transitively", () => {
+    // Filtering to "no cycle" keeps d and its direct blocker b — but not a,
+    // which only blocks d via b.
+    const result = applyCycleFilter(tickets, edges, CYCLE_FILTER_NONE);
+    expect(result.tickets.map((t) => t.id)).toEqual(["b", "d"]);
+    expect(Array.from(result.dimmedTicketIds)).toEqual(["b"]);
+  });
+
+  it("never dims in-cycle blockers", () => {
+    // b and c are both Sprint 12; add an in-cycle edge b→c.
+    const result = applyCycleFilter(
+      tickets,
+      [...edges, { fromTicketId: "b", toTicketId: "c" }],
+      "c12",
+    );
+    expect(result.dimmedTicketIds.has("b")).toBe(false);
+  });
+});

--- a/src/app/_components/product/graph/__tests__/cycleFilter.test.ts
+++ b/src/app/_components/product/graph/__tests__/cycleFilter.test.ts
@@ -99,6 +99,17 @@ describe("applyCycleFilter", () => {
     expect(Array.from(result.dimmedTicketIds)).toEqual(["b"]);
   });
 
+  it("ignores edges whose blocker is not in the ticket set", () => {
+    // e.g. the blocker was excluded upstream by includeCompleted: false.
+    const result = applyCycleFilter(
+      tickets,
+      [...edges, { fromTicketId: "ghost", toTicketId: "b" }],
+      "c12",
+    );
+    expect(result.dimmedTicketIds.has("ghost")).toBe(false);
+    expect(result.tickets.map((t) => t.id)).toEqual(["a", "b", "c", "d"]);
+  });
+
   it("never dims in-cycle blockers", () => {
     // b and c are both Sprint 12; add an in-cycle edge b→c.
     const result = applyCycleFilter(

--- a/src/app/_components/product/graph/cycleFilter.ts
+++ b/src/app/_components/product/graph/cycleFilter.ts
@@ -1,0 +1,85 @@
+import type {
+  DependencyGraphBlockingEdge,
+  DependencyGraphTicket,
+} from "~/plugins/product/server/services/DependencyGraphService";
+
+/**
+ * Cycle filter for the dependency graph. CYCLE_FILTER_ALL shows the whole
+ * graph; CYCLE_FILTER_NONE isolates unscheduled tickets; any other value is
+ * a cycle (List) id.
+ */
+export type CycleFilterValue = string;
+
+export const CYCLE_FILTER_ALL = "all";
+export const CYCLE_FILTER_NONE = "none";
+
+export interface CycleOption {
+  id: string;
+  name: string;
+}
+
+export interface CycleFilterResult {
+  /** Tickets to draw, in the input order. */
+  tickets: DependencyGraphTicket[];
+  /**
+   * Out-of-cycle direct blockers, rendered dimmed with a cycle chip.
+   * Always a subset of `tickets`' ids; empty when the filter is "all".
+   */
+  dimmedTicketIds: Set<string>;
+}
+
+/** Distinct cycles present in the graph, sorted by name. */
+export function deriveCycleOptions(
+  tickets: DependencyGraphTicket[],
+): CycleOption[] {
+  const byId = new Map<string, string>();
+  for (const t of tickets) {
+    if (t.cycle) byId.set(t.cycle.id, t.cycle.name);
+  }
+  return Array.from(byId, ([id, name]) => ({ id, name })).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+}
+
+/** Whether any ticket has no cycle — gates the "No cycle" dropdown entry. */
+export function hasUncycledTickets(tickets: DependencyGraphTicket[]): boolean {
+  return tickets.some((t) => t.cycle === null);
+}
+
+/**
+ * Restrict the graph to one cycle's tickets plus their direct (1-hop)
+ * out-of-cycle blockers. Blockers-only by design: downstream dependents and
+ * transitive chains stay hidden so the filtered view answers exactly
+ * "what outside work is jamming this cycle?".
+ */
+export function applyCycleFilter(
+  tickets: DependencyGraphTicket[],
+  blockingEdges: DependencyGraphBlockingEdge[],
+  filter: CycleFilterValue,
+): CycleFilterResult {
+  if (filter === CYCLE_FILTER_ALL) {
+    return { tickets, dimmedTicketIds: new Set() };
+  }
+
+  const inCycle = new Set<string>();
+  for (const t of tickets) {
+    const matches =
+      filter === CYCLE_FILTER_NONE ? t.cycle === null : t.cycle?.id === filter;
+    if (matches) inCycle.add(t.id);
+  }
+
+  // Direction convention: fromTicketId blocks toTicketId.
+  const dimmedTicketIds = new Set<string>();
+  for (const e of blockingEdges) {
+    if (inCycle.has(e.toTicketId) && !inCycle.has(e.fromTicketId)) {
+      dimmedTicketIds.add(e.fromTicketId);
+    }
+  }
+
+  return {
+    tickets: tickets.filter(
+      (t) => inCycle.has(t.id) || dimmedTicketIds.has(t.id),
+    ),
+    dimmedTicketIds,
+  };
+}

--- a/src/app/_components/product/graph/cycleFilter.ts
+++ b/src/app/_components/product/graph/cycleFilter.ts
@@ -61,6 +61,7 @@ export function applyCycleFilter(
     return { tickets, dimmedTicketIds: new Set() };
   }
 
+  const allTicketIds = new Set(tickets.map((t) => t.id));
   const inCycle = new Set<string>();
   for (const t of tickets) {
     const matches =
@@ -68,10 +69,16 @@ export function applyCycleFilter(
     if (matches) inCycle.add(t.id);
   }
 
-  // Direction convention: fromTicketId blocks toTicketId.
+  // Direction convention: fromTicketId blocks toTicketId. Skip blockers with
+  // no ticket in the input (e.g. an edge whose blocker was excluded upstream)
+  // so the returned set stays a strict subset of the input tickets' ids.
   const dimmedTicketIds = new Set<string>();
   for (const e of blockingEdges) {
-    if (inCycle.has(e.toTicketId) && !inCycle.has(e.fromTicketId)) {
+    if (
+      inCycle.has(e.toTicketId) &&
+      !inCycle.has(e.fromTicketId) &&
+      allTicketIds.has(e.fromTicketId)
+    ) {
       dimmedTicketIds.add(e.fromTicketId);
     }
   }

--- a/src/app/_components/product/graph/nodes/TicketNode.tsx
+++ b/src/app/_components/product/graph/nodes/TicketNode.tsx
@@ -5,6 +5,10 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { STATUS_LABELS } from "~/lib/ticket-statuses";
 import { BlockedIndicator } from "~/app/_components/product/TicketDependenciesSection";
 import {
+  PriorityIcon,
+  PRIORITY_LABELS,
+} from "~/app/_components/product/PriorityIcon";
+import {
   assigneePillColor,
   ROADMAP_CARD_CLASS,
   ROADMAP_CARD_WIDTH,
@@ -16,9 +20,20 @@ export interface TicketNodeData extends Record<string, unknown> {
   status: string;
   shortId: string | null;
   number: number;
+  priority: number | null;
+  points: number | null;
   assignee: { id: string; name: string | null; image: string | null } | null;
   openBlockerCount: number;
   isBlocked: boolean;
+  /** Out-of-cycle direct blocker shown under a cycle filter. */
+  dimmed: boolean;
+  /** Cycle name for the chip on dimmed cards; null reads as "No cycle". */
+  cycleName: string | null;
+}
+
+/** Priorities 0–3 carry signal; 4 / null ("No priority") renders nothing. */
+function hasPriority(priority: number | null): priority is number {
+  return priority !== null && priority >= 0 && priority <= 3;
 }
 
 export function TicketNode({ data }: NodeProps) {
@@ -28,7 +43,9 @@ export function TicketNode({ data }: NodeProps) {
 
   return (
     <div
-      className={`${ROADMAP_CARD_CLASS} hover:border-border-focus`}
+      className={`${ROADMAP_CARD_CLASS} hover:border-border-focus ${
+        d.dimmed ? "opacity-50" : ""
+      }`}
       style={{ width: ROADMAP_CARD_WIDTH }}
     >
       <Handle type="target" position={Position.Left} style={{ opacity: 0 }} />
@@ -44,6 +61,17 @@ export function TicketNode({ data }: NodeProps) {
             {ticketStatusEmoji(d.status)}
           </span>
         </Tooltip>
+        {hasPriority(d.priority) && (
+          <Tooltip
+            label={PRIORITY_LABELS[d.priority] ?? "Priority"}
+            position="top"
+            withArrow
+          >
+            <span className="shrink-0 leading-none">
+              <PriorityIcon priority={d.priority} size={16} />
+            </span>
+          </Tooltip>
+        )}
         <Text
           size="sm"
           fw={600}
@@ -52,11 +80,28 @@ export function TicketNode({ data }: NodeProps) {
         >
           {d.title}
         </Text>
+        {d.points !== null && (
+          <Tooltip label={`${d.points} points`} position="top" withArrow>
+            <Text size="xs" className="text-text-muted shrink-0">
+              {d.points}
+            </Text>
+          </Tooltip>
+        )}
         <BlockedIndicator
           openBlockerCount={d.openBlockerCount}
           isBlocked={d.isBlocked}
         />
-        {d.assignee ? (
+        {d.dimmed ? (
+          <Badge
+            variant="light"
+            color="gray"
+            radius="sm"
+            size="sm"
+            className="shrink-0 normal-case"
+          >
+            {d.cycleName ?? "No cycle"}
+          </Badge>
+        ) : d.assignee ? (
           <Badge
             variant="light"
             color={assigneePillColor(d.assignee.id)}

--- a/src/plugins/product/server/services/DependencyGraphService.ts
+++ b/src/plugins/product/server/services/DependencyGraphService.ts
@@ -12,7 +12,9 @@ export interface DependencyGraphTicket {
   title: string;
   status: TicketStatus;
   priority: number | null;
+  points: number | null;
   featureId: string | null;
+  cycle: { id: string; name: string } | null;
   assignee: { id: string; name: string | null; image: string | null } | null;
   openBlockerCount: number;
   isBlocked: boolean;
@@ -78,7 +80,9 @@ export async function buildGraph(
       title: true,
       status: true,
       priority: true,
+      points: true,
       featureId: true,
+      cycle: { select: { id: true, name: true } },
       assignee: { select: { id: true, name: true, image: true } },
       depsOut: { select: { dependsOn: { select: { status: true } } } },
     },
@@ -97,7 +101,9 @@ export async function buildGraph(
       title: t.title,
       status: t.status,
       priority: t.priority,
+      points: t.points,
       featureId: t.featureId,
+      cycle: t.cycle,
       assignee: t.assignee,
       openBlockerCount,
       isBlocked,


### PR DESCRIPTION
### **User description**
## What

Bring the high-value visual encodings from the linear-tools dependency graph into the per-Product Dependency graph canvas, without crowding the single-row ticket cards.

- **Priority icon** — the existing `PriorityIcon` (16px) next to the status emoji on `TicketNode`, **hidden when priority is null/4** — unprioritised boards pay zero pixels. The service already fetched `priority`; the node now renders it.
- **Points chip** — small muted chip after the title, **only when `Ticket.points` is set**. No node sizing — cards stay uniform 260px.
- **Cycle filter** — a `Select` next to "Show completed" (All cycles / each cycle with tickets / No cycle), client-side. With a cycle selected, the canvas shows that cycle's tickets **plus 1-hop out-of-cycle direct blockers**, dimmed with a cycle chip (same ghost pattern as ADR-0002's cross-product blockers). Direct blockers only — no downstream dependents, no transitive chains. Features/Objectives stay only while an in-cycle ticket needs them; "Show completed" stays orthogonal (a stale cycle selection falls back to All).
- `DependencyGraphService` payload gains `points` and `cycle { id, name }`.
- CONTEXT.md "Dependency graph" glossary entry sharpened (optional encodings, cycle-filter semantics, why spatial clustering was rejected).

Deliberately out of scope: spatial cluster boxes (they'd fight the left-to-right cascade where x = dependency rank; clustering goes in the CLI dot export instead — snowy.brook), cross-product ghost nodes (ADR-0002 Slice 2), node sizing by estimate.

## Tests

- New pure `cycleFilter` module with unit tests (options derivation, 1-hop blockers-only semantics, no transitive/downstream pull-in, in-cycle blockers never dimmed).
- `npx tsc` clean, eslint clean on changed files, full unit suite 1288/1288.

---

Ships: sandy.cocoa


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add cycle filter (All/per-cycle/No cycle) to dependency graph canvas

- Render priority icon and points chip on ticket nodes when set

- Dimmed out-of-cycle direct blockers shown with cycle chip badge

- New `cycleFilter` module with comprehensive unit tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  page["ProductGraphPage"]
  cycleFilter["cycleFilter.ts\n(applyCycleFilter,\nderiveCycleOptions)"]
  canvas["DependencyGraphCanvas"]
  ticketNode["TicketNode"]
  service["DependencyGraphService"]
  tests["cycleFilter.test.ts"]

  page -- "cycle filter state\n+ visible tickets/edges" --> canvas
  page -- "derives options\n+ applies filter" --> cycleFilter
  cycleFilter -- "dimmedTicketIds\n+ filtered tickets" --> canvas
  canvas -- "dimmed, cycleName,\npriority, points" --> ticketNode
  service -- "adds points\n+ cycle fields" --> page
  tests -- "unit tests" --> cycleFilter
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>page.tsx</strong><dd><code>Add cycle filter Select and filtered graph data derivation</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/352/files#diff-997d449b221b2c75d3ac20e1c5e916902fe382e87ed1811db0e97bd345653d22">+78/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DependencyGraphCanvas.tsx</strong><dd><code>Support dimmedTicketIds and consolidate alignment edge logic</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/352/files#diff-504273f6b675856867e9be8202656bec35a6fbe0fd3e72f80357948ce65368da">+39/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cycleFilter.ts</strong><dd><code>New cycle filter module with 1-hop blocker logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/352/files#diff-6036b5a966845667467ba01a3a667dca43204a241dd5a56a1187e769851b0154">+92/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TicketNode.tsx</strong><dd><code>Render priority icon, points chip, and dimmed cycle badge</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/352/files#diff-d5ef24b7188ba153b7af4d81a8a7e6c39fa0918f509678d7bdf07de329fca903">+47/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DependencyGraphService.ts</strong><dd><code>Add points and cycle fields to graph ticket payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/352/files#diff-b0064b74628036a6d43557c9388f9f05210dc7f0fcfacdaa66943899051ee05c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>cycleFilter.test.ts</strong><dd><code>Unit tests for cycleFilter module semantics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/352/files#diff-6bec8f3870a757ad0a7369761d7701b995ad39462187d80f3504e5a6be1d7181">+122/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CONTEXT.md</strong><dd><code>Document cycle filter semantics and optional ticket encodings</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/352/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

