### PR TITLE
feat: V2: Work hours + editable profile in Settings

### DIFF
--- a/src/app/(sidemenu)/settings/profile/ProfileCard.tsx
+++ b/src/app/(sidemenu)/settings/profile/ProfileCard.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Paper,
+  Avatar,
+  Group,
+  Stack,
+  Text,
+  TextInput,
+  ActionIcon,
+  Skeleton,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { IconCheck, IconPencil, IconX } from '@tabler/icons-react';
+import { api } from '~/trpc/react';
+
+export function ProfileCard() {
+  const utils = api.useUtils();
+  const { data: profile, isLoading } = api.user.getProfile.useQuery();
+
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState('');
+
+  const updateProfile = api.user.updateProfile.useMutation({
+    onSuccess: async () => {
+      await utils.user.getProfile.invalidate();
+      setIsEditingName(false);
+      notifications.show({
+        title: 'Profile updated',
+        message: 'Your name has been saved.',
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+    },
+    onError: (error) => {
+      notifications.show({
+        title: 'Error',
+        message: error.message || 'Failed to update your name. Please try again.',
+        color: 'red',
+      });
+    },
+  });
+
+  if (isLoading) {
+    return <Skeleton height={140} />;
+  }
+
+  const startEditingName = () => {
+    setNameDraft(profile?.name ?? '');
+    setIsEditingName(true);
+  };
+
+  const saveName = () => {
+    const trimmed = nameDraft.trim();
+    if (!trimmed) return;
+    updateProfile.mutate({ name: trimmed });
+  };
+
+  return (
+    <Paper p="lg" withBorder className="bg-surface-secondary">
+      <Group gap="lg" align="flex-start">
+        <Avatar
+          src={profile?.image}
+          size={72}
+          radius="xl"
+          className="bg-brand-primary"
+        >
+          {profile?.name
+            ?.split(' ')
+            .map((n) => n[0])
+            .join('')
+            .toUpperCase() ?? 'U'}
+        </Avatar>
+        <Stack gap="sm" className="flex-1">
+          <div>
+            <Text size="xs" className="text-text-muted mb-1">
+              Name
+            </Text>
+            {isEditingName ? (
+              <Group gap="xs">
+                <TextInput
+                  value={nameDraft}
+                  onChange={(event) => setNameDraft(event.currentTarget.value)}
+                  maxLength={100}
+                  autoFocus
+                  className="flex-1"
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') saveName();
+                    if (event.key === 'Escape') setIsEditingName(false);
+                  }}
+                  aria-label="Display name"
+                />
+                <ActionIcon
+                  variant="filled"
+                  color="brand"
+                  onClick={saveName}
+                  loading={updateProfile.isPending}
+                  disabled={!nameDraft.trim()}
+                  aria-label="Save name"
+                >
+                  <IconCheck size={16} />
+                </ActionIcon>
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  onClick={() => setIsEditingName(false)}
+                  disabled={updateProfile.isPending}
+                  aria-label="Cancel editing"
+                >
+                  <IconX size={16} />
+                </ActionIcon>
+              </Group>
+            ) : (
+              <Group gap="xs">
+                <Text size="lg" fw={500} className="text-text-primary">
+                  {profile?.name ?? 'Unknown'}
+                </Text>
+                <ActionIcon
+                  variant="subtle"
+                  color="gray"
+                  onClick={startEditingName}
+                  aria-label="Edit name"
+                >
+                  <IconPencil size={16} />
+                </ActionIcon>
+              </Group>
+            )}
+          </div>
+          <div>
+            <Text size="xs" className="text-text-muted mb-1">
+              Email
+            </Text>
+            <Text className="text-text-secondary">
+              {profile?.email ?? 'No email'}
+            </Text>
+          </div>
+        </Stack>
+      </Group>
+    </Paper>
+  );
+}

