### PR TITLE
refactor: Activity feed altitude — one event per sync run, suppress per-ticket noise

### DIFF
--- a/src/plugins/product/server/services/__tests__/createTicket.test.ts
+++ b/src/plugins/product/server/services/__tests__/createTicket.test.ts
@@ -140,6 +140,20 @@ describe("createTicketWithNumber", () => {
     );
   });
 
+  it("suppresses the activity event only when suppressActivity is set (sync engine path)", async () => {
+    primeDb({ ticketCounter: 9, funTicketIds: false });
+
+    const ticket = await createTicketWithNumber(
+      dbMock,
+      baseInput({ suppressActivity: true, createdById: "user-7" }),
+    );
+
+    // Feed altitude (ADR-0042): the sync run posts one `synced` event
+    // instead; authorship on the ticket itself is unchanged.
+    expect(recordActivity).not.toHaveBeenCalled();
+    expect(ticket.createdById).toBe("user-7");
+  });
+
   it("honors the supplied createdById, type, and status", async () => {
     primeDb({ ticketCounter: 5, funTicketIds: false });
 

--- a/src/plugins/product/server/services/createTicket.ts
+++ b/src/plugins/product/server/services/createTicket.ts
@@ -44,6 +44,13 @@ export interface CreateTicketInput {
   cycleId?: string | null;
   scopeId?: string | null;
   assigneeId?: string | null;
+  /**
+   * Skip the per-ticket `created` activity event. Only the ticket sync engine
+   * passes this — a run posts ONE `synced` event instead of one per ticket
+   * (feed altitude, ADR-0042/ADR-0023). Every other creation path (UI, agents,
+   * webhooks) must leave it unset.
+   */
+  suppressActivity?: boolean;
 }
 
 /**
@@ -107,16 +114,18 @@ export async function createTicketWithNumber(
   });
 
   // Workspace activity feed instrumentation — non-fatal if it fails.
-  await recordActivity(db, {
-    workspaceId: input.workspaceId,
-    userId: input.createdById,
-    entityType: "ticket",
-    entityId: ticket.id,
-    action: "created",
-    metadata: { title: input.title },
-  }).catch(() => {
-    /* instrumentation failure is non-fatal */
-  });
+  if (!input.suppressActivity) {
+    await recordActivity(db, {
+      workspaceId: input.workspaceId,
+      userId: input.createdById,
+      entityType: "ticket",
+      entityId: ticket.id,
+      action: "created",
+      metadata: { title: input.title },
+    }).catch(() => {
+      /* instrumentation failure is non-fatal */
+    });
+  }
 
   return ticket;
 }

--- a/src/server/services/activity/feedRenderHints.ts
+++ b/src/server/services/activity/feedRenderHints.ts
@@ -153,6 +153,13 @@ const HINTS: Record<string, FeedRenderHint> = {
     iconKind: "tracked",
   },
 
+  // Ticket sync runs (ADR-0042 feed altitude): one `synced` event per real
+  // run — per-ticket `created` events are suppressed on the engine path.
+  [key("ticket_sync_run", "synced")]: {
+    template: "{actor} synced tickets from Notion: {entityRef}",
+    iconKind: "updated",
+  },
+
   // Channel activity summaries (ADR-0023). The feed renders these rows with a
   // bespoke layout (provider icon + channel name as the actor, summary as the
   // body) rather than this template, but the hint still drives the icon kind

--- a/src/server/services/activity/recordActivity.ts
+++ b/src/server/services/activity/recordActivity.ts
@@ -12,7 +12,8 @@ export type ActivityAction =
   | "status_changed"
   | "completed"
   | "commented"
