### PR TITLE
fix(prd): sync descriptionDoc when feature description is updated via API

### DIFF
--- a/docs/adr/0024-prosemirror-json-for-rich-documents.md
+++ b/docs/adr/0024-prosemirror-json-for-rich-documents.md
@@ -25,4 +25,5 @@ This is a **scoped exception** to ADR-0017, not a reversal. ADR-0017 remains the
 
 - A second sanctioned storage format exists for a deliberately narrow set of entities. New use of it must clear the same bar (real need for node addressing), and must keep the Markdown projection so the read side stays ADR-0017-compatible.
 - The projection is lossy on round-trip (comment marks drop) — accepted, because the JSON is canonical and the Markdown is only a projection.
+- Markdown-only API writes (CLI/SDK/agents updating the Markdown without a doc) must not diverge from the canonical doc. Two sanctioned resolutions exist: `feature.update` re-derives `descriptionDoc` from the incoming Markdown server-side (`~/server/services/prd/markdown-doc` — the client codec run under a scoped happy-dom), while `page.update` nulls out `bodyDoc` and lets the editor re-derive it lazily on next open. Both bump `docVersion` so a stale open editor conflicts instead of clobbering. Anchored comment marks don't survive such a rewrite — same trade-off as a full-body rewrite in the editor.
 - Extended to **Pages** by [ADR-0033](0033-knowledge-pages.md), which reuses this exact pattern.

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "geist": "^1.3.0",
         "googleapis": "^155.0.1",
         "gray-matter": "^4.0.3",
+        "happy-dom": "^18.0.1",
         "html-to-image": "^1.11.13",
         "imapflow": "^1.2.9",
         "jsonwebtoken": "^9.0.2",
