### PR TITLE
feat: Sync run history table on product Notion sync settings

### DIFF
--- a/src/app/_components/products/NotionSyncSettings.tsx
+++ b/src/app/_components/products/NotionSyncSettings.tsx
@@ -20,6 +20,7 @@ import {
 } from "@tabler/icons-react";
 import { modals } from "@mantine/modals";
 import { api } from "~/trpc/react";
+import { SyncRunHistory } from "./SyncRunHistory";
 
 interface SyncRunItemView {
   externalId: string | null;
@@ -142,6 +143,7 @@ export function NotionSyncSettings({ productId }: { productId: string }) {
 
   const invalidate = async () => {
     await utils.product.ticketSync.getConfig.invalidate({ productId });
+    await utils.product.ticketSync.listRuns.invalidate({ productId });
   };
 
   const saveConfig = api.product.ticketSync.saveConfig.useMutation({
@@ -302,6 +304,8 @@ export function NotionSyncSettings({ productId }: { productId: string }) {
           </div>
         </div>
 
+        <SyncRunHistory productId={productId} />
+
         {error && (
           <Text size="sm" c="red">
             {error}
@@ -374,6 +378,8 @@ export function NotionSyncSettings({ productId }: { productId: string }) {
         {!connectionsLoading && !hasConnections
           ? connectNotionCard
           : pickerCard(true)}
+
+        <SyncRunHistory productId={productId} />
 
         {error && (
           <Text size="sm" c="red">

--- a/src/app/_components/products/SyncRunHistory.tsx
+++ b/src/app/_components/products/SyncRunHistory.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState } from "react";
+import { Badge, Button, Text } from "@mantine/core";
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconHistory,
+} from "@tabler/icons-react";
+import { api } from "~/trpc/react";
+
+interface RunItemView {
+  externalId: string | null;
+  ticketId: string | null;
+  title: string;
+  action: string;
+  reason?: string;
+}
+
+/** Narrow the run's `items` JSON column into the per-item outcome shape. */
+function parseRunItems(items: unknown): RunItemView[] {
+  if (!Array.isArray(items)) return [];
+  return items.filter(
+    (i): i is RunItemView =>
+      !!i && typeof i === "object" && typeof (i as RunItemView).title === "string",
+  );
+}
+
+function statusColor(status: string): string {
+  switch (status) {
+    case "success":
+      return "green";
+    case "error":
+      return "red";
+    default:
+      return "blue";
+  }
+}
+
+interface RunRowData {
+  id: string;
+  trigger: string;
+  direction: string;
+  dryRun: boolean;
+  status: string;
+  startedAt: Date | string;
+  error: string | null;
+  created: number;
+  updated: number;
+  skipped: number;
+  conflicts: number;
+  failed: number;
+  items: unknown;
+  triggeredBy: { id: string; name: string | null; email: string | null } | null;
+}
+
+function RunRow({ run }: { run: RunRowData }) {
+  const [expanded, setExpanded] = useState(false);
+  const items = parseRunItems(run.items);
+  const adopted = items.filter((i) => i.action === "adopted").length;
+
+  const counts: Array<{ label: string; value: number; color: string }> = [
+    { label: "created", value: run.created, color: "green" },
+    { label: "updated", value: run.updated, color: "blue" },
+    { label: "adopted", value: adopted, color: "teal" },
+    { label: "skipped", value: run.skipped, color: "gray" },
+    { label: "conflicts", value: run.conflicts, color: "yellow" },
+    { label: "failed", value: run.failed, color: "red" },
+  ];
+
+  return (
+    <div
+      className={`border-b border-border-primary py-2.5 last:border-b-0 ${run.dryRun ? "opacity-60" : ""}`}
+    >
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 text-left"
+        onClick={() => setExpanded((v) => !v)}
+        disabled={items.length === 0}
+      >
+        <span className="shrink-0 text-text-muted">
+          {items.length > 0 ? (
+            expanded ? (
+              <IconChevronDown size={14} />
+            ) : (
+              <IconChevronRight size={14} />
+            )
+          ) : (
+            <span className="inline-block w-3.5" />
+          )}
+        </span>
+        <Text size="xs" className="text-text-primary w-40 shrink-0">
+          {new Date(run.startedAt).toLocaleString()}
+        </Text>
+        <Text size="xs" className="text-text-muted w-16 shrink-0">
+          {run.trigger}
+        </Text>
+        {run.dryRun && (
+          <Badge size="xs" variant="outline" color="gray">
+            dry run
+          </Badge>
+        )}
+        <Badge size="xs" variant="light" color={statusColor(run.status)}>
+          {run.status}
+        </Badge>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {counts
+            .filter((c) => c.value > 0)
+            .map((c) => (
+              <Badge key={c.label} size="xs" variant="light" color={c.color}>
+                {c.value} {c.label}
+              </Badge>
+            ))}
+        </div>
+        <Text size="xs" className="text-text-muted ml-auto shrink-0 truncate max-w-40">
+          {run.triggeredBy?.name ?? run.triggeredBy?.email ?? "system"}
+        </Text>
+      </button>
+      {run.error && (
+        <Text size="xs" c="red" className="mt-1 ml-6">
+          {run.error}
+        </Text>
+      )}
+      {expanded && items.length > 0 && (
+        <div className="mt-2 ml-6 space-y-1">
+          {items.map((item, i) => (
+            <div
+              key={`${item.externalId ?? item.ticketId ?? i}-${i}`}
+              className="flex gap-2 text-xs"
+            >
+              <span className="text-text-muted w-16 shrink-0">{item.action}</span>
+              <span className="text-text-primary truncate">{item.title}</span>
+              {item.reason && (
+                <span className="text-text-muted truncate">— {item.reason}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Sync run history — the persisted ledger of every run for a product's
+ * Ticket sync connection (newest first), from `ticketSync.listRuns`. Unlike
+ * the in-memory "last run" panel this survives refresh and navigation, and it
+ * keeps showing history while the connection is disconnected.
+ */
+export function SyncRunHistory({ productId }: { productId: string }) {
+  const [limit, setLimit] = useState(10);
+  const { data: runs, isLoading } = api.product.ticketSync.listRuns.useQuery(
+    { productId, limit },
+    { enabled: !!productId },
+  );
+
+  if (isLoading || !runs || runs.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-border-primary bg-surface-secondary px-5 py-4">
+      <div className="flex items-center gap-2">
+        <IconHistory size={16} className="text-text-secondary" />
+        <Text size="sm" fw={600} className="text-text-primary">
+          Sync history
+        </Text>
+      </div>
+      <div className="mt-2">
+        {runs.map((run) => (
+          <RunRow key={run.id} run={run as RunRowData} />
+        ))}
+      </div>
+      {runs.length === limit && (
+        <Button
+          size="compact-xs"
+          variant="subtle"
+          className="mt-2"
+          onClick={() => setLimit((v) => Math.min(v + 20, 50))}
+        >
+          Show more
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/plugins/product/server/routers/__tests__/ticketSync.test.ts
+++ b/src/plugins/product/server/routers/__tests__/ticketSync.test.ts
@@ -226,6 +226,36 @@ describe("ticketSync router — soft disconnect (mocked)", () => {
     expect(dbMock.ticketSyncConfig.delete).not.toHaveBeenCalled();
   });
 
+  it("listRuns returns the persisted history newest-first with the triggering user", async () => {
+    dbMock.ticketSyncConfig.findUnique.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "cfg-1" } as any,
+    );
+    dbMock.ticketSyncRun.findMany.mockResolvedValue([]);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.product.ticketSync.listRuns({ productId, limit: 20 });
+
+    expect(dbMock.ticketSyncRun.findMany).toHaveBeenCalledWith({
+      where: { configId: "cfg-1" },
+      orderBy: { startedAt: "desc" },
+      take: 20,
+      include: {
+        triggeredBy: { select: { id: true, name: true, email: true } },
+      },
+    });
+  });
+
+  it("listRuns returns [] when the product has no sync config", async () => {
+    dbMock.ticketSyncConfig.findUnique.mockResolvedValue(null);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const runs = await caller.product.ticketSync.listRuns({ productId });
+
+    expect(runs).toEqual([]);
+    expect(dbMock.ticketSyncRun.findMany).not.toHaveBeenCalled();
+  });
+
   it("syncNow refuses to run on a disconnected connection", async () => {
     dbMock.ticketSyncConfig.findUnique.mockResolvedValue({
       id: "cfg-1",

--- a/src/plugins/product/server/routers/ticketSync.ts
+++ b/src/plugins/product/server/routers/ticketSync.ts
@@ -227,6 +227,11 @@ export const ticketSyncRouter = createTRPCRouter({
         where: { configId: config.id },
         orderBy: { startedAt: "desc" },
         take: input.limit ?? 10,
+        include: {
+          // Who triggered the run; null for cron/agent runs (and rows from
+          // before the ledger recorded it) — the UI renders those as system.
+          triggeredBy: { select: { id: true, name: true, email: true } },
+        },
       });
     }),
 });


### PR DESCRIPTION
### **User description**
## What

Surface the persisted Sync run history on the product's Notion sync settings section. The run-listing endpoint already existed with zero call sites — the settings page showed only an in-memory "last run" that vanished on refresh.

The history table shows, newest first: timestamp, trigger (manual/cron/agent), a dry-run badge (dry-run rows visually muted), status, per-outcome counts (created / updated / adopted / skipped / conflicts / failed), and who triggered the run. Rows expand to the per-item outcomes (action, title, reason). Manual syncs record the acting user (`triggeredById`, wired in #375); older rows without it render as "system".

## Acceptance criteria

- [x] Manual sync-now runs record `triggeredById`; cron/agent-triggered runs may leave it null.
- [x] Settings section renders the run history from persisted data — it survives page refresh and navigation.
- [x] Columns: timestamp, trigger, dry-run badge, status, outcome counts, triggered-by. Dry runs visible but visually secondary.
- [x] Rows expand to per-item outcomes (action, title, reason where present).
- [x] Running a sync (or dry run) refreshes the table without a manual reload.
- [x] Router/UI behavior covered by unit tests at the established mock-caller seam.

---

Ships: ivory.lens


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- New `SyncRunHistory` component surfaces persisted sync run ledger in settings UI

- History table shows timestamp, trigger, dry-run badge, status, outcome counts, and triggered-by user

- Rows expand to per-item outcomes; history survives refresh and disconnected state

- Two new unit tests cover `listRuns` router behavior (with and without config)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NotionSyncSettings"] -- "renders" --> B["SyncRunHistory component"]
  B -- "calls" --> C["ticketSync.listRuns query"]
  C -- "includes" --> D["triggeredBy user relation"]
  B -- "renders rows" --> E["RunRow (expandable)"]
  E -- "shows" --> F["outcome counts, dry-run badge, status"]
  C -- "invalidated after" --> G["sync / saveConfig mutations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SyncRunHistory.tsx</strong><dd><code>New SyncRunHistory component for persisted run ledger</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/products/SyncRunHistory.tsx

<ul><li>New component displaying persisted sync run history (newest-first) <br>from <code>ticketSync.listRuns</code><br> <li> <code>RunRow</code> sub-component renders timestamp, trigger, dry-run badge, <br>status, outcome counts, and triggered-by user<br> <li> Rows expand to show per-item outcomes (action, title, reason)<br> <li> Pagination via "Show more" button up to a max of 50 rows</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/376/files#diff-5d0caef3875a1c23742e28d220f74f924418bcae2c11072b585d157b5828623c">+184/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NotionSyncSettings.tsx</strong><dd><code>Integrate SyncRunHistory into NotionSyncSettings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/products/NotionSyncSettings.tsx

<ul><li>Imports and renders <code>SyncRunHistory</code> in both connected and disconnected <br>states<br> <li> Adds <code>listRuns</code> cache invalidation alongside <code>getConfig</code> after mutations</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/376/files#diff-b770e43cfa4e1263d83ed5a8602ab1dd1f50b9cb84070cd382c81eb5d89ba756">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ticketSync.ts</strong><dd><code>Include triggeredBy relation in listRuns query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/routers/ticketSync.ts

<ul><li>Adds <code>include.triggeredBy</code> to <code>listRuns</code> query, selecting id, name, and <br>email<br> <li> Null triggeredBy (cron/agent/legacy rows) rendered as "system" in the <br>UI</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/376/files#diff-585d5c60345724f010f2656d948c90004a42c63e4c7d1d85ec8901cadf4bd1c9">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ticketSync.test.ts</strong><dd><code>Unit tests for listRuns router behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/routers/__tests__/ticketSync.test.ts

<ul><li>New test: <code>listRuns</code> calls <code>findMany</code> with correct args including <br><code>triggeredBy</code> include<br> <li> New test: <code>listRuns</code> returns <code>[]</code> and skips <code>findMany</code> when no sync config <br>exists</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/376/files#diff-f282fbc54ade7d598aaa718e24310e475a56bb059f066ca41f4030b25174ad3c">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

