### PR TITLE
feat: Zoe canvas MVP on /home behind ?canvas=1

### DIFF
--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
 import { api } from "~/trpc/react";
-import { entitiesToRefresh } from "./manyChatToolRefresh";
 import DOMPurify from 'dompurify';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -29,8 +28,10 @@ import { DraftActionsReviewCard } from './DraftActionsReviewCard';
 import { useAgentModal, type ChatMessage, type PageContext } from '~/providers/AgentModalProvider';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { trimByTokenBudget } from '~/lib/trim-conversation';
-import { classifyStreamError, type StreamFailureKind } from '~/lib/chat/streamProtocol';
+import { classifyStreamError } from '~/lib/chat/streamProtocol';
 import { streamChatResponse } from '~/lib/chat/streamChatResponse';
+import { failureCopy } from '~/lib/chat/failureCopy';
+import { applyToolRefreshInvalidations } from './agent/toolRefreshInvalidation';
 
 // Module-level constants to avoid re-creation on every render
 const VIDEO_PATTERN = /\[Video ([a-zA-Z0-9_-]+)\]/g;
@@ -153,29 +154,6 @@ type Message = ChatMessage;
  * and re-spends tokens) — they finalize as `incomplete` with a Retry button.
  */
 const MAX_AUTO_RETRIES = 2;
-
-/**
- * User-facing copy for a *terminal* failure (auto-retries already exhausted).
- * Deliberately calm and free of alarming/irrelevant advice (the old text told
- * users to go check API keys on every network blip). A Retry button is rendered
- * alongside, so the copy stays short.
- */
-function failureCopy(kind: StreamFailureKind, severity: 'error' | 'incomplete'): string {
-  if (severity === 'incomplete') {
-    return `The connection dropped before this finished.`;
-  }
-  switch (kind) {
-    case 'transport':
-    case 'idle-timeout':
-      return `The connection to the assistant dropped before it could respond.`;
-    case 'auth':
-      return `Your session looks expired — try refreshing the page, or re-check /settings/api-keys.`;
-    case 'model':
-      return `The assistant hit a snag handling that request.`;
-    default:
-      return `Something went wrong handling that request.`;
-  }
-}
 
 function formatPageContextData(context: PageContext): string {
   const str = (val: unknown, fallback = 'None'): string => {
@@ -1301,43 +1279,7 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
       const executedToolNames = streamResult.toolCalls
         .filter((tc) => tc.status === 'success')
         .map((tc) => tc.name);
-      const toRefresh = entitiesToRefresh(executedToolNames, pageContext?.pageType);
-
-      if (toRefresh.has('goalActivity')) {
-        // Goal feed + count + the goal itself (for the health badge).
-        void utils.goalActivity.getFeed.invalidate();
-        void utils.goalActivity.getCount.invalidate();
-        void utils.goal.getById.invalidate();
-      }
-      if (toRefresh.has('action')) {
-        // Full canonical Action set, mirroring the hand-written create/update/bulk
-        // invalidation sets so create, update, move, and delete refresh every
-        // surface (today list, project board, calendar, score widgets).
-        void utils.action.getAll.invalidate();
-        void utils.action.getToday.invalidate();
-        void utils.action.getScheduledByDate.invalidate();
-        void utils.action.getScheduledByDateRange.invalidate();
-        void utils.action.getProjectActions.invalidate();
-        void utils.scoring.getTodayScore.invalidate();
-        void utils.scoring.getProductivityStats.invalidate();
-      }
-      if (toRefresh.has('okr')) {
-        // Objective cards, hero stats, the year/period counts, and the
-        // create-KR objective picker — the full set the OKR dashboard mounts,
-        // so agent-created objectives/KRs and (un)links appear without reload.
-        void utils.okr.getByObjective.invalidate();
-        void utils.okr.getStats.invalidate();
-        void utils.okr.getCountsByYear.invalidate();
-        void utils.okr.getAvailableGoals.invalidate();
-      }
-      if (toRefresh.has('crmContact')) {
-        // Contact list + the dashboard stat cards + per-contact interaction feed,
-        // so agent-created/updated contacts and logged interactions appear without
-        // a reload.
-        void utils.crmContact.getAll.invalidate();
-        void utils.crmContact.getStats.invalidate();
-        void utils.crmContact.getInteractions.invalidate();
-      }
+      applyToolRefreshInvalidations(utils, executedToolNames, pageContext?.pageType);
 
       const responseTime = Date.now() - startTime;
       // A turn that did tool work but produced no prose is NOT empty —

--- a/src/app/_components/agent/toolRefreshInvalidation.ts
+++ b/src/app/_components/agent/toolRefreshInvalidation.ts
@@ -1,0 +1,57 @@
+import type { api } from '~/trpc/react';
+import { entitiesToRefresh } from '../manyChatToolRefresh';
+
+type TrpcUtils = ReturnType<typeof api.useUtils>;
+
+/**
+ * Invalidate the React Query caches whose views an agent write just made
+ * stale. `entitiesToRefresh` (the pure, unit-tested matcher — see ADR-0023)
+ * decides *which* entities; this helper owns the actual `utils.*.invalidate()`
+ * wiring so every chat surface (the Zoe drawer via ManyChat, the Zoe canvas)
+ * refreshes the same set. Procedure-wide (no args) invalidation keeps it
+ * robust against arg source/coercion drift and only refetches mounted
+ * observers.
+ */
+export function applyToolRefreshInvalidations(
+  utils: TrpcUtils,
+  executedToolNames: string[],
+  pageType?: string,
+): void {
+  const toRefresh = entitiesToRefresh(executedToolNames, pageType);
+
+  if (toRefresh.has('goalActivity')) {
+    // Goal feed + count + the goal itself (for the health badge).
+    void utils.goalActivity.getFeed.invalidate();
+    void utils.goalActivity.getCount.invalidate();
+    void utils.goal.getById.invalidate();
+  }
+  if (toRefresh.has('action')) {
+    // Full canonical Action set, mirroring the hand-written create/update/bulk
+    // invalidation sets so create, update, move, and delete refresh every
+    // surface (today list, project board, calendar, score widgets).
+    void utils.action.getAll.invalidate();
+    void utils.action.getToday.invalidate();
+    void utils.action.getScheduledByDate.invalidate();
+    void utils.action.getScheduledByDateRange.invalidate();
+    void utils.action.getProjectActions.invalidate();
+    void utils.scoring.getTodayScore.invalidate();
+    void utils.scoring.getProductivityStats.invalidate();
+  }
+  if (toRefresh.has('okr')) {
+    // Objective cards, hero stats, the year/period counts, and the
+    // create-KR objective picker — the full set the OKR dashboard mounts,
+    // so agent-created objectives/KRs and (un)links appear without reload.
+    void utils.okr.getByObjective.invalidate();
+    void utils.okr.getStats.invalidate();
+    void utils.okr.getCountsByYear.invalidate();
+    void utils.okr.getAvailableGoals.invalidate();
+  }
+  if (toRefresh.has('crmContact')) {
+    // Contact list + the dashboard stat cards + per-contact interaction feed,
+    // so agent-created/updated contacts and logged interactions appear without
+    // a reload.
+    void utils.crmContact.getAll.invalidate();
+    void utils.crmContact.getStats.invalidate();
+    void utils.crmContact.getInteractions.invalidate();
+  }
+}

--- a/src/app/_components/home/UserHomeDashboard.module.css
+++ b/src/app/_components/home/UserHomeDashboard.module.css
@@ -679,3 +679,25 @@
   }
   .heroTitle { font-size: 22px; }
 }