@@ -9174,7 +9175,6 @@
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
@@ -15146,7 +15146,8 @@
     },
     "node_modules/happy-dom": {
       "version": "18.0.1",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-18.0.1.tgz",
+      "integrity": "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.0.0",
@@ -23347,7 +23348,6 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "geist": "^1.3.0",
     "googleapis": "^155.0.1",
     "gray-matter": "^4.0.3",
+    "happy-dom": "^18.0.1",
     "html-to-image": "^1.11.13",
     "imapflow": "^1.2.9",
     "jsonwebtoken": "^9.0.2",

--- a/src/lib/prd/codec.ts
+++ b/src/lib/prd/codec.ts
@@ -11,13 +11,17 @@ import { PRD_EXTENSIONS } from "./extensions";
  *    off-island readers (CLI, agents/SDK, card previews).
  *
  * The invariant: Markdown is written *from* the JSON, one way only, and never
- * read back into the editor. The single exception is the lazy, one-time
- * migration of a legacy `description` into `descriptionDoc` the first time a
- * feature is opened ({@link markdownToDoc}); thereafter the JSON is canonical.
+ * read back into the editor. The exceptions are the lazy, one-time migration
+ * of a legacy `description` into `descriptionDoc` the first time a feature is
+ * opened ({@link markdownToDoc}), and Markdown-only API writes (CLI/SDK),
+ * where the server re-derives the doc from the incoming Markdown; thereafter
+ * the JSON is canonical.
  *
  * Both functions spin up a throwaway headless Tiptap editor. That requires a
  * DOM, so they run in the browser and in unit tests (happy-dom) — never during
- * SSR. Callers must invoke them client-side (e.g. inside an effect).
+ * SSR. Client callers must invoke them client-side (e.g. inside an effect);
+ * server code goes through `~/server/services/prd/markdown-doc`, which runs
+ * this same codec under a scoped happy-dom.
  */
 
 /** Canonical empty document. */

--- a/src/plugins/product/server/routers/__tests__/feature-doc-sync.test.ts
+++ b/src/plugins/product/server/routers/__tests__/feature-doc-sync.test.ts
@@ -99,7 +99,6 @@ vi.mock("~/lib/blob", () => ({
 
 // ── Imports of code under test (must come AFTER vi.mock calls) ───────
 import { createMockCaller } from "~/test/trpc-helpers";
-import { markdownToDoc } from "~/lib/prd/codec";
 
 const callerId = "user-1";
 const workspaceId = "ws-1";
@@ -153,8 +152,44 @@ describe("feature.update — Markdown-only description sync (mocked)", () => {
 
     const data = updateData(dbMock);
     expect(data?.description).toBe(markdown);
-    expect(data?.descriptionDoc).toEqual(markdownToDoc(markdown));
     expect(data?.docVersion).toEqual({ increment: 1 });
+    // Structural assertion (not a comparison against the codec itself, which
+    // would be tautological): the Markdown became a real ProseMirror doc.
+    const doc = data?.descriptionDoc as {
+      type: string;
+      content: Array<{ type: string }>;
+    };
+    expect(doc.type).toBe("doc");
+    expect(doc.content.map((n) => n.type)).toEqual(["heading", "taskList"]);
+  });
+
+  it("skips the doc rewrite when the incoming Markdown is unchanged", async () => {
+    // An agent re-sending the stored description must not bump docVersion —
+    // that would hand every open editor tab a spurious CONFLICT.
+    const markdown = "# Same body";
+    dbMock.feature.findUnique.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {
+        id: featureId,
+        productId: "prod-1",
+        product: { workspaceId },
+        description: markdown,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    );
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+    await caller.product.feature.update({
+      id: featureId,
+      description: markdown,
+      priority: 1,
+    });
+
+    const data = updateData(dbMock);
+    expect(data?.description).toBe(markdown);
+    expect(data?.priority).toBe(1);
+    expect(data).not.toHaveProperty("descriptionDoc");
+    expect(data).not.toHaveProperty("docVersion");
   });
 
   it("leaves the doc alone when description is not part of the update", async () => {

--- a/src/plugins/product/server/routers/__tests__/feature-doc-sync.test.ts
+++ b/src/plugins/product/server/routers/__tests__/feature-doc-sync.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for `feature.update`'s Markdown-only description path (ADR-0024).
+ *
+ * A CLI/SDK caller sends `description` (Markdown) with no `descriptionDoc`.
+ * The router must re-derive the canonical doc server-side and bump
+ * `docVersion` — otherwise the edit is invisible in the UI (which renders the
+ * doc) and gets clobbered by the next editor save.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()`; mirrors the mock
+ * layout from `ticket.test.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+// Seed env vars before any module imports — `vi.hoisted` runs before regular
+// top-level statements. Mirrors ticket.test.ts.
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+// ── Stub heavy/IO modules pulled in by the wider router tree ─────────
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(_opts?: any) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({
+    auth: () => null,
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+// ── dbMock plumbing ─────────────────────────────────────────────────
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = {
+  current: null,
+};
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) {
+    dbHolder.current = mockDeep<PrismaClient>();
+  }
+  return dbHolder.current;
+}
+
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+// ── Stub side-effect-heavy modules used by sibling routers ───────────
+vi.mock("~/server/services/notifications/EmailNotificationService", () => ({
+  sendAssignmentNotifications: vi.fn().mockResolvedValue(undefined),
+  sendFeatureMentionNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/server/services/onboarding/syncOnboardingProgress", () => ({
+  completeOnboardingStep: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/lib/blob", () => ({
+  uploadToBlob: vi.fn().mockResolvedValue({ url: "blob://test" }),
+}));
+
+// ── Imports of code under test (must come AFTER vi.mock calls) ───────
+import { createMockCaller } from "~/test/trpc-helpers";
+import { markdownToDoc } from "~/lib/prd/codec";
+
+const callerId = "user-1";
+const workspaceId = "ws-1";
+const featureId = "feat-1";
+
+function stubFeatureAccess(dbMock: DeepMockProxy<PrismaClient>) {
+  // loadFeatureWithAccess's lookup.
+  dbMock.feature.findUnique.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    {
+      id: featureId,
+      productId: "prod-1",
+      product: { workspaceId },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+  );
+  // assertWorkspaceMember's membership probe.
+  dbMock.workspaceUser.findUnique.mockResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { role: "member", workspaceId } as any,
+  );
+}
+
+function updateData(dbMock: DeepMockProxy<PrismaClient>) {
+  return dbMock.feature.update.mock.calls[0]?.[0]?.data as
+    | Record<string, unknown>
+    | undefined;
+}
+
+describe("feature.update — Markdown-only description sync (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    stubFeatureAccess(dbMock);
+    dbMock.feature.update.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: featureId } as any,
+    );
+  });
+
+  it("re-derives descriptionDoc and bumps docVersion on a Markdown-only write", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const markdown = "# New body\n\n- [ ] a task";
+
+    await caller.product.feature.update({
+      id: featureId,
+      description: markdown,
+    });
+
+    const data = updateData(dbMock);
+    expect(data?.description).toBe(markdown);
+    expect(data?.descriptionDoc).toEqual(markdownToDoc(markdown));
+    expect(data?.docVersion).toEqual({ increment: 1 });
+  });
+
+  it("leaves the doc alone when description is not part of the update", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+    await caller.product.feature.update({
+      id: featureId,
+      name: "Renamed",
+      priority: 2,
+    });
+
+    const data = updateData(dbMock);
+    expect(data?.name).toBe("Renamed");
+    expect(data).not.toHaveProperty("descriptionDoc");
+    expect(data).not.toHaveProperty("docVersion");
+  });
+
+  it("does not interfere with the editor's own doc-save path", async () => {
+    // The PRD editor sends descriptionDoc + baseVersion; that path does its
+    // own compare-and-set via updateMany and must not hit the regeneration.
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const doc = { type: "doc", content: [{ type: "paragraph" }] };
+
+    // Second findUnique in that path reads the stored docVersion.
+    dbMock.feature.findUnique
+      .mockResolvedValueOnce(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: featureId, productId: "prod-1", product: { workspaceId } } as any,
+      )
+      .mockResolvedValueOnce(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { docVersion: 0 } as any,
+      );
+    dbMock.feature.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await caller.product.feature.update({
+      id: featureId,
+      descriptionDoc: doc,
+      description: "New body",
+      baseVersion: 0,
+    });
+
+    expect(dbMock.feature.update).not.toHaveBeenCalled();
+    const updateManyArgs = dbMock.feature.updateMany.mock.calls[0]?.[0];
+    expect(updateManyArgs?.where).toEqual({ id: featureId, docVersion: 0 });
+    expect(updateManyArgs?.data).toMatchObject({
+      description: "New body",
+      descriptionDoc: doc,
+      docVersion: { increment: 1 },
+    });
+    expect(result).toEqual({ id: featureId, docVersion: 1 });
+  });
+});

