### PR TITLE
refactor: extract stream-protocol parser + shared streaming hook from ManyChat

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -318,6 +318,10 @@ _Avoid_: Voice thread (ambiguous — say "voice memory thread"), conversation (o
 The shared in-app agent chat component (`src/app/_components/ManyChat.tsx`) behind every embedded chat surface — the Zoe drawer and the agent chat pages — rendering streamed responses, tool activity, voice input, and the per-message feedback stars. Talks to `/api/chat/stream` under the signed-in user's web session. The name is purely internal and predates any awareness of **manychat.com** (the WhatsApp/Instagram automation SaaS) — in this codebase "ManyChat" always means this component, never that product. Rename candidate if the collision keeps confusing people (and agents).
 _Avoid_: Reading it as manychat.com; chat widget, chatbox.
 
+**Zoe canvas**:
+The experimental `/home` surface where Zoe answers *in the page content* instead of the drawer: on send, the dashboard below the Zoe input collapses and the answer streams in its place, styled as a dashboard card. A third display mode of the **same** conversation state the Zoe drawer shows (the ADR-0006 "two surfaces, one thread" pattern again) — but each canvas **engagement** (one open→dismiss cycle) starts a **fresh Thread** (new `conversationId`, cleanly scorable), and the canvas renders only the current engagement; full history stays a drawer affordance. Dismissal (✕/Esc) or navigating away mid-stream aborts the stream and marks the turn `incomplete` — one rule for both. v1 renders markdown; native per-preset cards (standup first) are a fast-follow. See [ADR-0040](docs/adr/0040-zoe-canvas-fresh-thread-per-engagement.md).
+_Avoid_: Inline chat, inline mode (position, not identity), embedded drawer, answer canvas, home canvas (couples the concept to one route).
+
 ### Agent quality
 
 _Operations (what to run, when, in what order): [dev-docs/AGENT_QUALITY_RUNBOOK.md](dev-docs/AGENT_QUALITY_RUNBOOK.md)._

--- a/docs/adr/0040-zoe-canvas-fresh-thread-per-engagement.md
+++ b/docs/adr/0040-zoe-canvas-fresh-thread-per-engagement.md
@@ -1,0 +1,54 @@
+# Zoe canvas engagements are fresh Threads
+
+## Status
+
+Accepted — 2026-07-07
+
+## Context
+
+The **Zoe canvas** is the experimental `/home` surface where Zoe answers in the
+page content: on send (hero input or a suggestion chip), the dashboard below
+the input collapses and the answer streams in its place. The canvas shares the
+drawer's conversation *state* — it reads and writes the same
+`AgentModalProvider` messages, so a canvas engagement is visible in the drawer
+afterwards ("Continue in panel" is free).
+
+That sharing raised the question of conversational *identity*: should a canvas
+send continue the active `conversationId`, the way [ADR-0006](0006-web-voice-shares-text-thread.md)
+unified web voice and text onto one thread? The canvas deliberately renders
+only the current engagement (its identity is "the page answering", not a
+relocated chat window), so continuing the active thread would mean Zoe's
+answer is steered by prior turns the surface is *hiding* — a fresh-looking
+answer shaped by invisible context. It would also blur **Thread**-level
+quality scoring (ADR-0012 judges "did the user get what they came for?" per
+`conversationId`), mixing a crisp canvas intent ("standup on my projects")
+into an unrelated running conversation.
+
+## Decision
+
+Each canvas **engagement** (one open→dismiss cycle) starts a **fresh Thread**:
+a chip click or hero send is an implicit "new thread + send" with a new
+`conversationId`. Follow-ups within the engagement continue that thread;
+dismissal ends it. The previous drawer thread survives in conversation
+history — it just stops being the active one.
+
+This is a deliberate deviation from ADR-0006's "two surfaces, one thread"
+precedent. ADR-0006 unified surfaces that render **the same visual thread**
+(typed and spoken turns interleave in one transcript, so split memory caused
+observable amnesia). The canvas is the inverse case: it intentionally does
+*not* render the prior thread, so sharing the `conversationId` would create
+the hidden-context hazard rather than cure one. The rule generalises as:
+memory follows what the user can see.
+
+## Consequences
+
+- Canvas Threads are cleanly scorable and comparable: stamped with their own
+  `platform` value (`web-canvas`) in `AiInteractionHistory`, one engagement =
+  one Thread with one intent, judged against the drawer's Threads by the
+  existing ADR-0012 machinery.
+- Zoe does not carry yesterday's drawer context into a canvas ask. Users who
+  want continuation use the drawer (⌘J), which remains the full-history
+  surface.
+- Dismissing the canvas (✕/Esc) or navigating away mid-stream aborts the
+  stream and marks the turn `incomplete` (existing retry UI) — one rule for
+  both exits.

--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -26,9 +26,11 @@ import { AgentMessageFeedback } from './agent/AgentMessageFeedback';
 import { ToolActivity } from './agent/ToolActivity';
 import { ThinkingStatus } from './agent/ThinkingStatus';
 import { DraftActionsReviewCard } from './DraftActionsReviewCard';
-import { useAgentModal, type ChatMessage, type PageContext, type ToolCall } from '~/providers/AgentModalProvider';
+import { useAgentModal, type ChatMessage, type PageContext } from '~/providers/AgentModalProvider';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { trimByTokenBudget } from '~/lib/trim-conversation';
+import { classifyStreamError, type StreamFailureKind } from '~/lib/chat/streamProtocol';
+import { streamChatResponse } from '~/lib/chat/streamChatResponse';
 
 // Module-level constants to avoid re-creation on every render
 const VIDEO_PATTERN = /\[Video ([a-zA-Z0-9_-]+)\]/g;
@@ -151,42 +153,6 @@ type Message = ChatMessage;
  * and re-spends tokens) — they finalize as `incomplete` with a Retry button.
  */
 const MAX_AUTO_RETRIES = 2;
