### PR TITLE
feat(agent): let the assistant link projects to Key Results

### DIFF
--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -4163,6 +4163,87 @@ export const mastraRouter = createTRPCRouter({
       return { success: true, goalId: input.goalId, projectId: input.projectId };
     }),
 
+  linkProjectToKeyResult: protectedProcedure
+    .input(z.object({
+      keyResultId: z.string(),
+      projectId: z.string(),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      // Authorize the KR by ownership OR workspace membership (mirrors okr.linkProject),
+      // so the assistant can link a KR shared within the caller's workspace.
+      const keyResult = await ctx.db.keyResult.findFirst({
+        where: { id: input.keyResultId },
+        select: { id: true, userId: true, workspaceId: true },
+      });
+      if (
+        !keyResult ||
+        (keyResult.userId !== userId &&
+          !(keyResult.workspaceId &&
+            (await getWorkspaceMembership(ctx.db, userId, keyResult.workspaceId))))
+      ) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Key result not found or access denied' });
+      }
+
+      // Verify the caller can edit the project being linked.
+      const projectAccess = await getProjectAccess(ctx.db, userId, input.projectId);
+      if (!canEditProject(projectAccess)) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: "You don't have permission to link this project" });
+      }
+
+      // Idempotent: no-op if the link already exists (unique keyResultId+projectId).
+      await ctx.db.keyResultProject.upsert({
+        where: {
+          keyResultId_projectId: {
+            keyResultId: input.keyResultId,
+            projectId: input.projectId,
+          },
+        },
+        create: {
+          keyResultId: input.keyResultId,
+          projectId: input.projectId,
+        },
+        update: {},
+      });
+
+      console.log(`🔗 [tRPC linkProjectToKeyResult] Linked project ${input.projectId} to key result ${input.keyResultId}`);
+      return { success: true, keyResultId: input.keyResultId, projectId: input.projectId };
+    }),
+
+  unlinkProjectFromKeyResult: protectedProcedure
+    .input(z.object({
+      keyResultId: z.string(),
+      projectId: z.string(),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const keyResult = await ctx.db.keyResult.findFirst({
+        where: { id: input.keyResultId },
+        select: { id: true, userId: true, workspaceId: true },
+      });
+      if (
+        !keyResult ||
+        (keyResult.userId !== userId &&
+          !(keyResult.workspaceId &&
+            (await getWorkspaceMembership(ctx.db, userId, keyResult.workspaceId))))
+      ) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Key result not found or access denied' });
+      }
+
+      await ctx.db.keyResultProject.deleteMany({
+        where: {
+          keyResultId: input.keyResultId,
+          projectId: input.projectId,
+        },
+      });
+
+      console.log(`🔗 [tRPC unlinkProjectFromKeyResult] Unlinked project ${input.projectId} from key result ${input.keyResultId}`);
+      return { success: true, keyResultId: input.keyResultId, projectId: input.projectId };
+    }),
+
+
   deleteProject: protectedProcedure
     .input(z.object({
       projectId: z.string(),


### PR DESCRIPTION
### **User description**
## Problem
When a user asked the assistant to link projects to Key Results, it couldn't — the only project-linking endpoint was `linkProjectToGoal` (Objective/`GoalProjects` level). But the OKR dashboard renders linked projects **under each Key Result** (the `KeyResultProject` join), so goal-level links never surfaced on the board. Users saw "nothing linked."

## Fix
Add `linkProjectToKeyResult` / `unlinkProjectFromKeyResult` mastra procedures that write to `KeyResultProject`, mirroring `linkProjectToGoal` with the same KR-ownership/workspace + project-edit authorization as `okr.linkProject`. Link is an idempotent upsert; unlink is a no-op when absent.

Paired with the mastra agent tools that call these endpoints (separate PR in the mastra repo).

## Verification
- `npx tsc --noEmit` clean
- Full unit suite (1338 tests) + prisma migration check + color check pass via pre-push hook


___

### **PR Type**
Enhancement


___

### **Description**
- Add `linkProjectToKeyResult` and `unlinkProjectFromKeyResult` tRPC procedures

- Enables assistant to link projects to Key Results (not just Objectives)

- Authorization mirrors `okr.linkProject` with KR ownership/workspace checks

- Link uses idempotent upsert; unlink is a no-op when absent


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Assistant Request"] -- "keyResultId + projectId" --> B["linkProjectToKeyResult"]
  A -- "keyResultId + projectId" --> C["unlinkProjectFromKeyResult"]
  B -- "authorize KR" --> D["getWorkspaceMembership"]
  B -- "authorize project" --> E["getProjectAccess / canEditProject"]
  B -- "idempotent upsert" --> F["KeyResultProject table"]
  C -- "authorize KR" --> D
  C -- "deleteMany" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mastra.ts</strong><dd><code>Add link/unlink project to Key Result tRPC procedures</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/mastra.ts

<ul><li>Added <code>linkProjectToKeyResult</code> protected mutation that authorizes via KR <br>ownership or workspace membership, verifies project edit access, and <br>performs an idempotent upsert into <code>KeyResultProject</code><br> <li> Added <code>unlinkProjectFromKeyResult</code> protected mutation with the same KR <br>authorization, performing a <code>deleteMany</code> (no-op if link absent)<br> <li> Both procedures return <code>{ success, keyResultId, projectId }</code> and log the <br>operation</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/366/files#diff-afd76ed5d04839b106766464d541d99c9b1d0e8b28477ea826c7dcf52db960bb">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

