### PR TITLE
fix(okr): make "My Goals" a strictly DRI-scoped view

### DIFF
--- a/src/plugins/okr/server/routers/__tests__/getByObjectiveDri.test.ts
+++ b/src/plugins/okr/server/routers/__tests__/getByObjectiveDri.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression guard for the "My Goals" (onlyMine) view of the okr router.
+ *
+ * It must be a strictly DRI-scoped view: an objective/KR the user merely
+ * created (its `userId`) must NOT surface — only ones where the user is the DRI
+ * (`driUserId`). See the filters in ../keyResult.ts (getByObjective).
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const USER_ID = "user-1";
+const WORKSPACE_ID = "ws-1";
+
+// Recursively collect every `driUserId` / `userId` scalar reference in a where
+// clause so we can assert on which ownership fields the query keys off.
+function collectFields(node: unknown, out: string[]): void {
+  if (Array.isArray(node)) {
+    node.forEach((n) => collectFields(n, out));
+    return;
+  }
+  if (node && typeof node === "object") {
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "userId" || key === "driUserId") out.push(key);
+      collectFields(value, out);
+    }
+  }
+}
+
+describe("okr.getByObjective — My Goals (onlyMine) DRI scoping", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+    // Grant workspace membership so the procedure passes its access check.
+    db.workspaceUser.findUnique.mockResolvedValue({
+      role: "member",
+      workspaceId: WORKSPACE_ID,
+    } as never);
+    db.goal.findMany.mockResolvedValue([]);
+  });
+
+  it("filters objectives by DRI (objective or any KR), never by owner", async () => {
+    const caller = createMockCaller({ userId: USER_ID, db });
+    await caller.okr.getByObjective({
+      workspaceId: WORKSPACE_ID,
+      period: "Annual-2026",
+      includePairedPeriod: false,
+      onlyMine: true,
+    });
+
+    expect(db.goal.findMany).toHaveBeenCalledTimes(1);
+    const arg = db.goal.findMany.mock.calls[0]![0]!;
+    const where = arg.where as Record<string, unknown>;
+
+    // The onlyMine ownership clause lives under AND. It must reference driUserId
+    // (objective DRI + KR DRI via keyResults.some) and must NOT reference the
+    // owner field `userId` — owning an objective is not enough to see it here.
+    const ownershipFields: string[] = [];
+    collectFields(where.AND, ownershipFields);
+    expect(ownershipFields).toContain("driUserId");
+    expect(ownershipFields).not.toContain("userId");
+
+    // The objective filter reaches its KRs' DRI via a `keyResults.some` clause.
+    const serialized = JSON.stringify(where.AND);
+    expect(serialized).toContain("keyResults");
+    expect(serialized).toContain("some");
+
+    // The included key results are scoped to the ones the user is DRI for.
+    const include = arg.include as { keyResults?: { where?: unknown } };
+    const krFields: string[] = [];
+    collectFields(include.keyResults?.where, krFields);
+    expect(krFields).toContain("driUserId");
+    expect(krFields).not.toContain("userId");
+  });
+});

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -210,12 +210,20 @@ export const keyResultRouter = createTRPCRouter({
           // Both onlyMine and the period filter use `OR`, so combine them under
           // `AND` to avoid the two `OR` keys overwriting each other.
           AND: [
+            // "My Goals" is strictly a DRI view: show an objective only when the
+            // user is the DRI on the objective itself OR the DRI on at least one
+            // of its key results. Being the creator/owner (`userId`) is NOT
+            // enough — that's what surfaced objectives the user merely created.
             ...(isWorkspaceScoped && input.onlyMine
               ? [
                   {
                     OR: [
-                      { userId: ctx.session.user.id },
                       { driUserId: ctx.session.user.id },
+                      {
+                        keyResults: {
+                          some: { driUserId: ctx.session.user.id },
+                        },
+                      },
                     ],
                   },
                 ]
@@ -234,13 +242,16 @@ export const keyResultRouter = createTRPCRouter({
           keyResults: {
             where: {
               ...periodFilter,
-              // Show every key result only on the workspace-wide OKRs view.
-              // On the "My Goals" view (onlyMine) and outside any workspace,
-              // restrict to key results the user owns or is the DRI for — the
-              // same ownership test applied to goals above. Without this, a
-              // user's own objective would still surface other people's KRs.
-              ...(isWorkspaceScoped && !input.onlyMine
-                ? {}
+              // Workspace-wide OKRs view: show every key result.
+              // "My Goals" view (onlyMine): show only key results the user is the
+              // DRI for — being the creator/owner is not enough, matching the
+              // DRI-only objective filter above.
+              // Outside any workspace (personal view): scope to the user's own
+              // key results (owner or DRI).
+              ...(isWorkspaceScoped
+                ? input.onlyMine
+                  ? { driUserId: ctx.session.user.id }
+                  : {}
                 : {
                     OR: [
                       { userId: ctx.session.user.id },
@@ -857,29 +868,22 @@ export const keyResultRouter = createTRPCRouter({
           const period = `${periodType}-${input.year}`;
           const where = {
             ...(isWorkspaceScoped ? { workspaceId: input.workspaceId } : {}),
-            // Outside a workspace, or on the "My Goals" view, count only the
-            // KRs the user owns or is the DRI for — matching the cards, which
-            // render the same ownership-scoped key results.
-            ...(!isWorkspaceScoped || input.onlyMine
-              ? {
+            // "My Goals" view: count only the key results the user is the DRI
+            // for — matching the DRI-only cards. A my-DRI KR's objective always
+            // surfaces on some card (via the objective's `keyResults.some` DRI
+            // filter), so no extra goal-ownership scoping is needed here.
+            // Personal (non-workspace) view: count the user's own KRs (owner or
+            // DRI). Workspace-wide OKRs view: count every KR in the period.
+            ...(isWorkspaceScoped
+              ? input.onlyMine
+                ? { driUserId: ctx.session.user.id }
+                : {}
+              : {
                   OR: [
                     { userId: ctx.session.user.id },
                     { driUserId: ctx.session.user.id },
                   ],
-                }
-              : {}),
-            // Scope counts to KRs under my objectives so period-tab counts
-            // match the cards shown in the "My Goals" view.
-            ...(isWorkspaceScoped && input.onlyMine
-              ? {
-                  goal: {
-                    OR: [
-                      { userId: ctx.session.user.id },
-                      { driUserId: ctx.session.user.id },
-                    ],
-                  },
-                }
-              : {}),
+                }),
             period,
           };
 


### PR DESCRIPTION
### **User description**
## Problem

The **My Goals** tab (`?tab=my-goals`) showed objectives the user was not the DRI for. It filtered by **owner OR DRI** — so any objective the user *created* surfaced even after they assigned someone else as the DRI on the objective and all its key results.

## Fix

Scope the `onlyMine` path strictly to the DRI:

- **Objectives** — shown when the user is DRI on the objective **or** DRI on at least one of its key results (`keyResults.some`).
- **Key results** — only the ones the user is DRI for.
- **Period-tab counts** (`getCountsByYear`) — count only DRI key results, so the badges match the cards.

Personal (non-workspace) and the workspace-wide OKRs view are unchanged.

## Tests

Adds `getByObjectiveDri.test.ts` — asserts the query keys off `driUserId` and never off owner `userId` on the `onlyMine` path. Full `tsc --noEmit` passes clean.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix "My Goals" tab to show only DRI-scoped objectives/KRs

- Objectives now shown only when user is DRI on objective or any KR

- Key result and period-tab counts scoped to DRI only, not owner

- Add regression test asserting DRI-only query fields on `onlyMine` path


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["My Goals (onlyMine) request"] -- "objective filter" --> B["driUserId OR keyResults.some driUserId"]
  A -- "key result filter" --> C["driUserId only"]
  A -- "period-tab counts" --> D["driUserId only"]
  E["Workspace-wide OKRs view"] -- "unchanged" --> F["all objectives & KRs"]
  G["Personal (non-workspace) view"] -- "unchanged" --> H["owner OR DRI"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>keyResult.ts</strong><dd><code>Restrict My Goals view to DRI-only objective and KR filters</code></dd></summary>
<hr>

src/plugins/okr/server/routers/keyResult.ts

<ul><li>Replace <code>userId OR driUserId</code> objective filter with <code>driUserId OR </code><br><code>keyResults.some(driUserId)</code> on <code>onlyMine</code> path<br> <li> Scope included key results to <code>driUserId</code> only (not owner) on <code>onlyMine</code> <br>path<br> <li> Simplify <code>getCountsByYear</code> to count only <code>driUserId</code> KRs on <code>onlyMine</code>, <br>removing redundant goal-ownership sub-filter<br> <li> Personal and workspace-wide views remain unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/368/files#diff-bc84848f5eb855384754b26268587f4d82ba0a0d871410753ab5c0435dcfab3d">+31/-27</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getByObjectiveDri.test.ts</strong><dd><code>Add regression test for My Goals DRI-only query scoping</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/okr/server/routers/__tests__/getByObjectiveDri.test.ts

<ul><li>New regression test file for the <code>onlyMine</code> DRI-scoping behavior<br> <li> Uses <code>vitest-mock-extended</code> deep mock of <code>PrismaClient</code> — no real DB<br> <li> Asserts query <code>where</code> clause references <code>driUserId</code> and never <code>userId</code> on <br><code>onlyMine</code> path<br> <li> Verifies <code>keyResults.some</code> clause is present and included KRs are <br>filtered by <code>driUserId</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/368/files#diff-760b158b983e22043ed8462311682027024db7183d67be64238441903f67ecd9">+139/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

