### PR TITLE
feat: drawer-canvas handoff, collision rules, and navigate-away abort

### DIFF
--- a/src/app/_components/home/zoe-canvas/__tests__/useCanvasEngagement.test.tsx
+++ b/src/app/_components/home/zoe-canvas/__tests__/useCanvasEngagement.test.tsx
@@ -5,12 +5,14 @@
  * of that shared conversation state — provider semantics are the thing under
  * test), with the tRPC layer and the stream transport mocked (mirrors
  * useFavorite.test.ts). Covers: fresh conversationId per engagement,
- * follow-up continuity, dismiss-ends-engagement, and abort-on-dismiss
- * marking the in-flight turn `incomplete`.
+ * follow-up continuity, dismiss-ends-engagement, abort-on-dismiss marking
+ * the in-flight turn `incomplete`, and the drawer⇄canvas collision rules
+ * (handoff keeps the thread, chip-with-drawer-open closes the drawer,
+ * navigate-away aborts).
  */
 
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { act, renderHook } from '@testing-library/react';
+import { act, render, renderHook } from '@testing-library/react';
 import type { PropsWithChildren } from 'react';
 import type {
   ChatStreamPayload,
@@ -54,8 +56,8 @@ vi.mock('~/app/_components/agent/toolRefreshInvalidation', () => ({
   applyToolRefreshInvalidations: vi.fn(),
 }));
 
-import { AgentModalProvider } from '~/providers/AgentModalProvider';
-import { useCanvasEngagement } from '../useCanvasEngagement';
+import { AgentModalProvider, useAgentModal } from '~/providers/AgentModalProvider';
+import { useCanvasEngagement, type CanvasEngagement } from '../useCanvasEngagement';
 
 function wrapper({ children }: PropsWithChildren) {
   return <AgentModalProvider>{children}</AgentModalProvider>;
@@ -101,6 +103,25 @@ beforeEach(() => {
     },
   );
 });
