### PR TITLE
Disable Microsoft Entra ID sign-in

### DIFF
--- a/src/server/api/routers/auth.ts
+++ b/src/server/api/routers/auth.ts
@@ -2,6 +2,7 @@ import crypto from "crypto";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
+import { MICROSOFT_LOGIN_ENABLED } from "~/server/auth/config";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import { DEFAULT_EXPIRY, generateJWT } from "~/server/utils/jwt";
 import { verifyAuthCode, verifyPkce } from "~/server/utils/native-auth";
@@ -18,7 +19,7 @@ export const authRouter = createTRPCRouter({
    */
   getConfiguredProviders: publicProcedure.query(() => ({
     google: !!process.env.GOOGLE_CLIENT_ID,
-    microsoft: !!process.env.MICROSOFT_ENTRA_ID_CLIENT_ID,
+    microsoft: MICROSOFT_LOGIN_ENABLED && !!process.env.MICROSOFT_ENTRA_ID_CLIENT_ID,
     discord: !!process.env.AUTH_DISCORD_ID,
     postmark: !!(process.env.AUTH_POSTMARK_KEY ?? process.env.POSTMARK_SERVER_TOKEN),
   })),

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -10,6 +10,16 @@ import { db } from "~/server/db";
 import { sendMagicLinkEmail, sendWelcomeEmail, sendWelcomeWithMagicLinkEmail } from "~/server/services/EmailService";
 
 /**
+ * Kill switch for Microsoft Entra ID sign-in. Set to `false` to disable the
+ * "Sign in with Microsoft" option regardless of whether the
+ * `MICROSOFT_ENTRA_ID_*` env vars are configured. The provider code and env
+ * wiring are intentionally left in place so it can be re-enabled by flipping
+ * this back to `true`. Also consumed by the `auth` router
+ * (`getConfiguredProviders`) so the UI button stays in sync.
+ */
+export const MICROSOFT_LOGIN_ENABLED = false;
+
+/**
  * Auto-accept any pending workspace and team invitations matching this user's
  * email. Covers the case where an invitee signs up (or signs in) via a route
  * other than the invite accept page — e.g. OAuth, direct magic link, or a
@@ -151,7 +161,7 @@ export const authConfig = {
         },
       },
     }),
-    ...(process.env.MICROSOFT_ENTRA_ID_CLIENT_ID
+    ...(MICROSOFT_LOGIN_ENABLED && process.env.MICROSOFT_ENTRA_ID_CLIENT_ID
       ? [
           MicrosoftEntraID({
             clientId: process.env.MICROSOFT_ENTRA_ID_CLIENT_ID,


### PR DESCRIPTION
### **User description**
## What

Disables the "Sign in with Microsoft" option via a single kill-switch constant, `MICROSOFT_LOGIN_ENABLED = false`.

## Why

We want Microsoft login turned off. Keeping the provider code and env wiring in place (rather than deleting) makes it a one-line re-enable later.

## How

- `src/server/auth/config.ts` — new exported `MICROSOFT_LOGIN_ENABLED` flag; the NextAuth `MicrosoftEntraID` provider now only registers when the flag is `true` **and** `MICROSOFT_ENTRA_ID_CLIENT_ID` is set.
- `src/server/api/routers/auth.ts` — `getConfiguredProviders` imports the same flag, so the sign-in UI's `providers.microsoft` is `false` and the button disappears. Importing the shared constant keeps the button gate and provider gate from drifting.

With the flag off, `MICROSOFT_ENTRA_ID_CLIENT_ID` is ignored — no env changes needed. Re-enable by flipping the flag to `true`.

Does not touch the Microsoft **Calendar** integration (separate feature).


___

### **PR Type**
Enhancement


___

### **Description**
- Add `MICROSOFT_LOGIN_ENABLED` kill-switch constant (default `false`)

- Gate NextAuth provider registration behind the new flag

- Gate UI button visibility in `getConfiguredProviders` via same flag


___

### Diagram Walkthrough


```mermaid
flowchart LR
  flag["MICROSOFT_LOGIN_ENABLED = false"]
  config["auth/config.ts\n(NextAuth provider)"]
  router["auth.ts\n(getConfiguredProviders)"]
  ui["Sign-in UI\n(Microsoft button)"]

  flag -- "controls provider registration" --> config
  flag -- "controls button visibility" --> router
  router -- "microsoft: false" --> ui
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.ts</strong><dd><code>Add kill-switch constant to disable Microsoft provider</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/auth/config.ts

<ul><li>Adds exported <code>MICROSOFT_LOGIN_ENABLED</code> constant set to <code>false</code><br> <li> Adds JSDoc comment explaining the kill-switch purpose and re-enable <br>path<br> <li> Gates <code>MicrosoftEntraID</code> provider registration behind <br><code>MICROSOFT_LOGIN_ENABLED && env var</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/365/files#diff-0e2d0a0ece50e4e7afb5174dbcef88e68ad9bfe47d53450bede288ed13084cd7">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Gate Microsoft UI button behind shared kill-switch flag</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/auth.ts

<ul><li>Imports <code>MICROSOFT_LOGIN_ENABLED</code> from <code>auth/config.ts</code><br> <li> Updates <code>microsoft</code> field in <code>getConfiguredProviders</code> to also check the <br>flag</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/365/files#diff-6ffb7cb450b9b787a4681f1645f8beeb9288c49e07b7fb71bd809dbde4a59b03">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