-  | "summarized";
+  | "summarized"
+  | "synced";
 
 /**
  * Entity types we currently log activity for. New writers append new values
@@ -32,7 +33,8 @@ export type ActivityEntityType =
   | "deal"
   | "meeting"
   | "time_entry"
-  | "channel_summary";
+  | "channel_summary"
+  | "ticket_sync_run";
 
 export interface RecordActivityInput {
   workspaceId: string;

--- a/src/server/services/ticketSync/__tests__/engine.test.ts
+++ b/src/server/services/ticketSync/__tests__/engine.test.ts
@@ -12,11 +12,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
 import type { PrismaClient } from "@prisma/client";
 
-const { createTicketMock, resolveTagsMock, attachTagsMock } = vi.hoisted(() => ({
-  createTicketMock: vi.fn(),
-  resolveTagsMock: vi.fn(),
-  attachTagsMock: vi.fn(),
-}));
+const { createTicketMock, resolveTagsMock, attachTagsMock, recordActivityMock } =
+  vi.hoisted(() => ({
+    createTicketMock: vi.fn(),
+    resolveTagsMock: vi.fn(),
+    attachTagsMock: vi.fn(),
+    recordActivityMock: vi.fn(),
+  }));
 
 vi.mock("~/plugins/product/server/services/createTicket", () => ({
   createTicketWithNumber: createTicketMock,
@@ -25,6 +27,10 @@ vi.mock("~/plugins/product/server/services/createTicket", () => ({
 vi.mock("../../notionTicketImport", () => ({
   resolveOrCreateWorkspaceTags: resolveTagsMock,
   attachTicketTags: attachTagsMock,
+}));
+
+vi.mock("~/server/services/activity/recordActivity", () => ({
+  recordActivity: recordActivityMock,
 }));
 
 import {
@@ -114,6 +120,7 @@ beforeEach(() => {
   createTicketMock.mockReset();
   resolveTagsMock.mockReset();
   attachTagsMock.mockReset();
+  recordActivityMock.mockReset();
 
   db.ticketSyncConfig.findUniqueOrThrow.mockResolvedValue(CONFIG as never);
   db.ticketSyncRun.create.mockResolvedValue({ id: "run1" } as never);
@@ -126,6 +133,7 @@ beforeEach(() => {
   createTicketMock.mockResolvedValue({ id: "new-ticket" });
   resolveTagsMock.mockResolvedValue(["tag1"]);
   attachTagsMock.mockResolvedValue(undefined);
+  recordActivityMock.mockResolvedValue(true);
 });
 
 describe("runInboundTicketSync — creation", () => {
@@ -426,6 +434,88 @@ describe("runInboundTicketSync — windowing and failures", () => {
     expect(db.ticketSyncRun.update).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ status: "success", failed: 1 }),
+      }),
+    );
+  });
+});
+
+describe("runInboundTicketSync — feed altitude (one event per run)", () => {
+  it("creates engine tickets with per-ticket activity suppressed", async () => {
+    await runInboundTicketSync(db, fakeAdapter([row()]), {
+      configId: "cfg1",
+      trigger: "manual",
+    });
+
+    expect(createTicketMock).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ suppressActivity: true }),
+    );
+  });
+
+  it("posts exactly one synced event per real run, attributed to the triggering user", async () => {
+    await runInboundTicketSync(db, fakeAdapter([row()]), {
+      configId: "cfg1",
+      trigger: "manual",
+      triggeredById: "user-7",
+    });
+
+    expect(recordActivityMock).toHaveBeenCalledTimes(1);
+    expect(recordActivityMock).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        workspaceId: "ws1",
+        userId: "user-7",
+        entityType: "ticket_sync_run",
+        entityId: "run1",
+        action: "synced",
+        metadata: expect.objectContaining({
+          productId: "prod1",
+          status: "success",
+          created: 1,
+          adopted: 0,
+        }),
+      }),
+    );
+  });
+
+  it("falls back to an unattributed event for cron/agent runs", async () => {
+    await runInboundTicketSync(db, fakeAdapter([]), {
+      configId: "cfg1",
+      trigger: "cron",
+    });
+
+    expect(recordActivityMock).toHaveBeenCalledTimes(1);
+    expect(recordActivityMock).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ userId: null, action: "synced" }),
+    );
+  });
+
+  it("posts no event for dry runs", async () => {
+    await runInboundTicketSync(db, fakeAdapter([row()]), {
+      configId: "cfg1",
+      trigger: "manual",
+      dryRun: true,
+    });
+
+    expect(recordActivityMock).not.toHaveBeenCalled();
+  });
+
+  it("still posts the run event (status error) when the run fails partway", async () => {
+    const adapter = {
+      queryRows: () => Promise.reject(new Error("Notion exploded")),
+    };
+
+    await expect(
+      runInboundTicketSync(db, adapter, { configId: "cfg1", trigger: "manual" }),
+    ).rejects.toThrow("Notion exploded");
+
+    expect(recordActivityMock).toHaveBeenCalledTimes(1);
+    expect(recordActivityMock).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        action: "synced",
+        metadata: expect.objectContaining({ status: "error" }),
       }),
     );
   });

--- a/src/server/services/ticketSync/engine.ts
+++ b/src/server/services/ticketSync/engine.ts
@@ -1,6 +1,7 @@
 import { Prisma } from "@prisma/client";
 import type { PrismaClient, TicketStatus, TicketType } from "@prisma/client";
 import { createTicketWithNumber } from "~/plugins/product/server/services/createTicket";
+import { recordActivity } from "~/server/services/activity/recordActivity";
 import {
   attachTicketTags,
   resolveOrCreateWorkspaceTags,
@@ -342,6 +343,9 @@ export async function runInboundTicketSync(
               ...(row.url ? { notion: row.url } : {}),
               notionPageId: row.externalId,
             },
+            // Feed altitude: the run posts ONE `synced` event; per-ticket
+            // `created` events would flood the feed (99-row incident).
+            suppressActivity: true,
           });
 
           if (row.labels.length > 0) {
@@ -540,6 +544,7 @@ export async function runInboundTicketSync(
         where: { id: config.id },
         data: { lastPulledAt: startedAt },
       });
+      await postRunEvent("success");
     }
 
     return { runId: run.id, dryRun, ...counts, items };
@@ -558,6 +563,39 @@ export async function runInboundTicketSync(
         items: items as unknown as Prisma.InputJsonValue,
       },
     });
+    // A failed real run may still have created tickets before dying — the
+    // feed event is how that partial work stays visible.
+    if (!dryRun) await postRunEvent("error");
     throw error;
+  }
+
+  /**
+   * One `synced` activity event per real run (feed altitude, ADR-0042): the
+   * per-ticket `created` events are suppressed on this path, so the run-level
+   * event with its counts is the feed's whole story. Dry runs post nothing.
+   * `recordActivity` never throws — instrumentation can't fail the sync.
+   */
+  async function postRunEvent(status: "success" | "error") {
+    await recordActivity(db, {
+      workspaceId: config.product.workspaceId,
+      userId: params.triggeredById ?? null,
+      entityType: "ticket_sync_run",
+      entityId: run.id,
+      action: "synced",
+      metadata: {
+        // `title` is what the feed shows as the entity reference.
+        title:
+          `${counts.created} created · ${counts.updated} updated · ${counts.skipped} skipped` +
+          (counts.failed > 0 || status === "error" ? ` · ${counts.failed} failed` : ""),
+        productId: config.productId,
+        status,
+        created: counts.created,
+        updated: counts.updated,
+        adopted: items.filter((i) => i.action === "adopted").length,
+        skipped: counts.skipped,
+        conflicts: counts.conflicts,
+        failed: counts.failed,
+      },
+    });
   }
 }


