### PR TITLE
feat(prd): @-mention workspace members in feature/scope comments

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -358,6 +358,12 @@ _Avoid_: Tool chip, tool call list, tool badge.
 The experimental `/home` surface where Zoe answers *in the page content* instead of the drawer: on send, the dashboard below the Zoe input collapses and the answer streams in its place, styled as a dashboard card. A third display mode of the **same** conversation state the Zoe drawer shows (the ADR-0006 "two surfaces, one thread" pattern again) — but each canvas **engagement** (one open→dismiss cycle) starts a **fresh Thread** (new `conversationId`, cleanly scorable), and the canvas renders only the current engagement; full history stays a drawer affordance. Dismissal (✕/Esc) or navigating away mid-stream aborts the stream and marks the turn `incomplete` — one rule for both. v1 renders markdown; native per-preset cards (standup first) are a fast-follow. See [ADR-0040](docs/adr/0040-zoe-canvas-fresh-thread-per-engagement.md).
 _Avoid_: Inline chat, inline mode (position, not identity), embedded drawer, answer canvas, home canvas (couples the concept to one route).
 
+### Comments
+
+**Mention**:
+A reference to a workspace **member** (or an **agent**) written inside a comment by typing `@` and picking from the autocomplete. Canonically serialized in the stored comment body as `@[Name](id)`, rendered as a badge on read. A member mention **notifies** the referenced person (push, email, Zulip DM); an agent mention is a **visual tag only** — it neither triggers the agent nor notifies anyone, and non-member ids are silently ignored by delivery. The same mention affordance is meant to work identically on every commentable surface — **Actions**, **Features/PRDs**, and their **scopes** — not just tasks.
+_Avoid_: Tag (the verb "tag" is fine in UI copy, but the concept is a "mention"), @-ref, at-mention (one word: mention).
+
 ### Agent quality
 
 _Operations (what to run, when, in what order): [dev-docs/AGENT_QUALITY_RUNBOOK.md](dev-docs/AGENT_QUALITY_RUNBOOK.md)._

--- a/src/app/_components/product/FeatureActivitySection.tsx
+++ b/src/app/_components/product/FeatureActivitySection.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { useMemo } from "react";
 import { ActionIcon, Avatar, Group, Stack, Text } from "@mantine/core";
 import { IconTrash } from "@tabler/icons-react";
 import { useSession } from "next-auth/react";
 import { api } from "~/trpc/react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import type { MentionCandidate } from "~/hooks/useMentionAutocomplete";
 import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
 import { CommentInput } from "~/app/_components/shared/CommentInput";
 
