### PR TITLE
fix(tickets): show time alongside date on ticket activity comments

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
@@ -834,7 +834,7 @@ export default function TicketDetailPage() {
                             {c.author.name}
                           </Text>
                           <Text size="xs" className="text-text-muted">
-                            {new Date(c.createdAt).toLocaleDateString()}
+                            {new Date(c.createdAt).toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" })}
                           </Text>
                         </Group>
                         <div className="ml-6">


### PR DESCRIPTION
### **User description**
Ticket activity comments only showed the date (e.g. `16/07/2026`). They now use `toLocaleString` with `dateStyle: "short", timeStyle: "short"` so the time is shown too (e.g. `16/07/2026, 14:32`), in the viewer's locale.

UI-only change — no schema or API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Ticket activity comments now display time alongside date

- Uses `toLocaleString` with `dateStyle: "short", timeStyle: "short"` options


___

### Diagram Walkthrough


```mermaid
flowchart LR
  before["toLocaleDateString()
  (date only)"]
  after["toLocaleString(undefined, dateStyle+timeStyle)
  (date + time)"]
  before -- "fix" --> after
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Display time with date on ticket activity comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx

<ul><li>Replaced <code>toLocaleDateString()</code> with <code>toLocaleString(undefined, { </code><br><code>dateStyle: "short", timeStyle: "short" })</code><br> <li> Ticket activity comment timestamps now show both date and time in the <br>viewer's locale</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/382/files#diff-706c264109ddf1898c5e70d30b0818c48fce7c90f203b6163df7a766806d5642">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

