### PR TITLE
feat(pages): comment feed on Knowledge Pages via shared CommentSection base

### DIFF
--- a/prisma/migrations/20260716000000_add_knowledge_page_comment/migration.sql
+++ b/prisma/migrations/20260716000000_add_knowledge_page_comment/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "KnowledgePageComment" (
+    "id" TEXT NOT NULL,
+    "pageId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "KnowledgePageComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "KnowledgePageComment_pageId_idx" ON "KnowledgePageComment"("pageId");
+
+-- CreateIndex
+CREATE INDEX "KnowledgePageComment_createdById_idx" ON "KnowledgePageComment"("createdById");
+
+-- AddForeignKey
+ALTER TABLE "KnowledgePageComment" ADD CONSTRAINT "KnowledgePageComment_pageId_fkey" FOREIGN KEY ("pageId") REFERENCES "KnowledgePage"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "KnowledgePageComment" ADD CONSTRAINT "KnowledgePageComment_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -178,6 +178,7 @@ model User {
   // Action Discussion relations
   actionComments              ActionComment[]             @relation("ActionCommentAuthor")
   featureComments             FeatureComment[]            @relation("FeatureCommentAuthor")
+  knowledgePageComments       KnowledgePageComment[]      @relation("KnowledgePageCommentAuthor")
   // Blog Discussion relations
   blogComments                BlogComment[]               @relation("BlogCommentAuthor")
   // Daily Planning relations
@@ -2571,13 +2572,34 @@ model KnowledgePage {
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @updatedAt
 
-  workspace Workspace     @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  project   Project?      @relation(fields: [projectId], references: [id], onDelete: SetNull)
-  createdBy User          @relation(fields: [createdById], references: [id])
+  workspace Workspace              @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  project   Project?               @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  createdBy User                   @relation(fields: [createdById], references: [id])
   features  FeaturePage[]
+  comments  KnowledgePageComment[]
 
   @@index([workspaceId])
   @@index([projectId])
+  @@index([createdById])
+}
+
+/// Discussion note on a Knowledge Page — the doc-level comment feed under the
+/// page body, same card + composer pattern as FeatureComment's feature-level
+/// feed. No anchored threads: page bodies carry no `comment` marks, so the
+/// model stays flat (no threadId/parentId/quotedText until a real need).
+/// Bodies are Markdown (ADR-0017).
+model KnowledgePageComment {
+  id          String   @id @default(cuid())
+  pageId      String
+  body        String
+  createdById String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  page      KnowledgePage @relation(fields: [pageId], references: [id], onDelete: Cascade)
+  createdBy User          @relation("KnowledgePageCommentAuthor", fields: [createdById], references: [id])
+
+  @@index([pageId])
   @@index([createdById])
 }
 

--- a/src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx
@@ -8,6 +8,7 @@ import { api } from '~/trpc/react';
 import { PageDocument } from '~/app/_components/pages/PageDocument';
 import { PageShareMenu } from '~/app/_components/pages/PageShareMenu';
 import { PageSubpages } from '~/app/_components/pages/PageSubpages';
+import { PageCommentsSection } from '~/app/_components/pages/PageCommentsSection';
 import { FavoriteButton } from '~/app/_components/shared/FavoriteButton';
 import type { RichDocEditorHandle } from '~/app/_components/shared/RichDocEditor';
 
@@ -181,6 +182,7 @@ function PageEditorContent({
         editable={page.canEdit}
         onDetach={page.canEdit ? detachChild : undefined}
       />
+      <PageCommentsSection pageId={page.id} />
     </div>
   );
 }

--- a/src/app/_components/ActionDetailContent.tsx
+++ b/src/app/_components/ActionDetailContent.tsx
@@ -38,11 +38,11 @@ import { useSession } from "next-auth/react";
 import { api } from "~/trpc/react";
 import { notifications } from "@mantine/notifications";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
-import type { MentionCandidate } from "~/hooks/useMentionAutocomplete";
 import { PRIORITY_OPTIONS } from "~/types/action";
 import { ActivityComposer } from "~/app/_components/shared/ActivityComposer";
 import { ActivityFeed } from "~/app/_components/shared/ActivityFeed";
 import { useActionActivity } from "~/hooks/useActionActivity";
+import { useWorkspaceMentionCandidates } from "~/hooks/useWorkspaceMentionCandidates";
 import { AssignActionModal } from "./AssignActionModal";
 import { DeadlinePicker } from "./DeadlinePicker";
 import { UnifiedDatePicker } from "./UnifiedDatePicker";
@@ -94,17 +94,6 @@ export function ActionDetailContent({
   const { data: projects } = api.project.getAll.useQuery(
     { workspaceId: workspace?.id },
     { enabled: !!workspace },
-  );
-
-  // Fetch agents for @mention autocomplete
-  const { data: mastraAgents } = api.mastra.getMastraAgents.useQuery(undefined, {
-    staleTime: 5 * 60 * 1000,
-  });
-
-  // Fetch teams linked to this workspace (for @mention of team members)
-  const { data: teamsForLinking } = api.workspace.getUserTeamsForLinking.useQuery(
-    { workspaceId: workspace?.id ?? "" },
-    { enabled: !!workspace?.id },
   );
 
   // Local state for inline editing
@@ -213,49 +202,8 @@ export function ActionDetailContent({
     [actionId, setTagsMutation],
   );
 
-  // Build mention candidates from workspace members + linked team members + agents
-  const mentionCandidates: MentionCandidate[] = useMemo(() => {
-    const seenIds = new Set<string>();
-    const members: MentionCandidate[] = [];
-
-    // Direct workspace members
-    for (const m of workspace?.members ?? []) {
-      if (!seenIds.has(m.user.id)) {
-        seenIds.add(m.user.id);
-        members.push({
-          id: m.user.id,
-          name: m.user.name ?? m.user.email ?? "Unknown",
-          type: "member" as const,
-          image: m.user.image,
-        });
-      }
-    }
-
-    // Members from teams linked to this workspace
-    const linkedTeams = (teamsForLinking ?? []).filter((t) => t.isLinkedToThisWorkspace);
-    for (const team of linkedTeams) {
-      for (const tm of team.members) {
-        if (!seenIds.has(tm.user.id)) {
-          seenIds.add(tm.user.id);
-          members.push({
-            id: tm.user.id,
-            name: tm.user.name ?? tm.user.email ?? "Unknown",
-            type: "member" as const,
-            image: tm.user.image,
-          });
-        }
-      }
-    }
-
-    const agents: MentionCandidate[] = (mastraAgents ?? []).map((a) => ({
-      id: a.id,
-      name: a.name,
-      type: "agent" as const,
-      image: null,
-    }));
-
-    return [...members, ...agents];
-  }, [workspace?.members, teamsForLinking, mastraAgents]);
+  // Mention candidates: workspace members + linked team members + agents
+  const mentionCandidates = useWorkspaceMentionCandidates();
 
   const mentionNames = useMemo(
     () => mentionCandidates.map((c) => c.name),

--- a/src/app/_components/pages/PageCommentsSection.tsx
+++ b/src/app/_components/pages/PageCommentsSection.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Text } from "@mantine/core";
+import { useSession } from "next-auth/react";
+import { api } from "~/trpc/react";
+import { useWorkspaceMentionCandidates } from "~/hooks/useWorkspaceMentionCandidates";
+import { CommentSection } from "~/app/_components/shared/CommentSection";
+
+/**
+ * Comment feed under a Knowledge Page body — the shared CommentSection card
+ * base over the pageComment router. View access is the commenting gate
+ * (server-enforced), so the composer shows for everyone who can open the page.
+ */
+export function PageCommentsSection({ pageId }: { pageId: string }) {
+  const { data: session } = useSession();
+  const utils = api.useUtils();
+  const mentionCandidates = useWorkspaceMentionCandidates();
+
+  const { data: comments } = api.pageComment.list.useQuery(
+    { pageId },
+    { enabled: !!pageId },
+  );
+
+  const invalidate = () => {
+    void utils.pageComment.list.invalidate({ pageId });
+  };
+
+  const addComment = api.pageComment.create.useMutation({ onSuccess: invalidate });
+  const updateComment = api.pageComment.update.useMutation({ onSuccess: invalidate });
+  const deleteComment = api.pageComment.delete.useMutation({ onSuccess: invalidate });
+
+  return (
+    <div className="mt-10 border-t border-border-primary pt-6">
+      <Text size="sm" fw={600} className="text-text-primary" mb="sm">
+        Comments
+      </Text>
+      <CommentSection
+        comments={(comments ?? []).map((c) => ({
+          id: c.id,
+          content: c.body,
+          createdAt: c.createdAt,
+          updatedAt: c.updatedAt,
+          author: c.createdBy,
+        }))}
+        currentUserId={session?.user?.id}
+        mentionCandidates={mentionCandidates}
+        isSubmitting={addComment.isPending}
+        onSubmit={async (content) => {
+          await addComment.mutateAsync({ pageId, body: content });
+        }}
+        onEdit={async (commentId, content) => {
+          await updateComment.mutateAsync({ commentId, body: content });
+        }}
+        onDelete={(commentId) => deleteComment.mutate({ commentId })}
+      />
+    </div>
+  );
+}

--- a/src/app/_components/pages/PageCommentsSection.tsx
+++ b/src/app/_components/pages/PageCommentsSection.tsx
@@ -16,10 +16,7 @@ export function PageCommentsSection({ pageId }: { pageId: string }) {
   const utils = api.useUtils();
   const mentionCandidates = useWorkspaceMentionCandidates();
 
-  const { data: comments } = api.pageComment.list.useQuery(
-    { pageId },
-    { enabled: !!pageId },
-  );
+  const { data: comments } = api.pageComment.list.useQuery({ pageId });
 
   const invalidate = () => {
     void utils.pageComment.list.invalidate({ pageId });

--- a/src/app/_components/product/FeatureActivitySection.tsx
+++ b/src/app/_components/product/FeatureActivitySection.tsx
@@ -23,10 +23,9 @@ export function FeatureActivitySection({ featureId, scopeId }: FeatureActivitySe
   const utils = api.useUtils();
   const mentionCandidates = useWorkspaceMentionCandidates();
 
-  const { data: comments } = api.product.featureComment.list.useQuery(
-    { featureId },
-    { enabled: !!featureId },
-  );
+  const { data: comments } = api.product.featureComment.list.useQuery({
+    featureId,
+  });
 
   const invalidate = () => {
     void utils.product.featureComment.list.invalidate({ featureId });

--- a/src/app/_components/product/FeatureActivitySection.tsx
+++ b/src/app/_components/product/FeatureActivitySection.tsx
@@ -1,14 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
-import { ActionIcon, Avatar, Group, Stack, Text } from "@mantine/core";
-import { IconTrash } from "@tabler/icons-react";
 import { useSession } from "next-auth/react";
 import { api } from "~/trpc/react";
-import { useWorkspace } from "~/providers/WorkspaceProvider";
-import type { MentionCandidate } from "~/hooks/useMentionAutocomplete";
-import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
-import { CommentInput } from "~/app/_components/shared/CommentInput";
+import { useWorkspaceMentionCandidates } from "~/hooks/useWorkspaceMentionCandidates";
+import { CommentSection } from "~/app/_components/shared/CommentSection";
 
 interface FeatureActivitySectionProps {
   featureId: string;
@@ -17,80 +12,20 @@ interface FeatureActivitySectionProps {
 }
 
 /**
- * Comment feed for a feature or one of its scopes (Features V2) - the same
- * comment-card + composer pattern as the ticket detail page's Activity block.
- * Feature-level feed shows doc-level comments without a scope; a scope's feed
- * shows only its own. Anchored PRD-body comments (threadId set) stay inside
- * the PRD editor and never appear here.
+ * Comment feed for a feature or one of its scopes (Features V2) — the shared
+ * CommentSection card base over the featureComment router. Feature-level feed
+ * shows doc-level comments without a scope; a scope's feed shows only its own.
+ * Anchored PRD-body comments (threadId set) stay inside the PRD editor and
+ * never appear here.
  */
 export function FeatureActivitySection({ featureId, scopeId }: FeatureActivitySectionProps) {
   const { data: session } = useSession();
-  const { workspace } = useWorkspace();
   const utils = api.useUtils();
+  const mentionCandidates = useWorkspaceMentionCandidates();
 
   const { data: comments } = api.product.featureComment.list.useQuery(
     { featureId },
     { enabled: !!featureId },
-  );
-
-  // Fetch agents + linked-team members for @mention autocomplete (mirrors the
-  // Action comment path). Agents are taggable badges only; notifications go to
-  // human workspace members.
-  const { data: mastraAgents } = api.mastra.getMastraAgents.useQuery(undefined, {
-    staleTime: 5 * 60 * 1000,
-  });
-  const { data: teamsForLinking } = api.workspace.getUserTeamsForLinking.useQuery(
-    { workspaceId: workspace?.id ?? "" },
-    { enabled: !!workspace?.id },
-  );
-
-  // Build mention candidates from workspace members + linked team members + agents.
-  const mentionCandidates: MentionCandidate[] = useMemo(() => {
-    const seenIds = new Set<string>();
-    const members: MentionCandidate[] = [];
-
-    for (const m of workspace?.members ?? []) {
-      if (!seenIds.has(m.user.id)) {
-        seenIds.add(m.user.id);
-        members.push({
-          id: m.user.id,
-          name: m.user.name ?? m.user.email ?? "Unknown",
-          type: "member" as const,
-          image: m.user.image,
-        });
-      }
-    }
-
-    const linkedTeams = (teamsForLinking ?? []).filter(
-      (t) => t.isLinkedToThisWorkspace,
-    );
-    for (const team of linkedTeams) {
-      for (const tm of team.members) {
-        if (!seenIds.has(tm.user.id)) {
-          seenIds.add(tm.user.id);
-          members.push({
-            id: tm.user.id,
-            name: tm.user.name ?? tm.user.email ?? "Unknown",
-            type: "member" as const,
-            image: tm.user.image,
-          });
-        }
-      }
-    }
-
-    const agents: MentionCandidate[] = (mastraAgents ?? []).map((a) => ({
-      id: a.id,
-      name: a.name,
-      type: "agent" as const,
-      image: null,
-    }));
-
-    return [...members, ...agents];
-  }, [workspace?.members, teamsForLinking, mastraAgents]);
-
-  const mentionNames = useMemo(
-    () => mentionCandidates.map((c) => c.name),
-    [mentionCandidates],
   );
 
   const invalidate = () => {
@@ -98,6 +33,9 @@ export function FeatureActivitySection({ featureId, scopeId }: FeatureActivitySe
   };
 
   const addComment = api.product.featureComment.create.useMutation({
+    onSuccess: invalidate,
+  });
+  const updateComment = api.product.featureComment.update.useMutation({
     onSuccess: invalidate,
   });
   const deleteComment = api.product.featureComment.delete.useMutation({
@@ -112,52 +50,24 @@ export function FeatureActivitySection({ featureId, scopeId }: FeatureActivitySe
   );
 
   return (
-    <div>
-      {feed.length > 0 && (
-        <Stack gap="sm" mb="md">
-          {feed.map((c) => (
-            <div key={c.id} className="border border-border-primary rounded-lg p-3">
-              <Group justify="space-between" align="flex-start">
-                <div className="flex-1">
-                  <Group gap="xs" mb={4}>
-                    <Avatar size="xs" radius="xl" src={c.createdBy.image}>
-                      {(c.createdBy.name ?? "?")[0]?.toUpperCase()}
-                    </Avatar>
-                    <Text size="xs" fw={500} className="text-text-secondary">
-                      {c.createdBy.name}
-                    </Text>
-                    <Text size="xs" className="text-text-muted">
-                      {new Date(c.createdAt).toLocaleDateString()}
-                    </Text>
-                  </Group>
-                  <div className="ml-6">
-                    <MarkdownRenderer content={c.body} mentionNames={mentionNames} />
-                  </div>
-                </div>
-                {c.createdBy.id === session?.user?.id && (
-                  <ActionIcon
-                    variant="subtle"
-                    color="red"
-                    size="xs"
-                    onClick={() => deleteComment.mutate({ commentId: c.id })}
-                  >
-                    <IconTrash size={12} />
-                  </ActionIcon>
-                )}
-              </Group>
-            </div>
-          ))}
-        </Stack>
-      )}
-
-      <CommentInput
-        placeholder="Leave a comment..."
-        isSubmitting={addComment.isPending}
-        mentionCandidates={mentionCandidates}
-        onSubmit={async (content) => {
-          await addComment.mutateAsync({ featureId, scopeId, body: content });
-        }}
-      />
-    </div>
+    <CommentSection
+      comments={feed.map((c) => ({
+        id: c.id,
+        content: c.body,
+        createdAt: c.createdAt,
+        updatedAt: c.updatedAt,
+        author: c.createdBy,
+      }))}
+      currentUserId={session?.user?.id}
+      mentionCandidates={mentionCandidates}
+      isSubmitting={addComment.isPending}
+      onSubmit={async (content) => {
+        await addComment.mutateAsync({ featureId, scopeId, body: content });
+      }}
+      onEdit={async (commentId, content) => {
+        await updateComment.mutateAsync({ commentId, body: content });
+      }}
+      onDelete={(commentId) => deleteComment.mutate({ commentId })}
+    />
   );
 }

--- a/src/app/_components/shared/CommentSection.tsx
+++ b/src/app/_components/shared/CommentSection.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useMemo } from "react";
+import type { MentionCandidate } from "~/hooks/useMentionAutocomplete";
+import { CommentThread, type Comment } from "~/app/_components/shared/CommentThread";
+import { CommentInput } from "~/app/_components/shared/CommentInput";
+
+interface CommentSectionProps {
+  comments: Comment[];
+  currentUserId?: string;
+  mentionCandidates?: MentionCandidate[];
+  isSubmitting?: boolean;
+  placeholder?: string;
+  /** Shown when there are no comments; null hides the empty state entirely. */
+  emptyMessage?: string | null;
+  /** Hide the composer (e.g. read-only viewers). The thread still renders. */
+  canComment?: boolean;
+  onSubmit: (content: string) => Promise<void>;
+  onEdit?: (commentId: string, content: string) => Promise<void>;
+  onDelete?: (commentId: string) => void;
+}
+
+/**
+ * The reusable flat comment feed: a CommentThread card list over a
+ * CommentInput composer, wired for @mentions. Entity-specific wrappers
+ * (feature activity, page comments, …) own their tRPC queries/mutations and
+ * map rows into {@link Comment}; everything visual lives here so new comment
+ * surfaces don't re-implement the card.
+ */
+export function CommentSection({
+  comments,
+  currentUserId,
+  mentionCandidates,
+  isSubmitting = false,
+  placeholder = "Leave a comment...",
+  emptyMessage = null,
+  canComment = true,
+  onSubmit,
+  onEdit,
+  onDelete,
+}: CommentSectionProps) {
+  const mentionNames = useMemo(
+    () => mentionCandidates?.map((c) => c.name),
+    [mentionCandidates],
+  );
+
+  return (
+    <div>
+      <CommentThread
+        comments={comments}
+        currentUserId={currentUserId}
+        mentionNames={mentionNames}
+        emptyMessage={emptyMessage}
+        onEditComment={onEdit}
+        onDeleteComment={onDelete}
+      />
+      {canComment && (
+        <CommentInput
+          placeholder={placeholder}
+          isSubmitting={isSubmitting}
+          mentionCandidates={mentionCandidates}
+          onSubmit={onSubmit}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useWorkspaceMentionCandidates.ts
+++ b/src/hooks/useWorkspaceMentionCandidates.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useMemo } from "react";
+import { api } from "~/trpc/react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import type { MentionCandidate } from "~/hooks/useMentionAutocomplete";
+
+/**
+ * The canonical @mention candidate list for comment composers inside a
+ * workspace: direct workspace members + members of teams linked to the
+ * workspace (deduped) + Mastra agents. Agents are taggable badges only;
+ * notifications go to human workspace members (the server drops non-member
+ * ids on fan-out).
+ *
+ * Must be rendered under a WorkspaceProvider (any `/w/[workspaceSlug]/`
+ * route). Extracted from the identical blocks in ActionDetailContent and
+ * FeatureActivitySection so every comment surface shares one source.
+ */
+export function useWorkspaceMentionCandidates(): MentionCandidate[] {
+  const { workspace } = useWorkspace();
+
+  const { data: mastraAgents } = api.mastra.getMastraAgents.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  });
+  const { data: teamsForLinking } = api.workspace.getUserTeamsForLinking.useQuery(
+    { workspaceId: workspace?.id ?? "" },
+    { enabled: !!workspace?.id },
+  );
+
+  return useMemo(() => {
+    const seenIds = new Set<string>();
+    const members: MentionCandidate[] = [];
+
+    // Direct workspace members
+    for (const m of workspace?.members ?? []) {
+      if (!seenIds.has(m.user.id)) {
+        seenIds.add(m.user.id);
+        members.push({
+          id: m.user.id,
+          name: m.user.name ?? m.user.email ?? "Unknown",
+          type: "member" as const,
+          image: m.user.image,
+        });
+      }
+    }
+
+    // Members from teams linked to this workspace
+    const linkedTeams = (teamsForLinking ?? []).filter(
+      (t) => t.isLinkedToThisWorkspace,
+    );
+    for (const team of linkedTeams) {
+      for (const tm of team.members) {
+        if (!seenIds.has(tm.user.id)) {
+          seenIds.add(tm.user.id);
+          members.push({
+            id: tm.user.id,
+            name: tm.user.name ?? tm.user.email ?? "Unknown",
+            type: "member" as const,
+            image: tm.user.image,
+          });
+        }
+      }
+    }
+
+    const agents: MentionCandidate[] = (mastraAgents ?? []).map((a) => ({
+      id: a.id,
+      name: a.name,
+      type: "agent" as const,
+      image: null,
+    }));
+
+    return [...members, ...agents];
+  }, [workspace?.members, teamsForLinking, mastraAgents]);
+}

--- a/src/plugins/product/server/routers/featureComment.ts
+++ b/src/plugins/product/server/routers/featureComment.ts
@@ -136,7 +136,7 @@ export const featureCommentRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const existing = await ctx.db.featureComment.findFirst({
         where: { id: input.commentId, createdById: ctx.session.user.id },
-        select: { id: true },
+        select: { id: true, featureId: true, scopeId: true, body: true },
       });
       if (!existing) {
         throw new TRPCError({
@@ -144,11 +144,23 @@ export const featureCommentRouter = createTRPCRouter({
           message: "Comment not found or not yours",
         });
       }
-      return ctx.db.featureComment.update({
+      const updated = await ctx.db.featureComment.update({
         where: { id: input.commentId },
         data: { body: input.body },
         include: { createdBy: { select: authorSelect } },
       });
+
+      // Fire-and-forget: notify mentions added by the edit. Passing the old
+      // body means already-notified users aren't pinged again.
+      void sendFeatureMentionNotifications(ctx.db, {
+        featureId: existing.featureId,
+        scopeId: existing.scopeId ?? undefined,
+        commentContent: input.body,
+        commentAuthorId: ctx.session.user.id,
+        previousContent: existing.body,
+      });
+
+      return updated;
     }),
 
   delete: protectedProcedure

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -84,6 +84,7 @@ import { authRouter } from "./routers/auth";
 import { documentRouter } from "./routers/document";
 import { voiceRouter } from "./routers/voice";
 import { pageRouter } from "./routers/page";
+import { pageCommentRouter } from "./routers/pageComment";
 /**
  * This is the primary router for your server.
  *
@@ -170,6 +171,7 @@ export const appRouter = createTRPCRouter({
   document: documentRouter,
   voice: voiceRouter,
   page: pageRouter,
+  pageComment: pageCommentRouter,
   // Plugin system
   pluginConfig: pluginConfigRouter,
   okr: keyResultRouter,

--- a/src/server/api/routers/__tests__/pageComment.integration.test.ts
+++ b/src/server/api/routers/__tests__/pageComment.integration.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestDb } from "~/test/test-db";
+import { createTestCaller } from "~/test/trpc-helpers";
+import {
+  createUser,
+  createWorkspace,
+  addWorkspaceMember,
+} from "~/test/factories";
+
+async function createPage(
+  db: ReturnType<typeof getTestDb>,
+  args: { createdById: string; workspaceId: string; title?: string },
+) {
+  return db.knowledgePage.create({
+    data: {
+      createdById: args.createdById,
+      workspaceId: args.workspaceId,
+      title: args.title ?? "A page",
+      body: "hello world",
+    },
+  });
+}
+
+describe("pageComment router", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("creates a comment and lists it with its author", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const page = await createPage(db, {
+      createdById: user.id,
+      workspaceId: ws.id,
+    });
+
+    const caller = createTestCaller(user.id);
+    const created = await caller.pageComment.create({
+      pageId: page.id,
+      body: "First comment",
+    });
+    expect(created.createdBy.id).toBe(user.id);
+
+    const list = await caller.pageComment.list({ pageId: page.id });
+    expect(list).toHaveLength(1);
+    expect(list[0]?.body).toBe("First comment");
+    expect(list[0]?.createdBy.name).toBe(user.name);
+  });
+
+  it("lets any workspace member with view access comment", async () => {
+    const owner = await createUser(db);
+    const member = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: owner.id });
+    await addWorkspaceMember(db, ws.id, member.id, "member");
+    const page = await createPage(db, {
+      createdById: owner.id,
+      workspaceId: ws.id,
+    });
+
+    const caller = createTestCaller(member.id);
+    const created = await caller.pageComment.create({
+      pageId: page.id,
+      body: "Member comment",
+    });
+    expect(created.createdBy.id).toBe(member.id);
+  });
+
+  it("rejects list and create from a non-member", async () => {
+    const owner = await createUser(db);
+    const outsider = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: owner.id });
+    const page = await createPage(db, {
+      createdById: owner.id,
+      workspaceId: ws.id,
+    });
+
+    const caller = createTestCaller(outsider.id);
+    await expect(
+      caller.pageComment.list({ pageId: page.id }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    await expect(
+      caller.pageComment.create({ pageId: page.id, body: "nope" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("update and delete are author-only", async () => {
+    const owner = await createUser(db);
+    const member = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: owner.id });
+    await addWorkspaceMember(db, ws.id, member.id, "member");
+    const page = await createPage(db, {
+      createdById: owner.id,
+      workspaceId: ws.id,
+    });
+
+    const ownerCaller = createTestCaller(owner.id);
+    const comment = await ownerCaller.pageComment.create({
+      pageId: page.id,
+      body: "Original",
+    });
+
+    const memberCaller = createTestCaller(member.id);
+    await expect(
+      memberCaller.pageComment.update({
+        commentId: comment.id,
+        body: "hijacked",
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    await expect(
+      memberCaller.pageComment.delete({ commentId: comment.id }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    const updated = await ownerCaller.pageComment.update({
+      commentId: comment.id,
+      body: "Edited",
+    });
+    expect(updated.body).toBe("Edited");
+
+    const deleted = await ownerCaller.pageComment.delete({
+      commentId: comment.id,
+    });
+    expect(deleted.success).toBe(true);
+    const list = await ownerCaller.pageComment.list({ pageId: page.id });
+    expect(list).toHaveLength(0);
+  });
+
+  it("comments cascade away when the page is deleted", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const page = await createPage(db, {
+      createdById: user.id,
+      workspaceId: ws.id,
+    });
+
+    const caller = createTestCaller(user.id);
+    await caller.pageComment.create({ pageId: page.id, body: "doomed" });
+    await db.knowledgePage.delete({ where: { id: page.id } });
+
+    const orphans = await db.knowledgePageComment.findMany({
+      where: { pageId: page.id },
+    });
+    expect(orphans).toHaveLength(0);
+  });
+});

--- a/src/server/api/routers/page.ts
+++ b/src/server/api/routers/page.ts
@@ -72,7 +72,8 @@ type DuplicateRow = Prisma.KnowledgePageGetPayload<{
   select: typeof DUPLICATE_SELECT;
 }>;
 
-async function loadPageForAccess(db: PrismaClient, id: string) {
+/** Load the access-relevant slice of a Page (shared with the pageComment router). */
+export async function loadPageForAccess(db: PrismaClient, id: string) {
   const page = await db.knowledgePage.findUnique({
     where: { id },
     select: PAGE_ACCESS_SELECT,
@@ -83,7 +84,8 @@ async function loadPageForAccess(db: PrismaClient, id: string) {
   return page;
 }
 
-async function ensurePageAccess(
+/** Throw unless the user has view/edit access (shared with the pageComment router). */
+export async function ensurePageAccess(
   db: PrismaClient,
   userId: string,
   page: { createdById: string; projectId: string | null; workspaceId: string },

--- a/src/server/api/routers/pageComment.ts
+++ b/src/server/api/routers/pageComment.ts
@@ -73,7 +73,7 @@ export const pageCommentRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const existing = await ctx.db.knowledgePageComment.findFirst({
         where: { id: input.commentId, createdById: ctx.session.user.id },
-        select: { id: true },
+        select: { id: true, pageId: true, body: true },
       });
       if (!existing) {
         throw new TRPCError({
@@ -81,11 +81,22 @@ export const pageCommentRouter = createTRPCRouter({
           message: "Comment not found or not yours",
         });
       }
-      return ctx.db.knowledgePageComment.update({
+      const updated = await ctx.db.knowledgePageComment.update({
         where: { id: input.commentId },
         data: { body: input.body },
         include: { createdBy: { select: authorSelect } },
       });
+
+      // Fire-and-forget: notify mentions added by the edit. Passing the old
+      // body means already-notified users aren't pinged again.
+      void sendPageMentionNotifications(ctx.db, {
+        pageId: existing.pageId,
+        commentContent: input.body,
+        commentAuthorId: ctx.session.user.id,
+        previousContent: existing.body,
+      });
+
+      return updated;
     }),
 
   delete: protectedProcedure

--- a/src/server/api/routers/pageComment.ts
+++ b/src/server/api/routers/pageComment.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
+import { loadPageForAccess, ensurePageAccess } from "./page";
+import { sendPageMentionNotifications } from "~/server/services/notifications/EmailNotificationService";
+
+const authorSelect = {
+  id: true,
+  name: true,
+  image: true,
+} as const;
+
+/**
+ * Comments on a Knowledge Page — the flat doc-level feed under the page body
+ * (mirrors featureComment's feature-level feed). Bodies are Markdown
+ * (ADR-0017). View access is the commenting gate: anyone a page is shared
+ * with can join its discussion; read-only viewers can still comment, matching
+ * how feature comments admit every workspace member. Editing and deleting are
+ * author-only.
+ */
+export const pageCommentRouter = createTRPCRouter({
+  list: protectedProcedure
+    .input(z.object({ pageId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const page = await loadPageForAccess(ctx.db, input.pageId);
+      await ensurePageAccess(ctx.db, ctx.session.user.id, page, "view");
+
+      return ctx.db.knowledgePageComment.findMany({
+        where: { pageId: input.pageId },
+        include: { createdBy: { select: authorSelect } },
+        orderBy: { createdAt: "asc" },
+      });
+    }),
+
+  create: protectedProcedure
+    .input(
+      z.object({
+        pageId: z.string(),
+        body: boundedText("Comment", TEXT_LIMITS.LARGE, { min: 1 }),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const page = await loadPageForAccess(ctx.db, input.pageId);
+      await ensurePageAccess(ctx.db, ctx.session.user.id, page, "view");
+
+      const comment = await ctx.db.knowledgePageComment.create({
+        data: {
+          pageId: input.pageId,
+          body: input.body,
+          createdById: ctx.session.user.id,
+        },
+        include: { createdBy: { select: authorSelect } },
+      });
+
+      // Fire-and-forget: notify mentioned workspace members.
+      void sendPageMentionNotifications(ctx.db, {
+        pageId: input.pageId,
+        commentContent: input.body,
+        commentAuthorId: ctx.session.user.id,
+      });
+
+      return comment;
+    }),
+
+  update: protectedProcedure
+    .input(
+      z.object({
+        commentId: z.string(),
+        body: boundedText("Comment", TEXT_LIMITS.LARGE, { min: 1 }),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const existing = await ctx.db.knowledgePageComment.findFirst({
+        where: { id: input.commentId, createdById: ctx.session.user.id },
+        select: { id: true },
+      });
+      if (!existing) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Comment not found or not yours",
+        });
+      }
+      return ctx.db.knowledgePageComment.update({
+        where: { id: input.commentId },
+        data: { body: input.body },
+        include: { createdBy: { select: authorSelect } },
+      });
+    }),
+
+  delete: protectedProcedure
+    .input(z.object({ commentId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const existing = await ctx.db.knowledgePageComment.findFirst({
+        where: { id: input.commentId, createdById: ctx.session.user.id },
+        select: { id: true },
+      });
+      if (!existing) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Comment not found or not yours",
+        });
+      }
+      await ctx.db.knowledgePageComment.delete({
+        where: { id: input.commentId },
+      });
+      return { success: true };
+    }),
+});

--- a/src/server/services/notifications/EmailNotificationService.ts
+++ b/src/server/services/notifications/EmailNotificationService.ts
@@ -6,6 +6,7 @@ import {
 import { sendPushToUser } from "~/server/services/notifications/WebPushService";
 import { ZulipNotificationService } from "~/server/services/notifications/ZulipNotificationService";
 import { getPublicBaseUrlFromEnv } from "~/lib/urls";
+import { buildPageEditorPath } from "~/lib/pages/page-path";
 
 const BASE_URL = process.env.NEXTAUTH_URL ?? getPublicBaseUrlFromEnv();
 
@@ -513,5 +514,44 @@ export async function sendFeatureMentionNotifications(
     });
   } catch (error) {
     console.error("[EmailNotificationService] Failed to send feature mention notifications:", error);
+  }
+}
+
+/**
+ * Fire-and-forget: Send notifications to users mentioned in a
+ * KnowledgePageComment. Thin wrapper over {@link fanOutMentionNotifications}.
+ */
+export async function sendPageMentionNotifications(
+  db: PrismaClient,
+  params: {
+    pageId: string;
+    commentContent: string;
+    commentAuthorId: string;
+  },
+): Promise<void> {
+  try {
+    const { pageId, commentContent, commentAuthorId } = params;
+
+    const page = await db.knowledgePage.findUnique({
+      where: { id: pageId },
+      select: {
+        title: true,
+        workspace: { select: { id: true, slug: true, name: true } },
+      },
+    });
+    if (!page) return;
+
+    await fanOutMentionNotifications(db, {
+      workspaceId: page.workspace.id,
+      workspaceSlug: page.workspace.slug,
+      workspaceName: page.workspace.name,
+      targetName: page.title,
+      targetPath: buildPageEditorPath(page.workspace.slug, pageId),
+      viewLabel: "View page",
+      commentContent,
+      commentAuthorId,
+    });
+  } catch (error) {
+    console.error("[EmailNotificationService] Failed to send page mention notifications:", error);
   }
 }

--- a/src/server/services/notifications/EmailNotificationService.ts
+++ b/src/server/services/notifications/EmailNotificationService.ts
@@ -338,6 +338,10 @@ async function fanOutMentionNotifications(
     viewLabel: string;
     commentContent: string;
     commentAuthorId: string;
+    /** The comment's pre-edit body. Users already mentioned in it are skipped,
+     * so editing a comment only notifies newly added mentions — never re-spams
+     * everyone on each edit. */
+    previousContent?: string;
   },
 ): Promise<void> {
   const {
@@ -349,6 +353,7 @@ async function fanOutMentionNotifications(
     viewLabel,
     commentContent,
     commentAuthorId,
+    previousContent,
   } = params;
 
   const mentionedUserIds = await extractMentionedUserIds(
@@ -358,9 +363,16 @@ async function fanOutMentionNotifications(
   );
   if (mentionedUserIds.length === 0) return;
 
-  // Filter out the comment author (don't notify yourself). Non-member ids
-  // (e.g. mentioned agents) never match a User row below, so they drop out.
-  const recipientIds = mentionedUserIds.filter((id) => id !== commentAuthorId);
+  const previouslyMentioned = previousContent
+    ? new Set(await extractMentionedUserIds(db, previousContent, workspaceId))
+    : null;
+
+  // Filter out the comment author (don't notify yourself) and anyone already
+  // mentioned before an edit. Non-member ids (e.g. mentioned agents) never
+  // match a User row below, so they drop out.
+  const recipientIds = mentionedUserIds.filter(
+    (id) => id !== commentAuthorId && !previouslyMentioned?.has(id),
+  );
   if (recipientIds.length === 0) return;
 
   // Mention markup is client-supplied: only notify users who actually belong
@@ -492,10 +504,13 @@ export async function sendFeatureMentionNotifications(
     scopeId?: string;
     commentContent: string;
     commentAuthorId: string;
+    /** Pre-edit body — see {@link fanOutMentionNotifications}. */
+    previousContent?: string;
   },
 ): Promise<void> {
   try {
-    const { featureId, scopeId, commentContent, commentAuthorId } = params;
+    const { featureId, scopeId, commentContent, commentAuthorId, previousContent } =
+      params;
 
     const info = await resolveFeatureWorkspace(db, featureId);
     if (!info) return;
@@ -511,6 +526,7 @@ export async function sendFeatureMentionNotifications(
       viewLabel: "View PRD",
       commentContent,
       commentAuthorId,
+      previousContent,
     });
   } catch (error) {
     console.error("[EmailNotificationService] Failed to send feature mention notifications:", error);
@@ -527,10 +543,12 @@ export async function sendPageMentionNotifications(
     pageId: string;
     commentContent: string;
     commentAuthorId: string;
+    /** Pre-edit body — see {@link fanOutMentionNotifications}. */
+    previousContent?: string;
   },
 ): Promise<void> {
   try {
-    const { pageId, commentContent, commentAuthorId } = params;
+    const { pageId, commentContent, commentAuthorId, previousContent } = params;
 
     const page = await db.knowledgePage.findUnique({
       where: { id: pageId },
@@ -550,6 +568,7 @@ export async function sendPageMentionNotifications(
       viewLabel: "View page",
       commentContent,
       commentAuthorId,
+      previousContent,
     });
   } catch (error) {
     console.error("[EmailNotificationService] Failed to send page mention notifications:", error);


### PR DESCRIPTION
### **User description**
## Summary

Adds commenting to Knowledge Pages (`/w/{ws}/pages/{id}`) — the same discussion ability feature pages already have — and consolidates the existing comment surfaces onto one reusable base instead of adding another bespoke feed.

### Shared base (refactor)
- **New `CommentSection`** (`shared/CommentSection.tsx`): the reusable flat comment feed — `CommentThread` card list + `CommentInput` composer. Entity wrappers only supply tRPC queries/mutations.
- **New `useWorkspaceMentionCandidates`** hook: canonical @mention candidate list (workspace members + linked-team members + agents), extracted from byte-identical blocks in `ActionDetailContent` and `FeatureActivitySection`.
- `FeatureActivitySection` and `ActionDetailContent` migrated onto the base. Side benefit: feature comments gain inline editing (the `featureComment.update` endpoint existed but the old bespoke card never exposed it).

### Page comments (feature)
- **`KnowledgePageComment`** model — flat Markdown-body comments (ADR-0017), cascade-deleted with the page. No threads/anchors until there's a real need.
- **`pageComment` router** (`list`/`create`/`update`/`delete`) gated by the same `ensurePageAccess` resolvers as `page.get`; view access is the commenting gate (matches feature comments admitting all members), edit/delete are author-only.
- **Mention notifications** fan out through the existing target-agnostic core via `sendPageMentionNotifications` (push + Zulip + email, deep-links to the page).
- **`PageCommentsSection`** rendered below the body/sub-pages on the page detail route.

## ⚠️ Contains a migration

`20260716000000_add_knowledge_page_comment` — single additive `CREATE TABLE "KnowledgePageComment"`. Already applied to the shared dev DB.

## Testing
- New integration suite `pageComment.integration.test.ts` (5 tests): access gating for non-members, member commenting, author-only update/delete, cascade delete.
- Neighboring `page` and `featureComment` integration suites pass.
- Full unit suite (1,499 tests), typecheck, and ESLint clean.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Add comment feed to Knowledge Pages via new `pageComment` router and `PageCommentsSection` component

- Introduce shared `CommentSection` base and `useWorkspaceMentionCandidates` hook, eliminating duplicate code from `FeatureActivitySection` and `ActionDetailContent`

- Add `KnowledgePageComment` DB model with cascade delete, migration, and mention notifications via `sendPageMentionNotifications`

- Fix comment edits to only notify newly added mentions (not re-spam previously mentioned users), applied to both page and feature comments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  hook["useWorkspaceMentionCandidates"]
  base["CommentSection (shared base)"]
  pageSection["PageCommentsSection"]
  featureSection["FeatureActivitySection"]
  actionDetail["ActionDetailContent"]
  pageRouter["pageComment router"]
  featureRouter["featureComment router"]
  notifService["EmailNotificationService\nsendPageMentionNotifications"]
  db["KnowledgePageComment\n(DB model + migration)"]

  hook -- "provides candidates" --> base
  base -- "used by" --> pageSection
  base -- "used by" --> featureSection
  base -- "used by" --> actionDetail
  pageSection -- "tRPC calls" --> pageRouter
  pageRouter -- "writes" --> db
  pageRouter -- "triggers" --> notifService
  featureRouter -- "edit notifications" --> notifService
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>page.tsx</strong><dd><code>Render PageCommentsSection below page body</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-6b79b72a995acbd10cc157f1131181cd7ed46fc478f1fd996884e2c162db08b2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PageCommentsSection.tsx</strong><dd><code>New component: comment feed for Knowledge Pages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-55d3e9f98fb72c1ef22757cec7f28bcf66d1a85a2db4ad92d704fc39d04d0d85">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CommentSection.tsx</strong><dd><code>New reusable flat comment feed base component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-e068a50a8ece25c1aba1d8c3b24365504f61e401ccda42e3d38e486d808683ed">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useWorkspaceMentionCandidates.ts</strong><dd><code>New hook: canonical workspace @mention candidate list</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-4b457834a6c03096b5e81c3d06798d4f0d1d399cf519b2a10a7074141f86512d">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FeatureActivitySection.tsx</strong><dd><code>Migrate to shared CommentSection, add inline editing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-6098392683a7990e0d47970045d81f4042bc15115ded743b73e9f9b5ffcaf9f2">+32/-123</a></td>

</tr>

<tr>
  <td><strong>ActionDetailContent.tsx</strong><dd><code>Replace inline mention logic with shared hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-25a332a1a59ad9784416db610b6ffc77eafbf6a2e72a134d9d4c5cf9f0422072">+3/-55</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pageComment.ts</strong><dd><code>New tRPC router for page comment CRUD with access gating</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-a886964288273ca40ada4875f1a238260ed08dff833cd045f0fa803c3580bef7">+120/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.ts</strong><dd><code>Export page access helpers for pageComment router reuse</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-417f180698c610991876ae407a7d19f5f60eb699f3e815dc47afecc6971a6b30">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EmailNotificationService.ts</strong><dd><code>Add sendPageMentionNotifications and edit-aware dedup logic</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-f17fa722d8f985c7af8142bf980b69ab8cfd77853bb672a1205484660d5bb2a5">+63/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.prisma</strong><dd><code>Add KnowledgePageComment model and User relation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565c">+25/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>migration.sql</strong><dd><code>Migration: create KnowledgePageComment table with indexes</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-5d037af36abf31bb53c687ad67d00ddd1223ad5d86c42fea9d17c8862074c0bc">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>root.ts</strong><dd><code>Register pageCommentRouter in app router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-6a8cad7e52067d5afa93671900c038e0e0a9526f8f0e3bd10985cecf4295b4fc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>featureComment.ts</strong><dd><code>Notify newly added mentions on feature comment edit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-95b715d8a5cee23cf00793767dd9d410c03a0a98970c3dc0bad7da6516bdbc65">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pageComment.integration.test.ts</strong><dd><code>Integration tests for pageComment access gating and CRUD</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/384/files#diff-fcba794a427e7f0069ab8f8ae4270d9fa98fb04b296a669d5c1cd18008c5d1f9">+146/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