+
+/* Zoe canvas yield (ADR-0040): everything below the Zoe input collapses while
+   an engagement is active. The transitions live on the collapsed state only,
+   so entering the collapse is an animated yield and removing the class
+   restores the dashboard instantly. */
+.dashYield {
+  display: grid;
+  grid-template-rows: 1fr;
+}
+.dashYieldInner {
+  min-height: 0;
+}
+.dashYield_collapsed {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition: grid-template-rows 450ms ease, opacity 300ms ease;
+}
+.dashYield_collapsed .dashYieldInner {
+  overflow: hidden;
+  visibility: hidden;
+  transition: visibility 0s 450ms;
+}

--- a/src/app/_components/home/UserHomeDashboard.tsx
+++ b/src/app/_components/home/UserHomeDashboard.tsx
@@ -27,6 +27,9 @@ import { useAgentModal } from "~/providers/AgentModalProvider";
 import { stripHtml } from "~/lib/utils";
 import { calculateProjectHealth } from "./ProjectHealth";
 import { RitualCards } from "./RitualCards";
+import { ZoeCanvas } from "./zoe-canvas/ZoeCanvas";
+import { useCanvasEngagement } from "./zoe-canvas/useCanvasEngagement";
+import { useCanvasOptIn } from "./zoe-canvas/useCanvasOptIn";
 import classes from "./UserHomeDashboard.module.css";
 
 type ProjectPill = "ok" | "active" | "due" | "amber";
@@ -42,6 +45,12 @@ export function UserHomeDashboard() {
   const { workspace, workspaceId } = useWorkspace();
   const { data: session } = useSession();
   const { openWithPrompt } = useAgentModal();
+
+  // Zoe canvas experiment (ADR-0040): with the sticky ?canvas=1 opt-in, sends
+  // from the hero input / chips answer in the page instead of the drawer.
+  const canvasEnabled = useCanvasOptIn();
+  const canvas = useCanvasEngagement({ workspaceId, enabled: canvasEnabled });
+  const canvasActive = canvasEnabled && canvas.engaged;
 
   const [prompt, setPrompt] = useState("");
 
@@ -117,7 +126,11 @@ export function UserHomeDashboard() {
   const sendPrompt = (text: string) => {
     const trimmed = text.trim();
     if (!trimmed) return;
-    openWithPrompt(trimmed);
+    if (canvasEnabled) {
+      canvas.send(trimmed);
+    } else {
+      openWithPrompt(trimmed);
+    }
     setPrompt("");
   };
 
@@ -180,6 +193,10 @@ export function UserHomeDashboard() {
             if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
               e.preventDefault();
               sendPrompt(prompt);
+            } else if (canvasEnabled && e.key === "Enter" && !e.shiftKey) {
+              // Canvas mode: plain Enter sends, Shift+Enter inserts a newline.
+              e.preventDefault();
+              sendPrompt(prompt);
             }
           }}
           rows={2}
@@ -210,6 +227,20 @@ export function UserHomeDashboard() {
         </div>
       </section>
 
+      {/* Zoe canvas: the engagement answers in the page (ADR-0040) */}
+      {canvasActive && (
+        <ZoeCanvas
+          messages={canvas.messages}
+          isStreaming={canvas.isStreaming}
+          onDismiss={canvas.dismiss}
+          onRetry={canvas.retry}
+        />
+      )}
+
+      {/* Everything below the Zoe input yields to the canvas while an
+          engagement is active (animated collapse; instant restore). */}
+      <div className={clsx(classes.dashYield, canvasActive && classes.dashYield_collapsed)}>
+      <div className={classes.dashYieldInner}>
       <RitualCards />
 
       {/* Dashboard grid */}
@@ -439,6 +470,8 @@ export function UserHomeDashboard() {
             </div>
           </div>
         </div>
+      </div>
+      </div>
       </div>
     </div>
   );

--- a/src/app/_components/home/zoe-canvas/ZoeCanvas.module.css
+++ b/src/app/_components/home/zoe-canvas/ZoeCanvas.module.css
@@ -1,0 +1,107 @@
+/* Zoe canvas — the engagement rendered in the page, in the dashboard-card
+   visual language (mirrors .dashCard in UserHomeDashboard.module.css). Theme
+   tokens only. */
+
+.canvas {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 10px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 24px;
+  animation: canvasIn 300ms ease;
+}
+
+@keyframes canvasIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.headTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.headAvatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: linear-gradient(135deg, var(--accent-meetings), var(--brand-600));
+  display: grid;
+  place-items: center;
+  color: var(--color-text-inverse);
+  flex-shrink: 0;
+}
+
+.headSub {
+  font-weight: 400;
+  color: var(--color-text-muted);
+  font-size: 11.5px;
+  margin-left: 4px;
+}
+
+.dismissBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 5px;
+}
+.dismissBtn:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-muted);
+}
+
+.body {
+  padding: 14px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* The user's question, echoed as a quiet quoted line above each answer. */
+.userTurn {
+  font-size: 12.5px;
+  color: var(--color-text-muted);
+  border-left: 2px solid var(--color-border-primary);
+  padding-left: 10px;
+  white-space: pre-wrap;
+}
+
+.aiTurn {
+  font-size: 14px;
+  color: var(--color-text-primary);
+  line-height: 1.55;
+}
+
+.failureRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  margin-top: 6px;
+}

