### PR TITLE
feat: First-sync dry-run preview gate on Sync now

### DIFF
--- a/src/app/_components/products/NotionSyncSettings.tsx
+++ b/src/app/_components/products/NotionSyncSettings.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import {
   Badge,
   Button,
+  Modal,
   Select,
   Switch,
   Text,
@@ -281,6 +282,28 @@ export function NotionSyncSettings({ productId }: { productId: string }) {
     onError: (err) => setError(err.message),
   });
 
+  // First-sync gate (ADR-0042): on a never-pulled connection, "Sync now"
+  // first runs a dry run and shows its preview for explicit confirmation.
+  // UI-level only, deliberately not server-enforced — programmatic callers
+  // stay ungated; their safety net is Sync revert.
+  const [gatePreview, setGatePreview] = useState<SyncOutcomeView | null>(null);
+
+  const gateDryRun = api.product.ticketSync.syncNow.useMutation({
+    onSuccess: (result) => {
+      setError(null);
+      setGatePreview(result as SyncOutcomeView);
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  const onSyncNow = (neverPulled: boolean) => {
+    if (neverPulled) {
+      gateDryRun.mutate({ productId, dryRun: true });
+    } else {
+      syncNow.mutate({ productId, dryRun: false });
+    }
+  };
+
   const onDisconnect = () => {
     modals.openConfirmModal({
       title: "Disconnect Notion sync",
@@ -355,9 +378,12 @@ export function NotionSyncSettings({ productId }: { productId: string }) {
                 size="xs"
                 variant="light"
                 leftSection={<IconRefresh size={14} />}
-                onClick={() => syncNow.mutate({ productId, dryRun: false })}
-                loading={syncNow.isPending && syncNow.variables?.dryRun !== true}
-                disabled={syncNow.isPending || !config.enabled}
+                onClick={() => onSyncNow(!config.lastPulledAt)}
+                loading={
+                  gateDryRun.isPending ||
+                  (syncNow.isPending && syncNow.variables?.dryRun !== true)
+                }
+                disabled={syncNow.isPending || gateDryRun.isPending || !config.enabled}
               >
                 Sync now
               </Button>
@@ -376,6 +402,73 @@ export function NotionSyncSettings({ productId }: { productId: string }) {
         </div>
 
         {lastOutcome && <SyncOutcome outcome={lastOutcome} />}
+
+        {gatePreview && (
+          <Modal
+            opened
+            onClose={() => setGatePreview(null)}
+            title="First sync — check this is the right database"
+            size="lg"
+          >
+            <div className="space-y-4">
+              <Text size="sm" className="text-text-primary">
+                This connection has never pulled. Syncing{" "}
+                <b>{config.databaseName ?? "this Notion database"}</b> now would
+                create <b>{gatePreview.created}</b> ticket
+                {gatePreview.created === 1 ? "" : "s"} in this product
+                {gatePreview.updated > 0
+                  ? ` (and update ${gatePreview.updated})`
+                  : ""}
+                .
+              </Text>
+              {gatePreview.items.filter((i) => i.action === "created").length > 0 && (
+                <div>
+                  <Text size="xs" fw={600} className="text-text-secondary mb-1">
+                    Sample of what would be created
+                  </Text>
+                  <div className="max-h-48 space-y-0.5 overflow-y-auto rounded border border-border-primary p-2">
+                    {gatePreview.items
+                      .filter((i) => i.action === "created")
+                      .slice(0, 10)
+                      .map((item, i) => (
+                        <Text
+                          key={`${item.externalId ?? i}-${i}`}
+                          size="xs"
+                          className="text-text-primary truncate"
+                        >
+                          {item.title}
+                        </Text>
+                      ))}
+                  </div>
+                </div>
+              )}
+              <Text size="xs" className="text-text-muted">
+                Wrong database? Cancel and re-link — nothing has been created
+                yet.
+              </Text>
+              <div className="flex justify-end gap-2">
+                <Button
+                  size="xs"
+                  variant="default"
+                  onClick={() => setGatePreview(null)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="xs"
+                  color="brand"
+                  loading={syncNow.isPending}
+                  onClick={() => {
+                    setGatePreview(null);
+                    syncNow.mutate({ productId, dryRun: false });
+                  }}
+                >
+                  Looks right — sync now
+                </Button>
+              </div>
+            </div>
+          </Modal>
+        )}
 
         <RunHistory productId={productId} />
 


### PR DESCRIPTION
### **User description**
## What

First-sync preview gate, UI-only. When a Ticket sync connection has never pulled, "Sync now" does not fire the real pull directly: it runs the existing dry run and presents a preview — database name, would-create count, first ~10 ticket titles — requiring explicit confirmation. Confirm fires the real pull; cancel changes nothing. Once the connection has pulled at least once, "Sync now" behaves exactly as today.

Deliberately **not** server-enforced: the sync API keeps accepting real pulls with no prior-dry-run precondition, so programmatic callers (CLI, cron, agent) stay ungated — their safety net is Sync revert. A server-side dry-run handshake was explicitly rejected (the remote database can change between dry run and real pull anyway; the gate is a UX affordance, not a guarantee).

## Acceptance criteria

- [x] Never-pulled connection: "Sync now" triggers a dry run and shows the preview (database name, would-create count, sample titles) instead of pulling.
- [x] Real pull fires only on explicit confirm; cancel leaves backlog and connection state untouched.
- [x] Previously-pulled connection: "Sync now" is unchanged (no ceremony).
- [x] The dedicated "Dry run" button behaves as today.
- [x] No server-side gating added — the sync mutation's contract is unchanged.

---

Ships: plum.rune


___

### **PR Type**
Enhancement


___

### **Description**
- Add first-sync dry-run preview gate for "Sync now" button

- Never-pulled connections show preview modal before real sync

- Modal displays database name, ticket count, and sample titles

- Confirmed sync fires real pull; cancel leaves state untouched


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sync now clicked"] -- "lastPulledAt set" --> B["Real pull fires immediately"]
  A -- "never pulled" --> C["gateDryRun mutation (dryRun: true)"]
  C -- "success" --> D["Preview Modal opens"]
  D -- "database name, created count, sample titles" --> E{"User decision"}
  E -- "Cancel" --> F["Modal closes, nothing changed"]
  E -- "Looks right — sync now" --> G["Real pull fires (dryRun: false)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NotionSyncSettings.tsx</strong><dd><code>First-sync dry-run preview gate modal for Sync now</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/products/NotionSyncSettings.tsx

<ul><li>Import <code>Modal</code> from the UI component library<br> <li> Add <code>gatePreview</code> state to hold dry-run result for the preview gate<br> <li> Add <code>gateDryRun</code> mutation that runs a dry run on first sync<br> <li> Replace direct <code>syncNow.mutate</code> call with <code>onSyncNow</code> handler that checks <br><code>lastPulledAt</code><br> <li> Render a confirmation modal showing database name, ticket counts, and <br>sample titles when <code>gatePreview</code> is set</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/379/files#diff-b770e43cfa4e1263d83ed5a8602ab1dd1f50b9cb84070cd382c81eb5d89ba756">+95/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