--- a/src/app/(sidemenu)/settings/profile/ProfileCard.tsx
+++ b/src/app/(sidemenu)/settings/profile/ProfileCard.tsx
@@ -10,10 +10,15 @@ import {
   TextInput,
   ActionIcon,
   Skeleton,
+  FileButton,
+  Tooltip,
+  Loader,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import { IconCheck, IconPencil, IconX } from '@tabler/icons-react';
+import { IconCamera, IconCheck, IconPencil, IconX } from '@tabler/icons-react';
 import { api } from '~/trpc/react';
+
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 
 export function ProfileCard() {
   const utils = api.useUtils();
@@ -42,6 +47,46 @@ export function ProfileCard() {
     },
   });
 
+  const uploadProfileImage = api.user.uploadProfileImage.useMutation({
+    onSuccess: async () => {
+      await utils.user.getProfile.invalidate();
+      notifications.show({
+        title: 'Photo uploaded',
+        message: 'Your profile photo has been saved.',
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+    },
+    onError: (error) => {
+      notifications.show({
+        title: 'Upload failed',
+        message: error.message || 'Failed to upload image. Please try again.',
+        color: 'red',
+      });
+    },
+  });
+
+  const handleImageSelect = (file: File | null) => {
+    if (!file) return;
+
+    if (file.size > MAX_IMAGE_BYTES) {
+      notifications.show({
+        title: 'File too large',
+        message: 'Please select an image under 5MB.',
+        color: 'red',
+      });
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const base64 = (reader.result as string).split(',')[1];
+      if (!base64) return;
+      uploadProfileImage.mutate({ base64Data: base64 });
+    };
+    reader.readAsDataURL(file);
+  };
+
   if (isLoading) {
     return <Skeleton height={140} />;
   }
@@ -60,18 +105,42 @@ export function ProfileCard() {
   return (
     <Paper p="lg" withBorder className="bg-surface-secondary">
       <Group gap="lg" align="flex-start">
-        <Avatar
-          src={profile?.image}
-          size={72}
-          radius="xl"
-          className="bg-brand-primary"
-        >
-          {profile?.name
-            ?.split(' ')
-            .map((n) => n[0])
-            .join('')
-            .toUpperCase() ?? 'U'}
-        </Avatar>
+        <div className="relative">
+          <Avatar
+            src={profile?.image}
+            size={72}
+            radius="xl"
+            className="bg-brand-primary"
+          >
+            {profile?.name
+              ?.split(' ')
+              .map((n) => n[0])
+              .join('')
+              .toUpperCase() ?? 'U'}
+          </Avatar>
+          <FileButton onChange={handleImageSelect} accept="image/*">
+            {(props) => (
+              <Tooltip label="Change photo">
+                <ActionIcon
+                  {...props}
+                  variant="filled"
+                  color="brand"
+                  size="sm"
+                  radius="xl"
+                  className="absolute -bottom-1 -right-1"
+                  disabled={uploadProfileImage.isPending}
+                  aria-label="Upload profile photo"
+                >
+                  {uploadProfileImage.isPending ? (
+                    <Loader size={12} color="white" />
+                  ) : (
+                    <IconCamera size={14} />
+                  )}
+                </ActionIcon>
+              </Tooltip>
+            )}
+          </FileButton>
+        </div>
         <Stack gap="sm" className="flex-1">
           <div>
             <Text size="xs" className="text-text-muted mb-1">

--- a/src/app/(sidemenu)/settings/profile/WorkHoursCard.tsx
+++ b/src/app/(sidemenu)/settings/profile/WorkHoursCard.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Paper,
+  Title,
+  Text,
+  Group,
+  Button,
+  Switch,
+  Skeleton,
+  Stack,
+} from '@mantine/core';
+import { TimeInput } from '@mantine/dates';
+import { notifications } from '@mantine/notifications';
+import { IconCheck } from '@tabler/icons-react';
+import { api } from '~/trpc/react';
+
+const WORK_DAY_OPTIONS = [
+  { value: 'monday', label: 'Mon' },
+  { value: 'tuesday', label: 'Tue' },
+  { value: 'wednesday', label: 'Wed' },
+  { value: 'thursday', label: 'Thu' },
+  { value: 'friday', label: 'Fri' },
+  { value: 'saturday', label: 'Sat' },
+  { value: 'sunday', label: 'Sun' },
+] as const;
+
+const HHMM_REGEX = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+
+export function WorkHoursCard() {
+  const utils = api.useUtils();
+  const { data: workHours, isLoading } = api.user.getWorkHours.useQuery();
+
+  const [enabled, setEnabled] = useState(false);
+  const [workDays, setWorkDays] = useState<string[]>([]);
+  const [start, setStart] = useState('09:00');
+  const [end, setEnd] = useState('17:00');
+
+  useEffect(() => {
+    if (workHours) {
+      setEnabled(workHours.workHoursEnabled);
+      setWorkDays(
+        workHours.workDays.length > 0
+          ? workHours.workDays
+          : ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'],
+      );
+      setStart(workHours.workHoursStart ?? '09:00');
+      setEnd(workHours.workHoursEnd ?? '17:00');
+    }
+  }, [workHours]);
+
+  const updateWorkHours = api.user.updateWorkHours.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.user.getWorkHours.invalidate(),
+        utils.dailyPlan.getUserWorkHours.invalidate(),
+      ]);
+      notifications.show({
+        title: 'Work hours saved',
+        message: 'Daily-plan scheduling will use your new hours.',
+        color: 'green',
+        icon: <IconCheck size={16} />,
+      });
+    },
+    onError: (error) => {
+      notifications.show({
+        title: 'Error',
+        message: error.message || 'Failed to save work hours. Please try again.',
+        color: 'red',
+      });
+    },
+  });
+
+  const toggleWorkDay = (day: string) => {
+    setWorkDays((prev) =>
+      prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day],
+    );
+  };
+
+  const validTimes = HHMM_REGEX.test(start) && HHMM_REGEX.test(end);
+  const timesOrdered = !validTimes || start < end;
+
+  const handleSave = () => {
+    if (!validTimes || !timesOrdered) return;
+    updateWorkHours.mutate({
+      workHoursEnabled: enabled,
+      workDays,
+      workHoursStart: start,
+      workHoursEnd: end,
+    });
+  };
+
+  if (isLoading) {
+    return <Skeleton height={220} />;
+  }
+
+  return (
+    <Paper p="lg" withBorder className="bg-surface-secondary">
+      <Stack gap="md">
+        <Group justify="space-between" align="flex-start">
+          <div>
+            <Title order={4} className="text-text-primary">
+              Work hours
+            </Title>
+            <Text size="sm" c="dimmed" mt={4}>
+              Used by daily-plan scheduling. When off, scheduling falls back to
+              default hours.
+            </Text>
+          </div>
+          <Switch
+            checked={enabled}
+            onChange={(event) => setEnabled(event.currentTarget.checked)}
+            label="Enabled"
+            labelPosition="left"
+          />
+        </Group>
+
+        <div>
+          <Text size="sm" fw={500} className="text-text-primary mb-2">
+            Work days
+          </Text>
+          <Group gap="xs">
+            {WORK_DAY_OPTIONS.map((day) => (
+              <Button
+                key={day.value}
+                size="xs"
+                variant={workDays.includes(day.value) ? 'filled' : 'outline'}
+                color={workDays.includes(day.value) ? 'brand' : 'gray'}
+                className={
+                  workDays.includes(day.value)
+                    ? ''
+                    : 'border-border-primary text-text-primary'
+                }
+                onClick={() => toggleWorkDay(day.value)}
+                disabled={!enabled}
+              >
+                {day.label}
+              </Button>
+            ))}
+          </Group>
+        </div>
+
+        <Group gap="md" align="flex-start">
+          <TimeInput
+            label="Start time"
+            value={start}
+            onChange={(event) => setStart(event.currentTarget.value)}
+            disabled={!enabled}
+            className="flex-1"
+          />
+          <TimeInput
+            label="End time"
+            value={end}
+            onChange={(event) => setEnd(event.currentTarget.value)}
+            disabled={!enabled}
+            error={!timesOrdered ? 'End time must be after start time' : undefined}
+            className="flex-1"
+          />
+        </Group>
+
+        <Group justify="flex-end">
+          <Button
+            onClick={handleSave}
+            loading={updateWorkHours.isPending}
+            disabled={!validTimes || !timesOrdered}
+          >
+            Save work hours
+          </Button>
+        </Group>
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/app/(sidemenu)/settings/profile/page.tsx
+++ b/src/app/(sidemenu)/settings/profile/page.tsx
@@ -17,6 +17,7 @@ import {
   IconBrandGoogle,
   IconBrandNotion,
 } from '@tabler/icons-react';
+import { WorkHoursCard } from './WorkHoursCard';
 
 const PROVIDERS = [
   { id: 'discord', label: 'Discord', icon: IconBrandDiscord, color: 'indigo' },
@@ -87,6 +88,9 @@ export default function ProfileSettingsPage() {
             </Stack>
           </Group>
         </Paper>
+
+        {/* Work Hours */}
+        <WorkHoursCard />
 
         {/* Connected Accounts */}
         <div>

--- a/src/app/(sidemenu)/settings/profile/page.tsx
+++ b/src/app/(sidemenu)/settings/profile/page.tsx
@@ -1,22 +1,20 @@
 'use client';
 
-import { useSession } from 'next-auth/react';
 import {
   Container,
   Title,
   Text,
   Stack,
   Paper,
-  Avatar,
   Group,
   Badge,
-  Skeleton,
 } from '@mantine/core';
 import {
   IconBrandDiscord,
   IconBrandGoogle,
   IconBrandNotion,
 } from '@tabler/icons-react';
+import { ProfileCard } from './ProfileCard';
 import { WorkHoursCard } from './WorkHoursCard';
 
 const PROVIDERS = [
@@ -26,21 +24,6 @@ const PROVIDERS = [
 ] as const;
 
 export default function ProfileSettingsPage() {
-  const { data: session, status } = useSession();
-
-  if (status === 'loading') {
-    return (
-      <Container size="md" py="xl">
-        <Stack gap="lg">
-          <Skeleton height={32} width={120} />
-          <Skeleton height={200} />
-        </Stack>
-      </Container>
-    );
-  }
-
-  const user = session?.user;
-
   return (
     <Container size="md" py="xl">
       <Stack gap="xl">
@@ -49,45 +32,12 @@ export default function ProfileSettingsPage() {
             Profile
           </Title>
           <Text size="sm" c="dimmed" mt="xs">
-            Your account information from your sign-in provider
+            Your account information and work preferences
           </Text>
         </div>
 
         {/* User Info */}
-        <Paper p="lg" withBorder className="bg-surface-secondary">
-          <Group gap="lg" align="flex-start">
-            <Avatar
-              src={user?.image}
-              size={72}
-              radius="xl"
-              className="bg-brand-primary"
-            >
-              {user?.name
-                ?.split(' ')
-                .map((n) => n[0])
-                .join('')
-                .toUpperCase() ?? 'U'}
-            </Avatar>
-            <Stack gap="sm" className="flex-1">
-              <div>
-                <Text size="xs" className="text-text-muted mb-1">
-                  Name
-                </Text>
-                <Text size="lg" fw={500} className="text-text-primary">
-                  {user?.name ?? 'Unknown'}
-                </Text>
-              </div>
-              <div>
-                <Text size="xs" className="text-text-muted mb-1">
-                  Email
-                </Text>
-                <Text className="text-text-secondary">
-                  {user?.email ?? 'No email'}
-                </Text>
-              </div>
-            </Stack>
-          </Group>
-        </Paper>
+        <ProfileCard />
 
         {/* Work Hours */}
         <WorkHoursCard />

--- a/src/app/_components/OnboardingComponent.tsx
+++ b/src/app/_components/OnboardingComponent.tsx
@@ -197,7 +197,7 @@ export default function OnboardingPageComponent({ userName, userEmail }: Onboard
 
   // tRPC mutations
   const updateProfile = api.onboarding.updateProfile.useMutation();
-  const uploadProfileImage = api.onboarding.uploadProfileImage.useMutation();
+  const uploadProfileImage = api.user.uploadProfileImage.useMutation();
   const updateTools = api.onboarding.updateTools.useMutation();
   const updateWorkHours = api.onboarding.updateWorkHours.useMutation();
   const completeOnboarding = api.onboarding.completeOnboarding.useMutation();

--- a/src/server/api/routers/__tests__/user.test.ts
+++ b/src/server/api/routers/__tests__/user.test.ts
@@ -139,6 +139,45 @@ describe("user.updateWorkHours", () => {
   });
 });
 
+describe("user.updateProfile", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+  });
+
+  it("persists the new name to User.name", async () => {
+    db.user.update.mockResolvedValue({ name: "New Name" } as unknown as User);
+
+    const result = await caller(db).user.updateProfile({ name: "New Name" });
+
+    expect(db.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: USER_ID },
+        data: { name: "New Name" },
+      }),
+    );
+    expect(result).toEqual({ success: true, name: "New Name" });
+  });
+
+  it("rejects an empty name without writing", async () => {
+    await expect(
+      caller(db).user.updateProfile({ name: "" }),
+    ).rejects.toThrow();
+
+    expect(db.user.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects a name longer than 100 characters without writing", async () => {
+    await expect(
+      caller(db).user.updateProfile({ name: "x".repeat(101) }),
+    ).rejects.toThrow();
+
+    expect(db.user.update).not.toHaveBeenCalled();
+  });
+});
+
 describe("user.getWorkHours", () => {
   let db: DeepMockProxy<PrismaClient>;
 

--- a/src/server/api/routers/__tests__/user.test.ts
+++ b/src/server/api/routers/__tests__/user.test.ts
@@ -65,6 +65,12 @@ vi.mock("~/server/db", () => {
   return { db: proxy };
 });
 
+const uploadToBlobMock = vi.hoisted(() => vi.fn());
+vi.mock("~/lib/blob", () => ({
+  uploadToBlob: uploadToBlobMock,
+  deleteFromBlob: vi.fn(),
+}));
+
 import { createMockCaller } from "~/test/trpc-helpers";
 
 const USER_ID = "user-1";
@@ -173,6 +179,52 @@ describe("user.updateProfile", () => {
     await expect(
       caller(db).user.updateProfile({ name: "x".repeat(101) }),
     ).rejects.toThrow();
+
+    expect(db.user.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("user.uploadProfileImage", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+    uploadToBlobMock.mockReset();
+  });
+
+  it("uploads to blob storage and persists the URL to User.image", async () => {
+    uploadToBlobMock.mockResolvedValue({
+      url: "https://blob.example.com/profile-images/user-1.png",
+    });
+    db.user.update.mockResolvedValue({} as unknown as User);
+
+    const result = await caller(db).user.uploadProfileImage({
+      base64Data: Buffer.from("fake-image").toString("base64"),
+    });
+
+    expect(uploadToBlobMock).toHaveBeenCalledWith(
+      Buffer.from("fake-image").toString("base64"),
+      `profile-images/${USER_ID}.png`,
+    );
+    expect(db.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: USER_ID },
+        data: { image: "https://blob.example.com/profile-images/user-1.png" },
+      }),
+    );
+    expect(result).toEqual({
+      success: true,
+      imageUrl: "https://blob.example.com/profile-images/user-1.png",
+    });
+  });
+
+  it("does not write User.image when the blob upload fails", async () => {
+    uploadToBlobMock.mockRejectedValue(new Error("blob unavailable"));
+
+    await expect(
+      caller(db).user.uploadProfileImage({ base64Data: "aGVsbG8=" }),
+    ).rejects.toThrow("blob unavailable");
 
     expect(db.user.update).not.toHaveBeenCalled();
   });

--- a/src/server/api/routers/__tests__/user.test.ts
+++ b/src/server/api/routers/__tests__/user.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for the `user` router's Settings mutations (work hours, profile).
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient, User } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const USER_ID = "user-1";
+
+function caller(db: DeepMockProxy<PrismaClient>) {
+  return createMockCaller({ userId: USER_ID, db: db as unknown as PrismaClient });
+}
+
+describe("user.updateWorkHours", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+  });
+
+  it("persists enabled work hours to the User.workHours* fields", async () => {
+    db.user.update.mockResolvedValue({
+      workHoursEnabled: true,
+      workDaysJson: JSON.stringify(["monday", "tuesday"]),
+      workHoursStart: "10:00",
+      workHoursEnd: "16:00",
+    } as unknown as User);
+
+    const result = await caller(db).user.updateWorkHours({
+      workHoursEnabled: true,
+      workDays: ["monday", "tuesday"],
+      workHoursStart: "10:00",
+      workHoursEnd: "16:00",
+    });
+
+    expect(db.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: USER_ID },
+        data: {
+          workHoursEnabled: true,
+          workDaysJson: JSON.stringify(["monday", "tuesday"]),
+          workHoursStart: "10:00",
+          workHoursEnd: "16:00",
+        },
+      }),
+    );
+    expect(result).toEqual({
+      success: true,
+      workHoursEnabled: true,
+      workDays: ["monday", "tuesday"],
+      workHoursStart: "10:00",
+      workHoursEnd: "16:00",
+    });
+  });
+
+  it("rejects invalid HH:MM times without writing", async () => {
+    await expect(
+      caller(db).user.updateWorkHours({
+        workHoursEnabled: true,
+        workDays: ["monday"],
+        workHoursStart: "25:00",
+        workHoursEnd: "17:00",
+      }),
+    ).rejects.toThrow(/Invalid HH:MM/);
+
+    await expect(
+      caller(db).user.updateWorkHours({
+        workHoursEnabled: true,
+        workDays: ["monday"],
+        workHoursStart: "09:00",
+        workHoursEnd: "9pm",
+      }),
+    ).rejects.toThrow(/Invalid HH:MM/);
+
+    expect(db.user.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("user.getWorkHours", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+  });
+
+  it("returns stored work hours with parsed workDays", async () => {
+    db.user.findUnique.mockResolvedValue({
+      workHoursEnabled: true,
+      workDaysJson: JSON.stringify(["monday", "friday"]),
+      workHoursStart: "08:00",
+      workHoursEnd: "14:00",
+    } as unknown as User);
+
+    const result = await caller(db).user.getWorkHours();
+
+    expect(result).toEqual({
+      workHoursEnabled: true,
+      workDays: ["monday", "friday"],
+      workHoursStart: "08:00",
+      workHoursEnd: "14:00",
+    });
+  });
+
+  it("returns disabled defaults when work hours were never set", async () => {
+    db.user.findUnique.mockResolvedValue({
+      workHoursEnabled: false,
+      workDaysJson: null,
+      workHoursStart: null,
+      workHoursEnd: null,
+    } as unknown as User);
+
+    const result = await caller(db).user.getWorkHours();
+
+    expect(result).toEqual({
+      workHoursEnabled: false,
+      workDays: [],
+      workHoursStart: null,
+      workHoursEnd: null,
+    });
+  });
+
+  it("tolerates malformed workDaysJson", async () => {
+    db.user.findUnique.mockResolvedValue({
+      workHoursEnabled: true,
+      workDaysJson: "not-json",
+      workHoursStart: "09:00",
+      workHoursEnd: "17:00",
+    } as unknown as User);
+
+    const result = await caller(db).user.getWorkHours();
+
+    expect(result.workDays).toEqual([]);
+  });
+});

