### PR TITLE
fix(chat): render AI message links and paragraph breaks in ManyChat

### DIFF
--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -30,6 +30,7 @@ import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { trimByTokenBudget } from '~/lib/trim-conversation';
 import { classifyStreamError } from '~/lib/chat/streamProtocol';
 import { streamChatResponse } from '~/lib/chat/streamChatResponse';
+import { preprocessAgentMarkdown, linkifyBareUrls } from '~/lib/chat/agentMarkdown';
 import { failureCopy } from '~/lib/chat/failureCopy';
 import { applyToolRefreshInvalidations } from './agent/toolRefreshInvalidation';
 
@@ -235,18 +236,8 @@ function preprocessAgentHtml(html: string): string {
   return processed;
 }
 
-// Markdown equivalent of preprocessAgentHtml's paragraph splitting:
-// inserts `\n\n` at agent action boundaries so streamed narration renders
-// as separate paragraphs instead of one giant <Text>. Keep action-word
-// list in sync with preprocessAgentHtml above.
-function preprocessAgentMarkdown(content: string): string {
-  return content.replace(
-    /:(Now |Let |Great|Good|Perfect|Excellent|However, |I |The |Then |First, |Next )/g,
-    (_: string, word: string) => `:\n\n${word}`,
-  );
-}
-
 // Render message content with markdown/video support
+// (preprocessAgentMarkdown / linkifyBareUrls live in ~/lib/chat/agentMarkdown)
 function renderMessageContent(content: string, messageType: string) {
   // Handle video links first — reset lastIndex since VIDEO_PATTERN is a global regex
   const hasVideoLinks = VIDEO_PATTERN.test(content);
@@ -286,9 +277,13 @@ function renderMessageContent(content: string, messageType: string) {
     );
   }
 