### PR DESCRIPTION
### **User description**
## What

Activity-feed altitude for sync runs: one event per happening, not one per ticket touched. Previously a pull that created 99 tickets flooded the workspace activity feed with 99 per-ticket "created" events. Now the engine posts a **single** `synced` activity event per real run — new `ticket_sync_run` entity type, counts (created/updated/adopted/skipped/conflicts/failed) and product in metadata, attributed to the acting user when the run was manually triggered — and suppresses per-ticket `created` events on the engine path only, via an opt-in `suppressActivity` option on the ticket-creation service that nothing but the sync engine passes. Normal ticket creation (UI, agents, webhooks) is untouched. Dry runs post no events; a run that fails partway still posts its event (status `error`) so partial work stays visible. Includes a feed render hint so the event reads as a proper sentence rather than the fallback.

## Acceptance criteria

- [x] A real sync run posts exactly one `synced` event with counts and product in metadata; dry runs post none.
- [x] Per-ticket `created` events are suppressed for engine-created tickets only; tickets created through every other path still emit them (regression-tested).
- [x] Manual runs attribute the event to the acting user; cron/agent runs fall back to unattributed/system.
- [x] Ticket authorship (`createdById`) is unchanged — suppression affects feed events only.
- [x] Existing engine-seam tests extended to assert the single event and the suppression.

---

Ships: thin.tiger


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replace per-ticket activity events with one `synced` event per sync run

