### PR TITLE
feat(products): mission-control redesign of the product Overview tab

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
@@ -12,10 +12,13 @@ import {
   IconPlus,
   IconAffiliate,
   IconTargetArrow,
+  IconMicrophone,
+  IconTicket,
 } from "@tabler/icons-react";
 import {
   ActionIcon,
   Group,
+  Menu,
   Skeleton,
   Tabs,
   Text,
@@ -25,6 +28,7 @@ import {
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
 import { FavoriteButton } from "~/app/_components/shared/FavoriteButton";
+import { CreateTicketModal } from "~/app/_components/product/CreateTicketModal";
 import { buildProductFavoriteTarget } from "./favoriteTarget";
 
 const tabs = [
@@ -51,6 +55,7 @@ export default function ProductLayout({
   // Tab the user just clicked, shown as active immediately while the route
   // navigation is still pending — so the click feels acknowledged at once.
   const [optimisticTab, setOptimisticTab] = useState<string | null>(null);
+  const [ticketModalOpen, setTicketModalOpen] = useState(false);
 
   const utils = api.useUtils();
 
@@ -180,15 +185,65 @@ export default function ProductLayout({
                 variant="default"
               />
             )}
-            <ActionIcon
-              variant="filled"
-              size="lg"
-              title="Add"
-              className="hover:scale-105"
-              style={{ transition: "all 0.2s ease" }}
-            >
-              <IconPlus size={20} />
-            </ActionIcon>
+            <Menu position="bottom-end" width={244} shadow="md">
+              <Menu.Target>
+                <ActionIcon
+                  variant="filled"
+                  size="lg"
+                  title="Add"
+                  className="hover:scale-105"
+                  style={{ transition: "all 0.2s ease" }}
+                >
+                  <IconPlus size={20} />
+                </ActionIcon>
+              </Menu.Target>
+              <Menu.Dropdown>
+                <Menu.Label>Create</Menu.Label>
+                <Menu.Item
+                  leftSection={<IconTicket size={14} />}
+                  onClick={() => setTicketModalOpen(true)}
+                >
+                  New ticket
+                  <Text size="xs" c="dimmed">
+                    Add to the backlog
+                  </Text>
+                </Menu.Item>
+                <Menu.Item
+                  leftSection={<IconBulb size={14} />}
+                  onClick={() => router.push(`${basePath}/features/new`)}
+                >
+                  New feature
+                  <Text size="xs" c="dimmed">
+                    A larger unit of value
+                  </Text>
+                </Menu.Item>
+                <Menu.Item
+                  leftSection={<IconMicrophone size={14} />}
+                  onClick={() => router.push(`${basePath}/research/new`)}
+                >
+                  New research
+                  <Text size="xs" c="dimmed">
+                    Interview or finding
+                  </Text>
+                </Menu.Item>
+                <Menu.Item
+                  leftSection={<IconClipboardList size={14} />}
+                  onClick={() => router.push(`${basePath}/retrospectives/new`)}
+                >
+                  New retro
+                  <Text size="xs" c="dimmed">
+                    End-of-cycle review
+                  </Text>
+                </Menu.Item>
+                <Menu.Divider />
+                <Menu.Item
+                  leftSection={<IconCalendarClock size={14} />}
+                  onClick={() => router.push(`${basePath}/cycles/new`)}
+                >
+                  New cycle
+                </Menu.Item>
+              </Menu.Dropdown>
+            </Menu>
             <ActionIcon
               variant="filled"
               size="lg"
@@ -225,6 +280,16 @@ export default function ProductLayout({
           <div className="px-10 pb-6">{children}</div>
         </Stack>
       </Tabs>
+
+      {product && (
+        <CreateTicketModal
+          opened={ticketModalOpen}
+          onClose={() => setTicketModalOpen(false)}
+          productId={product.id}
+          productName={product.name}
+          basePath={`${basePath}/tickets`}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/page.tsx
@@ -1,59 +1,12 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import Link from "next/link";
-import {
-  Card,
-  Group,
-  SimpleGrid,
-  Skeleton,
-  Stack,
-  Text,
-  Title,
-} from "@mantine/core";
-import {
-  IconBulb,
-  IconTicket,
-  IconMicrophone,
-  IconCalendarClock,
-  IconClipboardList,
-} from "@tabler/icons-react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
-
-interface StatCardProps {
-  label: string;
-  value: number | undefined;
-  icon: React.ReactNode;
-  href: string;
-  isLoading: boolean;
-}
-
-function StatCard({ label, value, icon, href, isLoading }: StatCardProps) {
-  return (
-    <Link href={href}>
-      <Card className="border border-border-primary bg-surface-secondary hover:border-border-focus transition-colors">
-        <Group gap="md">
-          <div className="rounded-lg bg-background-primary p-3 text-text-muted">
-            {icon}
-          </div>
-          <div>
-            <Text size="sm" className="text-text-muted">
-              {label}
-            </Text>
-            {isLoading ? (
-              <Skeleton height={28} width={60} mt={4} />
-            ) : (
-              <Title order={3} className="text-text-primary">
-                {value ?? 0}
-              </Title>
-            )}
-          </div>
-        </Group>
-      </Card>
-    </Link>
-  );
-}
+import {
+  ProductOverview,
+  OverviewSkeleton,
+} from "~/app/_components/product/overview/ProductOverview";
 
 export default function ProductOverviewPage() {
   const params = useParams();
@@ -68,52 +21,25 @@ export default function ProductOverviewPage() {
   if (!workspace) return null;
   const basePath = `/w/${workspace.slug}/products/${productSlug}`;
 
-  return (
-    <Stack gap="lg">
-      <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">
-        <StatCard
-          label="Features"
-          value={product?._count.features}
-          icon={<IconBulb size={20} />}
-          href={`${basePath}/features`}
-          isLoading={isLoading}
-        />
-        <StatCard
-          label="Tickets"
-          value={product?._count.tickets}
-          icon={<IconTicket size={20} />}
-          href={`${basePath}/tickets`}
-          isLoading={isLoading}
-        />
-        <StatCard
-          label="Research"
-          value={product?._count.researches}
-          icon={<IconMicrophone size={20} />}
-          href={`${basePath}/research`}
-          isLoading={isLoading}
-        />
-        <StatCard
-          label="Retrospectives"
-          value={product?._count.retrospectives}
-          icon={<IconClipboardList size={20} />}
-          href={`${basePath}/retrospectives`}
-          isLoading={isLoading}
-        />
-      </SimpleGrid>
+  if (!product) {
+    // Skeleton while the product resolves; the layout handles not-found.
+    return isLoading ? (
+      <div className="product-overview">
+        <OverviewSkeleton />
+      </div>
+    ) : null;
+  }
 
-      <Card className="border border-border-primary bg-surface-secondary">
-        <Stack gap="sm">
-          <Group gap="sm">
-            <IconCalendarClock size={20} className="text-text-muted" />
-            <Title order={5} className="text-text-primary">
-              Quick links
-            </Title>
-          </Group>
-          <Text size="sm" className="text-text-muted">
-            Jump into the areas of this product.
-          </Text>
-        </Stack>
-      </Card>
-    </Stack>
+  return (
+    <ProductOverview
+      product={{
+        id: product.id,
+        name: product.name,
+        slug: product.slug,
+        color: product.color,
+        funTicketIds: product.funTicketIds,
+      }}
+      basePath={basePath}
+    />
   );
 }

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
 import {
   ActionIcon,
   Avatar,
@@ -37,6 +38,7 @@ import {
   IconSortAscending,
   IconSortDescending,
   IconTicket,
+  IconX,
 } from "@tabler/icons-react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
@@ -226,8 +228,20 @@ function StatusCell({ status, onUpdate }: { status: string; onUpdate: (s: Ticket
 export default function TicketsBacklogPage() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const { data: session } = useSession();
   const productSlug = params.productSlug as string;
   const { workspace, workspaceId } = useWorkspace();
+
+  // URL-driven filters — deep links from the Overview tab
+  // (?status=BLOCKED, ?assignee=me). Applied server-side via ticket.list.
+  const statusParam = searchParams.get("status");
+  const urlStatus =
+    statusParam && statusParam in STATUS_LABELS
+      ? (statusParam as TicketStatus)
+      : undefined;
+  const filterAssigneeMe = searchParams.get("assignee") === "me";
+  const sessionUserId = session?.user?.id;
   const [modalOpened, setModalOpened] = useState(false);
   const [editTicketId, setEditTicketId] = useState<string | null>(null);
   const [epicModalOpened, setEpicModalOpened] = useState(false);
@@ -316,8 +330,16 @@ export default function TicketsBacklogPage() {
   );
 
   const { data: tickets, isLoading } = api.product.ticket.list.useQuery(
-    { productId: product?.id ?? "" },
-    { enabled: !!product?.id },
+    {
+      productId: product?.id ?? "",
+      ...(urlStatus ? { status: urlStatus } : {}),
+      ...(filterAssigneeMe && sessionUserId
+        ? { assigneeId: sessionUserId }
+        : {}),
+    },
+    // When ?assignee=me is present, wait for the session so the first fetch
+    // is already filtered instead of flashing the full backlog.
+    { enabled: !!product?.id && (!filterAssigneeMe || !!sessionUserId) },
   );
 
   const { data: features } = api.product.feature.list.useQuery(
@@ -624,6 +646,31 @@ export default function TicketsBacklogPage() {
             </Menu.Item>
           </Menu.Dropdown>
         </Menu>
+
+        {(urlStatus ?? filterAssigneeMe) && (
+          <Badge
+            variant="light"
+            color={urlStatus ? STATUS_COLORS[urlStatus] : "brand"}
+            rightSection={
+              <ActionIcon
+                variant="transparent"
+                size="xs"
+                color="gray"
+                aria-label="Clear filter"
+                onClick={() => router.replace(basePath)}
+              >
+                <IconX size={11} />
+              </ActionIcon>
+            }
+          >
+            {[
+              urlStatus ? STATUS_LABELS[urlStatus] : null,
+              filterAssigneeMe ? "My tickets" : null,
+            ]
+              .filter(Boolean)
+              .join(" · ")}
+          </Badge>
+        )}
 
         <div className="flex-1" />
 

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
@@ -242,6 +242,9 @@ export default function TicketsBacklogPage() {
       : undefined;
   const filterAssigneeMe = searchParams.get("assignee") === "me";
   const sessionUserId = session?.user?.id;
+  // With ?assignee=me the ticket query stays disabled until the session
+  // resolves; treat that gap as loading so we don't flash an empty state.
+  const sessionPending = filterAssigneeMe && !sessionUserId;
   const [modalOpened, setModalOpened] = useState(false);
   const [editTicketId, setEditTicketId] = useState<string | null>(null);
   const [epicModalOpened, setEpicModalOpened] = useState(false);
@@ -427,6 +430,15 @@ export default function TicketsBacklogPage() {
 
   if (!workspace) return null;
   const basePath = `/w/${workspace.slug}/products/${productSlug}/tickets`;
+
+  // Clear only the overview deep-link params; keep any other query params.
+  const clearUrlFilters = () => {
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete("status");
+    next.delete("assignee");
+    const qs = next.toString();
+    router.replace(qs ? `${basePath}?${qs}` : basePath);
+  };
 
   // List item renderer (compact, no table)
   const renderListItem = (ticket: (typeof sorted)[number]) => (
@@ -657,7 +669,7 @@ export default function TicketsBacklogPage() {
                 size="xs"
                 color="gray"
                 aria-label="Clear filter"
-                onClick={() => router.replace(basePath)}
+                onClick={clearUrlFilters}
               >
                 <IconX size={11} />
               </ActionIcon>
@@ -787,7 +799,7 @@ export default function TicketsBacklogPage() {
         ) : (
           <EpicsList epics={epics ?? []} search={search} basePath={basePath} view={view === "list" ? "list" : "table"} />
         )
-      ) : isLoading ? (
+      ) : (isLoading || sessionPending) ? (
         <Stack gap="xs">
           {[1, 2, 3, 4].map((i) => <Skeleton key={i} height={36} />)}
         </Stack>

--- a/src/app/_components/product/overview/BacklogPulse.tsx
+++ b/src/app/_components/product/overview/BacklogPulse.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { IconArrowUpRight, IconListDetails } from "@tabler/icons-react";
+import { STATUS_LABELS } from "~/lib/ticket-statuses";
+import {
+  OPEN_PULSE_STATUSES,
+  statusCss,
+  type ProductOverviewData,
+} from "./overviewShared";
+
+export function BacklogPulse({
+  statusCounts,
+  counts,
+  basePath,
+}: {
+  statusCounts: ProductOverviewData["statusCounts"];
+  counts: ProductOverviewData["counts"];
+  basePath: string;
+}) {
+  const router = useRouter();
+  const byStatus = new Map(statusCounts.map((s) => [s.status, s.count]));
+  const open = OPEN_PULSE_STATUSES.map((status) => ({
+    status,
+    count: byStatus.get(status) ?? 0,
+  })).filter((s) => s.count > 0);
+  const total = open.reduce((sum, s) => sum + s.count, 0);
+
+  return (
+    <div className="po-block">
+      <div className="po-block__head">
+        <div className="po-block__title">
+          <IconListDetails size={13} /> Backlog pulse
+        </div>
+        <div className="po-block__spacer" />
+        <Link className="po-block__link" href={`${basePath}/tickets`}>
+          Open backlog <IconArrowUpRight size={11} />
+        </Link>
+      </div>
+      <div className="po-pulse__body">
+        {total === 0 ? (
+          <div className="po-pulse__empty">
+            No open tickets. New work lands here as soon as it&apos;s filed.
+          </div>
+        ) : (
+          <>
+            <div className="po-pulse__bar" role="img" aria-label={`${total} open tickets by status`}>
+              {open.map((s) => (
+                <div
+                  key={s.status}
+                  className="po-pulse__seg"
+                  title={`${STATUS_LABELS[s.status]} · ${s.count}`}
+                  style={{ flex: s.count, background: statusCss(s.status) }}
+                />
+              ))}
+            </div>
+            <div className="po-pulse__legend">
+              {open.map((s) => (
+                <button
+                  key={s.status}
+                  type="button"
+                  className="po-pulse__key"
+                  onClick={() =>
+                    router.push(`${basePath}/tickets?status=${s.status}`)
+                  }
+                >
+                  <i style={{ background: statusCss(s.status) }} />
+                  {STATUS_LABELS[s.status]} <b>{s.count}</b>
+                </button>
+              ))}
+              <span className="po-pulse__total">
+                {total} open · done &amp; archived hidden
+              </span>
+            </div>
+          </>
+        )}
+        <div className="po-pulse__nav">
+          <button
+            type="button"
+            className="po-pulse__nav-item"
+            onClick={() => router.push(`${basePath}/features`)}
+          >
+            <span className="po-pulse__nav-num">{counts.features}</span>{" "}
+            Features
+          </button>
+          <div className="po-pulse__nav-sep" />
+          <button
+            type="button"
+            className="po-pulse__nav-item"
+            onClick={() => router.push(`${basePath}/insights`)}
+          >
+            <span className="po-pulse__nav-num">{counts.researches}</span>{" "}
+            Research
+          </button>
+          <div className="po-pulse__nav-sep" />
+          <button
+            type="button"
+            className="po-pulse__nav-item"
+            onClick={() => router.push(`${basePath}/retrospectives`)}
+          >
+            <span className="po-pulse__nav-num">{counts.retrospectives}</span>{" "}
+            Retros
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/product/overview/CycleHero.tsx
+++ b/src/app/_components/product/overview/CycleHero.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import Link from "next/link";
+import { IconPlus, IconRefresh } from "@tabler/icons-react";
+import { Button } from "@mantine/core";
+import { STATUS_LABELS } from "~/lib/ticket-statuses";
+import {
+  statusCss,
+  ticketDisplayId,
+  type OverviewProduct,
+  type ProductOverviewData,
+} from "./overviewShared";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+const clamp = (n: number, lo: number, hi: number) =>
+  Math.max(lo, Math.min(hi, n));
+
+interface CycleHeroProps {
+  cycle: ProductOverviewData["cycle"];
+  product: OverviewProduct;
+  basePath: string;
+}
+
+function EmptyHero({
+  title,
+  sub,
+  cta,
+  href,
+}: {
+  title: string;
+  sub: string;
+  cta: string;
+  href: string;
+}) {
+  return (
+    <div className="po-hero is-empty">
+      <div className="po-hero-empty">
+        <div className="po-hero-empty__icon">
+          <IconRefresh size={22} />
+        </div>
+        <div className="po-hero-empty__body">
+          <div className="po-hero-empty__title">{title}</div>
+          <div className="po-hero-empty__sub">{sub}</div>
+        </div>
+        <Button
+          component={Link}
+          href={href}
+          leftSection={<IconPlus size={14} />}
+          size="xs"
+        >
+          {cta}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function CycleHero({ cycle, product, basePath }: CycleHeroProps) {
+  if (!cycle) {
+    return (
+      <EmptyHero
+        title="No active cycle"
+        sub="Plan a cycle to time-box the next stretch of work and track burn against it."
+        cta="Plan a cycle"
+        href={`${basePath}/cycles/new`}
+      />
+    );
+  }
+
+  if (cycle.committed === 0) {
+    return (
+      <EmptyHero
+        title={`${cycle.name} has no tickets from ${product.name}`}
+        sub="Commit tickets to the current cycle to start tracking progress here."
+        cta="Open backlog"
+        href={`${basePath}/tickets`}
+      />
+    );
+  }
+
+  const now = Date.now();
+  const end = cycle.endDate ? new Date(cycle.endDate).getTime() : null;
+  const start = cycle.startDate ? new Date(cycle.startDate).getTime() : null;
+
+  const daysLeft = end !== null ? Math.ceil((end - now) / DAY) : null;
+  const over = daysLeft !== null && daysLeft < 0;
+
+  const donePct = clamp((cycle.completed / cycle.committed) * 100, 0, 100);
+  const progPct = clamp(
+    ((cycle.completed + cycle.inProgress) / cycle.committed) * 100,
+    0,
+    100,
+  );
+  const timePct =
+    start !== null && end !== null && end > start
+      ? clamp(((now - start) / (end - start)) * 100, 0, 100)
+      : null;
+
+  const pace =
+    timePct === null
+      ? null
+      : donePct >= timePct + 15
+        ? "ahead"
+        : donePct + 1 >= timePct
+          ? "ontrack"
+          : "behind";
+  const paceLabel =
+    pace === "ahead" ? "Ahead" : pace === "behind" ? "Behind pace" : "On pace";
+
+  const dateFmt = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+  const range =
+    cycle.startDate && cycle.endDate
+      ? `${dateFmt.format(new Date(cycle.startDate))} – ${dateFmt.format(new Date(cycle.endDate))}`
+      : null;
+
+  const unit = cycle.usesPoints ? "pts" : "tickets";
+
+  return (
+    <Link
+      className="po-hero"
+      href={`${basePath}/cycles/${cycle.id}`}
+      aria-label={`Open cycle ${cycle.name}`}
+    >
+      <div className="po-hero__top">
+        <div>
+          <div className="po-hero__eyebrow">
+            <span className="po-hero__dot" /> Current cycle
+          </div>
+          <div className="po-hero__name">{cycle.name}</div>
+          {range && <div className="po-hero__dates">{range}</div>}
+        </div>
+        {daysLeft !== null && (
+          <div className="po-hero__countdown">
+            <div className={`po-hero__days ${over ? "is-over" : ""}`}>
+              {Math.abs(daysLeft)}
+            </div>
+            <div className="po-hero__days-unit">
+              {over ? "days over" : "days left"}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="po-viz">
+        <div className="po-viz__stat">
+          <span className="po-viz__num">
+            {cycle.completed}
+            <em>
+              {" "}
+              / {cycle.committed} {unit} done
+            </em>
+          </span>
+          {pace && (
+            <span className={`po-viz__pace po-viz__pace--${pace}`}>
+              {paceLabel}
+            </span>
+          )}
+        </div>
+        <div className="po-track">
+          <div
+            className="po-track__prog"
+            style={{
+              left: `${donePct}%`,
+              width: `${Math.max(0, progPct - donePct)}%`,
+            }}
+          />
+          <div className="po-track__done" style={{ width: `${donePct}%` }} />
+          {timePct !== null && (
+            <div
+              className="po-track__now"
+              style={{ left: `${timePct}%` }}
+              title={`${Math.round(timePct)}% of time elapsed`}
+            />
+          )}
+        </div>
+        <div className="po-viz__legend">
+          <span>
+            <i className="po-lg-done" /> Completed
+          </span>
+          <span>
+            <i className="po-lg-prog" /> In progress
+          </span>
+          {timePct !== null && (
+            <span>
+              <i className="po-lg-now" /> Time elapsed · {Math.round(timePct)}%
+            </span>
+          )}
+        </div>
+      </div>
+
+      {cycle.statusCounts.length > 0 && (
+        <div className="po-hero__chips">
+          {cycle.statusCounts.map((s) => (
+            <span className="po-chip" key={s.status}>
+              <span
+                className="po-chip__dot"
+                style={{ background: statusCss(s.status) }}
+              />
+              {STATUS_LABELS[s.status] ?? s.status} <b>{s.count}</b>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {cycle.myTickets.length > 0 && (
+        <div className="po-mine">
+          <div className="po-mine__label">Your tickets in this cycle</div>
+          {cycle.myTickets.map((t) => {
+            const done =
+              t.status === "DONE" ||
+              t.status === "DEPLOYED" ||
+              t.status === "ARCHIVED";
+            const blocked = t.status === "BLOCKED";
+            return (
+              <div
+                className={`po-mine__row ${done ? "is-done" : ""} ${blocked ? "is-blocked" : ""}`}
+                key={t.id}
+              >
+                <span className="po-mine__check" />
+                <span className="po-mine__id">
+                  {ticketDisplayId(product, t)}
+                </span>
+                <span className="po-mine__title">{t.title}</span>
+                <span className="po-mine__st">
+                  {STATUS_LABELS[t.status] ?? t.status}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/src/app/_components/product/overview/NeedsAttention.tsx
+++ b/src/app/_components/product/overview/NeedsAttention.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  IconAlertCircle,
+  IconCheck,
+  IconChevronRight,
+  IconEye,
+  IconFlag,
+  IconPencil,
+} from "@tabler/icons-react";
+import { ticketUrlId } from "~/lib/fun-ids";
+import {
+  compactAge,
+  isStale,
+  ticketDisplayId,
+  type OverviewProduct,
+  type ProductOverviewData,
+} from "./overviewShared";
+
+type Attention = ProductOverviewData["attention"];
+type AttentionGroup = Attention[keyof Attention];
+
+const GROUPS = [
+  {
+    key: "blocked",
+    status: "BLOCKED",
+    name: "Blocked",
+    mod: "blocked",
+    Icon: IconAlertCircle,
+  },
+  {
+    key: "needsRefinement",
+    status: "NEEDS_REFINEMENT",
+    name: "Needs refinement",
+    mod: "refine",
+    Icon: IconPencil,
+  },
+  { key: "qa", status: "QA", name: "In QA", mod: "qa", Icon: IconEye },
+] as const;
+
+function Group({
+  def,
+  group,
+  product,
+  basePath,
+  defaultOpen,
+}: {
+  def: (typeof GROUPS)[number];
+  group: AttentionGroup;
+  product: OverviewProduct;
+  basePath: string;
+  defaultOpen: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const top = group.items.slice(0, 3);
+  return (
+    <div className="po-attn__group">
+      <button
+        type="button"
+        className="po-attn__head"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <span className={`po-attn__icon po-attn__icon--${def.mod}`}>
+          <def.Icon size={13} />
+        </span>
+        <span className="po-attn__name">{def.name}</span>
+        <span className="po-attn__count">{group.count}</span>
+        <IconChevronRight
+          size={13}
+          className={`po-attn__chev ${open ? "is-open" : ""}`}
+        />
+      </button>
+      {open && (
+        <div className="po-attn__items">
+          {top.map((t) => (
+            <Link
+              className="po-attn__item"
+              key={t.id}
+              href={`${basePath}/tickets/${ticketUrlId(t)}`}
+            >
+              <span className="po-attn__item-id">
+                {ticketDisplayId(product, t)}
+              </span>
+              <span className="po-attn__item-title">{t.title}</span>
+              <span
+                className={`po-attn__item-age ${isStale(t.updatedAt) ? "is-stale" : ""}`}
+              >
+                {compactAge(t.updatedAt)}
+              </span>
+            </Link>
+          ))}
+          {group.count > 3 && (
+            <Link
+              className="po-attn__item po-attn__more"
+              href={`${basePath}/tickets?status=${def.status}`}
+            >
+              <span className="po-attn__item-title">
+                View all {group.count} →
+              </span>
+            </Link>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function NeedsAttention({
+  attention,
+  product,
+  basePath,
+}: {
+  attention: Attention;
+  product: OverviewProduct;
+  basePath: string;
+}) {
+  const total =
+    attention.blocked.count +
+    attention.needsRefinement.count +
+    attention.qa.count;
+  const hot = attention.blocked.count > 0;
+  const active = GROUPS.filter((g) => attention[g.key].count > 0);
+
+  return (
+    <div className={`po-block po-attn ${hot ? "is-hot" : ""}`}>
+      <div className="po-block__head">
+        <div className="po-block__title">
+          <IconFlag size={13} /> Needs attention
+        </div>
+        <div className="po-block__spacer" />
+        {total > 0 && <span className="po-block__count">{total} items</span>}
+      </div>
+      {total === 0 ? (
+        <div className="po-attn__clear">
+          <span className="po-attn__clear-icon">
+            <IconCheck size={13} />
+          </span>
+          <span className="po-attn__clear-text">
+            <b>All clear.</b> Nothing blocked, unrefined, or stuck in QA.
+          </span>
+        </div>
+      ) : (
+        <div>
+          {active.map((g, i) => (
+            <Group
+              key={g.key}
+              def={g}
+              group={attention[g.key]}
+              product={product}
+              basePath={basePath}
+              defaultOpen={hot ? g.key === "blocked" : i === 0}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/_components/product/overview/ProductOverview.tsx
+++ b/src/app/_components/product/overview/ProductOverview.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Skeleton } from "@mantine/core";
+import {
+  IconBulb,
+  IconLayoutGrid,
+  IconMicrophone,
+  IconRefresh,
+  IconTicket,
+} from "@tabler/icons-react";
+import { api } from "~/trpc/react";
+import { CreateTicketModal } from "~/app/_components/product/CreateTicketModal";
+import { CycleHero } from "./CycleHero";
+import { NeedsAttention } from "./NeedsAttention";
+import { BacklogPulse } from "./BacklogPulse";
+import { QuickActions } from "./QuickActions";
+import { RecentActivity } from "./RecentActivity";
+import type { OverviewProduct, ProductOverviewData } from "./overviewShared";
+import "./product-overview.css";
+
+export function OverviewSkeleton() {
+  return (
+    <div className="po-grid" aria-busy="true">
+      <div className="po-col">
+        <div className="po-block" style={{ padding: "20px 22px" }}>
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <Skeleton height={14} width={200} />
+            <Skeleton height={34} width={44} />
+          </div>
+          <Skeleton height={12} width="100%" mt={24} />
+          <div style={{ display: "flex", gap: 8, marginTop: 18 }}>
+            {[70, 60, 80, 66].map((w, i) => (
+              <Skeleton key={i} height={24} width={w} radius={20} />
+            ))}
+          </div>
+          <Skeleton height={11} width="100%" mt={22} />
+          <Skeleton height={11} width="92%" mt={10} />
+        </div>
+        <div className="po-block" style={{ padding: 16 }}>
+          <Skeleton height={11} width={130} />
+          <Skeleton height={11} width="90%" mt={14} />
+          <Skeleton height={11} width="78%" mt={10} />
+          <Skeleton height={11} width="66%" mt={10} />
+        </div>
+      </div>
+      <div className="po-col">
+        {[3, 4].map((lines, block) => (
+          <div key={block} className="po-block" style={{ padding: 16 }}>
+            <Skeleton height={11} width={130} />
+            {Array.from({ length: lines }).map((_, i) => (
+              <Skeleton key={i} height={11} width={`${90 - i * 12}%`} mt={12} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const FIRST_STEPS = [
+  {
+    n: 1,
+    Icon: IconTicket,
+    title: "Add your first ticket",
+    sub: "Capture the first thing that needs doing.",
+    href: "/tickets/new",
+  },
+  {
+    n: 2,
+    Icon: IconRefresh,
+    title: "Plan a cycle",
+    sub: "Time-box a stretch and commit work to it.",
+    href: "/cycles/new",
+  },
+  {
+    n: 3,
+    Icon: IconBulb,
+    title: "Define a feature",
+    sub: "Group tickets under a larger unit of value.",
+    href: "/features/new",
+  },
+  {
+    n: 4,
+    Icon: IconMicrophone,
+    title: "Log some research",
+    sub: "Capture an interview or a finding.",
+    href: "/research/new",
+  },
+];
+
+function FirstRun({
+  product,
+  basePath,
+}: {
+  product: OverviewProduct;
+  basePath: string;
+}) {
+  return (
+    <div className="po-firstrun">
+      <div className="po-firstrun__hero">
+        <div className="po-firstrun__badge">
+          <IconLayoutGrid size={24} />
+        </div>
+        <div className="po-firstrun__title">
+          Let&apos;s set up {product.name}
+        </div>
+        <div className="po-firstrun__sub">
+          This product is empty. Do one of these to get the Overview working
+          for you — it fills in as you go.
+        </div>
+        <div className="po-firstrun__steps">
+          {FIRST_STEPS.map((s) => (
+            <Link className="po-fr-step" key={s.n} href={`${basePath}${s.href}`}>
+              <span className="po-fr-step__num">{s.n}</span>
+              <span>
+                <span className="po-fr-step__title">
+                  <s.Icon size={14} /> {s.title}
+                </span>
+                <span className="po-fr-step__sub">{s.sub}</span>
+              </span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function isFirstRun(data: ProductOverviewData): boolean {
+  const totalTickets = data.statusCounts.reduce((s, g) => s + g.count, 0);
+  return (
+    totalTickets === 0 &&
+    data.counts.features === 0 &&
+    data.counts.researches === 0 &&
+    data.counts.retrospectives === 0
+  );
+}
+
+export function ProductOverview({
+  product,
+  basePath,
+}: {
+  product: OverviewProduct;
+  basePath: string;
+}) {
+  const [ticketModalOpen, setTicketModalOpen] = useState(false);
+
+  const { data, isLoading } = api.product.product.getOverview.useQuery({
+    productId: product.id,
+  });
+
+  // Per-product accent: product.color if set, else brand. All tints in the
+  // CSS derive from this one variable via color-mix, so any value works in
+  // both themes.
+  const accent = product.color ?? "var(--brand-500)";
+
+  return (
+    <div className="product-overview" style={{ "--po-accent": accent } as React.CSSProperties}>
+      {isLoading || !data ? (
+        <OverviewSkeleton />
+      ) : isFirstRun(data) ? (
+        <FirstRun product={product} basePath={basePath} />
+      ) : (
+        <div className="po-grid">
+          <div className="po-col">
+            <CycleHero cycle={data.cycle} product={product} basePath={basePath} />
+            <BacklogPulse
+              statusCounts={data.statusCounts}
+              counts={data.counts}
+              basePath={basePath}
+            />
+            <RecentActivity
+              activity={data.activity}
+              product={product}
+              basePath={basePath}
+            />
+          </div>
+          <div className="po-col">
+            <NeedsAttention
+              attention={data.attention}
+              product={product}
+              basePath={basePath}
+            />
+            <QuickActions
+              basePath={basePath}
+              onNewTicket={() => setTicketModalOpen(true)}
+            />
+          </div>
+        </div>
+      )}
+
+      <CreateTicketModal
+        opened={ticketModalOpen}
+        onClose={() => setTicketModalOpen(false)}
+        productId={product.id}
+        productName={product.name}
+        basePath={`${basePath}/tickets`}
+      />
+    </div>
+  );
+}

--- a/src/app/_components/product/overview/QuickActions.tsx
+++ b/src/app/_components/product/overview/QuickActions.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import Link from "next/link";
+import {
+  IconBolt,
+  IconBulb,
+  IconClipboardList,
+  IconMicrophone,
+  IconTargetArrow,
+  IconTicket,
+  IconUser,
+} from "@tabler/icons-react";
+
+export function QuickActions({
+  basePath,
+  onNewTicket,
+}: {
+  basePath: string;
+  onNewTicket: () => void;
+}) {
+  return (
+    <div className="po-block">
+      <div className="po-block__head">
+        <div className="po-block__title">
+          <IconBolt size={13} /> Quick actions
+        </div>
+      </div>
+      <div className="po-qa__body">
+        <button type="button" className="po-qa__item" onClick={onNewTicket}>
+          <span className="po-qa__icon">
+            <IconTicket size={14} />
+          </span>
+          <span className="po-qa__label">New ticket</span>
+        </button>
+        <Link className="po-qa__item" href={`${basePath}/features/new`}>
+          <span className="po-qa__icon">
+            <IconBulb size={14} />
+          </span>
+          <span className="po-qa__label">New feature</span>
+        </Link>
+        <Link className="po-qa__item" href={`${basePath}/research/new`}>
+          <span className="po-qa__icon">
+            <IconMicrophone size={14} />
+          </span>
+          <span className="po-qa__label">New research</span>
+        </Link>
+        <Link className="po-qa__item" href={`${basePath}/retrospectives/new`}>
+          <span className="po-qa__icon">
+            <IconClipboardList size={14} />
+          </span>
+          <span className="po-qa__label">New retro</span>
+        </Link>
+        <div className="po-qa__sep" />
+        <Link
+          className="po-qa__item po-qa__item--sub"
+          href={`${basePath}/tickets?assignee=me`}
+        >
+          <span className="po-qa__icon">
+            <IconUser size={14} />
+          </span>
+          <span className="po-qa__label">My tickets</span>
+        </Link>
+        <Link
+          className="po-qa__item po-qa__item--sub"
+          href={`${basePath}/insights`}
+        >
+          <span className="po-qa__icon">
+            <IconTargetArrow size={14} />
+          </span>
+          <span className="po-qa__label">Insights &amp; research</span>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/product/overview/RecentActivity.tsx
+++ b/src/app/_components/product/overview/RecentActivity.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import Link from "next/link";
+import { IconClock, IconSparkles } from "@tabler/icons-react";
+import { getAvatarColor, getInitial } from "~/utils/avatarColors";
+import { STATUS_LABELS } from "~/lib/ticket-statuses";
+import { ticketUrlId } from "~/lib/fun-ids";
+import {
+  compactAge,
+  statusCss,
+  ticketDisplayId,
+  type OverviewProduct,
+  type ProductOverviewData,
+} from "./overviewShared";
+
+type ActivityEvent = ProductOverviewData["activity"][number];
+
+function readMetaString(metadata: unknown, key: string): string | null {
+  if (metadata && typeof metadata === "object" && !Array.isArray(metadata)) {
+    const value = (metadata as Record<string, unknown>)[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return null;
+}
+
+function verbFor(event: ActivityEvent): string {
+  switch (event.action) {
+    case "created":
+      return "created";
+    case "status_changed":
+      return "moved";
+    case "completed":
+      return "completed";
+    case "commented":
+      return "commented on";
+    default:
+      return "updated";
+  }
+}
+
+export function RecentActivity({
+  activity,
+  product,
+  basePath,
+}: {
+  activity: ProductOverviewData["activity"];
+  product: OverviewProduct;
+  basePath: string;
+}) {
+  return (
+    <div className="po-block">
+      <div className="po-block__head">
+        <div className="po-block__title">
+          <IconClock size={13} /> Recent activity
+        </div>
+      </div>
+      {activity.length === 0 ? (
+        <div className="po-act__empty">
+          Nothing yet — changes to tickets show up here.
+        </div>
+      ) : (
+        <div className="po-act__body">
+          {activity.map((event) => {
+            const actorName = event.actor?.name ?? "Someone";
+            const movedTo =
+              event.action === "status_changed"
+                ? readMetaString(event.metadata, "to")
+                : null;
+            return (
+              <div className="po-act__row" key={event.id}>
+                <span
+                  className="po-act__ava"
+                  style={
+                    event.actor
+                      ? { background: getAvatarColor(event.actor.id) }
+                      : {
+                          background: "var(--brand-500)",
+                        }
+                  }
+                  title={actorName}
+                >
+                  {event.actor ? (
+                    event.actor.image ? (
+                      // eslint-disable-next-line @next/next/no-img-element -- 22px avatar; next/image is overkill here
+                      <img src={event.actor.image} alt="" />
+                    ) : (
+                      getInitial(event.actor.name, null)
+                    )
+                  ) : (
+                    <IconSparkles size={11} />
+                  )}
+                </span>
+                <span className="po-act__body-text">
+                  <b>{actorName}</b> {verbFor(event)}{" "}
+                  <Link
+                    href={`${basePath}/tickets/${ticketUrlId(event.ticket)}`}
+                    className="po-act__id"
+                  >
+                    {ticketDisplayId(product, event.ticket)}
+                  </Link>{" "}
+                  {movedTo ? (
+                    <>
+                      to
+                      <span
+                        className="po-act__badge"
+                        style={{
+                          color: statusCss(movedTo),
+                          background: `color-mix(in srgb, ${statusCss(movedTo)} 16%, transparent)`,
+                        }}
+                      >
+                        {STATUS_LABELS[movedTo] ?? movedTo}
+                      </span>
+                    </>
+                  ) : (
+                    <span>· {event.ticket.title}</span>
+                  )}
+                </span>
+                <span className="po-act__time">
+                  {compactAge(event.createdAt)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/_components/product/overview/RecentActivity.tsx
+++ b/src/app/_components/product/overview/RecentActivity.tsx
@@ -23,6 +23,23 @@ function readMetaString(metadata: unknown, key: string): string | null {
   return null;
 }
 
+/**
+ * Only render avatar URLs that are plain http(s) — rejects `javascript:` /
+ * `data:` and other schemes before they reach an <img src>. Falls back to
+ * initials otherwise.
+ */
+function safeHttpUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" || parsed.protocol === "http:"
+      ? url
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function verbFor(event: ActivityEvent): string {
   switch (event.action) {
     case "created":
@@ -62,6 +79,7 @@ export function RecentActivity({
         <div className="po-act__body">
           {activity.map((event) => {
             const actorName = event.actor?.name ?? "Someone";
+            const avatarUrl = safeHttpUrl(event.actor?.image);
             const movedTo =
               event.action === "status_changed"
                 ? readMetaString(event.metadata, "to")
@@ -80,9 +98,9 @@ export function RecentActivity({
                   title={actorName}
                 >
                   {event.actor ? (
-                    event.actor.image ? (
+                    avatarUrl ? (
                       // eslint-disable-next-line @next/next/no-img-element -- 22px avatar; next/image is overkill here
-                      <img src={event.actor.image} alt="" />
+                      <img src={avatarUrl} alt="" />
                     ) : (
                       getInitial(event.actor.name, null)
                     )

--- a/src/app/_components/product/overview/overviewShared.ts
+++ b/src/app/_components/product/overview/overviewShared.ts
@@ -1,0 +1,79 @@
+import type { RouterOutputs } from "~/trpc/react";
+import { generateLinearId } from "~/lib/fun-ids";
+import type { TicketStatus } from "~/lib/ticket-statuses";
+
+export type ProductOverviewData =
+  RouterOutputs["product"]["product"]["getOverview"];
+
+export interface OverviewProduct {
+  id: string;
+  name: string;
+  slug: string;
+  color: string | null;
+  funTicketIds: boolean;
+}
+
+/**
+ * Status → CSS color for this surface, per the design handoff's semantic
+ * mapping (accent tokens, not Mantine palette names — see the PR notes for
+ * the deliberate divergence from STATUS_COLORS).
+ */
+export const OVERVIEW_STATUS_CSS: Record<TicketStatus, string> = {
+  BACKLOG: "var(--color-text-faint)",
+  NEEDS_REFINEMENT: "var(--accent-okr)",
+  READY_TO_PLAN: "var(--accent-quick)",
+  COMMITTED: "var(--accent-ritual)",
+  IN_PROGRESS: "var(--brand-400)",
+  BLOCKED: "var(--accent-due)",
+  QA: "var(--accent-meetings)",
+  DONE: "var(--accent-crm)",
+  DEPLOYED: "var(--accent-crm)",
+  ARCHIVED: "var(--color-text-faint)",
+};
+
+export function statusCss(status: string): string {
+  return (
+    OVERVIEW_STATUS_CSS[status as TicketStatus] ?? "var(--color-text-faint)"
+  );
+}
+
+/** Open statuses shown by the backlog pulse, in workflow order. */
+export const OPEN_PULSE_STATUSES: TicketStatus[] = [
+  "BACKLOG",
+  "NEEDS_REFINEMENT",
+  "READY_TO_PLAN",
+  "COMMITTED",
+  "IN_PROGRESS",
+  "BLOCKED",
+  "QA",
+];
+
+/** "CLR-241"-style display id, honouring the product's fun-id setting. */
+export function ticketDisplayId(
+  product: { name: string; funTicketIds: boolean },
+  ticket: { shortId: string | null; number: number },
+): string {
+  if (product.funTicketIds && ticket.shortId) return ticket.shortId;
+  return ticket.number > 0
+    ? generateLinearId(product.name, ticket.number)
+    : "—";
+}
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/** Compact relative age ("4h", "2d") for ticket rows and activity times. */
+export function compactAge(date: Date | string): string {
+  const ms = Date.now() - new Date(date).getTime();
+  if (ms < MINUTE) return "now";
+  if (ms < HOUR) return `${Math.floor(ms / MINUTE)}m`;
+  if (ms < DAY) return `${Math.floor(ms / HOUR)}h`;
+  const days = Math.floor(ms / DAY);
+  return days > 30 ? `${Math.floor(days / 7)}w` : `${days}d`;
+}
+
+/** A ticket sitting untouched this long in an attention state is "stale". */
+export function isStale(updatedAt: Date | string): boolean {
+  return Date.now() - new Date(updatedAt).getTime() > 3 * DAY;
+}

--- a/src/app/_components/product/overview/overviewShared.ts
+++ b/src/app/_components/product/overview/overviewShared.ts
@@ -66,6 +66,7 @@ const DAY = 24 * HOUR;
 /** Compact relative age ("4h", "2d") for ticket rows and activity times. */
 export function compactAge(date: Date | string): string {
   const ms = Date.now() - new Date(date).getTime();
+  // Clamp future timestamps (client/server clock skew) to "now".
   if (ms < MINUTE) return "now";
   if (ms < HOUR) return `${Math.floor(ms / MINUTE)}m`;
   if (ms < DAY) return `${Math.floor(ms / HOUR)}h`;

--- a/src/app/_components/product/overview/product-overview.css
+++ b/src/app/_components/product/overview/product-overview.css
@@ -1,0 +1,865 @@
+/* ============================================================
+   Product Overview tab — "mission control" redesign.
+
+   STYLE RULES (per dev-docs/styling-architecture.md):
+   - NO hex / rgb literals in this file. Theme tokens only, via
+     var(--color-*, --accent-*, --brand-*) so light/dark both work.
+   - The per-product accent arrives as --po-accent, set inline by
+     ProductOverview.tsx from product.color (falls back to brand).
+     Tints derive via color-mix so any accent value works in both
+     themes.
+   ============================================================ */
+
+.product-overview {
+  max-width: 1160px;
+  --po-mono: var(--font-mono, ui-monospace, "SF Mono", Menlo, monospace);
+}
+
+/* ---- body grid ---- */
+.po-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.62fr) minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+.po-col {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+@media (max-width: 1080px) {
+  .po-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* ---- generic block card ---- */
+.po-block {
+  background: var(--color-surface-secondary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.po-block__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 16px 12px;
+}
+.po-block__title {
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.po-block__spacer {
+  flex: 1;
+}
+.po-block__link {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+.po-block__link:hover {
+  color: var(--brand-400);
+}
+.po-block__count {
+  font-size: 11.5px;
+  color: var(--color-text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* =========================================================
+   Cycle hero
+   ========================================================= */
+.po-hero {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: 1px solid color-mix(in srgb, var(--po-accent) 26%, var(--color-border-primary));
+  border-radius: 10px;
+  background:
+    radial-gradient(
+      120% 130% at 100% 0%,
+      color-mix(in srgb, var(--po-accent) 15%, transparent),
+      transparent 55%
+    ),
+    var(--color-surface-secondary);
+  padding: 20px 22px;
+  cursor: pointer;
+  position: relative;
+  transition: border-color 140ms;
+}
+.po-hero:hover {
+  border-color: color-mix(in srgb, var(--po-accent) 46%, var(--color-border-primary));
+}
+.po-hero::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 14px;
+  bottom: 14px;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: var(--po-accent);
+}
+.po-hero__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.po-hero__eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--po-accent) 70%, var(--color-text-muted));
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.po-hero__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--po-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--po-accent) 22%, transparent);
+}
+.po-hero__name {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--color-text-primary);
+  margin: 9px 0 4px;
+}
+.po-hero__dates {
+  font-size: 12.5px;
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+.po-hero__countdown {
+  text-align: right;
+  flex-shrink: 0;
+}
+.po-hero__days {
+  font-size: 34px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.po-hero__days.is-over {
+  color: var(--accent-due);
+}
+.po-hero__days-unit {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  margin-top: 5px;
+  font-weight: 500;
+}
+.po-hero__days.is-over + .po-hero__days-unit {
+  color: var(--accent-due);
+}
+
+/* dual-track progress viz (see README redlines) */
+.po-viz {
+  margin-top: 20px;
+}
+.po-viz__stat {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 9px;
+}
+.po-viz__num {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.po-viz__num em {
+  font-style: normal;
+  color: var(--color-text-muted);
+  font-weight: 400;
+}
+.po-viz__pace {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 2px 8px;
+  border-radius: 10px;
+}
+.po-viz__pace--ontrack {
+  color: var(--accent-crm);
+  background: color-mix(in srgb, var(--accent-crm) 16%, transparent);
+}
+.po-viz__pace--behind {
+  color: var(--accent-due);
+  background: color-mix(in srgb, var(--accent-due) 16%, transparent);
+}
+.po-viz__pace--ahead {
+  color: var(--accent-ritual);
+  background: color-mix(in srgb, var(--accent-ritual) 16%, transparent);
+}
+.po-track {
+  position: relative;
+  height: 12px;
+  border-radius: 6px;
+  background: var(--color-surface-muted);
+}
+.po-track__done {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  border-radius: 6px 0 0 6px;
+  background: var(--po-accent);
+}
+.po-track__prog {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background-image: repeating-linear-gradient(
+    45deg,
+    color-mix(in srgb, var(--po-accent) 14%, transparent),
+    color-mix(in srgb, var(--po-accent) 14%, transparent) 4px,
+    color-mix(in srgb, var(--po-accent) 40%, transparent) 4px,
+    color-mix(in srgb, var(--po-accent) 40%, transparent) 8px
+  );
+}
+.po-track__now {
+  position: absolute;
+  top: -3px;
+  bottom: -3px;
+  width: 2px;
+  background: var(--color-text-primary);
+  box-shadow: 0 0 0 2px var(--color-surface-secondary);
+  border-radius: 2px;
+}
+.po-viz__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 16px;
+  margin-top: 10px;
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+}
+.po-viz__legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.po-viz__legend i {
+  width: 9px;
+  height: 9px;
+  border-radius: 2px;
+}
+.po-lg-done {
+  background: var(--po-accent);
+}
+.po-lg-prog {
+  background: color-mix(in srgb, var(--po-accent) 42%, transparent);
+}
+.po-lg-now {
+  width: 2px !important;
+  height: 12px !important;
+  border-radius: 1px !important;
+  background: var(--color-text-primary);
+}
+
+/* in-cycle status chips */
+.po-hero__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 18px;
+}
+.po-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 9px;
+  border-radius: 20px;
+  background: var(--color-surface-muted);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+.po-chip b {
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.po-chip__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+/* "your tickets in this cycle" strip */
+.po-mine {
+  margin-top: 18px;
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: 14px;
+}
+.po-mine__label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin-bottom: 8px;
+}
+.po-mine__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  margin: 0 -8px;
+}
+.po-mine__row:hover {
+  background: var(--color-bg-hover);
+}
+.po-mine__check {
+  width: 15px;
+  height: 15px;
+  border-radius: 4px;
+  border: 1.5px solid var(--color-border-strong);
+  flex-shrink: 0;
+}
+.po-mine__row.is-done .po-mine__check {
+  background: var(--accent-crm);
+  border-color: var(--accent-crm);
+}
+.po-mine__row.is-blocked .po-mine__check {
+  border-color: var(--accent-due);
+}
+.po-mine__id {
+  font-family: var(--po-mono);
+  font-size: 11px;
+  color: var(--color-text-faint);
+  flex-shrink: 0;
+}
+.po-mine__title {
+  flex: 1;
+  font-size: 13px;
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.po-mine__row.is-done .po-mine__title {
+  color: var(--color-text-muted);
+  text-decoration: line-through;
+}
+.po-mine__st {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+.po-mine__row.is-blocked .po-mine__st {
+  color: var(--accent-due);
+}
+
+/* hero empty variants (no cycle / empty cycle) */
+.po-hero.is-empty {
+  cursor: default;
+  background: var(--color-surface-secondary);
+  border-style: dashed;
+  border-color: var(--color-border-primary);
+}
+.po-hero.is-empty::after {
+  display: none;
+}
+.po-hero-empty {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 6px 2px;
+  flex-wrap: wrap;
+}
+.po-hero-empty__icon {
+  width: 46px;
+  height: 46px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+.po-hero-empty__body {
+  flex: 1;
+  min-width: 220px;
+}
+.po-hero-empty__title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.po-hero-empty__sub {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  margin-top: 3px;
+  max-width: 440px;
+}
+
+/* =========================================================
+   Needs attention
+   ========================================================= */
+.po-attn.is-hot {
+  border-color: color-mix(in srgb, var(--accent-due) 45%, var(--color-border-primary));
+  background: color-mix(in srgb, var(--accent-due) 5%, var(--color-surface-secondary));
+}
+.po-attn.is-hot .po-block__title {
+  color: var(--accent-due);
+}
+.po-attn__group {
+  border-top: 1px solid var(--color-border-subtle);
+}
+.po-attn__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 11px 16px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+}
+.po-attn__head:hover {
+  background: var(--color-bg-hover);
+}
+.po-attn__icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.po-attn__icon--blocked {
+  color: var(--accent-due);
+  background: color-mix(in srgb, var(--accent-due) 15%, transparent);
+}
+.po-attn__icon--refine {
+  color: var(--accent-okr);
+  background: color-mix(in srgb, var(--accent-okr) 15%, transparent);
+}
+.po-attn__icon--qa {
+  color: var(--accent-meetings);
+  background: color-mix(in srgb, var(--accent-meetings) 15%, transparent);
+}
+.po-attn__name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  flex: 1;
+}
+.po-attn__count {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.po-attn__chev {
+  color: var(--color-text-faint);
+  transition: transform 120ms;
+}
+.po-attn__chev.is-open {
+  transform: rotate(90deg);
+}
+.po-attn__items {
+  padding: 0 16px 8px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.po-attn__item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 5px 8px;
+  margin: 0 -8px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  color: var(--color-text-secondary);
+}
+.po-attn__item:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+.po-attn__item-id {
+  font-family: var(--po-mono);
+  font-size: 11px;
+  color: var(--color-text-faint);
+  flex-shrink: 0;
+}
+.po-attn__item-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+.po-attn__item-age {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+.po-attn__item-age.is-stale {
+  color: var(--accent-due);
+}
+.po-attn__more {
+  color: var(--brand-400);
+}
+.po-attn__clear {
+  padding: 12px 16px 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.po-attn__clear-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: var(--accent-crm);
+  background: color-mix(in srgb, var(--accent-crm) 16%, transparent);
+  flex-shrink: 0;
+}
+.po-attn__clear-text {
+  font-size: 12.5px;
+  color: var(--color-text-secondary);
+}
+.po-attn__clear-text b {
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+/* =========================================================
+   Backlog pulse
+   ========================================================= */
+.po-pulse__body {
+  padding: 4px 16px 16px;
+}
+.po-pulse__bar {
+  display: flex;
+  height: 10px;
+  gap: 2px;
+}
+.po-pulse__seg {
+  height: 100%;
+  border-radius: 2px;
+  min-width: 3px;
+}
+.po-pulse__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 8px;
+  margin-top: 14px;
+  align-items: center;
+}
+.po-pulse__key {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 9px 4px 8px;
+  border-radius: 7px;
+  background: var(--color-surface-muted);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  border: 0;
+  cursor: pointer;
+  transition: background 120ms;
+}
+.po-pulse__key:hover {
+  background: var(--color-bg-hover);
+}
+.po-pulse__key i {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.po-pulse__key b {
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+  margin-left: 1px;
+}
+.po-pulse__total {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.po-pulse__nav {
+  display: flex;
+  gap: 8px;
+  margin-top: 14px;
+  padding-top: 13px;
+  border-top: 1px solid var(--color-border-subtle);
+}
+.po-pulse__nav-item {
+  flex: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+.po-pulse__nav-item:hover {
+  color: var(--color-text-primary);
+}
+.po-pulse__nav-num {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.po-pulse__nav-sep {
+  width: 1px;
+  align-self: stretch;
+  background: var(--color-border-subtle);
+}
+.po-pulse__empty {
+  font-size: 12.5px;
+  color: var(--color-text-muted);
+}
+
+/* =========================================================
+   Quick actions
+   ========================================================= */
+.po-qa__body {
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+}
+.po-qa__item {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+  color: var(--color-text-primary);
+  font-size: 13px;
+}
+.po-qa__item:hover {
+  background: var(--color-bg-hover);
+}
+.po-qa__icon {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  background: var(--color-surface-muted);
+  color: var(--color-text-secondary);
+}
+.po-qa__label {
+  flex: 1;
+}
+.po-qa__sep {
+  height: 1px;
+  background: var(--color-border-subtle);
+  margin: 5px 10px;
+}
+.po-qa__item--sub {
+  color: var(--color-text-secondary);
+  font-size: 12.5px;
+}
+.po-qa__item--sub .po-qa__icon {
+  background: transparent;
+  color: var(--color-text-muted);
+}
+
+/* =========================================================
+   Recent activity
+   ========================================================= */
+.po-act__body {
+  padding: 4px 16px 14px;
+}
+.po-act__row {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  padding: 8px 0;
+}
+.po-act__row + .po-act__row {
+  border-top: 1px solid var(--color-border-subtle);
+}
+.po-act__ava {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 1px;
+  display: grid;
+  place-items: center;
+  font-size: 9.5px;
+  font-weight: 600;
+  color: var(--color-text-inverse);
+  overflow: hidden;
+}
+.po-act__ava img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.po-act__body-text {
+  flex: 1;
+  min-width: 0;
+  font-size: 12.5px;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+.po-act__body-text b {
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+.po-act__id {
+  font-family: var(--po-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+.po-act__time {
+  font-size: 11px;
+  color: var(--color-text-faint);
+  flex-shrink: 0;
+  margin-top: 1px;
+  font-variant-numeric: tabular-nums;
+}
+.po-act__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  margin-left: 6px;
+}
+.po-act__empty {
+  padding: 4px 16px 16px;
+  font-size: 12.5px;
+  color: var(--color-text-muted);
+}
+
+/* =========================================================
+   First-run (brand-new product)
+   ========================================================= */
+.po-firstrun {
+  max-width: 720px;
+  margin: 48px auto 0;
+}
+.po-firstrun__hero {
+  border: 1px solid var(--color-border-primary);
+  border-radius: 10px;
+  background: var(--color-surface-secondary);
+  padding: 28px 30px;
+  text-align: center;
+}
+.po-firstrun__badge {
+  width: 52px;
+  height: 52px;
+  border-radius: 12px;
+  margin: 0 auto 16px;
+  display: grid;
+  place-items: center;
+  color: var(--color-text-inverse);
+  background: linear-gradient(
+    150deg,
+    color-mix(in srgb, var(--po-accent) 85%, var(--color-text-inverse)),
+    var(--po-accent)
+  );
+}
+.po-firstrun__title {
+  font-size: 21px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--color-text-primary);
+}
+.po-firstrun__sub {
+  font-size: 13.5px;
+  color: var(--color-text-secondary);
+  margin-top: 8px;
+  max-width: 440px;
+  margin-inline: auto;
+}
+.po-firstrun__steps {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  margin-top: 24px;
+  text-align: left;
+}
+@media (max-width: 720px) {
+  .po-firstrun__steps {
+    grid-template-columns: 1fr;
+  }
+}
+.po-fr-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 13px;
+  padding: 16px;
+  border-radius: 10px;
+  border: 1px solid var(--color-border-primary);
+  background: var(--color-bg-elevated);
+  cursor: pointer;
+  transition: border-color 140ms, transform 140ms;
+  width: 100%;
+  text-align: left;
+}
+.po-fr-step:hover {
+  border-color: var(--color-border-strong);
+  transform: translateY(-1px);
+}
+.po-fr-step__num {
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--brand-400);
+  background: color-mix(in srgb, var(--brand-500) 14%, transparent);
+}
+.po-fr-step__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.po-fr-step__sub {
+  font-size: 12.5px;
+  color: var(--color-text-secondary);
+  margin-top: 4px;
+}

--- a/src/plugins/product/server/routers/product.ts
+++ b/src/plugins/product/server/routers/product.ts
@@ -6,6 +6,10 @@ import { buildProjectAccessWhere } from "~/server/services/access";
 import type { PrismaClient, Prisma } from "@prisma/client";
 import { buildGraph } from "../services/DependencyGraphService";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
+import {
+  COMPLETED_TICKET_STATUSES,
+  STATUS_ORDER,
+} from "~/lib/ticket-statuses";
 
 /**
  * Ensure the caller is a member of the workspace. Throws FORBIDDEN otherwise.
@@ -177,6 +181,250 @@ export const productRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Product not found" });
       }
       return product;
+    }),
+
+  /**
+   * Single-round-trip aggregate for the product Overview tab: open-ticket
+   * counts by status, the current cycle (resolved read-only — never
+   * auto-creates or reconciles, unlike cycle.list) with this product's
+   * in-cycle points/status rollup and the caller's own tickets, the
+   * needs-attention lists (blocked / needs refinement / QA), demoted nav
+   * counts, and the last few ticket activity events for this product.
+   */
+  getOverview: protectedProcedure
+    .input(z.object({ productId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const product = await loadProductWithAccess(
+        ctx.db,
+        userId,
+        input.productId,
+      );
+      const now = new Date();
+
+      const attentionStatuses = [
+        "BLOCKED",
+        "NEEDS_REFINEMENT",
+        "QA",
+      ] as const;
+
+      const [statusGroups, navCounts, currentCycle, attentionTickets, rawEvents] =
+        await Promise.all([
+          ctx.db.ticket.groupBy({
+            by: ["status"],
+            where: { productId: input.productId },
+            _count: { _all: true },
+          }),
+          ctx.db.product.findUnique({
+            where: { id: input.productId },
+            select: {
+              _count: {
+                select: {
+                  features: true,
+                  researches: true,
+                  retrospectives: true,
+                },
+              },
+            },
+          }),
+          // Read-only "current cycle": an ACTIVE sprint that hasn't ended, or
+          // a PLANNED one whose window contains today (covers workspaces where
+          // the lazy reconcile in cycle.list hasn't run yet).
+          ctx.db.list.findFirst({
+            where: {
+              workspaceId: product.workspaceId,
+              listType: "SPRINT",
+              OR: [
+                {
+                  status: "ACTIVE",
+                  OR: [{ endDate: null }, { endDate: { gt: now } }],
+                },
+                {
+                  status: "PLANNED",
+                  startDate: { lte: now },
+                  endDate: { gt: now },
+                },
+                // Ended but never reconciled to COMPLETED — still the most
+                // recent "current" cycle the team was burning down.
+                { status: "ACTIVE", endDate: { lte: now } },
+              ],
+            },
+            orderBy: { startDate: "desc" },
+            select: {
+              id: true,
+              name: true,
+              status: true,
+              startDate: true,
+              endDate: true,
+            },
+          }),
+          ctx.db.ticket.findMany({
+            where: {
+              productId: input.productId,
+              status: { in: [...attentionStatuses] },
+            },
+            select: {
+              id: true,
+              shortId: true,
+              number: true,
+              title: true,
+              status: true,
+              updatedAt: true,
+            },
+            // Oldest first — the longest-rotting work is the most urgent.
+            orderBy: { updatedAt: "asc" },
+          }),
+          // Recent ticket events for the workspace; filtered to this product
+          // below (events carry no productId, so we resolve via the ticket).
+          ctx.db.workspaceActivityEvent.findMany({
+            where: { workspaceId: product.workspaceId, entityType: "ticket" },
+            orderBy: { createdAt: "desc" },
+            take: 50,
+            select: {
+              id: true,
+              entityId: true,
+              action: true,
+              metadata: true,
+              createdAt: true,
+              user: { select: { id: true, name: true, image: true } },
+            },
+          }),
+        ]);
+
+      // ---- current cycle rollup (scoped to this product's tickets) ----
+      let cycle: {
+        id: string;
+        name: string;
+        status: string;
+        startDate: Date | null;
+        endDate: Date | null;
+        usesPoints: boolean;
+        committed: number;
+        completed: number;
+        inProgress: number;
+        statusCounts: { status: string; count: number }[];
+        myTickets: {
+          id: string;
+          shortId: string | null;
+          number: number;
+          title: string;
+          status: string;
+        }[];
+      } | null = null;
+
+      if (currentCycle) {
+        const cycleTickets = await ctx.db.ticket.findMany({
+          where: { productId: input.productId, cycleId: currentCycle.id },
+          select: {
+            id: true,
+            shortId: true,
+            number: true,
+            title: true,
+            status: true,
+            points: true,
+            assigneeId: true,
+          },
+        });
+
+        const completedSet = new Set<string>(COMPLETED_TICKET_STATUSES);
+        const usesPoints = cycleTickets.some((t) => (t.points ?? 0) > 0);
+        const weight = (t: { points: number | null }) =>
+          usesPoints ? (t.points ?? 0) : 1;
+
+        const committed = cycleTickets.reduce((s, t) => s + weight(t), 0);
+        const completed = cycleTickets
+          .filter((t) => completedSet.has(t.status))
+          .reduce((s, t) => s + weight(t), 0);
+        const inProgress = cycleTickets
+          .filter((t) => t.status === "IN_PROGRESS")
+          .reduce((s, t) => s + weight(t), 0);
+
+        const cycleStatusCounts = new Map<string, number>();
+        for (const t of cycleTickets) {
+          cycleStatusCounts.set(
+            t.status,
+            (cycleStatusCounts.get(t.status) ?? 0) + 1,
+          );
+        }
+
+        const statusRank = (s: string) => STATUS_ORDER[s] ?? 99;
+        const myTickets = cycleTickets
+          .filter((t) => t.assigneeId === userId)
+          .sort((a, b) => statusRank(a.status) - statusRank(b.status))
+          .slice(0, 4)
+          .map(({ id, shortId, number, title, status }) => ({
+            id,
+            shortId,
+            number,
+            title,
+            status,
+          }));
+
+        cycle = {
+          id: currentCycle.id,
+          name: currentCycle.name,
+          status: currentCycle.status,
+          startDate: currentCycle.startDate,
+          endDate: currentCycle.endDate,
+          usesPoints,
+          committed,
+          completed,
+          inProgress,
+          statusCounts: Array.from(cycleStatusCounts.entries())
+            .map(([status, count]) => ({ status, count }))
+            .sort((a, b) => statusRank(a.status) - statusRank(b.status)),
+          myTickets,
+        };
+      }
+
+      // ---- needs-attention groups (top items + full counts) ----
+      const pickGroup = (status: (typeof attentionStatuses)[number]) => {
+        const items = attentionTickets.filter((t) => t.status === status);
+        return { count: items.length, items: items.slice(0, 5) };
+      };
+
+      // ---- recent activity, resolved to this product's tickets ----
+      const eventTicketIds = [...new Set(rawEvents.map((e) => e.entityId))];
+      const eventTickets = eventTicketIds.length
+        ? await ctx.db.ticket.findMany({
+            where: {
+              id: { in: eventTicketIds },
+              productId: input.productId,
+            },
+            select: { id: true, shortId: true, number: true, title: true },
+          })
+        : [];
+      const ticketById = new Map(eventTickets.map((t) => [t.id, t]));
+      const activity = rawEvents
+        .filter((e) => ticketById.has(e.entityId))
+        .slice(0, 5)
+        .map((e) => ({
+          id: e.id,
+          action: e.action,
+          metadata: e.metadata,
+          createdAt: e.createdAt,
+          actor: e.user,
+          ticket: ticketById.get(e.entityId)!,
+        }));
+
+      return {
+        statusCounts: statusGroups.map((g) => ({
+          status: g.status,
+          count: g._count._all,
+        })),
+        counts: {
+          features: navCounts?._count.features ?? 0,
+          researches: navCounts?._count.researches ?? 0,
+          retrospectives: navCounts?._count.retrospectives ?? 0,
+        },
+        cycle,
+        attention: {
+          blocked: pickGroup("BLOCKED"),
+          needsRefinement: pickGroup("NEEDS_REFINEMENT"),
+          qa: pickGroup("QA"),
+        },
+        activity,
+      };
     }),
 
   create: protectedProcedure

--- a/src/plugins/product/server/routers/product.ts
+++ b/src/plugins/product/server/routers/product.ts
@@ -211,94 +211,117 @@ export const productRouter = createTRPCRouter({
         "QA",
       ] as const;
 
-      const [statusGroups, navCounts, currentCycle, attentionTickets, rawEvents] =
-        await Promise.all([
-          ctx.db.ticket.groupBy({
-            by: ["status"],
-            where: { productId: input.productId },
-            _count: { _all: true },
-          }),
-          ctx.db.product.findUnique({
-            where: { id: input.productId },
-            select: {
-              _count: {
-                select: {
-                  features: true,
-                  researches: true,
-                  retrospectives: true,
-                },
+      // Read-only "current cycle" predicate: an ACTIVE sprint that hasn't
+      // ended, a PLANNED one whose window contains today (covers workspaces
+      // where the lazy reconcile in cycle.list hasn't run yet), or an ACTIVE
+      // one that ended but was never reconciled to COMPLETED. Cycles are
+      // workspace-scoped (List, listType SPRINT), so this matches any current
+      // sprint in the workspace; we prefer the one holding this product's
+      // tickets below.
+      const currentCycleWhere = {
+        workspaceId: product.workspaceId,
+        listType: "SPRINT" as const,
+        OR: [
+          { status: "ACTIVE" as const, OR: [{ endDate: null }, { endDate: { gt: now } }] },
+          {
+            status: "PLANNED" as const,
+            startDate: { lte: now },
+            endDate: { gt: now },
+          },
+          { status: "ACTIVE" as const, endDate: { lte: now } },
+        ],
+      };
+      const currentCycleSelect = {
+        id: true,
+        name: true,
+        status: true,
+        startDate: true,
+        endDate: true,
+      };
+      // Deterministic pick when several sprints qualify (e.g. parallel team
+      // cycles with the same startDate) — id breaks the tie so the same cycle
+      // is always chosen.
+      const currentCycleOrder = [
+        { startDate: "desc" as const },
+        { id: "desc" as const },
+      ];
+
+      const [
+        statusGroups,
+        navCounts,
+        cycleWithProductTickets,
+        anyCurrentCycle,
+        attentionTickets,
+        productTickets,
+      ] = await Promise.all([
+        ctx.db.ticket.groupBy({
+          by: ["status"],
+          where: { productId: input.productId },
+          _count: { _all: true },
+        }),
+        ctx.db.product.findUnique({
+          where: { id: input.productId },
+          select: {
+            _count: {
+              select: {
+                features: true,
+                researches: true,
+                retrospectives: true,
               },
             },
-          }),
-          // Read-only "current cycle": an ACTIVE sprint that hasn't ended, or
-          // a PLANNED one whose window contains today (covers workspaces where
-          // the lazy reconcile in cycle.list hasn't run yet).
-          ctx.db.list.findFirst({
-            where: {
-              workspaceId: product.workspaceId,
-              listType: "SPRINT",
-              OR: [
-                {
-                  status: "ACTIVE",
-                  OR: [{ endDate: null }, { endDate: { gt: now } }],
-                },
-                {
-                  status: "PLANNED",
-                  startDate: { lte: now },
-                  endDate: { gt: now },
-                },
-                // Ended but never reconciled to COMPLETED — still the most
-                // recent "current" cycle the team was burning down.
-                { status: "ACTIVE", endDate: { lte: now } },
-              ],
-            },
-            orderBy: { startDate: "desc" },
-            select: {
-              id: true,
-              name: true,
-              status: true,
-              startDate: true,
-              endDate: true,
-            },
-          }),
-          ctx.db.ticket.findMany({
-            where: {
-              productId: input.productId,
-              status: { in: [...attentionStatuses] },
-            },
-            select: {
-              id: true,
-              shortId: true,
-              number: true,
-              title: true,
-              status: true,
-              updatedAt: true,
-            },
-            // Oldest first — the longest-rotting work is the most urgent.
-            orderBy: { updatedAt: "asc" },
-          }),
-          // Recent ticket events for the workspace; filtered to this product
-          // below (events carry no productId, so we resolve via the ticket).
-          ctx.db.workspaceActivityEvent.findMany({
-            where: { workspaceId: product.workspaceId, entityType: "ticket" },
-            orderBy: { createdAt: "desc" },
-            take: 50,
-            select: {
-              id: true,
-              entityId: true,
-              action: true,
-              metadata: true,
-              createdAt: true,
-              user: { select: { id: true, name: true, image: true } },
-            },
-          }),
-        ]);
+          },
+        }),
+        // Prefer a current cycle that actually holds this product's tickets, so
+        // the hero shows "their" cycle rather than an unrelated workspace one.
+        ctx.db.list.findFirst({
+          where: {
+            ...currentCycleWhere,
+            tickets: { some: { productId: input.productId } },
+          },
+          orderBy: currentCycleOrder,
+          select: currentCycleSelect,
+        }),
+        // Fallback: the workspace's current cycle even if this product has no
+        // tickets in it yet — the hero then prompts to commit tickets.
+        ctx.db.list.findFirst({
+          where: currentCycleWhere,
+          orderBy: currentCycleOrder,
+          select: currentCycleSelect,
+        }),
+        ctx.db.ticket.findMany({
+          where: {
+            productId: input.productId,
+            status: { in: [...attentionStatuses] },
+          },
+          select: {
+            id: true,
+            shortId: true,
+            number: true,
+            title: true,
+            status: true,
+            updatedAt: true,
+          },
+          // Oldest first — the longest-rotting work is the most urgent.
+          orderBy: { updatedAt: "asc" },
+        }),
+        // This product's tickets (light fields), used to scope the activity
+        // events to this product *in the database* (events carry no productId)
+        // and to resolve the shown events' display. Never loads events from
+        // other products/workspaces. Lighter than the Backlog tab's own
+        // ticket.list, which already loads every product ticket with includes.
+        ctx.db.ticket.findMany({
+          where: { productId: input.productId },
+          select: { id: true, shortId: true, number: true, title: true },
+        }),
+      ]);
 
-      // Wave 2: the two lookups that depend on wave 1 (cycle-scoped tickets and
-      // the tickets behind the recent events) run together, so an active-cycle
-      // product still costs two DB round trips, not three.
-      const eventTicketIds = [...new Set(rawEvents.map((e) => e.entityId))];
-      const [cycleTickets, eventTickets] = await Promise.all([
+      const currentCycle = cycleWithProductTickets ?? anyCurrentCycle;
+      const productTicketIds = productTickets.map((t) => t.id);
+
+      // Wave 2: the two lookups that depend on wave 1 run together — the
+      // cycle-scoped tickets and this product's recent activity events (scoped
+      // by ticket id, so no cross-product events are ever fetched).
+      const [cycleTickets, recentEvents] = await Promise.all([
         currentCycle
           ? ctx.db.ticket.findMany({
               where: { productId: input.productId, cycleId: currentCycle.id },
@@ -313,10 +336,23 @@ export const productRouter = createTRPCRouter({
               },
             })
           : Promise.resolve([]),
-        eventTicketIds.length
-          ? ctx.db.ticket.findMany({
-              where: { id: { in: eventTicketIds }, productId: input.productId },
-              select: { id: true, shortId: true, number: true, title: true },
+        productTicketIds.length
+          ? ctx.db.workspaceActivityEvent.findMany({
+              where: {
+                workspaceId: product.workspaceId,
+                entityType: "ticket",
+                entityId: { in: productTicketIds },
+              },
+              orderBy: { createdAt: "desc" },
+              take: 5,
+              select: {
+                id: true,
+                entityId: true,
+                action: true,
+                metadata: true,
+                createdAt: true,
+                user: { select: { id: true, name: true, image: true } },
+              },
             })
           : Promise.resolve([]),
       ]);
@@ -401,8 +437,10 @@ export const productRouter = createTRPCRouter({
       };
 
       // ---- recent activity, resolved to this product's tickets ----
-      const ticketById = new Map(eventTickets.map((t) => [t.id, t]));
-      const activity = rawEvents
+      // recentEvents is already scoped to this product's ticket ids in the DB,
+      // so every event resolves; the map guard is defensive only.
+      const ticketById = new Map(productTickets.map((t) => [t.id, t]));
+      const activity = recentEvents
         .filter((e) => ticketById.has(e.entityId))
         .slice(0, 5)
         .map((e) => ({

--- a/src/plugins/product/server/routers/product.ts
+++ b/src/plugins/product/server/routers/product.ts
@@ -184,12 +184,15 @@ export const productRouter = createTRPCRouter({
     }),
 
   /**
-   * Single-round-trip aggregate for the product Overview tab: open-ticket
-   * counts by status, the current cycle (resolved read-only — never
-   * auto-creates or reconciles, unlike cycle.list) with this product's
-   * in-cycle points/status rollup and the caller's own tickets, the
-   * needs-attention lists (blocked / needs refinement / QA), demoted nav
-   * counts, and the last few ticket activity events for this product.
+   * Single-call aggregate for the product Overview tab: open-ticket counts by
+   * status, the current cycle (resolved read-only — never auto-creates or
+   * reconciles, unlike cycle.list) with this product's in-cycle points/status
+   * rollup and the caller's own tickets, the needs-attention lists (blocked /
+   * needs refinement / QA), demoted nav counts, and the last few ticket
+   * activity events for this product.
+   *
+   * Runs as two parallel DB waves: the independent aggregates first, then the
+   * cycle-ticket and event-ticket lookups (which depend on wave 1) together.
    */
   getOverview: protectedProcedure
     .input(z.object({ productId: z.string() }))
@@ -291,6 +294,33 @@ export const productRouter = createTRPCRouter({
           }),
         ]);
 
+      // Wave 2: the two lookups that depend on wave 1 (cycle-scoped tickets and
+      // the tickets behind the recent events) run together, so an active-cycle
+      // product still costs two DB round trips, not three.
+      const eventTicketIds = [...new Set(rawEvents.map((e) => e.entityId))];
+      const [cycleTickets, eventTickets] = await Promise.all([
+        currentCycle
+          ? ctx.db.ticket.findMany({
+              where: { productId: input.productId, cycleId: currentCycle.id },
+              select: {
+                id: true,
+                shortId: true,
+                number: true,
+                title: true,
+                status: true,
+                points: true,
+                assigneeId: true,
+              },
+            })
+          : Promise.resolve([]),
+        eventTicketIds.length
+          ? ctx.db.ticket.findMany({
+              where: { id: { in: eventTicketIds }, productId: input.productId },
+              select: { id: true, shortId: true, number: true, title: true },
+            })
+          : Promise.resolve([]),
+      ]);
+
       // ---- current cycle rollup (scoped to this product's tickets) ----
       let cycle: {
         id: string;
@@ -313,19 +343,6 @@ export const productRouter = createTRPCRouter({
       } | null = null;
 
       if (currentCycle) {
-        const cycleTickets = await ctx.db.ticket.findMany({
-          where: { productId: input.productId, cycleId: currentCycle.id },
-          select: {
-            id: true,
-            shortId: true,
-            number: true,
-            title: true,
-            status: true,
-            points: true,
-            assigneeId: true,
-          },
-        });
-
         const completedSet = new Set<string>(COMPLETED_TICKET_STATUSES);
         const usesPoints = cycleTickets.some((t) => (t.points ?? 0) > 0);
         const weight = (t: { points: number | null }) =>
@@ -384,16 +401,6 @@ export const productRouter = createTRPCRouter({
       };
 
       // ---- recent activity, resolved to this product's tickets ----
-      const eventTicketIds = [...new Set(rawEvents.map((e) => e.entityId))];
-      const eventTickets = eventTicketIds.length
-        ? await ctx.db.ticket.findMany({
-            where: {
-              id: { in: eventTicketIds },
-              productId: input.productId,
-            },
-            select: { id: true, shortId: true, number: true, title: true },
-          })
-        : [];
       const ticketById = new Map(eventTickets.map((t) => [t.id, t]));
       const activity = rawEvents
         .filter((e) => ticketById.has(e.entityId))


### PR DESCRIPTION
### **User description**
## Summary

Redesigns the product Overview tab (`/w/[workspace]/products/[product]`) from four lifetime-count stat cards + an empty "Quick links" stub into a mission control that answers *what's happening with this product right now?* Built from the design handoff bundle (healthy / on-fire / new-product / loading states, light + dark, tablet-responsive).

## What's in it

**New `product.product.getOverview` tRPC aggregate** (single round trip):
- Open ticket counts by status (`groupBy`)
- Current cycle resolved **read-only** — no `autoCreate`/reconcile side effects (unlike `cycle.list`) — with points/count rollups scoped to *this product's* tickets in the cycle, plus the caller's own in-cycle tickets
- Blocked / needs-refinement / QA lists with `updatedAt` ages
- Feature/research/retro counts and the last 5 ticket activity events for the product (resolved from the workspace feed)

**Overview UI** (`src/app/_components/product/overview/`, token-only feature CSS — `var()` + `color-mix()`, zero hex):
- **Cycle hero** with the custom dual-track progress bar (solid done fill, striped in-progress band, time-elapsed marker), pace pill, in-cycle status chips, "your tickets" strip; empty variants for no-active-cycle and cycle-without-product-tickets. Uses points when any ticket is sized, ticket counts otherwise.
- **Needs attention**: collapsible blocked/refinement/QA groups, stale ages in red, hot (red) card treatment when anything is blocked, compact all-clear line.
- **Backlog pulse**: segmented bar + clickable legend of open tickets by status (done/deployed/archived hidden), demoted Features/Research/Retros nav counts.
- **Quick actions** + **Recent activity** (last 5 ticket events, avatar/initials, status-change badges).
- First-run setup card for empty products; per-block skeletons; two-column grid collapsing at ≤1080px.
- Product color accent via `--po-accent` from `product.color` (falls back to brand); all tints derive via `color-mix` so it works in both themes.

**Shell + backlog wiring:**
- The header **"+" button** (previously had no handler) now opens a Mantine create menu (ticket modal, feature/research/retro/cycle routes).
- The backlog honours `?status=` and `?assignee=me` deep links (server-side via `ticket.list`) with a clearable filter chip.

## Deliberate divergences from the handoff

1. **Research/Problems quick links point at Insights** — those pages redirect there now (ADR-0036); the spec predates it.
2. **No kbd hints (T/F/R) and no "Import tickets…" item** — neither the shortcuts nor an import UI exist; didn't ship dead affordances.
3. **Status colors on this surface follow the handoff's accent mapping** (QA purple, refinement amber), which differs from the Mantine `STATUS_COLORS` badges on the backlog (QA orange, refinement grape). Open to unifying later.
4. **Cycles are workspace-scoped**, so all hero numbers are scoped to this product's tickets within the cycle.
5. Content is capped at 1160px but left-aligned to match the existing shell (the prototype centered its whole canvas, header included — header is out of scope).

## Notes

- No schema changes / migrations — UI + one read-only tRPC procedure, so fast-track eligible.
- Recent activity shows ticket events only (features/research/retros aren't instrumented in the activity feed yet).
- Checks: `tsc` clean, ESLint clean, 1,295 unit tests pass, pre-commit color check passes, pre-push Vercel build passed.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replaces static stat cards with a full mission-control Overview tab (cycle hero, needs attention, backlog pulse, quick actions, recent activity)

- Adds `product.product.getOverview` tRPC aggregate for single-round-trip data fetching with two parallel DB waves

- Fixes the previously dead "+" header button with a functional Mantine create menu for tickets, features, research, retros, and cycles

- Adds URL-driven deep-link filters (`?status=` and `?assignee=me`) to the Backlog page with a clearable filter chip


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["product.getOverview tRPC\n(two parallel DB waves)"] -- "statusCounts, cycle,\nattention, activity" --> B["ProductOverview.tsx\n(orchestrator)"]
  B --> C["CycleHero\n(dual-track progress bar)"]
  B --> D["NeedsAttention\n(blocked / refine / QA)"]
  B --> E["BacklogPulse\n(segmented bar + legend)"]
  B --> F["QuickActions\n(create shortcuts)"]
  B --> G["RecentActivity\n(last 5 events)"]
  H["Layout + button"] -- "Menu dropdown" --> I["CreateTicketModal\n+ route pushes"]
  J["Backlog page"] -- "?status= / ?assignee=me" --> K["Clearable filter chip\n+ server-side filter"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>layout.tsx</strong><dd><code>Replace dead "+" button with functional Mantine create menu</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/358/files#diff-e4b549b8684af1c44327f01d54fdb07cb6227e22f9b734f7cf17e8f3526dbd8f">+74/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Swap stat cards for new ProductOverview component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/358/files#diff-5aa60d643bf37a2a5e51a68c6da0c6475880ec5cb1919bf37119190a743305d7">+23/-97</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Add URL deep-link filters and clearable filter chip to backlog</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/358/files#diff-69941eb4af92853c12847ec637d5a3d8e18c01c445e6f9cea9242888c995d2d5">+63/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BacklogPulse.tsx</strong><dd><code>New segmented bar and legend for open ticket statuses</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/358/files#diff-a246d1466eee9113cb738ca6a6dfe42943eaa51dd4aa3ac3ce90d23be6cb7784">+109/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CycleHero.tsx</strong><dd><code>New cycle hero with dual-track progress bar and pace pill</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/358/files#diff-73edf67da9456f6c4e5bf9457f0fddb308871d2c37e47090a700e170235f9f5e">+238/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>NeedsAttention.tsx</strong><dd><code>New collapsible blocked/refinement/QA attention groups</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/358/files#diff-103f8f74ffe683479a916ccad9b6788b3029d41b76957f89611205ce5d16ed82">+161/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ProductOverview.tsx</strong><dd><code>New overview orchestrator with skeleton and first-run card</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/358/files#diff-d6531f66c025e93a4ef79c9dc8390337101d6ed4d6d24feaf81d6f742015e109">+203/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>QuickActions.tsx</strong><dd><code>New quick-action shortcuts panel for create and nav links</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/358/files#diff-09ac46d68007c0c88026ba39275dc8d8424d16ec6e5c727e31888f75a862ec62">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RecentActivity.tsx</strong><dd><code>New recent activity feed with avatar and status-change badges</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/358/files#diff-e2c968730259b74600c6cf706f28153ca9f789a4ccc63665fb158640ab62fbe1">+146/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>overviewShared.ts</strong><dd><code>Shared types, status CSS map, and utility helpers for overview</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/358/files#diff-354b175f9c7a974d0c220def0f0c8baa4cf14526b62b93954f6161297bf80e62">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>product-overview.css</strong><dd><code>Token-only CSS for all overview blocks, light and dark themes</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/358/files#diff-561ce81739ea40fad8956b2cc8bb6026c6690bc36f6f6d9a42edb37ae6fb2e81">+865/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>product.ts</strong><dd><code>Add getOverview tRPC aggregate with two parallel DB waves</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/358/files#diff-42fdfc371bf516482c4f54d564895e47783af20d863576815fd83cbe77796891">+293/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

