### PR TITLE
feat(cycles): edit cycle name and dates from the cycle detail page

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx
@@ -12,8 +12,10 @@ import {
   Stack,
   Text,
   Textarea,
+  TextInput,
   Title,
 } from "@mantine/core";
+import { DateInput } from "@mantine/dates";
 import { modals } from "@mantine/modals";
 import { api } from "~/trpc/react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
@@ -44,11 +46,20 @@ export default function CycleDetailPage() {
   const [cycleGoal, setCycleGoal] = useState("");
   const [achievements, setAchievements] = useState("");
 
+  const [isEditingHeader, setIsEditingHeader] = useState(false);
+  const [name, setName] = useState("");
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [endDate, setEndDate] = useState<Date | null>(null);
+  const [headerError, setHeaderError] = useState<string | null>(null);
+
   useEffect(() => {
     if (cycle) {
       setStatus(cycle.status as CycleStatus);
       setCycleGoal(cycle.cycleGoal ?? "");
       setAchievements(cycle.achievements ?? "");
+      setName(cycle.name);
+      setStartDate(cycle.startDate ? new Date(cycle.startDate) : null);
+      setEndDate(cycle.endDate ? new Date(cycle.endDate) : null);
     }
   }, [cycle]);
 
@@ -61,6 +72,20 @@ export default function CycleDetailPage() {
         });
       }
     },
+  });
+
+  const updateHeader = api.product.cycle.update.useMutation({
+    onSuccess: async () => {
+      setHeaderError(null);
+      setIsEditingHeader(false);
+      await utils.product.cycle.getById.invalidate({ id: cycleId });
+      if (cycle?.workspaceId) {
+        await utils.product.cycle.list.invalidate({
+          workspaceId: cycle.workspaceId,
+        });
+      }
+    },
+    onError: (err) => setHeaderError(err.message),
   });
 
   const deleteCycle = api.product.cycle.delete.useMutation({
@@ -95,6 +120,25 @@ export default function CycleDetailPage() {
     });
   };
 