--- a/src/plugins/product/server/routers/__tests__/feature.integration.test.ts
+++ b/src/plugins/product/server/routers/__tests__/feature.integration.test.ts
@@ -80,6 +80,60 @@ describe("feature router", () => {
     });
   });
 
+  describe("update", () => {
+    it("re-derives descriptionDoc from a Markdown-only description write (ADR-0024)", async () => {
+      // Exercises the real server path: node environment, no DOM globals —
+      // the regeneration must still produce the canonical ProseMirror doc.
+      const user = await createUser(db);
+      const ws = await createWorkspace(db, { ownerId: user.id });
+      const product = await createProduct(db, {
+        workspaceId: ws.id,
+        createdById: user.id,
+      });
+      const feature = await createFeature(db, {
+        productId: product.id,
+        createdById: user.id,
+        name: "Doc sync",
+      });
+      // Simulate a feature whose PRD was already opened in the editor.
+      await db.feature.update({
+        where: { id: feature.id },
+        data: {
+          descriptionDoc: {
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "stale body" }],
+              },
+            ],
+          },
+          docVersion: 3,
+        },
+      });
+
+      const caller = createTestCaller(user.id);
+      await caller.product.feature.update({
+        id: feature.id,
+        description: "# Fresh body\n\n- [x] shipped it",
+      });
+
+      const stored = await db.feature.findUniqueOrThrow({
+        where: { id: feature.id },
+        select: { description: true, descriptionDoc: true, docVersion: true },
+      });
+      expect(stored.description).toBe("# Fresh body\n\n- [x] shipped it");
+      expect(stored.docVersion).toBe(4);
+      const doc = stored.descriptionDoc as {
+        type: string;
+        content: Array<{ type: string }>;
+      };
+      expect(doc.type).toBe("doc");
+      expect(doc.content.map((n) => n.type)).toEqual(["heading", "taskList"]);
+      expect(JSON.stringify(doc)).not.toContain("stale body");
+    });
+  });
+
   describe("scopes", () => {
     it("adds scopes in display order", async () => {
       const user = await createUser(db);

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -5,6 +5,7 @@ import { loadProductWithAccess, assertWorkspaceMember } from "./product";
 import { Prisma, type PrismaClient } from "@prisma/client";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 import { checkStaleWrite } from "~/lib/prd/stale-write";
+import { markdownToDocServer } from "~/server/services/prd/markdown-doc";
 import { uploadToBlob } from "~/lib/blob";
 import { getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
 import { hasMinimumWorkspaceRole } from "~/server/services/access";
@@ -555,6 +556,26 @@ export const featureRouter = createTRPCRouter({
 
       const { id, descriptionDoc, baseVersion, deprecateScopes, ...rest } = input;
 
+      // Markdown-only description write (CLI/SDK/agents): the caller has no
+      // editor, so derive the canonical `descriptionDoc` from the Markdown
+      // server-side (ADR-0024 - the doc is canonical; leaving it stale would
+      // make the edit invisible in the UI and get clobbered on the next
+      // editor save). Bumping `docVersion` turns any open editor tab's next
+      // autosave into a CONFLICT instead of a silent overwrite. Anchored
+      // comment marks don't survive the rewrite - the Markdown projection
+      // never carried them - which is the same trade-off as a full-body
+      // rewrite in the editor.
+      const data =
+        descriptionDoc === undefined && rest.description !== undefined
+          ? {
+              ...rest,
+              descriptionDoc: markdownToDocServer(
+                rest.description,
+              ) as Prisma.InputJsonValue,
+              docVersion: { increment: 1 },
+            }
+          : rest;
+
       // Deprecation cascade: only LIVE scopes become DEPRECATED (deprecated =
       // was live, sunset - a PLANNED scope was never live, so it keeps its
       // status). Runs in one transaction with the feature update below so a
@@ -565,7 +586,7 @@ export const featureRouter = createTRPCRouter({
             where: { featureId: id, status: "SHIPPED" },
             data: { status: "DEPRECATED" },
           }),
-          ctx.db.feature.update({ where: { id }, data: rest }),
+          ctx.db.feature.update({ where: { id }, data }),
         ]);
         return updated;
       }
@@ -617,7 +638,7 @@ export const featureRouter = createTRPCRouter({
 
       const updated = await ctx.db.feature.update({
         where: { id },
-        data: rest,
+        data,
       });
       return updated;
     }),

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -574,7 +574,12 @@ export const featureRouter = createTRPCRouter({
           where: { id },
           select: { description: true },
         });
-        if (current?.description === rest.description) syncDoc = false;
+        if (!current) {
+          // Deleted between the access check and this read - fail the same
+          // way the access check would have.
+          throw new TRPCError({ code: "NOT_FOUND", message: "Feature not found" });
+        }
+        if (current.description === rest.description) syncDoc = false;
       }
       let data: Prisma.FeatureUncheckedUpdateInput = rest;
       if (syncDoc) {

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -565,16 +565,36 @@ export const featureRouter = createTRPCRouter({
       // comment marks don't survive the rewrite - the Markdown projection
       // never carried them - which is the same trade-off as a full-body
       // rewrite in the editor.
-      const data =
-        descriptionDoc === undefined && rest.description !== undefined
-          ? {
-              ...rest,
-              descriptionDoc: markdownToDocServer(
-                rest.description,
-              ) as Prisma.InputJsonValue,
-              docVersion: { increment: 1 },
-            }
-          : rest;
+      let syncDoc = descriptionDoc === undefined && rest.description !== undefined;
+      if (syncDoc) {
+        // Re-sending the stored Markdown unchanged (agents retry-write a lot)
+        // must not rewrite the doc: it would bump `docVersion` for nothing
+        // and hand every open editor tab a spurious CONFLICT.
+        const current = await ctx.db.feature.findUnique({
+          where: { id },
+          select: { description: true },
+        });
+        if (current?.description === rest.description) syncDoc = false;
+      }
+      let data: Prisma.FeatureUncheckedUpdateInput = rest;
+      if (syncDoc) {
+        try {
+          data = {
+            ...rest,
+            descriptionDoc: markdownToDocServer(
+              rest.description,
+            ) as Prisma.InputJsonValue,
+            docVersion: { increment: 1 },
+          };
+        } catch (err) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message:
+              "Failed to derive the PRD document from the Markdown description",
+            cause: err,
+          });
+        }
+      }
 
       // Deprecation cascade: only LIVE scopes become DEPRECATED (deprecated =
       // was live, sunset - a PLANNED scope was never live, so it keeps its

--- a/src/server/services/prd/__tests__/markdown-doc.test.ts
+++ b/src/server/services/prd/__tests__/markdown-doc.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the server-side Markdown → ProseMirror codec wrapper.
+ *
+ * The wrapper's whole contract is (1) byte-identical output to the client
+ * codec (it runs the same code) and (2) leaving the process globals exactly
+ * as it found them — the swap must be invisible to everything else on the
+ * server.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { markdownToDocServer } from "../markdown-doc";
+import { markdownToDoc, EMPTY_DOC } from "~/lib/prd/codec";
+
+// Exercises every node type the PRD schema supports: headings, marks, links,
+// task lists (nested + checked state), tables, block images, code blocks,
+// blockquotes and ordered lists.
+const SAMPLE_MD = `# Heading one
+
+Some **bold** and *italic* and \`code\` and a [link](https://example.com).
+
+- [ ] unchecked task
+- [x] checked task
+  - [ ] nested task
+
+| Col A | Col B |
+| --- | --- |
+| a1 | b1 |
+
+![alt text](https://example.com/img.png)
+
+\`\`\`ts
+const x = 1;
+\`\`\`
+
+> a blockquote
+
+1. ordered one
+2. ordered two
+`;
+
+describe("markdownToDocServer", () => {
+  it("produces exactly what the client codec produces", () => {
+    expect(markdownToDocServer(SAMPLE_MD)).toEqual(markdownToDoc(SAMPLE_MD));
+  });
+
+  it("parses every PRD node type", () => {
+    const doc = markdownToDocServer(SAMPLE_MD);
+    const types = (doc.content ?? []).map((n) => n.type);
+    expect(types).toEqual([
+      "heading",
+      "paragraph",
+      "taskList",
+      "table",
+      "image",
+      "codeBlock",
+      "blockquote",
+      "orderedList",
+    ]);
+  });
+
+  it("returns the canonical empty doc for empty input", () => {
+    expect(markdownToDocServer("")).toEqual(EMPTY_DOC);
+    expect(markdownToDocServer("   ")).toEqual(EMPTY_DOC);
+    expect(markdownToDocServer(null)).toEqual(EMPTY_DOC);
+    expect(markdownToDocServer(undefined)).toEqual(EMPTY_DOC);
+  });
+
+  it("restores pre-existing globals untouched", () => {
+    // The unit-test environment registers happy-dom globals; the swap must
+    // put back the very same object references.
+    const before = { window: globalThis.window, document: globalThis.document };
+    markdownToDocServer("# Hi");
+    expect(globalThis.window).toBe(before.window);
+    expect(globalThis.document).toBe(before.document);
+  });
+
+  it("works with no ambient DOM globals (server conditions)", () => {
+    const g = globalThis as Record<string, unknown>;
+    const saved = { window: g.window, document: g.document };
+    delete g.window;
+    delete g.document;
+    try {
+      const doc = markdownToDocServer("# Hi");
+      expect(doc.content?.[0]?.type).toBe("heading");
+      // ...and it must not have re-introduced them.
+      expect(g.window).toBeUndefined();
+      expect(g.document).toBeUndefined();
+    } finally {
+      g.window = saved.window;
+      g.document = saved.document;
+    }
+  });
+});

--- a/src/server/services/prd/markdown-doc.ts
+++ b/src/server/services/prd/markdown-doc.ts
@@ -1,0 +1,98 @@
+import "server-only";
+
+import type { JSONContent } from "@tiptap/core";
+import { Window } from "happy-dom";
+
+import { markdownToDoc } from "~/lib/prd/codec";
+
+/**
+ * Server-side Markdown → ProseMirror JSON, for API writes that carry only the
+ * Markdown projection (CLI/SDK/agents updating `Feature.description`). Without
+ * this, a Markdown-only write silently diverges from the canonical
+ * `descriptionDoc` (ADR-0024) and the UI keeps rendering the stale doc forever.
+ *
+ * The codec needs a DOM (it spins up a headless Tiptap editor), which the
+ * server lacks. Rather than duplicating the tiptap-markdown parse pipeline,
+ * this installs happy-dom globals around the conversion so the *exact* client
+ * codec runs — the server and the browser can never disagree on the schema.
+ *
+ * Safety of the global swap: the entire install → convert → restore sequence
+ * is synchronous, so on Node's single thread no concurrent request (or SSR
+ * render checking `typeof window`) can observe the temporary globals. Keep it
+ * that way — never `await` inside {@link withDom}.
+ */
+
+/**
+ * The globals the headless Editor + tiptap-markdown parse path touches. This
+ * set is validated by the unit tests, which run the conversion across every
+ * PRD node type (headings, task lists, tables, block images, code blocks).
+ */
+const DOM_GLOBALS = [
+  "window",
+  "document",
+  "navigator",
+  "Node",
+  "Element",
+  "HTMLElement",
+  "SVGElement",
+  "Text",
+  "Comment",
+  "DocumentFragment",
+  "DOMParser",
+  "MutationObserver",
+  "getComputedStyle",
+  "requestAnimationFrame",
+  "cancelAnimationFrame",
+  "CustomEvent",
+  "KeyboardEvent",
+  "MouseEvent",
+  "InputEvent",
+  "ClipboardEvent",
+  "DragEvent",
+  "Range",
+] as const;
+
+function withDom<T>(fn: () => T): T {
+  const win = new Window();
+  // Some of these exist on globalThis as accessor properties (e.g. Node ships
+  // a getter-only `navigator`), so plain assignment would throw. Swap via
+  // property descriptors and restore the original descriptor afterwards.
+  const saved = new Map<string, PropertyDescriptor | undefined>();
+  for (const key of DOM_GLOBALS) {
+    const desc = Object.getOwnPropertyDescriptor(globalThis, key);
+    if (desc && !desc.configurable) continue; // can't swap; leave it be
+    saved.set(key, desc);
+    Object.defineProperty(globalThis, key, {
+      value:
+        key === "window"
+          ? win
+          : (win as unknown as Record<string, unknown>)[key],
+      configurable: true,
+      writable: true,
+      enumerable: desc?.enumerable ?? true,
+    });
+  }
+  try {
+    return fn();
+  } finally {
+    for (const [key, desc] of saved) {
+      if (desc) Object.defineProperty(globalThis, key, desc);
+      else delete (globalThis as Record<string, unknown>)[key];
+    }
+    void win.happyDOM.close();
+  }
+}
+
+/**
+ * Convert a Markdown `description` into the canonical `descriptionDoc` form.
+ * Same output as the client's lazy migration ({@link markdownToDoc}) — it *is*
+ * that function, run under a throwaway DOM. Comment marks cannot survive (the
+ * Markdown projection never carried them), so callers rewriting an existing
+ * doc orphan any anchored comment threads — the same trade-off as a full-body
+ * rewrite in the editor.
+ */
+export function markdownToDocServer(
+  markdown: string | null | undefined,
+): JSONContent {
+  return withDom(() => markdownToDoc(markdown));
+}

--- a/src/server/services/prd/markdown-doc.ts
+++ b/src/server/services/prd/markdown-doc.ts
@@ -60,7 +60,18 @@ function withDom<T>(fn: () => T): T {
   const saved = new Map<string, PropertyDescriptor | undefined>();
   for (const key of DOM_GLOBALS) {
     const desc = Object.getOwnPropertyDescriptor(globalThis, key);
-    if (desc && !desc.configurable) continue; // can't swap; leave it be
+    if (desc && !desc.configurable) {
+      // `window`/`document` are what the codec actually renders through — if
+      // they exist and can't be swapped, the conversion would silently use
+      // the wrong DOM. Fail loudly instead. The rest of the list is
+      // quirk-detection surface where the ambient value is tolerable.
+      if (key === "window" || key === "document") {
+        throw new Error(
+          `Cannot install temporary DOM: globalThis.${key} exists and is non-configurable`,
+        );
+      }
+      continue;
+    }
     saved.set(key, desc);
     Object.defineProperty(globalThis, key, {
       value:
@@ -73,13 +84,29 @@ function withDom<T>(fn: () => T): T {
     });
   }
   try {
-    return fn();
-  } finally {
-    for (const [key, desc] of saved) {
-      if (desc) Object.defineProperty(globalThis, key, desc);
-      else delete (globalThis as Record<string, unknown>)[key];
+    const result = fn();
+    // The no-concurrent-observer guarantee holds only while the callback is
+    // synchronous. A thenable here means async work started with the
+    // temporary globals installed — refuse it loudly so the hazard is caught
+    // in tests, not production.
+    if (
+      result != null &&
+      typeof (result as { then?: unknown }).then === "function"
+    ) {
+      throw new Error(
+        "withDom callback must be synchronous - an async callback would leak DOM globals to concurrent requests",
+      );
     }
-    void win.happyDOM.close();
+    return result;
+  } finally {
+    try {
+      for (const [key, desc] of saved) {
+        if (desc) Object.defineProperty(globalThis, key, desc);
+        else delete (globalThis as Record<string, unknown>)[key];
+      }
+    } finally {
+      void win.happyDOM.close();
+    }
   }
 }
 

--- a/src/test/integration-setup.ts
+++ b/src/test/integration-setup.ts
@@ -13,6 +13,10 @@ process.env.MASTRA_API_URL = "http://localhost:4111";
 // (e.g. CRM contacts). Read at import time by src/server/utils/encryption.ts.
 process.env.DATABASE_ENCRYPTION_KEY = "MMeRcJFimqp98NsQ5i2cawtF4LbcftnfiCNJWLhO/YQ=";
 
+// `server-only` throws outside a React Server environment; stub it so tests
+// can import server modules (e.g. the feature router's Markdown->doc codec).
+vi.mock("server-only", () => ({}));
+
 // Mock next-auth and related modules that depend on Next.js runtime
 vi.mock("next-auth", () => ({
   default: () => ({

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,9 @@
-import { beforeAll, afterAll } from 'vitest';
+import { beforeAll, afterAll, vi } from 'vitest';
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
+
+// `server-only` throws outside a React Server environment; stub it so unit
+// tests can import server modules (e.g. via the tRPC routers).
+vi.mock('server-only', () => ({}));
 
 // Register Happy DOM before all tests
 GlobalRegistrator.register();


### PR DESCRIPTION
### **User description**
## Problem

`exponential features update --description ...` (and any SDK/agent Markdown-only write) updated the `description` column but left the canonical `descriptionDoc` (ADR-0024) untouched. Once a feature's PRD had been opened in the editor — which materialises the doc via the write-once lazy migration — every subsequent CLI edit became **invisible in the UI**, and the next editor save re-serialised the stale doc back over `description`, silently clobbering the edit. (Observed on feature `cmrnczxvb0001l104g9efnhb9`: "description updates stopped rendering in the UI".)

## Fix

When `feature.update` receives `description` without `descriptionDoc`, it now:

- re-derives the canonical `descriptionDoc` from the incoming Markdown **server-side**, and
- bumps `docVersion`, so a stale open editor tab's next autosave gets a CONFLICT instead of overwriting the CLI edit.

The conversion (`src/server/services/prd/markdown-doc.ts`) runs the **exact client codec** — headless Tiptap with the shared `buildPrdExtensions()` schema — under happy-dom globals installed only around the fully synchronous conversion call, then restored. On Node's single thread nothing else (SSR renders checking `typeof window`, concurrent requests) can observe the temporary globals; the descriptor-based swap also copes with getter-only globals like Node's `navigator`. `happy-dom` moves to production dependencies for this.

## Trade-offs / notes

- Anchored comment marks don't survive the rewrite (the Markdown projection never carried them) — same trade-off as a full-body rewrite in the editor; threads degrade to unanchored.
- `page.update` handles the same situation differently: it **nulls** `bodyDoc` and lets the editor re-derive lazily on next open. ADR-0024 now documents both resolutions. Unifying pages onto server-side regeneration (doc never has a null window) is a possible follow-up.
- The deprecation-cascade path also picks up the sync (a `status: DEPRECATED` update carrying a description now syncs the doc too).

## Tests

- `markdown-doc.test.ts` — parity with the client codec across every PRD node type (task lists, tables, block images, code blocks…), empty-input canonical doc, global-restoration hygiene, and conversion with no ambient DOM globals.
- `feature-doc-sync.test.ts` — mocked-Prisma router tests: Markdown-only write regenerates doc + bumps version; metadata-only updates don't touch the doc; the editor's own compare-and-set save path is untouched.
- `feature.integration.test.ts` — new case running the real server path (node env, no DOM, real Postgres): stale doc + `docVersion 3` → CLI-style update → regenerated doc, `docVersion 4`, stale content gone.

Full unit suite (1507), integration file, `tsc --noEmit`, and eslint on changed files all pass. No schema changes — no migrations.


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Fix `feature.update` silently diverging `descriptionDoc` from `description` on Markdown-only API writes

- Add server-side `markdownToDocServer` using scoped happy-dom globals to run the client codec safely

- Bump `docVersion` on doc re-derivation to prevent stale editor tabs from clobbering CLI edits

- Add unit and integration tests covering all sync, skip, and editor-path scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI/SDK/Agent\nfeature.update(description)"]
  B["feature.ts router\nMarkdown-only path"]
  C["markdownToDocServer\n~/server/services/prd/markdown-doc"]
  D["withDom()\nscoped happy-dom globals"]
  E["markdownToDoc()\nclient codec"]
  F["DB update\ndescriptionDoc + docVersion++"]
  G["Open editor tab\ngets CONFLICT"]

  A -- "description only\n(no descriptionDoc)" --> B
  B -- "description changed?" --> C
  C -- "installs DOM globals" --> D
  D -- "runs" --> E
  E -- "ProseMirror JSON" --> F
  F -- "docVersion bumped" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>markdown-doc.ts</strong><dd><code>New server-side Markdown-to-doc codec with scoped happy-dom</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/383/files#diff-770b935668b3a05c4114441c904bd52d0f1f8cf98f44573722467591dc5b2331">+125/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>feature.ts</strong><dd><code>Re-derive descriptionDoc and bump docVersion on Markdown-only writes</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/383/files#diff-bff1a29f77efa7f846d655a0106c96302d007305d09f09ecb53ab204ef97d03d">+48/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>markdown-doc.test.ts</strong><dd><code>Unit tests for markdownToDocServer and DOM global restoration</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/383/files#diff-ac86221d281b880e4280b86af5f6ce3f2d95095494d61250307798fb4adaabbe">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>feature-doc-sync.test.ts</strong><dd><code>Mocked unit tests for feature.update Markdown-only sync paths</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/383/files#diff-4a0cf9e849794f87aa12affe7975f87cb71cf00de014a5d9dafa61909fd0316a">+245/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>feature.integration.test.ts</strong><dd><code>Integration test for descriptionDoc re-derivation on real DB</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/383/files#diff-5ec75ea5a0290c8343f3ac89a546fc382086b055539b8baa58da411a56e46058">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>codec.ts</strong><dd><code>Update codec comments to document server-side Markdown write exception</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/383/files#diff-ae53df3ccce234e693b1272b9db309552ae4f93d95f502594e0643134e66b8c2">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0024-prosemirror-json-for-rich-documents.md</strong><dd><code>Document two sanctioned resolutions for Markdown-only API writes</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/383/files#diff-39fa6a42c2bd30ff3e28889384302d6b910d61c9d5150605d07056511d32391e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>integration-setup.ts</strong><dd><code>Stub server-only module for integration test imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/383/files#diff-7ebc26781a908017ff4873da89a2339860716f454d5a8ee5bc43003c44965271">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>setup.ts</strong><dd><code>Stub server-only module in unit test setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/383/files#diff-b38f1f15eee087a5b4a28827bab8f9cdcc2569a63018b1c53a56cc90a5d8df61">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Move happy-dom to production dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/383/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

