### PR TITLE
feat(tickets): wire up the Filter button on the tickets backlog

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
@@ -396,15 +396,19 @@ export default function TicketsBacklogPage() {
         setEntity(savedPrefs.entity);
       }
       if (savedPrefs.filters && typeof savedPrefs.filters === "object") {
+        // Saved prefs are untrusted JSON — guard each facet is actually an
+        // array. Stale values (e.g. a deleted epic id) are harmless: they
+        // simply match no tickets and aren't offered in facetOptions.
         const f = savedPrefs.filters as Partial<TicketFilters>;
+        const arr = (v: unknown): string[] => (Array.isArray(v) ? (v as string[]) : []);
         setFilters({
-          status: f.status ?? [],
-          priority: f.priority ?? [],
-          type: f.type ?? [],
-          assignee: f.assignee ?? [],
-          epic: f.epic ?? [],
-          cycle: f.cycle ?? [],
-          labels: f.labels ?? [],
+          status: arr(f.status),
+          priority: arr(f.priority),
+          type: arr(f.type),
+          assignee: arr(f.assignee),
+          epic: arr(f.epic),
+          cycle: arr(f.cycle),
+          labels: arr(f.labels),
         });
       }
       setPrefsLoaded(true);
@@ -1096,7 +1100,13 @@ export default function TicketsBacklogPage() {
         )
       ) : tickets && tickets.length > 0 ? (
         <Text size="sm" className="text-text-muted py-8 text-center">
-          No tickets match your {activeFilterCount > 0 ? "filters" : "search"}.
+          No tickets match your{" "}
+          {activeFilterCount > 0 && search.trim()
+            ? "filters and search"
+            : activeFilterCount > 0
+              ? "filters"
+              : "search"}
+          .
         </Text>
       ) : (
         <EmptyState

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
@@ -75,6 +75,40 @@ const TYPE_COLORS: Record<string, string> = {
   BUG: "red", FEATURE: "blue", CHORE: "gray", IMPROVEMENT: "teal", SPIKE: "violet", RESEARCH: "yellow",
 };
 
+// ---------------------------------------------------------------------------
+// Filters
+// ---------------------------------------------------------------------------
+
+type FilterKey = "status" | "priority" | "type" | "assignee" | "epic" | "cycle" | "labels";
+
+interface TicketFilters {
+  status: string[];
+  priority: string[];
+  type: string[];
+  assignee: string[];
+  epic: string[];
+  cycle: string[];
+  labels: string[];
+}
+
+// Arrays are never mutated in place (all updates spread), so a shared empty
+// reference is safe to use as the default / cleared state.
+const EMPTY_FILTERS: TicketFilters = {
+  status: [], priority: [], type: [], assignee: [], epic: [], cycle: [], labels: [],
+};
+
+const FILTER_FACET_META: Array<{ key: FilterKey; label: string }> = [
+  { key: "status", label: "Status" },
+  { key: "priority", label: "Priority" },
+  { key: "type", label: "Type" },
+  { key: "assignee", label: "DRI" },
+  { key: "epic", label: "Epic" },
+  { key: "cycle", label: "Cycle" },
+  { key: "labels", label: "Labels" },
+];
+
+type FacetOptions = Record<FilterKey, Array<{ value: string; label: string }>>;
+
 
 // ---------------------------------------------------------------------------
 // Sort
@@ -220,6 +254,93 @@ function StatusCell({ status, onUpdate }: { status: string; onUpdate: (s: Ticket
 }
 
 // ---------------------------------------------------------------------------
+// Filter popover
+// ---------------------------------------------------------------------------
+
+function FilterPopover({ facetOptions, filters, activeCount, onToggle, onClear }: {
+  facetOptions: FacetOptions;
+  filters: TicketFilters;
+  activeCount: number;
+  onToggle: (key: FilterKey, value: string) => void;
+  onClear: () => void;
+}) {
+  return (
+    <Popover position="bottom-end" withinPortal shadow="md">
+      <Popover.Target>
+        <Tooltip label="Filter" position="bottom">
+          <ActionIcon
+            variant="subtle"
+            size="sm"
+            className="text-text-muted hover:text-text-primary rounded-none"
+            style={{ height: 30, width: 30, position: "relative" }}
+            aria-label="Filter tickets"
+          >
+            <IconFilter size={15} />
+            {activeCount > 0 && (
+              <span className="absolute -top-0.5 -right-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-brand-primary px-1 text-[9px] font-semibold text-white">
+                {activeCount}
+              </span>
+            )}
+          </ActionIcon>
+        </Tooltip>
+      </Popover.Target>
+      <Popover.Dropdown
+        styles={{
+          dropdown: {
+            backgroundColor: "var(--color-bg-elevated)",
+            border: "1px solid var(--color-border-primary)",
+            minWidth: 240,
+            maxWidth: 280,
+            maxHeight: 440,
+            overflowY: "auto",
+          },
+        }}
+      >
+        <div className="flex items-center justify-between mb-2">
+          <Text size="xs" fw={600} className="text-text-primary">Filter</Text>
+          {activeCount > 0 && (
+            <UnstyledButton onClick={onClear} className="text-[10px] text-text-muted hover:text-text-primary">
+              Clear all
+            </UnstyledButton>
+          )}
+        </div>
+        <Stack gap="sm">
+          {FILTER_FACET_META.map((facet) => {
+            const opts = facetOptions[facet.key];
+            if (opts.length === 0) return null;
+            const sel = filters[facet.key];
+            return (
+              <div key={facet.key}>
+                <Text size="xs" className="text-text-muted mb-1.5">{facet.label}</Text>
+                <div className="flex flex-wrap gap-1">
+                  {opts.map((o) => {
+                    const on = sel.includes(o.value);
+                    return (
+                      <button
+                        key={o.value}
+                        type="button"
+                        onClick={() => onToggle(facet.key, o.value)}
+                        className={`rounded-full px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                          on
+                            ? "bg-brand-primary text-white"
+                            : "bg-surface-hover text-text-muted hover:text-text-primary"
+                        }`}
+                      >
+                        {o.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </Stack>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
@@ -237,6 +358,7 @@ export default function TicketsBacklogPage() {
   const [view, setView] = useState("table");
   const [entity, setEntity] = useState<"tickets" | "epics">("tickets");
   const [groupBy, setGroupBy] = useState<GroupByField>("none");
+  const [filters, setFilters] = useState<TicketFilters>(EMPTY_FILTERS);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [visibleColumns, setVisibleColumns] = useState<Set<string>>(
     new Set(["id", "status", "title", "priority", "dri", "type", "labels", "epic", "cycle"]),
@@ -258,7 +380,7 @@ export default function TicketsBacklogPage() {
     if (!workspaceId) return;
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(() => {
-      saveMutateRef.current({ productSlug, workspaceId, prefs: prefs as { view?: string; groupBy?: string; sortField?: string; sortDir?: string; visibleColumns?: string[]; entity?: "tickets" | "epics" } });
+      saveMutateRef.current({ productSlug, workspaceId, prefs: prefs as { view?: string; groupBy?: string; sortField?: string; sortDir?: string; visibleColumns?: string[]; entity?: "tickets" | "epics"; filters?: TicketFilters } });
     }, 500);
   }, [workspaceId, productSlug]);
 
@@ -272,6 +394,18 @@ export default function TicketsBacklogPage() {
       if (savedPrefs.visibleColumns) setVisibleColumns(new Set(savedPrefs.visibleColumns as string[]));
       if (savedPrefs.entity === "epics" || savedPrefs.entity === "tickets") {
         setEntity(savedPrefs.entity);
+      }
+      if (savedPrefs.filters && typeof savedPrefs.filters === "object") {
+        const f = savedPrefs.filters as Partial<TicketFilters>;
+        setFilters({
+          status: f.status ?? [],
+          priority: f.priority ?? [],
+          type: f.type ?? [],
+          assignee: f.assignee ?? [],
+          epic: f.epic ?? [],
+          cycle: f.cycle ?? [],
+          labels: f.labels ?? [],
+        });
       }
       setPrefsLoaded(true);
     }
@@ -361,18 +495,89 @@ export default function TicketsBacklogPage() {
     updateTicket.mutate({ id: ticketId, status: newStatus });
   };
 
+  // ── Filters ──
+  // Facet options are derived from the loaded tickets, so only values actually
+  // present in the product are offered. "none" is a synthetic value for the
+  // unset bucket (no priority / unassigned / no epic / no cycle).
+  const facetOptions = useMemo<FacetOptions>(() => {
+    const status = new Map<string, string>();
+    const priority = new Map<string, string>();
+    const type = new Map<string, string>();
+    const assignee = new Map<string, string>();
+    const epic = new Map<string, string>();
+    const cycle = new Map<string, string>();
+    const labels = new Map<string, string>();
+
+    for (const t of tickets ?? []) {
+      status.set(t.status, STATUS_LABELS[t.status] ?? t.status);
+      const pKey = t.priority == null ? "none" : String(t.priority);
+      priority.set(pKey, t.priority == null ? "No priority" : (PRIORITY_LABELS[t.priority] ?? pKey));
+      type.set(t.type, t.type.toLowerCase());
+      assignee.set(t.assignee?.id ?? "none", t.assignee?.name ?? "Unassigned");
+      epic.set(t.epic?.id ?? "none", t.epic?.name ?? "No epic");
+      cycle.set(t.cycle?.id ?? "none", t.cycle?.name ?? "No cycle");
+      for (const x of t.tags ?? []) labels.set(x.tag.id, x.tag.name);
+    }
+
+    const toOpts = (m: Map<string, string>) =>
+      Array.from(m, ([value, label]) => ({ value, label }));
+    // "none" always sorts last; other values alphabetical by label.
+    const alpha = (m: Map<string, string>) =>
+      toOpts(m).sort((a, b) =>
+        a.value === "none" ? 1 : b.value === "none" ? -1 : a.label.localeCompare(b.label, undefined, { sensitivity: "base" }),
+      );
+
+    return {
+      status: toOpts(status).sort((a, b) => (STATUS_ORDER[a.value] ?? 99) - (STATUS_ORDER[b.value] ?? 99)),
+      priority: toOpts(priority).sort(
+        (a, b) => (a.value === "none" ? 99 : Number(a.value)) - (b.value === "none" ? 99 : Number(b.value)),
+      ),
+      type: alpha(type),
+      assignee: alpha(assignee),
+      epic: alpha(epic),
+      cycle: alpha(cycle),
+      labels: alpha(labels),
+    };
+  }, [tickets]);
+
+  const activeFilterCount = FILTER_FACET_META.reduce((n, f) => n + filters[f.key].length, 0);
+
+  const toggleFilter = (key: FilterKey, value: string) => {
+    setFilters((prev) => {
+      const cur = prev[key];
+      const next = cur.includes(value) ? cur.filter((v) => v !== value) : [...cur, value];
+      const updated = { ...prev, [key]: next };
+      debouncedSave({ filters: updated });
+      return updated;
+    });
+  };
+
+  const clearFilters = () => {
+    setFilters(EMPTY_FILTERS);
+    debouncedSave({ filters: EMPTY_FILTERS });
+  };
+
   // Filter + sort
   const sorted = useMemo(() => {
     if (!tickets) return [];
     const q = search.toLowerCase().trim();
-    const list = q
-      ? tickets.filter(
-          (t) =>
-            t.title.toLowerCase().includes(q) ||
-            t.type.toLowerCase().includes(q) ||
-            (t.assignee?.name ?? "").toLowerCase().includes(q),
-        )
-      : [...tickets];
+    const matchesFilters = (t: (typeof tickets)[number]) => {
+      if (filters.status.length && !filters.status.includes(t.status)) return false;
+      if (filters.priority.length && !filters.priority.includes(t.priority == null ? "none" : String(t.priority))) return false;
+      if (filters.type.length && !filters.type.includes(t.type)) return false;
+      if (filters.assignee.length && !filters.assignee.includes(t.assignee?.id ?? "none")) return false;
+      if (filters.epic.length && !filters.epic.includes(t.epic?.id ?? "none")) return false;
+      if (filters.cycle.length && !filters.cycle.includes(t.cycle?.id ?? "none")) return false;
+      if (filters.labels.length && !(t.tags ?? []).some((x) => filters.labels.includes(x.tag.id))) return false;
+      return true;
+    };
+    const matchesSearch = (t: (typeof tickets)[number]) =>
+      !q ||
+      t.title.toLowerCase().includes(q) ||
+      t.type.toLowerCase().includes(q) ||
+      (t.assignee?.name ?? "").toLowerCase().includes(q);
+
+    const list = tickets.filter((t) => matchesFilters(t) && matchesSearch(t));
     list.sort((a, b) =>
       cmp(
         sortValue(a as unknown as Record<string, unknown>, sortField),
@@ -381,7 +586,7 @@ export default function TicketsBacklogPage() {
       ),
     );
     return list;
-  }, [tickets, search, sortField, sortDir]);
+  }, [tickets, search, sortField, sortDir, filters]);
 
   // Split completed tickets from active
   const { active: activeTickets, completed: completedTickets } = useMemo(() => {
@@ -639,11 +844,13 @@ export default function TicketsBacklogPage() {
         />
 
         <div className="flex items-center border border-border-primary rounded-md overflow-hidden">
-          <Tooltip label="Filter" position="bottom">
-            <ActionIcon variant="subtle" size="sm" className="text-text-muted hover:text-text-primary rounded-none" style={{ height: 30, width: 30 }}>
-              <IconFilter size={15} />
-            </ActionIcon>
-          </Tooltip>
+          <FilterPopover
+            facetOptions={facetOptions}
+            filters={filters}
+            activeCount={activeFilterCount}
+            onToggle={toggleFilter}
+            onClear={clearFilters}
+          />
           <div className="w-px h-4 bg-border-primary" />
           <Popover position="bottom-end" withinPortal shadow="md">
             <Popover.Target>
@@ -889,7 +1096,7 @@ export default function TicketsBacklogPage() {
         )
       ) : tickets && tickets.length > 0 ? (
         <Text size="sm" className="text-text-muted py-8 text-center">
-          No tickets match your search.
+          No tickets match your {activeFilterCount > 0 ? "filters" : "search"}.
         </Text>
       ) : (
         <EmptyState

--- a/src/plugins/product/server/routers/product.ts
+++ b/src/plugins/product/server/routers/product.ts
@@ -447,6 +447,17 @@ export const productRouter = createTRPCRouter({
         sortDir: z.string().optional(),
         visibleColumns: z.array(z.string()).optional(),
         entity: z.enum(["tickets", "epics"]).optional(),
+        filters: z
+          .object({
+            status: z.array(z.string()).optional(),
+            priority: z.array(z.string()).optional(),
+            type: z.array(z.string()).optional(),
+            assignee: z.array(z.string()).optional(),
+            epic: z.array(z.string()).optional(),
+            cycle: z.array(z.string()).optional(),
+            labels: z.array(z.string()).optional(),
+          })
+          .optional(),
       }),
     }))
     .mutation(async ({ ctx, input }) => {

--- a/src/plugins/product/server/routers/product.ts
+++ b/src/plugins/product/server/routers/product.ts
@@ -448,14 +448,17 @@ export const productRouter = createTRPCRouter({
         visibleColumns: z.array(z.string()).optional(),
         entity: z.enum(["tickets", "epics"]).optional(),
         filters: z
+          // Bounded so a buggy/malicious client can't bloat the persisted
+          // settings JSON. Facet values are ids/enums, so these caps sit far
+          // above any realistic selection.
           .object({
-            status: z.array(z.string()).optional(),
-            priority: z.array(z.string()).optional(),
-            type: z.array(z.string()).optional(),
-            assignee: z.array(z.string()).optional(),
-            epic: z.array(z.string()).optional(),
-            cycle: z.array(z.string()).optional(),
-            labels: z.array(z.string()).optional(),
+            status: z.array(z.string().max(200)).max(200).optional(),
+            priority: z.array(z.string().max(200)).max(200).optional(),
+            type: z.array(z.string().max(200)).max(200).optional(),
+            assignee: z.array(z.string().max(200)).max(200).optional(),
+            epic: z.array(z.string().max(200)).max(200).optional(),
+            cycle: z.array(z.string().max(200)).max(200).optional(),
+            labels: z.array(z.string().max(200)).max(200).optional(),
           })
           .optional(),
       }),


### PR DESCRIPTION
### **User description**
## Problem

On the product **Tickets** backlog page, the funnel (Filter) icon in the toolbar was rendered but never wired to anything — clicking it did nothing. The only working filtering was the Search box.

Reported on `.../products/<product>/tickets`.

## Change

- **Working filter popover** on the funnel icon, with facets for **Status, Priority, Type, DRI, Epic, Cycle, and Labels**.
- Facet options are **derived from the loaded tickets**, so only values present in the product are offered. Unset buckets are surfaced as a synthetic `none` option (No priority / Unassigned / No epic / No cycle).
- Filters **combine with** the existing search box and sort. An active-count badge appears on the funnel icon; a **Clear all** resets them.
- Selections **persist per-product** via the existing `saveViewPrefs` prefs blob — the prefs schema is widened with an optional `filters` object, matching how `view`/`groupBy`/`visibleColumns` are already saved.

All filtering is client-side over the already-loaded ticket list; no new queries.

## Notes

- No DB/schema migration — `filters` lives inside the existing `PluginConfig.settings` JSON.
- Styling uses existing semantic tokens (no hardcoded colors).

## Test plan

- [ ] Open the tickets page; click the funnel — popover opens with facets.
- [ ] Toggle facets; list narrows; badge count updates; combines with Search.
- [ ] Reload — selected filters restore from saved prefs.
- [ ] Clear all resets the list.


___

### **PR Type**
Enhancement


___

### **Description**
- Wire up Filter button on tickets backlog with a working popover

- Add faceted filtering for status, priority, type, DRI, epic, cycle, and labels

- Persist filter selections per-product via existing `saveViewPrefs` prefs blob

- Harden prefs restore with `Array.isArray` guards and bound server-side schema


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Toolbar Filter Icon"] -- "replaced with" --> B["FilterPopover component"]
  B -- "derives options from" --> C["loaded tickets (facetOptions)"]
  B -- "toggleFilter / clearFilters" --> D["filters state (TicketFilters)"]
  D -- "combined with search+sort" --> E["sorted ticket list"]
  D -- "debouncedSave" --> F["saveViewPrefs prefs blob"]
  F -- "validated by" --> G["Zod schema (bounded arrays)"]
  F -- "restored on load" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Wire up functional filter popover with facets and persistence</code></dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx

<ul><li>Defines <code>TicketFilters</code> type, <code>EMPTY_FILTERS</code> constant, and <br><code>FILTER_FACET_META</code> metadata for seven filter facets<br> <li> Adds <code>FilterPopover</code> component rendering a Mantine <code>Popover</code> with <br>pill-style toggle buttons and an active-count badge<br> <li> Adds <code>filters</code> state, <code>facetOptions</code> memo (derived from loaded tickets), <br><code>toggleFilter</code>, and <code>clearFilters</code> handlers<br> <li> Replaces the inert <code>ActionIcon</code> filter button with the new <code>FilterPopover</code> <br>and updates the empty-state message to reflect active filters and/or <br>search<br> <li> Restores persisted filters from <code>savedPrefs</code> with <code>Array.isArray</code> guards; <br>includes <code>filters</code> in <code>debouncedSave</code> calls</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/363/files#diff-69941eb4af92853c12847ec637d5a3d8e18c01c445e6f9cea9242888c995d2d5">+233/-16</a></td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>product.ts</strong><dd><code>Add bounded filters schema to saveViewPrefs endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/routers/product.ts

<ul><li>Extends the <code>saveViewPrefs</code> Zod input schema with an optional <code>filters</code> <br>object<br> <li> Each facet array is bounded to max 200 items with each string max 200 <br>chars to prevent settings blob bloat</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/363/files#diff-42fdfc371bf516482c4f54d564895e47783af20d863576815fd83cbe77796891">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

