### PR TITLE
fix(content): collapse whitespace-only soft-break runs into a single <br>

### DIFF
--- a/src/lib/content/__tests__/remarkSoftBreaks.test.ts
+++ b/src/lib/content/__tests__/remarkSoftBreaks.test.ts
@@ -8,14 +8,15 @@ interface MdNode {
   children?: MdNode[];
 }
 
-/** A paragraph whose single text node holds the given raw value. */
-function paragraph(value: string): MdNode {
+/** A document root wrapping one paragraph whose single text node holds `value`. */
+function doc(value: string): MdNode {
   return {
     type: "root",
     children: [{ type: "paragraph", children: [{ type: "text", value }] }],
   };
 }
 
+/** Children of the paragraph inside the document root. */
 function paragraphChildren(tree: MdNode): MdNode[] {
   return tree.children![0]!.children!;
 }
@@ -29,7 +30,7 @@ function shape(children: MdNode[]): string {
 
 describe("applySoftBreaks", () => {
   it("turns a single newline into a hard break", () => {
-    const tree = paragraph("line1\nline2");
+    const tree = doc("line1\nline2");
     applySoftBreaks(tree);
     expect(shape(paragraphChildren(tree))).toBe("line1|<br>|line2");
   });
@@ -37,19 +38,19 @@ describe("applySoftBreaks", () => {
   it("collapses a run of whitespace-only lines into a single break", () => {
     // CommonMark keeps whitespace-only lines (a lone space, an nbsp) inside one
     // paragraph — the exact shape that used to stack into a wall of <br>.
-    const tree = paragraph("Hello\n \n \n \nWorld");
+    const tree = doc("Hello\n \n \n \nWorld");
     applySoftBreaks(tree);
     expect(shape(paragraphChildren(tree))).toBe("Hello|<br>|World");
   });
 
   it("drops trailing whitespace-only lines entirely (no dangling break)", () => {
-    const tree = paragraph("Let me pull the key actions:\n \n \n \n ");
+    const tree = doc("Let me pull the key actions:\n \n \n \n ");
     applySoftBreaks(tree);
     expect(shape(paragraphChildren(tree))).toBe("Let me pull the key actions:");
   });
 
   it("drops leading whitespace-only lines (no leading break)", () => {
-    const tree = paragraph(" \n \nWorld");
+    const tree = doc(" \n \nWorld");
     applySoftBreaks(tree);
     expect(shape(paragraphChildren(tree))).toBe("World");
   });
@@ -72,7 +73,7 @@ describe("applySoftBreaks", () => {
   });
 
   it("leaves text without newlines untouched", () => {
-    const tree = paragraph("just one line");
+    const tree = doc("just one line");
     applySoftBreaks(tree);
     expect(shape(paragraphChildren(tree))).toBe("just one line");
   });

--- a/src/lib/content/__tests__/remarkSoftBreaks.test.ts
+++ b/src/lib/content/__tests__/remarkSoftBreaks.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+
+import { applySoftBreaks } from "../remarkSoftBreaks";
+
+interface MdNode {
+  type: string;
+  value?: string;
+  children?: MdNode[];
+}
+
+/** A paragraph whose single text node holds the given raw value. */
+function paragraph(value: string): MdNode {
+  return {
+    type: "root",
+    children: [{ type: "paragraph", children: [{ type: "text", value }] }],
+  };
+}
+
+function paragraphChildren(tree: MdNode): MdNode[] {
+  return tree.children![0]!.children!;
+}
+
+/** Compact string form: text values verbatim, breaks as "<br>". */
+function shape(children: MdNode[]): string {
+  return children
+    .map((c) => (c.type === "break" ? "<br>" : (c.value ?? `<${c.type}>`)))
+    .join("|");
+}
+
+describe("applySoftBreaks", () => {
+  it("turns a single newline into a hard break", () => {
+    const tree = paragraph("line1\nline2");
+    applySoftBreaks(tree);
+    expect(shape(paragraphChildren(tree))).toBe("line1|<br>|line2");
+  });
+
+  it("collapses a run of whitespace-only lines into a single break", () => {
+    // CommonMark keeps whitespace-only lines (a lone space, an nbsp) inside one
+    // paragraph — the exact shape that used to stack into a wall of <br>.
+    const tree = paragraph("Hello\n \n \n \nWorld");
+    applySoftBreaks(tree);
+    expect(shape(paragraphChildren(tree))).toBe("Hello|<br>|World");
+  });
+
+  it("drops trailing whitespace-only lines entirely (no dangling break)", () => {
+    const tree = paragraph("Let me pull the key actions:\n \n \n \n ");
+    applySoftBreaks(tree);
+    expect(shape(paragraphChildren(tree))).toBe("Let me pull the key actions:");
+  });
+
+  it("drops leading whitespace-only lines (no leading break)", () => {
+    const tree = paragraph(" \n \nWorld");
+    applySoftBreaks(tree);
+    expect(shape(paragraphChildren(tree))).toBe("World");
+  });
+
+  it("preserves a soft break next to a non-text sibling", () => {
+    const tree: MdNode = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            { type: "emphasis", children: [{ type: "text", value: "lot" }] },
+            { type: "text", value: "\nWorld" },
+          ],
+        },
+      ],
+    };
+    applySoftBreaks(tree);
+    expect(shape(paragraphChildren(tree))).toBe("<emphasis>|<br>|World");
+  });
+
+  it("leaves text without newlines untouched", () => {
+    const tree = paragraph("just one line");
+    applySoftBreaks(tree);
+    expect(shape(paragraphChildren(tree))).toBe("just one line");
+  });
+});

--- a/src/lib/content/remarkSoftBreaks.ts
+++ b/src/lib/content/remarkSoftBreaks.ts
@@ -26,6 +26,16 @@ export function applySoftBreaks(tree: MdNode): void {
     if (!children) return;
 
     const out: MdNode[] = [];
+    // Emit a break only after real content and never twice in a row, so a run
+    // of blank/whitespace-only lines can't stack into a wall of <br>. (Such a
+    // run reaches us because CommonMark keeps whitespace-only lines — a single
+    // space, an nbsp — inside one paragraph rather than splitting it, unlike a
+    // truly empty line.)
+    const pushBreak = () => {
+      if (out.length > 0 && out[out.length - 1]?.type !== "break") {
+        out.push({ type: "break" });
+      }
+    };
     for (const child of children) {
       if (
         child.type === "text" &&
@@ -34,14 +44,18 @@ export function applySoftBreaks(tree: MdNode): void {
       ) {
         const segments = child.value.split("\n");
         segments.forEach((segment, index) => {
-          if (segment) out.push({ type: "text", value: segment });
-          if (index < segments.length - 1) out.push({ type: "break" });
+          // Whitespace-only lines carry no content — skip the text node and let
+          // their surrounding breaks collapse away.
+          if (segment.trim()) out.push({ type: "text", value: segment });
+          if (index < segments.length - 1) pushBreak();
         });
       } else {
         walk(child);
         out.push(child);
       }
     }
+    // Drop trailing breaks: blank lines at the end of a block add only a gap.
+    while (out.length > 0 && out[out.length - 1]?.type === "break") out.pop();
     node.children = out;
   }
 


### PR DESCRIPTION
### **User description**
## What

`applySoftBreaks` turned every newline inside a paragraph into a hard `<br>`. But CommonMark keeps whitespace-only lines (a lone space, an nbsp) *inside* one paragraph rather than splitting it, so a run of them stacked into a wall of `<br>` — and trailing/leading whitespace lines left dangling breaks.

This change:
- emits a break only after real content and never twice in a row,
- skips whitespace-only text nodes,
- drops leading and trailing breaks.

## Why

Fixes markdown prose (chat replies, notes) rendering with large vertical gaps when the source had whitespace-only lines.

## Tests

New unit tests in `remarkSoftBreaks.test.ts` cover single breaks, collapsed runs of whitespace-only lines, and leading/trailing whitespace-only lines. `npm run test` green.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix `applySoftBreaks` collapsing whitespace-only soft-break runs into single `<br>`

- Skip whitespace-only text nodes and prevent consecutive `<br>` emission

- Drop leading and trailing dangling breaks from paragraph output

- Add unit tests covering all new edge cases in `remarkSoftBreaks.test.ts`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Input text node\nwith newlines"] -- "split on newline" --> B["Segments"]
  B -- "whitespace-only segment" --> C["Skip segment"]
  B -- "real content segment" --> D["Push text node"]
  D -- "next segment exists" --> E["pushBreak()"]
  E -- "last node is break?" --> F["Skip duplicate break"]
  E -- "last node is not break?" --> G["Emit break node"]
  G --> H["Trim trailing breaks"]
  H --> I["Final children array"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remarkSoftBreaks.ts</strong><dd><code>Collapse whitespace-only soft-break runs, drop trailing breaks</code></dd></summary>
<hr>

src/lib/content/remarkSoftBreaks.ts

<ul><li>Introduced <code>pushBreak()</code> helper that only emits a break if the last node <br>is not already a break, preventing consecutive <code><br> </code> nodes<br> <li> Changed segment emission to skip whitespace-only segments <br>(<code>segment.trim()</code> check)<br> <li> Added trailing-break removal loop after processing all children</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/372/files#diff-bde559119d94e6971e0dbdfb63e5551c0fab284b342d080645810d18753c2fb7">+16/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remarkSoftBreaks.test.ts</strong><dd><code>Add unit tests for soft-break collapsing edge cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/content/__tests__/remarkSoftBreaks.test.ts

<ul><li>New test file with <code>describe</code> block for <code>applySoftBreaks</code><br> <li> Tests cover: single newline, whitespace-only line runs, trailing <br>whitespace-only lines, leading whitespace-only lines, non-text <br>siblings, and plain text without newlines<br> <li> Helper functions <code>doc()</code>, <code>paragraphChildren()</code>, and <code>shape()</code> added for <br>concise test setup and assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/372/files#diff-de448d81e10044243d5b5d4abd14c7ee0ed915e592581ced4727da7b7d12eb78">+80/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

