### PR TITLE
feat(agent): read tickets/cycles + link dependencies from the assistant

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/layout.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/layout.tsx
@@ -18,6 +18,12 @@ function WorkspaceContextRegistrar({ children }: { children: React.ReactNode }) 
 
   const pageContext = useMemo(() => {
     if (!workspace || !workspaceId) return null;
+    // Product routes register their own richer context (ProductLayout). Yield
+    // here: this registrar's effect re-runs on every pathname change and runs
+    // AFTER child effects (parent effects fire last), so registering the
+    // generic workspace context on product routes would clobber the product
+    // context on every product tab switch.
+    if (/\/products\/[^/]+/.test(pathname)) return null;
     return {
       pageType: 'workspace',
       pageTitle: workspace.name,

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import {
   IconHome,
@@ -23,6 +23,7 @@ import {
   Stack,
 } from "@mantine/core";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
+import { useRegisterPageContext } from "~/hooks/useRegisterPageContext";
 import { api } from "~/trpc/react";
 import { FavoriteButton } from "~/app/_components/shared/FavoriteButton";
 import { buildProductFavoriteTarget } from "./favoriteTarget";
@@ -107,6 +108,35 @@ export default function ProductLayout({
     const id = window.setTimeout(warm, 200);
     return () => window.clearTimeout(id);
   }, [productId, workspaceId, utils]);
+
+  // Tell the AI assistant which product (and tab) the user is looking at, so
+  // "the tickets in cycle 10" resolves without the agent asking. The workspace
+  // layout registrar yields on /products/ routes — this is the sole owner here.
+  const pageContext = useMemo(() => {
+    if (!product || !workspace || !workspaceId) return null;
+    const base = `/w/${workspace.slug}/products/${productSlug}`;
+    const view =
+      tabs.find(
+        (t) =>
+          t.href !== "" &&
+          (pathname === `${base}${t.href}` || pathname.startsWith(`${base}${t.href}/`)),
+      )?.value ?? "overview";
+    return {
+      pageType: "product",
+      pageTitle: product.name,
+      pagePath: pathname,
+      data: {
+        productId: product.id,
+        productName: product.name,
+        productSlug,
+        workspaceId,
+        workspaceSlug: workspace.slug,
+        view,
+      },
+    };
+  }, [product, workspace, workspaceId, productSlug, pathname]);
+
+  useRegisterPageContext(pageContext);
 
   if (!workspace) return null;
   const basePath = `/w/${workspace.slug}/products/${productSlug}`;

--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -180,6 +180,13 @@ function formatPageContextData(context: PageContext): string {
       return `  - The user is viewing their Meetings list (${count} meetings shown).
   - To read, reference, or discuss meetings, call the \`get-meeting-transcriptions\` tool (pass includeTranscript: false for a fast title/date list). Do NOT ask the user to paste them.`;
     }
+    case 'product': {
+      const d = context.data;
+      return `  - The user is viewing the product "${str(d.productName)}" (productId: ${str(d.productId)}), on its "${str(d.view, 'overview')}" tab.
+  - To read, reference, or analyze this product's tickets, cycles, or dependencies, call \`list-tickets\` / \`list-cycles\` with this productId. Do NOT ask the user to paste tickets.
+  - Cycle references like "cycle 10" go straight into \`list-tickets\`'s \`cycle\` input — the server resolves the name.
+  - To link tickets ("X blocks Y" / "Y depends on X"), propose the edges first, then call \`add-ticket-dependencies\` once the user confirms.`;
+    }
     case 'recording': {
       const d = context.data;
       const rawSummary = str(d.summary, 'No summary');

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -2,9 +2,10 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { loadProductWithAccess, assertWorkspaceMember } from "./product";
-import type { PrismaClient, Prisma } from "@prisma/client";
+import type { PrismaClient } from "@prisma/client";
 import { recordActivity } from "~/server/services/activity/recordActivity";
 import { createTicketWithNumber } from "../services/createTicket";
+import { wouldCreateCycle } from "../services/ticketDependencies";
 import {
   COMPLETED_TICKET_STATUSES,
   IN_FLIGHT_TICKET_STATUSES,
@@ -87,34 +88,6 @@ const DEP_TICKET_SELECT = {
   priority: true,
   assignee: { select: { id: true, name: true, image: true } },
 } as const;
-
-/**
- * BFS from `startId` following depsOut edges. Returns true if `targetId` is
- * transitively reachable. Used to prevent cycles when adding a dependency.
- */
-async function wouldCreateCycle(
-  db: PrismaClient | Prisma.TransactionClient,
-  startId: string,
-  targetId: string,
-): Promise<boolean> {
-  if (startId === targetId) return true;
-  const visited = new Set<string>();
-  const queue: string[] = [startId];
-  while (queue.length > 0) {
-    const current = queue.shift()!;
-    if (visited.has(current)) continue;
-    visited.add(current);
-    const edges = await db.ticketDependency.findMany({
-      where: { ticketId: current },
-      select: { dependsOnId: true },
-    });
-    for (const e of edges) {
-      if (e.dependsOnId === targetId) return true;
-      if (!visited.has(e.dependsOnId)) queue.push(e.dependsOnId);
-    }
-  }
-  return false;
-}
 
 async function loadTemplateWithAccess(
   db: PrismaClient,

--- a/src/plugins/product/server/services/__tests__/ticketDependencies.test.ts
+++ b/src/plugins/product/server/services/__tests__/ticketDependencies.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the pure cycle-matching helper. `wouldCreateCycle` hits the
+ * DB (covered by ticket integration tests); `matchCycle` is pure and gets the
+ * bulk of the edge-case coverage here — it's what turns a human "cycle 10"
+ * into a real cycle id for the agent read tools.
+ */
+import { describe, it, expect } from "vitest";
+import { matchCycle, type MatchableCycle } from "../ticketDependencies";
+
+const cycles: MatchableCycle[] = [
+  { id: "c1", name: "Cycle 9", slug: "cycle-9" },
+  { id: "c10", name: "Cycle 10", slug: "cycle-10" },
+  { id: "cx", name: "Hardening Sprint", slug: "hardening-sprint" },
+];
+
+describe("matchCycle", () => {
+  it("matches an exact cycle id", () => {
+    expect(matchCycle(cycles, "c10")?.id).toBe("c10");
+  });
+
+  it("matches an exact slug case-insensitively", () => {
+    expect(matchCycle(cycles, "Cycle-10")?.id).toBe("c10");
+  });
+
+  it("matches the full name case-insensitively", () => {
+    expect(matchCycle(cycles, "cycle 10")?.id).toBe("c10");
+  });
+
+  it('matches a bare number ("10" → "Cycle 10")', () => {
+    expect(matchCycle(cycles, "10")?.id).toBe("c10");
+  });
+
+  it('matches "cycle 10" against "Cycle 10" without exact-name reliance', () => {
+    // Even if name formatting varied, the number path resolves it.
+    expect(matchCycle([{ id: "z", name: "Cycle  10", slug: "s" }], "cycle 10")?.id).toBe("z");
+  });
+
+  it("does not confuse 9 and 10 (no substring bleed)", () => {
+    expect(matchCycle(cycles, "9")?.id).toBe("c1");
+    expect(matchCycle(cycles, "cycle 9")?.id).toBe("c1");
+  });
+
+  it("matches a non-numeric named cycle by name", () => {
+    expect(matchCycle(cycles, "Hardening Sprint")?.id).toBe("cx");
+  });
+
+  it("returns undefined for an unknown reference", () => {
+    expect(matchCycle(cycles, "Cycle 42")).toBeUndefined();
+    expect(matchCycle(cycles, "42")).toBeUndefined();
+    expect(matchCycle(cycles, "nonsense")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty/whitespace query", () => {
+    expect(matchCycle(cycles, "")).toBeUndefined();
+    expect(matchCycle(cycles, "   ")).toBeUndefined();
+  });
+
+  it("prefers an id/slug match over the number heuristic", () => {
+    // A cycle whose *name* number is 10 but whose slug someone queries directly.
+    const list: MatchableCycle[] = [
+      { id: "a", name: "Cycle 10", slug: "cycle-10" },
+      { id: "b", name: "Cycle 3", slug: "10" }, // pathological slug
+    ];
+    // "10" is an exact slug of b → slug wins over the "Cycle 10" number match.
+    expect(matchCycle(list, "10")?.id).toBe("b");
+  });
+});

--- a/src/plugins/product/server/services/ticketDependencies.ts
+++ b/src/plugins/product/server/services/ticketDependencies.ts
@@ -1,0 +1,80 @@
+/**
+ * ticketDependencies — shared helpers for the ticket dependency graph.
+ *
+ * Lives in the services layer (ADR-0016 pattern, like createTicket.ts) so both
+ * the product plugin's `ticket` router and the agent-facing `mastra` router
+ * enforce the same safety rules (no self-deps, no cycles) through one code path.
+ */
+import type { PrismaClient, Prisma } from "@prisma/client";
+
+/**
+ * BFS from `startId` following depsOut edges. Returns true if `targetId` is
+ * transitively reachable. Used to prevent cycles when adding a dependency.
+ */
+export async function wouldCreateCycle(
+  db: PrismaClient | Prisma.TransactionClient,
+  startId: string,
+  targetId: string,
+): Promise<boolean> {
+  if (startId === targetId) return true;
+  const visited = new Set<string>();
+  const queue: string[] = [startId];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    const edges = await db.ticketDependency.findMany({
+      where: { ticketId: current },
+      select: { dependsOnId: true },
+    });
+    for (const e of edges) {
+      if (e.dependsOnId === targetId) return true;
+      if (!visited.has(e.dependsOnId)) queue.push(e.dependsOnId);
+    }
+  }
+  return false;
+}
+
+/** Minimal cycle shape needed for name matching. */
+export interface MatchableCycle {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+/**
+ * Resolve a human cycle reference to a cycle row. Agents and users say
+ * "cycle 10", "Cycle 10", "cycle-10", or just "10"; cycles are stored as
+ * workspace Lists named "Cycle N" with slugs like "cycle-10". Matches, in
+ * order: exact id, exact slug, case-insensitive name, then bare number
+ * against a trailing number in the name (so "10" finds "Cycle 10").
+ */
+export function matchCycle(
+  cycles: MatchableCycle[],
+  query: string,
+): MatchableCycle | undefined {
+  const q = query.trim();
+  if (!q) return undefined;
+
+  const byId = cycles.find((c) => c.id === q);
+  if (byId) return byId;
+
+  const lower = q.toLowerCase();
+  const bySlug = cycles.find((c) => c.slug.toLowerCase() === lower);
+  if (bySlug) return bySlug;
+
+  const byName = cycles.find((c) => c.name.trim().toLowerCase() === lower);
+  if (byName) return byName;
+
+  // "cycle 10" / "cycle-10" / "10" → match the number in "Cycle 10".
+  const numberMatch = /^(?:cycle[\s_-]*)?(\d+)$/i.exec(lower);
+  if (numberMatch) {
+    const n = numberMatch[1];
+    return cycles.find((c) => {
+      const cycleNumber = /(\d+)\s*$/.exec(c.name.trim());
+      return cycleNumber?.[1] === n;
+    });
+  }
+
+  return undefined;
+}

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -23,8 +23,10 @@ import { getWorkspaceMembership } from "~/server/services/access/resolvers/works
 import { getAiInteractionLogger } from "~/server/services/AiInteractionLogger";
 import { PRODUCT_NAME } from "~/lib/brand";
 import { filterAgentInstructions } from "~/server/services/agent-routing/agentInstructionFilter";
-import { loadProductWithAccess } from "~/plugins/product/server/routers/product";
+import { loadProductWithAccess, assertWorkspaceMember } from "~/plugins/product/server/routers/product";
 import { createTicketWithNumber } from "~/plugins/product/server/services/createTicket";
+import { matchCycle, wouldCreateCycle } from "~/plugins/product/server/services/ticketDependencies";
+import { COMPLETED_TICKET_STATUSES } from "~/lib/ticket-statuses";
 import { generateFunId } from "~/lib/fun-ids";
 import { recordActivity } from "~/server/services/activity/recordActivity";
 import { ingestChannelSummary } from "~/server/services/activity/ingestChannelSummary";
@@ -4627,6 +4629,288 @@ export const mastraRouter = createTRPCRouter({
       }
 
       return result;
+    }),
+
+  // List the cycles (SPRINT lists) an agent can reference. Cycles are
+  // workspace-scoped; pass a productId to resolve the workspace from a product
+  // the agent already knows. Pure read — unlike the plugin's cycle.list, this
+  // never auto-creates upcoming cycles. Declared as a query per ADR-0041
+  // (agent tools POST; allowMethodOverride accepts it).
+  listCycles: protectedProcedure
+    .input(
+      z.object({
+        productId: z.string().optional(),
+        workspaceId: z.string().optional(),
+      }).refine((v) => v.productId ?? v.workspaceId, {
+        message: "Provide productId or workspaceId",
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      let workspaceId = input.workspaceId;
+      if (input.productId) {
+        const product = await loadProductWithAccess(ctx.db, userId, input.productId);
+        workspaceId = product.workspaceId;
+      } else if (workspaceId) {
+        await assertWorkspaceMember(ctx.db, userId, workspaceId);
+      }
+
+      const cycles = await ctx.db.list.findMany({
+        where: { workspaceId, listType: "SPRINT" },
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          status: true,
+          startDate: true,
+          endDate: true,
+          cycleGoal: true,
+          _count: { select: { tickets: true } },
+        },
+        orderBy: [{ startDate: "desc" }, { name: "desc" }],
+      });
+
+      return {
+        cycles: cycles.map((c) => ({
+          id: c.id,
+          name: c.name,
+          slug: c.slug,
+          status: c.status,
+          startDate: c.startDate?.toISOString() ?? null,
+          endDate: c.endDate?.toISOString() ?? null,
+          cycleGoal: c.cycleGoal,
+          ticketCount: c._count.tickets,
+        })),
+      };
+    }),
+
+  // List a product's tickets, optionally scoped to one cycle, with their
+  // dependency edges — enough for an agent to answer "what's in cycle 10 and
+  // what blocks what?" in a single call. `cycle` accepts anything a human
+  // would say: "Cycle 10", "cycle-10", "10", or a cycle id. If the cycle
+  // doesn't resolve, the response carries the available cycle names so the
+  // agent can self-correct without another lookup round-trip.
+  listTickets: protectedProcedure
+    .input(
+      z.object({
+        productId: z.string(),
+        cycle: z.string().optional(),
+        status: z.enum([
+          'BACKLOG', 'NEEDS_REFINEMENT', 'READY_TO_PLAN', 'COMMITTED',
+          'IN_PROGRESS', 'BLOCKED', 'QA', 'DONE', 'DEPLOYED', 'ARCHIVED',
+        ]).optional(),
+        type: z.enum(['BUG', 'FEATURE', 'CHORE', 'IMPROVEMENT', 'SPIKE', 'RESEARCH']).optional(),
+        limit: z.number().int().min(1).max(200).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const product = await loadProductWithAccess(ctx.db, userId, input.productId);
+      const limit = input.limit ?? 100;
+
+      // Resolve the human cycle reference against the workspace's cycles.
+      let cycleFilter: { id: string; name: string } | undefined;
+      let cycleWarning: string | undefined;
+      let availableCycles: string[] | undefined;
+      if (input.cycle) {
+        const cycles = await ctx.db.list.findMany({
+          where: { workspaceId: product.workspaceId, listType: "SPRINT" },
+          select: { id: true, name: true, slug: true },
+        });
+        const matched = matchCycle(cycles, input.cycle);
+        if (matched) {
+          cycleFilter = { id: matched.id, name: matched.name };
+        } else {
+          availableCycles = cycles.map((c) => c.name);
+          cycleWarning = `Cycle "${input.cycle}" not found in this workspace.`;
+          return { tickets: [], totalCount: 0, cycle: null, warning: cycleWarning, availableCycles };
+        }
+      }
+
+      const where = {
+        productId: input.productId,
+        ...(cycleFilter ? { cycleId: cycleFilter.id } : {}),
+        ...(input.status ? { status: input.status } : {}),
+        ...(input.type ? { type: input.type } : {}),
+      };
+
+      const [totalCount, tickets] = await Promise.all([
+        ctx.db.ticket.count({ where }),
+        ctx.db.ticket.findMany({
+          where,
+          orderBy: [{ status: "asc" }, { number: "asc" }],
+          take: limit,
+          select: {
+            id: true,
+            number: true,
+            shortId: true,
+            title: true,
+            body: true,
+            status: true,
+            type: true,
+            priority: true,
+            points: true,
+            assignee: { select: { name: true } },
+            cycle: { select: { name: true } },
+            feature: { select: { name: true } },
+            epic: { select: { name: true } },
+            depsOut: {
+              select: {
+                dependsOn: { select: { number: true, title: true, status: true } },
+              },
+            },
+            depsIn: {
+              select: {
+                ticket: { select: { number: true, title: true, status: true } },
+              },
+            },
+          },
+        }),
+      ]);
+
+      const completed = new Set<string>(COMPLETED_TICKET_STATUSES);
+      const BODY_PREVIEW_LENGTH = 600;
+
+      return {
+        cycle: cycleFilter ?? null,
+        totalCount,
+        // When totalCount > tickets.length the agent should say so, not
+        // silently reason over a truncated list.
+        tickets: tickets.map((t) => {
+          const dependsOn = t.depsOut.map((d) => d.dependsOn);
+          return {
+            number: t.number,
+            shortId: t.shortId,
+            title: t.title,
+            body:
+              t.body && t.body.length > BODY_PREVIEW_LENGTH
+                ? `${t.body.slice(0, BODY_PREVIEW_LENGTH)}… [truncated]`
+                : t.body,
+            status: t.status,
+            type: t.type,
+            priority: t.priority,
+            points: t.points,
+            assignee: t.assignee?.name ?? null,
+            cycle: t.cycle?.name ?? null,
+            feature: t.feature?.name ?? null,
+            epic: t.epic?.name ?? null,
+            dependsOn,
+            requiredFor: t.depsIn.map((d) => d.ticket),
+            isBlocked: dependsOn.some((d) => !completed.has(d.status)),
+          };
+        }),
+      };
+    }),
+
+  // Create dependency edges between tickets in one product, by ticket number
+  // ("#12 depends on #7"). Enforces the same rules as the plugin's
+  // ticket.addDependency — same product, no self-deps, no cycles (shared
+  // wouldCreateCycle) — and reports per-edge outcomes so an agent can relay
+  // exactly what was linked and what was rejected.
+  addTicketDependencies: protectedProcedure
+    .input(
+      z.object({
+        productId: z.string(),
+        dependencies: z.array(
+          z.object({
+            ticketNumber: z.number().int().positive(),
+            dependsOnNumber: z.number().int().positive(),
+          }),
+        ).min(1).max(50),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      await loadProductWithAccess(ctx.db, userId, input.productId);
+
+      console.log(`🔗 [tRPC addTicketDependencies] RECEIVED: productId=${input.productId}, edges=${input.dependencies.length}, userId=${userId}`);
+
+      // Resolve every referenced number → ticket id in one query.
+      const numbers = [
+        ...new Set(input.dependencies.flatMap((d) => [d.ticketNumber, d.dependsOnNumber])),
+      ];
+      const tickets = await ctx.db.ticket.findMany({
+        where: { productId: input.productId, number: { in: numbers } },
+        select: { id: true, number: true, title: true },
+      });
+      const byNumber = new Map(tickets.map((t) => [t.number, t]));
+
+      const added: { ticket: number; dependsOn: number }[] = [];
+      const failed: { ticket: number; dependsOn: number; error: string }[] = [];
+
+      for (const dep of input.dependencies) {
+        const ticket = byNumber.get(dep.ticketNumber);
+        const dependsOn = byNumber.get(dep.dependsOnNumber);
+        if (!ticket || !dependsOn) {
+          failed.push({
+            ticket: dep.ticketNumber,
+            dependsOn: dep.dependsOnNumber,
+            error: `Ticket #${!ticket ? dep.ticketNumber : dep.dependsOnNumber} not found in this product`,
+          });
+          continue;
+        }
+        if (ticket.id === dependsOn.id) {
+          failed.push({ ticket: dep.ticketNumber, dependsOn: dep.dependsOnNumber, error: "A ticket cannot depend on itself" });
+          continue;
+        }
+        try {
+          await ctx.db.$transaction(async (tx) => {
+            if (await wouldCreateCycle(tx, dependsOn.id, ticket.id)) {
+              throw new Error("This would create a dependency cycle");
+            }
+            await tx.ticketDependency.upsert({
+              where: { ticketId_dependsOnId: { ticketId: ticket.id, dependsOnId: dependsOn.id } },
+              create: { ticketId: ticket.id, dependsOnId: dependsOn.id, createdById: userId },
+              update: {},
+            });
+          });
+          added.push({ ticket: dep.ticketNumber, dependsOn: dep.dependsOnNumber });
+        } catch (err) {
+          failed.push({
+            ticket: dep.ticketNumber,
+            dependsOn: dep.dependsOnNumber,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      console.log(`✅ [tRPC addTicketDependencies] Done: ${added.length} added, ${failed.length} failed`);
+
+      return { added, failed, totalAdded: added.length, totalFailed: failed.length };
+    }),
+
+  // Remove one dependency edge, by ticket number. Symmetric undo for
+  // addTicketDependencies; deleting a non-existent edge is a no-op success.
+  removeTicketDependency: protectedProcedure
+    .input(
+      z.object({
+        productId: z.string(),
+        ticketNumber: z.number().int().positive(),
+        dependsOnNumber: z.number().int().positive(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      await loadProductWithAccess(ctx.db, userId, input.productId);
+
+      const [ticket, dependsOn] = await Promise.all([
+        ctx.db.ticket.findUnique({
+          where: { productId_number: { productId: input.productId, number: input.ticketNumber } },
+          select: { id: true },
+        }),
+        ctx.db.ticket.findUnique({
+          where: { productId_number: { productId: input.productId, number: input.dependsOnNumber } },
+          select: { id: true },
+        }),
+      ]);
+      if (!ticket || !dependsOn) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Ticket not found in this product" });
+      }
+
+      const result = await ctx.db.ticketDependency.deleteMany({
+        where: { ticketId: ticket.id, dependsOnId: dependsOn.id },
+      });
+      return { removed: result.count > 0 };
     }),
 });
 


### PR DESCRIPTION
### **User description**
## Why

The AI assistant could *create* tickets but never *read* them. Asking "look at the tickets in cycle 10 — could any have dependencies?" (while viewing a product's graph page) dead-ended in the agent asking the user to paste the tickets, because (a) there was no read tool and (b) the product page passed the agent only the workspace name + a raw URL string — no productId, no cycle.

Pairs with mastra PR `positonic/mastra#agent-ticket-read-tools` (the tool definitions). **Both must deploy together.** No DB migration — `TicketDependency` already exists.

## What

**Agent-facing endpoints (`mastra` router):**
- `listTickets` — a product's tickets scoped by cycle/status/type, **with dependency edges** (`dependsOn`/`requiredFor`) and an `isBlocked` flag. Resolves a human cycle ref ("Cycle 10" / "cycle-10" / "10") server-side; returns `availableCycles` when it can't so the agent self-corrects. Emits `totalCount` for honest truncation.
- `listCycles` — cycles with status/dates/goal/count; a **pure read** (never auto-creates cycles, unlike the UI's `cycle.list`).
- `addTicketDependencies` / `removeTicketDependency` — link tickets by number, reusing the UI's self-link + cycle-safety guards.
- Reads declared as `.query()` per [ADR-0041](docs/adr/0041-agent-tools-post-trpc-method-override.md).

**Shared service + tests:**
- Extracted `wouldCreateCycle` out of the product plugin router into `services/ticketDependencies.ts` so UI and agent paths enforce identical rules, plus a pure `matchCycle` resolver with **10 unit tests**.

**Page context:**
- Product layout now registers real `product` page context (productId, name, active tab); the workspace registrar yields on product routes so it no longer clobbers it. `ManyChat` formats it into an instruction to call `list-tickets` with the productId it already has.

## Testing
- `tsc --noEmit`: 0 errors repo-wide
- ESLint: clean on changed files
- `vitest run src/plugins/product`: 118 pass; new `matchCycle` suite: 10 pass


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add agent-facing tRPC endpoints: `listTickets`, `listCycles`, `addTicketDependencies`, `removeTicketDependency`

- Extract `wouldCreateCycle` into shared service; add pure `matchCycle` helper with 10 unit tests

- Product layout now registers structured page context (productId, tab) for the AI assistant

- Workspace layout yields on product routes to prevent context clobbering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Product Layout"] -- "registers productId + tab" --> B["useRegisterPageContext"]
  C["Workspace Layout"] -- "yields on /products/ routes" --> B
  B -- "formats context" --> D["ManyChat formatter"]
  D -- "instructs agent" --> E["AI Assistant"]
  E -- "calls" --> F["mastra tRPC router"]
  F -- "listTickets / listCycles" --> G["DB (tickets, cycles)"]
  F -- "addTicketDependencies / removeTicketDependency" --> H["ticketDependencies service"]
  H -- "wouldCreateCycle + matchCycle" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>layout.tsx</strong><dd><code>Yield workspace context registration on product routes</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/362/files#diff-105716c238cff80d796e369628fa34fff3a43a1770fefda42b5c6a2f516c895d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>layout.tsx</strong><dd><code>Register structured product page context for AI assistant</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/362/files#diff-e4b549b8684af1c44327f01d54fdb07cb6227e22f9b734f7cf17e8f3526dbd8f">+31/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ManyChat.tsx</strong><dd><code>Format product page context into agent instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/362/files#diff-6f0e68ce865b0629e85c68dbd985a102db9f321cea87620c205f1863eece6ed4">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ticket.ts</strong><dd><code>Replace inline wouldCreateCycle with shared service import</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/362/files#diff-2c667429b802690451b0f2771795cba4b39b00fb9a8b2cca853b1f95497032c5">+2/-29</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ticketDependencies.ts</strong><dd><code>New shared service: wouldCreateCycle and matchCycle helpers</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/362/files#diff-1d7a305f67db85b91f3ad332698631bc7d3929a2805004c9ea5ec43a1853f20d">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mastra.ts</strong><dd><code>Add listTickets, listCycles, addTicketDependencies, </code><br><code>removeTicketDependency endpoints</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/362/files#diff-afd76ed5d04839b106766464d541d99c9b1d0e8b28477ea826c7dcf52db960bb">+285/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ticketDependencies.test.ts</strong><dd><code>Unit tests for matchCycle with 10 edge-case scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/362/files#diff-33f68c69732b07acb25823ea1e7c8c515dd889b80dbd27c573d805957501eeef">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