-
-type StreamFailureKind = 'transport' | 'idle-timeout' | 'auth' | 'model' | 'unknown';
-
-/**
- * Bucket a thrown stream error into an actionable class. The decisive split is
- * `transport` (the HTTP body was cut mid-flight — a `TypeError`/network drop,
- * the dominant mobile failure) which is safe to auto-retry, vs. everything else
- * (idle stall, auth, model/agent error) which is not. Previously ManyChat
- * lumped every `TypeError` into one scary "check your API keys" message; this
- * keeps the copy honest and gates the retry logic.
- */
-function classifyStreamError(error: unknown): { kind: StreamFailureKind; retryable: boolean } {
-  if (!(error instanceof Error)) return { kind: 'unknown', retryable: false };
-  const text = error.message.toLowerCase();
-  if (error.name === 'AbortError' || text.includes('stream-idle-timeout')) {
-    return { kind: 'idle-timeout', retryable: true };
-  }
-  if (text.includes('unauthorized') || text.includes('401') || text.includes('forbidden') || text.includes('403')) {
-    return { kind: 'auth', retryable: false };
-  }
-  if (
-    error.name === 'TypeError' ||
-    text.includes('network') ||
-    text.includes('failed to fetch') ||
-    text.includes('load failed') ||
-    text.includes('timeout') ||
-    text.includes('stream request failed') ||
-    text.includes('connection')
-  ) {
-    return { kind: 'transport', retryable: true };
-  }
-  if (text.includes('mastra') || text.includes('agent')) {
-    return { kind: 'model', retryable: false };
-  }
-  return { kind: 'unknown', retryable: false };
-}
 
 /**
  * User-facing copy for a *terminal* failure (auto-retries already exhausted).
@@ -1301,172 +1267,30 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
         })),
       });
 
-      // Idle-timeout watchdog: abort if no chunk arrives for IDLE_TIMEOUT_MS.
-      // Prevents the stuck-isStreaming state when the server stream stalls silently.
-      const abortController = new AbortController();
-      const IDLE_TIMEOUT_MS = 60_000;
-      let idleTimer: ReturnType<typeof setTimeout> | null = null;
-      const clearIdleTimer = () => {
-        if (idleTimer) {
-          clearTimeout(idleTimer);
-          idleTimer = null;
-        }
-      };
-      const resetIdleTimer = () => {
-        clearIdleTimer();
-        idleTimer = setTimeout(() => {
-          abortController.abort(new DOMException('stream-idle-timeout', 'AbortError'));
-        }, IDLE_TIMEOUT_MS);
-      };
-      resetIdleTimer();
-
-      const response = await fetch('/api/chat/stream', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(streamPayload),
-        signal: abortController.signal,
-      });
-
-      if (!response.ok) {
-        clearIdleTimer();
-        throw new Error('Stream request failed');
-      }
-
-      const reader = response.body?.getReader();
-      const decoder = new TextDecoder();
-      let fullResponse = '';
-      // Server emits a final  __exp_meta__:{...}\n frame carrying
-      // { interactionId, modelId } — strip it from rendered text.
-      // U+001E is virtually never present in normal AI output.
-      const META_RE = /\n?__exp_meta__:([^\n]*)\n?/;
-      // Mid-stream __exp_tool__:{...}\n frames carry structured tool-call
-      // events (call/result/error). Multiple per stream; only fully
-      // terminated frames match. Incomplete tail is stripped separately.
-      const TOOL_RE = /\n?__exp_tool__:([^\n]*)\n/g;
-      const TOOL_PREFIX = '__exp_tool__:';
-      let interactionId: string | undefined;
-      // Keyed by tool-call id; rebuilt from scratch each iteration since we
-      // re-parse `fullResponse` cumulatively. setMessages overwrites the
-      // toolCalls array on every chunk so the UI reflects the latest state.
-      const toolCallsById = new Map<string, ToolCall>();
-
-      if (reader) {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          resetIdleTimer();
-
-          const chunk = decoder.decode(value, { stream: true });
-          fullResponse += chunk;
-          streamedChars = fullResponse.length;
-
-          // If the meta frame has arrived (possibly mid-chunk), peel it off
-          // before rendering so the user never briefly sees the sentinel.
-          let displayResponse = fullResponse;
-          const metaMatch = META_RE.exec(fullResponse);
-          if (metaMatch) {
-            displayResponse = fullResponse.slice(0, metaMatch.index);
-            try {
-              const meta = JSON.parse(metaMatch[1] ?? "") as {
-                interactionId?: string;
-              };
-              if (meta.interactionId) interactionId = meta.interactionId;
-            } catch {
-              // Frame split across chunks: try again next iteration.
-            }
-          }
-          // Extract every complete tool frame and update the call map.
-          // Idempotent: re-parsing the same frame just re-sets the same value.
-          displayResponse = displayResponse.replace(TOOL_RE, (_match, json: string) => {
-            try {
-              const payload = JSON.parse(json) as
-                | { phase: 'call'; id: string; name: string; args?: Record<string, unknown> }
-                | { phase: 'result'; id: string; name: string }
-                | { phase: 'error'; id: string; name: string; msg?: string };
-              if (payload.phase === 'call') {
-                toolCallsById.set(payload.id, {
-                  id: payload.id,
-                  name: payload.name,
-                  args: payload.args,
-                  status: 'running',
-                });
-              } else if (payload.phase === 'result') {
-                const existing = toolCallsById.get(payload.id);
-                toolCallsById.set(payload.id, {
-                  id: payload.id,
-                  name: payload.name,
-                  args: existing?.args,
-                  status: 'success',
-                });
-              } else {
-                const existing = toolCallsById.get(payload.id);
-                toolCallsById.set(payload.id, {
-                  id: payload.id,
-                  name: payload.name,
-                  args: existing?.args,
-                  status: 'error',
-                  errorMsg: payload.msg,
-                });
-              }
-            } catch {
-              // Malformed frame — drop it from the display anyway.
-            }
-            return '';
-          });
-          TOOL_RE.lastIndex = 0;
-
-          // Hide a partial frame at the tail (e.g. "...__exp_tool__:{partia")
-          // so the sentinel doesn't briefly leak into the bubble.
-          const incompleteAt = displayResponse.lastIndexOf(TOOL_PREFIX);
-          if (incompleteAt !== -1 && !displayResponse.slice(incompleteAt).includes('\n')) {
-            displayResponse = displayResponse.slice(0, incompleteAt).replace(/\n$/, '');
-          }
-
-          // Strip zero-width-space keepalives the server emits on
-          // non-text chunks (see route.ts). They reset the idle timer
-          // above (every reader.read() resets) but must not appear in
-          // the rendered text.
-          displayResponse = displayResponse.replace(/​/g, '');
-
-          const toolCallsSnapshot = Array.from(toolCallsById.values());
-
+      // Fetch + incremental protocol parsing (sentinel frames, keepalive
+      // stripping, idle-timeout watchdog) live in ~/lib/chat so every chat
+      // surface consumes one implementation. Each update rewrites the trailing
+      // AI bubble with the cumulative parsed state.
+      const streamResult = await streamChatResponse(streamPayload, {
+        onUpdate: (update) => {
+          streamedChars = update.rawLength;
           setMessages(prev => {
             const updated = [...prev];
             const lastMessage = updated[updated.length - 1];
             if (lastMessage && lastMessage.type === 'ai') {
               updated[updated.length - 1] = {
                 ...lastMessage,
-                content: displayResponse,
-                ...(toolCallsSnapshot.length > 0 ? { toolCalls: toolCallsSnapshot } : {}),
+                content: update.displayText,
+                ...(update.toolCalls.length > 0 ? { toolCalls: update.toolCalls } : {}),
               };
             }
             return updated;
           });
-        }
-      }
+        },
+      });
+      const fullResponse = streamResult.displayText;
+      const interactionId = streamResult.interactionId;
 
-      // Final strip: ensure fullResponse used downstream (length checks,
-      // emptyResponse logic) excludes the meta sentinel.
-      const finalMatch = META_RE.exec(fullResponse);
-      if (finalMatch) {
-        fullResponse = fullResponse.slice(0, finalMatch.index);
-        try {
-          const meta = JSON.parse(finalMatch[1] ?? "") as { interactionId?: string };
-          interactionId ??= meta.interactionId;
-        } catch {
-          // Unparseable meta frame — interactionId stays undefined; feedback
-          // UI handles missing IDs by not rendering the rating affordance.
-        }
-      }
-      // Strip any remaining __exp_tool__ frames so they don't pollute the
-      // log preview or trigger length checks based on metadata bytes.
-      TOOL_RE.lastIndex = 0;
-      fullResponse = fullResponse.replace(TOOL_RE, '');
-      // Also strip server-side zero-width-space keepalives so they don't
-      // count toward emptyResponse / length checks.
-      fullResponse = fullResponse.replace(/​/g, '');
-
-      clearIdleTimer();
       setIsStreaming(false);
 
       // Agent writes leave sibling views (each with its own React Query cache)
@@ -1474,7 +1298,7 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
       // entities whose mounted views need invalidating (see manyChatToolRefresh /
       // ADR-0023). Procedure-wide (no args) invalidation keeps it robust against
       // arg source/coercion drift and only refetches mounted observers.
-      const executedToolNames = Array.from(toolCallsById.values())
+      const executedToolNames = streamResult.toolCalls
         .filter((tc) => tc.status === 'success')
         .map((tc) => tc.name);
       const toRefresh = entitiesToRefresh(executedToolNames, pageContext?.pageType);
@@ -1518,7 +1342,7 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
       const responseTime = Date.now() - startTime;
       // A turn that did tool work but produced no prose is NOT empty —
       // the user sees those calls in the ToolActivity row.
-      const isEmptyResponse = fullResponse.trim() === '' && toolCallsById.size === 0;
+      const isEmptyResponse = fullResponse.trim() === '' && streamResult.toolCalls.length === 0;
 
       // Debug: log what we received back
       console.log('📥 [Mastra → ManyChat] Response:', {

--- a/src/lib/chat/__tests__/streamProtocol.test.ts
+++ b/src/lib/chat/__tests__/streamProtocol.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseChatStreamBuffer,
+  classifyStreamError,
+} from '../streamProtocol';
+
+const toolFrame = (payload: Record<string, unknown>) =>
+  `__exp_tool__:${JSON.stringify(payload)}\n`;
+const metaFrame = (payload: Record<string, unknown>) =>
+  `__exp_meta__:${JSON.stringify(payload)}\n`;
+
+describe('parseChatStreamBuffer', () => {
+  it('passes plain text through untouched', () => {
+    const result = parseChatStreamBuffer('Hello **world**');
+    expect(result.displayText).toBe('Hello **world**');
+    expect(result.toolCalls).toEqual([]);
+    expect(result.interactionId).toBeUndefined();
+  });
+
+  it('is cumulative and idempotent: re-parsing a longer buffer re-derives the same prefix state', () => {
+    const b1 = 'Working on it';
+    const b2 = b1 + toolFrame({ phase: 'call', id: 't1', name: 'getProjects' });
+    expect(parseChatStreamBuffer(b1).displayText).toBe('Working on it');
+    const r2 = parseChatStreamBuffer(b2);
+    expect(r2.displayText).toBe('Working on it');
+    expect(r2.toolCalls).toEqual([
+      { id: 't1', name: 'getProjects', args: undefined, status: 'running' },
+    ]);
+  });
+
+  describe('tool frames', () => {
+    it('parses a call frame into a running tool call with args', () => {
+      const buffer = toolFrame({
+        phase: 'call',
+        id: 't1',
+        name: 'createAction',
+        args: { name: 'Pay Malte' },
+      });
+      const result = parseChatStreamBuffer(buffer);
+      expect(result.displayText).toBe('');
+      expect(result.toolCalls).toEqual([
+        { id: 't1', name: 'createAction', args: { name: 'Pay Malte' }, status: 'running' },
+      ]);
+    });
+
+    it('folds call → result into success, preserving args from the call frame', () => {
+      const buffer =
+        toolFrame({ phase: 'call', id: 't1', name: 'createAction', args: { name: 'x' } }) +
+        toolFrame({ phase: 'result', id: 't1', name: 'createAction' });
+      const result = parseChatStreamBuffer(buffer);
+      expect(result.toolCalls).toEqual([
+        { id: 't1', name: 'createAction', args: { name: 'x' }, status: 'success' },
+      ]);
+    });
+
+    it('folds call → error into error with the message, preserving args', () => {
+      const buffer =
+        toolFrame({ phase: 'call', id: 't1', name: 'createAction', args: { name: 'x' } }) +
+        toolFrame({ phase: 'error', id: 't1', name: 'createAction', msg: 'boom' });
+      const result = parseChatStreamBuffer(buffer);
+      expect(result.toolCalls).toEqual([
+        { id: 't1', name: 'createAction', args: { name: 'x' }, status: 'error', errorMsg: 'boom' },
+      ]);
+    });
+
+    it('keeps first-seen order across multiple tool calls', () => {
+      const buffer =
+        toolFrame({ phase: 'call', id: 'a', name: 'one' }) +
+        toolFrame({ phase: 'call', id: 'b', name: 'two' }) +
+        toolFrame({ phase: 'result', id: 'a', name: 'one' });
+      const result = parseChatStreamBuffer(buffer);
+      expect(result.toolCalls.map((t) => `${t.id}:${t.status}`)).toEqual([
+        'a:success',
+        'b:running',
+      ]);
+    });
+
+    it('strips frames embedded between prose without eating surrounding text', () => {
+      const buffer =
+        'Let me check.\n' +
+        toolFrame({ phase: 'call', id: 't1', name: 'getProjects' }) +
+        'Found 3 projects.';
+      const result = parseChatStreamBuffer(buffer);
+      expect(result.displayText).toBe('Let me check.Found 3 projects.');
+      expect(result.toolCalls).toHaveLength(1);
+    });
+
+    it('drops a malformed but terminated frame from display without creating a call', () => {
+      const buffer = 'before\n__exp_tool__:{not json}\nafter';
+      const result = parseChatStreamBuffer(buffer);
+      expect(result.displayText).toBe('beforeafter');
+      expect(result.toolCalls).toEqual([]);
+    });
+
+    it('hides an incomplete frame at the tail so sentinels never leak', () => {
+      const buffer = 'Answer so far\n__exp_tool__:{"phase":"call","id":"t1"';
+      const result = parseChatStreamBuffer(buffer);
+      expect(result.displayText).toBe('Answer so far');
+      expect(result.displayText).not.toContain('__exp_tool__');
+      expect(result.toolCalls).toEqual([]);
+    });
+
+    it('parses the frame once the split tail completes on a later chunk', () => {
+      const frame = toolFrame({ phase: 'call', id: 't1', name: 'getProjects' });
+      const partial = 'Text\n' + frame.slice(0, 20);
+      expect(parseChatStreamBuffer(partial).toolCalls).toEqual([]);
+      const full = 'Text\n' + frame + 'more';
+      const result = parseChatStreamBuffer(full);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.displayText).toBe('Textmore');
+    });
+  });
+
+  describe('meta frame', () => {
+    it('captures interactionId and strips the frame from display', () => {
+      const buffer = 'Final answer.' + metaFrame({ interactionId: 'int_123' });
+      const result = parseChatStreamBuffer(buffer);
+      expect(result.displayText).toBe('Final answer.');
+      expect(result.interactionId).toBe('int_123');
+    });
+
+    it('hides text after the meta frame from display', () => {
+      const buffer = 'Answer.' + metaFrame({ interactionId: 'int_1' }) + 'trailing noise';
+      const result = parseChatStreamBuffer(buffer);
+      expect(result.displayText).toBe('Answer.');
+    });
+
+    it('recovers when the meta JSON is split across chunks', () => {
+      const full = 'Answer.' + metaFrame({ interactionId: 'int_123' });
+      const partial = full.slice(0, full.length - 15); // cut inside the JSON
+      const early = parseChatStreamBuffer(partial);
+      expect(early.interactionId).toBeUndefined();
+      expect(early.displayText).toBe('Answer.'); // sentinel already sliced off
+      const late = parseChatStreamBuffer(full);
+      expect(late.interactionId).toBe('int_123');
+      expect(late.displayText).toBe('Answer.');
+    });
+  });
+
+  it('strips zero-width-space keepalives from display', () => {
+    const buffer = 'Hel​lo​';
+    const result = parseChatStreamBuffer(buffer);
+    expect(result.displayText).toBe('Hello');
+  });
+
+  it('handles a realistic full turn: prose, tool lifecycle, meta', () => {
+    const buffer =
+      'Let me look.\n' +
+      toolFrame({ phase: 'call', id: 't1', name: 'getProjects', args: { workspaceId: 'w1' } }) +
+      '​' +
+      toolFrame({ phase: 'result', id: 't1', name: 'getProjects' }) +
+      'You have 3 active projects.' +
+      metaFrame({ interactionId: 'int_9' });
+    const result = parseChatStreamBuffer(buffer);
+    expect(result.displayText).toBe('Let me look.You have 3 active projects.');
+    expect(result.toolCalls).toEqual([
+      { id: 't1', name: 'getProjects', args: { workspaceId: 'w1' }, status: 'success' },
+    ]);
+    expect(result.interactionId).toBe('int_9');
+  });
+});
+
+describe('classifyStreamError', () => {
+  it('classifies AbortError / idle timeout as retryable idle-timeout', () => {
+    expect(classifyStreamError(new DOMException('stream-idle-timeout', 'AbortError'))).toEqual({
+      kind: 'idle-timeout',
+      retryable: true,
+    });
+  });
+
+  it('classifies auth-ish messages as non-retryable auth', () => {
+    expect(classifyStreamError(new Error('401 Unauthorized'))).toEqual({
+      kind: 'auth',
+      retryable: false,
+    });
+  });
+
+  it('classifies network drops and failed requests as retryable transport', () => {
+    expect(classifyStreamError(new TypeError('Failed to fetch'))).toEqual({
+      kind: 'transport',
+      retryable: true,
+    });
+    expect(classifyStreamError(new Error('Stream request failed'))).toEqual({
+      kind: 'transport',
+      retryable: true,
+    });
+  });
+
+  it('classifies agent/mastra errors as non-retryable model errors', () => {
+    expect(classifyStreamError(new Error('Mastra agent exploded'))).toEqual({
+      kind: 'model',
+      retryable: false,
+    });
+  });
+
+  it('classifies non-Error throwables as unknown', () => {
+    expect(classifyStreamError('nope')).toEqual({ kind: 'unknown', retryable: false });
+  });
+});

--- a/src/lib/chat/streamChatResponse.ts
+++ b/src/lib/chat/streamChatResponse.ts
@@ -1,0 +1,122 @@
+import { parseChatStreamBuffer, type ParsedChatStream } from './streamProtocol';
+
+export interface ChatStreamCoreMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+/** Request body for POST /api/chat/stream. */
+export interface ChatStreamPayload {
+  messages: ChatStreamCoreMessage[];
+  agentId?: string;
+  assistantId?: string | null;
+  workspaceId?: string | null;
+  projectId?: string | null;
+  conversationId?: string | null;
+  platform: string;
+}
+
+export interface ChatStreamUpdate extends ParsedChatStream {
+  /**
+   * Raw bytes-of-stream seen so far, sentinels included. Callers use this (not
+   * displayText) to decide whether a failed turn "had content": tool frames
+   * without prose still represent real, non-retryable work.
+   */
+  rawLength: number;
+}
+
+export interface StreamChatOptions {
+  /** Called after every chunk with the cumulative parsed state. */
+  onUpdate?: (update: ChatStreamUpdate) => void;
+  /**
+   * Optional external abort (e.g. the Zoe canvas dismiss/navigate rule).
+   * Aborting rejects the stream with an AbortError carrying this signal's
+   * reason, exactly like the internal idle-timeout abort.
+   */
+  signal?: AbortSignal;
+  /** Abort if no chunk arrives for this long. Default 60s. */
+  idleTimeoutMs?: number;
+}
+
+const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
+
+/**
+ * POST to /api/chat/stream and consume the response incrementally, parsing the
+ * wire protocol (see streamProtocol.ts) after every chunk. Resolves with the
+ * final parsed state; throws on HTTP failure, transport drop, external abort,
+ * or idle timeout (an AbortError whose message includes "stream-idle-timeout",
+ * matching what classifyStreamError expects).
+ *
+ * Deliberately framework-free: surfaces own their React state and call this
+ * from wherever they hold it (ManyChat's submit path, the Zoe canvas hook).
+ */
+export async function streamChatResponse(
+  payload: ChatStreamPayload,
+  options: StreamChatOptions = {},
+): Promise<ChatStreamUpdate> {
+  const { onUpdate, signal, idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS } = options;
+
+  // Idle-timeout watchdog: abort if no chunk arrives for idleTimeoutMs.
+  // Prevents a stuck-streaming state when the server stream stalls silently.
+  const abortController = new AbortController();
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  const clearIdleTimer = () => {
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+      idleTimer = null;
+    }
+  };
+  const resetIdleTimer = () => {
+    clearIdleTimer();
+    idleTimer = setTimeout(() => {
+      abortController.abort(new DOMException('stream-idle-timeout', 'AbortError'));
+    }, idleTimeoutMs);
+  };
+
+  const onExternalAbort = () => {
+    abortController.abort(
+      signal?.reason ?? new DOMException('stream-aborted', 'AbortError'),
+    );
+  };
+  if (signal) {
+    if (signal.aborted) onExternalAbort();
+    else signal.addEventListener('abort', onExternalAbort, { once: true });
+  }
+
+  try {
+    resetIdleTimer();
+
+    const response = await fetch('/api/chat/stream', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: abortController.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error('Stream request failed');
+    }
+
+    const reader = response.body?.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let parsed = parseChatStreamBuffer('');
+
+    if (reader) {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        resetIdleTimer();
+
+        buffer += decoder.decode(value, { stream: true });
+        parsed = parseChatStreamBuffer(buffer);
+        onUpdate?.({ ...parsed, rawLength: buffer.length });
+      }
+    }
+
+    return { ...parsed, rawLength: buffer.length };
+  } finally {
+    clearIdleTimer();
+    signal?.removeEventListener('abort', onExternalAbort);
+  }
+}

