### PR TITLE
feat(crm): choose pipeline on deal create + edit, default stage to Lead

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/pipeline/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/pipeline/page.tsx
@@ -213,9 +213,9 @@ export default function PipelinePage() {
       <CreateDealModal
         opened={createModalOpen}
         onClose={() => setCreateModalOpen(false)}
-        projectId={pipeline.id}
+        pipelines={pipelines ?? []}
+        defaultProjectId={pipeline.id}
         workspaceId={workspaceId!}
-        stages={stages}
       />
 
       <PipelineSettingsModal
@@ -230,6 +230,7 @@ export default function PipelinePage() {
         projectId={pipeline.id}
         opened={!!selectedDealId}
         onClose={() => setSelectedDealId(null)}
+        pipelines={pipelines ?? []}
       />
 
       <Modal

--- a/src/app/_components/pipeline/CreateDealModal.tsx
+++ b/src/app/_components/pipeline/CreateDealModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Modal,
   TextInput,
@@ -24,29 +24,57 @@ interface PipelineStage {
   type: string;
 }
 
+interface PipelineOption {
+  id: string;
+  name: string;
+  pipelineStages: PipelineStage[];
+}
+
 interface CreateDealModalProps {
   opened: boolean;
   onClose: () => void;
-  projectId: string;
+  /** Every pipeline in the workspace the deal can be created on. */
+  pipelines: PipelineOption[];
+  /** The pipeline selected on the page — the modal's default destination. */
+  defaultProjectId: string;
   workspaceId: string;
-  stages: PipelineStage[];
 }
 
 export function CreateDealModal({
   opened,
   onClose,
-  projectId,
+  pipelines,
+  defaultProjectId,
   workspaceId,
-  stages,
 }: CreateDealModalProps) {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [value, setValue] = useState<number | undefined>();
   const [probability, setProbability] = useState<number | undefined>();
-  const [stageId, setStageId] = useState<string>(stages[0]?.id ?? "");
+  const [projectId, setProjectId] = useState<string>(defaultProjectId);
+  const [stageId, setStageId] = useState<string>("");
   const [contactId, setContactId] = useState<string | null>(null);
   const [organizationId, setOrganizationId] = useState<string | null>(null);
   const [expectedCloseDate, setExpectedCloseDate] = useState<Date | null>(null);
+
+  // Stages of the currently-selected pipeline (ordered, so [0] is "Lead").
+  const selectedPipeline =
+    pipelines.find((p) => p.id === projectId) ?? pipelines[0];
+  const stages = selectedPipeline?.pipelineStages ?? [];
+
+  // Each time the modal opens, default the destination to the pipeline the page
+  // is showing.
+  useEffect(() => {
+    if (opened) setProjectId(defaultProjectId);
+  }, [opened, defaultProjectId]);
+
+  // Keep the stage valid: default to the first stage ("Lead") whenever the
+  // pipeline changes or the current stage isn't part of the selected pipeline.
+  useEffect(() => {
+    if (!stages.some((s) => s.id === stageId)) {
+      setStageId(stages[0]?.id ?? "");
+    }
+  }, [stages, stageId]);
 
   const utils = api.useUtils();
 
@@ -94,7 +122,8 @@ export function CreateDealModal({
     setDescription("");
     setValue(undefined);
     setProbability(undefined);
-    setStageId(stages[0]?.id ?? "");
+    setProjectId(defaultProjectId);
+    // stageId re-defaults to the first stage via the stages effect.
     setContactId(null);
     setOrganizationId(null);
     setExpectedCloseDate(null);
@@ -125,6 +154,11 @@ export function CreateDealModal({
   const orgOptions = (orgsData?.organizations ?? []).map((o) => ({
     value: o.id,
     label: o.name,
+  }));
+
+  const pipelineOptions = pipelines.map((p) => ({
+    value: p.id,
+    label: p.name,
   }));
 
   const stageOptions = stages.map((s) => ({
@@ -176,6 +210,16 @@ export function CreateDealModal({
             onChange={(val) => setProbability(typeof val === "number" ? val : undefined)}
           />
         </Group>
+
+        {pipelines.length > 1 && (
+          <Select
+            label="Pipeline"
+            data={pipelineOptions}
+            value={projectId}
+            onChange={(val) => val && setProjectId(val)}
+            allowDeselect={false}
+          />
+        )}
 
         <Select
           label="Stage"

--- a/src/app/_components/pipeline/CreateDealModal.tsx
+++ b/src/app/_components/pipeline/CreateDealModal.tsx
@@ -70,11 +70,13 @@ export function CreateDealModal({
 
   // Keep the stage valid: default to the first stage ("Lead") whenever the
   // pipeline changes or the current stage isn't part of the selected pipeline.
+  // A functional update reads the current stage without depending on it, so the
+  // effect only reacts to the stage list itself.
   useEffect(() => {
-    if (!stages.some((s) => s.id === stageId)) {
-      setStageId(stages[0]?.id ?? "");
-    }
-  }, [stages, stageId]);
+    setStageId((current) =>
+      stages.some((s) => s.id === current) ? current : (stages[0]?.id ?? ""),
+    );
+  }, [stages]);
 
   const utils = api.useUtils();
 

--- a/src/app/_components/pipeline/DealDetailDrawer.tsx
+++ b/src/app/_components/pipeline/DealDetailDrawer.tsx
@@ -16,6 +16,7 @@ import {
   NumberInput,
   TextInput,
   Input,
+  Select,
 } from "@mantine/core";
 import { UnifiedDatePicker } from "~/app/_components/UnifiedDatePicker";
 import {
@@ -31,11 +32,27 @@ import { api } from "~/trpc/react";
 import { notifications } from "@mantine/notifications";
 import { getAvatarColor, getInitial, getColorSeed, getTextColor } from "~/utils/avatarColors";
 
+interface PipelineStage {
+  id: string;
+  name: string;
+  color: string;
+  order: number;
+  type: string;
+}
+
+interface PipelineOption {
+  id: string;
+  name: string;
+  pipelineStages: PipelineStage[];
+}
+
 interface DealDetailDrawerProps {
   dealId: string | null;
   projectId: string;
   opened: boolean;
   onClose: () => void;
+  /** Every pipeline in the workspace — lets the deal be moved between them. */
+  pipelines: PipelineOption[];
 }
 
 export function DealDetailDrawer({
@@ -43,6 +60,7 @@ export function DealDetailDrawer({
   projectId,
   opened,
   onClose,
+  pipelines,
 }: DealDetailDrawerProps) {
   const [noteText, setNoteText] = useState("");
   const [isEditing, setIsEditing] = useState(false);
@@ -50,6 +68,13 @@ export function DealDetailDrawer({
   const [editValue, setEditValue] = useState<number | undefined>();
   const [editProbability, setEditProbability] = useState<number | undefined>();
   const [editExpectedCloseDate, setEditExpectedCloseDate] = useState<Date | null>(null);
+  const [editProjectId, setEditProjectId] = useState<string>("");
+  const [editStageId, setEditStageId] = useState<string>("");
+
+  // Stages of the pipeline currently chosen in the editor.
+  const editPipeline =
+    pipelines.find((p) => p.id === editProjectId) ?? pipelines[0];
+  const editStages = editPipeline?.pipelineStages ?? [];
 
   const utils = api.useUtils();
 
@@ -69,8 +94,14 @@ export function DealDetailDrawer({
     onSuccess: () => {
       setIsEditing(false);
       void utils.pipeline.getDeal.invalidate({ id: dealId! });
+      // Refresh both the pipeline being viewed and the destination pipeline, in
+      // case the deal was moved between them.
       void utils.pipeline.getDeals.invalidate({ projectId });
       void utils.pipeline.getStats.invalidate({ projectId });
+      if (editProjectId && editProjectId !== projectId) {
+        void utils.pipeline.getDeals.invalidate({ projectId: editProjectId });
+        void utils.pipeline.getStats.invalidate({ projectId: editProjectId });
+      }
       notifications.show({
         title: "Deal updated",
         message: "Changes saved successfully",
@@ -98,7 +129,22 @@ export function DealDetailDrawer({
     setEditValue(deal.value ?? undefined);
     setEditProbability(deal.probability ?? undefined);
     setEditExpectedCloseDate(deal.expectedCloseDate ? new Date(deal.expectedCloseDate) : null);
+    setEditProjectId(deal.projectId);
+    setEditStageId(deal.stageId);
     setIsEditing(true);
+  }
+
+  function handleEditPipelineChange(value: string | null) {
+    if (!value) return;
+    setEditProjectId(value);
+    // Stages are per-pipeline, so switching pipelines re-defaults the stage to
+    // the destination's first stage ("Lead") unless the current one survives.
+    const stages = pipelines.find((p) => p.id === value)?.pipelineStages ?? [];
+    setEditStageId(
+      stages.some((s) => s.id === editStageId)
+        ? editStageId
+        : (stages[0]?.id ?? ""),
+    );
   }
 
   function saveEdits() {
@@ -109,6 +155,8 @@ export function DealDetailDrawer({
       value: editValue ?? null,
       probability: editProbability ?? null,
       expectedCloseDate: editExpectedCloseDate,
+      projectId: editProjectId,
+      stageId: editStageId,
     });
   }
 
@@ -191,14 +239,32 @@ export function DealDetailDrawer({
             </Group>
           </Group>
 
-          {/* Stage badge */}
-          <Badge variant="light" color={deal.stage.color} size="lg">
-            {deal.stage.name}
-          </Badge>
+          {/* Stage badge (read-only view) */}
+          {!isEditing && (
+            <Badge variant="light" color={deal.stage.color} size="lg">
+              {deal.stage.name}
+            </Badge>
+          )}
 
           {/* Editable fields */}
           {isEditing ? (
             <Stack gap="sm">
+              {pipelines.length > 1 && (
+                <Select
+                  label="Pipeline"
+                  data={pipelines.map((p) => ({ value: p.id, label: p.name }))}
+                  value={editProjectId}
+                  onChange={handleEditPipelineChange}
+                  allowDeselect={false}
+                />
+              )}
+              <Select
+                label="Stage"
+                data={editStages.map((s) => ({ value: s.id, label: s.name }))}
+                value={editStageId}
+                onChange={(val) => val && setEditStageId(val)}
+                allowDeselect={false}
+              />
               <Group grow>
                 <NumberInput
                   label="Value"

--- a/src/app/_components/pipeline/DealDetailDrawer.tsx
+++ b/src/app/_components/pipeline/DealDetailDrawer.tsx
@@ -91,16 +91,21 @@ export function DealDetailDrawer({
   });
 
   const updateDealMutation = api.pipeline.updateDeal.useMutation({
-    onSuccess: () => {
+    onSuccess: (updatedDeal) => {
       setIsEditing(false);
       void utils.pipeline.getDeal.invalidate({ id: dealId! });
       // Refresh both the pipeline being viewed and the destination pipeline, in
-      // case the deal was moved between them.
+      // case the deal was moved between them. Read the destination from the
+      // mutation response rather than component state, which may have changed.
       void utils.pipeline.getDeals.invalidate({ projectId });
       void utils.pipeline.getStats.invalidate({ projectId });
-      if (editProjectId && editProjectId !== projectId) {
-        void utils.pipeline.getDeals.invalidate({ projectId: editProjectId });
-        void utils.pipeline.getStats.invalidate({ projectId: editProjectId });
+      if (updatedDeal.projectId !== projectId) {
+        void utils.pipeline.getDeals.invalidate({
+          projectId: updatedDeal.projectId,
+        });
+        void utils.pipeline.getStats.invalidate({
+          projectId: updatedDeal.projectId,
+        });
       }
       notifications.show({
         title: "Deal updated",

--- a/src/server/api/routers/pipeline.ts
+++ b/src/server/api/routers/pipeline.ts
@@ -559,20 +559,109 @@ export const pipelineRouter = createTRPCRouter({
         contactId: z.string().nullable().optional(),
         organizationId: z.string().nullable().optional(),
         assignedToId: z.string().nullable().optional(),
+        // Move the deal to a different pipeline and/or stage. Stages are
+        // per-pipeline, so the two travel together: when projectId changes, a
+        // stageId in the destination pipeline must resolve (falls back to that
+        // pipeline's first stage — "Lead").
+        projectId: z.string().optional(),
+        stageId: z.string().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const { id, ...data } = input;
+      const { id, projectId, stageId, ...data } = input;
       await ensureDealAccess(ctx.db, ctx.session.user.id, id, "edit");
 
       const oldDeal = await ctx.db.deal.findUniqueOrThrow({
         where: { id },
-        select: { value: true },
+        select: {
+          value: true,
+          projectId: true,
+          stageId: true,
+          closedAt: true,
+          workspaceId: true,
+          stage: { select: { name: true } },
+        },
       });
+
+      // Resolve the destination pipeline + stage when a move is requested.
+      const targetProjectId = projectId ?? oldDeal.projectId;
+      const isPipelineChange = targetProjectId !== oldDeal.projectId;
+
+      let targetStageId = stageId;
+      if (!targetStageId && isPipelineChange) {
+        // Moving pipeline without an explicit stage → land in the destination's
+        // first stage (lowest order, i.e. "Lead").
+        const firstStage = await ctx.db.pipelineStage.findFirst({
+          where: { projectId: targetProjectId },
+          orderBy: { order: "asc" },
+          select: { id: true },
+        });
+        if (!firstStage) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Destination pipeline has no stages",
+          });
+        }
+        targetStageId = firstStage.id;
+      }
+
+      const isStageChange =
+        targetStageId != null && targetStageId !== oldDeal.stageId;
+
+      // Validate + authorize the destination stage before mutating.
+      let newStage:
+        | { id: string; name: string; type: string; projectId: string }
+        | undefined;
+      let moveData: {
+        projectId?: string;
+        stageId?: string;
+        stageOrder?: number;
+        closedAt?: Date | null;
+      } = {};
+      if (targetStageId && (isStageChange || isPipelineChange)) {
+        const stage = await ctx.db.pipelineStage.findUnique({
+          where: { id: targetStageId },
+          select: { id: true, name: true, type: true, projectId: true },
+        });
+        if (!stage) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Stage not found" });
+        }
+        if (stage.projectId !== targetProjectId) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Stage does not belong to the destination pipeline",
+          });
+        }
+        if (isPipelineChange) {
+          await ensurePipelineProjectAccess(
+            ctx.db,
+            ctx.session.user.id,
+            targetProjectId,
+            "edit",
+          );
+        }
+        newStage = stage;
+
+        // Append to the end of the destination stage and reconcile closedAt
+        // with the stage type (mirrors moveDeal).
+        const lastDeal = await ctx.db.deal.findFirst({
+          where: { projectId: targetProjectId, stageId: stage.id },
+          orderBy: { stageOrder: "desc" },
+          select: { stageOrder: true },
+        });
+        const isTerminal = stage.type === "won" || stage.type === "lost";
+        moveData = {
+          projectId: targetProjectId,
+          stageId: stage.id,
+          stageOrder: (lastDeal?.stageOrder ?? -1) + 1,
+          ...(isTerminal && !oldDeal.closedAt ? { closedAt: new Date() } : {}),
+          ...(!isTerminal && oldDeal.closedAt ? { closedAt: null } : {}),
+        };
+      }
 
       const deal = await ctx.db.deal.update({
         where: { id },
-        data,
+        data: { ...data, ...moveData },
         include: {
           stage: true,
           contact: {
@@ -598,6 +687,51 @@ export const pipelineRouter = createTRPCRouter({
             },
           },
         });
+      }
+
+      // Log stage / pipeline moves
+      if (newStage) {
+        const isTerminal =
+          newStage.type === "won" || newStage.type === "lost";
+        await ctx.db.dealActivity.create({
+          data: {
+            dealId: deal.id,
+            userId: ctx.session.user.id,
+            type: isTerminal ? "CLOSED" : "STAGE_CHANGE",
+            content: `Moved from ${oldDeal.stage.name} to ${newStage.name}`,
+            metadata: {
+              fromStageId: oldDeal.stageId,
+              fromStageName: oldDeal.stage.name,
+              toStageId: newStage.id,
+              toStageName: newStage.name,
+              ...(isPipelineChange
+                ? {
+                    fromProjectId: oldDeal.projectId,
+                    toProjectId: targetProjectId,
+                  }
+                : {}),
+            },
+          },
+        });
+
+        // Surface a newly-closed deal as a workspace milestone, matching
+        // moveDeal — only on the transition into a terminal stage.
+        if (isTerminal && !oldDeal.closedAt) {
+          await recordActivity(ctx.db, {
+            workspaceId: oldDeal.workspaceId,
+            userId: ctx.session.user.id,
+            entityType: "deal",
+            entityId: deal.id,
+            action: "completed",
+            metadata: {
+              name: deal.title,
+              outcome: newStage.type, // "won" | "lost"
+              value: oldDeal.value,
+            },
+          }).catch(() => {
+            /* instrumentation failure is non-fatal */
+          });
+        }
       }
 
       return deal;


### PR DESCRIPTION
### **User description**
## Summary

Two related CRM pipeline fixes on the `/w/[workspaceSlug]/crm/pipeline` page.

### 1. Create Deal modal
- Adds a **Pipeline** selector (shown when the workspace has more than one pipeline), defaulting to the pipeline currently selected on the page.
- **Stage** now reliably defaults to the first stage (**Lead**) instead of blank. Previously the default was seeded only once in the `useState` initializer, so if the modal mounted before stages loaded (or the pipeline changed) it stayed empty.
- Switching pipeline in the modal re-defaults the stage to that pipeline's first stage.

### 2. Deal Details drawer (edit slide-over)
- Edit mode now shows a **Pipeline** selector and a **Stage** selector, defaulting to the deal's current values.
- A deal can be **moved between pipelines** from the drawer; switching pipeline re-defaults the stage.
- Success invalidates both the source and destination pipeline caches so the deal moves boards correctly.

### 3. `pipeline.updateDeal` (server)
- Gains optional `projectId` and `stageId`.
- On a move it validates the destination stage belongs to the destination pipeline, checks edit access to that pipeline, appends the deal to the end of the target stage, reconciles `closedAt` with the stage type, and logs a `STAGE_CHANGE`/`CLOSED` activity (recording a workspace milestone on a new win/loss) — mirroring `moveDeal`. Passing the unchanged pipeline/stage is a no-op, so ordinary field edits are unaffected.

## Testing
- `tsc` typecheck clean.
- Full unit suite (1338 tests) passes via the pre-commit hook.


___

### **PR Type**
Enhancement


___

### **Description**
- Add pipeline selector to Create Deal modal and Deal Details drawer

- Stage defaults to first stage ("Lead") and resets on pipeline change

- `updateDeal` server mutation gains optional `projectId`/`stageId` for cross-pipeline moves

- Move validation checks stage ownership, edit access, and logs activity/milestones


___

### Diagram Walkthrough


```mermaid
flowchart LR
  page["PipelinePage"]
  createModal["CreateDealModal"]
  detailDrawer["DealDetailDrawer"]
  server["pipeline.updateDeal (server)"]

  page -- "pipelines + defaultProjectId" --> createModal
  page -- "pipelines" --> detailDrawer
  createModal -- "pipeline selector\nstage defaults to Lead" --> createModal
  detailDrawer -- "pipeline + stage selectors\nedit mode" --> detailDrawer
  detailDrawer -- "projectId + stageId" --> server
  server -- "validate stage ownership\ncheck edit access\nlog STAGE_CHANGE/CLOSED\nrecord milestone" --> server
  server -- "invalidate source + dest caches" --> detailDrawer
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Pass pipelines list to modal and drawer components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/crm/pipeline/page.tsx

<ul><li>Passes full <code>pipelines</code> array and <code>defaultProjectId</code> to <code>CreateDealModal</code> <br>instead of single <code>projectId</code> and <code>stages</code><br> <li> Passes <code>pipelines</code> array to <code>DealDetailDrawer</code> to enable cross-pipeline <br>moves</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/371/files#diff-9bc12fc6d52ce5f24b4a784f2f91d4f565fb5f0ec50899528c76a13fee60922a">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CreateDealModal.tsx</strong><dd><code>Add pipeline selector and reliable stage defaulting to Create Deal </code><br><code>modal</code></dd></summary>
<hr>

src/app/_components/pipeline/CreateDealModal.tsx

<ul><li>Introduces <code>PipelineOption</code> interface and replaces <code>projectId</code>/<code>stages</code> <br>props with <code>pipelines</code>/<code>defaultProjectId</code><br> <li> Adds <code>useEffect</code> to reset pipeline to <code>defaultProjectId</code> when modal opens<br> <li> Adds <code>useEffect</code> to default stage to first stage ("Lead") whenever the <br>pipeline changes<br> <li> Renders a <code>Pipeline</code> selector (only when workspace has more than one <br>pipeline)</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/371/files#diff-47d0b5238fbac8475ff74dfd60e426dd5082295b15126c1eea185a6e9bcfa0e1">+53/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DealDetailDrawer.tsx</strong><dd><code>Add pipeline/stage selectors and cross-pipeline cache invalidation to </code><br><code>Deal drawer</code></dd></summary>
<hr>

src/app/_components/pipeline/DealDetailDrawer.tsx

<ul><li>Adds <code>pipelines</code> prop and <code>editProjectId</code>/<code>editStageId</code> state for edit mode<br> <li> Renders pipeline and stage selectors in edit mode; stage badge hidden <br>while editing<br> <li> <code>handleEditPipelineChange</code> re-defaults stage to destination pipeline's <br>first stage<br> <li> <code>updateDeal</code> <code>onSuccess</code> invalidates both source and destination pipeline <br>caches using mutation response</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/371/files#diff-0047ade494073da4c3186eab46adcdb61649653b66530292c3df86ee67675711">+76/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pipeline.ts</strong><dd><code>Extend updateDeal to support cross-pipeline moves with validation and </code><br><code>activity logging</code></dd></summary>
<hr>

src/server/api/routers/pipeline.ts

<ul><li>Adds optional <code>projectId</code> and <code>stageId</code> fields to <code>updateDeal</code> input schema<br> <li> Resolves destination pipeline/stage, validates stage belongs to <br>destination pipeline, and checks edit access<br> <li> Appends deal to end of destination stage and reconciles <code>closedAt</code> with <br>stage type (mirrors <code>moveDeal</code>)<br> <li> Logs <code>STAGE_CHANGE</code>/<code>CLOSED</code> activity and records workspace milestone on <br>new win/loss transition</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/371/files#diff-eb52415f20f23bfbc6195a68fc124fe417d54658c72dc85592e321ef7d874a8d">+137/-3</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

