### PR TITLE
feat: derive Action.source from the caller's JWT token type (Matrix provenance)

### DIFF
--- a/src/app/api/webhooks/slack/route.ts
+++ b/src/app/api/webhooks/slack/route.ts
@@ -1003,6 +1003,7 @@ async function chatWithZoeUsingTRPC(
     const caller = createCaller({
       db,
       session: mockSession,
+      tokenType: undefined,
       headers: new Headers() // Mock headers for server-side call
     });
 

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -7,6 +7,7 @@ import { PRIORITY_VALUES } from "~/types/priority";
 import { getKnowledgeService } from "~/server/services/KnowledgeService";
 import { generateAgentJWT, generateJWT } from "~/server/utils/jwt";
 import { capToolCallsForTurn, redactToolArgs } from "~/server/utils/redactToolArgs";
+import { deriveActionSource } from "~/server/utils/actionSource";
 import jwt from "jsonwebtoken";
 import crypto from "crypto";
 import { testFirefliesConnection } from "./integration";
@@ -1198,7 +1199,7 @@ export const mastraRouter = createTRPCRouter({
           createdById: userId,
           scheduledStart: parsed.scheduledStart,
           dueDate: parsed.dueDate,
-          source: "whatsapp",
+          source: deriveActionSource(ctx.tokenType),
           kanbanStatus: parsed.projectId ? "TODO" : null,
           kanbanOrder,
           workspaceId: quickMastraWsId,

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -120,6 +120,9 @@ export const createTRPCContext = async (opts: { headers: Headers }) => {
           return {
             db,
             session: jwtSession,
+            // Surface the JWT token type so procedures can attribute writes to
+            // the calling surface (e.g. Action.source for chat gateways).
+            tokenType: decoded.tokenType,
             ...opts,
           };
         }
@@ -131,6 +134,7 @@ export const createTRPCContext = async (opts: { headers: Headers }) => {
   return {
     db,
     session,
+    tokenType: undefined as string | undefined,
     ...opts,
   };
 };

--- a/src/server/utils/__tests__/actionSource.test.ts
+++ b/src/server/utils/__tests__/actionSource.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+
+import { deriveActionSource } from "../actionSource";
+
+describe("deriveActionSource", () => {
+  it("maps matrix-gateway tokens to source 'matrix'", () => {
+    expect(deriveActionSource("matrix-gateway")).toBe("matrix");
+  });
+
+  it("maps telegram-gateway tokens to source 'telegram'", () => {
+    expect(deriveActionSource("telegram-gateway")).toBe("telegram");
+  });
+
+  it("maps whatsapp-gateway tokens to source 'whatsapp'", () => {
+    expect(deriveActionSource("whatsapp-gateway")).toBe("whatsapp");
+  });
+
+  it("keeps the historical 'whatsapp' default for unknown or absent token types", () => {
+    expect(deriveActionSource("agent-context")).toBe("whatsapp");
+    expect(deriveActionSource(undefined)).toBe("whatsapp");
+  });
+});

--- a/src/server/utils/actionSource.ts
+++ b/src/server/utils/actionSource.ts
@@ -1,0 +1,19 @@
+/**
+ * Derive an Action's `source` from the caller's JWT token type.
+ *
+ * Chat-gateway callbacks (agent tools invoked from WhatsApp/Telegram/Matrix
+ * conversations) authenticate with a gateway-typed JWT, so the token type is
+ * the ground truth for which surface a conversation-created action came from.
+ * Historically the value was hardcoded to "whatsapp" (the first gateway);
+ * unknown/absent token types keep that default so existing callers are
+ * unchanged.
+ */
+const GATEWAY_TOKEN_SOURCES: Record<string, string> = {
+  "whatsapp-gateway": "whatsapp",
+  "telegram-gateway": "telegram",
+  "matrix-gateway": "matrix",
+};
+
+export function deriveActionSource(tokenType: string | undefined): string {
+  return GATEWAY_TOKEN_SOURCES[tokenType ?? ""] ?? "whatsapp";
+}


### PR DESCRIPTION
### **User description**
## What

Actions created from chat conversations now carry the correct provenance. `quickCreateAction` hardcoded `source: "whatsapp"` (a relic of the WhatsApp-only days — Telegram-created actions were mislabeled too). The tRPC context now exposes the verified JWT's `tokenType`, and a pure `deriveActionSource()` maps gateway token types to sources: `whatsapp-gateway` → `whatsapp`, `telegram-gateway` → `telegram`, `matrix-gateway` → `matrix`, with the historical `whatsapp` default for unknown/absent types (non-gateway callers unchanged). Note this corrects Telegram attribution as a side effect — flagging in case anything downstream filters on `source = "whatsapp"`.

## Tracer bullet (V1 end-to-end, run live)

Local Synapse in Docker + this app's real routes + the real MatrixGateway class (agent stubbed; the agent leg is unit-tested):

- `/pair` → bot **created the unencrypted DM** (`m.room.encryption` state: `M_NOT_FOUND`) and prompted for the code
- code redemption → **IntegrationUserMapping row persisted in the dev DB** via the real mappings route (system Integration row auto-created)
- welcome message posted; chat message → reply with `formatted_body` HTML (`<strong>`, `<em>`, `<ul>`, `<a href>`) rendered from agent markdown
- encrypted-room invite → **surfaced a real bug** (SDK refuses all sends into encrypted rooms → leave never ran); fixed + regression-tested in mastra PR positonic/mastra#53, then re-verified live (bot membership → `leave`)
- test artifacts cleaned (mapping row deleted; Synapse container removed)

Not covered here (deliberately): real-agent LLM leg (unit-tested; Telegram-proven pattern) and the production homeserver — both land with ultra.shard (HITL deploy ticket).

## Acceptance criteria

- [x] Actions created via Matrix conversations persist source "matrix" (unit test on the derivation)
- [x] Full tracer bullet passes on a local homeserver, each step observed
- [x] Gap found was fixed within this ticket (mastra PR #53)

---

Ships: aqua.finch

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cmroxzsqs000hjt04bbxk1nou)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Derive `Action.source` from JWT `tokenType` instead of hardcoded `"whatsapp"`

- New `deriveActionSource()` maps gateway token types to correct sources (whatsapp/telegram/matrix)

- `tokenType` surfaced from verified JWT in tRPC context for all procedures

- Unit tests added for all token type mappings and fallback behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  jwt["JWT Token\n(tokenType field)"]
  ctx["tRPC Context\n(ctx.tokenType)"]
  derive["deriveActionSource()\n(actionSource.ts)"]
  action["Action.source\n(whatsapp/telegram/matrix)"]
  fallback["Default: 'whatsapp'\n(unknown/absent types)"]

  jwt -- "decoded.tokenType" --> ctx
  ctx -- "ctx.tokenType" --> derive
  derive -- "gateway match" --> action
  derive -- "no match" --> fallback
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actionSource.ts</strong><dd><code>New pure utility to derive Action source from token type</code>&nbsp; </dd></summary>
<hr>

src/server/utils/actionSource.ts

<ul><li>New utility file introducing <code>deriveActionSource()</code> function<br> <li> Maps gateway JWT token types (<code>whatsapp-gateway</code>, <code>telegram-gateway</code>, <br><code>matrix-gateway</code>) to their respective source strings<br> <li> Falls back to historical <code>"whatsapp"</code> default for unknown or absent <br>token types</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/394/files#diff-9893b1e04bb19830e463e3661c8b96b8109304ca30dbc9b197fd27f5abaa4cf5">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>trpc.ts</strong><dd><code>Expose JWT tokenType in tRPC context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/trpc.ts

<ul><li>Surfaces <code>decoded.tokenType</code> from verified JWT into the tRPC context<br> <li> Adds <code>tokenType: undefined</code> as typed default in the <br>unauthenticated/fallback context path<br> <li> Enables downstream procedures to access the caller's token type</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/394/files#diff-d1873554bffe6aae1ccd90d4e0c7643119f59236073129fff81d21a049e77e91">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actionSource.test.ts</strong><dd><code>Unit tests for deriveActionSource utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/utils/__tests__/actionSource.test.ts

<ul><li>New test file for <code>deriveActionSource()</code> utility<br> <li> Tests all three gateway token type mappings (matrix, telegram, <br>whatsapp)<br> <li> Tests fallback behavior for unknown and undefined token types</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/394/files#diff-d4a183c178125baa54ccfc14367d8c831d8d76ded5bc70fdd226efab911374a5">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mastra.ts</strong><dd><code>Use dynamic source derivation in quickCreateAction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/mastra.ts

<ul><li>Replaces hardcoded <code>source: "whatsapp"</code> with <code>source: </code><br><code>deriveActionSource(ctx.tokenType)</code> in <code>quickCreateAction</code><br> <li> Imports new <code>deriveActionSource</code> utility</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/394/files#diff-afd76ed5d04839b106766464d541d99c9b1d0e8b28477ea826c7dcf52db960bb">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Add tokenType to Slack webhook mock tRPC context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/webhooks/slack/route.ts

<ul><li>Adds <code>tokenType: undefined</code> to the mock tRPC context used in the Slack <br>webhook server-side caller<br> <li> Keeps compatibility with the updated tRPC context shape</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/394/files#diff-0112c377b18661439c25e9e2133560b7c08f68b4631187cfd312ddbda38d5a73">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