--- a/src/lib/chat/streamProtocol.ts
+++ b/src/lib/chat/streamProtocol.ts
@@ -1,0 +1,157 @@
+/**
+ * Pure parser for the /api/chat/stream wire protocol.
+ *
+ * The stream is plain model text interleaved with two sentinel frame types:
+ *
+ *  - `__exp_tool__:{...}\n`  — mid-stream structured tool-call events
+ *    (phase: call/result/error). Multiple per stream.
+ *  - `__exp_meta__:{...}\n`  — a single final frame carrying
+ *    `{ interactionId, modelId }`.
+ *
+ * The parser is cumulative and stateless: feed it the *entire* buffer received
+ * so far and it returns what should be rendered right now. Re-parsing the same
+ * frames is idempotent, which is what makes a pure function safe here — the
+ * caller just calls it again on every chunk. Shared by every surface that
+ * consumes the chat stream (the Zoe drawer via ManyChat, the Zoe canvas).
+ */
+
+// One agent tool invocation, accumulated from __exp_tool__ frames.
+export interface ToolCall {
+  id: string;
+  name: string;
+  args?: Record<string, unknown>;
+  status: 'running' | 'success' | 'error';
+  errorMsg?: string;
+}
+
+export interface ParsedChatStream {
+  /**
+   * The text to render: the buffer with the meta frame (and anything after
+   * it), all complete tool frames, any incomplete trailing tool frame, and
+   * keepalive characters removed.
+   */
+  displayText: string;
+  /** Tool calls in first-seen order, each at its latest lifecycle state. */
+  toolCalls: ToolCall[];
+  /** Set once the meta frame has fully arrived and parsed. */
+  interactionId?: string;
+}
+
+const META_RE = /\n?__exp_meta__:([^\n]*)\n?/;
+// Only fully terminated frames match; an incomplete tail is handled separately.
+const TOOL_RE = /\n?__exp_tool__:([^\n]*)\n/g;
+const TOOL_PREFIX = '__exp_tool__:';
+// Zero-width-space keepalives the server emits on non-text chunks. They reset
+// the reader's idle timer but must never appear in rendered text.
+const KEEPALIVE_RE = /​/g;
+
+type ToolFramePayload =
+  | { phase: 'call'; id: string; name: string; args?: Record<string, unknown> }
+  | { phase: 'result'; id: string; name: string }
+  | { phase: 'error'; id: string; name: string; msg?: string };
+
+export function parseChatStreamBuffer(buffer: string): ParsedChatStream {
+  let displayText = buffer;
+  let interactionId: string | undefined;
+
+  // Peel the meta frame (and anything after it) off before rendering so the
+  // user never sees the sentinel. A frame whose JSON is still arriving simply
+  // fails to parse this pass and succeeds on a later one.
+  const metaMatch = META_RE.exec(buffer);
+  if (metaMatch) {
+    displayText = buffer.slice(0, metaMatch.index);
+    try {
+      const meta = JSON.parse(metaMatch[1] ?? '') as { interactionId?: string };
+      if (meta.interactionId) interactionId = meta.interactionId;
+    } catch {
+      // Frame split across chunks: try again on the next, fuller buffer.
+    }
+  }
+
+  // Extract every complete tool frame and fold it into the call map. A
+  // `result`/`error` frame inherits `args` from its earlier `call` frame,
+  // which necessarily precedes it in the buffer.
+  const toolCallsById = new Map<string, ToolCall>();
+  displayText = displayText.replace(TOOL_RE, (_match, json: string) => {
+    try {
+      const payload = JSON.parse(json) as ToolFramePayload;
+      if (payload.phase === 'call') {
+        toolCallsById.set(payload.id, {
+          id: payload.id,
+          name: payload.name,
+          args: payload.args,
+          status: 'running',
+        });
+      } else if (payload.phase === 'result') {
+        const existing = toolCallsById.get(payload.id);
+        toolCallsById.set(payload.id, {
+          id: payload.id,
+          name: payload.name,
+          args: existing?.args,
+          status: 'success',
+        });
+      } else {
+        const existing = toolCallsById.get(payload.id);
+        toolCallsById.set(payload.id, {
+          id: payload.id,
+          name: payload.name,
+          args: existing?.args,
+          status: 'error',
+          errorMsg: payload.msg,
+        });
+      }
+    } catch {
+      // Malformed frame — drop it from the display anyway.
+    }
+    return '';
+  });
+
+  // Hide a partial frame at the tail (e.g. "...__exp_tool__:{partia") so the
+  // sentinel doesn't briefly leak into the rendered text.
+  const incompleteAt = displayText.lastIndexOf(TOOL_PREFIX);
+  if (incompleteAt !== -1 && !displayText.slice(incompleteAt).includes('\n')) {
+    displayText = displayText.slice(0, incompleteAt).replace(/\n$/, '');
+  }
+
+  displayText = displayText.replace(KEEPALIVE_RE, '');
+
+  return {
+    displayText,
+    toolCalls: Array.from(toolCallsById.values()),
+    interactionId,
+  };
+}
+
+export type StreamFailureKind = 'transport' | 'idle-timeout' | 'auth' | 'model' | 'unknown';
+
+/**
+ * Bucket a thrown stream error into an actionable class. The decisive split is
+ * `transport` (the HTTP body was cut mid-flight — a `TypeError`/network drop,
+ * the dominant mobile failure) which is safe to auto-retry, vs. everything else
+ * (idle stall, auth, model/agent error) which is not.
+ */
+export function classifyStreamError(error: unknown): { kind: StreamFailureKind; retryable: boolean } {
+  if (!(error instanceof Error)) return { kind: 'unknown', retryable: false };
+  const text = error.message.toLowerCase();
+  if (error.name === 'AbortError' || text.includes('stream-idle-timeout')) {
+    return { kind: 'idle-timeout', retryable: true };
+  }
+  if (text.includes('unauthorized') || text.includes('401') || text.includes('forbidden') || text.includes('403')) {
+    return { kind: 'auth', retryable: false };
+  }
+  if (
+    error.name === 'TypeError' ||
+    text.includes('network') ||
+    text.includes('failed to fetch') ||
+    text.includes('load failed') ||
+    text.includes('timeout') ||
+    text.includes('stream request failed') ||
+    text.includes('connection')
+  ) {
+    return { kind: 'transport', retryable: true };
+  }
+  if (text.includes('mastra') || text.includes('agent')) {
+    return { kind: 'model', retryable: false };
+  }
+  return { kind: 'unknown', retryable: false };
+}