--- a/src/server/api/routers/onboarding.ts
+++ b/src/server/api/routers/onboarding.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
-import { uploadToBlob } from "~/lib/blob";
 import { slugify } from "~/utils/slugify";
 import {
   ONBOARDING_PROJECT_NAME,
@@ -101,38 +100,6 @@ export const onboardingRouter = createTRPCRouter({
         emailMarketingOptIn: updatedUser.emailMarketingOptIn,
         attributionSource: updatedUser.attributionSource,
         nextStep: updatedUser.onboardingStep,
-      };
-    }),
-
-  /**
-   * Upload profile image and save URL to user record
-   */
-  uploadProfileImage: protectedProcedure
-    .input(
-      z.object({
-        base64Data: z.string(),
-        contentType: z.string().optional(),
-      })
-    )
-    .mutation(async ({ ctx, input }) => {
-      const { base64Data } = input;
-      const userId = ctx.session.user.id;
-
-      // Upload to Vercel Blob
-      const filename = `profile-images/${userId}.png`;
-      const blob = await uploadToBlob(base64Data, filename);
-
-      // Update user's image field
-      await ctx.db.user.update({
-        where: { id: userId },
-        data: {
-          image: blob.url,
-        },
-      });
-
-      return {
-        success: true,
-        imageUrl: blob.url,
       };
     }),
 

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -191,6 +191,72 @@ export const userRouter = createTRPCRouter({
       return project;
     }),
 