- Add `suppressActivity` opt-in flag to ticket creation service for engine path

- New `ticket_sync_run` entity type and `synced` action in activity system

- Comprehensive engine tests covering feed altitude behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  engine["Sync Engine\n(runInboundTicketSync)"]
  createTicket["createTicketWithNumber\n(suppressActivity: true)"]
  postRunEvent["postRunEvent()\n(one synced event)"]
  recordActivity["recordActivity\n(ticket_sync_run / synced)"]
  feedHints["feedRenderHints\n(ticket_sync_run template)"]
  activityTypes["recordActivity types\n(synced action, ticket_sync_run entity)"]

  engine -- "creates tickets" --> createTicket
  createTicket -- "suppressActivity=true\nskips per-ticket event" --> createTicket
  engine -- "after run completes" --> postRunEvent
  postRunEvent -- "posts single event" --> recordActivity
  recordActivity -- "uses hint" --> feedHints
  activityTypes -- "extended with" --> recordActivity
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>createTicket.ts</strong><dd><code>Add opt-in suppressActivity flag to ticket creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/services/createTicket.ts

<ul><li>Added optional <code>suppressActivity</code> field to <code>CreateTicketInput</code> interface <br>with JSDoc explaining its purpose<br> <li> Wrapped <code>recordActivity</code> call in a conditional so per-ticket events are <br>skipped when <code>suppressActivity</code> is true</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/377/files#diff-925a40e958094e15d1678669e3028677e77819847d9c0c88327be734ab057519">+19/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>recordActivity.ts</strong><dd><code>Extend activity types for sync run events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/activity/recordActivity.ts

<ul><li>Added <code>"synced"</code> to the <code>ActivityAction</code> union type<br> <li> Added <code>"ticket_sync_run"</code> to the <code>ActivityEntityType</code> union type</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/377/files#diff-ec0497c5f380dd634d83d42ccd858ac179924cb0a17770a0b08e4650d53ba356">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>feedRenderHints.ts</strong><dd><code>Add feed render hint for ticket sync run events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/activity/feedRenderHints.ts

<ul><li>Added feed render hint for <code>ticket_sync_run</code> / <code>synced</code> event<br> <li> Template reads "{actor} synced tickets from Notion: {entityRef}" with <br><code>updated</code> icon kind</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/377/files#diff-0ac3c61aee5e71e9b01643e40ecb972e63ef7f3dac140e646e5fd790b8034991">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>engine.ts</strong><dd><code>Post single synced event per run, suppress per-ticket events</code></dd></summary>
<hr>

src/server/services/ticketSync/engine.ts

<ul><li>Imported <code>recordActivity</code> into the sync engine<br> <li> Added <code>suppressActivity: true</code> to all engine-path ticket creation calls<br> <li> Added <code>postRunEvent()</code> inner function that posts one <code>synced</code> activity <br>event with counts and metadata<br> <li> Called <code>postRunEvent("success")</code> after successful runs and <br><code>postRunEvent("error")</code> in the catch block; dry runs post nothing</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/377/files#diff-efe07be6916b5447498a2588f188ac30db90f9345dd6188473dea22c7866e658">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>createTicket.test.ts</strong><dd><code>Test suppressActivity flag in ticket creation service</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/services/__tests__/createTicket.test.ts

<ul><li>Added test asserting <code>recordActivity</code> is not called when <br><code>suppressActivity: true</code> is passed<br> <li> Verifies ticket <code>createdById</code> is still set correctly even when activity <br>is suppressed</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/377/files#diff-b51b14264f9946a4b06c035cef84bab0a6eb352b802eedd47dd26fcdc8bf9c31">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>engine.test.ts</strong><dd><code>Add engine tests for feed altitude behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/ticketSync/__tests__/engine.test.ts

<ul><li>Added <code>recordActivityMock</code> to hoisted mocks and wired up the module mock<br> <li> Reset <code>recordActivityMock</code> in <code>beforeEach</code> and set default resolved value<br> <li> Added new describe block "feed altitude (one event per run)" with five <br>tests covering: suppression flag, single attributed event, <br>unattributed cron runs, no event for dry runs, and error-path event <br>posting</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/377/files#diff-1842eb3834aa6ce71989236566db12f9f93564ac1c6d3b83951c371c66f41899">+95/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

