### PR TITLE
feat(cycles): back-to-cycles nav + cycle-name favourite label

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/__tests__/favoriteTarget.test.ts
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/__tests__/favoriteTarget.test.ts
@@ -49,6 +49,30 @@ describe("buildProductFavoriteTarget", () => {
     });
   });
 
+  test("detailLabel overrides the tab label on a detail route, keeping path + icon", () => {
+    expect(
+      buildProductFavoriteTarget({
+        ...common,
+        pathname: "/w/clear/products/acme/cycles/xyz789",
+        detailLabel: "Cycle 10",
+      }),
+    ).toEqual({
+      entityId: "products/acme/cycles/xyz789",
+      label: "Cycle 10",
+      icon: "cycles",
+    });
+  });
+
+  test("blank detailLabel falls back to the tab label", () => {
+    expect(
+      buildProductFavoriteTarget({
+        ...common,
+        pathname: "/w/clear/products/acme/cycles/xyz789",
+        detailLabel: "   ",
+      }).label,
+    ).toBe("Acme · Cycles");
+  });
+
   test("strips the workspace prefix to a workspace-relative entityId", () => {
     const { entityId } = buildProductFavoriteTarget({
       ...common,

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx
@@ -159,18 +159,24 @@ export default function CycleDetailPage() {
     .filter((t) => t.status === "DONE")
     .reduce((sum, t) => sum + (t.points ?? 0), 0);
 
-  const backPath = `/w/${workspace?.slug}/products/${productSlug}/cycles`;
+  // Only render the back link once the workspace has resolved — otherwise the
+  // slug is undefined and the href becomes "/w/undefined/…" (a broken link).
+  const backPath = workspace
+    ? `/w/${workspace.slug}/products/${productSlug}/cycles`
+    : null;
 
   return (
     <Stack gap="lg">
       {/* Back nav */}
-      <Link
-        href={backPath}
-        className="inline-flex items-center gap-1.5 text-xs text-text-muted hover:text-text-primary transition-colors"
-      >
-        <IconArrowLeft size={14} />
-        Cycles
-      </Link>
+      {backPath && (
+        <Link
+          href={backPath}
+          className="inline-flex items-center gap-1.5 text-xs text-text-muted hover:text-text-primary transition-colors"
+        >
+          <IconArrowLeft size={14} />
+          Cycles
+        </Link>
+      )}
 
       <Group justify="space-between" align="flex-start">
         {isEditingHeader ? (

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import {
   Badge,
@@ -14,6 +15,7 @@ import {
   Textarea,
   Title,
 } from "@mantine/core";
+import { IconArrowLeft } from "@tabler/icons-react";
 import { modals } from "@mantine/modals";
 import { api } from "~/trpc/react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
@@ -113,8 +115,19 @@ export default function CycleDetailPage() {
     .filter((t) => t.status === "DONE")
     .reduce((sum, t) => sum + (t.points ?? 0), 0);
 
+  const backPath = `/w/${workspace?.slug}/products/${productSlug}/cycles`;
+
   return (
     <Stack gap="lg">
+      {/* Back nav */}
+      <Link
+        href={backPath}
+        className="inline-flex items-center gap-1.5 text-xs text-text-muted hover:text-text-primary transition-colors"
+      >
+        <IconArrowLeft size={14} />
+        Cycles
+      </Link>
+
       <Group justify="space-between" align="flex-start">
         <div>
           <Title order={2} className="text-text-primary">

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/favoriteTarget.ts
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/favoriteTarget.ts
@@ -46,8 +46,15 @@ export function buildProductFavoriteTarget(args: {
   workspaceSlug: string;
   productSlug: string;
   productName: string;
+  /**
+   * Optional label for a specific detail route (e.g. a cycle's name). When
+   * provided it wins over the tab-level label, so favouriting "Cycle 10"
+   * snapshots "Cycle 10" rather than the generic "<Product> · Cycles".
+   */
+  detailLabel?: string | null;
 }): ProductFavoriteTarget {
-  const { pathname, workspaceSlug, productSlug, productName } = args;
+  const { pathname, workspaceSlug, productSlug, productName, detailLabel } =
+    args;
 
   // Workspace-relative path (strip the /w/<slug>/ prefix).
   const wsPrefix = `/w/${workspaceSlug}/`;
@@ -64,7 +71,8 @@ export function buildProductFavoriteTarget(args: {
 
   const tab =
     PRODUCT_TABS.find((t) => t.segment === segment) ?? PRODUCT_TABS[0]!;
-  const label = tab.label ? `${productName} · ${tab.label}` : productName;
+  const tabLabel = tab.label ? `${productName} · ${tab.label}` : productName;
+  const label = detailLabel?.trim() ? detailLabel.trim() : tabLabel;
 
   return { entityId, label, icon: tab.icon };
 }

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
@@ -62,6 +62,16 @@ export default function ProductLayout({
     { enabled: !!workspaceId && !!productSlug },
   );
 
+  // On a cycle detail route the URL exposes a `cycleId`; fetch it so the
+  // favourite snapshots the cycle's own name (e.g. "Cycle 10") instead of the
+  // generic "<Product> · Cycles" tab label. React Query dedupes this with the
+  // cycle detail page's identical getById call, so it's not an extra request.
+  const cycleId = params.cycleId as string | undefined;
+  const { data: cycleForFavorite } = api.product.cycle.getById.useQuery(
+    { id: cycleId ?? "" },
+    { enabled: !!cycleId },
+  );
+
   // Warm every sibling tab's route (RSC payload + JS chunk) as soon as a
   // product page mounts, so the first click on any tab is instant instead of
   // paying the cold route-fetch cost. Mirrors what Next <Link> prefetch does
@@ -174,6 +184,7 @@ export default function ProductLayout({
                   workspaceSlug: workspace.slug,
                   productSlug,
                   productName: product.name,
+                  detailLabel: cycleForFavorite?.name,
                 })}
                 workspaceId={workspaceId}
                 size="lg"

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
@@ -68,11 +68,22 @@ export default function ProductLayout({
     { enabled: !!workspaceId && !!productSlug },
   );
 
-  // On a cycle detail route the URL exposes a `cycleId`; fetch it so the
-  // favourite snapshots the cycle's own name (e.g. "Cycle 10") instead of the
-  // generic "<Product> · Cycles" tab label. React Query dedupes this with the
-  // cycle detail page's identical getById call, so it's not an extra request.
-  const cycleId = params.cycleId as string | undefined;
+  // On a cycle detail route (…/cycles/<id>) fetch that cycle so the favourite
+  // snapshots the cycle's own name (e.g. "Cycle 10") instead of the generic
+  // "<Product> · Cycles" tab label. Derive the id from the pathname rather than
+  // params — this layout owns the `[productSlug]` segment, so `params` does not
+  // reliably expose the deeper `[cycleId]` segment. Excludes the "/cycles/new"
+  // create route. React Query dedupes this with the cycle detail page's own
+  // getById call, so it's not an extra request; when navigating to any other
+  // tab the id resolves to undefined and the label falls back to the tab label.
+  const cyclesPrefix = `/products/${productSlug}/cycles/`;
+  const cyclesIdx = pathname.indexOf(cyclesPrefix);
+  const cycleSegment =
+    cyclesIdx === -1
+      ? undefined
+      : pathname.slice(cyclesIdx + cyclesPrefix.length).split("/")[0];
+  const cycleId =
+    cycleSegment && cycleSegment !== "new" ? cycleSegment : undefined;
   const { data: cycleForFavorite } = api.product.cycle.getById.useQuery(
     { id: cycleId ?? "" },
     { enabled: !!cycleId },


### PR DESCRIPTION
### **User description**
## What

Two UX fixes on the product **Cycle detail** page (`/w/<ws>/products/<product>/cycles/<cycleId>`):

1. **Back-to-cycles navigation.** Previously there was no way back to the Cycles listing from a cycle detail page — you had to refresh. Added a `← Cycles` back link, matching the existing Features detail page pattern (same `IconArrowLeft` + muted-text styling).

2. **Favourite label uses the cycle name.** Favouriting/bookmarking a specific cycle snapshotted the generic tab label (`Clear · Cycles`) instead of the cycle's own name. Now it snapshots e.g. **"Cycle 10"**.

## How

- `buildProductFavoriteTarget` gains an optional `detailLabel` that wins over the tab-level label (falls back to the tab label when blank/absent), so existing behaviour for tabs and other detail routes is unchanged.
- The shared product layout reads `cycleId` from the current route via `useParams()` and fetches the cycle on a cycle detail route, passing its name as `detailLabel`. The `getById` call is deduped by React Query with the detail page's own query, so it's not an extra request.

## Tests

- Added unit tests for `detailLabel` (override + blank-fallback) in `favoriteTarget.test.ts`. Full unit suite + lint + typecheck green.

## Notes

The entityId (favourite path) is still the full cycle URL, so the bookmark links to the specific cycle — only the label changed.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add "← Cycles" back navigation link on cycle detail pages

- Fix favourite label to use cycle name instead of generic tab label

- `buildProductFavoriteTarget` gains optional `detailLabel` parameter

- Add unit tests for `detailLabel` override and blank-fallback behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cycle Detail Page"]
  B["ProductLayout"]
  C["buildProductFavoriteTarget"]
  D["FavoriteButton"]
  E["Back Link (← Cycles)"]

  A -- "renders" --> E
  B -- "derives cycleId from pathname" --> F["api.cycle.getById"]
  F -- "cycleForFavorite.name" --> C
  C -- "detailLabel overrides tab label" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add back-to-cycles navigation link on cycle detail page</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx

<ul><li>Import <code>Link</code> from Next.js and <code>IconArrowLeft</code> from tabler icons<br> <li> Compute <code>backPath</code> only when workspace is resolved to avoid broken <br><code>/w/undefined/…</code> href<br> <li> Render a "← Cycles" back navigation link at the top of the cycle <br>detail page</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/364/files#diff-f04f2dca8cdb906f9cf22ec215d1dd0531a9791e6726fab6ea8b2a90e726210f">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>favoriteTarget.ts</strong><dd><code>Support detailLabel override in buildProductFavoriteTarget</code></dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/favoriteTarget.ts

<ul><li>Add optional <code>detailLabel</code> parameter to <code>buildProductFavoriteTarget</code><br> <li> Use <code>detailLabel</code> (trimmed) over the tab-level label when non-blank<br> <li> Fall back to tab label when <code>detailLabel</code> is absent or whitespace-only</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/364/files#diff-8820e6c4e2807967e23c3626c791e1be499e4fb85416feee662de9449a3a202e">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Fetch cycle name in layout for accurate favourite label</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx

<ul><li>Derive <code>cycleId</code> from pathname (not params) to reliably detect cycle <br>detail routes<br> <li> Exclude <code>/cycles/new</code> route from cycle id detection<br> <li> Fetch cycle by id via React Query (deduped with detail page's own <br>query)<br> <li> Pass <code>cycleForFavorite?.name</code> as <code>detailLabel</code> to <br><code>buildProductFavoriteTarget</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/364/files#diff-e4b549b8684af1c44327f01d54fdb07cb6227e22f9b734f7cf17e8f3526dbd8f">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>favoriteTarget.test.ts</strong><dd><code>Add unit tests for detailLabel override behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/__tests__/favoriteTarget.test.ts

<ul><li>Add test verifying <code>detailLabel</code> overrides tab label while preserving <br>path and icon<br> <li> Add test verifying blank/whitespace <code>detailLabel</code> falls back to tab <br>label</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/364/files#diff-8920753da8137498af5d9a28ebc3b64933808ab561d1a9b949388560d2b3f2ff">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

