### PR TITLE
docs: route feature work to /to-prd → /to-robo-prd → /to-tickets; add Wayfinding operations

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -61,8 +61,9 @@ exponential tickets list --product exponential --status BLOCKED --json          
 
 ## When a skill says "publish to the issue tracker"
 
-- If the source is a **plan, spec, or PRD that needs to be broken into multiple tickets**: invoke `/to-expo`. It handles vertical slicing, dependency wiring, and decision comments.
-- If the source is a **single ticket** (e.g. a PRD as a feature, or a one-off bug): run `exponential tickets create ...` directly, or `exponential features create ...` for PRD-shaped work.
+- If the source is **feature work** (a PRD-shaped plan for a product capability): follow the registry flow — `/to-prd` (human PRD page + native EARS requirement rows on the Feature) → `/to-robo-prd` (Agent PRD on the same page) → `/to-tickets` (few tickets, default one per scope, with the vertical slices as ordered actions). Do NOT route feature work to `/to-expo`.
+- If the source is a **loose plan that doesn't belong to a registry feature** (a cross-product epic, standalone chores): invoke `/to-expo`. It handles vertical slicing, dependency wiring, and decision comments.
+- If the source is a **single ticket** (e.g. a one-off bug): run `exponential tickets create ...` directly.
 
 ## When a skill says "fetch the relevant ticket"
 
@@ -76,3 +77,15 @@ This repo ALSO uses [beads](https://github.com/beads-project/beads) for fine-gra
 - **Beads issues** — implementation-scope tracking inside a single session or PR: "I'm about to write code, claim it, close it when committed."
 
 When in doubt for skill-driven flows (`/triage`, `/to-issues`, `/to-prd`, `/qa`), use **Exponential**. Beads remains the right answer for the day-to-day `bd ready → bd update → bd close` loop.
+
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a Feature; its tickets are the map's children.
+
+- **Map**: a Feature named `Wayfinder: <destination>` (`exponential features create --product exponential -n "Wayfinder: <destination>" -d "<one-line destination>" --status DEFINED --json`). The map body (Notes / Decisions-so-far / Fog) lives on a linked Knowledge page: `exponential pages create -t "Wayfinder map: <destination>" --body-file <path> --json`, then `exponential features link-page --feature <id> --page <id>`. Use an **epic** instead of a feature only when the destination spans products.
+- **Child ticket**: a ticket under the map feature (`exponential tickets create --product exponential --feature <map-feature-cuid> ...`). Ticket types map as: `research` → `RESEARCH`, `grilling` → `RESEARCH`, `prototype` → `SPIKE`, `task` → `CHORE`. HITL types (`grilling`, `prototype`) get `--status NEEDS_REFINEMENT`; AFK types (`research`, and `task` when an agent can do it) get `--status READY_TO_PLAN`.
+- **Blocking**: native edges — `exponential tickets block <child-cuid> --by <blocker-cuid>`. A ticket is unblocked when `openBlockerCount` is 0.
+- **Frontier query**: `exponential tickets list --feature <map-feature-cuid> --json`, keep open tickets with `openBlockerCount == 0` and no assignee; first in map order wins.
+- **Claim**: `exponential tickets update --id <cuid> --assignee <user-id>` — the session's first write. The assignee is the claim.
+- **Resolve**: `exponential tickets comment add --id <cuid> -m "<the decision>"`, then `exponential tickets update --id <cuid> --status DONE`, then update the map page's Decisions-so-far with a one-line gist + the ticket CUID (`exponential pages update`).


### PR DESCRIPTION
### **User description**
Agent-facing tracker doc fixes:

1. The "publish to the issue tracker" rule predated `/to-tickets` and sent all plan-shaped work to `/to-expo` — so grilling sessions kept recommending `/to-expo` for feature work. Feature work now routes `/to-prd` → `/to-robo-prd` → `/to-tickets`; `/to-expo` stays for loose plans outside the feature registry.
2. Adds the **Wayfinding operations** section `/wayfinder` reads (map = Feature + linked Knowledge page, children = tickets with native blocking, assignee-as-claim).

Docs only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Reroute feature work from `/to-expo` to `/to-prd` → `/to-robo-prd` → `/to-tickets`

- Restrict `/to-expo` to loose plans outside the feature registry

- Add new **Wayfinding operations** section for `/wayfinder` agent usage

- Document map creation, child tickets, blocking, frontier query, claim, and resolve flows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Feature Work (PRD-shaped)"] -- "/to-prd" --> B["Human PRD page + EARS rows"]
  B -- "/to-robo-prd" --> C["Agent PRD on same page"]
  C -- "/to-tickets" --> D["Tickets (one per scope)"]
  E["Loose Plan (cross-product/chores)"] -- "/to-expo" --> F["Vertical slices + dependency wiring"]
  G["Single Ticket (one-off bug)"] -- "exponential tickets create" --> H["Direct ticket creation"]
  I["Wayfinder Map (Feature)"] -- "child tickets" --> J["Research / Spike / Chore tickets"]
  J -- "native blocking edges" --> K["Frontier: unblocked + unassigned"]
  K -- "claim (assignee)" --> L["Resolve + update map page"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issue-tracker.md</strong><dd><code>Fix feature routing and add Wayfinding operations docs</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/agents/issue-tracker.md

<ul><li>Replaced the single "plan/spec/PRD" bullet with a dedicated **feature <br>work** route: <code>/to-prd</code> → <code>/to-robo-prd</code> → <code>/to-tickets</code><br> <li> Narrowed <code>/to-expo</code> usage to loose plans that don't belong to a registry <br>feature<br> <li> Simplified the single-ticket bullet to cover only one-off bugs<br> <li> Added a new **Wayfinding operations** section documenting map <br>creation, child ticket types, blocking edges, frontier query, claim, <br>and resolve steps</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/390/files#diff-ae2f28c43b72f5b82620c61d5ddc59e68e532d376d179e566977594258d46116">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

