### PR TITLE
fix(cycles): cancelled cycles no longer block dates; allow deleting them

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/page.tsx
@@ -365,6 +365,16 @@ function CycleCard({
                   </Menu.Item>
                 </>
               )}
+              {(cycle.status === "COMPLETED" ||
+                cycle.status === "ARCHIVED") && (
+                <Menu.Item
+                  color="red"
+                  leftSection={<IconTrash size={14} />}
+                  onClick={() => actions.onDelete(cycle.id, cycle.name)}
+                >
+                  Delete cycle
+                </Menu.Item>
+              )}
             </Menu.Dropdown>
           </Menu>
         </Group>

--- a/src/plugins/product/server/routers/cycle.ts
+++ b/src/plugins/product/server/routers/cycle.ts
@@ -408,6 +408,8 @@ export const cycleRouter = createTRPCRouter({
           where: {
             workspaceId: input.workspaceId,
             listType: "SPRINT",
+            // Cancelled cycles are dead — they shouldn't block new dates
+            status: { not: "ARCHIVED" },
             ...(input.startDate ? { endDate: { gt: input.startDate } } : {}),
             ...(input.endDate ? { startDate: { lt: input.endDate } } : {}),
           },
@@ -477,6 +479,8 @@ export const cycleRouter = createTRPCRouter({
               workspaceId: cycle.workspaceId,
               listType: "SPRINT",
               id: { not: input.id },
+              // Cancelled cycles are dead — they shouldn't block new dates
+              status: { not: "ARCHIVED" },
               ...(newStart ? { endDate: { gt: newStart } } : {}),
               ...(newEnd ? { startDate: { lt: newEnd } } : {}),
             },


### PR DESCRIPTION
### **User description**
## Problem

Saving new dates on a cycle failed with *"Updated dates overlap with 'Cycle 3'. Adjust the dates to avoid conflicts."* even though Cycle 3 was **cancelled**. Cancelled cycles (status `ARCHIVED`) should never block scheduling.

Separately, cancelled and completed cycles had **no overflow-menu actions** on the cycles list — there was no way to delete them from that page.

## Fix

- **Overlap checks** in both `product.cycle.create` and `product.cycle.update` now exclude `ARCHIVED` (cancelled) cycles (`status: { not: "ARCHIVED" }`). Active/planned/completed cycles still block overlaps as before.
- **Cycles list menu** now offers **Delete cycle** for `COMPLETED` and `ARCHIVED` cycles (previously only `PLANNED`). The cycle detail page already had a delete button.

No schema/migration changes.

## Verification

- `tsc --noEmit`: 0 errors
- ESLint: clean
- Unit tests: pass (pre-commit hook)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Exclude `ARCHIVED` (cancelled) cycles from date overlap checks on create/update

- Add "Delete cycle" menu option for `COMPLETED` and `ARCHIVED` cycles in cycles list


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cycle Create/Update"] -- "overlap check" --> B["Exclude ARCHIVED cycles"]
  B -- "status: not ARCHIVED" --> C["Valid date saved"]
  D["Cycles List Menu"] -- "COMPLETED or ARCHIVED" --> E["Show Delete cycle option"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add delete menu action for completed and cancelled cycles</code></dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/page.tsx

<ul><li>Added overflow menu "Delete cycle" item for cycles with <code>COMPLETED</code> or <br><code>ARCHIVED</code> status<br> <li> Previously only <code>PLANNED</code> cycles had delete action in the list menu</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/357/files#diff-419d1ea72c73197fe908413a7be1a4a524e862720aaced3e2d78f14b0cbe99f1">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cycle.ts</strong><dd><code>Exclude cancelled cycles from date overlap validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/routers/cycle.ts

<ul><li>Added <code>status: { not: "ARCHIVED" }</code> filter to overlap check in cycle <br>create handler<br> <li> Added <code>status: { not: "ARCHIVED" }</code> filter to overlap check in cycle <br>update handler<br> <li> Prevents cancelled cycles from blocking valid date assignments</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/357/files#diff-498883b4d63ffa3c679f3fe2afb5ad58e0d01f24d59783eacd1f9a6673531824">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

