### PR TITLE
fix(prd): surface non-conflict autosave failures instead of failing silently

### DIFF
--- a/src/app/_components/shared/RichDocEditor.tsx
+++ b/src/app/_components/shared/RichDocEditor.tsx
@@ -277,7 +277,8 @@ export function RichDocEditor({
 
   // Latest save fn behind a ref so the queue's closure never goes stale. It
   // reads the editor, content and version base at execution time, and never
-  // rejects (the conflict modal handles the error) — the queue relies on that.
+  // rejects (errors surface via the conflict modal or an error notification
+  // instead) — the queue relies on that.
   const saveRef = useRef<() => Promise<void>>(() => Promise.resolve());
   saveRef.current = () => {
     const editor = editorRef.current;
@@ -296,7 +297,8 @@ export function RichDocEditor({
         lastSavedRef.current = serialized;
       })
       .catch((err: { data?: { code?: string } }) => {
-        if (err?.data?.code === "CONFLICT" && !conflictShown.current) {
+        if (err?.data?.code === "CONFLICT") {
+          if (conflictShown.current) return;
           conflictShown.current = true;
           modals.openConfirmModal({
             title: conflict?.title ?? "This document changed",
@@ -312,7 +314,14 @@ export function RichDocEditor({
               conflictShown.current = false;
             },
           });
+          return;
         }
+        notifications.show({
+          title: "Couldn't save changes",
+          message:
+            "Your edits haven't been saved. Check your connection and try again.",
+          color: "red",
+        });
       });
   };
 

--- a/src/app/_components/shared/RichDocEditor.tsx
+++ b/src/app/_components/shared/RichDocEditor.tsx
@@ -296,7 +296,7 @@ export function RichDocEditor({
         }
         lastSavedRef.current = serialized;
       })
-      .catch((err: { data?: { code?: string } }) => {
+      .catch((err: { data?: { code?: string }; message?: string }) => {
         if (err?.data?.code === "CONFLICT") {
           if (conflictShown.current) return;
           conflictShown.current = true;
@@ -316,9 +316,14 @@ export function RichDocEditor({
           });
           return;
         }
+        // Stable id so a persistent failure (e.g. content over the server's
+        // length cap) updates one toast instead of stacking a new one on
+        // every autosave retry.
         notifications.show({
+          id: "richdoc-save-error",
           title: "Couldn't save changes",
           message:
+            err?.message ||
             "Your edits haven't been saved. Check your connection and try again.",
           color: "red",
         });


### PR DESCRIPTION
### **User description**
## What

- \`RichDocEditor\`'s autosave now shows a "Couldn't save changes" notification for any non-CONFLICT save failure (network error, server error), instead of swallowing it silently.
- Minor comment cleanup around the save-error branching for clarity.

## Why

Diagnosed while investigating a report that a pasted screenshot appeared to vanish after a page refresh. The autosave path only reacted to CONFLICT errors from the optimistic-concurrency check; any other failure left the editor showing unsaved content with zero user-facing feedback, so an edit could look saved and then disappear on refresh with no explanation. This editor is shared by both the Feature PRD body and Knowledge Pages, so the fix covers both surfaces.


___

### **PR Type**
Bug fix


___

### **Description**
- Surface non-conflict autosave failures with user-facing toast notification

- Add stable toast ID to prevent stacking notifications on repeated failures

- Prefer actual server error message over generic fallback text

- Fix silent failure where edits could appear saved but vanish on refresh


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Autosave triggered"] -- "onSave() called" --> B["Save result"]
  B -- "success" --> C["Update version & lastSavedRef"]
  B -- "CONFLICT error" --> D["Show conflict modal"]
  B -- "other error (network/server)" --> E["Show error toast\n(id: richdoc-save-error)"]
  E -- "persistent failure\n(retry)" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RichDocEditor.tsx</strong><dd><code>Surface non-conflict autosave errors with deduped toast notification</code></dd></summary>
<hr>

src/app/_components/shared/RichDocEditor.tsx

<ul><li>Added error notification (<code>notifications.show</code>) for non-CONFLICT save <br>failures<br> <li> Used stable toast ID <code>richdoc-save-error</code> to prevent stacking toasts on <br>retries<br> <li> Prefer actual <code>err.message</code> from server over generic fallback message<br> <li> Refactored CONFLICT guard to early-return pattern for clarity<br> <li> Updated comment to reflect that errors surface via modal or <br>notification</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/396/files#diff-94ac9cac79aa08ce267f273a39bca6d43488b86f079813d3132a5a8770c18913">+17/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