+
+function hangingStream() {
+  mockStreamChatResponse.mockImplementation(
+    (payload: ChatStreamPayload, options: StreamChatOptions) => {
+      streamCalls.push({ payload, options });
+      return new Promise<ChatStreamUpdate>((_resolve, reject) => {
+        // A partial answer streams, then the stream hangs until aborted.
+        options.onUpdate?.({
+          displayText: 'Partial…',
+          toolCalls: [],
+          rawLength: 8,
+        });
+        options.signal?.addEventListener('abort', () => {
+          reject(new DOMException('canvas-dismissed', 'AbortError'));
+        });
+      });
+    },
+  );
+}
 
 describe('useCanvasEngagement', () => {
   test('opening an engagement mints a fresh conversationId and streams on it', async () => {
@@ -179,22 +200,7 @@ describe('useCanvasEngagement', () => {
   });
 
   test('dismissing mid-stream aborts and marks the turn incomplete with Retry', async () => {
-    mockStreamChatResponse.mockImplementation(
-      (payload: ChatStreamPayload, options: StreamChatOptions) => {
-        streamCalls.push({ payload, options });
-        return new Promise<ChatStreamUpdate>((_resolve, reject) => {
-          // A partial answer streams, then the stream hangs until aborted.
-          options.onUpdate?.({
-            displayText: 'Partial…',
-            toolCalls: [],
-            rawLength: 8,
-          });
-          options.signal?.addEventListener('abort', () => {
-            reject(new DOMException('canvas-dismissed', 'AbortError'));
-          });
-        });
-      },
-    );
+    hangingStream();
 
     const { result } = renderHook(() => useCanvasEngagement({ workspaceId: 'ws-1' }), {
       wrapper,
@@ -213,6 +219,92 @@ describe('useCanvasEngagement', () => {
     const last = result.current.messages.at(-1);
     expect(last?.type).toBe('ai');
     // Partial answer kept, turn finalized as incomplete with Retry available.
+    expect(last?.content).toBe('Partial…');
+    expect(last?.failure).toMatchObject({
+      severity: 'incomplete',
+      canRetry: true,
+      retryText: 'Long question',
+    });
+  });
+
+  test('handoff: drawer opening mid-engagement dismisses the canvas and keeps the thread', async () => {
+    const { result } = renderHook(
+      () => ({ canvas: useCanvasEngagement({ workspaceId: 'ws-1' }), modal: useAgentModal() }),
+      { wrapper },
+    );
+
+    act(() => result.current.canvas.send('Standup on my projects'));
+    await flush();
+    const turnsBefore = result.current.canvas.messages.filter((m) => m.type !== 'system');
+
+    // ⌘J / FAB — the drawer opens: the "continue in panel" gesture.
+    act(() => result.current.modal.openModal());
+
+    expect(result.current.canvas.engaged).toBe(false);
+    // Identical thread, no duplicates: same conversationId, same turns.
+    expect(result.current.canvas.conversationId).toBe('conv-1');
+    expect(result.current.canvas.messages.filter((m) => m.type !== 'system')).toEqual(
+      turnsBefore,
+    );
+  });
+
+  test('collision: a canvas send with the drawer open closes the drawer and engages inline', async () => {
+    const { result } = renderHook(
+      () => ({ canvas: useCanvasEngagement({ workspaceId: 'ws-1' }), modal: useAgentModal() }),
+      { wrapper },
+    );
+
+    act(() => result.current.modal.openModal());
+    expect(result.current.modal.isOpen).toBe(true);
+
+    act(() => result.current.canvas.send('Health-check my active work'));
+    await flush();
+
+    expect(result.current.modal.isOpen).toBe(false);
+    expect(result.current.canvas.engaged).toBe(true);
+    expect(result.current.canvas.conversationId).toBe('conv-1');
+    expect(streamCalls).toHaveLength(1);
+  });
+
+  test('navigate-away mid-stream aborts and marks the turn incomplete in the surviving provider state', async () => {
+    hangingStream();
+
+    // The provider is app-level and survives navigation; only the /home
+    // surface (the canvas hook's host) unmounts. Model that split directly.
+    const canvasRef: { current: CanvasEngagement | null } = { current: null };
+    const modalRef: { current: ReturnType<typeof useAgentModal> | null } = { current: null };
+    function CanvasHost() {
+      canvasRef.current = useCanvasEngagement({ workspaceId: 'ws-1' });
+      return null;
+    }
+    function ModalProbe() {
+      modalRef.current = useAgentModal();
+      return null;
+    }
+
+    const { rerender } = render(
+      <AgentModalProvider>
+        <ModalProbe />
+        <CanvasHost />
+      </AgentModalProvider>,
+    );
+
+    act(() => canvasRef.current!.send('Long question'));
+    await flush();
+    expect(canvasRef.current!.isStreaming).toBe(true);
+
+    // Navigate away: the canvas host unmounts, the provider stays.
+    rerender(
+      <AgentModalProvider>
+        <ModalProbe />
+      </AgentModalProvider>,
+    );
+    await flush();
+
+    expect(streamCalls[0]?.options.signal?.aborted).toBe(true);
+    expect(modalRef.current!.canvasEngaged).toBe(false);
+    const last = modalRef.current!.messages.at(-1);
+    expect(last?.type).toBe('ai');
     expect(last?.content).toBe('Partial…');
     expect(last?.failure).toMatchObject({
       severity: 'incomplete',

--- a/src/app/_components/home/zoe-canvas/useCanvasEngagement.ts
+++ b/src/app/_components/home/zoe-canvas/useCanvasEngagement.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '~/trpc/react';
 import { useAgentModal, type ChatMessage } from '~/providers/AgentModalProvider';
 import { streamChatResponse, type ChatStreamCoreMessage } from '~/lib/chat/streamChatResponse';
@@ -56,6 +56,8 @@ export function useCanvasEngagement({
     canvasEngaged,
     setCanvasEngaged,
     pageContext,
+    isOpen: drawerOpen,
+    closeModal: closeDrawer,
   } = useAgentModal();
   const utils = api.useUtils();
 
@@ -98,6 +100,10 @@ export function useCanvasEngagement({
       const trimmedText = text.trim();
       if (!trimmedText || isStreaming) return;
       const isRetry = attempt > 0;
+
+      // Collision rule: a canvas send with the drawer open closes the drawer
+      // and answers inline — the canvas is the surface the user just chose.
+      if (drawerOpen) closeDrawer();
 
       const agentName = customAssistant?.name ?? 'Zoe';
       let engagementConversationId = engagementIdRef.current;
@@ -269,6 +275,8 @@ export function useCanvasEngagement({
       workspaceId,
       utils,
       pageContext?.pageType,
+      drawerOpen,
+      closeDrawer,
     ],
   );
 
@@ -284,6 +292,26 @@ export function useCanvasEngagement({
     // The engagement's thread stays the provider's active conversationId, so
     // opening the drawer next shows these same turns (drawer = full history).
   }, [setCanvasEngaged]);
+
+  // Handoff (canvas → drawer): the drawer opening while an engagement is
+  // active is the "continue in panel" gesture (⌘J or the FAB). The drawer
+  // reads the same provider state, so it shows the identical turns; the
+  // canvas dismisses — mid-stream that aborts and marks the turn incomplete,
+  // the one abort rule (ADR-0040). Rising-edge detection so a send that just
+  // CLOSED the drawer (the chip collision rule) can't trigger a dismissal.
+  const prevDrawerOpenRef = useRef(drawerOpen);
+  useEffect(() => {
+    const wasOpen = prevDrawerOpenRef.current;
+    prevDrawerOpenRef.current = drawerOpen;
+    if (drawerOpen && !wasOpen && canvasEngaged) dismiss();
+  }, [drawerOpen, canvasEngaged, dismiss]);
+
+  // Navigate-away abort: leaving /home mid-engagement is a dismissal — same
+  // abort + `incomplete` treatment as ✕/Esc. The partial turn stays in the
+  // (app-level) provider state, recoverable via Retry in the drawer.
+  const dismissRef = useRef(dismiss);
+  dismissRef.current = dismiss;
+  useEffect(() => () => dismissRef.current(), []);
 
   return {
     engaged: canvasEngaged,

--- a/src/app/_components/layout/ZoeDrawer.tsx
+++ b/src/app/_components/layout/ZoeDrawer.tsx
@@ -53,7 +53,9 @@ function getInitials(name: string): string {
 export function ZoeDrawer() {
   const {
     isOpen,
+    openModal,
     closeModal,
+    canvasEngaged,
     clearChat,
     drawerSize,
     setDrawerSize,
@@ -75,18 +77,22 @@ export function ZoeDrawer() {
   const [defaultAgent, setDefaultAgent] = useState<{ id: string; name: string } | null>(null);
   const [loadingConversationId, setLoadingConversationId] = useState<string | null>(null);
 
-  // Cmd+J toggle + Esc close
+  // Cmd+J toggle + Esc close. With a Zoe canvas engagement active, ⌘J is the
+  // handoff gesture: opening the drawer shows the same thread and the canvas
+  // dismisses itself (useCanvasEngagement watches isOpen). ⌘J behaviour
+  // outside that case is unchanged.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "j") {
         e.preventDefault();
         if (isOpen) closeModal();
+        else if (canvasEngaged) openModal();
       }
       if (e.key === "Escape" && isOpen) closeModal();
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [isOpen, closeModal]);
+  }, [isOpen, closeModal, canvasEngaged, openModal]);
 
   const { data: workspaces } = api.workspace.list.useQuery(undefined, {
     enabled: isOpen,


### PR DESCRIPTION
### **User description**
## What

The interaction rules between the Zoe canvas and the Zoe drawer, for opted-in users (ADR-0040):

- **Handoff (canvas → drawer)**: with the canvas open, ⌘J (or the FAB) opens the drawer showing the same thread — identical turns, no duplicates — and dismisses the canvas. This is the "continue in panel" gesture. `useCanvasEngagement` watches the drawer's open state with **rising-edge detection** so a chip-send that just closed the drawer (the collision rule) can't re-trigger a handoff dismiss.
- **Collision (drawer → canvas)**: with the drawer open on /home, clicking a suggestion chip (or hero send) closes the drawer and answers inline in a fresh engagement.
- **Navigate-away abort**: navigating off /home mid-stream unmounts the canvas host, whose cleanup dismisses the engagement — same abort + `incomplete` + Retry treatment as a mid-stream ✕/Esc. The partial turn survives in the app-level provider state, recoverable from the drawer.
- **Invariance**: ⌘J now also *opens* the drawer when a canvas engagement is active (the handoff); its behaviour outside these collision cases is untouched. The PM Agent card run buttons and workspace-home WeekInReview prompts are not touched.

## Acceptance criteria

- [x] ⌘J/FAB with canvas open: drawer opens on the same conversationId with identical turns; canvas dismisses
- [x] Chip click with drawer open on /home: drawer closes, canvas opens with a fresh engagement
- [x] Navigation mid-stream aborts and marks the turn incomplete; the turn is recoverable (Retry) from the drawer
- [x] FAB/⌘J unchanged everywhere else; flag-off users see no change anywhere
- [x] Hook tests for the collision rules (handoff keeps thread, chip-with-drawer-open closes drawer, navigate-abort marks incomplete)
- [x] Typecheck, lint and unit tests pass (1326 unit tests, tsc clean)

---

Ships: cold.hen


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implements drawer⇄canvas handoff, collision, and navigate-away abort rules

- Handoff: ⌘J/FAB with canvas open transfers thread to drawer and dismisses canvas

- Collision: canvas send with drawer open closes drawer and answers inline

- Navigate-away mid-stream aborts engagement and marks turn incomplete with Retry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Canvas Engagement Active"]
  B["Drawer Opens (⌘J / FAB)"]
  C["Canvas Dismissed\n(handoff)"]
  D["Drawer Open on /home"]
  E["Canvas Send (chip/hero)"]
  F["Drawer Closes\n(collision)"]
  G["Navigate Away\nMid-Stream"]
  H["Abort + Incomplete\n+ Retry in Drawer"]

  A -- "rising-edge detect" --> B
  B -- "same thread, no duplicates" --> C
  D -- "user chose canvas" --> E
  E -- "closeDrawer()" --> F
  A -- "unmount cleanup" --> G
  G -- "dismissRef.current()" --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useCanvasEngagement.ts</strong><dd><code>Add handoff, collision, and navigate-away abort logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/home/zoe-canvas/useCanvasEngagement.ts

<ul><li>Imports <code>useEffect</code> and pulls <code>isOpen</code>/<code>closeModal</code> from <code>useAgentModal</code><br> <li> Adds collision rule: closes drawer before starting a canvas send if <br>drawer is open<br> <li> Adds handoff effect with rising-edge detection: dismisses canvas when <br>drawer opens while engaged<br> <li> Adds navigate-away cleanup effect: calls <code>dismiss</code> on unmount to abort <br>mid-stream turns</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/361/files#diff-37a04847b8d4387cc6f7ab379cf60dd50aef6f6ad1074e2a69ac02ac1e45b76c">+29/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ZoeDrawer.tsx</strong><dd><code>Wire ⌘J handoff gesture in ZoeDrawer keyboard handler</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/layout/ZoeDrawer.tsx

<ul><li>Pulls <code>openModal</code> and <code>canvasEngaged</code> from <code>useAgentModal</code><br> <li> Updates ⌘J handler: when canvas is engaged and drawer is closed, opens <br>drawer (handoff gesture)<br> <li> Updates <code>useEffect</code> dependency array to include <code>canvasEngaged</code> and <br><code>openModal</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/361/files#diff-eb251afe64bce320035ae982586d6659cc574e66584644d41a0e864e05485aed">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useCanvasEngagement.test.tsx</strong><dd><code>Add three collision-rule hook tests for drawer-canvas interactions</code></dd></summary>
<hr>

src/app/_components/home/zoe-canvas/__tests__/useCanvasEngagement.test.tsx

<ul><li>Extracts reusable <code>hangingStream()</code> helper for mid-stream abort tests<br> <li> Adds test: handoff keeps thread when drawer opens mid-engagement<br> <li> Adds test: collision closes drawer when canvas send fires with drawer <br>open<br> <li> Adds test: navigate-away unmount aborts stream and marks turn <br>incomplete</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/361/files#diff-7c0cff7641be70178a2871406613050c2e70f9848fa7d3405ae8070c88c03f78">+113/-21</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