--- a/src/providers/AgentModalProvider.tsx
+++ b/src/providers/AgentModalProvider.tsx
@@ -1,6 +1,12 @@
 'use client';
 
 import { createContext, useContext, useState, useCallback, useEffect, useMemo, type PropsWithChildren, type Dispatch, type SetStateAction } from 'react';
+import type { ToolCall } from '~/lib/chat/streamProtocol';
+
+// One agent tool invocation, accumulated client-side from __exp_tool__ frames.
+// Canonically defined next to the wire-protocol parser; re-exported here so
+// existing importers keep working.
+export type { ToolCall };
 
 // sessionStorage keys for per-tab isolation (prevents context bleeding between tabs)
 const CHAT_STORAGE_KEY = 'agent-chat-messages';
@@ -8,15 +14,6 @@ const CONVERSATION_STORAGE_KEY = 'agent-chat-conversation-id';
 const DRAWER_SIZE_STORAGE_KEY = 'zoe-drawer-size';
 
 export type DrawerSize = 's' | 'm' | 'l';
-
-// One agent tool invocation, accumulated client-side from __exp_tool__ frames.
-export interface ToolCall {
-  id: string;
-  name: string;
-  args?: Record<string, unknown>;
-  status: 'running' | 'success' | 'error';
-  errorMsg?: string;
-}
 
 // Message type shared between provider and ManyChat
 export interface ChatMessage {


### PR DESCRIPTION
### **User description**
## What

Extract the chat streaming internals currently inline in ManyChat into two shared, reusable units, with the Zoe drawer's behaviour verifiably unchanged:

1. **A pure stream-protocol parser module** (`src/lib/chat/streamProtocol.ts`) — feed it the cumulative buffer; it returns display text, the tool-call map (call → result/error lifecycle), and the interaction id. It owns all sentinel handling: `__exp_tool__` frames (including frames split across chunk boundaries), the `__exp_meta__` frame, hiding a partial frame at the tail, stripping zero-width-space keepalives, dropping malformed frames. Also home to the `StreamFailureKind` taxonomy + `classifyStreamError`.
2. **A shared streaming loop** (`src/lib/chat/streamChatResponse.ts`) — the fetch/reader loop, idle-timeout watchdog, and optional external abort signal, calling the parser per chunk.

ManyChat consumes both (−185 net lines); `ToolCall` is canonically defined next to the parser and re-exported from `AgentModalProvider` so existing importers keep working.

Also carries the design docs from the originating session: ADR-0040 (Zoe canvas engagements are fresh Threads) and the CONTEXT.md **Zoe canvas** glossary entry.

This is the enabling refactor for the Zoe canvas (feature `cmra84pog0003l20498h17ago`) and deliberately ships alone so any drawer regression is isolated to this PR.

## Acceptance criteria

- [x] Parser is a pure module with unit tests covering: tool/meta frames split across chunk boundaries; partial tail frame never leaks sentinels; keepalives stripped; malformed frames dropped; tool-call call→result and call→error lifecycles; interaction id captured (20 tests)
- [x] ManyChat consumes the extracted parser + hook; no behaviour change in the drawer
- [x] The extracted units have no dependency on drawer-specific UI, so a second surface can consume them
- [x] Typecheck (npx tsc, 8GB heap), eslint on touched files, and the full unit suite (1314 tests) pass

---

Ships: sunny.snail


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Extract stream-protocol parser and streaming loop into reusable `src/lib/chat` modules

- `streamProtocol.ts`: pure cumulative parser for `__exp_tool__`/`__exp_meta__` frames, keepalive stripping, and `classifyStreamError`

- `streamChatResponse.ts`: fetch/reader loop with idle-timeout watchdog and optional external abort signal

- Add 20 unit tests for parser; refactor `ManyChat` to consume both modules; add ADR-0040 and glossary entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ManyChat.tsx"] -- "consumes" --> B["streamChatResponse.ts"]
  B -- "calls per chunk" --> C["streamProtocol.ts"]
  C -- "exports" --> D["parseChatStreamBuffer()"]
  C -- "exports" --> E["classifyStreamError()"]
  C -- "exports" --> F["ToolCall type"]
  F -- "re-exported via" --> G["AgentModalProvider.tsx"]
  H["streamProtocol.test.ts"] -- "tests" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>streamProtocol.ts</strong><dd><code>New pure cumulative stream-protocol parser module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/354/files#diff-9f328aba9385ac4a48cfffc01f2f5436997fc1206974864755b745f18701ba6d">+157/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>streamChatResponse.ts</strong><dd><code>New fetch/reader loop with idle-timeout and abort support</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/354/files#diff-f1419e71a105b95e0e250d2149c0a2826b715e502a8648f92a3c0e6cebc4e027">+122/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ManyChat.tsx</strong><dd><code>Refactor to consume extracted parser and streaming loop</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/354/files#diff-6f0e68ce865b0629e85c68dbd985a102db9f321cea87620c205f1863eece6ed4">+18/-194</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>streamProtocol.test.ts</strong><dd><code>20 unit tests for parser and error classifier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/354/files#diff-cfc32a4de076d5708d4623ced457b8525c10a33e54197c297c3b7e9cb8e72114">+199/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>AgentModalProvider.tsx</strong><dd><code>Re-export ToolCall from canonical streamProtocol location</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/354/files#diff-91b32ce785a23a94025446165797b003d893890e876b862e7382e7546609f198">+6/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CONTEXT.md</strong><dd><code>Add Zoe canvas glossary entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/354/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0040-zoe-canvas-fresh-thread-per-engagement.md</strong><dd><code>New ADR for Zoe canvas fresh-thread-per-engagement decision</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/354/files#diff-78a2daaee740cc289bbc0930b549d72cd84d4d4691734c3f5652319af614f3ea">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

