### PR TITLE
feat: Sync revert — revert a sync run with guardrail and preview

### DIFF
--- a/src/app/_components/products/NotionSyncSettings.tsx
+++ b/src/app/_components/products/NotionSyncSettings.tsx
@@ -41,109 +41,6 @@ interface SyncOutcomeView {
   items: SyncRunItemView[];
 }
 
-interface SyncRunView {
-  id: string;
-  trigger: string;
-  dryRun: boolean;
-  status: string;
-  startedAt: Date | string;
-  error: string | null;
-  created: number;
-  updated: number;
-  skipped: number;
-  conflicts: number;
-  archived: number;
-  failed: number;
-  items: unknown;
-}
-
-function RunRow({ run }: { run: SyncRunView }) {
-  const [expanded, setExpanded] = useState(false);
-  const items = Array.isArray(run.items) ? (run.items as SyncRunItemView[]) : [];
-  const statusColor =
-    run.status === "success" ? "green" : run.status === "error" ? "red" : "yellow";
-
-  return (
-    <div className="border-t border-border-primary py-2.5 first:border-t-0">
-      <button
-        type="button"
-        className="flex w-full items-center justify-between gap-3 text-left"
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <div className="flex items-center gap-2 min-w-0">
-          {expanded ? (
-            <IconChevronDown size={14} className="text-text-muted shrink-0" />
-          ) : (
-            <IconChevronRight size={14} className="text-text-muted shrink-0" />
-          )}
-          <Badge size="xs" variant="light" color={statusColor}>
-            {run.status}
-          </Badge>
-          <Text size="xs" className="text-text-secondary">
-            {run.trigger}
-            {run.dryRun ? " · dry run" : ""}
-          </Text>
-          <Text size="xs" className="text-text-muted truncate">
-            {new Date(run.startedAt).toLocaleString()}
-          </Text>
-        </div>
-        <Text size="xs" className="text-text-muted shrink-0">
-          {run.created} created · {run.updated} updated · {run.skipped} skipped
-          {run.conflicts > 0 ? ` · ${run.conflicts} conflicts` : ""}
-          {run.archived > 0 ? ` · ${run.archived} archived` : ""}
-          {run.failed > 0 ? ` · ${run.failed} failed` : ""}
-        </Text>
-      </button>
-      {expanded && (
-        <div className="mt-2 space-y-1 pl-6">
-          {run.error && (
-            <Text size="xs" c="red">
-              {run.error}
-            </Text>
-          )}
-          {items.length === 0 && !run.error && (
-            <Text size="xs" className="text-text-muted">
-              No item-level changes recorded.
-            </Text>
-          )}
-          {items.map((item, i) => (
-            <div
-              key={`${item.externalId ?? item.ticketId ?? i}-${i}`}
-              className="flex gap-2 text-xs"
-            >
-              <span className="text-text-muted shrink-0 w-16">{item.action}</span>
-              <span className="text-text-primary truncate">{item.title}</span>
-              {item.reason && (
-                <span className="text-text-muted truncate">— {item.reason}</span>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function RunHistory({ productId }: { productId: string }) {
-  const { data: runs } = api.product.ticketSync.listRuns.useQuery(
-    { productId, limit: 15 },
-    { enabled: !!productId, refetchInterval: 60_000 },
-  );
-
-  if (!runs || runs.length === 0) return null;
-
-  return (
-    <div className="rounded-lg border border-border-primary bg-surface-secondary px-5 py-3">
-      <Text size="sm" fw={600} className="text-text-primary mb-1">
-        Run history
-      </Text>
-      {runs.map((run) => (
-        <RunRow key={run.id} run={run as SyncRunView} />
-      ))}
-    </div>
-  );
-}
-
 function SyncOutcome({ outcome }: { outcome: SyncOutcomeView }) {
   const [expanded, setExpanded] = useState(false);
   const interesting = outcome.items.filter((i) => i.action !== "skipped");
@@ -376,8 +273,6 @@ export function NotionSyncSettings({ productId }: { productId: string }) {
         </div>
 
         {lastOutcome && <SyncOutcome outcome={lastOutcome} />}
-
-        <RunHistory productId={productId} />
 
         <div className="rounded-lg border border-border-primary bg-surface-secondary px-5 py-1">
           <div className="flex items-center justify-between border-b border-border-primary py-3.5 last:border-b-0">

--- a/src/app/_components/products/SyncRunHistory.tsx
+++ b/src/app/_components/products/SyncRunHistory.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { Badge, Button, Text } from "@mantine/core";
+import { Badge, Button, Modal, Text } from "@mantine/core";
 import {
+  IconArrowBackUp,
   IconChevronDown,
   IconChevronRight,
   IconHistory,
@@ -37,7 +38,7 @@ function statusColor(status: string): string {
   }
 }
 
-interface RunRowData {
+export interface RunRowData {
   id: string;
   trigger: string;
   direction: string;
@@ -49,22 +50,45 @@ interface RunRowData {
   updated: number;
   skipped: number;
   conflicts: number;
+  archived: number;
   failed: number;
   items: unknown;
+  revertedAt: Date | string | null;
   triggeredBy: { id: string; name: string | null; email: string | null } | null;
 }
 
-function RunRow({ run }: { run: RunRowData }) {
+/** A run can be reverted when it's a real pull that created tickets and
+ * hasn't been reverted yet (ADR-0042: revertible at most once). */
+export function isRevertible(run: RunRowData): boolean {
+  return (
+    run.direction === "pull" &&
+    !run.dryRun &&
+    run.created > 0 &&
+    !run.revertedAt
+  );
+}
+
+function RunRow({
+  run,
+  onRevert,
+}: {
+  run: RunRowData;
+  onRevert: (runIds: string[]) => void;
+}) {
   const [expanded, setExpanded] = useState(false);
   const items = parseRunItems(run.items);
   const adopted = items.filter((i) => i.action === "adopted").length;
+  const deleted = items.filter((i) => i.action === "deleted").length;
+  const isRevert = run.direction === "revert";
 
   const counts: Array<{ label: string; value: number; color: string }> = [
+    { label: "deleted", value: deleted, color: "red" },
     { label: "created", value: run.created, color: "green" },
     { label: "updated", value: run.updated, color: "blue" },
     { label: "adopted", value: adopted, color: "teal" },
     { label: "skipped", value: run.skipped, color: "gray" },
     { label: "conflicts", value: run.conflicts, color: "yellow" },
+    { label: "archived", value: run.archived, color: "gray" },
     { label: "failed", value: run.failed, color: "red" },
   ];
 
@@ -72,50 +96,76 @@ function RunRow({ run }: { run: RunRowData }) {
     <div
       className={`border-b border-border-primary py-2.5 last:border-b-0 ${run.dryRun ? "opacity-60" : ""}`}
     >
-      <button
-        type="button"
-        className="flex w-full items-center gap-2 text-left"
-        onClick={() => setExpanded((v) => !v)}
-        disabled={items.length === 0}
-      >
-        <span className="shrink-0 text-text-muted">
-          {items.length > 0 ? (
-            expanded ? (
-              <IconChevronDown size={14} />
+      <div className="flex w-full items-center gap-2">
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          onClick={() => setExpanded((v) => !v)}
+          disabled={items.length === 0}
+        >
+          <span className="shrink-0 text-text-muted">
+            {items.length > 0 ? (
+              expanded ? (
+                <IconChevronDown size={14} />
+              ) : (
+                <IconChevronRight size={14} />
+              )
             ) : (
-              <IconChevronRight size={14} />
-            )
-          ) : (
-            <span className="inline-block w-3.5" />
+              <span className="inline-block w-3.5" />
+            )}
+          </span>
+          <Text size="xs" className="text-text-primary w-40 shrink-0">
+            {new Date(run.startedAt).toLocaleString()}
+          </Text>
+          <Text size="xs" className="text-text-muted w-16 shrink-0">
+            {run.trigger}
+          </Text>
+          {isRevert && (
+            <Badge size="xs" variant="light" color="orange">
+              revert
+            </Badge>
           )}
-        </span>
-        <Text size="xs" className="text-text-primary w-40 shrink-0">
-          {new Date(run.startedAt).toLocaleString()}
-        </Text>
-        <Text size="xs" className="text-text-muted w-16 shrink-0">
-          {run.trigger}
-        </Text>
-        {run.dryRun && (
-          <Badge size="xs" variant="outline" color="gray">
-            dry run
+          {run.dryRun && (
+            <Badge size="xs" variant="outline" color="gray">
+              dry run
+            </Badge>
+          )}
+          <Badge size="xs" variant="light" color={statusColor(run.status)}>
+            {run.status}
           </Badge>
+          {run.revertedAt && (
+            <Badge size="xs" variant="outline" color="orange">
+              reverted
+            </Badge>
+          )}
+          <div className="flex flex-wrap items-center gap-1.5">
+            {counts
+              .filter((c) => c.value > 0)
+              .map((c) => (
+                <Badge key={c.label} size="xs" variant="light" color={c.color}>
+                  {c.value} {c.label}
+                </Badge>
+              ))}
+          </div>
+          <Text
+            size="xs"
+            className="text-text-muted ml-auto shrink-0 truncate max-w-40"
+          >
+            {run.triggeredBy?.name ?? run.triggeredBy?.email ?? "system"}
+          </Text>
+        </button>
+        {isRevertible(run) && (
+          <Button
+            size="compact-xs"
+            variant="subtle"
+            color="orange"
+            leftSection={<IconArrowBackUp size={12} />}
+            onClick={() => onRevert([run.id])}
+          >
+            Revert
+          </Button>
         )}
-        <Badge size="xs" variant="light" color={statusColor(run.status)}>
-          {run.status}
-        </Badge>
-        <div className="flex flex-wrap items-center gap-1.5">
-          {counts
-            .filter((c) => c.value > 0)
-            .map((c) => (
-              <Badge key={c.label} size="xs" variant="light" color={c.color}>
-                {c.value} {c.label}
-              </Badge>
-            ))}
-        </div>
-        <Text size="xs" className="text-text-muted ml-auto shrink-0 truncate max-w-40">
-          {run.triggeredBy?.name ?? run.triggeredBy?.email ?? "system"}
-        </Text>
-      </button>
+      </div>
       {run.error && (
         <Text size="xs" c="red" className="mt-1 ml-6">
           {run.error}
@@ -142,13 +192,137 @@ function RunRow({ run }: { run: RunRowData }) {
 }
 
 /**
+ * Revert preview + confirm (ADR-0042). Shows exactly what would be deleted
+ * and what the local-work guardrail protects (with reasons) before anything
+ * mutates; the server re-plans on execute, so this preview is advisory.
+ */
+function RevertModal({
+  productId,
+  runIds,
+  onClose,
+}: {
+  productId: string;
+  runIds: string[];
+  onClose: () => void;
+}) {
+  const utils = api.useUtils();
+  const [error, setError] = useState<string | null>(null);
+
+  const { data: preview, isLoading, error: previewError } =
+    api.product.ticketSync.previewRevert.useQuery(
+      { productId, runIds },
+      { retry: false },
+    );
+
+  const revert = api.product.ticketSync.revertRuns.useMutation({
+    onSuccess: async () => {
+      await utils.product.ticketSync.listRuns.invalidate({ productId });
+      await utils.product.ticketSync.getConfig.invalidate({ productId });
+      onClose();
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  return (
+    <Modal
+      opened
+      onClose={onClose}
+      title={`Revert ${runIds.length === 1 ? "sync run" : `${runIds.length} sync runs`}`}
+      size="lg"
+    >
+      {isLoading && (
+        <Text size="sm" className="text-text-muted">
+          Building revert preview…
+        </Text>
+      )}
+      {previewError && (
+        <Text size="sm" c="red">
+          {previewError.message}
+        </Text>
+      )}
+      {preview && (
+        <div className="space-y-4">
+          <Text size="sm" className="text-text-primary">
+            This permanently deletes the{" "}
+            <b>{preview.deletable.length}</b> ticket
+            {preview.deletable.length === 1 ? "" : "s"} this sync created.
+            Updates made by the sync to other tickets are not undone.
+          </Text>
+
+          {preview.deletable.length > 0 && (
+            <div>
+              <Text size="xs" fw={600} className="text-text-secondary mb-1">
+                Will be deleted ({preview.deletable.length})
+              </Text>
+              <div className="max-h-48 space-y-0.5 overflow-y-auto rounded border border-border-primary p-2">
+                {preview.deletable.map((t) => (
+                  <Text key={t.ticketId} size="xs" className="text-text-primary truncate">
+                    {t.title}
+                  </Text>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {preview.skipped.length > 0 && (
+            <div>
+              <Text size="xs" fw={600} className="text-text-secondary mb-1">
+                Kept — someone worked on these ({preview.skipped.length})
+              </Text>
+              <div className="max-h-48 space-y-0.5 overflow-y-auto rounded border border-border-primary p-2">
+                {preview.skipped.map((t) => (
+                  <div key={t.ticketId} className="flex gap-2 text-xs">
+                    <span className="text-text-primary truncate">{t.title}</span>
+                    <span className="text-text-muted truncate">
+                      — {t.reasons.join("; ")}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              <Text size="xs" className="text-text-muted mt-1">
+                Kept tickets stop syncing (their link is tombstoned) but stay
+                in the backlog. Delete them individually if needed.
+              </Text>
+            </div>
+          )}
+
+          {error && (
+            <Text size="sm" c="red">
+              {error}
+            </Text>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button size="xs" variant="default" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              size="xs"
+              color="red"
+              loading={revert.isPending}
+              disabled={preview.deletable.length === 0 && preview.skipped.length === 0}
+              onClick={() => revert.mutate({ productId, runIds })}
+            >
+              Delete {preview.deletable.length} ticket
+              {preview.deletable.length === 1 ? "" : "s"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+/**
  * Sync run history — the persisted ledger of every run for a product's
  * Ticket sync connection (newest first), from `ticketSync.listRuns`. Unlike
  * the in-memory "last run" panel this survives refresh and navigation, and it
- * keeps showing history while the connection is disconnected.
+ * keeps showing history while the connection is disconnected. Eligible runs
+ * carry a Revert action (ADR-0042).
  */
 export function SyncRunHistory({ productId }: { productId: string }) {
   const [limit, setLimit] = useState(10);
+  const [revertTarget, setRevertTarget] = useState<string[] | null>(null);
   const { data: runs, isLoading } = api.product.ticketSync.listRuns.useQuery(
     { productId, limit },
     { enabled: !!productId },
@@ -166,7 +340,11 @@ export function SyncRunHistory({ productId }: { productId: string }) {
       </div>
       <div className="mt-2">
         {runs.map((run) => (
-          <RunRow key={run.id} run={run as RunRowData} />
+          <RunRow
+            key={run.id}
+            run={run as RunRowData}
+            onRevert={setRevertTarget}
+          />
         ))}
       </div>
       {runs.length === limit && (
@@ -178,6 +356,13 @@ export function SyncRunHistory({ productId }: { productId: string }) {
         >
           Show more
         </Button>
+      )}
+      {revertTarget && (
+        <RevertModal
+          productId={productId}
+          runIds={revertTarget}
+          onClose={() => setRevertTarget(null)}
+        />
       )}
     </div>
   );

--- a/src/app/_components/products/SyncRunHistory.tsx
+++ b/src/app/_components/products/SyncRunHistory.tsx
@@ -330,6 +330,13 @@ export function SyncRunHistory({ productId }: { productId: string }) {
 
   if (isLoading || !runs || runs.length === 0) return null;
 
+  // Connection-wide revert is a SELECTION of all eligible runs, not a second
+  // mechanism (ADR-0042) — the same run-scoped mutation and the same
+  // aggregated preview/confirm flow.
+  const eligibleRunIds = runs
+    .filter((run) => isRevertible(run as RunRowData))
+    .map((run) => run.id);
+
   return (
     <div className="rounded-lg border border-border-primary bg-surface-secondary px-5 py-4">
       <div className="flex items-center gap-2">
@@ -337,6 +344,18 @@ export function SyncRunHistory({ productId }: { productId: string }) {
         <Text size="sm" fw={600} className="text-text-primary">
           Sync history
         </Text>
+        {eligibleRunIds.length > 0 && (
+          <Button
+            size="compact-xs"
+            variant="subtle"
+            color="orange"
+            className="ml-auto"
+            leftSection={<IconArrowBackUp size={12} />}
+            onClick={() => setRevertTarget(eligibleRunIds)}
+          >
+            Remove all tickets created by this sync
+          </Button>
+        )}
       </div>
       <div className="mt-2">
         {runs.map((run) => (

--- a/src/plugins/product/server/routers/ticketSync.ts
+++ b/src/plugins/product/server/routers/ticketSync.ts
@@ -4,6 +4,10 @@ import { TRPCError } from "@trpc/server";
 import { loadProductWithAccess } from "./product";
 import { DEFAULT_STATUS_MAP } from "~/server/services/ticketSync/mapping";
 import { runInboundTicketSync } from "~/server/services/ticketSync/engine";
+import {
+  executeTicketSyncRevert,
+  planTicketSyncRevert,
+} from "~/server/services/ticketSync/revert";
 import { createNotionTicketSyncAdapter } from "~/server/services/ticketSync/notionAdapter";
 
 /**
@@ -232,6 +236,71 @@ export const ticketSyncRouter = createTRPCRouter({
           // before the ledger recorded it) — the UI renders those as system.
           triggeredBy: { select: { id: true, name: true, email: true } },
         },
+      });
+    }),
+
+  /**
+   * Preview a Sync revert (ADR-0042): what would be deleted, what the
+   * local-work guardrail protects (with reasons), what's already gone.
+   * Read-only — nothing mutates until revertRuns.
+   */
+  previewRevert: protectedProcedure
+    .input(
+      z.object({
+        productId: z.string(),
+        runIds: z.array(z.string()).min(1).max(100),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      await loadProductWithAccess(ctx.db, ctx.session.user.id, input.productId);
+      const config = await ctx.db.ticketSyncConfig.findUnique({
+        where: {
+          productId_provider: { productId: input.productId, provider: "notion" },
+        },
+        select: { id: true },
+      });
+      if (!config) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "No Notion sync configured for this product",
+        });
+      }
+      return planTicketSyncRevert(ctx.db, {
+        configId: config.id,
+        runIds: input.runIds,
+      });
+    }),
+
+  /**
+   * Execute a Sync revert: hard-delete the selected runs' created tickets
+   * (guardrail-protected tickets are skipped and tombstoned), stamp the runs
+   * reverted, and record the revert as its own run in the ledger.
+   */
+  revertRuns: protectedProcedure
+    .input(
+      z.object({
+        productId: z.string(),
+        runIds: z.array(z.string()).min(1).max(100),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await loadProductWithAccess(ctx.db, ctx.session.user.id, input.productId);
+      const config = await ctx.db.ticketSyncConfig.findUnique({
+        where: {
+          productId_provider: { productId: input.productId, provider: "notion" },
+        },
+        select: { id: true },
+      });
+      if (!config) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "No Notion sync configured for this product",
+        });
+      }
+      return executeTicketSyncRevert(ctx.db, {
+        configId: config.id,
+        runIds: input.runIds,
+        triggeredById: ctx.session.user.id,
       });
     }),
 });

--- a/src/server/services/activity/feedRenderHints.ts
+++ b/src/server/services/activity/feedRenderHints.ts
@@ -153,6 +153,12 @@ const HINTS: Record<string, FeedRenderHint> = {
     iconKind: "tracked",
   },
 
+  // Ticket sync reverts (ADR-0042): one `reverted` event per revert run.
+  [key("ticket_sync_run", "reverted")]: {
+    template: "{actor} reverted a ticket sync: {entityRef}",
+    iconKind: "status_changed",
+  },
+
   // Channel activity summaries (ADR-0023). The feed renders these rows with a
   // bespoke layout (provider icon + channel name as the actor, summary as the
   // body) rather than this template, but the hint still drives the icon kind

--- a/src/server/services/activity/recordActivity.ts
+++ b/src/server/services/activity/recordActivity.ts
@@ -12,7 +12,8 @@ export type ActivityAction =
   | "status_changed"
   | "completed"
   | "commented"
-  | "summarized";
+  | "summarized"
+  | "reverted";
 
 /**
  * Entity types we currently log activity for. New writers append new values
@@ -32,7 +33,8 @@ export type ActivityEntityType =
   | "deal"
   | "meeting"
   | "time_entry"
-  | "channel_summary";
+  | "channel_summary"
+  | "ticket_sync_run";
 
 export interface RecordActivityInput {
   workspaceId: string;

--- a/src/server/services/ticketSync/__tests__/engine.test.ts
+++ b/src/server/services/ticketSync/__tests__/engine.test.ts
@@ -808,3 +808,29 @@ describe("runInboundTicketSync — feed altitude (one event per run)", () => {
     );
   });
 });
+
+describe("runInboundTicketSync — revert-tombstoned links (ADR-0042)", () => {
+  it("skips a revert-tombstoned link instead of restoring it", async () => {
+    db.ticketSync.findMany.mockResolvedValue([
+      {
+        id: "s1",
+        ticketId: "t1",
+        externalId: "page-1",
+        snapshot: { title: "Imported row", revertTombstoned: true },
+        tombstonedAt: new Date("2026-07-15T10:00:00Z"),
+      },
+    ] as never);
+
+    const result = await runInboundTicketSync(db, fakeAdapter([row()]), {
+      configId: "cfg1",
+      trigger: "manual",
+    });
+
+    expect(result.skipped).toBe(1);
+    expect(db.ticket.update).not.toHaveBeenCalled();
+    expect(createTicketMock).not.toHaveBeenCalled();
+    const item = result.items.find((i) => i.externalId === "page-1");
+    expect(item?.action).toBe("skipped");
+    expect(item?.reason).toContain("tombstoned by revert");
+  });
+});

--- a/src/server/services/ticketSync/__tests__/revert.test.ts
+++ b/src/server/services/ticketSync/__tests__/revert.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Engine-seam tests for the Sync revert service (ADR-0042): deep-mocked
+ * Prisma, module-mocked activity writer, assertions on external behavior —
+ * which tickets get deleted, which the guardrail protects and why, what the
+ * revert run manifest reports, what gets tombstoned, and what event fires.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+const { recordActivityMock } = vi.hoisted(() => ({
+  recordActivityMock: vi.fn(),
+}));
+
+vi.mock("~/server/services/activity/recordActivity", () => ({
+  recordActivity: recordActivityMock,
+}));
+
+import {
+  executeTicketSyncRevert,
+  planTicketSyncRevert,
+  REVERT_TOMBSTONE_KEY,
+} from "../revert";
+
+const db = mockDeep<PrismaClient>() as DeepMockProxy<PrismaClient>;
+
+const CONFIG = {
+  id: "cfg1",
+  productId: "prod1",
+  provider: "notion",
+  product: { id: "prod1", workspaceId: "ws1" },
+};
+
+function pullRun(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "runA",
+    direction: "pull",
+    dryRun: false,
+    revertedAt: null,
+    items: [
+      { externalId: "page-1", ticketId: "t1", title: "Clean one", action: "created" },
+      { externalId: "page-2", ticketId: "t2", title: "Touched one", action: "created" },
+      { externalId: "page-3", ticketId: "t3", title: "Adopted one", action: "adopted" },
+      { externalId: "page-4", ticketId: "t4", title: "Updated one", action: "updated" },
+    ],
+    ...overrides,
+  };
+}
+
+function cleanTicket(id: string, title: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    title,
+    status: "BACKLOG",
+    type: "FEATURE",
+    priority: null,
+    points: null,
+    prUrl: null,
+    branchName: null,
+    assigneeId: null,
+    featureId: null,
+    epicId: null,
+    scopeId: null,
+    cycleId: null,
+    _count: { comments: 0, actions: 0, depsOut: 0, depsIn: 0 },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockReset(db);
+  recordActivityMock.mockReset();
+  recordActivityMock.mockResolvedValue(true);
+
+  db.ticketSyncConfig.findUniqueOrThrow.mockResolvedValue(CONFIG as never);
+  db.ticketSyncRun.findMany.mockResolvedValue([pullRun()] as never);
+  db.ticket.findMany.mockResolvedValue([
+    cleanTicket("t1", "Clean one"),
+    cleanTicket("t2", "Touched one"),
+  ] as never);
+  db.ticketSync.findMany.mockResolvedValue([] as never);
+  db.ticketSyncRun.create.mockResolvedValue({ id: "revert1" } as never);
+  db.ticketSyncRun.update.mockResolvedValue({} as never);
+  db.ticketSyncRun.updateMany.mockResolvedValue({ count: 1 } as never);
+  db.ticket.deleteMany.mockResolvedValue({ count: 2 } as never);
+  db.ticketSync.findUnique.mockResolvedValue({
+    id: "link2",
+    snapshot: { title: "Touched one", status: "BACKLOG" },
+  } as never);
+  db.ticketSync.update.mockResolvedValue({} as never);
+  // Interactive transaction: run the callback against the same mock.
+  db.$transaction.mockImplementation(
+    (async (fn: (tx: unknown) => Promise<unknown>) => fn(db)) as never,
+  );
+});
+
+describe("planTicketSyncRevert — eligibility", () => {
+  it("rejects a run that was already reverted", async () => {
+    db.ticketSyncRun.findMany.mockResolvedValue([
+      pullRun({ revertedAt: new Date() }),
+    ] as never);
+
+    await expect(
+      planTicketSyncRevert(db, { configId: "cfg1", runIds: ["runA"] }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+  });
+
+  it("rejects dry runs and non-pull directions", async () => {
+    db.ticketSyncRun.findMany.mockResolvedValue([pullRun({ dryRun: true })] as never);
+    await expect(
+      planTicketSyncRevert(db, { configId: "cfg1", runIds: ["runA"] }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    db.ticketSyncRun.findMany.mockResolvedValue([
+      pullRun({ direction: "revert" }),
+    ] as never);
+    await expect(
+      planTicketSyncRevert(db, { configId: "cfg1", runIds: ["runA"] }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+  });
+
+  it("rejects runs that belong to another connection (scoped by configId)", async () => {
+    db.ticketSyncRun.findMany.mockResolvedValue([] as never);
+
+    await expect(
+      planTicketSyncRevert(db, { configId: "cfg1", runIds: ["foreign-run"] }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+    expect(db.ticketSyncRun.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ configId: "cfg1" }),
+      }),
+    );
+  });
+
+  it("rejects runs with no created items (nothing to revert)", async () => {
+    db.ticketSyncRun.findMany.mockResolvedValue([
+      pullRun({
+        items: [
+          { externalId: "p", ticketId: "t3", title: "x", action: "adopted" },
+        ],
+      }),
+    ] as never);
+
+    await expect(
+      planTicketSyncRevert(db, { configId: "cfg1", runIds: ["runA"] }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+  });
+
+  it("plans only created items — adopted and updated are never candidates", async () => {
+    const plan = await planTicketSyncRevert(db, {
+      configId: "cfg1",
+      runIds: ["runA"],
+    });
+
+    const planned = [...plan.deletable, ...plan.skipped, ...plan.missing].map(
+      (e) => e.ticketId,
+    );
+    expect(planned).toEqual(expect.arrayContaining(["t1", "t2"]));
+    expect(planned).not.toContain("t3");
+    expect(planned).not.toContain("t4");
+  });
+
+  it("reports already-deleted tickets as missing", async () => {
+    db.ticket.findMany.mockResolvedValue([cleanTicket("t1", "Clean one")] as never);
+
+    const plan = await planTicketSyncRevert(db, {
+      configId: "cfg1",
+      runIds: ["runA"],
+    });
+
+    expect(plan.deletable.map((e) => e.ticketId)).toEqual(["t1"]);
+    expect(plan.missing.map((e) => e.ticketId)).toEqual(["t2"]);
+  });
+});
+
+describe("planTicketSyncRevert — local-work guardrail", () => {
+  const signals: Array<[string, Record<string, unknown>, string]> = [
+    ["comments", { _count: { comments: 2, actions: 0, depsOut: 0, depsIn: 0 } }, "has comments"],
+    ["linked actions", { _count: { comments: 0, actions: 1, depsOut: 0, depsIn: 0 } }, "has linked actions"],
+    ["dependencies", { _count: { comments: 0, actions: 0, depsOut: 1, depsIn: 0 } }, "has ticket dependencies"],
+    ["PR url", { prUrl: "https://github.com/x/y/pull/1" }, "has a PR linked"],
+    ["branch name", { branchName: "feat/x" }, "has a branch name"],
+    ["assignee", { assigneeId: "user-9" }, "has an assignee"],
+    ["feature link", { featureId: "feat-1" }, "linked to a feature"],
+    ["epic link", { epicId: "epic-1" }, "linked to an epic"],
+    ["scope link", { scopeId: "scope-1" }, "linked to a scope"],
+    ["cycle link", { cycleId: "cycle-1" }, "linked to a cycle"],
+  ];
+
+  it.each(signals)("skips a ticket with %s", async (_label, overrides, reason) => {
+    db.ticket.findMany.mockResolvedValue([
+      cleanTicket("t1", "Clean one"),
+      cleanTicket("t2", "Touched one", overrides),
+    ] as never);
+
+    const plan = await planTicketSyncRevert(db, {
+      configId: "cfg1",
+      runIds: ["runA"],
+    });
+
+    expect(plan.deletable.map((e) => e.ticketId)).toEqual(["t1"]);
+    expect(plan.skipped).toHaveLength(1);
+    expect(plan.skipped[0]).toMatchObject({ ticketId: "t2" });
+    expect(plan.skipped[0]!.reasons).toContain(reason);
+  });
+
+  it("skips on synced-field drift vs the link snapshot", async () => {
+    db.ticket.findMany.mockResolvedValue([
+      cleanTicket("t2", "Renamed by a human", { status: "IN_PROGRESS" }),
+    ] as never);
+    db.ticketSync.findMany.mockResolvedValue([
+      {
+        ticketId: "t2",
+        snapshot: {
+          title: "Touched one",
+          status: "BACKLOG",
+          priority: null,
+          type: "FEATURE",
+          points: null,
+        },
+      },
+    ] as never);
+    db.ticketSyncRun.findMany.mockResolvedValue([
+      pullRun({
+        items: [
+          { externalId: "page-2", ticketId: "t2", title: "Touched one", action: "created" },
+        ],
+      }),
+    ] as never);
+
+    const plan = await planTicketSyncRevert(db, {
+      configId: "cfg1",
+      runIds: ["runA"],
+    });
+
+    expect(plan.deletable).toHaveLength(0);
+    expect(plan.skipped[0]!.reasons.join()).toContain("local edits since last sync");
+    expect(plan.skipped[0]!.reasons.join()).toContain("title");
+    expect(plan.skipped[0]!.reasons.join()).toContain("status");
+  });
+
+  it("does not treat an unchanged snapshot as drift", async () => {
+    db.ticketSync.findMany.mockResolvedValue([
+      {
+        ticketId: "t1",
+        snapshot: {
+          title: "Clean one",
+          status: "BACKLOG",
+          priority: null,
+          type: "FEATURE",
+          points: null,
+        },
+      },
+    ] as never);
+
+    const plan = await planTicketSyncRevert(db, {
+      configId: "cfg1",
+      runIds: ["runA"],
+    });
+
+    expect(plan.deletable.map((e) => e.ticketId)).toContain("t1");
+  });
+});
+
+describe("executeTicketSyncRevert", () => {
+  it("hard-deletes exactly the deletable tickets", async () => {
+    await executeTicketSyncRevert(db, {
+      configId: "cfg1",
+      runIds: ["runA"],
+      triggeredById: "user-7",
+    });
+
+    expect(db.ticket.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["t1", "t2"] } },
+    });
+  });
+
+  it("stamps the reverted runs with a null-guard in the same transaction", async () => {
+    await executeTicketSyncRevert(db, {
+      configId: "cfg1",
+      runIds: ["runA"],
+      triggeredById: "user-7",
+    });
+
+    expect(db.ticketSyncRun.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["runA"] }, configId: "cfg1", revertedAt: null },
+      data: expect.objectContaining({
+        revertedAt: expect.any(Date),
+        revertedByRunId: "revert1",
+      }),
+    });
+  });
+
+  it("rejects when a run was reverted concurrently (stamp count mismatch) and marks the revert run errored", async () => {
+    db.ticketSyncRun.updateMany.mockResolvedValue({ count: 0 } as never);
+
+    await expect(
+      executeTicketSyncRevert(db, { configId: "cfg1", runIds: ["runA"] }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    expect(db.ticket.deleteMany).not.toHaveBeenCalled();
+    expect(db.ticketSyncRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "revert1" },
+        data: expect.objectContaining({ status: "error" }),
+      }),
+    );
+    expect(recordActivityMock).not.toHaveBeenCalled();
+  });
+
+  it("tombstones skipped survivors' links with the revert sentinel, preserving the snapshot", async () => {
+    db.ticket.findMany.mockResolvedValue([
+      cleanTicket("t1", "Clean one"),
+      cleanTicket("t2", "Touched one", { assigneeId: "user-9" }),
+    ] as never);
+
+    await executeTicketSyncRevert(db, {
+      configId: "cfg1",
+      runIds: ["runA"],
+      triggeredById: "user-7",
+    });
+
+    expect(db.ticketSync.update).toHaveBeenCalledWith({
+      where: { id: "link2" },
+      data: {
+        tombstonedAt: expect.any(Date),
+        snapshot: {
+          title: "Touched one",
+          status: "BACKLOG",
+          [REVERT_TOMBSTONE_KEY]: true,
+        },
+      },
+    });
+    // Only the survivor is deleted from the deletable set.
+    expect(db.ticket.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["t1"] } },
+    });
+  });
+
+  it("writes the revert as its own run with per-item outcomes", async () => {
+    db.ticket.findMany.mockResolvedValue([
+      cleanTicket("t1", "Clean one"),
+      cleanTicket("t2", "Touched one", { assigneeId: "user-9" }),
+    ] as never);
+
+    const result = await executeTicketSyncRevert(db, {
+      configId: "cfg1",
+      runIds: ["runA"],
+      triggeredById: "user-7",
+    });
+
+    expect(db.ticketSyncRun.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        configId: "cfg1",
+        direction: "revert",
+        trigger: "manual",
+        triggeredById: "user-7",
+      }),
+    });
+    expect(db.ticketSyncRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "revert1" },
+        data: expect.objectContaining({
+          status: "success",
+          skipped: 1,
+          items: expect.arrayContaining([
+            expect.objectContaining({ ticketId: "t1", action: "deleted" }),
+            expect.objectContaining({
+              ticketId: "t2",
+              action: "skipped",
+              reason: expect.stringContaining("assignee"),
+            }),
+          ]),
+        }),
+      }),
+    );
+    expect(result).toMatchObject({ revertRunId: "revert1", deleted: 1, skipped: 1 });
+  });
+
+  it("posts exactly one reverted activity event with counts in metadata", async () => {
+    await executeTicketSyncRevert(db, {
+      configId: "cfg1",
+      runIds: ["runA"],
+      triggeredById: "user-7",
+    });
+
+    expect(recordActivityMock).toHaveBeenCalledTimes(1);
+    expect(recordActivityMock).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        workspaceId: "ws1",
+        userId: "user-7",
+        entityType: "ticket_sync_run",
+        entityId: "revert1",
+        action: "reverted",
+        metadata: expect.objectContaining({ deleted: 2, skipped: 0 }),
+      }),
+    );
+  });
+});

--- a/src/server/services/ticketSync/__tests__/revert.test.ts
+++ b/src/server/services/ticketSync/__tests__/revert.test.ts
@@ -263,6 +263,50 @@ describe("planTicketSyncRevert — local-work guardrail", () => {
   });
 });
 
+describe("connection-wide revert — multiple runs in one selection", () => {
+  const runB = pullRun({
+    id: "runB",
+    items: [
+      { externalId: "page-9", ticketId: "t9", title: "From run B", action: "created" },
+    ],
+  });
+
+  beforeEach(() => {
+    db.ticketSyncRun.findMany.mockResolvedValue([pullRun(), runB] as never);
+    db.ticket.findMany.mockResolvedValue([
+      cleanTicket("t1", "Clean one"),
+      cleanTicket("t2", "Touched one"),
+      cleanTicket("t9", "From run B"),
+    ] as never);
+    db.ticketSyncRun.updateMany.mockResolvedValue({ count: 2 } as never);
+  });
+
+  it("aggregates created items across all selected runs into one plan", async () => {
+    const plan = await planTicketSyncRevert(db, {
+      configId: "cfg1",
+      runIds: ["runA", "runB"],
+    });
+
+    expect(plan.deletable.map((e) => e.ticketId).sort()).toEqual(["t1", "t2", "t9"]);
+  });
+
+  it("stamps every selected run against the one revert run", async () => {
+    await executeTicketSyncRevert(db, {
+      configId: "cfg1",
+      runIds: ["runA", "runB"],
+      triggeredById: "user-7",
+    });
+
+    expect(db.ticketSyncRun.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["runA", "runB"] }, configId: "cfg1", revertedAt: null },
+      data: expect.objectContaining({ revertedByRunId: "revert1" }),
+    });
+    expect(db.ticket.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["t1", "t2", "t9"] } },
+    });
+  });
+});
+
 describe("executeTicketSyncRevert", () => {
   it("hard-deletes exactly the deletable tickets", async () => {
     await executeTicketSyncRevert(db, {

--- a/src/server/services/ticketSync/engine.ts
+++ b/src/server/services/ticketSync/engine.ts
@@ -6,6 +6,7 @@ import {
   resolveOrCreateWorkspaceTags,
 } from "../notionTicketImport";
 import { mapPoints, mapPriority, mapStatus, mapType } from "./mapping";
+import { REVERT_TOMBSTONE_KEY } from "./revert";
 import {
   findCycleIdByName,
   resolveAssigneeIdByEmail,
@@ -216,6 +217,15 @@ async function relationalPreviewWarnings(
     }
   }
   return warnings;
+}
+
+function hasRevertTombstone(snapshot: Prisma.JsonValue | null): boolean {
+  return (
+    !!snapshot &&
+    typeof snapshot === "object" &&
+    !Array.isArray(snapshot) &&
+    (snapshot as Record<string, unknown>)[REVERT_TOMBSTONE_KEY] === true
+  );
 }
 
 function extractNotionPageId(links: Prisma.JsonValue | null): string | null {
@@ -554,6 +564,22 @@ export async function runInboundTicketSync(
             title: fields.title,
             action: "created",
             reason: warnings.length > 0 ? warnings.join("; ") : undefined,
+          });
+          continue;
+        }
+
+        // A revert-tombstoned link is permanent: the survivor kept local
+        // work, so a revived connection must never overwrite it again
+        // (ADR-0042). Distinct from the archive-mirror tombstone below,
+        // which restores when the page leaves the Notion trash.
+        if (record.tombstonedAt && hasRevertTombstone(record.snapshot)) {
+          counts.skipped++;
+          items.push({
+            externalId: row.externalId,
+            ticketId: record.ticketId,
+            title: row.title,
+            action: "skipped",
+            reason: "link tombstoned by revert — no longer syncing",
           });
           continue;
         }

--- a/src/server/services/ticketSync/revert.ts
+++ b/src/server/services/ticketSync/revert.ts
@@ -1,0 +1,423 @@
+import { type Prisma } from "@prisma/client";
+import type { PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+import { recordActivity } from "~/server/services/activity/recordActivity";
+import type { SyncRunItem } from "./engine";
+
+/**
+ * ticketSync/revert — undo what one or more Sync runs *created* (ADR-0042).
+ *
+ * Strictly creation-undo: only `items[action === "created"]` tickets are
+ * touched — never `adopted` (the sync didn't create those) and never
+ * `updated` (pre-sync values aren't kept; revert is not a time machine).
+ * Deletion is hard: an archived sync ticket would keep its Notion page id and
+ * be re-adopted (and un-archived) by the next sync — zombie resurrection.
+ *
+ * The safety net is the local-work guardrail: any human-touch signal on a
+ * ticket skips it, with no bulk override — over-skipping is cheap (the
+ * single-ticket delete exists), under-skipping is irreversible. Skipped
+ * survivors get their sync link tombstoned so a revived connection can't
+ * keep overwriting them, while their provenance stays intact.
+ *
+ * A revert is itself a Sync run (`direction: "revert"`) with the same
+ * per-item outcome shape, and stamps the reverted runs (`revertedAt`,
+ * `revertedByRunId`) in the same transaction — a run is revertible at most
+ * once, enforced under concurrency by the stamp's null-guard.
+ */
+
+/** Sentinel stored inside the link snapshot JSON by revert-tombstoning.
+ * Distinguishes "stop syncing forever" (revert) from the archive-mirror
+ * tombstone the engine restores when a page leaves the Notion trash. */
+export const REVERT_TOMBSTONE_KEY = "revertTombstoned";
+
+export interface RevertRunItem {
+  externalId: string | null;
+  ticketId: string | null;
+  title: string;
+  action: "deleted" | "skipped";
+  reason?: string;
+}
+
+export interface RevertPlanEntry {
+  runId: string;
+  ticketId: string;
+  externalId: string | null;
+  title: string;
+}
+
+export interface RevertPlanSkip extends RevertPlanEntry {
+  reasons: string[];
+}
+
+export interface TicketSyncRevertPlan {
+  configId: string;
+  runIds: string[];
+  /** Tickets the revert will hard-delete. */
+  deletable: RevertPlanEntry[];
+  /** Tickets protected by the local-work guardrail (link gets tombstoned). */
+  skipped: RevertPlanSkip[];
+  /** Created-items whose ticket is already gone — nothing to do. */
+  missing: RevertPlanEntry[];
+}
+
+export interface TicketSyncRevertResult {
+  revertRunId: string;
+  deleted: number;
+  skipped: number;
+  items: RevertRunItem[];
+}
+
+interface SyncedSnapshotScalars {
+  title?: string;
+  status?: string;
+  priority?: number | null;
+  type?: string;
+  points?: number | null;
+}
+
+function asRunItems(items: Prisma.JsonValue | null): SyncRunItem[] {
+  return Array.isArray(items) ? (items as unknown as SyncRunItem[]) : [];
+}
+
+/**
+ * Build the revert plan for a set of run ids: which tickets would be deleted,
+ * which are protected by the guardrail (and why), which are already gone.
+ * Pure read — powers both the preview endpoint and the execute path (which
+ * re-plans server-side; the client's preview is never trusted).
+ *
+ * Throws PRECONDITION_FAILED when any requested run is not revertible
+ * (wrong config, dry run, wrong direction, already reverted, no created
+ * items) — eligibility is the caller-visible contract, not a silent filter.
+ */
+export async function planTicketSyncRevert(
+  db: PrismaClient,
+  params: { configId: string; runIds: string[] },
+): Promise<TicketSyncRevertPlan> {
+  if (params.runIds.length === 0) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "No runs selected to revert",
+    });
+  }
+
+  const runs = await db.ticketSyncRun.findMany({
+    where: { id: { in: params.runIds }, configId: params.configId },
+    select: {
+      id: true,
+      direction: true,
+      dryRun: true,
+      revertedAt: true,
+      items: true,
+    },
+  });
+  const byId = new Map(runs.map((r) => [r.id, r]));
+
+  for (const runId of params.runIds) {
+    const run = byId.get(runId);
+    if (!run) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: `Run ${runId} not found on this connection`,
+      });
+    }
+    if (run.direction !== "pull" || run.dryRun) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: `Run ${runId} is not a real pull run`,
+      });
+    }
+    if (run.revertedAt) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: `Run ${runId} has already been reverted`,
+      });
+    }
+  }
+
+  // Created-items only — the whole point of the run ledger is that this set
+  // is authoritative (Ticket.links.notionPageId alone is ambiguous: imports
+  // stamp it too, and adopted tickets were never created by the sync).
+  const createdEntries: RevertPlanEntry[] = [];
+  for (const run of runs) {
+    for (const item of asRunItems(run.items)) {
+      if (item.action === "created" && item.ticketId) {
+        createdEntries.push({
+          runId: run.id,
+          ticketId: item.ticketId,
+          externalId: item.externalId,
+          title: item.title,
+        });
+      }
+    }
+  }
+  if (createdEntries.length === 0) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "The selected runs created no tickets",
+    });
+  }
+
+  const ticketIds = createdEntries.map((e) => e.ticketId);
+  const tickets = await db.ticket.findMany({
+    where: { id: { in: ticketIds } },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      type: true,
+      priority: true,
+      points: true,
+      prUrl: true,
+      branchName: true,
+      assigneeId: true,
+      featureId: true,
+      epicId: true,
+      scopeId: true,
+      cycleId: true,
+      _count: {
+        select: { comments: true, actions: true, depsOut: true, depsIn: true },
+      },
+    },
+  });
+  const ticketById = new Map(tickets.map((t) => [t.id, t]));
+
+  const links = await db.ticketSync.findMany({
+    where: { configId: params.configId, ticketId: { in: ticketIds } },
+    select: { ticketId: true, snapshot: true },
+  });
+  const snapshotByTicketId = new Map(
+    links.map((l) => [l.ticketId, l.snapshot]),
+  );
+
+  const deletable: RevertPlanEntry[] = [];
+  const skipped: RevertPlanSkip[] = [];
+  const missing: RevertPlanEntry[] = [];
+
+  for (const entry of createdEntries) {
+    const ticket = ticketById.get(entry.ticketId);
+    if (!ticket) {
+      missing.push(entry);
+      continue;
+    }
+
+    const reasons: string[] = [];
+    if (ticket._count.comments > 0) reasons.push("has comments");
+    if (ticket._count.actions > 0) reasons.push("has linked actions");
+    if (ticket._count.depsOut + ticket._count.depsIn > 0)
+      reasons.push("has ticket dependencies");
+    if (ticket.prUrl) reasons.push("has a PR linked");
+    if (ticket.branchName) reasons.push("has a branch name");
+    if (ticket.assigneeId) reasons.push("has an assignee");
+    if (ticket.featureId) reasons.push("linked to a feature");
+    if (ticket.epicId) reasons.push("linked to an epic");
+    if (ticket.scopeId) reasons.push("linked to a scope");
+    if (ticket.cycleId) reasons.push("linked to a cycle");
+
+    // Synced-field drift vs the link snapshot = a local edit since the last
+    // sync. Missing snapshot (never re-synced) means nothing to compare.
+    const snapshot = snapshotByTicketId.get(entry.ticketId) as
+      | SyncedSnapshotScalars
+      | null
+      | undefined;
+    if (snapshot && typeof snapshot === "object") {
+      const drifted: string[] = [];
+      if (snapshot.title !== undefined && snapshot.title !== ticket.title)
+        drifted.push("title");
+      if (snapshot.status !== undefined && snapshot.status !== ticket.status)
+        drifted.push("status");
+      if (
+        snapshot.priority !== undefined &&
+        (snapshot.priority ?? null) !== ticket.priority
+      )
+        drifted.push("priority");
+      if (snapshot.type !== undefined && snapshot.type !== ticket.type)
+        drifted.push("type");
+      if (
+        snapshot.points !== undefined &&
+        (snapshot.points ?? null) !== ticket.points
+      )
+        drifted.push("points");
+      if (drifted.length > 0)
+        reasons.push(`local edits since last sync (${drifted.join(", ")})`);
+    }
+
+    if (reasons.length > 0) {
+      skipped.push({ ...entry, title: ticket.title, reasons });
+    } else {
+      deletable.push({ ...entry, title: ticket.title });
+    }
+  }
+
+  return {
+    configId: params.configId,
+    runIds: params.runIds,
+    deletable,
+    skipped,
+    missing,
+  };
+}
+
+/**
+ * Execute a revert: re-plan, then atomically stamp the reverted runs, delete
+ * the deletable tickets, and tombstone the skipped survivors' links. Records
+ * itself as a `direction: "revert"` run and posts ONE `reverted` activity
+ * event (feed altitude — never one per ticket).
+ */
+export async function executeTicketSyncRevert(
+  db: PrismaClient,
+  params: {
+    configId: string;
+    runIds: string[];
+    triggeredById?: string | null;
+  },
+): Promise<TicketSyncRevertResult> {
+  const config = await db.ticketSyncConfig.findUniqueOrThrow({
+    where: { id: params.configId },
+    include: { product: { select: { id: true, workspaceId: true } } },
+  });
+
+  const plan = await planTicketSyncRevert(db, {
+    configId: params.configId,
+    runIds: params.runIds,
+  });
+
+  const revertRun = await db.ticketSyncRun.create({
+    data: {
+      configId: config.id,
+      trigger: "manual",
+      direction: "revert",
+      dryRun: false,
+      status: "running",
+      triggeredById: params.triggeredById ?? null,
+    },
+  });
+
+  const items: RevertRunItem[] = [
+    ...plan.deletable.map((e) => ({
+      externalId: e.externalId,
+      ticketId: e.ticketId,
+      title: e.title,
+      action: "deleted" as const,
+    })),
+    ...plan.skipped.map((e) => ({
+      externalId: e.externalId,
+      ticketId: e.ticketId,
+      title: e.title,
+      action: "skipped" as const,
+      reason: e.reasons.join("; "),
+    })),
+    ...plan.missing.map((e) => ({
+      externalId: e.externalId,
+      ticketId: e.ticketId,
+      title: e.title,
+      action: "skipped" as const,
+      reason: "ticket already deleted",
+    })),
+  ];
+
+  try {
+    await db.$transaction(async (tx) => {
+      // Stamp first, with a null-guard: if a concurrent revert got here
+      // before us the count mismatches and the whole transaction rolls
+      // back — a run is revertible at most once.
+      const stamped = await tx.ticketSyncRun.updateMany({
+        where: {
+          id: { in: plan.runIds },
+          configId: config.id,
+          revertedAt: null,
+        },
+        data: { revertedAt: new Date(), revertedByRunId: revertRun.id },
+      });
+      if (stamped.count !== plan.runIds.length) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "A selected run was reverted concurrently",
+        });
+      }
+
+      // Hard-delete the created tickets. Their TicketSync links cascade away
+      // with them; the run ledger keeps the forensic record.
+      if (plan.deletable.length > 0) {
+        await tx.ticket.deleteMany({
+          where: { id: { in: plan.deletable.map((e) => e.ticketId) } },
+        });
+      }
+
+      // Tombstone the skipped survivors' links so a revived connection can't
+      // keep overwriting them. The snapshot sentinel distinguishes this
+      // permanent tombstone from the archive-mirror one the engine restores
+      // when a page leaves the Notion trash.
+      for (const skip of plan.skipped) {
+        const link = await tx.ticketSync.findUnique({
+          where: {
+            ticketId_provider: {
+              ticketId: skip.ticketId,
+              provider: config.provider,
+            },
+          },
+          select: { id: true, snapshot: true },
+        });
+        if (!link) continue;
+        const priorSnapshot =
+          link.snapshot && typeof link.snapshot === "object" && !Array.isArray(link.snapshot)
+            ? (link.snapshot)
+            : {};
+        await tx.ticketSync.update({
+          where: { id: link.id },
+          data: {
+            tombstonedAt: new Date(),
+            snapshot: {
+              ...priorSnapshot,
+              [REVERT_TOMBSTONE_KEY]: true,
+            } as Prisma.InputJsonValue,
+          },
+        });
+      }
+    });
+  } catch (error) {
+    await db.ticketSyncRun.update({
+      where: { id: revertRun.id },
+      data: {
+        status: "error",
+        finishedAt: new Date(),
+        error: error instanceof Error ? error.message : "unknown error",
+        items: items as unknown as Prisma.InputJsonValue,
+      },
+    });
+    throw error;
+  }
+
+  await db.ticketSyncRun.update({
+    where: { id: revertRun.id },
+    data: {
+      status: "success",
+      finishedAt: new Date(),
+      skipped: plan.skipped.length + plan.missing.length,
+      items: items as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  // ONE event per revert (feed altitude, ADR-0042) — the per-ticket story
+  // lives in the revert run's items, not the feed. Never throws.
+  await recordActivity(db, {
+    workspaceId: config.product.workspaceId,
+    userId: params.triggeredById ?? null,
+    entityType: "ticket_sync_run",
+    entityId: revertRun.id,
+    action: "reverted",
+    metadata: {
+      title: `${plan.deletable.length} deleted · ${plan.skipped.length} skipped`,
+      productId: config.productId,
+      deleted: plan.deletable.length,
+      skipped: plan.skipped.length,
+      runIds: plan.runIds,
+    },
+  });
+
+  return {
+    revertRunId: revertRun.id,
+    deleted: plan.deletable.length,
+    skipped: plan.skipped.length + plan.missing.length,
+    items,
+  };
+}


### PR DESCRIPTION
### **User description**
## What

Sync revert end-to-end (ADR-0042): remove the Tickets that a Sync run *created* — mutation + service, local-work guardrail, preview modal, per-run Revert button in the history table.

- **Run-scoped, creation-only**: collects `items[action === "created"]` — never `adopted`, never `updated` (revert is creation-undo, not a time machine). Hard-deletes (archive-as-revert was rejected: zombie resurrection).
- **Local-work guardrail**: any human-touch signal skips the ticket — comments, linked Actions, PR url / branch name, assignee, feature/epic/scope/cycle linkage, dependencies, synced-field drift vs the link snapshot. No force-override.
- **Tombstoned survivors**: skipped tickets' sync links get `tombstonedAt` + a snapshot sentinel. The engine skips these permanently — distinct from #374's restorable archive-mirror tombstone, which un-tombstones when a page leaves the Notion trash (that path would otherwise resurrect overwriting of revert-skipped survivors).
- **Ledger**: the revert writes its own run (`direction: "revert"`, per-item `deleted | skipped` outcomes, `triggeredById`) and stamps reverted runs (`revertedAt`, `revertedByRunId`) transactionally with a null-guard — revertible at most once, raceproof.
- **One `reverted` activity event** per revert (counts in metadata), matching the feed-altitude rule.
- **UI**: Revert renders only on eligible rows; preview shows deletions and skips (with reasons) before confirm. Also consolidates the duplicate run-history table that the concurrent #374/#376 merge left behind (both an inline `RunHistory` and `SyncRunHistory` were rendering).

## Acceptance criteria

- [x] Revert deletes exactly the run's created-item tickets; adopted and updated items are untouched.
- [x] Guardrail skips on every human-touch signal listed above; skipped tickets reported with reasons; no bulk override exists.
- [x] Skipped survivors' sync links are tombstoned; subsequent sync runs ignore tombstoned links.
- [x] A revert run row is written (direction revert, per-item outcomes, triggeredById) and appears in the history table.
- [x] Reverted runs are stamped (revertedAt, revertedByRunId) transactionally; a second revert of the same run is rejected; the Revert button disables and the row shows a reverted indicator.
- [x] Preview modal shows deletions and skips before confirm; cancel mutates nothing.
- [x] One `reverted` activity event per revert with counts in metadata.
- [x] Revert service tested at the engine seam (mocked persistence, run-manifest assertions): guardrail matrix, tombstoning, stamping, event emission.

---

Ships: lunar.ram


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds sync revert service (`revert.ts`) with local-work guardrail, tombstoning, and atomic run stamping

- New `previewRevert`/`revertRuns` tRPC endpoints with preview modal and per-run Revert button in history UI

- Connection-wide revert aggregates all eligible runs into one preview/confirm flow

- Comprehensive test suite (445 lines) covering plan eligibility, guardrail signals, multi-run selection, and execute path


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["SyncRunHistory UI"]
  RevertModal["RevertModal component"]
  RouterPreview["ticketSync.previewRevert"]
  RouterExecute["ticketSync.revertRuns"]
  PlanFn["planTicketSyncRevert()"]
  ExecFn["executeTicketSyncRevert()"]
  Engine["engine.ts (revert-tombstone guard)"]
  Activity["recordActivity (reverted event)"]
  DB["Prisma DB (deleteMany / tombstone / stamp)"]

  UI -- "Revert button" --> RevertModal
  RevertModal -- "preview query" --> RouterPreview
  RevertModal -- "confirm mutation" --> RouterExecute
  RouterPreview -- "calls" --> PlanFn
  RouterExecute -- "calls" --> ExecFn
  ExecFn -- "re-plans" --> PlanFn
  ExecFn -- "atomic tx" --> DB
  ExecFn -- "one event" --> Activity
  Engine -- "checks revertTombstoned sentinel" --> DB
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>revert.ts</strong><dd><code>New revert service with plan, execute, guardrail, and tombstoning</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/378/files#diff-78f2c600228817b903e3ace24531b93636b4fae76185f3841ba90096eb23ea6c">+423/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SyncRunHistory.tsx</strong><dd><code>Add Revert button, RevertModal, and connection-wide revert action</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/378/files#diff-5d0caef3875a1c23742e28d220f74f924418bcae2c11072b585d157b5828623c">+249/-45</a></td>

</tr>

<tr>
  <td><strong>ticketSync.ts</strong><dd><code>Add previewRevert and revertRuns tRPC endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/378/files#diff-585d5c60345724f010f2656d948c90004a42c63e4c7d1d85ec8901cadf4bd1c9">+69/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NotionSyncSettings.tsx</strong><dd><code>Remove duplicate inline RunHistory component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/378/files#diff-b770e43cfa4e1263d83ed5a8602ab1dd1f50b9cb84070cd382c81eb5d89ba756">+0/-105</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>recordActivity.ts</strong><dd><code>Add reverted action type to ActivityAction union</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/378/files#diff-ec0497c5f380dd634d83d42ccd858ac179924cb0a17770a0b08e4650d53ba356">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>feedRenderHints.ts</strong><dd><code>Add feed render hint for ticket_sync_run reverted event</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/378/files#diff-0ac3c61aee5e71e9b01643e40ecb972e63ef7f3dac140e646e5fd790b8034991">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>revert.test.ts</strong><dd><code>Comprehensive tests for revert plan, guardrail, and execute path</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/378/files#diff-737bf895d5323119bcd91580fab9e283cb2835ce70266299b4d9ee10ac77017d">+445/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>engine.test.ts</strong><dd><code>Add test for revert-tombstoned link skip behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/378/files#diff-1842eb3834aa6ce71989236566db12f9f93564ac1c6d3b83951c371c66f41899">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>engine.ts</strong><dd><code>Skip revert-tombstoned links permanently in inbound sync</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/378/files#diff-efe07be6916b5447498a2588f188ac30db90f9345dd6188473dea22c7866e658">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