@@ -22,11 +25,72 @@ interface FeatureActivitySectionProps {
  */
 export function FeatureActivitySection({ featureId, scopeId }: FeatureActivitySectionProps) {
   const { data: session } = useSession();
+  const { workspace } = useWorkspace();
   const utils = api.useUtils();
 
   const { data: comments } = api.product.featureComment.list.useQuery(
     { featureId },
     { enabled: !!featureId },
+  );
+
+  // Fetch agents + linked-team members for @mention autocomplete (mirrors the
+  // Action comment path). Agents are taggable badges only; notifications go to
+  // human workspace members.
+  const { data: mastraAgents } = api.mastra.getMastraAgents.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  });
+  const { data: teamsForLinking } = api.workspace.getUserTeamsForLinking.useQuery(
+    { workspaceId: workspace?.id ?? "" },
+    { enabled: !!workspace?.id },
+  );
+
+  // Build mention candidates from workspace members + linked team members + agents.
+  const mentionCandidates: MentionCandidate[] = useMemo(() => {
+    const seenIds = new Set<string>();
+    const members: MentionCandidate[] = [];
+
+    for (const m of workspace?.members ?? []) {
+      if (!seenIds.has(m.user.id)) {
+        seenIds.add(m.user.id);
+        members.push({
+          id: m.user.id,
+          name: m.user.name ?? m.user.email ?? "Unknown",
+          type: "member" as const,
+          image: m.user.image,
+        });
+      }
+    }
+
+    const linkedTeams = (teamsForLinking ?? []).filter(
+      (t) => t.isLinkedToThisWorkspace,
+    );
+    for (const team of linkedTeams) {
+      for (const tm of team.members) {
+        if (!seenIds.has(tm.user.id)) {
+          seenIds.add(tm.user.id);
+          members.push({
+            id: tm.user.id,
+            name: tm.user.name ?? tm.user.email ?? "Unknown",
+            type: "member" as const,
+            image: tm.user.image,
+          });
+        }
+      }
+    }
+
+    const agents: MentionCandidate[] = (mastraAgents ?? []).map((a) => ({
+      id: a.id,
+      name: a.name,
+      type: "agent" as const,
+      image: null,
+    }));
+
+    return [...members, ...agents];
+  }, [workspace?.members, teamsForLinking, mastraAgents]);
+
+  const mentionNames = useMemo(
+    () => mentionCandidates.map((c) => c.name),
+    [mentionCandidates],
   );
 
   const invalidate = () => {
@@ -67,7 +131,7 @@ export function FeatureActivitySection({ featureId, scopeId }: FeatureActivitySe
                     </Text>
                   </Group>
                   <div className="ml-6">
-                    <MarkdownRenderer content={c.body} />
+                    <MarkdownRenderer content={c.body} mentionNames={mentionNames} />
                   </div>
                 </div>
                 {c.createdBy.id === session?.user?.id && (
@@ -89,6 +153,7 @@ export function FeatureActivitySection({ featureId, scopeId }: FeatureActivitySe
       <CommentInput
         placeholder="Leave a comment..."
         isSubmitting={addComment.isPending}
+        mentionCandidates={mentionCandidates}
         onSubmit={async (content) => {
           await addComment.mutateAsync({ featureId, scopeId, body: content });
         }}

--- a/src/plugins/product/server/routers/featureComment.ts
+++ b/src/plugins/product/server/routers/featureComment.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 import { loadFeatureWithAccess } from "./feature";
+import { sendFeatureMentionNotifications } from "~/server/services/notifications/EmailNotificationService";
 
 const authorSelect = {
   id: true,
@@ -61,7 +62,7 @@ export const featureCommentRouter = createTRPCRouter({
         }
       }
 
-      return ctx.db.featureComment.create({
+      const comment = await ctx.db.featureComment.create({
         data: {
           featureId: input.featureId,
           scopeId: input.scopeId,
@@ -72,6 +73,16 @@ export const featureCommentRouter = createTRPCRouter({
         },
         include: { createdBy: { select: authorSelect } },
       });
+
+      // Fire-and-forget: notify mentioned workspace members.
+      void sendFeatureMentionNotifications(ctx.db, {
+        featureId: input.featureId,
+        scopeId: input.scopeId,
+        commentContent: input.body,
+        commentAuthorId: ctx.session.user.id,
+      });
+
+      return comment;
     }),
 
   reply: protectedProcedure
@@ -84,14 +95,14 @@ export const featureCommentRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const parent = await ctx.db.featureComment.findUnique({
         where: { id: input.parentId },
-        select: { featureId: true, threadId: true, parentId: true },
+        select: { featureId: true, threadId: true, parentId: true, scopeId: true },
       });
       if (!parent) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Comment not found" });
       }
       await loadFeatureWithAccess(ctx.db, ctx.session.user.id, parent.featureId);
 
-      return ctx.db.featureComment.create({
+      const comment = await ctx.db.featureComment.create({
         data: {
           featureId: parent.featureId,
           threadId: parent.threadId,
@@ -102,6 +113,17 @@ export const featureCommentRouter = createTRPCRouter({
         },
         include: { createdBy: { select: authorSelect } },
       });
+
+      // Fire-and-forget: notify mentioned workspace members. Deep-link to the
+      // parent's scope thread when the conversation lives on a scope.
+      void sendFeatureMentionNotifications(ctx.db, {
+        featureId: parent.featureId,
+        scopeId: parent.scopeId ?? undefined,
+        commentContent: input.body,
+        commentAuthorId: ctx.session.user.id,
+      });
+
+      return comment;
     }),
 
   update: protectedProcedure

--- a/src/server/services/notifications/EmailNotificationService.ts
+++ b/src/server/services/notifications/EmailNotificationService.ts
@@ -362,13 +362,23 @@ async function fanOutMentionNotifications(
   const recipientIds = mentionedUserIds.filter((id) => id !== commentAuthorId);
   if (recipientIds.length === 0) return;
 
+  // Mention markup is client-supplied: only notify users who actually belong
+  // to this workspace, directly or via a team linked to it. Anyone else a
+  // crafted @[Name](id) names is silently dropped — never leak comment
+  // content outside the workspace.
   const [author, recipients] = await Promise.all([
     db.user.findUnique({
       where: { id: commentAuthorId },
       select: { name: true, email: true },
     }),
     db.user.findMany({
-      where: { id: { in: recipientIds } },
+      where: {
+        id: { in: recipientIds },
+        OR: [
+          { workspaceMemberships: { some: { workspaceId } } },
+          { teams: { some: { team: { workspaceId } } } },
+        ],
+      },
       select: { id: true, name: true, email: true },
     }),
   ]);

--- a/src/server/services/notifications/EmailNotificationService.ts
+++ b/src/server/services/notifications/EmailNotificationService.ts
@@ -276,8 +276,164 @@ async function extractMentionedUserIds(
 }
 
 /**
- * Fire-and-forget: Send email notifications to mentioned users in a comment.
- * Call this after creating an ActionComment.
+ * Resolve the workspace + product slug + name for a feature (PRD). Features
+ * inherit their workspace via their product; there is no direct workspaceId.
+ */
+async function resolveFeatureWorkspace(
+  db: PrismaClient,
+  featureId: string,
+): Promise<
+  | {
+      workspaceId: string;
+      workspaceSlug: string;
+      workspaceName: string;
+      productSlug: string;
+      featureName: string;
+    }
+  | null
+> {
+  const feature = await db.feature.findUnique({
+    where: { id: featureId },
+    select: {
+      name: true,
+      product: {
+        select: {
+          slug: true,
+          workspace: { select: { id: true, slug: true, name: true } },
+        },
+      },
+    },
+  });
+
+  const ws = feature?.product?.workspace;
+  if (!feature || !ws) return null;
+
+  return {
+    workspaceId: ws.id,
+    workspaceSlug: ws.slug,
+    workspaceName: ws.name,
+    productSlug: feature.product.slug,
+    featureName: feature.name,
+  };
+}
+
+/**
+ * Target-agnostic core: notify every mentioned user (minus the author) across
+ * push, Zulip DM, and email. Callers resolve the entity (action, feature, …)
+ * to a workspace + display name + deep-link path and hand it here so the
+ * multi-channel fan-out and per-recipient gating live in exactly one place.
+ */
+async function fanOutMentionNotifications(
+  db: PrismaClient,
+  params: {
+    workspaceId: string;
+    workspaceSlug: string;
+    workspaceName: string;
+    /** Display name of the thing the comment is on (action name, feature name). */
+    targetName: string;
+    /** Relative deep-link path to the comment thread, e.g. /w/slug/actions/id. */
+    targetPath: string;
+    /** Link label used in the Zulip DM, e.g. "View task", "View PRD". */
+    viewLabel: string;
+    commentContent: string;
+    commentAuthorId: string;
+  },
+): Promise<void> {
+  const {
+    workspaceId,
+    workspaceSlug,
+    workspaceName,
+    targetName,
+    targetPath,
+    viewLabel,
+    commentContent,
+    commentAuthorId,
+  } = params;
+
+  const mentionedUserIds = await extractMentionedUserIds(
+    db,
+    commentContent,
+    workspaceId,
+  );
+  if (mentionedUserIds.length === 0) return;
+
+  // Filter out the comment author (don't notify yourself). Non-member ids
+  // (e.g. mentioned agents) never match a User row below, so they drop out.
+  const recipientIds = mentionedUserIds.filter((id) => id !== commentAuthorId);
+  if (recipientIds.length === 0) return;
+
+  const [author, recipients] = await Promise.all([
+    db.user.findUnique({
+      where: { id: commentAuthorId },
+      select: { name: true, email: true },
+    }),
+    db.user.findMany({
+      where: { id: { in: recipientIds } },
+      select: { id: true, name: true, email: true },
+    }),
+  ]);
+  if (!author) return;
+
+  const targetUrl = `${BASE_URL}${targetPath}`;
+  const personalSettingsUrl = `${BASE_URL}/settings/notifications`;
+  const workspaceSettingsUrl = `${BASE_URL}/w/${workspaceSlug}/settings`;
+  const authorName = author.name ?? author.email ?? "Someone";
+  // Strip mention markup for preview and limit to 200 chars
+  const cleanContent = commentContent.replace(/@\[([^\]]+)\](?:\([^)]+\))?/g, "@$1");
+  const commentPreview =
+    cleanContent.length > 200
+      ? cleanContent.substring(0, 200) + "..."
+      : cleanContent;
+
+  await Promise.allSettled(
+    recipients.map(async (recipient) => {
+      const shouldSend = await shouldSendEmailNotification(
+        db,
+        recipient.id,
+        workspaceId,
+      );
+      if (!shouldSend) return;
+
+      // Send push notification
+      void sendPushToUser(
+        recipient.id,
+        {
+          title: `${authorName} mentioned you in ${targetName}`,
+          body: commentPreview,
+          tag: "mention",
+          url: targetPath,
+        },
+        db,
+      );
+
+      // Send Zulip DM
+      void sendZulipDmToUser(db, recipient.id, workspaceId, {
+        title: `${authorName} mentioned you in ${targetName}`,
+        message: `${commentPreview}\n\n[${viewLabel}](${targetUrl})`,
+        priority: "normal",
+      });
+
+      if (!recipient.email) return;
+
+      await sendMentionNotificationEmail({
+        to: recipient.email,
+        mentionedName: recipient.name ?? "",
+        authorName,
+        actionName: targetName,
+        commentPreview,
+        actionUrl: targetUrl,
+        workspaceName,
+        personalSettingsUrl,
+        workspaceSettingsUrl,
+        workspaceId,
+      });
+    }),
+  );
+}
+
+/**
+ * Fire-and-forget: Send notifications to users mentioned in an ActionComment.
+ * Thin wrapper over {@link fanOutMentionNotifications}.
  */
 export async function sendMentionNotifications(
   db: PrismaClient,
@@ -293,87 +449,59 @@ export async function sendMentionNotifications(
     const ws = await resolveActionWorkspace(db, actionId);
     if (!ws) return;
 
-    const mentionedUserIds = await extractMentionedUserIds(
-      db,
+    const action = await db.action.findUnique({
+      where: { id: actionId },
+      select: { name: true },
+    });
+    if (!action) return;
+
+    await fanOutMentionNotifications(db, {
+      workspaceId: ws.workspaceId,
+      workspaceSlug: ws.workspaceSlug,
+      workspaceName: ws.workspaceName,
+      targetName: action.name,
+      targetPath: `/w/${ws.workspaceSlug}/actions/${actionId}`,
+      viewLabel: "View task",
       commentContent,
-      ws.workspaceId,
-    );
-    if (mentionedUserIds.length === 0) return;
-
-    // Filter out the comment author (don't notify yourself)
-    const recipientIds = mentionedUserIds.filter((id) => id !== commentAuthorId);
-    if (recipientIds.length === 0) return;
-
-    const [action, author, recipients] = await Promise.all([
-      db.action.findUnique({
-        where: { id: actionId },
-        select: { name: true },
-      }),
-      db.user.findUnique({
-        where: { id: commentAuthorId },
-        select: { name: true, email: true },
-      }),
-      db.user.findMany({
-        where: { id: { in: recipientIds } },
-        select: { id: true, name: true, email: true },
-      }),
-    ]);
-    if (!action || !author) return;
-
-    const urls = buildNotificationUrls(ws.workspaceSlug, actionId);
-    const authorName = author.name ?? author.email ?? "Someone";
-    // Strip mention markup for preview and limit to 200 chars
-    const cleanContent = commentContent.replace(/@\[([^\]]+)\](?:\([^)]+\))?/g, "@$1");
-    const commentPreview =
-      cleanContent.length > 200
-        ? cleanContent.substring(0, 200) + "..."
-        : cleanContent;
-
-    await Promise.allSettled(
-      recipients.map(async (recipient) => {
-        const shouldSend = await shouldSendEmailNotification(
-          db,
-          recipient.id,
-          ws.workspaceId,
-        );
-        if (!shouldSend) return;
-
-        // Send push notification
-        void sendPushToUser(
-          recipient.id,
-          {
-            title: `${authorName} mentioned you in ${action.name}`,
-            body: commentPreview,
-            tag: "mention",
-            url: `/w/${ws.workspaceSlug}/actions/${actionId}`,
-          },
-          db,
-        );
-
-        // Send Zulip DM
-        void sendZulipDmToUser(db, recipient.id, ws.workspaceId, {
-          title: `${authorName} mentioned you in ${action.name}`,
-          message: `${commentPreview}\n\n[View task](${urls.actionUrl})`,
-          priority: "normal",
-        });
-
-        if (!recipient.email) return;
-
-        await sendMentionNotificationEmail({
-          to: recipient.email,
-          mentionedName: recipient.name ?? "",
-          authorName,
-          actionName: action.name,
-          commentPreview,
-          actionUrl: urls.actionUrl,
-          workspaceName: ws.workspaceName,
-          personalSettingsUrl: urls.personalSettingsUrl,
-          workspaceSettingsUrl: urls.workspaceSettingsUrl,
-          workspaceId: ws.workspaceId,
-        });
-      }),
-    );
+      commentAuthorId,
+    });
   } catch (error) {
     console.error("[EmailNotificationService] Failed to send mention notifications:", error);
+  }
+}
+
+/**
+ * Fire-and-forget: Send notifications to users mentioned in a FeatureComment
+ * (PRD or one of its scopes). Thin wrapper over {@link fanOutMentionNotifications}.
+ */
+export async function sendFeatureMentionNotifications(
+  db: PrismaClient,
+  params: {
+    featureId: string;
+    scopeId?: string;
+    commentContent: string;
+    commentAuthorId: string;
+  },
+): Promise<void> {
+  try {
+    const { featureId, scopeId, commentContent, commentAuthorId } = params;
+
+    const info = await resolveFeatureWorkspace(db, featureId);
+    if (!info) return;
+
+    const basePath = `/w/${info.workspaceSlug}/products/${info.productSlug}/features/${featureId}`;
+
+    await fanOutMentionNotifications(db, {
+      workspaceId: info.workspaceId,
+      workspaceSlug: info.workspaceSlug,
+      workspaceName: info.workspaceName,
+      targetName: info.featureName,
+      targetPath: scopeId ? `${basePath}/scopes/${scopeId}` : basePath,
+      viewLabel: "View PRD",
+      commentContent,
+      commentAuthorId,
+    });
+  } catch (error) {
+    console.error("[EmailNotificationService] Failed to send feature mention notifications:", error);
   }
 }

--- a/src/server/services/notifications/EmailNotificationService.ts
+++ b/src/server/services/notifications/EmailNotificationService.ts
@@ -456,14 +456,14 @@ export async function sendMentionNotifications(
   try {
     const { actionId, commentContent, commentAuthorId } = params;
 
-    const ws = await resolveActionWorkspace(db, actionId);
-    if (!ws) return;
-
-    const action = await db.action.findUnique({
-      where: { id: actionId },
-      select: { name: true },
-    });
-    if (!action) return;
+    const [ws, action] = await Promise.all([
+      resolveActionWorkspace(db, actionId),
+      db.action.findUnique({
+        where: { id: actionId },
+        select: { name: true },
+      }),
+    ]);
+    if (!ws || !action) return;
 
     await fanOutMentionNotifications(db, {
       workspaceId: ws.workspaceId,

--- a/src/server/services/notifications/__tests__/EmailNotificationService.mentions.test.ts
+++ b/src/server/services/notifications/__tests__/EmailNotificationService.mentions.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import {
+  sendMentionNotifications,
+  sendFeatureMentionNotifications,
+} from "~/server/services/notifications/EmailNotificationService";
+import { sendMentionNotificationEmail } from "~/server/services/EmailService";
+import { sendPushToUser } from "~/server/services/notifications/WebPushService";
+
+vi.mock("~/server/services/EmailService", () => ({
+  sendAssignmentNotificationEmail: vi.fn().mockResolvedValue(undefined),
+  sendMentionNotificationEmail: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/server/services/notifications/WebPushService", () => ({
+  sendPushToUser: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/server/services/notifications/ZulipNotificationService", () => ({
+  ZulipNotificationService: vi.fn(),
+}));
+
+const db = mockDeep<PrismaClient>();
+
+const WORKSPACE = { id: "ws1", slug: "acme", name: "Acme" };
+
+/** Default happy-path DB fixtures shared by both wrappers. */
+function stubCommonLookups() {
+  // Recipient user rows (membership-filtered query in the fan-out core)
+  db.user.findMany.mockResolvedValue([
+    { id: "member1", name: "Member One", email: "member1@acme.test" },
+  ] as never);
+  // Author lookup
+  db.user.findUnique.mockResolvedValue({
+    id: "author1",
+    name: "Author",
+    email: "author@acme.test",
+  } as never);
+  // Per-recipient email gating: no global pref, no override, workspace allows
+  db.notificationPreference.findUnique.mockResolvedValue(null);
+  db.workspaceNotificationOverride.findUnique.mockResolvedValue(null);
+  db.workspace.findUnique.mockResolvedValue({
+    enableEmailNotifications: true,
+  } as never);
+  // Zulip DM: no mapping — skipped
+  db.integrationUserMapping.findFirst.mockResolvedValue(null);
+}
+
+beforeEach(() => {
+  mockReset(db);
+  vi.clearAllMocks();
+  stubCommonLookups();
+});
+
+describe("sendMentionNotifications (action comments)", () => {
+  beforeEach(() => {
+    db.action.findUnique.mockResolvedValue({
+      id: "a1",
+      name: "Ship the thing",
+      workspace: WORKSPACE,
+      project: null,
+    } as never);
+  });
+
+  it("notifies a mentioned workspace member via push and email, excluding the author", async () => {
+    await sendMentionNotifications(db, {
+      actionId: "a1",
+      commentContent: "cc @[Member One](member1) and @[Author](author1)",
+      commentAuthorId: "author1",
+    });
+
+    // Author excluded from the recipient query
+    expect(db.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: { in: ["member1"] } }),
+      }),
+    );
+    expect(sendPushToUser).toHaveBeenCalledWith(
+      "member1",
+      expect.objectContaining({
+        tag: "mention",
+        url: "/w/acme/actions/a1",
+        title: expect.stringContaining("mentioned you in Ship the thing"),
+      }),
+      db,
+    );
+    expect(sendMentionNotificationEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "member1@acme.test",
+        actionName: "Ship the thing",
+      }),
+    );
+  });
+
+  it("only queries recipients who belong to the workspace (directly or via a linked team)", async () => {
+    await sendMentionNotifications(db, {
+      actionId: "a1",
+      commentContent: "hi @[Outsider](outsider1)",
+      commentAuthorId: "author1",
+    });
+
+    // The recipient query itself must carry the membership constraint —
+    // crafted @[Name](id) markup must never reach non-members.
+    expect(db.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { workspaceMemberships: { some: { workspaceId: "ws1" } } },
+            { teams: { some: { team: { workspaceId: "ws1" } } } },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("does nothing when the comment has no mentions", async () => {
+    await sendMentionNotifications(db, {
+      actionId: "a1",
+      commentContent: "no mentions here",
+      commentAuthorId: "author1",
+    });
+
+    expect(db.user.findMany).not.toHaveBeenCalled();
+    expect(sendPushToUser).not.toHaveBeenCalled();
+    expect(sendMentionNotificationEmail).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the only mention is the author", async () => {
+    await sendMentionNotifications(db, {
+      actionId: "a1",
+      commentContent: "note to self @[Author](author1)",
+      commentAuthorId: "author1",
+    });
+
+    expect(sendPushToUser).not.toHaveBeenCalled();
+    expect(sendMentionNotificationEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendFeatureMentionNotifications (feature/scope comments)", () => {
+  beforeEach(() => {
+    db.feature.findUnique.mockResolvedValue({
+      name: "Comment mentions",
+      product: { slug: "agent-skills", workspace: WORKSPACE },
+    } as never);
+  });
+
+  it("deep-links to the feature page and uses the feature name", async () => {
+    await sendFeatureMentionNotifications(db, {
+      featureId: "f1",
+      commentContent: "ping @[Member One](member1)",
+      commentAuthorId: "author1",
+    });
+
+    expect(sendPushToUser).toHaveBeenCalledWith(
+      "member1",
+      expect.objectContaining({
+        tag: "mention",
+        url: "/w/acme/products/agent-skills/features/f1",
+        title: expect.stringContaining("mentioned you in Comment mentions"),
+      }),
+      db,
+    );
+    expect(sendMentionNotificationEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "member1@acme.test",
+        actionName: "Comment mentions",
+        actionUrl: expect.stringContaining(
+          "/w/acme/products/agent-skills/features/f1",
+        ),
+      }),
+    );
+  });
+
+  it("deep-links to the scope thread when scopeId is set", async () => {
+    await sendFeatureMentionNotifications(db, {
+      featureId: "f1",
+      scopeId: "s1",
+      commentContent: "ping @[Member One](member1)",
+      commentAuthorId: "author1",
+    });
+
+    expect(sendPushToUser).toHaveBeenCalledWith(
+      "member1",
+      expect.objectContaining({
+        url: "/w/acme/products/agent-skills/features/f1/scopes/s1",
+      }),
+      db,
+    );
+  });
+
+  it("does nothing when the feature or its workspace cannot be resolved", async () => {
+    db.feature.findUnique.mockResolvedValue(null);
+
+    await sendFeatureMentionNotifications(db, {
+      featureId: "gone",
+      commentContent: "ping @[Member One](member1)",
+      commentAuthorId: "author1",
+    });
+
+    expect(sendPushToUser).not.toHaveBeenCalled();
+    expect(sendMentionNotificationEmail).not.toHaveBeenCalled();
+  });
+
+  it("never notifies anyone the membership-filtered query does not return", async () => {
+    // DB returns no rows for the mentioned id (non-member / agent id)
+    db.user.findMany.mockResolvedValue([] as never);
+
+    await sendFeatureMentionNotifications(db, {
+      featureId: "f1",
+      commentContent: "ping @[Zoe Agent](agent-zoe)",
+      commentAuthorId: "author1",
+    });
+
+    expect(sendPushToUser).not.toHaveBeenCalled();
+    expect(sendMentionNotificationEmail).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### **User description**
## What

- Wire the existing @-mention machinery (autocomplete dropdown, `@[Name](id)` storage format, badge rendering) into the feature/PRD and scope comment threads
- Notify mentioned workspace members via push, email, and Zulip DM when they're tagged in a feature or scope comment
- `FeatureActivitySection` builds mention candidates from workspace members + linked-team members + Mastra agents (agents are visual-only tags — no notification, no trigger), mirroring the Action comment path
- `EmailNotificationService`: extract a target-agnostic `fanOutMentionNotifications` core; `sendMentionNotifications` (Actions) becomes a thin wrapper over it; add `sendFeatureMentionNotifications` resolving workspace via Feature → Product with feature/scope deep links
- `featureComment.create` / `reply` fire the notification fan-out (fire-and-forget)
- CONTEXT.md: add **Mention** glossary entry

## Why

Tagging someone on a PRD discussion previously did nothing — the comment box reused `CommentInput` but never passed mention candidates, so `@` was inert and nobody got notified.

No schema changes — mentions are parsed from the comment body. Verified: `tsc` 0 errors, eslint clean, 1481 unit tests pass.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Wire @-mention autocomplete and notifications into feature/PRD and scope comment threads

- Extract target-agnostic `fanOutMentionNotifications` core; add `sendFeatureMentionNotifications` for feature comments

- Restrict mention notifications to workspace members only (security guard against crafted markup)

- Add unit tests covering recipient resolution, author exclusion, membership filtering, and deep links


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FeatureActivitySection\n(UI)"] -- "mentionCandidates\n(members + agents)" --> B["CommentInput\n(autocomplete)"]
  A -- "mentionNames" --> C["MarkdownRenderer\n(badge rendering)"]
  D["featureComment.create/reply\n(tRPC router)"] -- "fire-and-forget" --> E["sendFeatureMentionNotifications"]
  E -- "resolves workspace\nvia Feature→Product" --> F["fanOutMentionNotifications\n(core)"]
  G["sendMentionNotifications\n(Actions wrapper)"] -- "thin wrapper" --> F
  F -- "membership-filtered\nrecipients" --> H["push / email / Zulip DM"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FeatureActivitySection.tsx</strong><dd><code>Enable @-mention autocomplete and badge rendering in feature comments</code></dd></summary>
<hr>

src/app/_components/product/FeatureActivitySection.tsx

<ul><li>Fetches Mastra agents and linked-team members alongside workspace <br>members to build <code>mentionCandidates</code><br> <li> Passes <code>mentionCandidates</code> to <code>CommentInput</code> to enable @-mention <br>autocomplete<br> <li> Passes <code>mentionNames</code> to <code>MarkdownRenderer</code> for badge rendering of <br>mentions<br> <li> Uses <code>useMemo</code> to deduplicate and combine member/agent candidates <br>efficiently</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/380/files#diff-6098392683a7990e0d47970045d81f4042bc15115ded743b73e9f9b5ffcaf9f2">+66/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>featureComment.ts</strong><dd><code>Fire mention notifications on feature comment create and reply</code></dd></summary>
<hr>

src/plugins/product/server/routers/featureComment.ts

<ul><li>Imports <code>sendFeatureMentionNotifications</code> from the notification service<br> <li> Converts <code>create</code> and <code>reply</code> mutations to <code>await</code> the DB call and capture <br>the result<br> <li> Fires <code>sendFeatureMentionNotifications</code> as fire-and-forget after each <br>comment creation<br> <li> Fetches <code>scopeId</code> in the <code>reply</code> parent query to pass correct deep-link <br>context</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/380/files#diff-95b715d8a5cee23cf00793767dd9d410c03a0a98970c3dc0bad7da6516bdbc65">+25/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EmailNotificationService.ts</strong><dd><code>Refactor notification service with shared mention fan-out core and </code><br><code>feature support</code></dd></summary>
<hr>

src/server/services/notifications/EmailNotificationService.ts

<ul><li>Extracts <code>fanOutMentionNotifications</code> as a target-agnostic core handling <br>push, Zulip DM, and email fan-out<br> <li> Adds <code>resolveFeatureWorkspace</code> to resolve workspace/product context from <br>a feature ID<br> <li> Adds <code>sendFeatureMentionNotifications</code> as a thin wrapper for <br>feature/scope comment mentions with deep links<br> <li> Refactors <code>sendMentionNotifications</code> (Actions) to delegate to <br><code>fanOutMentionNotifications</code>; parallelizes workspace and action queries<br> <li> Enforces membership guard: recipients must belong to the workspace <br>directly or via a linked team</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/380/files#diff-f17fa722d8f985c7af8142bf980b69ab8cfd77853bb672a1205484660d5bb2a5">+215/-77</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EmailNotificationService.mentions.test.ts</strong><dd><code>Add unit tests for mention notification fan-out for actions and </code><br><code>features</code></dd></summary>
<hr>

src/server/services/notifications/__tests__/EmailNotificationService.mentions.test.ts

<ul><li>New test file covering <code>sendMentionNotifications</code> and <br><code>sendFeatureMentionNotifications</code><br> <li> Tests recipient resolution, author exclusion, membership-filtered <br>query shape, and no-mention early returns<br> <li> Verifies feature and scope deep-link URLs in push and email <br>notifications<br> <li> Confirms non-member/agent IDs are silently dropped by the membership <br>filter</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/380/files#diff-951235122ad5ff5bc536135f6e2792dc3a0a7076d33243eeb84068a2e73f43ab">+218/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONTEXT.md</strong><dd><code>Document mention concept and behavior in project glossary</code></dd></summary>
<hr>

CONTEXT.md

<ul><li>Adds a new "Comments" section with a "Mention" glossary entry<br> <li> Documents the <code>@[Name](id)</code> storage format, badge rendering, <br>notification behavior, and agent-mention semantics<br> <li> Clarifies that mentions work identically across Actions, <br>Features/PRDs, and scopes</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/380/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