--- a/src/app/_components/home/zoe-canvas/ZoeCanvas.tsx
+++ b/src/app/_components/home/zoe-canvas/ZoeCanvas.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useMemo, useRef } from 'react';
+import { Button } from '@mantine/core';
+import { IconRefresh, IconSparkles, IconX } from '@tabler/icons-react';
+import { MarkdownRenderer } from '~/app/_components/shared/MarkdownRenderer';
+import { ToolActivity } from '~/app/_components/agent/ToolActivity';
+import { ThinkingStatus } from '~/app/_components/agent/ThinkingStatus';
+import { DraftActionsReviewCard } from '~/app/_components/DraftActionsReviewCard';
+import { failureCopy } from '~/lib/chat/failureCopy';
+import { useAgentModal, type ChatMessage } from '~/providers/AgentModalProvider';
+import classes from './ZoeCanvas.module.css';
+
+interface ZoeCanvasProps {
+  messages: ChatMessage[];
+  isStreaming: boolean;
+  onDismiss: () => void;
+  onRetry: (text: string) => void;
+}
+
+/**
+ * The Zoe canvas (ADR-0040): the current engagement rendered in the /home
+ * page content, in the dashboard-card visual language. Renders full
+ * ChatMessage objects — markdown via the canonical MarkdownRenderer
+ * (ADR-0017), live tool-activity chips, the failure/incomplete + Retry
+ * treatment, and the structured `card` slot (ADR-0007) — so a future native
+ * card is a new card kind, with zero canvas changes.
+ */
+export function ZoeCanvas({ messages, isStreaming, onDismiss, onRetry }: ZoeCanvasProps) {
+  const { isOpen: drawerOpen } = useAgentModal();
+
+  const visibleMessages = useMemo(
+    () => messages.filter(m => m.type === 'human' || m.type === 'ai'),
+    [messages],
+  );
+
+  // Esc dismisses the engagement — unless the drawer is open on top, whose own
+  // Esc handler takes precedence.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !drawerOpen) onDismiss();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [drawerOpen, onDismiss]);
+
+  // Keep the newest turn in view as follow-ups append below the fold.
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const prevCountRef = useRef(visibleMessages.length);
+  useEffect(() => {
+    if (visibleMessages.length > prevCountRef.current) {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+    prevCountRef.current = visibleMessages.length;
+  }, [visibleMessages.length]);
+
+  const lastUserText = [...visibleMessages].reverse().find(m => m.type === 'human')?.content;
+
+  return (
+    <section className={classes.canvas} aria-label="Zoe canvas">
+      <div className={classes.head}>
+        <div className={classes.headTitle}>
+          <span className={classes.headAvatar}>
+            <IconSparkles size={13} />
+          </span>
+          Zoe
+          <span className={classes.headSub}>{isStreaming ? 'working…' : 'answer'}</span>
+        </div>
+        <button
+          type="button"
+          className={classes.dismissBtn}
+          onClick={onDismiss}
+          aria-label="Dismiss (Esc)"
+        >
+          <IconX size={14} />
+        </button>
+      </div>
+
+      <div className={classes.body}>
+        {visibleMessages.map((message, index) =>
+          message.type === 'human' ? (
+            <div key={`human-${index}`} className={classes.userTurn}>
+              {message.content}
+            </div>
+          ) : (
+            <div key={message.interactionId ?? `ai-${index}`} className={classes.aiTurn}>
+              {message.toolCalls && message.toolCalls.length > 0 && (
+                <ToolActivity calls={message.toolCalls} />
+              )}
+              {isStreaming &&
+                index === visibleMessages.length - 1 &&
+                message.content === '' && (
+                  <ThinkingStatus toolCalls={message.toolCalls} requestText={lastUserText} />
+                )}
+              {/* A clean error with no usable content renders only the failure
+                  footer; otherwise the streamed text (full or partial). */}
+              {!(message.failure?.severity === 'error' && message.content === '') && (
+                <MarkdownRenderer content={message.content} variant="compact" />
+              )}
+              {message.failure && (
+                <div className={classes.failureRow}>
+                  {(message.failure.severity === 'incomplete' || message.content === '') && (
+                    <span>{failureCopy(message.failure.kind, message.failure.severity)}</span>
+                  )}
+                  {message.failure.canRetry && message.failure.retryText && (
+                    <Button
+                      size="compact-xs"
+                      variant="subtle"
+                      color="gray"
+                      leftSection={<IconRefresh size={13} />}
+                      onClick={() => onRetry(message.failure!.retryText!)}
+                    >
+                      Try again
+                    </Button>
+                  )}
+                </div>
+              )}
+              {message.card?.kind === 'draft-actions' && (
+                <DraftActionsReviewCard transcriptionId={message.card.transcriptionId} />
+              )}
+            </div>
+          ),
+        )}
+        <div ref={bottomRef} />
+      </div>
+    </section>
+  );
+}

--- a/src/app/_components/home/zoe-canvas/__tests__/useCanvasEngagement.test.tsx
+++ b/src/app/_components/home/zoe-canvas/__tests__/useCanvasEngagement.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * Engagement-lifecycle tests for the Zoe canvas hook (ADR-0040).
+ *
+ * Rendered against the REAL AgentModalProvider (the canvas is a display mode
+ * of that shared conversation state — provider semantics are the thing under
+ * test), with the tRPC layer and the stream transport mocked (mirrors
+ * useFavorite.test.ts). Covers: fresh conversationId per engagement,
+ * follow-up continuity, dismiss-ends-engagement, and abort-on-dismiss
+ * marking the in-flight turn `incomplete`.
+ */
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import type {
+  ChatStreamPayload,
+  ChatStreamUpdate,
+  StreamChatOptions,
+} from '~/lib/chat/streamChatResponse';
+
+const { mockStartConversation, mockStreamChatResponse, streamCalls } = vi.hoisted(() => {
+  const streamCalls: { payload: ChatStreamPayload; options: StreamChatOptions }[] = [];
+  return {
+    mockStartConversation: vi.fn(),
+    mockStreamChatResponse: vi.fn(),
+    streamCalls,
+  };
+});
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    useUtils: () => ({}),
+    aiInteraction: {
+      startConversation: {
+        useMutation: () => ({ mutateAsync: mockStartConversation }),
+      },
+    },
+    assistant: {
+      getDefault: { useQuery: () => ({ data: undefined }) },
+    },
+    mastra: {
+      getMastraAgents: {
+        useQuery: () => ({ data: [{ id: 'zoeAgent', name: 'Zoe' }] }),
+      },
+    },
+  },
+}));
+
+vi.mock('~/lib/chat/streamChatResponse', () => ({
+  streamChatResponse: mockStreamChatResponse,
+}));
+
+vi.mock('~/app/_components/agent/toolRefreshInvalidation', () => ({
+  applyToolRefreshInvalidations: vi.fn(),
+}));
+
+import { AgentModalProvider } from '~/providers/AgentModalProvider';
+import { useCanvasEngagement } from '../useCanvasEngagement';
+
+function wrapper({ children }: PropsWithChildren) {
+  return <AgentModalProvider>{children}</AgentModalProvider>;
+}
+
+function completedStream(update: Partial<ChatStreamUpdate> = {}): ChatStreamUpdate {
+  return {
+    displayText: 'Here is your standup.',
+    toolCalls: [],
+    interactionId: 'int-1',
+    rawLength: 21,
+    ...update,
+  };
+}
+
+const flush = () =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+beforeEach(() => {
+  sessionStorage.clear();
+  localStorage.clear();
+  streamCalls.length = 0;
+  let mintCount = 0;
+  mockStartConversation.mockReset();
+  mockStartConversation.mockImplementation(async () => ({
+    conversationId: `conv-${++mintCount}`,
+  }));
+  mockStreamChatResponse.mockReset();
+  mockStreamChatResponse.mockImplementation(
+    async (payload: ChatStreamPayload, options: StreamChatOptions) => {
+      streamCalls.push({ payload, options });
+      const final = completedStream();
+      // The real transport calls onUpdate with the cumulative parsed state on
+      // every chunk before resolving with the same final state.
+      options.onUpdate?.({
+        displayText: final.displayText,
+        toolCalls: final.toolCalls,
+        rawLength: final.rawLength,
+      });
+      return final;
+    },
+  );
+});
+
+describe('useCanvasEngagement', () => {
+  test('opening an engagement mints a fresh conversationId and streams on it', async () => {
+    const { result } = renderHook(() => useCanvasEngagement({ workspaceId: 'ws-1' }), {
+      wrapper,
+    });
+
+    act(() => result.current.send('Standup on my projects'));
+    expect(result.current.engaged).toBe(true);
+    await flush();
+
+    expect(mockStartConversation).toHaveBeenCalledTimes(1);
+    expect(result.current.conversationId).toBe('conv-1');
+    expect(streamCalls[0]?.payload.conversationId).toBe('conv-1');
+
+    // The engagement transcript: the echoed question + the streamed answer.
+    const visible = result.current.messages.filter((m) => m.type !== 'system');
+    expect(visible).toHaveLength(2);
+    expect(visible[0]).toMatchObject({ type: 'human', content: 'Standup on my projects' });
+    expect(visible[1]).toMatchObject({
+      type: 'ai',
+      content: 'Here is your standup.',
+      interactionId: 'int-1',
+    });
+  });
+
+  test('follow-ups stay on the engagement thread (no second mint)', async () => {
+    const { result } = renderHook(() => useCanvasEngagement({ workspaceId: 'ws-1' }), {
+      wrapper,
+    });
+
+    act(() => result.current.send('First ask'));
+    await flush();
+    act(() => result.current.send('Follow-up'));
+    await flush();
+
+    expect(mockStartConversation).toHaveBeenCalledTimes(1);
+    expect(streamCalls).toHaveLength(2);
+    expect(streamCalls[1]?.payload.conversationId).toBe('conv-1');
+    // The follow-up request carries the first exchange as history.
+    const roles = streamCalls[1]?.payload.messages.map((m) => m.role);
+    expect(roles).toContain('assistant');
+    expect(streamCalls[1]?.payload.messages.at(-1)).toMatchObject({
+      role: 'user',
+      content: 'Follow-up',
+    });
+
+    const visible = result.current.messages.filter((m) => m.type !== 'system');
+    expect(visible.map((m) => m.type)).toEqual(['human', 'ai', 'human', 'ai']);
+  });
+
+  test('dismissal ends the engagement; the next send starts a fresh Thread', async () => {
+    const { result } = renderHook(() => useCanvasEngagement({ workspaceId: 'ws-1' }), {
+      wrapper,
+    });
+
+    act(() => result.current.send('First engagement'));
+    await flush();
+    act(() => result.current.dismiss());
+    expect(result.current.engaged).toBe(false);
+    // The finished thread stays the active conversation for the drawer.
+    expect(result.current.conversationId).toBe('conv-1');
+
+    act(() => result.current.send('Second engagement'));
+    await flush();
+
+    expect(result.current.engaged).toBe(true);
+    expect(mockStartConversation).toHaveBeenCalledTimes(2);
+    expect(result.current.conversationId).toBe('conv-2');
+    expect(streamCalls[1]?.payload.conversationId).toBe('conv-2');
+
+    // The canvas transcript was reset — only the new engagement's turns.
+    const visible = result.current.messages.filter((m) => m.type !== 'system');
+    expect(visible).toHaveLength(2);
+    expect(visible[0]).toMatchObject({ type: 'human', content: 'Second engagement' });
+  });
+
+  test('dismissing mid-stream aborts and marks the turn incomplete with Retry', async () => {
+    mockStreamChatResponse.mockImplementation(
+      (payload: ChatStreamPayload, options: StreamChatOptions) => {
+        streamCalls.push({ payload, options });
+        return new Promise<ChatStreamUpdate>((_resolve, reject) => {
+          // A partial answer streams, then the stream hangs until aborted.
+          options.onUpdate?.({
+            displayText: 'Partial…',
+            toolCalls: [],
+            rawLength: 8,
+          });
+          options.signal?.addEventListener('abort', () => {
+            reject(new DOMException('canvas-dismissed', 'AbortError'));
+          });
+        });
+      },
+    );
+
+    const { result } = renderHook(() => useCanvasEngagement({ workspaceId: 'ws-1' }), {
+      wrapper,
+    });
+
+    act(() => result.current.send('Long question'));
+    await flush();
+    expect(result.current.isStreaming).toBe(true);
+
+    act(() => result.current.dismiss());
+    await flush();
+
+    expect(result.current.engaged).toBe(false);
+    expect(result.current.isStreaming).toBe(false);
+
+    const last = result.current.messages.at(-1);
+    expect(last?.type).toBe('ai');
+    // Partial answer kept, turn finalized as incomplete with Retry available.
+    expect(last?.content).toBe('Partial…');
+    expect(last?.failure).toMatchObject({
+      severity: 'incomplete',
+      canRetry: true,
+      retryText: 'Long question',
+    });
+  });
+});

