### PR TITLE
feat: stamp Zoe canvas turns web-canvas in interaction history

### DIFF
--- a/src/app/_components/home/zoe-canvas/__tests__/useCanvasEngagement.test.tsx
+++ b/src/app/_components/home/zoe-canvas/__tests__/useCanvasEngagement.test.tsx
@@ -115,6 +115,10 @@ describe('useCanvasEngagement', () => {
     expect(mockStartConversation).toHaveBeenCalledTimes(1);
     expect(result.current.conversationId).toBe('conv-1');
     expect(streamCalls[0]?.payload.conversationId).toBe('conv-1');
+    // Canvas turns are stamped with their own platform (ADR-0040) so the
+    // agent-quality machinery compares canvas vs drawer Threads.
+    expect(streamCalls[0]?.payload.platform).toBe('web-canvas');
+    expect(mockStartConversation).toHaveBeenCalledWith({ platform: 'web-canvas' });
 
     // The engagement transcript: the echoed question + the streamed answer.
     const visible = result.current.messages.filter((m) => m.type !== 'system');

--- a/src/app/_components/home/zoe-canvas/useCanvasEngagement.ts
+++ b/src/app/_components/home/zoe-canvas/useCanvasEngagement.ts
@@ -133,7 +133,7 @@ export function useCanvasEngagement({
         // Fresh Thread per engagement (ADR-0040). Fall back to a client id on
         // failure — /api/chat/stream accepts client-provided conversation ids.
         try {
-          const res = await startConversation.mutateAsync({ platform: 'manychat' });
+          const res = await startConversation.mutateAsync({ platform: 'web-canvas' });
           engagementConversationId = res.conversationId;
         } catch {
           engagementConversationId = `conv_canvas_${Date.now()}_${Math.random().toString(36).slice(2, 15)}`;
@@ -193,7 +193,10 @@ export function useCanvasEngagement({
             assistantId: customAssistant?.id ?? null,
             workspaceId: workspaceId ?? null,
             conversationId: engagementConversationId,
-            platform: 'manychat',
+            // Distinct stamp for canvas turns (ADR-0040): the interaction-
+            // history rows this send produces are attributed to the canvas so
+            // the agent-quality machinery compares canvas vs drawer Threads.
+            platform: 'web-canvas',
           },
           {
             signal: abortController.signal,

--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -106,7 +106,9 @@ export async function POST(req: Request) {
       platform?: string;
     };
 
-    const ALLOWED_PLATFORMS = ["web", "manychat"] as const;
+    // "web-canvas" stamps Zoe canvas turns (ADR-0040) so engagement volume and
+    // judged Thread quality compare canvas vs drawer with no new analytics.
+    const ALLOWED_PLATFORMS = ["web", "manychat", "web-canvas"] as const;
     type ChatPlatform = typeof ALLOWED_PLATFORMS[number];
     const isAllowedPlatform = (p: string): p is ChatPlatform =>
       (ALLOWED_PLATFORMS as readonly string[]).includes(p);

--- a/src/server/api/routers/aiInteraction.ts
+++ b/src/server/api/routers/aiInteraction.ts
@@ -7,7 +7,7 @@ import { getProjectAccess, hasProjectAccess } from "~/server/services/access";
 // Zod schema for AI interaction logging
 const AiInteractionSchema = z.object({
   // Source Information (Required)
-  platform: z.enum(["slack", "manychat", "api", "webhook", "direct"]),
+  platform: z.enum(["slack", "manychat", "web-canvas", "api", "webhook", "direct"]),
   sourceId: z.string().optional(), // Platform-specific ID
 
   // User Context  
@@ -110,7 +110,7 @@ export const aiInteractionRouter = createTRPCRouter({
       z.object({
         limit: z.number().min(1).max(100).default(20),
         cursor: z.string().nullish(),
-        platform: z.enum(["slack", "manychat", "api", "webhook", "direct"]).optional(),
+        platform: z.enum(["slack", "manychat", "web-canvas", "api", "webhook", "direct"]).optional(),
         projectId: z.string().optional(),
         agentName: z.string().optional(),
         conversationId: z.string().optional(),
@@ -201,7 +201,7 @@ export const aiInteractionRouter = createTRPCRouter({
   getInteractionStats: protectedProcedure
     .input(
       z.object({
-        platform: z.enum(["slack", "manychat", "api", "webhook", "direct"]).optional(),
+        platform: z.enum(["slack", "manychat", "web-canvas", "api", "webhook", "direct"]).optional(),
         projectId: z.string().optional(),
         startDate: z.date().optional(),
         endDate: z.date().optional(),
@@ -488,7 +488,7 @@ export const aiInteractionRouter = createTRPCRouter({
   startConversation: protectedProcedure
     .input(
       z.object({
-        platform: z.enum(["slack", "manychat", "api", "webhook", "direct"]),
+        platform: z.enum(["slack", "manychat", "web-canvas", "api", "webhook", "direct"]),
         projectId: z.string().optional(),
       })
     )

--- a/src/server/services/AgentEvalService.ts
+++ b/src/server/services/AgentEvalService.ts
@@ -29,17 +29,20 @@ export const SETTLED_AFTER_MS = 60 * 60 * 1000;
 
 /**
  * Platforms where the brain actually reasoned (decision 1):
- * - "web"      — typed web chat (/api/chat/stream)
- * - "manychat" — WhatsApp via ManyChat (same stream route)
- * - "slack"    — Slack bot turns
- * - "api"      — API/webhook callers
- * - "direct"   — mastra.sendMessage tRPC path
+ * - "web"        — typed web chat (/api/chat/stream)
+ * - "manychat"   — WhatsApp via ManyChat (same stream route)
+ * - "web-canvas" — Zoe canvas engagements on /home (same stream route,
+ *                  distinct stamp so canvas vs drawer Threads compare, ADR-0040)
+ * - "slack"      — Slack bot turns
+ * - "api"        — API/webhook callers
+ * - "direct"     — mastra.sendMessage tRPC path
  * Excluded: "voice" (coarse-tool dispatcher + realtime transcript duplicates —
  * deterministic router turns, not brain reasoning).
  */
 export const BRAIN_REASONED_PLATFORMS = [
   "web",
   "manychat",
+  "web-canvas",
   "slack",
   "api",
   "direct",

--- a/src/server/services/AiInteractionLogger.ts
+++ b/src/server/services/AiInteractionLogger.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 
 export interface AiInteractionData {
   // Source Information (Required)
-  platform: "slack" | "manychat" | "api" | "webhook" | "direct" | "web" | "voice";
+  platform: "slack" | "manychat" | "web-canvas" | "api" | "webhook" | "direct" | "web" | "voice";
   sourceId?: string; // Platform-specific ID (Slack channel, chat session, etc.)
 
   // User Context

--- a/src/server/services/__tests__/AgentEvalService.test.ts
+++ b/src/server/services/__tests__/AgentEvalService.test.ts
@@ -196,7 +196,7 @@ describe("findSettledThreadIds (mocked Prisma)", () => {
     await service.findSettledThreadIds(NOW);
     const groupByArgs = db.aiInteractionHistory.groupBy.mock.calls[0]?.[0];
     expect(groupByArgs?.where?.platform).toEqual({
-      in: ["web", "manychat", "slack", "api", "direct"],
+      in: ["web", "manychat", "web-canvas", "slack", "api", "direct"],
     });
   });
 


### PR DESCRIPTION
### **User description**
## What

The measurement slice for the Zoe canvas experiment (ADR-0040): sends originating from the canvas carry their origin to the chat stream endpoint, and the interaction-history logging path stamps those rows with a distinct `platform` value (`web-canvas`). Drawer turns keep today's platform value unchanged.

- Canvas hook (`useCanvasEngagement`) sends `platform: 'web-canvas'` for both the engagement's `startConversation` call and every stream payload (follow-ups included — they reuse the same send path).
- `/api/chat/stream` allowlists `web-canvas` (unknown values still fall back to `web`).
- `AiInteractionLogger`'s platform union and the `aiInteraction` router enums (start/log/filter/stats) accept `web-canvas`; the `AiInteractionHistory.platform` column is a plain `String`, so no migration.
- `BRAIN_REASONED_PLATFORMS` includes `web-canvas` so canvas Threads are judge-scored (ADR-0012) and canvas vs drawer compare through the existing agent-quality machinery — deliberately no new analytics.

## Acceptance criteria

- [x] A send from the canvas produces an AiInteractionHistory row with `platform = "web-canvas"` (hook test asserts the payload stamp; the row write is the existing logging path)
- [x] Drawer sends (and all other surfaces) keep their current platform values (only the canvas hook changed; ManyChat still sends `manychat`)
- [x] Follow-up turns within a canvas engagement are also stamped `web-canvas` (same send path, covered by the follow-up hook test)
- [ ] Verified against real interaction-history rows in dev — **QA step**: opt in with `?canvas=1`, send from /home, check the newest `AiInteractionHistory` row has `platform = 'web-canvas'`
- [x] Typecheck, lint and unit tests pass

---

Ships: red.spruce


___

### **PR Type**
Enhancement


___

### **Description**
- Add `web-canvas` platform stamp for Zoe canvas interaction history

- Update allowlists and enums across stream route, routers, and logger

- Include `web-canvas` in `BRAIN_REASONED_PLATFORMS` for agent-quality scoring

- Add tests asserting canvas turns carry `web-canvas` platform stamp


___

### Diagram Walkthrough


```mermaid
flowchart LR
  hook["useCanvasEngagement hook"]
  stream["POST /api/chat/stream"]
  logger["AiInteractionLogger"]
  router["aiInteraction tRPC router"]
  eval["AgentEvalService BRAIN_REASONED_PLATFORMS"]

  hook -- "platform: 'web-canvas'" --> stream
  hook -- "startConversation platform: 'web-canvas'" --> router
  stream -- "allowlists 'web-canvas'" --> logger
  logger -- "types 'web-canvas'" --> router
  router -- "enums accept 'web-canvas'" --> eval
  eval -- "includes 'web-canvas' for judge scoring" --> eval
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>useCanvasEngagement.ts</strong><dd><code>Replace `manychat` with `web-canvas` platform stamp in canvas hook</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/360/files#diff-37a04847b8d4387cc6f7ab379cf60dd50aef6f6ad1074e2a69ac02ac1e45b76c">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>route.ts</strong><dd><code>Allowlist `web-canvas` in stream route platform validation</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/360/files#diff-44aee62d94edbf4662fd83225c2eecc607c675caf170aa4a280ab60ebe45f226">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>aiInteraction.ts</strong><dd><code>Add `web-canvas` to all platform enums in aiInteraction router</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/360/files#diff-c3572518b17bfda452e52fce1700ac82e7507c1116729c769f51d2c0cb6b6214">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AiInteractionLogger.ts</strong><dd><code>Add `web-canvas` to platform union type in logger interface</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/360/files#diff-42a212ec743d54f21d9125fa8d9a8e5b67c0cce58c7eac89b0ae7fd064565dbe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgentEvalService.ts</strong><dd><code>Include `web-canvas` in brain-reasoned platforms for judge scoring</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/360/files#diff-5cecf004c43a3e64b51b158657803627671904d32d65609892c6b06c6aa37351">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>useCanvasEngagement.test.tsx</strong><dd><code>Assert canvas turns carry `web-canvas` platform in tests</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/360/files#diff-7c0cff7641be70178a2871406613050c2e70f9848fa7d3405ae8070c88c03f78">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgentEvalService.test.ts</strong><dd><code>Update platform scope test to include `web-canvas`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/360/files#diff-2235e351901e1f5034f2132d61232764ee974cadd309f477ae63a0854794c772">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