+  const onSaveHeader = () => {
+    updateHeader.mutate({
+      id: cycleId,
+      name: name.trim(),
+      startDate: startDate ?? null,
+      endDate: endDate ?? null,
+    });
+  };
+
+  const onCancelHeader = () => {
+    if (cycle) {
+      setName(cycle.name);
+      setStartDate(cycle.startDate ? new Date(cycle.startDate) : null);
+      setEndDate(cycle.endDate ? new Date(cycle.endDate) : null);
+    }
+    setHeaderError(null);
+    setIsEditingHeader(false);
+  };
+
   const onDelete = () => {
     modals.openConfirmModal({
       title: "Delete cycle",
@@ -116,22 +160,83 @@ export default function CycleDetailPage() {
   return (
     <Stack gap="lg">
       <Group justify="space-between" align="flex-start">
-        <div>
-          <Title order={2} className="text-text-primary">
-            {cycle.name}
-          </Title>
-          {(cycle.startDate ?? cycle.endDate) && (
-            <Text size="sm" className="text-text-muted mt-1">
-              {cycle.startDate
-                ? new Date(cycle.startDate).toLocaleDateString()
-                : "?"}
-              {" - "}
-              {cycle.endDate
-                ? new Date(cycle.endDate).toLocaleDateString()
-                : "?"}
-            </Text>
-          )}
-        </div>
+        {isEditingHeader ? (
+          <Stack gap="sm" style={{ flex: 1 }} maw={520}>
+            <TextInput
+              label="Name"
+              value={name}
+              onChange={(e) => setName(e.currentTarget.value)}
+              maxLength={120}
+              required
+            />
+            <Group grow>
+              <DateInput
+                label="Start date"
+                value={startDate}
+                onChange={(v) =>
+                  setStartDate(
+                    v ? (typeof v === "string" ? new Date(v) : v) : null,
+                  )
+                }
+                clearable
+              />
+              <DateInput
+                label="End date"
+                value={endDate}
+                onChange={(v) =>
+                  setEndDate(
+                    v ? (typeof v === "string" ? new Date(v) : v) : null,
+                  )
+                }
+                clearable
+              />
+            </Group>
+            {headerError && (
+              <Text size="sm" className="text-text-error">
+                {headerError}
+              </Text>
+            )}
+            <Group>
+              <Button
+                size="sm"
+                onClick={onSaveHeader}
+                loading={updateHeader.isPending}
+                disabled={!name.trim()}
+              >
+                Save
+              </Button>
+              <Button size="sm" variant="subtle" onClick={onCancelHeader}>
+                Cancel
+              </Button>
+            </Group>
+          </Stack>
+        ) : (
+          <div>
+            <Group gap="xs" align="center">
+              <Title order={2} className="text-text-primary">
+                {cycle.name}
+              </Title>
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                onClick={() => setIsEditingHeader(true)}
+              >
+                Edit
+              </Button>
+            </Group>
+            {(cycle.startDate ?? cycle.endDate) && (
+              <Text size="sm" className="text-text-muted mt-1">
+                {cycle.startDate
+                  ? new Date(cycle.startDate).toLocaleDateString()
+                  : "?"}
+                {" - "}
+                {cycle.endDate
+                  ? new Date(cycle.endDate).toLocaleDateString()
+                  : "?"}
+              </Text>
+            )}
+          </div>
+        )}
         <Group>
           <Select
             data={STATUS_OPTIONS}


### PR DESCRIPTION
### **User description**
## What

Adds inline editing of a cycle's **name** and **start/end dates** directly on the cycle detail page (`/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]`).

Previously the header showed the name and dates as read-only text; only status, goal, and achievements were editable.

## How

Frontend-only — the `product.cycle.update` mutation already accepted `name`, `startDate`, and `endDate`.

- An **Edit** button next to the title toggles the header into a small form: a name `TextInput` and two clearable `DateInput`s (matching the "new cycle" page pattern).
- Save calls `product.cycle.update` and invalidates the cycle + list queries; Cancel reverts to saved values.
- Server-side validation errors (date overlap with an adjacent cycle, end-before-start) are surfaced inline instead of failing silently.

No schema/backend changes, no migration, no hardcoded colors.

## Verification

- `tsc --noEmit`: 0 errors
- ESLint: clean
- Unit tests: pass (pre-commit hook)


___

### **PR Type**
Enhancement


___

### **Description**
- Add inline editing of cycle name and start/end dates in detail header

- Toggle between read-only view and edit form with Save/Cancel actions

- Surface server-side validation errors (overlap, end-before-start) inline

- Save via existing `product.cycle.update` mutation with query invalidation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cycle Detail Header (read-only)"] -- "Click Edit" --> B["Inline Edit Form"]
  B["Inline Edit Form"] -- "TextInput + DateInput fields" --> C["onSaveHeader()"]
  C["onSaveHeader()"] -- "product.cycle.update mutation" --> D["Success: invalidate queries"]
  C["onSaveHeader()"] -- "Error" --> E["Display headerError inline"]
  B["Inline Edit Form"] -- "Click Cancel" --> A["Cycle Detail Header (read-only)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Inline edit form for cycle name and dates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx

<ul><li>Added <code>isEditingHeader</code>, <code>name</code>, <code>startDate</code>, <code>endDate</code>, and <code>headerError</code> state <br>variables<br> <li> Initialized new state from cycle data in the existing <code>useEffect</code><br> <li> Added a second <code>updateHeader</code> mutation instance with inline error <br>handling<br> <li> Added <code>onSaveHeader</code> and <code>onCancelHeader</code> handler functions<br> <li> Replaced static title/dates display with a conditional edit form <br>(TextInput + two DateInputs) toggled by an Edit button</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/356/files#diff-f04f2dca8cdb906f9cf22ec215d1dd0531a9791e6726fab6ea8b2a90e726210f">+121/-16</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

