### PR TITLE
feat(insights): detail page, decision-based triage, board publishing, duplicates + activity

### DIFF
--- a/prisma/migrations/20260707120000_insight_body_doc/migration.sql
+++ b/prisma/migrations/20260707120000_insight_body_doc/migration.sql
@@ -1,0 +1,8 @@
+-- Insight detail-page rich body (ADR-0024 storage model, third adopter after
+-- Feature and KnowledgePage): bodyDoc is the canonical ProseMirror JSON,
+-- the existing body column is its derived Markdown projection, docVersion is
+-- the optimistic-concurrency guard.
+
+-- AlterTable
+ALTER TABLE "public"."Insight" ADD COLUMN     "bodyDoc" JSONB,
+ADD COLUMN     "docVersion" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/migrations/20260708095551_insight_published_at/migration.sql
+++ b/prisma/migrations/20260708095551_insight_published_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Insight" ADD COLUMN     "publishedAt" TIMESTAMP(3);

--- a/prisma/migrations/20260708102142_insight_duplicates_comments/migration.sql
+++ b/prisma/migrations/20260708102142_insight_duplicates_comments/migration.sql
@@ -1,0 +1,32 @@
+-- AlterTable
+ALTER TABLE "Insight" ADD COLUMN     "duplicateOfId" TEXT;
+
+-- CreateTable
+CREATE TABLE "InsightComment" (
+    "id" TEXT NOT NULL,
+    "insightId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "InsightComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "InsightComment_insightId_idx" ON "InsightComment"("insightId");
+
+-- CreateIndex
+CREATE INDEX "InsightComment_authorId_idx" ON "InsightComment"("authorId");
+
+-- CreateIndex
+CREATE INDEX "Insight_duplicateOfId_idx" ON "Insight"("duplicateOfId");
+
+-- AddForeignKey
+ALTER TABLE "Insight" ADD CONSTRAINT "Insight_duplicateOfId_fkey" FOREIGN KEY ("duplicateOfId") REFERENCES "Insight"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InsightComment" ADD CONSTRAINT "InsightComment_insightId_fkey" FOREIGN KEY ("insightId") REFERENCES "Insight"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InsightComment" ADD CONSTRAINT "InsightComment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4075,6 +4075,12 @@ model Insight {
   type        InsightType
   title       String
   body        String?
+  // Rich detail-page body (ADR-0024 storage model, third adopter after
+  // Feature and KnowledgePage): bodyDoc is the canonical ProseMirror JSON,
+  // body above is its derived write-only Markdown projection, docVersion is
+  // the optimistic-concurrency guard.
+  bodyDoc     Json?
+  docVersion  Int           @default(0)
   source      String?
   sentiment   String?
   description String        @default("")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -256,6 +256,7 @@ model User {
   ticketComments        TicketComment[]    @relation("TicketCommentAuthor")
   ticketDepsCreated     TicketDependency[] @relation("TicketDependencyCreatedBy")
   insightsCreated       Insight[]          @relation("InsightCreatedBy")
+  insightComments       InsightComment[]   @relation("InsightCommentAuthor")
 
   // One2b agent schema additions
   phone            Bytes?  @map("phone_encrypted") @db.ByteA
@@ -2534,14 +2535,14 @@ model KnowledgeChunk {
   @@index([workspaceId])
 }
 
-/// A free-form, human- or Zoe-authored rich document (ADR-0033) — a spec, doc,
+/// A free-form, human- or Zoe-authored rich document (ADR-0033) - a spec, doc,
 /// or wiki page that stands on its own, not scoped to a Product/Day/Meeting. Its
 /// own top-level area (/w/[slug]/pages). Storage reuses the Feature PRD
 /// dual-format (ADR-0024): `bodyDoc` is the canonical ProseMirror JSON the
 /// editor reads/writes; `body` is a derived, write-only Markdown projection
 /// (greppable, embeddable, agent-readable); `docVersion` powers the
 /// optimistic-concurrency stale-write guard. Workspace-scoped with an optional
-/// Project link (flat — no nesting in v1); visibility mirrors Meetings
+/// Project link (flat - no nesting in v1); visibility mirrors Meetings
 /// (project-linked inherits the Project's rules incl. restriction; project-less
 /// is workspace-visible). When `includeInSearch` is on, the Markdown projection
 /// feeds the shared Knowledge index as `KnowledgeChunk.sourceType = "page"`.
@@ -2596,7 +2597,7 @@ model CrmContact {
   skills              String[]
   tags                String[]
   // Field keys whose CURRENT value came from enrichment, not a human (ADR-0036).
-  // The UI badges these "AI — verify". A human edit clears the key; re-enrich may
+  // The UI badges these "AI - verify". A human edit clears the key; re-enrich may
   // refresh a still-AI field but never a human-locked one. Defaults to [] so the
   // ADD COLUMN backfills existing rows (never NULL).
   aiSourcedFields     String[]  @default([])
@@ -2849,7 +2850,7 @@ model Form {
   offerApplicantAccount  Boolean @default(true)
   applicantAccountPrompt String? @db.Text
   // Public renderer copy overrides: the submit button label (null = "Submit")
-  // and a small dimmed note rendered under the button (null = nothing) —
+  // and a small dimmed note rendered under the button (null = nothing) -
   // e.g. "We'll only use your email for updates and follow-ups."
   submitLabel String?
   footnote    String? @db.Text
@@ -4094,21 +4095,56 @@ model Insight {
   evidence    String?
   parkedAt    DateTime?
   parkReason  String?
+  // Feedback-board visibility: set by an explicit human "publish" act, never
+  // automatically. Only user-voice insights (FEEDBACK/PAIN_POINT/OPPORTUNITY)
+  // may be published - internal evidence (PROBLEM, COMPETITIVE, ...) never
+  // reaches the public board. The board read path must filter on this.
+  publishedAt DateTime?
+  // Linear-style duplicate marking: a non-destructive "this describes the same
+  // thing as" pointer. The duplicate keeps ALL its content (insights are
+  // evidence - two reports are two data points); it just drops out of default
+  // lists and defers to its canonical. Chains are flattened at write time
+  // (marking A dup-of B where B is dup-of C points A at C), so this is always
+  // one level deep.
+  duplicateOfId String?
   createdById String
   createdAt   DateTime      @default(now())
   updatedAt   DateTime      @updatedAt
 
-  product   Product          @relation(fields: [productId], references: [id], onDelete: Cascade)
-  research  Research?        @relation(fields: [researchId], references: [id], onDelete: SetNull)
-  createdBy User             @relation("InsightCreatedBy", fields: [createdById], references: [id])
-  features  FeatureInsight[]
-  tags      InsightTag[]
+  product     Product          @relation(fields: [productId], references: [id], onDelete: Cascade)
+  research    Research?        @relation(fields: [researchId], references: [id], onDelete: SetNull)
+  createdBy   User             @relation("InsightCreatedBy", fields: [createdById], references: [id])
+  duplicateOf Insight?         @relation("InsightDuplicateOf", fields: [duplicateOfId], references: [id], onDelete: SetNull)
+  duplicates  Insight[]        @relation("InsightDuplicateOf")
+  features    FeatureInsight[]
+  tags        InsightTag[]
+  comments    InsightComment[]
 
   @@index([productId])
   @@index([researchId])
   @@index([status])
   @@index([type])
   @@index([createdById])
+  @@index([duplicateOfId])
+}
+
+// Per-insight discussion, mirroring TicketComment. Events ("status changed",
+// "marked duplicate of ...") are NOT stored here - they live in
+// WorkspaceActivityEvent (entityType "insight") and the detail page merges the
+// two into one activity feed.
+model InsightComment {
+  id        String   @id @default(cuid())
+  insightId String
+  authorId  String
+  content   String   @db.Text
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  insight Insight @relation(fields: [insightId], references: [id], onDelete: Cascade)
+  author  User    @relation("InsightCommentAuthor", fields: [authorId], references: [id])
+
+  @@index([insightId])
+  @@index([authorId])
 }
 
 model FeatureInsight {
@@ -4340,7 +4376,7 @@ model InsightTag {
   @@index([tagId])
 }
 
-// Pipeline Triage — Problem/ProblemApproach/ProblemStage removed (ADR-0036,
+// Pipeline Triage - Problem/ProblemApproach/ProblemStage removed (ADR-0036,
 // supersedes ADR-0008). A Problem is now an Insight of type PROBLEM; the general
 // triage fields on Insight (impact/confidence/category/evidence/parkedAt/
 // parkReason) absorb its extra columns. The Problem↔Project "Approach" links

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/insights/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/insights/[id]/page.tsx
@@ -44,6 +44,7 @@ import {
   IconWorldOff,
 } from "@tabler/icons-react";
 import { modals } from "@mantine/modals";
+import { useSession } from "next-auth/react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
 import {
@@ -108,6 +109,7 @@ export default function InsightDetailPage() {
   const productSlug = params.productSlug as string;
   const insightId = params.id as string;
   const { workspace } = useWorkspace();
+  const { data: session } = useSession();
   const utils = api.useUtils();
 
   const { data: insight, isLoading } = api.product.insight.getById.useQuery(
@@ -483,14 +485,18 @@ export default function InsightDetailPage() {
                             <MarkdownRenderer content={item.comment.content} />
                           </div>
                         </div>
-                        <ActionIcon
-                          variant="subtle"
-                          color="red"
-                          size="xs"
-                          onClick={() => deleteComment.mutate({ id: item.comment.id })}
-                        >
-                          <IconTrash size={12} />
-                        </ActionIcon>
+                        {/* Server restricts deletes to the author - only
+                            offer the button where it can succeed. */}
+                        {item.comment.author.id === session?.user?.id && (
+                          <ActionIcon
+                            variant="subtle"
+                            color="red"
+                            size="xs"
+                            onClick={() => deleteComment.mutate({ id: item.comment.id })}
+                          >
+                            <IconTrash size={12} />
+                          </ActionIcon>
+                        )}
                       </Group>
                     </div>
                   ) : (

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/insights/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/insights/[id]/page.tsx
@@ -24,11 +24,14 @@ import {
   IconArrowLeft,
   IconCalendar,
   IconCategory,
+  IconChevronDown,
+  IconChevronRight,
   IconCircleDot,
   IconCopy,
   IconDots,
   IconFlask,
   IconGauge,
+  IconGitMerge,
   IconLink,
   IconMoodSmile,
   IconPlayerPause,
@@ -37,6 +40,8 @@ import {
   IconTarget,
   IconTrash,
   IconUser,
+  IconWorld,
+  IconWorldOff,
 } from "@tabler/icons-react";
 import { modals } from "@mantine/modals";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
@@ -48,11 +53,13 @@ import {
 } from "~/app/_components/PropertiesSidebar";
 import { InsightDocument } from "~/app/_components/product/InsightDocument";
 import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
+import { CommentInput } from "~/app/_components/shared/CommentInput";
 import {
   INSIGHT_TYPES,
   TYPE_MAP,
   STATUS_OPTIONS,
   STATUS_COLORS,
+  PUBLISHABLE_INSIGHT_TYPES,
   type InsightStatus,
   type InsightType,
 } from "~/app/_components/product/insightMeta";
@@ -64,6 +71,36 @@ const SENTIMENT_OPTIONS = [
   { value: "neutral", label: "Neutral" },
   { value: "negative", label: "Negative" },
 ];
+
+const statusLabel = (v: unknown): string =>
+  STATUS_OPTIONS.find((s) => s.value === v)?.label ??
+  (typeof v === "string" ? v : "?");
+
+/**
+ * Human copy for a WorkspaceActivityEvent row on this insight's timeline.
+ * Events carry their specifics in `metadata` (`change` discriminates the
+ * "updated" events); unknown events render as null and are skipped.
+ */
+function describeEvent(action: string, metadata: unknown): string | null {
+  const meta = (metadata ?? {}) as Record<string, unknown>;
+  if (action === "status_changed") {
+    return `changed status from ${statusLabel(meta.from)} to ${statusLabel(meta.to)}`;
+  }
+  switch (meta.change) {
+    case "published":
+      return "published this to the feedback board";
+    case "unpublished":
+      return "removed this from the feedback board";
+    case "marked_duplicate":
+      return `marked this as a duplicate of "${typeof meta.canonicalTitle === "string" ? meta.canonicalTitle : "another insight"}"`;
+    case "duplicate_added":
+      return `marked "${typeof meta.duplicateTitle === "string" ? meta.duplicateTitle : "another insight"}" as a duplicate of this`;
+    case "unmarked_duplicate":
+      return "removed the duplicate mark";
+    default:
+      return null;
+  }
+}
 
 export default function InsightDetailPage() {
   const params = useParams();
@@ -84,6 +121,9 @@ export default function InsightDetailPage() {
   const [source, setSource] = useState("");
   const [parkModalOpen, setParkModalOpen] = useState(false);
   const [parkReason, setParkReason] = useState("");
+  const [dupModalOpen, setDupModalOpen] = useState(false);
+  const [dupTargetId, setDupTargetId] = useState<string | null>(null);
+  const [activityCollapsed, setActivityCollapsed] = useState(false);
 
   useEffect(() => {
     if (insight) {
@@ -106,13 +146,43 @@ export default function InsightDetailPage() {
   const deleteInsight = api.product.insight.delete.useMutation();
   const parkInsight = api.product.insight.park.useMutation({ onSuccess: invalidate });
   const unparkInsight = api.product.insight.unpark.useMutation({ onSuccess: invalidate });
+  const publishInsight = api.product.insight.publish.useMutation({ onSuccess: invalidate });
+  const unpublishInsight = api.product.insight.unpublish.useMutation({ onSuccess: invalidate });
   const setFeatures = api.product.insight.setFeatures.useMutation({
     onSuccess: invalidate,
   });
 
+  const invalidateActivity = async () => {
+    await invalidate();
+    await utils.product.insight.listEvents.invalidate({ id: insightId });
+  };
+  const markDuplicate = api.product.insight.markDuplicate.useMutation({
+    onSuccess: invalidateActivity,
+  });
+  const unmarkDuplicate = api.product.insight.unmarkDuplicate.useMutation({
+    onSuccess: invalidateActivity,
+  });
+  const addComment = api.product.insight.addComment.useMutation({ onSuccess: invalidate });
+  const deleteComment = api.product.insight.deleteComment.useMutation({
+    onSuccess: invalidate,
+  });
+
+  const { data: events } = api.product.insight.listEvents.useQuery(
+    { id: insightId },
+    { enabled: !!insightId },
+  );
+
   const { data: features } = api.product.feature.list.useQuery(
     { productId: insight?.product.id ?? "" },
     { enabled: !!insight?.product.id },
+  );
+
+  // Candidates for the "Mark as duplicate" picker: other insights of the same
+  // product (the list excludes duplicates by default, so targets are always
+  // canonical).
+  const { data: dupCandidates } = api.product.insight.list.useQuery(
+    { productId: insight?.product.id ?? "" },
+    { enabled: dupModalOpen && !!insight?.product.id },
   );
 
   if (isLoading) {
@@ -131,6 +201,22 @@ export default function InsightDetailPage() {
   const typeDef = TYPE_MAP[insight.type];
   const TypeIcon = typeDef?.icon ?? IconTarget;
   const isParked = insight.parkedAt != null;
+
+  // Unified activity feed: comments + system events, oldest first.
+  const commentItems = insight.comments.map((c) => ({
+    kind: "comment" as const,
+    createdAt: new Date(c.createdAt),
+    comment: c,
+  }));
+  const eventItems = (events ?? []).flatMap((e) => {
+    const text = describeEvent(e.action, e.metadata);
+    return text
+      ? [{ kind: "event" as const, createdAt: new Date(e.createdAt), event: e, text }]
+      : [];
+  });
+  const feed = [...commentItems, ...eventItems].sort(
+    (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+  );
 
   const saveTitle = () => {
     const next = title.trim();
@@ -178,6 +264,31 @@ export default function InsightDetailPage() {
             Insights
           </Link>
 
+          {/* Duplicate banner - this insight defers to its canonical. */}
+          {insight.duplicateOf && (
+            <div className="flex items-center gap-2 border border-border-primary rounded-lg px-3 py-2 bg-surface-secondary">
+              <IconGitMerge size={14} className="text-text-muted shrink-0" />
+              <Text size="sm" className="text-text-secondary flex-1 min-w-0" lineClamp={1}>
+                Duplicate of{" "}
+                <Link
+                  href={`${backPath}/${insight.duplicateOf.id}`}
+                  className="text-brand-primary hover:underline"
+                >
+                  {insight.duplicateOf.title}
+                </Link>
+              </Text>
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                color="gray"
+                onClick={() => unmarkDuplicate.mutate({ id: insight.id })}
+                loading={unmarkDuplicate.isPending}
+              >
+                Not a duplicate
+              </Button>
+            </div>
+          )}
+
           {/* Badges + title + overflow menu */}
           <div>
             <Group gap="sm" mb={8}>
@@ -195,6 +306,16 @@ export default function InsightDetailPage() {
               {isParked && (
                 <Badge size="xs" variant="light" color="orange">
                   parked
+                </Badge>
+              )}
+              {insight.publishedAt != null && (
+                <Badge
+                  size="xs"
+                  variant="light"
+                  color="teal"
+                  leftSection={<IconWorld size={11} />}
+                >
+                  public
                 </Badge>
               )}
             </Group>
@@ -238,6 +359,33 @@ export default function InsightDetailPage() {
                   >
                     Copy link
                   </Menu.Item>
+                  {!insight.duplicateOf && (
+                    <Menu.Item
+                      leftSection={<IconGitMerge size={14} />}
+                      onClick={() => {
+                        setDupTargetId(null);
+                        setDupModalOpen(true);
+                      }}
+                    >
+                      Mark as duplicate...
+                    </Menu.Item>
+                  )}
+                  {PUBLISHABLE_INSIGHT_TYPES.includes(insight.type) &&
+                    (insight.publishedAt != null ? (
+                      <Menu.Item
+                        leftSection={<IconWorldOff size={14} />}
+                        onClick={() => unpublishInsight.mutate({ id: insight.id })}
+                      >
+                        Unpublish from board
+                      </Menu.Item>
+                    ) : (
+                      <Menu.Item
+                        leftSection={<IconWorld size={14} />}
+                        onClick={() => publishInsight.mutate({ id: insight.id })}
+                      >
+                        Publish to board
+                      </Menu.Item>
+                    ))}
                   <Menu.Divider />
                   <Menu.Item
                     color="red"
@@ -270,6 +418,108 @@ export default function InsightDetailPage() {
               <MarkdownRenderer content={insight.evidence} variant="compact" />
             </div>
           )}
+
+          {/* Duplicates of this (canonical) insight - each is a separate piece
+              of evidence for the same thing. */}
+          {insight.duplicates.length > 0 && (
+            <div className="border border-border-primary rounded-lg p-3">
+              <Text size="xs" className="text-text-muted uppercase tracking-wider mb-2">
+                Duplicates ({insight.duplicates.length})
+              </Text>
+              <Stack gap={4}>
+                {insight.duplicates.map((d) => (
+                  <Link
+                    key={d.id}
+                    href={`${backPath}/${d.id}`}
+                    className="flex items-center gap-2 text-sm text-text-secondary hover:text-text-primary transition-colors"
+                  >
+                    <IconGitMerge size={13} className="text-text-muted shrink-0" />
+                    <span className="truncate">{d.title}</span>
+                  </Link>
+                ))}
+              </Stack>
+            </div>
+          )}
+
+          {/* Activity - comments merged with system events (status changes,
+              publish/unpublish, duplicate marks) by time. */}
+          <div>
+            <button
+              className="flex items-center gap-1.5 mb-3"
+              onClick={() => setActivityCollapsed((v) => !v)}
+            >
+              {activityCollapsed ? (
+                <IconChevronRight size={13} className="text-text-muted" />
+              ) : (
+                <IconChevronDown size={13} className="text-text-muted" />
+              )}
+              <Text size="xs" fw={600} className="text-text-muted uppercase tracking-wider">
+                Activity
+              </Text>
+            </button>
+
+            {!activityCollapsed && feed.length > 0 && (
+              <Stack gap="sm" mb="md">
+                {feed.map((item) =>
+                  item.kind === "comment" ? (
+                    <div
+                      key={`c-${item.comment.id}`}
+                      className="border border-border-primary rounded-lg p-3"
+                    >
+                      <Group justify="space-between" align="flex-start">
+                        <div className="flex-1">
+                          <Group gap="xs" mb={4}>
+                            <Avatar size="xs" radius="xl" src={item.comment.author.image}>
+                              {(item.comment.author.name ?? "?")[0]?.toUpperCase()}
+                            </Avatar>
+                            <Text size="xs" fw={500} className="text-text-secondary">
+                              {item.comment.author.name}
+                            </Text>
+                            <Text size="xs" className="text-text-muted">
+                              {new Date(item.comment.createdAt).toLocaleDateString()}
+                            </Text>
+                          </Group>
+                          <div className="ml-6">
+                            <MarkdownRenderer content={item.comment.content} />
+                          </div>
+                        </div>
+                        <ActionIcon
+                          variant="subtle"
+                          color="red"
+                          size="xs"
+                          onClick={() => deleteComment.mutate({ id: item.comment.id })}
+                        >
+                          <IconTrash size={12} />
+                        </ActionIcon>
+                      </Group>
+                    </div>
+                  ) : (
+                    <Group key={`e-${item.event.id}`} gap="xs" wrap="nowrap" className="px-1">
+                      <Avatar size={16} radius="xl" src={item.event.user?.image}>
+                        {(item.event.user?.name ?? "?")[0]?.toUpperCase()}
+                      </Avatar>
+                      <Text size="xs" className="text-text-muted min-w-0" lineClamp={2}>
+                        <Text span size="xs" fw={500} className="text-text-secondary">
+                          {item.event.user?.name ?? "Someone"}
+                        </Text>{" "}
+                        {item.text} · {new Date(item.event.createdAt).toLocaleDateString()}
+                      </Text>
+                    </Group>
+                  ),
+                )}
+              </Stack>
+            )}
+
+            {!activityCollapsed && (
+              <CommentInput
+                placeholder="Leave a comment..."
+                isSubmitting={addComment.isPending}
+                onSubmit={async (content) => {
+                  await addComment.mutateAsync({ insightId: insight.id, content });
+                }}
+              />
+            )}
+          </div>
         </Stack>
       </div>
 
@@ -501,6 +751,54 @@ export default function InsightDetailPage() {
               loading={parkInsight.isPending}
             >
               Park
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+
+      {/* Mark-as-duplicate modal - pick the canonical insight this one
+          duplicates. Non-destructive: content stays, the insight just defers
+          to the canonical and drops out of default lists. */}
+      <Modal
+        opened={dupModalOpen}
+        onClose={() => setDupModalOpen(false)}
+        title="Mark as duplicate"
+        size="md"
+      >
+        <Stack gap="md">
+          <Text size="sm" className="text-text-muted">
+            &quot;{insight.title}&quot; keeps all its content and remains linked as
+            evidence, but defers to the insight you pick and is hidden from the
+            default list.
+          </Text>
+          <Select
+            label="Duplicate of"
+            placeholder="Pick the canonical insight"
+            value={dupTargetId}
+            onChange={setDupTargetId}
+            data={(dupCandidates ?? [])
+              .filter((c) => c.id !== insight.id)
+              .map((c) => ({ value: c.id, label: c.title }))}
+            searchable
+            nothingFoundMessage="No other insights"
+            data-autofocus
+            comboboxProps={{ withinPortal: true }}
+          />
+          <Group justify="flex-end">
+            <Button variant="subtle" onClick={() => setDupModalOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              leftSection={<IconGitMerge size={14} />}
+              onClick={() => {
+                if (!dupTargetId) return;
+                markDuplicate.mutate({ id: insight.id, canonicalId: dupTargetId });
+                setDupModalOpen(false);
+              }}
+              disabled={!dupTargetId}
+              loading={markDuplicate.isPending}
+            >
+              Mark duplicate
             </Button>
           </Group>
         </Stack>

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/insights/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/insights/[id]/page.tsx
@@ -1,0 +1,510 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import type { JSONContent } from "@tiptap/core";
+import {
+  ActionIcon,
+  Avatar,
+  Badge,
+  Button,
+  Group,
+  Menu,
+  Modal,
+  MultiSelect,
+  Select,
+  Skeleton,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from "@mantine/core";
+import {
+  IconArrowLeft,
+  IconCalendar,
+  IconCategory,
+  IconCircleDot,
+  IconCopy,
+  IconDots,
+  IconFlask,
+  IconGauge,
+  IconLink,
+  IconMoodSmile,
+  IconPlayerPause,
+  IconPlayerPlay,
+  IconTag,
+  IconTarget,
+  IconTrash,
+  IconUser,
+} from "@tabler/icons-react";
+import { modals } from "@mantine/modals";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import { api } from "~/trpc/react";
+import {
+  PropertiesSidebar,
+  PropertyRow,
+  PropertyDivider,
+} from "~/app/_components/PropertiesSidebar";
+import { InsightDocument } from "~/app/_components/product/InsightDocument";
+import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
+import {
+  INSIGHT_TYPES,
+  TYPE_MAP,
+  STATUS_OPTIONS,
+  STATUS_COLORS,
+  type InsightStatus,
+  type InsightType,
+} from "~/app/_components/product/insightMeta";
+
+const SCORE_OPTIONS = ["1", "2", "3", "4", "5"].map((v) => ({ value: v, label: v }));
+
+const SENTIMENT_OPTIONS = [
+  { value: "positive", label: "Positive" },
+  { value: "neutral", label: "Neutral" },
+  { value: "negative", label: "Negative" },
+];
+
+export default function InsightDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const productSlug = params.productSlug as string;
+  const insightId = params.id as string;
+  const { workspace } = useWorkspace();
+  const utils = api.useUtils();
+
+  const { data: insight, isLoading } = api.product.insight.getById.useQuery(
+    { id: insightId },
+    { enabled: !!insightId },
+  );
+
+  // Local drafts for text fields that save on blur.
+  const [title, setTitle] = useState("");
+  const [category, setCategory] = useState("");
+  const [source, setSource] = useState("");
+  const [parkModalOpen, setParkModalOpen] = useState(false);
+  const [parkReason, setParkReason] = useState("");
+
+  useEffect(() => {
+    if (insight) {
+      setTitle(insight.title);
+      setCategory(insight.category ?? "");
+      setSource(insight.source ?? "");
+    }
+  }, [insight]);
+
+  const invalidate = async () => {
+    await utils.product.insight.getById.invalidate({ id: insightId });
+    if (insight?.product.id) {
+      void utils.product.insight.list.invalidate({ productId: insight.product.id });
+    }
+  };
+
+  const updateInsight = api.product.insight.update.useMutation({
+    onSuccess: invalidate,
+  });
+  const deleteInsight = api.product.insight.delete.useMutation();
+  const parkInsight = api.product.insight.park.useMutation({ onSuccess: invalidate });
+  const unparkInsight = api.product.insight.unpark.useMutation({ onSuccess: invalidate });
+  const setFeatures = api.product.insight.setFeatures.useMutation({
+    onSuccess: invalidate,
+  });
+
+  const { data: features } = api.product.feature.list.useQuery(
+    { productId: insight?.product.id ?? "" },
+    { enabled: !!insight?.product.id },
+  );
+
+  if (isLoading) {
+    return (
+      <Stack gap="md">
+        <Skeleton height={20} width={120} />
+        <Skeleton height={36} width="60%" />
+        <Skeleton height={200} />
+      </Stack>
+    );
+  }
+
+  if (!insight) return <Text className="text-text-muted">Insight not found</Text>;
+
+  const backPath = `/w/${workspace?.slug}/products/${productSlug}/insights`;
+  const typeDef = TYPE_MAP[insight.type];
+  const TypeIcon = typeDef?.icon ?? IconTarget;
+  const isParked = insight.parkedAt != null;
+
+  const saveTitle = () => {
+    const next = title.trim();
+    if (next && next !== insight.title) {
+      updateInsight.mutate({ id: insight.id, title: next });
+    } else {
+      setTitle(insight.title);
+    }
+  };
+
+  const handleDelete = () => {
+    modals.openConfirmModal({
+      title: "Delete insight",
+      children: (
+        <Text size="sm">Delete &quot;{insight.title}&quot;? This cannot be undone.</Text>
+      ),
+      labels: { confirm: "Delete", cancel: "Cancel" },
+      confirmProps: { color: "red" },
+      onConfirm: () =>
+        deleteInsight.mutate(
+          { id: insight.id },
+          {
+            onSuccess: () => {
+              void utils.product.insight.list.invalidate({
+                productId: insight.product.id,
+              });
+              router.push(backPath);
+            },
+          },
+        ),
+    });
+  };
+
+  return (
+    <div className="flex min-h-0">
+      {/* Main content */}
+      <div className="flex-1 overflow-y-auto pr-6">
+        <Stack gap="lg">
+          {/* Back nav */}
+          <Link
+            href={backPath}
+            className="inline-flex items-center gap-1.5 text-xs text-text-muted hover:text-text-primary transition-colors"
+          >
+            <IconArrowLeft size={14} />
+            Insights
+          </Link>
+
+          {/* Badges + title + overflow menu */}
+          <div>
+            <Group gap="sm" mb={8}>
+              <Badge
+                size="xs"
+                variant="light"
+                color={typeDef?.color ?? "gray"}
+                leftSection={<TypeIcon size={11} />}
+              >
+                {typeDef?.label ?? insight.type}
+              </Badge>
+              <Badge size="xs" variant="light" color={STATUS_COLORS[insight.status] ?? "gray"}>
+                {STATUS_OPTIONS.find((s) => s.value === insight.status)?.label ?? insight.status}
+              </Badge>
+              {isParked && (
+                <Badge size="xs" variant="light" color="orange">
+                  parked
+                </Badge>
+              )}
+            </Group>
+
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
+              <Textarea
+                value={title}
+                onChange={(e) => setTitle(e.currentTarget.value)}
+                onBlur={saveTitle}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    e.currentTarget.blur();
+                  }
+                }}
+                variant="unstyled"
+                autosize
+                minRows={1}
+                className="flex-1"
+                styles={{
+                  input: {
+                    fontSize: "1.375rem",
+                    fontWeight: 700,
+                    color: "var(--color-text-primary)",
+                    padding: 0,
+                  },
+                }}
+              />
+              <Menu position="bottom-end" withinPortal>
+                <Menu.Target>
+                  <ActionIcon variant="subtle" className="text-text-muted">
+                    <IconDots size={18} />
+                  </ActionIcon>
+                </Menu.Target>
+                <Menu.Dropdown>
+                  <Menu.Item
+                    leftSection={<IconCopy size={14} />}
+                    onClick={() => {
+                      void navigator.clipboard.writeText(window.location.href);
+                    }}
+                  >
+                    Copy link
+                  </Menu.Item>
+                  <Menu.Divider />
+                  <Menu.Item
+                    color="red"
+                    leftSection={<IconTrash size={14} />}
+                    onClick={handleDelete}
+                  >
+                    Delete insight
+                  </Menu.Item>
+                </Menu.Dropdown>
+              </Menu>
+            </Group>
+          </div>
+
+          {/* Body - rich document (ADR-0024). Editable for any workspace member
+              (getById already gates membership). */}
+          <InsightDocument
+            insightId={insight.id}
+            bodyDoc={(insight.bodyDoc as JSONContent | null) ?? null}
+            body={insight.body ?? null}
+            docVersion={insight.docVersion}
+            editable
+          />
+
+          {/* Legacy evidence field (pre-fold Problems / older insights). */}
+          {insight.evidence && (
+            <div className="border border-border-primary rounded-lg p-3">
+              <Text size="xs" className="text-text-muted uppercase tracking-wider mb-1">
+                Evidence
+              </Text>
+              <MarkdownRenderer content={insight.evidence} variant="compact" />
+            </div>
+          )}
+        </Stack>
+      </div>
+
+      {/* Properties sidebar */}
+      <PropertiesSidebar>
+        <PropertyRow icon={<IconCircleDot size={14} />} label="Status">
+          <Select
+            value={insight.status}
+            onChange={(v) =>
+              v && updateInsight.mutate({ id: insight.id, status: v as InsightStatus })
+            }
+            data={STATUS_OPTIONS}
+            size="xs"
+            variant="unstyled"
+            comboboxProps={{ withinPortal: true }}
+          />
+        </PropertyRow>
+
+        <PropertyRow icon={<IconCategory size={14} />} label="Type">
+          <Select
+            value={insight.type}
+            onChange={(v) =>
+              v && updateInsight.mutate({ id: insight.id, type: v as InsightType })
+            }
+            data={INSIGHT_TYPES.map((t) => ({ value: t.value, label: t.label }))}
+            size="xs"
+            variant="unstyled"
+            comboboxProps={{ withinPortal: true }}
+          />
+        </PropertyRow>
+
+        <PropertyRow icon={<IconGauge size={14} />} label="Impact">
+          <Select
+            value={insight.impact != null ? String(insight.impact) : null}
+            onChange={(v) =>
+              updateInsight.mutate({ id: insight.id, impact: v ? Number(v) : null })
+            }
+            data={SCORE_OPTIONS}
+            placeholder="1-5"
+            size="xs"
+            variant="unstyled"
+            clearable
+            comboboxProps={{ withinPortal: true }}
+          />
+        </PropertyRow>
+
+        <PropertyRow icon={<IconGauge size={14} />} label="Confidence">
+          <Select
+            value={insight.confidence != null ? String(insight.confidence) : null}
+            onChange={(v) =>
+              updateInsight.mutate({ id: insight.id, confidence: v ? Number(v) : null })
+            }
+            data={SCORE_OPTIONS}
+            placeholder="1-5"
+            size="xs"
+            variant="unstyled"
+            clearable
+            comboboxProps={{ withinPortal: true }}
+          />
+        </PropertyRow>
+
+        <PropertyRow icon={<IconTag size={14} />} label="Category">
+          <TextInput
+            value={category}
+            onChange={(e) => setCategory(e.currentTarget.value)}
+            onBlur={() => {
+              const next = category.trim();
+              if (next !== (insight.category ?? "")) {
+                updateInsight.mutate({ id: insight.id, category: next || null });
+              }
+            }}
+            placeholder="None"
+            size="xs"
+            variant="unstyled"
+          />
+        </PropertyRow>
+
+        {insight.type === "FEEDBACK" && (
+          <PropertyRow icon={<IconMoodSmile size={14} />} label="Sentiment">
+            <Select
+              value={insight.sentiment}
+              onChange={(v) =>
+                updateInsight.mutate({
+                  id: insight.id,
+                  sentiment: (v ?? null) as "positive" | "neutral" | "negative" | null,
+                })
+              }
+              data={SENTIMENT_OPTIONS}
+              placeholder="None"
+              size="xs"
+              variant="unstyled"
+              clearable
+              comboboxProps={{ withinPortal: true }}
+            />
+          </PropertyRow>
+        )}
+
+        <PropertyRow icon={<IconLink size={14} />} label="Source">
+          <TextInput
+            value={source}
+            onChange={(e) => setSource(e.currentTarget.value)}
+            onBlur={() => {
+              const next = source.trim();
+              if (next !== (insight.source ?? "")) {
+                updateInsight.mutate({ id: insight.id, source: next || null });
+              }
+            }}
+            placeholder="None"
+            size="xs"
+            variant="unstyled"
+          />
+        </PropertyRow>
+
+        <PropertyDivider />
+
+        <PropertyRow icon={<IconTarget size={14} />} label="Features">
+          <MultiSelect
+            value={insight.features.map((f) => f.feature.id)}
+            onChange={(next) =>
+              setFeatures.mutate({ insightId: insight.id, featureIds: next })
+            }
+            data={(features ?? []).map((f) => ({ value: f.id, label: f.name }))}
+            placeholder={insight.features.length === 0 ? "None" : undefined}
+            size="xs"
+            variant="unstyled"
+            searchable
+            comboboxProps={{ withinPortal: true }}
+            nothingFoundMessage="No features yet"
+          />
+        </PropertyRow>
+
+        {insight.research && (
+          <PropertyRow icon={<IconFlask size={14} />} label="Research">
+            <Text size="xs" className="text-text-secondary" lineClamp={1}>
+              {insight.research.title}
+            </Text>
+          </PropertyRow>
+        )}
+
+        <PropertyDivider />
+
+        {isParked ? (
+          <>
+            <PropertyRow icon={<IconPlayerPause size={14} />} label="Parked">
+              <Text size="xs" className="text-text-secondary" lineClamp={2}>
+                {insight.parkReason}
+              </Text>
+            </PropertyRow>
+            <Button
+              size="xs"
+              variant="light"
+              leftSection={<IconPlayerPlay size={14} />}
+              onClick={() => unparkInsight.mutate({ id: insight.id })}
+              loading={unparkInsight.isPending}
+            >
+              Unpark
+            </Button>
+          </>
+        ) : (
+          <Button
+            size="xs"
+            variant="subtle"
+            color="gray"
+            leftSection={<IconPlayerPause size={14} />}
+            onClick={() => {
+              setParkReason("");
+              setParkModalOpen(true);
+            }}
+          >
+            Park
+          </Button>
+        )}
+
+        <PropertyDivider />
+
+        <PropertyRow icon={<IconUser size={14} />} label="Created by">
+          <div className="flex items-center gap-1.5">
+            <Avatar size="xs" radius="xl" src={insight.createdBy?.image}>
+              {(insight.createdBy?.name ?? "?")[0]?.toUpperCase()}
+            </Avatar>
+            <Text size="xs" className="text-text-secondary" lineClamp={1}>
+              {insight.createdBy?.name ?? "Unknown"}
+            </Text>
+          </div>
+        </PropertyRow>
+
+        <PropertyRow icon={<IconCalendar size={14} />} label="Created">
+          <Text size="xs" className="text-text-secondary">
+            {new Date(insight.createdAt).toLocaleDateString()}
+          </Text>
+        </PropertyRow>
+      </PropertiesSidebar>
+
+      {/* Park modal - collects a meaningful reason (parking = defer WITH a reason). */}
+      <Modal
+        opened={parkModalOpen}
+        onClose={() => setParkModalOpen(false)}
+        title="Park insight"
+        size="md"
+      >
+        <Stack gap="md">
+          <Text size="sm" className="text-text-muted">
+            Parking defers &quot;{insight.title}&quot; with a reason; it keeps its status and
+            can be revived later.
+          </Text>
+          <Textarea
+            label="Reason"
+            placeholder="Why park this? e.g. out of scope, duplicate, insufficient evidence"
+            value={parkReason}
+            onChange={(e) => setParkReason(e.currentTarget.value)}
+            data-autofocus
+            autosize
+            minRows={2}
+            maxRows={5}
+            required
+          />
+          <Group justify="flex-end">
+            <Button variant="subtle" onClick={() => setParkModalOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                const reason = parkReason.trim();
+                if (!reason) return;
+                parkInsight.mutate({ id: insight.id, reason });
+                setParkModalOpen(false);
+              }}
+              disabled={!parkReason.trim()}
+              loading={parkInsight.isPending}
+            >
+              Park
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/insights/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/insights/page.tsx
@@ -37,6 +37,8 @@ import {
   IconSearch,
   IconTarget,
   IconTrash,
+  IconWorld,
+  IconWorldOff,
   IconX,
 } from "@tabler/icons-react";
 import { modals } from "@mantine/modals";
@@ -53,6 +55,7 @@ import {
   TYPE_MAP,
   STATUS_OPTIONS,
   STATUS_COLORS,
+  PUBLISHABLE_INSIGHT_TYPES,
   type InsightStatus,
 } from "~/app/_components/product/insightMeta";
 
@@ -232,7 +235,7 @@ function FilterChip({ label, onClear }: { label: string; onClear: () => void }) 
 
 // Status groups render in triage order; Dismissed starts collapsed (the
 // backlog's "Completed" treatment).
-const GROUP_ORDER: InsightStatus[] = ["INBOX", "TRIAGED", "LINKED", "DISMISSED"];
+const GROUP_ORDER: InsightStatus[] = ["INBOX", "TRIAGED", "DISMISSED"];
 
 export default function InsightsPage() {
   const params = useParams();
@@ -246,6 +249,7 @@ export default function InsightsPage() {
   const [view, setView] = useState<"list" | "board">("list");
   const [origin, setOrigin] = useState<InsightOrigin>("all");
   const [showParked, setShowParked] = useState(false);
+  const [showDuplicates, setShowDuplicates] = useState(false);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set(["DISMISSED"]));
   const [parkTarget, setParkTarget] = useState<{ id: string; title: string } | null>(null);
   const [parkReason, setParkReason] = useState("");
@@ -283,7 +287,12 @@ export default function InsightsPage() {
   );
 
   const { data: insights, isLoading } = api.product.insight.list.useQuery(
-    { productId: product?.id ?? "", includeParked: showParked, origin },
+    {
+      productId: product?.id ?? "",
+      includeParked: showParked,
+      includeDuplicates: showDuplicates,
+      origin,
+    },
     { enabled: !!product?.id },
   );
 
@@ -296,6 +305,8 @@ export default function InsightsPage() {
   const deleteInsight = api.product.insight.delete.useMutation({ onSuccess: invalidate });
   const parkInsight = api.product.insight.park.useMutation({ onSuccess: invalidate });
   const unparkInsight = api.product.insight.unpark.useMutation({ onSuccess: invalidate });
+  const publishInsight = api.product.insight.publish.useMutation({ onSuccess: invalidate });
+  const unpublishInsight = api.product.insight.unpublish.useMutation({ onSuccess: invalidate });
 
   const moveInsight = (itemId: string, toColumnId: string) =>
     updateInsight.mutateAsync({ id: itemId, status: toColumnId as InsightStatus });
@@ -346,7 +357,8 @@ export default function InsightsPage() {
     (typeFilter ? 1 : 0) +
     (statusFilter ? 1 : 0) +
     (origin !== "all" ? 1 : 0) +
-    (showParked ? 1 : 0);
+    (showParked ? 1 : 0) +
+    (showDuplicates ? 1 : 0);
 
   const handleDelete = (id: string, title: string) => {
     modals.openConfirmModal({
@@ -408,6 +420,26 @@ export default function InsightsPage() {
             </Badge>
           </Tooltip>
         )}
+        {insight.publishedAt != null && (
+          <Tooltip label="Visible on the public feedback board" position="top">
+            <Badge
+              size="xs"
+              variant="light"
+              color="teal"
+              className="shrink-0"
+              leftSection={<IconWorld size={10} />}
+            >
+              public
+            </Badge>
+          </Tooltip>
+        )}
+        {insight.duplicateOfId != null && (
+          <Tooltip label="Duplicate of another insight" position="top">
+            <Badge size="xs" variant="light" color="gray" className="shrink-0">
+              duplicate
+            </Badge>
+          </Tooltip>
+        )}
         {(insight.impact != null || insight.confidence != null) && (
           <Tooltip
             label={`Impact ${insight.impact ?? "-"} / Confidence ${insight.confidence ?? "-"}`}
@@ -455,6 +487,22 @@ export default function InsightsPage() {
             </ActionIcon>
           </Menu.Target>
           <Menu.Dropdown>
+            {PUBLISHABLE_INSIGHT_TYPES.includes(insight.type) &&
+              (insight.publishedAt != null ? (
+                <Menu.Item
+                  leftSection={<IconWorldOff size={14} />}
+                  onClick={() => unpublishInsight.mutate({ id: insight.id })}
+                >
+                  Unpublish from board
+                </Menu.Item>
+              ) : (
+                <Menu.Item
+                  leftSection={<IconWorld size={14} />}
+                  onClick={() => publishInsight.mutate({ id: insight.id })}
+                >
+                  Publish to board
+                </Menu.Item>
+              ))}
             {isParked ? (
               <Menu.Item
                 leftSection={<IconPlayerPlay size={14} />}
@@ -523,6 +571,9 @@ export default function InsightsPage() {
           />
         )}
         {showParked && <FilterChip label="Parked" onClear={() => setShowParked(false)} />}
+        {showDuplicates && (
+          <FilterChip label="Duplicates" onClear={() => setShowDuplicates(false)} />
+        )}
 
         <div className="flex-1" />
 
@@ -639,6 +690,16 @@ export default function InsightsPage() {
                   size="xs"
                   checked={showParked}
                   onChange={(e) => setShowParked(e.currentTarget.checked)}
+                />
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <Text size="xs" className="text-text-muted whitespace-nowrap">
+                  Show duplicates
+                </Text>
+                <Switch
+                  size="xs"
+                  checked={showDuplicates}
+                  onChange={(e) => setShowDuplicates(e.currentTarget.checked)}
                 />
               </div>
             </Stack>

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/insights/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/insights/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import {
   ActionIcon,
@@ -20,11 +20,15 @@ import {
   Text,
   Textarea,
   TextInput,
+  Tooltip,
   UnstyledButton,
 } from "@mantine/core";
 import {
   IconBulb,
+  IconChevronDown,
+  IconChevronRight,
   IconDots,
+  IconFilter,
   IconLayoutKanban,
   IconList,
   IconPlayerPause,
@@ -33,6 +37,7 @@ import {
   IconSearch,
   IconTarget,
   IconTrash,
+  IconX,
 } from "@tabler/icons-react";
 import { modals } from "@mantine/modals";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
@@ -41,18 +46,15 @@ import { EmptyState } from "~/app/_components/EmptyState";
 import { KanbanBoard } from "~/app/_components/shared/kanban";
 import type { KanbanItem } from "~/app/_components/shared/kanban";
 import { InsightCard } from "~/app/_components/product/InsightCard";
+import { CreateInsightModal } from "~/app/_components/product/CreateInsightModal";
 import {
   INSIGHT_TYPES,
   INSIGHT_STATUS_COLUMNS,
   TYPE_MAP,
   STATUS_OPTIONS,
   STATUS_COLORS,
-  SENTIMENT_COLORS,
-  type InsightType,
   type InsightStatus,
 } from "~/app/_components/product/insightMeta";
-
-const SCORE_OPTIONS = ["1", "2", "3", "4", "5"].map((v) => ({ value: v, label: v }));
 
 // Provenance filter (ADR-0037). `form` = arrived via a form (source starts with
 // `form:`), `manual` = everything else, `all` = both.
@@ -72,185 +74,46 @@ function formatSource(source: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Create modal
+// Inline status badge - click to change status in place (backlog StatusCell
+// pattern), replacing the old "Mark as ..." burrow in the row overflow menu.
 // ---------------------------------------------------------------------------
 
-function CreateInsightModal({
-  opened,
-  onClose,
-  productId,
+function InsightStatusBadge({
+  status,
+  onUpdate,
 }: {
-  opened: boolean;
-  onClose: () => void;
-  productId: string;
+  status: string;
+  onUpdate: (s: InsightStatus) => void;
 }) {
-  const utils = api.useUtils();
-  const [type, setType] = useState<InsightType>("PAIN_POINT");
-  const [title, setTitle] = useState("");
-  const [body, setBody] = useState("");
-  const [source, setSource] = useState("");
-  const [sentiment, setSentiment] = useState<string | null>(null);
-  const [featureIds, setFeatureIds] = useState<string[]>([]);
-  const [category, setCategory] = useState("");
-  const [evidence, setEvidence] = useState("");
-  const [impact, setImpact] = useState<string | null>(null);
-  const [confidence, setConfidence] = useState<string | null>(null);
-
-  const { data: features } = api.product.feature.list.useQuery(
-    { productId },
-    { enabled: !!productId && opened },
-  );
-
-  const reset = () => {
-    setTitle("");
-    setBody("");
-    setSource("");
-    setSentiment(null);
-    setFeatureIds([]);
-    setCategory("");
-    setEvidence("");
-    setImpact(null);
-    setConfidence(null);
-  };
-
-  const create = api.product.insight.create.useMutation({
-    onSuccess: async () => {
-      await utils.product.insight.list.invalidate({ productId });
-      onClose();
-      reset();
-    },
-  });
-
   return (
-    <Modal opened={opened} onClose={onClose} title="New insight" size="lg">
-      <Stack gap="md">
-        <Select
-          label="Type"
-          value={type}
-          onChange={(v) => v && setType(v as InsightType)}
-          data={INSIGHT_TYPES.map((t) => ({ value: t.value, label: t.label }))}
-          size="sm"
-        />
-        <TextInput
-          label="Title"
-          placeholder="What did you learn?"
-          value={title}
-          onChange={(e) => setTitle(e.currentTarget.value)}
-          size="sm"
-          required
-        />
-        <Textarea
-          label="Details"
-          placeholder="Describe the insight, evidence, or context..."
-          value={body}
-          onChange={(e) => setBody(e.currentTarget.value)}
-          autosize
-          minRows={3}
-          maxRows={8}
-          size="sm"
-        />
-        <TextInput
-          label="Source"
-          placeholder="e.g. User interview, Zendesk #4231, G2 review"
-          value={source}
-          onChange={(e) => setSource(e.currentTarget.value)}
-          size="sm"
-        />
-        {type === "FEEDBACK" && (
-          <Select
-            label="Sentiment"
-            value={sentiment}
-            onChange={setSentiment}
-            data={[
-              { value: "positive", label: "Positive" },
-              { value: "neutral", label: "Neutral" },
-              { value: "negative", label: "Negative" },
-            ]}
-            size="sm"
-            clearable
-          />
-        )}
-
-        {/* General triage fields — usable by any type (ADR-0036) */}
-        <Group grow>
-          <Select
-            label="Impact"
-            placeholder="1–5"
-            value={impact}
-            onChange={setImpact}
-            data={SCORE_OPTIONS}
-            size="sm"
-            clearable
-          />
-          <Select
-            label="Confidence"
-            placeholder="1–5"
-            value={confidence}
-            onChange={setConfidence}
-            data={SCORE_OPTIONS}
-            size="sm"
-            clearable
-          />
-        </Group>
-        <TextInput
-          label="Category"
-          placeholder="e.g. Onboarding, Billing"
-          value={category}
-          onChange={(e) => setCategory(e.currentTarget.value)}
-          size="sm"
-        />
-        <Textarea
-          label="Evidence"
-          placeholder="Links, quotes, or data backing this up..."
-          value={evidence}
-          onChange={(e) => setEvidence(e.currentTarget.value)}
-          autosize
-          minRows={2}
-          maxRows={6}
-          size="sm"
-        />
-
-        <MultiSelect
-          label="Features"
-          placeholder="Link to one or more features..."
-          value={featureIds}
-          onChange={setFeatureIds}
-          data={(features ?? []).map((f) => ({ value: f.id, label: f.name }))}
-          searchable
-          clearable
-          size="sm"
-          comboboxProps={{ withinPortal: true }}
-          nothingFoundMessage="No features yet"
-        />
-        <Group justify="flex-end">
-          <Button variant="subtle" onClick={onClose}>Cancel</Button>
-          <Button
-            onClick={() => create.mutate({
-              productId,
-              type,
-              title: title.trim(),
-              body: body.trim() || undefined,
-              source: source.trim() || undefined,
-              sentiment: (sentiment ?? undefined) as "positive" | "neutral" | "negative" | undefined,
-              category: category.trim() || undefined,
-              evidence: evidence.trim() || undefined,
-              impact: impact ? Number(impact) : undefined,
-              confidence: confidence ? Number(confidence) : undefined,
-              featureIds: featureIds.length > 0 ? featureIds : undefined,
-            })}
-            loading={create.isPending}
-            disabled={!title.trim()}
-          >
-            Create
-          </Button>
-        </Group>
-      </Stack>
-    </Modal>
+    <Menu position="bottom-start" withinPortal>
+      <Menu.Target>
+        <Badge
+          size="xs"
+          variant="light"
+          color={STATUS_COLORS[status] ?? "gray"}
+          className="cursor-pointer hover:opacity-80 transition-opacity shrink-0"
+        >
+          {STATUS_OPTIONS.find((s) => s.value === status)?.label ?? status}
+        </Badge>
+      </Menu.Target>
+      <Menu.Dropdown>
+        {STATUS_OPTIONS.map((s) => (
+          <Menu.Item key={s.value} onClick={() => onUpdate(s.value)}>
+            <div className="flex items-center gap-2">
+              <Badge size="xs" variant="light" color={STATUS_COLORS[s.value] ?? "gray"}>
+                {s.label}
+              </Badge>
+            </div>
+          </Menu.Item>
+        ))}
+      </Menu.Dropdown>
+    </Menu>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Inline features editor
+// Inline features editor - compact icon + count trigger, popover multiselect
 // ---------------------------------------------------------------------------
 
 function InsightFeaturesEditor({
@@ -279,11 +142,15 @@ function InsightFeaturesEditor({
     },
   });
 
-  const hasFeatures = currentFeatures.length > 0;
+  const count = currentFeatures.length;
+  const label =
+    count > 0
+      ? currentFeatures.map((f) => f.feature.name).join(", ")
+      : "Link features";
 
   return (
     <Popover
-      position="bottom-start"
+      position="bottom-end"
       withinPortal
       shadow="md"
       opened={opened}
@@ -293,19 +160,18 @@ function InsightFeaturesEditor({
       }}
     >
       <Popover.Target>
-        <UnstyledButton
-          onClick={() => setOpened((o) => !o)}
-          className="inline-flex items-center gap-1 text-text-muted hover:text-text-primary transition-colors"
-        >
-          <IconTarget size={10} />
-          {hasFeatures ? (
-            <Text size="xs">
-              {currentFeatures.map((f) => f.feature.name).join(", ")}
-            </Text>
-          ) : (
-            <Text size="xs">Add feature</Text>
-          )}
-        </UnstyledButton>
+        <Tooltip label={label} position="top">
+          <UnstyledButton
+            onClick={(e: React.MouseEvent) => {
+              e.stopPropagation();
+              setOpened((o) => !o);
+            }}
+            className="inline-flex items-center gap-1 text-text-muted hover:text-text-primary transition-colors shrink-0"
+          >
+            <IconTarget size={12} />
+            <Text size="xs">{count > 0 ? count : ""}</Text>
+          </UnstyledButton>
+        </Tooltip>
       </Popover.Target>
       <Popover.Dropdown
         styles={{
@@ -337,10 +203,31 @@ function InsightFeaturesEditor({
 }
 
 // ---------------------------------------------------------------------------
+// Active filter chip - shows a set filter in the action bar, removable
+// ---------------------------------------------------------------------------
+
+function FilterChip({ label, onClear }: { label: string; onClear: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClear}
+      className="inline-flex items-center gap-1 rounded-full bg-surface-hover px-2 py-0.5 text-xs font-medium text-text-secondary hover:text-text-primary transition-colors cursor-pointer"
+    >
+      {label}
+      <IconX size={11} />
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
-export default function ResearchPage() {
+// Status groups render in triage order; Dismissed starts collapsed (the
+// backlog's "Completed" treatment).
+const GROUP_ORDER: InsightStatus[] = ["INBOX", "TRIAGED", "LINKED", "DISMISSED"];
+
+export default function InsightsPage() {
   const params = useParams();
   const productSlug = params.productSlug as string;
   const { workspace, workspaceId } = useWorkspace();
@@ -351,8 +238,36 @@ export default function ResearchPage() {
   const [view, setView] = useState<"list" | "board">("list");
   const [origin, setOrigin] = useState<InsightOrigin>("all");
   const [showParked, setShowParked] = useState(false);
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set(["DISMISSED"]));
   const [parkTarget, setParkTarget] = useState<{ id: string; title: string } | null>(null);
   const [parkReason, setParkReason] = useState("");
+  const [prefsLoaded, setPrefsLoaded] = useState(false);
+
+  // View preference persists per user via the plugin-config prefs map. The
+  // map is keyed by an opaque string; suffixing the slug keeps insights prefs
+  // separate from the tickets page's prefs for the same product.
+  const prefsKey = `${productSlug}/insights`;
+  const { data: savedPrefs } = api.product.product.getViewPrefs.useQuery(
+    { productSlug: prefsKey, workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId },
+  );
+  const savePrefs = api.product.product.saveViewPrefs.useMutation();
+
+  useEffect(() => {
+    if (savedPrefs && !prefsLoaded) {
+      if (savedPrefs.view === "list" || savedPrefs.view === "board") {
+        setView(savedPrefs.view);
+      }
+      setPrefsLoaded(true);
+    }
+  }, [savedPrefs, prefsLoaded]);
+
+  const changeView = (v: "list" | "board") => {
+    setView(v);
+    if (workspaceId) {
+      savePrefs.mutate({ productSlug: prefsKey, workspaceId, prefs: { view: v } });
+    }
+  };
 
   const { data: product } = api.product.product.getBySlug.useQuery(
     { workspaceId: workspaceId ?? "", slug: productSlug },
@@ -400,6 +315,31 @@ export default function ResearchPage() {
     [filtered],
   );
 
+  const groups = useMemo(
+    () =>
+      GROUP_ORDER.map((status) => ({
+        status,
+        label: STATUS_OPTIONS.find((s) => s.value === status)?.label ?? status,
+        items: filtered.filter((i) => i.status === status),
+      })).filter((g) => g.items.length > 0),
+    [filtered],
+  );
+
+  const toggleCollapsed = (key: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const activeFilterCount =
+    (typeFilter ? 1 : 0) +
+    (statusFilter ? 1 : 0) +
+    (origin !== "all" ? 1 : 0) +
+    (showParked ? 1 : 0);
+
   const handleDelete = (id: string, title: string) => {
     modals.openConfirmModal({
       title: "Delete insight",
@@ -424,74 +364,150 @@ export default function ResearchPage() {
 
   if (!workspace) return null;
 
+  // Single-line row (backlog list pattern): icon, status, title, then compact
+  // meta on the right. Body preview intentionally dropped from the list.
+  const renderRow = (insight: (typeof filtered)[number], isLast: boolean) => {
+    const typeDef = TYPE_MAP[insight.type];
+    const Icon = typeDef?.icon ?? IconBulb;
+    const isParked = insight.parkedAt != null;
+    return (
+      <div
+        key={insight.id}
+        className={`flex items-center gap-3 px-3 py-2 hover:bg-surface-hover transition-colors ${
+          isLast ? "" : "border-b border-border-primary"
+        }`}
+      >
+        <Tooltip label={typeDef?.label ?? insight.type} position="top">
+          <div className="shrink-0 flex items-center">
+            <Icon size={15} className={`text-${typeDef?.color ?? "gray"}-400`} />
+          </div>
+        </Tooltip>
+        <InsightStatusBadge
+          status={insight.status}
+          onUpdate={(s) => updateInsight.mutate({ id: insight.id, status: s })}
+        />
+        <Text size="sm" className="text-text-primary flex-1 min-w-0" lineClamp={1}>
+          {insight.title}
+        </Text>
+        {isParked && (
+          <Tooltip label={insight.parkReason ?? "Parked"} position="top">
+            <Badge size="xs" variant="light" color="orange" className="shrink-0">
+              parked
+            </Badge>
+          </Tooltip>
+        )}
+        {(insight.impact != null || insight.confidence != null) && (
+          <Tooltip
+            label={`Impact ${insight.impact ?? "-"} / Confidence ${insight.confidence ?? "-"}`}
+            position="top"
+          >
+            <Text size="xs" className="text-text-muted font-mono shrink-0">
+              {insight.impact != null ? `I${insight.impact}` : ""}
+              {insight.impact != null && insight.confidence != null ? "·" : ""}
+              {insight.confidence != null ? `C${insight.confidence}` : ""}
+            </Text>
+          </Tooltip>
+        )}
+        {insight.category && (
+          <Badge size="xs" variant="outline" color="gray" className="shrink-0">
+            {insight.category}
+          </Badge>
+        )}
+        {insight.source && (
+          <Text size="xs" className="text-text-muted shrink-0 max-w-[160px]" lineClamp={1}>
+            {formatSource(insight.source)}
+          </Text>
+        )}
+        {product && (
+          <InsightFeaturesEditor
+            insightId={insight.id}
+            productId={product.id}
+            currentFeatures={insight.features}
+          />
+        )}
+        <Avatar size="xs" radius="xl" src={insight.createdBy?.image} className="shrink-0">
+          {(insight.createdBy?.name ?? "?")[0]?.toUpperCase()}
+        </Avatar>
+        <Text size="xs" className="text-text-muted shrink-0 w-16 text-right">
+          {new Date(insight.createdAt).toLocaleDateString()}
+        </Text>
+        <Menu position="bottom-end" withinPortal>
+          <Menu.Target>
+            <ActionIcon variant="subtle" size="xs" className="text-text-muted shrink-0">
+              <IconDots size={14} />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
+            {isParked ? (
+              <Menu.Item
+                leftSection={<IconPlayerPlay size={14} />}
+                onClick={() => unparkInsight.mutate({ id: insight.id })}
+              >
+                Unpark
+              </Menu.Item>
+            ) : (
+              <Menu.Item
+                leftSection={<IconPlayerPause size={14} />}
+                onClick={() => openParkModal(insight.id, insight.title)}
+              >
+                Park
+              </Menu.Item>
+            )}
+            <Menu.Item
+              color="red"
+              leftSection={<IconTrash size={14} />}
+              onClick={() => handleDelete(insight.id, insight.title)}
+            >
+              Delete
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </div>
+    );
+  };
+
   return (
     <Stack gap="sm">
-      {/* Action bar */}
-      <div className="flex items-center gap-2 flex-wrap">
-        {/* Type filter pills */}
-        <div className="flex gap-1">
-          <button
-            type="button"
-            onClick={() => setTypeFilter(null)}
-            className={`rounded-full px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer ${
-              typeFilter === null
-                ? "bg-surface-hover text-text-primary"
-                : "bg-transparent text-text-muted hover:text-text-secondary"
-            }`}
-          >
-            All
-          </button>
-          {INSIGHT_TYPES.map((t) => {
-            const Icon = t.icon;
-            return (
-              <button
-                key={t.value}
-                type="button"
-                onClick={() => setTypeFilter(typeFilter === t.value ? null : t.value)}
-                className={`rounded-full px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer flex items-center gap-1 ${
-                  typeFilter === t.value
-                    ? "bg-surface-hover text-text-primary"
-                    : "bg-transparent text-text-muted hover:text-text-secondary"
-                }`}
-              >
-                <Icon size={12} />
-                {t.label}
-              </button>
-            );
-          })}
-        </div>
-
-        <div className="flex-1" />
-
-        {/* Origin filter (ADR-0037) — form-sourced vs manual insights. */}
-        <SegmentedControl
-          size="xs"
-          value={origin}
-          onChange={(v) => setOrigin(v as InsightOrigin)}
-          data={[
-            { value: "all", label: "All" },
-            { value: "form", label: "Form" },
-            { value: "manual", label: "Manual" },
-          ]}
-        />
-
-        <Switch
-          size="xs"
-          label="Parked"
-          checked={showParked}
-          onChange={(e) => setShowParked(e.currentTarget.checked)}
-          styles={{ label: { fontSize: "0.8rem", color: "var(--color-text-muted)" } }}
-        />
-
+      {/* Action bar - view toggle + active filter chips | search, filters, new */}
+      <div className="flex items-center gap-2">
         <SegmentedControl
           size="xs"
           value={view}
-          onChange={(v) => setView(v as "list" | "board")}
+          onChange={(v) => changeView(v as "list" | "board")}
           data={[
             { value: "list", label: <IconList size={14} /> },
             { value: "board", label: <IconLayoutKanban size={14} /> },
           ]}
+          styles={{
+            root: {
+              backgroundColor: "var(--color-surface-secondary)",
+              border: "1px solid var(--color-border-primary)",
+            },
+          }}
         />
+
+        {/* Active filters stay visible as removable chips */}
+        {typeFilter && (
+          <FilterChip
+            label={TYPE_MAP[typeFilter]?.label ?? typeFilter}
+            onClear={() => setTypeFilter(null)}
+          />
+        )}
+        {statusFilter && (
+          <FilterChip
+            label={STATUS_OPTIONS.find((s) => s.value === statusFilter)?.label ?? statusFilter}
+            onClear={() => setStatusFilter(null)}
+          />
+        )}
+        {origin !== "all" && (
+          <FilterChip
+            label={origin === "form" ? "Form" : "Manual"}
+            onClear={() => setOrigin("all")}
+          />
+        )}
+        {showParked && <FilterChip label="Parked" onClear={() => setShowParked(false)} />}
+
+        <div className="flex-1" />
 
         <TextInput
           placeholder="Search..."
@@ -501,23 +517,116 @@ export default function ResearchPage() {
           leftSection={<IconSearch size={14} />}
           styles={{
             root: { width: 200 },
-            input: { backgroundColor: "transparent", border: "1px solid var(--color-border-primary)", fontSize: "0.8rem", height: 30, minHeight: 30 },
+            input: {
+              backgroundColor: "transparent",
+              border: "1px solid var(--color-border-primary)",
+              fontSize: "0.8rem",
+              height: 30,
+              minHeight: 30,
+            },
           }}
         />
 
-        <Select
-          value={statusFilter}
-          onChange={setStatusFilter}
-          data={STATUS_OPTIONS}
-          placeholder="Status"
-          size="xs"
-          clearable
-          comboboxProps={{ withinPortal: true }}
-          styles={{
-            root: { width: 120 },
-            input: { height: 30, minHeight: 30, fontSize: "0.8rem" },
-          }}
-        />
+        <Popover position="bottom-end" withinPortal shadow="md">
+          <Popover.Target>
+            <Tooltip label="Filter" position="bottom">
+              <ActionIcon
+                variant="subtle"
+                size="sm"
+                className="text-text-muted hover:text-text-primary border border-border-primary rounded-md"
+                style={{ height: 30, width: 30 }}
+              >
+                <div className="relative flex items-center justify-center">
+                  <IconFilter size={15} />
+                  {activeFilterCount > 0 && (
+                    <span className="absolute -top-1.5 -right-1.5 w-2 h-2 rounded-full bg-brand-primary" />
+                  )}
+                </div>
+              </ActionIcon>
+            </Tooltip>
+          </Popover.Target>
+          <Popover.Dropdown
+            styles={{
+              dropdown: {
+                backgroundColor: "var(--color-bg-elevated)",
+                border: "1px solid var(--color-border-primary)",
+                minWidth: 260,
+                maxWidth: 280,
+              },
+            }}
+          >
+            <Stack gap="sm">
+              <div>
+                <Text size="xs" className="text-text-muted mb-1.5">
+                  Type
+                </Text>
+                <div className="flex flex-wrap gap-1">
+                  {INSIGHT_TYPES.map((t) => {
+                    const on = typeFilter === t.value;
+                    return (
+                      <button
+                        key={t.value}
+                        type="button"
+                        onClick={() => setTypeFilter(on ? null : t.value)}
+                        className={`rounded-full px-2 py-0.5 text-[10px] font-medium transition-colors cursor-pointer ${
+                          on
+                            ? "bg-surface-hover text-text-primary"
+                            : "bg-transparent text-text-muted/60 hover:text-text-muted"
+                        }`}
+                      >
+                        {t.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <Text size="xs" className="text-text-muted whitespace-nowrap">
+                  Status
+                </Text>
+                <Select
+                  value={statusFilter}
+                  onChange={setStatusFilter}
+                  data={STATUS_OPTIONS}
+                  placeholder="Any"
+                  size="xs"
+                  clearable
+                  variant="filled"
+                  comboboxProps={{ withinPortal: true }}
+                  styles={{
+                    root: { flex: 1 },
+                    input: { fontSize: "0.8rem", height: 28, minHeight: 28 },
+                  }}
+                />
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <Text size="xs" className="text-text-muted whitespace-nowrap">
+                  Origin
+                </Text>
+                <SegmentedControl
+                  size="xs"
+                  value={origin}
+                  onChange={(v) => setOrigin(v as InsightOrigin)}
+                  data={[
+                    { value: "all", label: "All" },
+                    { value: "form", label: "Form" },
+                    { value: "manual", label: "Manual" },
+                  ]}
+                />
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <Text size="xs" className="text-text-muted whitespace-nowrap">
+                  Show parked
+                </Text>
+                <Switch
+                  size="xs"
+                  checked={showParked}
+                  onChange={(e) => setShowParked(e.currentTarget.checked)}
+                />
+              </div>
+            </Stack>
+          </Popover.Dropdown>
+        </Popover>
 
         <Button
           size="xs"
@@ -533,8 +642,10 @@ export default function ResearchPage() {
 
       {/* Content */}
       {isLoading ? (
-        <Stack gap="sm">
-          {[1, 2, 3].map((i) => <Skeleton key={i} height={80} />)}
+        <Stack gap="xs">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} height={36} />
+          ))}
         </Stack>
       ) : filtered.length === 0 ? (
         insights && insights.length > 0 ? (
@@ -569,134 +680,30 @@ export default function ResearchPage() {
         />
       ) : (
         <div className="border border-border-primary rounded-lg overflow-hidden">
-          {filtered.map((insight, i) => {
-            const typeDef = TYPE_MAP[insight.type];
-            const Icon = typeDef?.icon ?? IconBulb;
-            const isParked = insight.parkedAt != null;
-            return (
+          {groups.map((group) => (
+            <React.Fragment key={group.status}>
               <div
-                key={insight.id}
-                className={`px-4 py-3 hover:bg-surface-hover transition-colors ${
-                  i < filtered.length - 1 ? "border-b border-border-primary" : ""
-                }`}
+                className="bg-surface-secondary/50 px-3 pt-4 pb-2 border-b border-border-primary cursor-pointer select-none flex items-center gap-1.5"
+                onClick={() => toggleCollapsed(group.status)}
               >
-                <div className="flex items-start gap-3">
-                  {/* Type icon */}
-                  <div className="mt-0.5 shrink-0">
-                    <Icon size={16} className={`text-${typeDef?.color ?? "gray"}-400`} />
-                  </div>
-
-                  {/* Content */}
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1 flex-wrap">
-                      <Text size="sm" fw={500} className="text-text-primary">
-                        {insight.title}
-                      </Text>
-                      <Badge size="xs" variant="light" color={typeDef?.color ?? "gray"}>
-                        {typeDef?.label ?? insight.type}
-                      </Badge>
-                      <Badge size="xs" variant="light" color={STATUS_COLORS[insight.status] ?? "gray"}>
-                        {insight.status.toLowerCase()}
-                      </Badge>
-                      {insight.category && (
-                        <Badge size="xs" variant="outline" color="gray">
-                          {insight.category}
-                        </Badge>
-                      )}
-                      {insight.sentiment && (
-                        <Badge size="xs" variant="dot" color={SENTIMENT_COLORS[insight.sentiment] ?? "gray"}>
-                          {insight.sentiment}
-                        </Badge>
-                      )}
-                      {isParked && (
-                        <Badge size="xs" variant="light" color="orange">
-                          parked
-                        </Badge>
-                      )}
-                    </div>
-
-                    {insight.body && (
-                      <Text size="xs" className="text-text-muted line-clamp-2 mb-1">
-                        {insight.body}
-                      </Text>
-                    )}
-
-                    <div className="flex items-center gap-3 flex-wrap">
-                      {(insight.impact != null || insight.confidence != null) && (
-                        <Text size="xs" className="text-text-muted">
-                          {insight.impact != null ? `Impact ${insight.impact}` : ""}
-                          {insight.impact != null && insight.confidence != null ? " · " : ""}
-                          {insight.confidence != null ? `Confidence ${insight.confidence}` : ""}
-                        </Text>
-                      )}
-                      {insight.source && (
-                        <Text size="xs" className="text-text-muted">
-                          {formatSource(insight.source)}
-                        </Text>
-                      )}
-                      {product && (
-                        <InsightFeaturesEditor
-                          insightId={insight.id}
-                          productId={product.id}
-                          currentFeatures={insight.features}
-                        />
-                      )}
-                      <Text size="xs" className="text-text-muted">
-                        {new Date(insight.createdAt).toLocaleDateString()}
-                      </Text>
-                    </div>
-                  </div>
-
-                  {/* Actions */}
-                  <div className="flex items-center gap-1 shrink-0">
-                    <Avatar size="xs" radius="xl" src={insight.createdBy?.image}>
-                      {(insight.createdBy?.name ?? "?")[0]?.toUpperCase()}
-                    </Avatar>
-                    <Menu position="bottom-end" withinPortal>
-                      <Menu.Target>
-                        <ActionIcon variant="subtle" size="xs" className="text-text-muted">
-                          <IconDots size={14} />
-                        </ActionIcon>
-                      </Menu.Target>
-                      <Menu.Dropdown>
-                        {STATUS_OPTIONS.filter((s) => s.value !== insight.status).map((s) => (
-                          <Menu.Item
-                            key={s.value}
-                            onClick={() => updateInsight.mutate({ id: insight.id, status: s.value })}
-                          >
-                            Mark as {s.label.toLowerCase()}
-                          </Menu.Item>
-                        ))}
-                        <Menu.Divider />
-                        {isParked ? (
-                          <Menu.Item
-                            leftSection={<IconPlayerPlay size={14} />}
-                            onClick={() => unparkInsight.mutate({ id: insight.id })}
-                          >
-                            Unpark
-                          </Menu.Item>
-                        ) : (
-                          <Menu.Item
-                            leftSection={<IconPlayerPause size={14} />}
-                            onClick={() => openParkModal(insight.id, insight.title)}
-                          >
-                            Park
-                          </Menu.Item>
-                        )}
-                        <Menu.Item
-                          color="red"
-                          leftSection={<IconTrash size={14} />}
-                          onClick={() => handleDelete(insight.id, insight.title)}
-                        >
-                          Delete
-                        </Menu.Item>
-                      </Menu.Dropdown>
-                    </Menu>
-                  </div>
-                </div>
+                {collapsed.has(group.status) ? (
+                  <IconChevronRight size={14} className="text-text-muted" />
+                ) : (
+                  <IconChevronDown size={14} className="text-text-muted" />
+                )}
+                <Text size="xs" fw={600} className="text-text-muted uppercase tracking-wide">
+                  {group.label}
+                </Text>
+                <Badge size="xs" variant="light">
+                  {group.items.length}
+                </Badge>
               </div>
-            );
-          })}
+              {!collapsed.has(group.status) &&
+                group.items.map((insight, i) =>
+                  renderRow(insight, i === group.items.length - 1),
+                )}
+            </React.Fragment>
+          ))}
         </div>
       )}
 
@@ -705,10 +712,11 @@ export default function ResearchPage() {
           opened={modalOpened}
           onClose={() => setModalOpened(false)}
           productId={product.id}
+          productName={product.name}
         />
       )}
 
-      {/* Park modal — collects a meaningful reason (parking = defer WITH a reason). */}
+      {/* Park modal - collects a meaningful reason (parking = defer WITH a reason). */}
       <Modal
         opened={!!parkTarget}
         onClose={() => setParkTarget(null)}
@@ -732,7 +740,9 @@ export default function ResearchPage() {
             required
           />
           <Group justify="flex-end">
-            <Button variant="subtle" onClick={() => setParkTarget(null)}>Cancel</Button>
+            <Button variant="subtle" onClick={() => setParkTarget(null)}>
+              Cancel
+            </Button>
             <Button onClick={confirmPark} disabled={!parkReason.trim()} loading={parkInsight.isPending}>
               Park
             </Button>

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/insights/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/insights/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import {
   ActionIcon,
   Avatar,
@@ -93,13 +93,20 @@ function InsightStatusBadge({
           variant="light"
           color={STATUS_COLORS[status] ?? "gray"}
           className="cursor-pointer hover:opacity-80 transition-opacity shrink-0"
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
         >
           {STATUS_OPTIONS.find((s) => s.value === status)?.label ?? status}
         </Badge>
       </Menu.Target>
       <Menu.Dropdown>
         {STATUS_OPTIONS.map((s) => (
-          <Menu.Item key={s.value} onClick={() => onUpdate(s.value)}>
+          <Menu.Item
+            key={s.value}
+            onClick={(e: React.MouseEvent) => {
+              e.stopPropagation();
+              onUpdate(s.value);
+            }}
+          >
             <div className="flex items-center gap-2">
               <Badge size="xs" variant="light" color={STATUS_COLORS[s.value] ?? "gray"}>
                 {s.label}
@@ -229,6 +236,7 @@ const GROUP_ORDER: InsightStatus[] = ["INBOX", "TRIAGED", "LINKED", "DISMISSED"]
 
 export default function InsightsPage() {
   const params = useParams();
+  const router = useRouter();
   const productSlug = params.productSlug as string;
   const { workspace, workspaceId } = useWorkspace();
   const [modalOpened, setModalOpened] = useState(false);
@@ -364,8 +372,11 @@ export default function InsightsPage() {
 
   if (!workspace) return null;
 
+  const basePath = `/w/${workspace.slug}/products/${productSlug}/insights`;
+
   // Single-line row (backlog list pattern): icon, status, title, then compact
-  // meta on the right. Body preview intentionally dropped from the list.
+  // meta on the right. Body preview intentionally dropped from the list; the
+  // row itself opens the detail page.
   const renderRow = (insight: (typeof filtered)[number], isLast: boolean) => {
     const typeDef = TYPE_MAP[insight.type];
     const Icon = typeDef?.icon ?? IconBulb;
@@ -373,9 +384,10 @@ export default function InsightsPage() {
     return (
       <div
         key={insight.id}
-        className={`flex items-center gap-3 px-3 py-2 hover:bg-surface-hover transition-colors ${
+        className={`flex items-center gap-3 px-3 py-2 hover:bg-surface-hover transition-colors cursor-pointer ${
           isLast ? "" : "border-b border-border-primary"
         }`}
+        onClick={() => router.push(`${basePath}/${insight.id}`)}
       >
         <Tooltip label={typeDef?.label ?? insight.type} position="top">
           <div className="shrink-0 flex items-center">
@@ -433,7 +445,12 @@ export default function InsightsPage() {
         </Text>
         <Menu position="bottom-end" withinPortal>
           <Menu.Target>
-            <ActionIcon variant="subtle" size="xs" className="text-text-muted shrink-0">
+            <ActionIcon
+              variant="subtle"
+              size="xs"
+              className="text-text-muted shrink-0"
+              onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            >
               <IconDots size={14} />
             </ActionIcon>
           </Menu.Target>
@@ -675,7 +692,11 @@ export default function InsightsPage() {
           onMove={moveInsight}
           getItemLabel={(item) => item.title}
           renderCard={(item, { isOverlay }) => (
-            <InsightCard insight={item} isDragOverlay={isOverlay} />
+            <InsightCard
+              insight={item}
+              isDragOverlay={isOverlay}
+              onClick={() => router.push(`${basePath}/${item.id}`)}
+            />
           )}
         />
       ) : (

--- a/src/app/_components/product/CreateInsightModal.tsx
+++ b/src/app/_components/product/CreateInsightModal.tsx
@@ -235,7 +235,7 @@ export function CreateInsightModal({
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            placeholder="What did you learn?"
+            placeholder="Title"
             className="w-full bg-transparent text-base font-medium text-text-primary placeholder-text-muted outline-none"
             autoFocus
           />
@@ -246,7 +246,7 @@ export function CreateInsightModal({
           <Textarea
             value={body}
             onChange={(e) => setBody(e.currentTarget.value)}
-            placeholder="Describe the insight - context, quotes, evidence, links..."
+            placeholder="Description"
             autosize
             minRows={4}
             maxRows={12}

--- a/src/app/_components/product/CreateInsightModal.tsx
+++ b/src/app/_components/product/CreateInsightModal.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import { useRef, useState } from "react";
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Menu,
+  Modal,
+  MultiSelect,
+  Switch,
+  Text,
+  Textarea,
+  TextInput,
+} from "@mantine/core";
+import {
+  IconDots,
+  IconGauge,
+  IconMoodSmile,
+  IconTargetArrow,
+  IconX,
+} from "@tabler/icons-react";
+import { api } from "~/trpc/react";
+import {
+  INSIGHT_TYPES,
+  TYPE_MAP,
+  type InsightType,
+} from "~/app/_components/product/insightMeta";
+
+const SCORE_VALUES = [1, 2, 3, 4, 5];
+
+const SENTIMENT_OPTIONS = [
+  { value: "positive", label: "Positive" },
+  { value: "neutral", label: "Neutral" },
+  { value: "negative", label: "Negative" },
+];
+
+// ---------------------------------------------------------------------------
+// Pill button - a Menu trigger that looks like a compact chip
+// ---------------------------------------------------------------------------
+
+function Pill({
+  icon,
+  label,
+  children,
+}: {
+  icon?: React.ReactNode;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Menu position="bottom-start" withinPortal>
+      <Menu.Target>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 rounded-full border border-border-primary px-2.5 py-1 text-xs font-medium text-text-secondary hover:border-border-focus hover:text-text-primary transition-colors cursor-pointer bg-transparent whitespace-nowrap"
+        >
+          {icon}
+          <span>{label}</span>
+        </button>
+      </Menu.Target>
+      <Menu.Dropdown>{children}</Menu.Dropdown>
+    </Menu>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface CreateInsightModalProps {
+  opened: boolean;
+  onClose: () => void;
+  productId: string;
+  productName: string;
+}
+
+export function CreateInsightModal({
+  opened,
+  onClose,
+  productId,
+  productName,
+}: CreateInsightModalProps) {
+  const utils = api.useUtils();
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  // core
+  const [type, setType] = useState<InsightType>("PAIN_POINT");
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [impact, setImpact] = useState<number | null>(null);
+  const [confidence, setConfidence] = useState<number | null>(null);
+  const [sentiment, setSentiment] = useState<string | null>(null);
+
+  // overflow
+  const [source, setSource] = useState("");
+  const [category, setCategory] = useState("");
+  const [featureIds, setFeatureIds] = useState<string[]>([]);
+  const [showSource, setShowSource] = useState(false);
+  const [showCategory, setShowCategory] = useState(false);
+  const [showFeatures, setShowFeatures] = useState(false);
+
+  const [createMore, setCreateMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { data: features } = api.product.feature.list.useQuery(
+    { productId },
+    { enabled: !!productId && opened && showFeatures },
+  );
+
+  // Reset capture fields but keep type + revealed rows - "create more" is for
+  // batch capture (e.g. dumping interview notes), where consecutive insights
+  // usually share a type and source.
+  const resetCapture = () => {
+    setTitle("");
+    setBody("");
+    setImpact(null);
+    setConfidence(null);
+    setSentiment(null);
+    setFeatureIds([]);
+    setError(null);
+  };
+
+  const resetAll = () => {
+    resetCapture();
+    setType("PAIN_POINT");
+    setSource("");
+    setCategory("");
+    setShowSource(false);
+    setShowCategory(false);
+    setShowFeatures(false);
+  };
+
+  const create = api.product.insight.create.useMutation({
+    onSuccess: async () => {
+      await utils.product.insight.list.invalidate({ productId });
+      if (createMore) {
+        resetCapture();
+        titleRef.current?.focus();
+      } else {
+        resetAll();
+        onClose();
+      }
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  const handleSubmit = () => {
+    if (!title.trim() || create.isPending) return;
+    create.mutate({
+      productId,
+      type,
+      title: title.trim(),
+      body: body.trim() || undefined,
+      source: source.trim() || undefined,
+      sentiment: (sentiment ?? undefined) as
+        | "positive"
+        | "neutral"
+        | "negative"
+        | undefined,
+      category: category.trim() || undefined,
+      impact: impact ?? undefined,
+      confidence: confidence ?? undefined,
+      featureIds: featureIds.length > 0 ? featureIds : undefined,
+    });
+  };
+
+  const handleClose = () => {
+    resetAll();
+    onClose();
+  };
+
+  const typeDef = TYPE_MAP[type];
+  const TypeIcon = typeDef?.icon ?? IconTargetArrow;
+  const sentimentLabel = sentiment
+    ? SENTIMENT_OPTIONS.find((o) => o.value === sentiment)?.label ?? "Sentiment"
+    : "Sentiment";
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={handleClose}
+      size="lg"
+      radius="lg"
+      padding={0}
+      withCloseButton={false}
+      styles={{
+        content: {
+          backgroundColor: "var(--color-bg-elevated)",
+          color: "var(--color-text-primary)",
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden",
+        },
+        body: {
+          padding: 0,
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+        },
+      }}
+    >
+      <div
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.preventDefault();
+            handleSubmit();
+          }
+        }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-border-primary">
+          <div className="flex items-center gap-2 text-sm">
+            <Badge variant="light" size="sm" radius="sm" className="uppercase">
+              {productName}
+            </Badge>
+            <Text span size="sm" className="text-text-muted">
+              New insight
+            </Text>
+          </div>
+          <ActionIcon
+            variant="subtle"
+            size="sm"
+            onClick={handleClose}
+            className="text-text-muted hover:text-text-primary"
+          >
+            <IconX size={16} />
+          </ActionIcon>
+        </div>
+
+        {/* Title */}
+        <div className="px-5 pt-5">
+          <input
+            ref={titleRef}
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="What did you learn?"
+            className="w-full bg-transparent text-base font-medium text-text-primary placeholder-text-muted outline-none"
+            autoFocus
+          />
+        </div>
+
+        {/* Body - plain Markdown (ADR-0017); evidence and quotes go here. */}
+        <div className="px-5 py-1" style={{ minHeight: 140 }}>
+          <Textarea
+            value={body}
+            onChange={(e) => setBody(e.currentTarget.value)}
+            placeholder="Describe the insight - context, quotes, evidence, links..."
+            autosize
+            minRows={4}
+            maxRows={12}
+            variant="unstyled"
+            styles={{
+              input: { fontSize: "0.875rem", padding: 0 },
+            }}
+          />
+        </div>
+
+        {/* Property pills */}
+        <div className="border-t border-border-primary px-5 py-3">
+          <div className="flex flex-wrap items-center gap-1.5">
+            {/* Type */}
+            <Pill icon={<TypeIcon size={14} />} label={typeDef?.label ?? type}>
+              {INSIGHT_TYPES.map((t) => {
+                const Icon = t.icon;
+                return (
+                  <Menu.Item
+                    key={t.value}
+                    leftSection={<Icon size={14} />}
+                    onClick={() => setType(t.value)}
+                  >
+                    {t.label}
+                  </Menu.Item>
+                );
+              })}
+            </Pill>
+
+            {/* Impact */}
+            <Pill
+              icon={<IconGauge size={14} />}
+              label={impact != null ? `Impact ${impact}` : "Impact"}
+            >
+              {SCORE_VALUES.map((n) => (
+                <Menu.Item key={n} onClick={() => setImpact(n)}>
+                  {n}
+                </Menu.Item>
+              ))}
+              {impact != null && (
+                <>
+                  <Menu.Divider />
+                  <Menu.Item onClick={() => setImpact(null)}>Clear</Menu.Item>
+                </>
+              )}
+            </Pill>
+
+            {/* Confidence */}
+            <Pill
+              icon={<IconGauge size={14} />}
+              label={confidence != null ? `Confidence ${confidence}` : "Confidence"}
+            >
+              {SCORE_VALUES.map((n) => (
+                <Menu.Item key={n} onClick={() => setConfidence(n)}>
+                  {n}
+                </Menu.Item>
+              ))}
+              {confidence != null && (
+                <>
+                  <Menu.Divider />
+                  <Menu.Item onClick={() => setConfidence(null)}>Clear</Menu.Item>
+                </>
+              )}
+            </Pill>
+
+            {/* Sentiment - only meaningful for feedback */}
+            {type === "FEEDBACK" && (
+              <Pill icon={<IconMoodSmile size={14} />} label={sentimentLabel}>
+                {SENTIMENT_OPTIONS.map((o) => (
+                  <Menu.Item key={o.value} onClick={() => setSentiment(o.value)}>
+                    {o.label}
+                  </Menu.Item>
+                ))}
+                {sentiment && (
+                  <>
+                    <Menu.Divider />
+                    <Menu.Item onClick={() => setSentiment(null)}>Clear</Menu.Item>
+                  </>
+                )}
+              </Pill>
+            )}
+
+            {/* 3-dot overflow menu */}
+            <Menu position="top-end" withinPortal>
+              <Menu.Target>
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center rounded-full border border-border-primary w-7 h-7 text-text-muted hover:border-border-focus hover:text-text-primary transition-colors cursor-pointer bg-transparent"
+                >
+                  <IconDots size={14} />
+                </button>
+              </Menu.Target>
+              <Menu.Dropdown>
+                {!showSource && (
+                  <Menu.Item onClick={() => setShowSource(true)}>Source</Menu.Item>
+                )}
+                {!showCategory && (
+                  <Menu.Item onClick={() => setShowCategory(true)}>
+                    Category
+                  </Menu.Item>
+                )}
+                {!showFeatures && (
+                  <Menu.Item onClick={() => setShowFeatures(true)}>
+                    Features
+                  </Menu.Item>
+                )}
+              </Menu.Dropdown>
+            </Menu>
+          </div>
+
+          {/* Revealed extras */}
+          {(showSource || showCategory) && (
+            <div className="mt-3 flex gap-2">
+              {showSource && (
+                <TextInput
+                  size="xs"
+                  placeholder="Source - e.g. User interview, Zendesk #4231"
+                  value={source}
+                  onChange={(e) => setSource(e.currentTarget.value)}
+                  className="flex-1"
+                />
+              )}
+              {showCategory && (
+                <TextInput
+                  size="xs"
+                  placeholder="Category - e.g. Onboarding, Billing"
+                  value={category}
+                  onChange={(e) => setCategory(e.currentTarget.value)}
+                  className="flex-1"
+                />
+              )}
+            </div>
+          )}
+          {showFeatures && (
+            <div className="mt-3">
+              <MultiSelect
+                size="xs"
+                placeholder="Link to one or more features..."
+                value={featureIds}
+                onChange={setFeatureIds}
+                data={(features ?? []).map((f) => ({ value: f.id, label: f.name }))}
+                searchable
+                clearable
+                comboboxProps={{ withinPortal: true }}
+                nothingFoundMessage="No features yet"
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between border-t border-border-primary px-5 py-3">
+          <div className="flex items-center gap-3">
+            <Switch
+              size="xs"
+              label="Create more"
+              checked={createMore}
+              onChange={(e) => setCreateMore(e.currentTarget.checked)}
+              styles={{
+                label: { fontSize: "0.75rem", color: "var(--color-text-muted)" },
+              }}
+            />
+            {error && (
+              <Text size="xs" c="red">
+                {error}
+              </Text>
+            )}
+          </div>
+          <Button
+            size="sm"
+            color="brand"
+            radius="md"
+            onClick={handleSubmit}
+            loading={create.isPending}
+            disabled={!title.trim()}
+          >
+            Create insight
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/_components/product/InsightDocument.tsx
+++ b/src/app/_components/product/InsightDocument.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { JSONContent } from "@tiptap/core";
+import { api } from "~/trpc/react";
+import { RichDocEditor } from "~/app/_components/shared/RichDocEditor";
+
+interface InsightDocumentProps {
+  insightId: string;
+  /** Canonical ProseMirror document; null until the insight is first migrated. */
+  bodyDoc: JSONContent | null;
+  /** Derived Markdown projection - source of the one-time migration. */
+  body: string | null;
+  docVersion?: number;
+  editable?: boolean;
+}
+
+/**
+ * The Insight detail-page body editor: the shared {@link RichDocEditor} engine
+ * wired to the Insight `bodyDoc`/`body`/`docVersion` storage (ADR-0024, same
+ * shape as PageDocument/PrdDocument). No comment layer and no /page command in
+ * v1 - just the document surface.
+ */
+export function InsightDocument({
+  insightId,
+  bodyDoc,
+  body,
+  docVersion = 0,
+  editable = false,
+}: InsightDocumentProps) {
+  const initBodyDoc = api.product.insight.initBodyDoc.useMutation();
+  const updateInsight = api.product.insight.update.useMutation();
+  const uploadImage = api.product.insight.uploadImage.useMutation();
+
+  return (
+    <RichDocEditor
+      initialDoc={bodyDoc}
+      initialMarkdown={body}
+      docVersion={docVersion}
+      editable={editable}
+      placeholder="Describe the insight - context, quotes, evidence, links. Select text to format, or type / for blocks."
+      conflict={{
+        title: "This insight changed",
+        message:
+          "Someone else saved a newer version of this insight. Reload to get the latest? Unsaved changes in this tab will be lost.",
+      }}
+      onSave={async ({ doc, markdown, baseVersion }) =>
+        updateInsight.mutateAsync({
+          id: insightId,
+          bodyDoc: doc,
+          body: markdown,
+          baseVersion,
+        })
+      }
+      onInitDoc={(doc) => initBodyDoc.mutate({ id: insightId, doc })}
+      uploadImage={(base64Data) =>
+        uploadImage.mutateAsync({ id: insightId, base64Data })
+      }
+    />
+  );
+}

--- a/src/app/_components/product/insightMeta.tsx
+++ b/src/app/_components/product/insightMeta.tsx
@@ -32,21 +32,37 @@ export type InsightType = (typeof INSIGHT_TYPES)[number]["value"];
 export const TYPE_MAP: Record<string, { value: string; label: string; icon: TablerIcon; color: string }> =
   Object.fromEntries(INSIGHT_TYPES.map((t) => [t.value, t]));
 
-export type InsightStatus = "INBOX" | "TRIAGED" | "LINKED" | "DISMISSED";
+/**
+ * Insight status is the triage DECISION, not a lifecycle: INBOX = not yet
+ * reviewed, TRIAGED (shown as "Accepted") = reviewed and kept, DISMISSED =
+ * reviewed and rejected. "Reviewed" is the transition out of INBOX, never a
+ * state. Feature linkage is a relational fact (FeatureInsight), not a status -
+ * the DB enum's legacy LINKED value is coalesced to TRIAGED at read in the
+ * insight router and must not reach the client.
+ */
+export type InsightStatus = "INBOX" | "TRIAGED" | "DISMISSED";
 
 export const STATUS_OPTIONS: { value: InsightStatus; label: string }[] = [
   { value: "INBOX", label: "Inbox" },
-  { value: "TRIAGED", label: "Triaged" },
-  { value: "LINKED", label: "Linked" },
+  { value: "TRIAGED", label: "Accepted" },
   { value: "DISMISSED", label: "Dismissed" },
 ];
 
 export const STATUS_COLORS: Record<string, string> = {
   INBOX: "gray",
   TRIAGED: "blue",
-  LINKED: "green",
   DISMISSED: "dark",
 };
+
+/**
+ * Types that may be published to the public feedback board (user-voice only;
+ * mirrors PUBLISHABLE_TYPES in the insight router, which enforces it).
+ */
+export const PUBLISHABLE_INSIGHT_TYPES: string[] = [
+  "FEEDBACK",
+  "PAIN_POINT",
+  "OPPORTUNITY",
+];
 
 export const SENTIMENT_COLORS: Record<string, string> = {
   positive: "green",
@@ -54,10 +70,9 @@ export const SENTIMENT_COLORS: Record<string, string> = {
   negative: "red",
 };
 
-/** Kanban columns for the insights board — the four InsightStatus values. */
+/** Kanban columns for the insights board - the three InsightStatus values. */
 export const INSIGHT_STATUS_COLUMNS: { id: InsightStatus; title: string; accent: ColumnAccent }[] = [
   { id: "INBOX", title: "Inbox", accent: "slate" },
-  { id: "TRIAGED", title: "Triaged", accent: "brand" },
-  { id: "LINKED", title: "Linked", accent: "green" },
+  { id: "TRIAGED", title: "Accepted", accent: "brand" },
   { id: "DISMISSED", title: "Dismissed", accent: "red" },
 ];

--- a/src/plugins/product/server/routers/__tests__/insight.test.ts
+++ b/src/plugins/product/server/routers/__tests__/insight.test.ts
@@ -120,7 +120,7 @@ describe("insight router (mocked)", () => {
   beforeEach(() => {
     dbMock = getDbMock();
     mockReset(dbMock);
-    // The create mutation runs inside a $transaction — invoke the callback with
+    // The create mutation runs inside a $transaction - invoke the callback with
     // the same mock as the transactional client.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     dbMock.$transaction.mockImplementation(async (cb: any) => cb(dbMock));
@@ -185,7 +185,12 @@ describe("insight router (mocked)", () => {
 
       expect(dbMock.insight.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { productId, category: "Onboarding", parkedAt: null },
+          where: {
+            productId,
+            category: "Onboarding",
+            parkedAt: null,
+            duplicateOfId: null,
+          },
         }),
       );
     });
@@ -199,7 +204,7 @@ describe("insight router (mocked)", () => {
       await caller.product.insight.list({ productId, includeParked: true });
 
       expect(dbMock.insight.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { productId } }),
+        expect.objectContaining({ where: { productId, duplicateOfId: null } }),
       );
     });
 

--- a/src/plugins/product/server/routers/__tests__/research.integration.test.ts
+++ b/src/plugins/product/server/routers/__tests__/research.integration.test.ts
@@ -42,7 +42,7 @@ describe("research router", () => {
     expect(insight.status).toBe("INBOX");
   });
 
-  it("links insight to feature and updates status to LINKED", async () => {
+  it("links insight to feature and promotes status to TRIAGED", async () => {
     const user = await createUser(db);
     const ws = await createWorkspace(db, { ownerId: user.id });
     const product = await createProduct(db, {
@@ -75,7 +75,9 @@ describe("research router", () => {
     const refreshedInsight = await db.insight.findUnique({
       where: { id: insight.id },
     });
-    expect(refreshedInsight?.status).toBe("LINKED");
+    // Linking promotes un-triaged evidence to TRIAGED ("Accepted"); linkage
+    // itself is the FeatureInsight row, not a status.
+    expect(refreshedInsight?.status).toBe("TRIAGED");
 
     const link = await db.featureInsight.findUnique({
       where: {

--- a/src/plugins/product/server/routers/insight.ts
+++ b/src/plugins/product/server/routers/insight.ts
@@ -2,8 +2,13 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { loadProductWithAccess, assertWorkspaceMember } from "./product";
-import type { PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
+import { checkStaleWrite } from "~/lib/prd/stale-write";
+import { uploadToBlob } from "~/lib/blob";
+
+// Loose shape for a ProseMirror document (same treatment as feature.ts).
+const prosemirrorDoc = z.record(z.string(), z.unknown());
 
 const insightTypeEnum = z.enum([
   "PAIN_POINT",
@@ -206,19 +211,126 @@ export const insightRouter = createTRPCRouter({
         category: boundedText("Category", TEXT_LIMITS.LABEL).nullable().optional(),
         impact: scoreSchema.nullable().optional(),
         confidence: scoreSchema.nullable().optional(),
+        // Detail-page body save (ADR-0024, mirrors feature.update): bodyDoc is
+        // the canonical document, the existing `body` field above rides along
+        // as its client-serialised Markdown projection, `baseVersion` is the
+        // optimistic-concurrency check.
+        bodyDoc: prosemirrorDoc.optional(),
+        baseVersion: z.number().int().min(0).optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
       await loadInsightWithAccess(ctx.db, ctx.session.user.id, input.id);
-      const { id, ...data } = input;
+      const { id, bodyDoc, baseVersion, ...data } = input;
+
+      // Body autosave path: optimistic-concurrency guard + version bump.
+      if (bodyDoc !== undefined) {
+        if (baseVersion === undefined) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "baseVersion is required when saving the insight body",
+          });
+        }
+        const current = await ctx.db.insight.findUnique({
+          where: { id },
+          select: { docVersion: true },
+        });
+        const decision = checkStaleWrite({
+          storedVersion: current?.docVersion ?? 0,
+          baseVersion,
+        });
+        if (!decision.accept) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "This insight was updated in another tab or by another member. Reload to get the latest version.",
+          });
+        }
+        // Atomic compare-and-set: the WHERE on docVersion closes the
+        // read-to-write race so two concurrent saves can't both bump from the
+        // same base.
+        const res = await ctx.db.insight.updateMany({
+          where: { id, docVersion: baseVersion },
+          data: {
+            ...data,
+            bodyDoc: bodyDoc as Prisma.InputJsonValue,
+            docVersion: { increment: 1 },
+          },
+        });
+        if (res.count === 0) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "This insight was updated concurrently. Reload to get the latest version.",
+          });
+        }
+        return { id, docVersion: decision.nextVersion };
+      }
+
       return ctx.db.insight.update({
         where: { id },
         data: {
           ...data,
           // Keep description in sync with title so both columns stay consistent
           ...(input.title ? { description: input.title } : {}),
+          // A Markdown-only body write (no bodyDoc) invalidates the canonical
+          // doc: null it and bump docVersion so the editor re-derives from
+          // Markdown on next open (mirrors page.update's agent path).
+          ...(data.body !== undefined
+            ? { bodyDoc: Prisma.DbNull, docVersion: { increment: 1 } }
+            : {}),
         },
       });
+    }),
+
+  /**
+   * Persist the one-time lazy migration of a legacy Markdown `body` into the
+   * canonical `bodyDoc` (ADR-0024, mirrors feature.initDescriptionDoc).
+   * Idempotent and write-once: an existing bodyDoc always wins.
+   */
+  initBodyDoc: protectedProcedure
+    .input(z.object({ id: z.string(), doc: prosemirrorDoc }))
+    .mutation(async ({ ctx, input }) => {
+      await loadInsightWithAccess(ctx.db, ctx.session.user.id, input.id);
+
+      const existing = await ctx.db.insight.findUnique({
+        where: { id: input.id },
+        select: { bodyDoc: true },
+      });
+      if (existing?.bodyDoc != null) {
+        return { migrated: false, bodyDoc: existing.bodyDoc };
+      }
+
+      const updated = await ctx.db.insight.update({
+        where: { id: input.id },
+        data: { bodyDoc: input.doc as Prisma.InputJsonValue },
+        select: { bodyDoc: true },
+      });
+      return { migrated: true, bodyDoc: updated.bodyDoc };
+    }),
+
+  /**
+   * Upload an image pasted/dropped into the insight body, mirroring
+   * feature.uploadImage: base64 in, public Vercel Blob URL out.
+   */
+  uploadImage: protectedProcedure
+    .input(z.object({ id: z.string(), base64Data: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      await loadInsightWithAccess(ctx.db, ctx.session.user.id, input.id);
+
+      // Same 5MB cap as feature.uploadImage (base64 is ~4/3 the byte size).
+      const approxBytes = Math.floor((input.base64Data.length * 3) / 4);
+      if (approxBytes > 5 * 1024 * 1024) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Image too large. Please use an image under 5MB.",
+        });
+      }
+
+      const timestamp = new Date().toISOString().replace(/[/:]/g, "-");
+      const filename = `screenshots/insights/${input.id}/${timestamp}.png`;
+      const blob = await uploadToBlob(input.base64Data, filename);
+      return { url: blob.url };
     }),
 
   delete: protectedProcedure

--- a/src/plugins/product/server/routers/insight.ts
+++ b/src/plugins/product/server/routers/insight.ts
@@ -590,15 +590,26 @@ export const insightRouter = createTRPCRouter({
         });
       }
 
-      // Flatten chains: if the chosen canonical is itself a duplicate, point
-      // at ITS canonical instead.
-      let canonical: { id: string; title: string } = target;
-      if (target.duplicateOfId) {
+      // Flatten chains: if the chosen canonical is itself a duplicate, walk up
+      // to the true root. Writes keep the tree one level deep, but a race or a
+      // direct DB write could leave a deeper chain - loop with a cycle guard
+      // instead of trusting the invariant.
+      let canonical: { id: string; title: string; duplicateOfId: string | null } = target;
+      const visited = new Set<string>([input.id, target.id]);
+      while (canonical.duplicateOfId) {
+        if (visited.has(canonical.duplicateOfId)) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "This would create a duplicate cycle",
+          });
+        }
+        visited.add(canonical.duplicateOfId);
         const resolved = await ctx.db.insight.findUnique({
-          where: { id: target.duplicateOfId },
-          select: { id: true, title: true },
+          where: { id: canonical.duplicateOfId },
+          select: { id: true, title: true, duplicateOfId: true },
         });
-        if (resolved) canonical = resolved;
+        if (!resolved) break;
+        canonical = resolved;
       }
       if (canonical.id === input.id) {
         throw new TRPCError({

--- a/src/plugins/product/server/routers/insight.ts
+++ b/src/plugins/product/server/routers/insight.ts
@@ -2,10 +2,11 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { loadProductWithAccess, assertWorkspaceMember } from "./product";
-import { Prisma, type PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient, type InsightType } from "@prisma/client";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 import { checkStaleWrite } from "~/lib/prd/stale-write";
 import { uploadToBlob } from "~/lib/blob";
+import { recordActivity } from "~/server/services/activity/recordActivity";
 
 // Loose shape for a ProseMirror document (same treatment as feature.ts).
 const prosemirrorDoc = z.record(z.string(), z.unknown());
@@ -21,7 +22,22 @@ const insightTypeEnum = z.enum([
   "PROBLEM",
 ]);
 
-const insightStatusEnum = z.enum(["INBOX", "TRIAGED", "LINKED", "DISMISSED"]);
+// Status is the triage decision: INBOX = not yet reviewed, TRIAGED (shown as
+// "Accepted" in the UI) = reviewed and kept, DISMISSED = reviewed and rejected.
+// Feature linkage is a relational fact (FeatureInsight), never a status. The
+// DB enum retains a legacy LINKED value (kept to avoid a schema migration);
+// it is no longer accepted as input and is coalesced to TRIAGED at read.
+const insightStatusEnum = z.enum(["INBOX", "TRIAGED", "DISMISSED"]);
+
+// Read-time coalescing of the legacy LINKED status (see insightStatusEnum).
+function coalesceStatus<T extends { status: string }>(row: T): T {
+  return row.status === "LINKED" ? { ...row, status: "TRIAGED" } : row;
+}
+
+// The only insight types that may appear on the public feedback board: the
+// user's own voice (feedback, pain points, feature requests / opportunities).
+// Everything else is internal evidence and is rejected by `publish`.
+const PUBLISHABLE_TYPES: InsightType[] = ["FEEDBACK", "PAIN_POINT", "OPPORTUNITY"];
 
 // Provenance filter (ADR-0037). An insight "came from a form" iff its `source`
 // starts with `form:` (stamped by the `create_insight` destination). `manual`
@@ -29,7 +45,7 @@ const insightStatusEnum = z.enum(["INBOX", "TRIAGED", "LINKED", "DISMISSED"]);
 const insightOriginEnum = z.enum(["form", "manual", "all"]);
 
 // General triage scores (impact/confidence), 1–5. Usable by any insight type
-// (ADR-0036) — formerly Problem-only.
+// (ADR-0036) - formerly Problem-only.
 const scoreSchema = z.number().int().min(1).max(5);
 
 async function loadInsightWithAccess(
@@ -41,6 +57,10 @@ async function loadInsightWithAccess(
     where: { id: insightId },
     select: {
       id: true,
+      type: true,
+      title: true,
+      status: true,
+      duplicateOfId: true,
       productId: true,
       product: { select: { workspaceId: true } },
     },
@@ -64,10 +84,14 @@ export const insightRouter = createTRPCRouter({
         // (`source` starts with `form:`), `manual` = anything else, `all`
         // (default) applies no source filter.
         origin: insightOriginEnum.optional(),
-        // Parked insights are hidden by default — parking is independent of
+        // Parked insights are hidden by default - parking is independent of
         // status (an insight keeps its status while parked). Pass true to
         // include them (the "Show parked" toggle / a Parked lane).
         includeParked: z.boolean().optional(),
+        // Duplicates (Linear-style, `duplicateOfId` set) are hidden by
+        // default - they defer to their canonical insight. Pass true to
+        // include them.
+        includeDuplicates: z.boolean().optional(),
       }),
     )
     .query(async ({ ctx, input }) => {
@@ -88,14 +112,23 @@ export const insightRouter = createTRPCRouter({
               }
             : {};
 
-      return ctx.db.insight.findMany({
+      const rows = await ctx.db.insight.findMany({
         where: {
           productId: input.productId,
           ...(input.type ? { type: input.type } : {}),
-          ...(input.status ? { status: input.status } : {}),
+          // Legacy LINKED rows count as TRIAGED (see insightStatusEnum).
+          ...(input.status
+            ? {
+                status:
+                  input.status === "TRIAGED"
+                    ? { in: ["TRIAGED", "LINKED"] }
+                    : input.status,
+              }
+            : {}),
           ...(input.category ? { category: input.category } : {}),
           ...originWhere,
           ...(input.includeParked ? {} : { parkedAt: null }),
+          ...(input.includeDuplicates ? {} : { duplicateOfId: null }),
         },
         orderBy: [{ createdAt: "desc" }],
         include: {
@@ -104,9 +137,10 @@ export const insightRouter = createTRPCRouter({
           features: {
             include: { feature: { select: { id: true, name: true } } },
           },
-          _count: { select: { features: true } },
+          _count: { select: { features: true, duplicates: true } },
         },
       });
+      return rows.map(coalesceStatus);
     }),
 
   getById: protectedProcedure
@@ -122,13 +156,22 @@ export const insightRouter = createTRPCRouter({
           features: {
             include: { feature: { select: { id: true, name: true, status: true } } },
           },
+          duplicateOf: { select: { id: true, title: true } },
+          duplicates: {
+            select: { id: true, title: true, type: true, createdAt: true },
+            orderBy: { createdAt: "asc" },
+          },
+          comments: {
+            include: { author: { select: { id: true, name: true, image: true } } },
+            orderBy: { createdAt: "asc" },
+          },
         },
       });
       if (!insight) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Insight not found" });
       }
       await assertWorkspaceMember(ctx.db, ctx.session.user.id, insight.product.workspaceId);
-      return insight;
+      return coalesceStatus(insight);
     }),
 
   create: protectedProcedure
@@ -141,7 +184,7 @@ export const insightRouter = createTRPCRouter({
         source: boundedText("Source", 500).optional(),
         sentiment: z.enum(["positive", "neutral", "negative"]).optional(),
         status: insightStatusEnum.optional(),
-        // General triage fields (ADR-0036) — usable by any type.
+        // General triage fields (ADR-0036) - usable by any type.
         evidence: boundedText("Evidence", TEXT_LIMITS.LARGE).optional(),
         category: boundedText("Category", TEXT_LIMITS.LABEL).optional(),
         impact: scoreSchema.optional(),
@@ -166,7 +209,9 @@ export const insightRouter = createTRPCRouter({
             impact: input.impact,
             confidence: input.confidence,
             description: input.title,
-            status: input.status ?? "INBOX",
+            // Created pre-linked to features = already reviewed and kept.
+            status:
+              input.status ?? (input.featureIds?.length ? "TRIAGED" : "INBOX"),
             createdById: ctx.session.user.id,
           },
         });
@@ -220,8 +265,22 @@ export const insightRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      await loadInsightWithAccess(ctx.db, ctx.session.user.id, input.id);
+      const existing = await loadInsightWithAccess(ctx.db, ctx.session.user.id, input.id);
       const { id, bodyDoc, baseVersion, ...data } = input;
+
+      // Feed the detail page's activity trail (fire-and-forget). Compare
+      // against the coalesced status so a legacy LINKED row reads as TRIAGED.
+      const previousStatus = coalesceStatus(existing).status;
+      if (data.status && data.status !== previousStatus) {
+        await recordActivity(ctx.db, {
+          workspaceId: existing.product.workspaceId,
+          userId: ctx.session.user.id,
+          entityType: "insight",
+          entityId: id,
+          action: "status_changed",
+          metadata: { from: previousStatus, to: data.status },
+        });
+      }
 
       // Body autosave path: optimistic-concurrency guard + version bump.
       if (bodyDoc !== undefined) {
@@ -363,6 +422,12 @@ export const insightRouter = createTRPCRouter({
         create: { insightId: input.insightId, featureId: input.featureId },
         update: {},
       });
+      // Linking evidence to a feature implies it was reviewed and kept:
+      // promote un-triaged insights to TRIAGED. Never resurrect DISMISSED.
+      await ctx.db.insight.updateMany({
+        where: { id: input.insightId, status: { in: ["INBOX", "LINKED"] } },
+        data: { status: "TRIAGED" },
+      });
       return { success: true };
     }),
 
@@ -395,6 +460,13 @@ export const insightRouter = createTRPCRouter({
             });
           }
         }
+        if (uniqueFeatureIds.length > 0) {
+          // Same promotion as linkToFeature: linking implies reviewed-and-kept.
+          await tx.insight.updateMany({
+            where: { id: input.insightId, status: { in: ["INBOX", "LINKED"] } },
+            data: { status: "TRIAGED" },
+          });
+        }
         await tx.featureInsight.deleteMany({ where: { insightId: input.insightId } });
         await tx.featureInsight.createMany({
           data: uniqueFeatureIds.map((featureId) => ({
@@ -409,7 +481,7 @@ export const insightRouter = createTRPCRouter({
 
   // ── Parking ───────────────────────────────────────────────────────────
   // A general, reversible "defer with a reason" affordance on any insight
-  // (ADR-0036) — set aside WITH A REASON, never deleted, and revivable at its
+  // (ADR-0036) - set aside WITH A REASON, never deleted, and revivable at its
   // prior status. Parked-ness is independent of `status`.
 
   park: protectedProcedure
@@ -436,6 +508,238 @@ export const insightRouter = createTRPCRouter({
       return ctx.db.insight.update({
         where: { id: input.id },
         data: { parkedAt: null, parkReason: null },
+      });
+    }),
+
+  // ── Publishing ────────────────────────────────────────────────────────
+  // Feedback-board visibility. Publishing is always an explicit human act -
+  // form intake and triage never set it. Only user-voice insight types may be
+  // published; internal evidence (PROBLEM, COMPETITIVE, OBSERVATION, PERSONA,
+  // JOURNEY) is rejected server-side so the future public board can never
+  // leak it. The board read path must filter on `publishedAt`.
+
+  publish: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const insight = await loadInsightWithAccess(ctx.db, ctx.session.user.id, input.id);
+      if (!PUBLISHABLE_TYPES.includes(insight.type)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Only user feedback (feedback, pain points, opportunities) can be published to the board",
+        });
+      }
+      const updated = await ctx.db.insight.update({
+        where: { id: input.id },
+        data: { publishedAt: new Date() },
+      });
+      await recordActivity(ctx.db, {
+        workspaceId: insight.product.workspaceId,
+        userId: ctx.session.user.id,
+        entityType: "insight",
+        entityId: input.id,
+        action: "updated",
+        metadata: { change: "published" },
+      });
+      return updated;
+    }),
+
+  unpublish: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const insight = await loadInsightWithAccess(ctx.db, ctx.session.user.id, input.id);
+      const updated = await ctx.db.insight.update({
+        where: { id: input.id },
+        data: { publishedAt: null },
+      });
+      await recordActivity(ctx.db, {
+        workspaceId: insight.product.workspaceId,
+        userId: ctx.session.user.id,
+        entityType: "insight",
+        entityId: input.id,
+        action: "updated",
+        metadata: { change: "unpublished" },
+      });
+      return updated;
+    }),
+
+  // ── Duplicates ────────────────────────────────────────────────────────
+  // Linear-style non-destructive duplicate marking. The duplicate keeps all
+  // its content (insights are evidence; two reports are two data points) but
+  // drops out of default lists and defers to its canonical. Chains are
+  // flattened at write time so `duplicateOfId` is always one level deep.
+
+  markDuplicate: protectedProcedure
+    .input(z.object({ id: z.string(), canonicalId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      if (input.id === input.canonicalId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "An insight cannot be a duplicate of itself",
+        });
+      }
+      const insight = await loadInsightWithAccess(ctx.db, ctx.session.user.id, input.id);
+      const target = await ctx.db.insight.findUnique({
+        where: { id: input.canonicalId },
+        select: { id: true, title: true, productId: true, duplicateOfId: true },
+      });
+      if (!target || target.productId !== insight.productId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Canonical insight must belong to the same product",
+        });
+      }
+
+      // Flatten chains: if the chosen canonical is itself a duplicate, point
+      // at ITS canonical instead.
+      let canonical: { id: string; title: string } = target;
+      if (target.duplicateOfId) {
+        const resolved = await ctx.db.insight.findUnique({
+          where: { id: target.duplicateOfId },
+          select: { id: true, title: true },
+        });
+        if (resolved) canonical = resolved;
+      }
+      if (canonical.id === input.id) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "This would create a duplicate cycle",
+        });
+      }
+
+      await ctx.db.$transaction([
+        // Re-point any duplicates of this insight at the new canonical so the
+        // tree stays one level deep.
+        ctx.db.insight.updateMany({
+          where: { duplicateOfId: input.id },
+          data: { duplicateOfId: canonical.id },
+        }),
+        ctx.db.insight.update({
+          where: { id: input.id },
+          data: { duplicateOfId: canonical.id },
+        }),
+      ]);
+
+      await recordActivity(ctx.db, {
+        workspaceId: insight.product.workspaceId,
+        userId: ctx.session.user.id,
+        entityType: "insight",
+        entityId: input.id,
+        action: "updated",
+        metadata: {
+          change: "marked_duplicate",
+          canonicalId: canonical.id,
+          canonicalTitle: canonical.title,
+        },
+      });
+      await recordActivity(ctx.db, {
+        workspaceId: insight.product.workspaceId,
+        userId: ctx.session.user.id,
+        entityType: "insight",
+        entityId: canonical.id,
+        action: "updated",
+        metadata: {
+          change: "duplicate_added",
+          duplicateId: input.id,
+          duplicateTitle: insight.title,
+        },
+      });
+      return { success: true, canonicalId: canonical.id };
+    }),
+
+  unmarkDuplicate: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const insight = await loadInsightWithAccess(ctx.db, ctx.session.user.id, input.id);
+      if (!insight.duplicateOfId) return { success: true };
+      await ctx.db.insight.update({
+        where: { id: input.id },
+        data: { duplicateOfId: null },
+      });
+      await recordActivity(ctx.db, {
+        workspaceId: insight.product.workspaceId,
+        userId: ctx.session.user.id,
+        entityType: "insight",
+        entityId: input.id,
+        action: "updated",
+        metadata: { change: "unmarked_duplicate" },
+      });
+      return { success: true };
+    }),
+
+  // ── Activity ──────────────────────────────────────────────────────────
+  // The detail page's activity feed merges InsightComment rows with
+  // WorkspaceActivityEvent rows (entityType "insight") by createdAt.
+
+  addComment: protectedProcedure
+    .input(
+      z.object({
+        insightId: z.string(),
+        content: boundedText("Comment", TEXT_LIMITS.MEDIUM, { min: 1 }),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const insight = await loadInsightWithAccess(ctx.db, ctx.session.user.id, input.insightId);
+      const comment = await ctx.db.insightComment.create({
+        data: {
+          insightId: input.insightId,
+          authorId: ctx.session.user.id,
+          content: input.content,
+        },
+        include: { author: { select: { id: true, name: true, image: true } } },
+      });
+      await recordActivity(ctx.db, {
+        workspaceId: insight.product.workspaceId,
+        userId: ctx.session.user.id,
+        entityType: "insight_comment",
+        entityId: comment.id,
+        action: "created",
+        metadata: { insightId: input.insightId, snippet: input.content.slice(0, 120) },
+      });
+      return comment;
+    }),
+
+  deleteComment: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const comment = await ctx.db.insightComment.findUnique({
+        where: { id: input.id },
+        select: {
+          id: true,
+          authorId: true,
+          insight: { select: { product: { select: { workspaceId: true } } } },
+        },
+      });
+      if (!comment) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Comment not found" });
+      }
+      await assertWorkspaceMember(
+        ctx.db,
+        ctx.session.user.id,
+        comment.insight.product.workspaceId,
+      );
+      if (comment.authorId !== ctx.session.user.id) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You can only delete your own comments",
+        });
+      }
+      await ctx.db.insightComment.delete({ where: { id: input.id } });
+      return { success: true };
+    }),
+
+  listEvents: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const insight = await loadInsightWithAccess(ctx.db, ctx.session.user.id, input.id);
+      return ctx.db.workspaceActivityEvent.findMany({
+        where: {
+          workspaceId: insight.product.workspaceId,
+          entityType: "insight",
+          entityId: input.id,
+        },
+        orderBy: { createdAt: "asc" },
+        include: { user: { select: { id: true, name: true, image: true } } },
       });
     }),
 });

--- a/src/plugins/product/server/routers/research.ts
+++ b/src/plugins/product/server/routers/research.ts
@@ -16,7 +16,10 @@ const researchTypeEnum = z.enum([
 ]);
 
 const insightTypeEnum = z.enum(["PAIN_POINT", "OPPORTUNITY", "FEEDBACK", "PERSONA", "JOURNEY", "OBSERVATION", "COMPETITIVE"]);
-const insightStatusEnum = z.enum(["INBOX", "TRIAGED", "LINKED", "DISMISSED"]);
+// Mirrors insight.ts: status is the triage decision (INBOX / TRIAGED shown as
+// "Accepted" / DISMISSED). The legacy LINKED DB value is no longer written or
+// accepted as input; feature linkage lives in FeatureInsight.
+const insightStatusEnum = z.enum(["INBOX", "TRIAGED", "DISMISSED"]);
 
 async function loadResearchWithAccess(
   db: PrismaClient,
@@ -181,7 +184,15 @@ export const researchRouter = createTRPCRouter({
       return ctx.db.insight.findMany({
         where: {
           research: { productId: input.productId },
-          ...(input.status ? { status: input.status } : {}),
+          // Legacy LINKED rows count as TRIAGED (see insight.ts).
+          ...(input.status
+            ? {
+                status:
+                  input.status === "TRIAGED"
+                    ? { in: ["TRIAGED", "LINKED"] }
+                    : input.status,
+              }
+            : {}),
           ...(input.type ? { type: input.type } : {}),
         },
         orderBy: { createdAt: "desc" },
@@ -299,10 +310,11 @@ export const researchRouter = createTRPCRouter({
         update: {},
       });
 
-      // Auto-update insight status to LINKED
-      await ctx.db.insight.update({
-        where: { id: input.insightId },
-        data: { status: "LINKED" },
+      // Linking evidence to a feature implies it was reviewed and kept:
+      // promote un-triaged insights to TRIAGED. Never resurrect DISMISSED.
+      await ctx.db.insight.updateMany({
+        where: { id: input.insightId, status: { in: ["INBOX", "LINKED"] } },
+        data: { status: "TRIAGED" },
       });
 
       return { success: true };

--- a/src/server/services/activity/__tests__/recordActivity.test.ts
+++ b/src/server/services/activity/__tests__/recordActivity.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for recordActivity — the load-bearing primitive that any future
+ * Unit tests for recordActivity - the load-bearing primitive that any future
  * write site calls to log a workspace activity event.
  *
  * Uses mockDeep<PrismaClient>() so the test runs in milliseconds and CANNOT
@@ -9,7 +9,7 @@
  * `/services/` MUST stay mocked.
  *
  * We mock `~/env` rather than mutate process.env, because t3-env caches its
- * Proxy at module-load time — stubbing process.env after the fact has no
+ * Proxy at module-load time - stubbing process.env after the fact has no
  * effect on the existing `env.NODE_ENV` value.
  */
 
@@ -25,7 +25,7 @@ vi.hoisted(() => {
   process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
 });
 
-// Mocked env — the test toggles fakeEnv.NODE_ENV directly. The mock factory
+// Mocked env - the test toggles fakeEnv.NODE_ENV directly. The mock factory
 // returns a getter so each access reads the current value.
 const fakeEnv = { NODE_ENV: "test" as "development" | "test" | "production" };
 vi.mock("~/env", () => ({
@@ -173,7 +173,7 @@ describe("recordActivity", () => {
 
     expect(ok).toBe(false);
     expect(warnSpy).toHaveBeenCalledWith(
-      "[recordActivity] missing workspaceId — skipping",
+      "[recordActivity] missing workspaceId - skipping",
       expect.objectContaining({ entityType: "action", entityId: "action-1" }),
     );
     expect(dbMock.workspaceActivityEvent.create).not.toHaveBeenCalled();

--- a/src/server/services/activity/recordActivity.ts
+++ b/src/server/services/activity/recordActivity.ts
@@ -4,7 +4,7 @@ import { env } from "~/env";
 /**
  * Significant workspace events that feed the home-page heatmap, activity feed,
  * and weekly-review sparkline. Each value is stored as the `action` column on
- * `WorkspaceActivityEvent` — keep this list in sync with the column comment.
+ * `WorkspaceActivityEvent` - keep this list in sync with the column comment.
  */
 export type ActivityAction =
   | "created"
@@ -23,6 +23,8 @@ export type ActivityEntityType =
   | "action_comment"
   | "ticket"
   | "ticket_comment"
+  | "insight"
+  | "insight_comment"
   | "project"
   | "goal"
   | "weekly_review"
@@ -48,7 +50,7 @@ export interface RecordActivityInput {
 
 /**
  * Append one row to `WorkspaceActivityEvent`. This is a fire-and-forget
- * primitive for write sites — it MUST NOT throw, because instrumentation
+ * primitive for write sites - it MUST NOT throw, because instrumentation
  * failures should never break the user's mutation.
  *
  * Behavior:
@@ -59,7 +61,7 @@ export interface RecordActivityInput {
  *   normally.
  *
  * Returns true on a successful write, false otherwise. Callers can ignore the
- * return value — it exists for tests and observability.
+ * return value - it exists for tests and observability.
  */
 export async function recordActivity(
   db: PrismaClient,
@@ -68,11 +70,11 @@ export async function recordActivity(
   if (!input.workspaceId) {
     if (env.NODE_ENV === "development") {
       throw new Error(
-        "[recordActivity] workspaceId is required — instrumentation call site is missing it",
+        "[recordActivity] workspaceId is required - instrumentation call site is missing it",
       );
     }
     console.warn(
-      "[recordActivity] missing workspaceId — skipping",
+      "[recordActivity] missing workspaceId - skipping",
       { entityType: input.entityType, entityId: input.entityId, action: input.action },
     );
     return false;


### PR DESCRIPTION
## Summary

Builds out Insights V2 on four fronts:

**Detail page & editing** (first three commits)
- Compact list layout + Linear-style create modal
- Detail page with rich body editor (ADR-0024 storage model: `bodyDoc` canonical ProseMirror JSON + Markdown projection + optimistic-concurrency guard) and properties sidebar

**Decision-based status taxonomy**
- Status now encodes the triage *decision*: `INBOX` (unreviewed) -> `TRIAGED` (shown as **Accepted**) or `DISMISSED`. "Reviewed" is the transition, not a state.
- `LINKED` is retired as a status - feature linkage is a relational fact (`FeatureInsight`), shown from the relation. The legacy DB enum value stays (no destructive migration); it is no longer written or accepted as input and coalesces to `TRIAGED` at read.
- Linking evidence to a feature promotes un-triaged insights to Accepted (never resurrects Dismissed).

**Feedback-board publishing (groundwork)**
- `Insight.publishedAt`: explicit publish/unpublish, restricted server-side to user-voice types (`FEEDBACK`/`PAIN_POINT`/`OPPORTUNITY`) so internal evidence (PROBLEM, COMPETITIVE, ...) can never reach a future public board. Publish/unpublish UI + "public" badges.

**Duplicates + activity**
- Linear-style non-destructive duplicates: `duplicateOfId` self-relation with chain flattening; duplicates keep all content, drop out of default lists ("Show duplicates" filter), banner/backlinks on detail pages.
- Activity section on the detail page: new `InsightComment` model + `WorkspaceActivityEvent` instrumentation (status changes, publish/unpublish, duplicate marks) merged into one timeline, with the shared `CommentInput` composer.

## Migrations (note: targeting main directly)

Three **additive-only** migrations: `insight_body_doc`, `insight_published_at`, `insight_duplicates_comments` (new nullable columns + one new table; no data rewrites, no drops). Flagging explicitly since the documented flow routes migrations through `develop` - going direct to main here as discussed, given develop is far behind and the changes are purely additive.

## Test plan

- [x] Typecheck + lint clean
- [x] Unit tests 1275 passed (3 updated for the new list filter + log message)
- [x] Integration tests green under CI conditions (Node 20, UTC); research router test updated: linking now promotes to TRIAGED instead of LINKED
- [x] Production build + smoketest pass
- [x] Manually exercised: triage flow, publish/unpublish, mark/unmark duplicate, comments + event timeline