--- a/src/app/_components/home/zoe-canvas/useCanvasEngagement.ts
+++ b/src/app/_components/home/zoe-canvas/useCanvasEngagement.ts
@@ -1,0 +1,297 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { api } from '~/trpc/react';
+import { useAgentModal, type ChatMessage } from '~/providers/AgentModalProvider';
+import { streamChatResponse, type ChatStreamCoreMessage } from '~/lib/chat/streamChatResponse';
+import { classifyStreamError } from '~/lib/chat/streamProtocol';
+import { trimByTokenBudget } from '~/lib/trim-conversation';
+import { applyToolRefreshInvalidations } from '~/app/_components/agent/toolRefreshInvalidation';
+
+/** Mirrors ManyChat: silent re-attempts after a contentless transport drop. */
+const MAX_AUTO_RETRIES = 2;
+const HISTORY_TOKEN_BUDGET = 20_000;
+
+interface UseCanvasEngagementOptions {
+  workspaceId?: string | null;
+  /** Gate the hook's queries off entirely for opted-out users. */
+  enabled?: boolean;
+}
+
+export interface CanvasEngagement {
+  /** True while an engagement (open→dismiss cycle, ADR-0040) is active. */
+  engaged: boolean;
+  isStreaming: boolean;
+  /** The shared conversation state, system message included. */
+  messages: ChatMessage[];
+  conversationId: string;
+  /** Send from the hero input or a chip. Starts an engagement if none is active. */
+  send: (text: string) => void;
+  /** Re-run a failed/incomplete turn, reusing the trailing assistant bubble. */
+  retry: (text: string) => void;
+  /** ✕/Esc: abort any in-flight stream (marking the turn incomplete) and end the engagement. */
+  dismiss: () => void;
+}
+
+/**
+ * Engagement lifecycle + streaming loop for the Zoe canvas (ADR-0040).
+ *
+ * The canvas is a third display surface of the SAME conversation state the
+ * Zoe drawer shows (`AgentModalProvider` messages/conversationId — the
+ * ADR-0006 sharing pattern), but each engagement starts a fresh Thread: a
+ * chip click or hero send is an implicit "new thread + send" with a new
+ * conversationId. Follow-ups continue that thread; dismissal ends it. The
+ * previous drawer thread survives in conversation history — it just stops
+ * being the active one.
+ */
+export function useCanvasEngagement({
+  workspaceId,
+  enabled = true,
+}: UseCanvasEngagementOptions = {}): CanvasEngagement {
+  const {
+    messages,
+    setMessages,
+    conversationId,
+    setConversationId,
+    canvasEngaged,
+    setCanvasEngaged,
+    pageContext,
+  } = useAgentModal();
+  const utils = api.useUtils();
+
+  const [isStreaming, setIsStreaming] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const dismissedRef = useRef(false);
+  // The active engagement's conversationId, readable synchronously (provider
+  // state updates are async, and a follow-up can fire before a re-render).
+  const engagementIdRef = useRef<string | null>(null);
+
+  const startConversation = api.aiInteraction.startConversation.useMutation();
+  const { data: customAssistant } = api.assistant.getDefault.useQuery(
+    { workspaceId: workspaceId ?? '' },
+    { enabled: enabled && !!workspaceId },
+  );
+  const { data: mastraAgents } = api.mastra.getMastraAgents.useQuery(undefined, {
+    enabled,
+    staleTime: 10 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  /** Rewrite the trailing assistant bubble (the one this turn streams into). */
+  const patchTrailingAi = useCallback(
+    (patch: Partial<ChatMessage> | ((last: ChatMessage) => Partial<ChatMessage>)) => {
+      setMessages(prev => {
+        const updated = [...prev];
+        const last = updated[updated.length - 1];
+        if (last && last.type === 'ai') {
+          const resolved = typeof patch === 'function' ? patch(last) : patch;
+          updated[updated.length - 1] = { ...last, ...resolved };
+        }
+        return updated;
+      });
+    },
+    [setMessages],
+  );
+
+  const sendTurn = useCallback(
+    async (text: string, attempt: number): Promise<void> => {
+      const trimmedText = text.trim();
+      if (!trimmedText || isStreaming) return;
+      const isRetry = attempt > 0;
+
+      const agentName = customAssistant?.name ?? 'Zoe';
+      let engagementConversationId = engagementIdRef.current;
+      const isNewEngagement = !canvasEngaged || !engagementConversationId;
+
+      // Seed the transcript synchronously so the dashboard yields and the
+      // user's question echoes before the (async) thread mint resolves.
+      if (isNewEngagement) {
+        dismissedRef.current = false;
+        setCanvasEngaged(true);
+        setMessages(prev => {
+          const system = prev.find(m => m.type === 'system');
+          const seed: ChatMessage[] = system ? [system] : [];
+          return [
+            ...seed,
+            { type: 'human', content: trimmedText },
+            { type: 'ai', agentName, content: '' },
+          ];
+        });
+      } else if (!isRetry) {
+        setMessages(prev => [
+          ...prev,
+          { type: 'human', content: trimmedText },
+          { type: 'ai', agentName, content: '' },
+        ]);
+      } else {
+        // Retry reuses the trailing (failed/incomplete) bubble — reset its text
+        // and clear the failure/tool markers so the re-stream renders cleanly.
+        patchTrailingAi({ agentName, content: '', failure: undefined, toolCalls: undefined });
+      }
+
+      if (isNewEngagement) {
+        // Fresh Thread per engagement (ADR-0040). Fall back to a client id on
+        // failure — /api/chat/stream accepts client-provided conversation ids.
+        try {
+          const res = await startConversation.mutateAsync({ platform: 'manychat' });
+          engagementConversationId = res.conversationId;
+        } catch {
+          engagementConversationId = `conv_canvas_${Date.now()}_${Math.random().toString(36).slice(2, 15)}`;
+        }
+        setConversationId(engagementConversationId);
+        // Dismissed while the mint was in flight — the engagement is over
+        // before it streamed. Same abort rule: the turn ends `incomplete`.
+        if (dismissedRef.current) {
+          patchTrailingAi({
+            failure: {
+              severity: 'incomplete',
+              kind: 'unknown',
+              canRetry: true,
+              retryText: trimmedText,
+            },
+          });
+          return;
+        }
+        engagementIdRef.current = engagementConversationId;
+      }
+
+      // Route like ManyChat's default path: a custom assistant rides the
+      // blank-canvas assistantAgent; otherwise Zoe.
+      const zoeAgent = mastraAgents?.find(
+        a => a.name.toLowerCase() === 'zoe' || a.id.toLowerCase() === 'zoeagent',
+      );
+      const agentId = customAssistant ? 'assistantAgent' : zoeAgent?.id;
+
+      // Prior turns of THIS engagement only (fresh Thread — never steered by
+      // hidden context). Failed/incomplete bubbles aren't real prior turns.
+      const coreMessages: ChatStreamCoreMessage[] = [];
+      const systemContent = messages.find(m => m.type === 'system')?.content;
+      if (systemContent) coreMessages.push({ role: 'system', content: systemContent });
+      if (!isNewEngagement) {
+        for (const msg of messages) {
+          if (msg.type === 'human') {
+            coreMessages.push({ role: 'user', content: msg.content });
+          } else if (msg.type === 'ai' && msg.content && !msg.failure) {
+            coreMessages.push({ role: 'assistant', content: msg.content });
+          }
+        }
+      }
+      coreMessages.push({ role: 'user', content: trimmedText });
+      const trimmed = trimByTokenBudget(coreMessages, HISTORY_TOKEN_BUDGET);
+
+      const abortController = new AbortController();
+      abortRef.current = abortController;
+      setIsStreaming(true);
+      // Bytes of stream seen this attempt — decides auto-retry vs `incomplete`.
+      let streamedChars = 0;
+
+      try {
+        const streamResult = await streamChatResponse(
+          {
+            messages: trimmed.messages,
+            agentId,
+            assistantId: customAssistant?.id ?? null,
+            workspaceId: workspaceId ?? null,
+            conversationId: engagementConversationId,
+            platform: 'manychat',
+          },
+          {
+            signal: abortController.signal,
+            onUpdate: update => {
+              streamedChars = update.rawLength;
+              patchTrailingAi({
+                content: update.displayText,
+                ...(update.toolCalls.length > 0 ? { toolCalls: update.toolCalls } : {}),
+              });
+            },
+          },
+        );
+
+        setIsStreaming(false);
+
+        const executedToolNames = streamResult.toolCalls
+          .filter(tc => tc.status === 'success')
+          .map(tc => tc.name);
+        applyToolRefreshInvalidations(utils, executedToolNames, pageContext?.pageType);
+
+        // A turn that did tool work but produced no prose is NOT empty — the
+        // user sees those calls in the tool-activity row.
+        if (streamResult.displayText.trim() === '' && streamResult.toolCalls.length === 0) {
+          patchTrailingAi({
+            content: `The assistant started but didn't produce a reply — a tool may have failed or the step budget ran out.`,
+            failure: { severity: 'error', kind: 'model', canRetry: true, retryText: trimmedText },
+          });
+        }
+
+        if (streamResult.interactionId) {
+          patchTrailingAi({ interactionId: streamResult.interactionId });
+        }
+      } catch (error) {
+        const wasDismissed = dismissedRef.current;
+        const { kind, retryable } = classifyStreamError(error);
+        const hadContent = streamedChars > 0;
+
+        // Auto-retry a contentless transport blip, exactly like ManyChat —
+        // but never a deliberate dismiss.
+        if (!wasDismissed && retryable && !hadContent && attempt < MAX_AUTO_RETRIES) {
+          await new Promise(resolve => setTimeout(resolve, 600 * (attempt + 1)));
+          void sendTurn(text, attempt + 1);
+          return;
+        }
+
+        setIsStreaming(false);
+
+        // One abort rule (ADR-0040): a dismissal mid-stream marks the turn
+        // `incomplete` — the existing partial-answer + Retry treatment, visible
+        // in the drawer where the thread lives on.
+        const severity: 'error' | 'incomplete' =
+          wasDismissed || hadContent ? 'incomplete' : 'error';
+        patchTrailingAi(last => ({
+          agentName: severity === 'error' ? (last.agentName ?? 'Assistant') : last.agentName,
+          content: severity === 'error' ? '' : last.content,
+          failure: { severity, kind, canRetry: kind !== 'auth', retryText: trimmedText },
+        }));
+      } finally {
+        if (abortRef.current === abortController) abortRef.current = null;
+      }
+    },
+    [
+      isStreaming,
+      canvasEngaged,
+      setCanvasEngaged,
+      setMessages,
+      setConversationId,
+      patchTrailingAi,
+      messages,
+      customAssistant,
+      mastraAgents,
+      startConversation,
+      workspaceId,
+      utils,
+      pageContext?.pageType,
+    ],
+  );
+
+  const send = useCallback((text: string) => void sendTurn(text, 0), [sendTurn]);
+  const retry = useCallback((text: string) => void sendTurn(text, 1), [sendTurn]);
+
+  const dismiss = useCallback(() => {
+    dismissedRef.current = true;
+    abortRef.current?.abort(new DOMException('canvas-dismissed', 'AbortError'));
+    abortRef.current = null;
+    engagementIdRef.current = null;
+    setCanvasEngaged(false);
+    // The engagement's thread stays the provider's active conversationId, so
+    // opening the drawer next shows these same turns (drawer = full history).
+  }, [setCanvasEngaged]);
+
+  return {
+    engaged: canvasEngaged,
+    isStreaming,
+    messages,
+    conversationId,
+    send,
+    retry,
+    dismiss,
+  };
+}

--- a/src/app/_components/home/zoe-canvas/useCanvasOptIn.ts
+++ b/src/app/_components/home/zoe-canvas/useCanvasOptIn.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+const CANVAS_OPT_IN_KEY = 'zoe-canvas-opt-in';
+
+/**
+ * Sticky self-serve opt-in for the Zoe canvas experiment (ADR-0040).
+ * `?canvas=1` opts the browser in (persisted to localStorage), `?canvas=0`
+ * opts it out; with no param the stored value applies. Default off — opted-out
+ * users keep today's drawer behaviour exactly. Deliberately not a feature
+ * flag: graduation, if the experiment wins, is a real preference.
+ */
+export function useCanvasOptIn(): boolean {
+  const searchParams = useSearchParams();
+  const param = searchParams.get('canvas');
+  // false until the post-mount effect reads localStorage — keeps SSR and the
+  // first client render identical (the flag only ever adds behaviour).
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    if (param === '1') {
+      localStorage.setItem(CANVAS_OPT_IN_KEY, '1');
+      setEnabled(true);
+    } else if (param === '0') {
+      localStorage.removeItem(CANVAS_OPT_IN_KEY);
+      setEnabled(false);
+    } else {
+      setEnabled(localStorage.getItem(CANVAS_OPT_IN_KEY) === '1');
+    }
+  }, [param]);
+
+  return enabled;
+}