-  // For AI messages, check if content looks like markdown and render accordingly
-  if (messageType === 'ai' && (content.includes('###') || content.includes('**') || content.includes('- ') || content.includes('| ') || content.includes('```'))) {
-    const processed = preprocessAgentMarkdown(content);
+  // AI messages are always markdown: the stream inserts `\n\n` between text
+  // blocks separated by tool calls, and prose routinely carries links —
+  // rendering as plain text collapses the paragraph break into a stray gap
+  // and leaves "[CRM](https://…)" raw. (A keyword heuristic used to gate
+  // this; it missed links entirely.)
+  if (messageType === 'ai') {
+    const processed = preprocessAgentMarkdown(linkifyBareUrls(content));
     return (
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
@@ -299,7 +294,7 @@ function renderMessageContent(content: string, messageType: string) {
     );
   }
 
-  // For regular text, return as-is
+  // For regular (human) text, return as-is
   return content;
 }
 

--- a/src/lib/chat/__tests__/agentMarkdown.test.ts
+++ b/src/lib/chat/__tests__/agentMarkdown.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { preprocessAgentMarkdown, linkifyBareUrls } from '../agentMarkdown';
+
+describe('linkifyBareUrls', () => {
+  it('linkifies a bare domain with a path', () => {
+    expect(linkifyBareUrls('their GitHub profile (github.com/Banksy-said-hi) linked')).toBe(
+      'their GitHub profile ([github.com/Banksy-said-hi](https://github.com/Banksy-said-hi)) linked',
+    );
+  });
+
+  it('linkifies www.-prefixed hosts without a path', () => {
+    expect(linkifyBareUrls('see www.example.com today')).toBe(
+      'see [www.example.com](https://www.example.com) today',
+    );
+  });
+
+  it('keeps trailing punctuation out of the link', () => {
+    expect(linkifyBareUrls('go to exponential.im/home.')).toBe(
+      'go to [exponential.im/home](https://exponential.im/home).',
+    );
+  });
+
+  it('leaves existing markdown links untouched', () => {
+    const input = 'in your [CRM](https://exponential.im/w/syntrofi/crm/contacts).';
+    expect(linkifyBareUrls(input)).toBe(input);
+  });
+
+  it('leaves protocol URLs untouched (GFM already autolinks them)', () => {
+    const input = 'visit https://github.com/foo/bar for details';
+    expect(linkifyBareUrls(input)).toBe(input);
+  });
+
+  it('does not linkify bare domains without a path (e.g. package names)', () => {
+    const input = 'we use socket.io for transport';
+    expect(linkifyBareUrls(input)).toBe(input);
+  });
+
+  it('does not linkify file paths with code-ish extensions', () => {
+    const input = 'see route.ts/handler and ManyChat.tsx for details';
+    expect(linkifyBareUrls(input)).toBe(input);
+  });
+});
+
+describe('preprocessAgentMarkdown', () => {
+  it('splits narration at colon-followed action boundaries', () => {
+    expect(preprocessAgentMarkdown('Here is the plan:Now I will create the task.')).toBe(
+      'Here is the plan:\n\nNow I will create the task.',
+    );
+  });
+
+  it('leaves ordinary colons alone', () => {
+    const input = 'Status: done. Priority: high.';
+    expect(preprocessAgentMarkdown(input)).toBe(input);
+  });
+});

--- a/src/lib/chat/__tests__/agentMarkdown.test.ts
+++ b/src/lib/chat/__tests__/agentMarkdown.test.ts
@@ -25,6 +25,11 @@ describe('linkifyBareUrls', () => {
     expect(linkifyBareUrls(input)).toBe(input);
   });
 
+  it('leaves protocol-less markdown link targets untouched', () => {
+    const input = 'in your [CRM](exponential.im/w/syntrofi/crm/contacts).';
+    expect(linkifyBareUrls(input)).toBe(input);
+  });
+
   it('leaves protocol URLs untouched (GFM already autolinks them)', () => {
     const input = 'visit https://github.com/foo/bar for details';
     expect(linkifyBareUrls(input)).toBe(input);

--- a/src/lib/chat/agentMarkdown.ts
+++ b/src/lib/chat/agentMarkdown.ts
@@ -27,9 +27,19 @@ const BARE_URL_RE =
   /(^|[\s(])((?:[a-z0-9-]+\.)+(?:com|org|net|io|im|dev|ai|co|app|me|sh|so|xyz|gg|fm|to)\/[^\s)<]*|www\.(?:[a-z0-9-]+\.)+[a-z]{2,})/gi;
 
 export function linkifyBareUrls(content: string): string {
-  return content.replace(BARE_URL_RE, (_match, prefix: string, url: string) => {
-    const trimmed = url.replace(/[.,;:!?]+$/, '');
-    const trailing = url.slice(trimmed.length);
-    return `${prefix}[${trimmed}](https://${trimmed})${trailing}`;
-  });
+  return content.replace(
+    BARE_URL_RE,
+    (match: string, prefix: string, url: string, offset: number) => {
+      // A protocol-less markdown link target — "[CRM](exponential.im/w/…)" —
+      // starts with "(" preceded by "]"; wrapping it again would corrupt the
+      // link. (Targets with a protocol never match: the domain there is
+      // preceded by "/", not whitespace/"(".)
+      if (prefix === '(' && offset > 0 && content[offset - 1] === ']') {
+        return match;
+      }
+      const trimmed = url.replace(/[.,;:!?]+$/, '');
+      const trailing = url.slice(trimmed.length);
+      return `${prefix}[${trimmed}](https://${trimmed})${trailing}`;
+    },
+  );
 }

--- a/src/lib/chat/agentMarkdown.ts
+++ b/src/lib/chat/agentMarkdown.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure text transforms applied to agent prose before it is handed to
+ * ReactMarkdown. Kept out of the chat components so every surface that
+ * renders agent markdown (ManyChat drawer, Zoe canvas) can share them and
+ * they stay unit-testable.
+ */
+
+// Markdown equivalent of ManyChat's preprocessAgentHtml paragraph splitting:
+// inserts `\n\n` at agent action boundaries so streamed narration renders
+// as separate paragraphs instead of one giant <Text>. Keep the action-word
+// list in sync with preprocessAgentHtml in ManyChat.tsx.
+export function preprocessAgentMarkdown(content: string): string {
+  return content.replace(
+    /:(Now |Let |Great|Good|Perfect|Excellent|However, |I |The |Then |First, |Next )/g,
+    (_: string, word: string) => `:\n\n${word}`,
+  );
+}
+
+// GFM autolinks only URLs with a protocol or `www.` prefix, so agent prose
+// like "(github.com/Banksy-said-hi)" stays dead text. Convert bare domains —
+// requiring a path plus a common TLD (so file paths like "route.ts/handler"
+// and names like "socket.io" don't match), or a www. prefix — into markdown
+// links. A match must start the string or follow whitespace/"(", which keeps
+// it out of existing markdown link targets and protocol URLs (those are
+// preceded by "/" or "[").
+const BARE_URL_RE =
+  /(^|[\s(])((?:[a-z0-9-]+\.)+(?:com|org|net|io|im|dev|ai|co|app|me|sh|so|xyz|gg|fm|to)\/[^\s)<]*|www\.(?:[a-z0-9-]+\.)+[a-z]{2,})/gi;
+
+export function linkifyBareUrls(content: string): string {
+  return content.replace(BARE_URL_RE, (_match, prefix: string, url: string) => {
+    const trimmed = url.replace(/[.,;:!?]+$/, '');
+    const trailing = url.slice(trimmed.length);
+    return `${prefix}[${trimmed}](https://${trimmed})${trailing}`;
+  });
+}


### PR DESCRIPTION
### **User description**
## Problem

On /home, Zoe's replies rendered with a stray gap mid-sentence and raw, unclickable links (e.g. `[CRM](https://exponential.im/w/syntrofi/crm/contacts)` shown literally, `github.com/Banksy-said-hi` as dead text).

Root cause: `renderMessageContent` only routed AI messages through ReactMarkdown when a keyword heuristic matched (`###`, `**`, `- `, `| `, code fence). Plain prose fell through to raw text rendering, so:
- markdown links stayed literal
- the `\n\n` paragraph separator the stream server injects between text blocks around tool calls (route.ts `text-start` handler) collapsed into a weird gap instead of a paragraph break

## Fix

- **Always render AI messages through ReactMarkdown** (human messages unchanged). Paragraph breaks and links now render properly.
- **Linkify bare domains** (`github.com/foo`) that GFM won't autolink — gated on a path + common-TLD allowlist or `www.` prefix, so file paths (`route.ts/handler`) and package names (`socket.io`) don't turn into fake links. Trailing punctuation stays out of the URL.
- **Moved the pure text transforms** to `~/lib/chat/agentMarkdown.ts` (alongside the other shared chat-stream helpers) and added 9 unit tests.

## Testing

- New unit tests: `src/lib/chat/__tests__/agentMarkdown.test.ts` (9 tests)
- Full unit suite green via pre-commit (155 files / 1,498 tests)
- ESLint clean on touched files; Vercel build passed in pre-push hook

No migrations, UI-only — fast-track candidate.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Always render AI messages through ReactMarkdown, fixing raw links and paragraph breaks

- Extract `preprocessAgentMarkdown` and add new `linkifyBareUrls` to shared `agentMarkdown.ts`

- Linkify bare domains (e.g. `github.com/foo`) with TLD/path gating to avoid false matches

- Add 9 unit tests covering both text transform functions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ManyChat.tsx\nrenderMessageContent"] -- "AI message" --> B["linkifyBareUrls()"]
  B -- "bare URLs converted" --> C["preprocessAgentMarkdown()"]
  C -- "paragraph breaks inserted" --> D["ReactMarkdown\n+ remarkGfm"]
  E["agentMarkdown.ts"] -- "exports" --> B
  E -- "exports" --> C
  F["agentMarkdown.test.ts"] -- "9 unit tests" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ManyChat.tsx</strong><dd><code>Always render AI messages as markdown with bare URL linkification</code></dd></summary>
<hr>

src/app/_components/ManyChat.tsx

<ul><li>Removed local <code>preprocessAgentMarkdown</code> function (moved to <br><code>agentMarkdown.ts</code>)<br> <li> Imported <code>preprocessAgentMarkdown</code> and <code>linkifyBareUrls</code> from <br><code>~/lib/chat/agentMarkdown</code><br> <li> Removed keyword heuristic gate; AI messages now always render through <br>ReactMarkdown<br> <li> Applied <code>linkifyBareUrls</code> before <code>preprocessAgentMarkdown</code> in the render <br>pipeline</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/381/files#diff-6f0e68ce865b0629e85c68dbd985a102db9f321cea87620c205f1863eece6ed4">+10/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agentMarkdown.ts</strong><dd><code>New shared agent markdown text transform utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/chat/agentMarkdown.ts

<ul><li>New shared module for pure text transforms applied before <br>ReactMarkdown rendering<br> <li> Exports <code>preprocessAgentMarkdown</code> (paragraph splitting at action <br>boundaries)<br> <li> Exports <code>linkifyBareUrls</code> with TLD/path allowlist and <code>www.</code> prefix gating<br> <li> Guards against double-linkifying protocol-less markdown link targets</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/381/files#diff-834ccead9f90b4cbd5e67316118a510ba2246093479734a302c923670d305599">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agentMarkdown.test.ts</strong><dd><code>Unit tests for agentMarkdown text transform functions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/chat/__tests__/agentMarkdown.test.ts

<ul><li>New test file with 9 unit tests for <code>linkifyBareUrls</code> and <br><code>preprocessAgentMarkdown</code><br> <li> Covers bare domain linkification, <code>www.</code> prefix, trailing punctuation <br>trimming<br> <li> Verifies existing markdown links, protocol URLs, package names, and <br>file paths are untouched<br> <li> Tests colon-boundary paragraph splitting and ordinary colon <br>preservation</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/381/files#diff-db4518fe56c52585fd01b98229542df407dc8fd772537c1e2e0e3f9e3fcc4b5b">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

