### PR TITLE
feat: Matrix settings surface — matrixGateway tRPC router + MatrixGatewayCard

### DIFF
--- a/src/app/(sidemenu)/settings/assistant/page.tsx
+++ b/src/app/(sidemenu)/settings/assistant/page.tsx
@@ -18,6 +18,7 @@ import { useState, useEffect } from 'react';
 import { api } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { TelegramGatewayCard } from '~/app/_components/TelegramGatewayCard';
+import { MatrixGatewayCard } from '~/app/_components/MatrixGatewayCard';
 
 const PERSONALITY_PLACEHOLDER = `Example: You're warm, direct, and a little playful. You have opinions and share them honestly. Skip the corporate tone — be real. When something doesn't add up, say so (kindly). You're genuinely helpful, not performatively helpful.`;
 
@@ -243,6 +244,9 @@ export default function AssistantSettingsPage() {
 
         {/* Telegram Integration */}
         <TelegramGatewayCard assistantSaved={!!assistant || saved} />
+
+        {/* Matrix Integration */}
+        <MatrixGatewayCard assistantSaved={!!assistant || saved} />
 
         {/* Save */}
         <Stack gap="sm">

--- a/src/app/_components/MatrixGatewayCard.tsx
+++ b/src/app/_components/MatrixGatewayCard.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import {
+  Card,
+  Text,
+  Button,
+  Group,
+  Badge,
+  Stack,
+  TextInput,
+  Code,
+  Loader,
+} from "@mantine/core";
+import { IconMessageCircle } from "@tabler/icons-react";
+import { api } from "~/trpc/react";
+
+interface MatrixGatewayCardProps {
+  assistantSaved?: boolean;
+  /** When true, renders without the outer Card wrapper (for use inside a Modal) */
+  embedded?: boolean;
+}
+
+/**
+ * "Connect Matrix" card for /settings/assistant, mirroring TelegramGatewayCard.
+ * Flow difference (ADR-0043): the user enters their Matrix ID, the BOT creates
+ * an unencrypted DM and invites them, and they reply there with the pairing
+ * code shown here — the bot cannot read user-created (encrypted) DMs.
+ */
+export function MatrixGatewayCard({
+  assistantSaved = false,
+  embedded = false,
+}: MatrixGatewayCardProps) {
+  const [mxid, setMxid] = useState("");
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const status = api.matrixGateway.getStatus.useQuery(undefined, {
+    refetchOnWindowFocus: true,
+  });
+
+  const initiatePairing = api.matrixGateway.initiatePairing.useMutation({
+    onSuccess: () => {
+      // Start polling for pairing completion
+      pollRef.current = setInterval(() => {
+        void status.refetch();
+      }, 2500);
+    },
+  });
+
+  const disconnect = api.matrixGateway.disconnect.useMutation({
+    onSuccess: () => {
+      void status.refetch();
+    },
+  });
+
+  // Stop polling when paired
+  useEffect(() => {
+    if (status.data?.paired && pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [status.data?.paired]);
+
+  const isPaired = status.data?.paired;
+  const isPairing = initiatePairing.isSuccess && !isPaired;
+
+  const content = (
+    <>
+      {!embedded && (
+        <Group justify="space-between" mb="md">
+          <Group gap="sm">
+            <IconMessageCircle size={24} className="text-brand-primary" />
+            <Text fw={600} className="text-text-primary">
+              Matrix
+            </Text>
+          </Group>
+          <Badge color={isPaired ? "green" : "gray"} variant="light">
+            {isPaired ? "Connected" : "Not connected"}
+          </Badge>
+        </Group>
+      )}
+
+      {isPaired ? (
+        <Stack gap="sm">
+          <Text size="sm" className="text-text-secondary">
+            Connected as <b>{status.data?.mxid}</b>
+          </Text>
+          <Text size="xs" className="text-text-muted">
+            Switch agents from the chat with <Code>!agent NAME</Code>, or
+            @mention one inline.
+          </Text>
+
+          <Button
+            variant="light"
+            color="red"
+            onClick={() => disconnect.mutate()}
+            loading={disconnect.isPending}
+          >
+            Disconnect Matrix
+          </Button>
+        </Stack>
+      ) : isPairing ? (
+        <Stack gap="sm" align="center">
+          <Text size="sm" ta="center" className="text-text-secondary">
+            <b>{initiatePairing.data?.botUserId}</b> has invited you to a chat.
+            Accept the invite in your Matrix client, then send this code there:
+          </Text>
+
+          <Code fz="xl" px="md" py="xs">
+            {initiatePairing.data?.pairingCode}
+          </Code>
+
+          <Group gap="xs">
+            <Loader size="xs" />
+            <Text size="xs" className="text-text-muted">
+              Waiting for you to send the code... (expires in{" "}
+              {Math.round((initiatePairing.data?.expiresInSeconds ?? 600) / 60)}{" "}
+              minutes)
+            </Text>
+          </Group>
+        </Stack>
+      ) : (
+        <Stack gap="sm">
+          <Text size="sm" className="text-text-secondary">
+            Chat with your AI assistant from any Matrix client (Element, etc.).
+          </Text>
+
+          <TextInput
+            label="Your Matrix ID"
+            placeholder="@you:syntro.fi"
+            value={mxid}
+            onChange={(e) => setMxid(e.currentTarget.value)}
+            error={
+              initiatePairing.error ? initiatePairing.error.message : undefined
+            }
+            classNames={{
+              input:
+                "bg-surface-primary border-border-primary text-text-primary",
+              label: "text-text-secondary",
+            }}
+          />
+
+          <Button
+            onClick={() => initiatePairing.mutate({ mxid: mxid.trim() })}
+            loading={initiatePairing.isPending}
+            leftSection={<IconMessageCircle size={18} />}
+            disabled={!assistantSaved || !mxid.trim()}
+          >
+            {assistantSaved ? "Connect Matrix" : "1st - Click Update Assistant"}
+          </Button>
+        </Stack>
+      )}
+    </>
+  );
+
+  if (embedded) return content;
+
+  return (
+    <Card
+      className="bg-surface-secondary border-border-primary"
+      withBorder
+      radius="md"
+      p="lg"
+    >
+      {content}
+    </Card>
+  );
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -27,6 +27,7 @@ import { featureRequestRouter } from "./routers/featureRequest";
 import { whatsappRouter } from "./routers/whatsapp";
 import { whatsappGatewayRouter } from "./routers/whatsappGateway";
 import { telegramGatewayRouter } from "./routers/telegramGateway";
+import { matrixGatewayRouter } from "./routers/matrixGateway";
 import { notificationRouter } from "./routers/notification";
 import { pushSubscriptionRouter } from "./routers/pushSubscription";
 import { onboardingRouter } from "./routers/onboarding";
@@ -120,6 +121,7 @@ export const appRouter = createTRPCRouter({
   whatsapp: whatsappRouter,
   whatsappGateway: whatsappGatewayRouter,
   telegramGateway: telegramGatewayRouter,
+  matrixGateway: matrixGatewayRouter,
   notification: notificationRouter,
   pushSubscription: pushSubscriptionRouter,
   onboarding: onboardingRouter,

--- a/src/server/api/routers/__tests__/matrixGateway.test.ts
+++ b/src/server/api/routers/__tests__/matrixGateway.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for the `matrixGateway` router (ADR-0043).
+ *
+ * Mirrors the telegramGateway surface but with no session table: live status
+ * comes from the gateway HTTP API (mocked fetch here), the DB fallback is the
+ * IntegrationUserMapping row under the system "matrix" Integration.
+ * Uses `mockDeep<PrismaClient>()` — no real DB, ever.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const USER_ID = "user-1";
+const MXID = "@james:syntro.fi";
+
+function okJson(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("matrixGateway router (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("getStatus", () => {
+    it("returns live gateway status when the gateway is reachable", async () => {
+      fetchMock.mockResolvedValue(okJson({ paired: true, mxid: MXID, agentId: "zoe" }));
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(caller.matrixGateway.getStatus()).resolves.toMatchObject({
+        paired: true,
+        mxid: MXID,
+      });
+      expect(dbMock.integrationUserMapping.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the IntegrationUserMapping row when the gateway is unreachable", async () => {
+      fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+      dbMock.integrationUserMapping.findFirst.mockResolvedValue({
+        externalUserId: MXID,
+        userId: USER_ID,
+      } as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(caller.matrixGateway.getStatus()).resolves.toEqual({
+        paired: true,
+        mxid: MXID,
+      });
+    });
+
+    it("reports unpaired when the gateway is down and no mapping exists", async () => {
+      fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+      dbMock.integrationUserMapping.findFirst.mockResolvedValue(null as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(caller.matrixGateway.getStatus()).resolves.toMatchObject({
+        paired: false,
+      });
+    });
+  });
+
+  describe("initiatePairing", () => {
+    it("rejects an invalid Matrix ID before touching the gateway", async () => {
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.matrixGateway.initiatePairing({ mxid: "not-an-mxid" }),
+      ).rejects.toThrow(/Matrix ID/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("passes mxid + default-assistant context to the gateway and returns the code", async () => {
+      dbMock.assistant.findFirst.mockResolvedValue({
+        id: "asst-1",
+        name: "Zoe",
+        workspaceId: "ws-1",
+      } as never);
+      fetchMock.mockResolvedValue(
+        okJson({
+          pairingCode: "A3F1B2",
+          roomId: "!dm:syntro.fi",
+          botUserId: "@zoe:syntro.fi",
+          expiresInSeconds: 600,
+        }),
+      );
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      const result = await caller.matrixGateway.initiatePairing({ mxid: MXID });
+
+      expect(result).toMatchObject({ pairingCode: "A3F1B2", botUserId: "@zoe:syntro.fi" });
+      const [url, init] = fetchMock.mock.calls[0]!;
+      expect(String(url)).toContain("/pair");
+      expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({
+        mxid: MXID,
+        agentId: "assistant",
+        assistantId: "asst-1",
+        assistantName: "Zoe",
+        workspaceId: "ws-1",
+      });
+    });
+
+    it("surfaces a friendly error when the gateway is unreachable", async () => {
+      dbMock.assistant.findFirst.mockResolvedValue(null as never);
+      fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.matrixGateway.initiatePairing({ mxid: MXID }),
+      ).rejects.toThrow(TRPCError);
+      await expect(
+        caller.matrixGateway.initiatePairing({ mxid: MXID }),
+      ).rejects.toThrow(/Unable to reach the Matrix gateway/);
+    });
+  });
+
+  describe("disconnect", () => {
+    it("calls the gateway and always clears the mapping row", async () => {
+      fetchMock.mockResolvedValue(okJson({ success: true }));
+      dbMock.integrationUserMapping.deleteMany.mockResolvedValue({ count: 1 } as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(caller.matrixGateway.disconnect()).resolves.toEqual({ success: true });
+
+      const [url, init] = fetchMock.mock.calls[0]!;
+      expect(String(url)).toContain("/pair");
+      expect((init as RequestInit).method).toBe("DELETE");
+      expect(dbMock.integrationUserMapping.deleteMany).toHaveBeenCalledWith({
+        where: {
+          userId: USER_ID,
+          integration: { provider: "matrix", status: "ACTIVE", userId: null },
+        },
+      });
+    });
+
+    it("still succeeds (and clears the mapping) when the gateway is down", async () => {
+      fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+      dbMock.integrationUserMapping.deleteMany.mockResolvedValue({ count: 1 } as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(caller.matrixGateway.disconnect()).resolves.toEqual({ success: true });
+      expect(dbMock.integrationUserMapping.deleteMany).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/api/routers/matrixGateway.ts
+++ b/src/server/api/routers/matrixGateway.ts
@@ -1,0 +1,156 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { generateJWT } from "~/server/utils/jwt";
+
+const MATRIX_GATEWAY_URL =
+  process.env.MATRIX_GATEWAY_URL ?? "http://localhost:4114";
+
+const MXID_PATTERN = /^@[^:\s]+:\S+$/;
+
+/**
+ * Mirrors telegramGateway procedure-for-procedure, with one structural
+ * difference: there is no MatrixGatewaySession table (V1 is deliberately
+ * migration-free). Live status comes from the gateway; the DB fallback is the
+ * IntegrationUserMapping row under the system "matrix" Integration (ADR-0043).
+ */
+export const matrixGatewayRouter = createTRPCRouter({
+  // Check if user has a connected Matrix account
+  getStatus: protectedProcedure.query(async ({ ctx }) => {
+    try {
+      const authToken = generateJWT(ctx.session.user, {
+        tokenType: "matrix-gateway",
+      });
+      const res = await fetch(`${MATRIX_GATEWAY_URL}/status`, {
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      if (res.ok) {
+        return (await res.json()) as {
+          paired: boolean;
+          mxid?: string;
+          agentId?: string;
+          lastActive?: string;
+        };
+      }
+    } catch (error) {
+      console.error("[matrixGateway] Failed to check gateway status:", error);
+    }
+
+    // Fallback to DB truth: a pairing mapping under the system matrix Integration
+    const mapping = await ctx.db.integrationUserMapping.findFirst({
+      where: {
+        userId: ctx.session.user.id,
+        integration: { provider: "matrix", status: "ACTIVE", userId: null },
+      },
+    });
+
+    return {
+      paired: !!mapping,
+      mxid: mapping?.externalUserId,
+    };
+  }),
+
+  // Begin pairing: the gateway creates the unencrypted DM and returns the code
+  initiatePairing: protectedProcedure
+    .input(
+      z.object({
+        mxid: z
+          .string()
+          .regex(
+            MXID_PATTERN,
+            "Enter your full Matrix ID, e.g. @you:syntro.fi",
+          ),
+        agentId: z.string().default("assistant"),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const authToken = generateJWT(ctx.session.user, {
+        tokenType: "matrix-gateway",
+      });
+
+      // Look up the user's default assistant to pass its name to the gateway
+      const assistant = await ctx.db.assistant.findFirst({
+        where: { createdById: ctx.session.user.id, isDefault: true },
+        select: { name: true, id: true, workspaceId: true },
+      });
+
+      let res: Response;
+      try {
+        res = await fetch(`${MATRIX_GATEWAY_URL}/pair`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            mxid: input.mxid,
+            agentId: input.agentId,
+            assistantId: assistant?.id,
+            assistantName: assistant?.name,
+            workspaceId: assistant?.workspaceId,
+          }),
+        });
+      } catch (error) {
+        console.error(
+          "[matrixGateway] Failed to reach gateway for pairing:",
+          error,
+        );
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message:
+            "Unable to reach the Matrix gateway service. Please try again later.",
+        });
+      }
+
+      if (!res.ok) {
+        const error = (await res.json().catch(() => ({
+          error: "Gateway error",
+        }))) as { error: string };
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: error.error ?? `Gateway returned ${res.status}`,
+        });
+      }
+
+      const data = (await res.json()) as {
+        pairingCode: string;
+        roomId: string | null;
+        botUserId: string;
+        expiresInSeconds: number;
+      };
+
+      return data;
+    }),
+
+  // Disconnect Matrix account
+  disconnect: protectedProcedure.mutation(async ({ ctx }) => {
+    const authToken = generateJWT(ctx.session.user, {
+      tokenType: "matrix-gateway",
+    });
+
+    try {
+      await fetch(`${MATRIX_GATEWAY_URL}/pair`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+    } catch (error) {
+      console.error(
+        "[matrixGateway] Failed to call gateway disconnect:",
+        error,
+      );
+    }
+
+    // Always clear the mapping row too, so disconnect works even when the
+    // gateway is unreachable (the gateway's own unpair also deletes it; both
+    // paths are idempotent).
+    await ctx.db.integrationUserMapping.deleteMany({
+      where: {
+        userId: ctx.session.user.id,
+        integration: { provider: "matrix", status: "ACTIVE", userId: null },
+      },
+    });
+
+    return { success: true };
+  }),
+});


### PR DESCRIPTION
### **User description**
## What

The user-facing connect flow: a matrixGateway tRPC router mirroring telegramGateway (getStatus / initiatePairing / disconnect, minting matrix-gateway JWTs, MATRIX_GATEWAY_URL default http://localhost:4114) and a MatrixGatewayCard beside the Telegram card on /settings/assistant. Structural difference from Telegram: no session table — live status from the gateway, DB fallback via IntegrationUserMapping (V1 stays migration-free). The card collects the user's Matrix ID (the gateway creates the unencrypted DM per ADR-0043), then shows the pairing code + waiting state with 2.5s polling.

## Acceptance criteria

- [x] Connect Matrix produces a code with clear send-it-in-the-bot-room instructions; card reflects paired status after redemption (poll + refetch)
- [x] Disconnect unpairs (gateway + mapping row) and the card returns to unconnected state — works even when the gateway is down
- [x] Gateway unreachable → friendly TRPCError, no crash
- [x] Router unit tests with createMockCaller and mocked fetch (8 tests; full unit suite green)
- [x] tsc + eslint clean (8GB-heap direct runs; stock scripts OOM at inline 4GB)

Semantic color tokens only; Mantine components.

---

Ships: micro.ember

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cmroxzqzb0005l504jg3b3jt0)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `matrixGateway` tRPC router with `getStatus`, `initiatePairing`, `disconnect` procedures

- Add `MatrixGatewayCard` React component for Matrix connect flow on `/settings/assistant`

- Register `matrixGatewayRouter` in the app tRPC root router

- Add 8 unit tests covering all router procedures with mocked fetch and DB


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["/settings/assistant page"] -- "renders" --> B["MatrixGatewayCard"]
  B -- "tRPC calls" --> C["matrixGateway router"]
  C -- "registered in" --> D["appRouter (root.ts)"]
  C -- "getStatus / initiatePairing / disconnect" --> E["Matrix Gateway HTTP API\n(MATRIX_GATEWAY_URL)"]
  C -- "DB fallback" --> F["IntegrationUserMapping\n(Prisma)"]
  G["matrixGateway.test.ts"] -- "unit tests" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add MatrixGatewayCard to assistant settings page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/settings/assistant/page.tsx

<ul><li>Import <code>MatrixGatewayCard</code> component<br> <li> Render <code>MatrixGatewayCard</code> below the existing <code>TelegramGatewayCard</code> in the <br>assistant settings page</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/393/files#diff-d9f7f588f4bc2604b38f6b2f96ce43638d22aeba7351f9eccd797504c5e40cee">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MatrixGatewayCard.tsx</strong><dd><code>New MatrixGatewayCard component for Matrix connect flow</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/MatrixGatewayCard.tsx

<ul><li>New client component mirroring <code>TelegramGatewayCard</code> for Matrix connect <br>flow<br> <li> Three UI states: unconnected (Matrix ID input + connect button), <br>pairing (show code + polling loader), paired (connected info + <br>disconnect button)<br> <li> Polls gateway every 2.5s after pairing initiation; stops polling when <br>paired<br> <li> Supports <code>embedded</code> prop to render without outer <code>Card</code> wrapper</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/393/files#diff-8253c888c1d3e11e33b0a563040f6294b0815df233805face0f208bc5a74e7b3">+171/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>matrixGateway.ts</strong><dd><code>New matrixGateway tRPC router with three procedures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/matrixGateway.ts

<ul><li>New tRPC router with three protected procedures: <code>getStatus</code>, <br><code>initiatePairing</code>, <code>disconnect</code><br> <li> <code>getStatus</code> fetches live status from gateway, falls back to <br><code>IntegrationUserMapping</code> DB row<br> <li> <code>initiatePairing</code> validates Matrix ID format, calls gateway <code>/pair</code> POST <br>with assistant context, returns pairing code<br> <li> <code>disconnect</code> calls gateway DELETE and always clears the DB mapping row <br>(idempotent, works when gateway is down)</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/393/files#diff-1a88de67850480195d09678a44ad34d6efa1fd3afd9e633343da03bf6bdd4991">+156/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>root.ts</strong><dd><code>Register matrixGatewayRouter in tRPC app router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/root.ts

<ul><li>Import <code>matrixGatewayRouter</code> from the new router file<br> <li> Register <code>matrixGateway</code> key in the <code>appRouter</code> object</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/393/files#diff-6a8cad7e52067d5afa93671900c038e0e0a9526f8f0e3bd10985cecf4295b4fc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>matrixGateway.test.ts</strong><dd><code>Unit tests for matrixGateway router with mocked fetch and DB</code></dd></summary>
<hr>

src/server/api/routers/__tests__/matrixGateway.test.ts

<ul><li>8 unit tests covering <code>getStatus</code>, <code>initiatePairing</code>, and <code>disconnect</code> <br>procedures<br> <li> Uses <code>mockDeep<PrismaClient>()</code> for DB mocking and <code>vi.stubGlobal("fetch", ...)</code> for <br>HTTP mocking<br> <li> Tests cover: live gateway response, DB fallback, gateway-down <br>scenarios, invalid Matrix ID rejection, and disconnect idempotency</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/393/files#diff-202655c3b86581e335a7cdd7df9cd37caa6659e1ce0e3eae58e21c46923e221b">+217/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