+  getWorkHours: protectedProcedure
+    .query(async ({ ctx }) => {
+      const user = await ctx.db.user.findUnique({
+        where: { id: ctx.session.user.id },
+        select: {
+          workHoursEnabled: true,
+          workDaysJson: true,
+          workHoursStart: true,
+          workHoursEnd: true,
+        },
+      });
+
+      let workDays: string[] = [];
+      if (user?.workDaysJson) {
+        try {
+          workDays = JSON.parse(user.workDaysJson) as string[];
+        } catch {
+          workDays = [];
+        }
+      }
+
+      return {
+        workHoursEnabled: user?.workHoursEnabled ?? false,
+        workDays,
+        workHoursStart: user?.workHoursStart ?? null,
+        workHoursEnd: user?.workHoursEnd ?? null,
+      };
+    }),
+
+  updateWorkHours: protectedProcedure
+    .input(
+      z.object({
+        workHoursEnabled: z.boolean(),
+        workDays: z.array(z.string()), // ["monday", "tuesday", ...]
+        workHoursStart: z.string().regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/, 'Invalid HH:MM (00:00-23:59)'),
+        workHoursEnd: z.string().regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/, 'Invalid HH:MM (00:00-23:59)'),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { workHoursEnabled, workDays, workHoursStart, workHoursEnd } = input;
+
+      const updatedUser = await ctx.db.user.update({
+        where: { id: ctx.session.user.id },
+        data: {
+          workHoursEnabled,
+          workDaysJson: JSON.stringify(workDays),
+          workHoursStart,
+          workHoursEnd,
+        },
+        select: {
+          workHoursEnabled: true,
+          workDaysJson: true,
+          workHoursStart: true,
+          workHoursEnd: true,
+        },
+      });
+
+      return {
+        success: true,
+        workHoursEnabled: updatedUser.workHoursEnabled,
+        workDays: updatedUser.workDaysJson ? JSON.parse(updatedUser.workDaysJson) as string[] : [],
+        workHoursStart: updatedUser.workHoursStart,
+        workHoursEnd: updatedUser.workHoursEnd,
+      };
+    }),
+
   completeWelcome: protectedProcedure
     .mutation(async ({ ctx }) => {
       const userId = ctx.session.user.id;

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -191,6 +191,43 @@ export const userRouter = createTRPCRouter({
       return project;
     }),
 
+  getProfile: protectedProcedure
+    .query(async ({ ctx }) => {
+      const user = await ctx.db.user.findUnique({
+        where: { id: ctx.session.user.id },
+        select: {
+          name: true,
+          email: true,
+          image: true,
+        },
+      });
+
+      if (!user) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "User not found",
+        });
+      }
+
+      return user;
+    }),
+
+  updateProfile: protectedProcedure
+    .input(
+      z.object({
+        name: z.string().min(1).max(100),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const updatedUser = await ctx.db.user.update({
+        where: { id: ctx.session.user.id },
+        data: { name: input.name },
+        select: { name: true },
+      });
+
+      return { success: true, name: updatedUser.name };
+    }),
+
   getWorkHours: protectedProcedure
     .query(async ({ ctx }) => {
       const user = await ctx.db.user.findUnique({

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { completeOnboardingStep } from "~/server/services/onboarding/syncOnboardingProgress";
+import { uploadToBlob } from "~/lib/blob";
 
 export const userRouter = createTRPCRouter({
   getCurrentUser: protectedProcedure
@@ -226,6 +227,39 @@ export const userRouter = createTRPCRouter({
       });
 
       return { success: true, name: updatedUser.name };
+    }),
+
+  /**
+   * Upload profile image and save URL to user record.
+   * (Re-homed from the onboarding router; same behavior.)
+   */
+  uploadProfileImage: protectedProcedure
+    .input(
+      z.object({
+        base64Data: z.string(),
+        contentType: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { base64Data } = input;
+      const userId = ctx.session.user.id;
+
+      // Upload to Vercel Blob
+      const filename = `profile-images/${userId}.png`;
+      const blob = await uploadToBlob(base64Data, filename);
+
+      // Update user's image field
+      await ctx.db.user.update({
+        where: { id: userId },
+        data: {
+          image: blob.url,
+        },
+      });
+
+      return {
+        success: true,
+        imageUrl: blob.url,
+      };
     }),
 
   getWorkHours: protectedProcedure


### PR DESCRIPTION
### **User description**
## What

Makes work hours and profile (name + photo) editable on the existing `/settings/profile` page, re-homing capture from the onboarding wizard before it is retired in V3 (feature `cmrov1scr0007jx04neuxelh2`, scope V2).

- New `user.updateWorkHours` mutation (HH:MM-validated, same input schema as the wizard's) + Work hours card; saving invalidates `dailyPlan.getUserWorkHours` so the daily-plan TimeGrid renders the chosen window
- New `user.updateProfile({ name })` mutation + inline name editing (DB-backed `user.getProfile` so edits show without re-login)
- `uploadProfileImage` moved from the onboarding router to the user router unchanged; wizard call-site repointed (wizard stays alive during V2); avatar upload UI added

## Acceptance criteria

- [x] V2 requirement rows met: work hours persist to `User.workHours*` and scheduling uses them; unset work hours fall back to scheduler defaults; name/photo edits persist to `User.name`/`User.image`
- [x] No attribution / email-opt-in / tools fields reintroduced
- [x] Mocked-caller tests (`createMockCaller`) for all three mutations, incl. HH:MM rejection and mocked `uploadToBlob`

---

Ships: copper.reed


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add editable profile (name + photo) and work hours to `/settings/profile` page

- New `user.updateProfile`, `user.getProfile`, `user.updateWorkHours`, `user.getWorkHours`, and `user.uploadProfileImage` tRPC mutations

- Move `uploadProfileImage` from onboarding router to user router; repoint wizard call-site

- Add mocked-caller unit tests for all new mutations including validation edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Settings Profile Page"] -- "renders" --> B["ProfileCard"]
  A -- "renders" --> C["WorkHoursCard"]
  B -- "calls" --> D["user.getProfile\nuser.updateProfile\nuser.uploadProfileImage"]
  C -- "calls" --> E["user.getWorkHours\nuser.updateWorkHours"]
  F["OnboardingComponent"] -- "repointed to" --> D
  G["onboarding router"] -- "uploadProfileImage removed" --> H["user router"]
  D -- "persists to" --> I["User.name / User.image"]
  E -- "persists to" --> J["User.workHours*"]
  E -- "invalidates" --> K["dailyPlan.getUserWorkHours"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>ProfileCard.tsx</strong><dd><code>New editable profile card with name and photo upload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/389/files#diff-dad83492d989a725ba7a46e8e4684db5c7570fbae7c5f5df609a2ebd8abc199c">+211/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>WorkHoursCard.tsx</strong><dd><code>New work hours card with day/time selectors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/389/files#diff-dd6efeaa080fe4799606626155af41558c77b8fad3a6ff93b45d6c2cc27269c5">+174/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Replace static profile UI with ProfileCard and WorkHoursCard</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/389/files#diff-f20c9b97cf1976351dbe13e6cac6112339b5c2c4471e8c8025b111dece62b6e1">+7/-53</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OnboardingComponent.tsx</strong><dd><code>Repoint uploadProfileImage call to user router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/389/files#diff-a8fc3dccb34aa4605234c268817c47a07aa3965d688ca1687ddea17b8f23d13e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>onboarding.ts</strong><dd><code>Remove uploadProfileImage from onboarding router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/389/files#diff-a3e17b252ffc68a99cff4226fc92b133253c8eefa125da3fca4dd70f6b2b9288">+0/-33</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>user.ts</strong><dd><code>Add getProfile, updateProfile, uploadProfileImage, getWorkHours, </code><br><code>updateWorkHours</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/389/files#diff-0be33a0caef24060bbdb3f9704a54d9ab53e0e233001120194cf64f87026a3d6">+137/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>user.test.ts</strong><dd><code>Add mocked-caller tests for all new user mutations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/389/files#diff-db0aba300672c8b9c59ac8fd2421d3b2b8aabe480ce5d8a86b079cb01c9b3252">+289/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