--- a/src/lib/chat/failureCopy.ts
+++ b/src/lib/chat/failureCopy.ts
@@ -1,0 +1,25 @@
+import type { StreamFailureKind } from './streamProtocol';
+
+/**
+ * User-facing copy for a *terminal* stream failure (auto-retries already
+ * exhausted). Deliberately calm and free of alarming/irrelevant advice (the
+ * old text told users to go check API keys on every network blip). A Retry
+ * button is rendered alongside, so the copy stays short. Shared by every chat
+ * surface (the Zoe drawer via ManyChat, the Zoe canvas).
+ */
+export function failureCopy(kind: StreamFailureKind, severity: 'error' | 'incomplete'): string {
+  if (severity === 'incomplete') {
+    return `The connection dropped before this finished.`;
+  }
+  switch (kind) {
+    case 'transport':
+    case 'idle-timeout':
+      return `The connection to the assistant dropped before it could respond.`;
+    case 'auth':
+      return `Your session looks expired — try refreshing the page, or re-check /settings/api-keys.`;
+    case 'model':
+      return `The assistant hit a snag handling that request.`;
+    default:
+      return `Something went wrong handling that request.`;
+  }
+}

--- a/src/providers/AgentModalProvider.tsx
+++ b/src/providers/AgentModalProvider.tsx
@@ -58,6 +58,12 @@ export interface ChatMessage {
 
 export type ChatDisplayMode = 'panel' | 'modal';
 
+// The Zoe canvas (ADR-0040) is a third display surface of this same
+// conversation state: /home renders the current engagement in the page while
+// `canvasEngaged` is true. Engagement lifecycle (fresh conversationId per
+// engagement, abort-on-dismiss) lives in useCanvasEngagement; the provider
+// only holds the flag so sibling surfaces (drawer, FAB) can see it.
+
 // Notification from background workflows (e.g. standup report ready)
 export interface PendingNotification {
   message: string;
@@ -118,6 +124,8 @@ interface AgentModalContextValue {
   pendingContext: string | null;
   openWithPrompt: (text: string, context?: string) => void;
   consumePendingPrompt: () => void;
+  canvasEngaged: boolean;
+  setCanvasEngaged: Dispatch<SetStateAction<boolean>>;
 }
 
 const AgentModalContext = createContext<AgentModalContextValue>({
@@ -149,6 +157,8 @@ const AgentModalContext = createContext<AgentModalContextValue>({
   pendingContext: null,
   openWithPrompt: () => undefined,
   consumePendingPrompt: () => undefined,
+  canvasEngaged: false,
+  setCanvasEngaged: () => undefined,
 });
 
 export function useAgentModal() {
@@ -178,6 +188,7 @@ export function AgentModalProvider({ children }: PropsWithChildren) {
   const [maximised, setMaximised] = useState(false);
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [pendingContext, setPendingContext] = useState<string | null>(null);
+  const [canvasEngaged, setCanvasEngaged] = useState(false);
 
   // Hydrate state from sessionStorage / localStorage after mount (per-tab, avoids SSR mismatch)
   useEffect(() => {
@@ -312,6 +323,8 @@ export function AgentModalProvider({ children }: PropsWithChildren) {
     pendingContext,
     openWithPrompt,
     consumePendingPrompt,
+    canvasEngaged,
+    setCanvasEngaged,
   }), [
     isOpen,
     displayMode,
@@ -337,6 +350,7 @@ export function AgentModalProvider({ children }: PropsWithChildren) {
     pendingContext,
     openWithPrompt,
     consumePendingPrompt,
+    canvasEngaged,
   ]);
 
   return (


### PR DESCRIPTION
### **User description**
## What

The Zoe canvas tracer bullet (vocabulary: CONTEXT.md Chat section; thread semantics: ADR-0040). For an opted-in user on /home:

- **Gating**: `?canvas=1` sets a sticky localStorage opt-in, `?canvas=0` clears it; default off. Opted-out users keep today's drawer behaviour exactly (hero sends and chips open the drawer).
- **Send → canvas**: clicking a suggestion chip or sending from the hero input collapses everything below the Zoe input (greeting/hero stays; animated yield, not a jump) and streams the answer into a canvas styled like the existing dashboard cards. The hero input stays pinned and becomes the follow-up composer. Plain Enter sends; Shift+Enter inserts a newline; Cmd/Ctrl+Enter still sends.
- **Canvas is a third display mode** of the shared conversation state in the agent modal provider (alongside panel/modal). Each engagement (open→dismiss cycle) starts a fresh conversationId — a chip click is an implicit "new thread + send". Follow-ups continue that thread and stack as a transcript in the canvas. The previous thread stays available in the drawer's history.
- **Renderer**: the canvas renders full ChatMessage objects — markdown via the canonical MarkdownRenderer, live tool-activity chips from tool frames, the existing failure/incomplete + Retry treatment, and the structured `card` slot (no new card kinds in this ticket, but the slot renders).
- **Dismiss**: ✕ and Esc restore the dashboard instantly and end the engagement. Dismissing mid-stream aborts the stream and marks the turn incomplete (existing retry UI).

Consumes the parser + streaming hook extracted in `sunny.snail` (#354). Also extracts `failureCopy` and the tool-refresh invalidation wiring out of ManyChat into shared modules so both surfaces consume one implementation — drawer behaviour unchanged.

## Acceptance criteria

- [x] With the flag off, /home behaviour is byte-for-byte today's (drawer opens)
- [x] With the flag on: chip or hero send collapses the dashboard and streams the answer inline in dashboard-card styling, theme tokens only, both light and dark
- [x] Enter sends, Shift+Enter newline, Cmd/Ctrl+Enter sends
- [x] Each engagement gets a fresh conversationId; follow-ups stay on it; the prior thread remains in drawer history; opening the drawer after an engagement shows the same turns
- [x] Tool activity renders as live chips while streaming
- [x] ✕/Esc restore the dashboard instantly; mid-stream dismiss aborts and marks the turn incomplete with Retry
- [x] Engagement-lifecycle hook tests (renderHook, per existing hook-test pattern): fresh id per engagement, follow-up continuity, dismiss-ends-engagement, abort-on-dismiss
- [x] Typecheck, ESLint and unit tests pass (1319 unit tests, tsc clean)

---

Ships: prime.robin


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add Zoe canvas MVP on `/home` behind `?canvas=1` sticky opt-in flag

- New `ZoeCanvas` component and `useCanvasEngagement` hook stream answers inline in the page per ADR-0040 (fresh Thread per engagement, abort-on-dismiss)

- Extract `failureCopy` and tool-refresh invalidation into shared modules consumed by both drawer and canvas

- Add 4 lifecycle tests for `useCanvasEngagement` covering mint, follow-up, dismiss, and mid-stream abort


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UserHomeDashboard.tsx"] -- "canvasEnabled?" --> B["useCanvasOptIn.ts"]
  A -- "send/dismiss/retry" --> C["useCanvasEngagement.ts"]
  C -- "streams via" --> D["streamChatResponse.ts"]
  C -- "parses errors via" --> E["streamProtocol.ts"]
  C -- "invalidates cache via" --> F["applyToolRefreshInvalidations.ts"]
  C -- "shared state" --> G["AgentModalProvider.tsx"]
  A -- "renders" --> H["ZoeCanvas.tsx"]
  H -- "failure copy" --> I["failureCopy.ts"]
  G -- "canvasEngaged flag" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>UserHomeDashboard.tsx</strong><dd><code>Wire canvas opt-in, engagement hook, and ZoeCanvas render</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/359/files#diff-1a1d06addd4f586e7df6e93c981c42845efc5a2906f7c3e882d0ca2c678c2338">+34/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ZoeCanvas.tsx</strong><dd><code>New canvas component rendering engagement in dashboard-card style</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/359/files#diff-17d63c82eb858f5f10c45da2c25e8d40fa49c2bcc5f5ee241a7c37117ab844bb">+128/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useCanvasEngagement.ts</strong><dd><code>New hook managing engagement lifecycle and streaming loop</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/359/files#diff-37a04847b8d4387cc6f7ab379cf60dd50aef6f6ad1074e2a69ac02ac1e45b76c">+297/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useCanvasOptIn.ts</strong><dd><code>Sticky localStorage opt-in hook for canvas experiment</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/359/files#diff-56833505e5b120eaaff82da073988468e536d8fdae39c56a55a6a7f4f3249a6b">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ZoeCanvas.module.css</strong><dd><code>CSS for canvas card, header, body, and failure row</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/359/files#diff-e3e496179e8e8b245c99289bb2fc4c05d1ebda70a4a3e290cd73b75b7fbe6c9a">+107/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>UserHomeDashboard.module.css</strong><dd><code>Add animated dashboard yield/collapse CSS for canvas mode</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/359/files#diff-1b81aba8ba488af1afcbf5fe00ccdf11ec56cda58c22275ea49c0f82e38cd106">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>toolRefreshInvalidation.ts</strong><dd><code>Extract tRPC cache invalidation wiring into shared helper</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/359/files#diff-33b6758db757ac754ae6d9a758f830d0a09ccc27d3694b272693430e4fefa026">+57/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>failureCopy.ts</strong><dd><code>Extract failure copy function into shared chat module</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/359/files#diff-01775dd213fd81ed12e6d7928a4998b9d9aa00ba11c3148ea28f502b44463145">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ManyChat.tsx</strong><dd><code>Consume extracted failureCopy and toolRefreshInvalidation modules</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/359/files#diff-6f0e68ce865b0629e85c68dbd985a102db9f321cea87620c205f1863eece6ed4">+4/-62</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgentModalProvider.tsx</strong><dd><code>Add canvasEngaged flag and setter to shared provider context</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/359/files#diff-91b32ce785a23a94025446165797b003d893890e876b862e7382e7546609f198">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>useCanvasEngagement.test.tsx</strong><dd><code>Four lifecycle tests for canvas engagement hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/359/files#diff-7c0cff7641be70178a2871406613050c2e70f9848fa7d3405ae8070c88c03f78">+223/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

