### PR TITLE
chore(agent-quality): load .env.local in score-threads + PRD doc/pointer

### DIFF
--- a/dev-docs/AGENT_QUALITY_RUNBOOK.md
+++ b/dev-docs/AGENT_QUALITY_RUNBOOK.md
@@ -7,6 +7,13 @@ and [ADR-0013](../docs/adr/0013-eval-replay-frozen-prefix.md); glossary terms
 in [CONTEXT.md](../CONTEXT.md#agent-quality). This file is just *what to do
 and when*.
 
+The **PRD** — problem, goals, rollout, and where we are in the process — is the
+place for team discussion:
+[PRD page](https://www.exponential.im/w/syntrofi/pages/cmruptufm0009jp04e5jv1tsf)
+· [feature + requirement rows](https://www.exponential.im/w/syntrofi/products/exponential/features/cmq9u39kr0001ky04encxm1t8)
+in Exponential, mirrored in-repo at
+[PRD_AGENT_QUALITY_SELF_IMPROVEMENT_LOOP.md](./PRD_AGENT_QUALITY_SELF_IMPROVEMENT_LOOP.md).
+
 > Status as of 2026-06-12. The measuring/verifying machinery is live; the
 > automation is deliberately not running yet — partly unbuilt (tickets
 > below), partly locked behind the calibration gate.

--- a/dev-docs/PRD_AGENT_QUALITY_SELF_IMPROVEMENT_LOOP.md
+++ b/dev-docs/PRD_AGENT_QUALITY_SELF_IMPROVEMENT_LOOP.md
@@ -1,0 +1,111 @@
+# PRD: Agent quality self-improvement loop
+
+*A closed loop that measures every Zoe conversation, routes each failure to whoever owns the fix, and verifies fixes offline before they ship — so response quality compounds instead of drifting.*
+
+> **Canonical copy lives in Exponential** (workspace `syntrofi` / product `exponential`) — comment there for the team discussion:
+> - PRD page: https://www.exponential.im/w/syntrofi/pages/cmruptufm0009jp04e5jv1tsf
+> - Feature (scopes + requirement rows): https://www.exponential.im/w/syntrofi/products/exponential/features/cmq9u39kr0001ky04encxm1t8
+>
+> This in-repo copy is a convenience mirror for reviewers reading the code. If the two drift, the Exponential feature (with its checkable requirement rows) wins.
+
+**Decisions:** [ADR-0012 — Agent quality Thread scoring](../docs/adr/0012-agent-quality-thread-scoring.md) · [ADR-0013 — Eval replay frozen-prefix](../docs/adr/0013-eval-replay-frozen-prefix.md)
+**Operator guide:** [AGENT_QUALITY_RUNBOOK.md](./AGENT_QUALITY_RUNBOOK.md) · **Glossary:** [CONTEXT.md](../CONTEXT.md) → *Agent quality*
+
+---
+
+## Problem
+
+**Zoe's quality is invisible, and improving it is entirely manual.**
+
+- **We only hear about the failures users bother to report.** Human thumbs-ratings are sparse and selection-biased. Nothing at all assesses the silent majority of conversations — where Zoe fabricated a fact, deflected ("check your list…"), or hit a broken tool and the user just quietly gave up.
+- **We can't verify a fix without shipping it.** Today the only way to know whether a prompt change helped is to deploy it and watch live traffic for a week. That makes every prompt edit a slow, risky guess.
+- **Nobody owns the fix by default.** A bad answer might be a server bug (this repo), a prompt defect (split across this repo's router persona *and* Zoe-the-brain in `../mastra`), or a genuinely missing product capability. Without triage, every failure looks the same and lands nowhere.
+
+The net effect: quality drifts silently, regressions reappear, and the same failure modes recur because nothing turns a past failure into a permanent guard.
+
+## Goals
+
+- **Measure quality on every settled conversation**, not just the rated ones — a score against Zoe's contract for each Thread.
+- **Route every failure to the owner of the fix** automatically (three lanes: `code_bug`, `agent_behaviour`, `capability_gap`).
+- **Verify a candidate prompt offline in minutes**, against the accumulated set of past failures, with zero production side-effects — no more week-long live-traffic waits.
+- **Make every failure a permanent regression test** — the eval suite only grows, so a fixed problem stays fixed.
+- **Attribute score movements to specific prompt changes**, so we can prove (or disprove) that a deploy helped.
+- **Keep the judge honest** — no autonomous action unlocks until the judge agrees with human ratings above a threshold.
+
+**Success looks like:** each week, a ranked report of Zoe's worst conversations grouped by owner; `agent_behaviour` fixes shipped as PRs carrying eval evidence (pass-rate diff, zero regressions); and live score-by-prompt-version trends confirming the change landed.
+
+## Non-goals
+
+- **Auto-merging prompt patches.** A human always merges. The loop deliberately ends at "PR opened with eval evidence."
+- **Generic NLP quality metrics** (relevance/helpfulness scores). The rubric is *Zoe's contract only* — Resolved / Grounded / Tool success / No deflection.
+- **Judging created entities beyond the transcript.** Human ratings remain ground truth for "did the thing Zoe made actually make sense."
+- **Scoring coarse-tool turns and iOS voice Threads** — deferred until iOS issues per-exchange Thread ids (ADR-0012).
+- **A nightly cron as the deliverable.** The manual trigger is the product; scheduling is a thin wrapper added later.
+
+## Solution
+
+Five moving parts, staged so value arrives at part one:
+
+1. **Judge** — an LLM judge (Haiku 4.5) scores every *settled* Thread (no turn in the last hour) against Zoe's four-axis contract, writing a `ThreadScore`. Runs via `npm run score-threads`, idempotent, refuses to touch a non-local DB without an explicit flag.
+2. **Route** — each failing Thread is classified into one **Failure lane** by owner-of-the-fix: `code_bug` (tRPC/tool fix here), `agent_behaviour` (prompt fix, this repo's persona + `../mastra`'s brain), or `capability_gap` (a product Ticket, not a bug). A ranked **Level-A report** surfaces the worst first.
+3. **Distil** — every failure is frozen into an **EvalCase**: the conversation prefix up to the violating turn plus the contract expectation it broke. The suite is a growing regression harness.
+4. **Verify** — **Eval replay** (`npm run eval-prompt`) runs a candidate prompt (whatever branch `../mastra` has checked out) against the EvalCase suite in-process. It regenerates *only* the violating turn, judges it with the same versioned judge, and prints a pass-rate diff vs baseline. **Tools never execute** — calls are captured as intent, so a candidate Zoe can't mutate production.
+5. **Attribute** — every interaction is stamped `promptVersion = router@<hash>+brain@<hash>`. After a deploy, the admin **Thread-score trends by prompt version** confirm or refute that the change helped on live traffic.
+
+A **calibration gate** tracks judge-vs-human directional agreement; only once it clears a threshold do the autonomous stages (auto-filing, AI-proposed patches) unlock. Humans always merge.
+
+**Why this way** — the design choices worth defending (full rationale in the ADRs):
+
+- **Judge whole Threads, not single turns** — resolution is a property of the conversation, not one message. Settled-only avoids grading unfinished work as "unresolved."
+- **Frozen-prefix, single-call replay** — deterministic, fast, side-effect-free. We reject full multi-turn replay with mocked tool results as brittle and slow (ADR-0013).
+- **Candidate = a real git branch of the brain repo** — evals test the exact artifact that deploys, not a stand-in.
+- **Two repos, one loop** — the brain (`../mastra`) stays a stateless execution engine; all scores, cases, and calibration data live in this app's database, stamped truthfully at the deploy boundary.
+- **Staged autonomy behind calibration** — the eval set only protects against *previously seen* failures, so live version-stamped scores are the real backstop and a human is always in the merge path.
+
+## Requirements
+
+Canonical, checkable copies of these live as requirement rows on the [feature](https://www.exponential.im/w/syntrofi/products/exponential/features/cmq9u39kr0001ky04encxm1t8).
+
+**Measure & route (V1 — live)**
+
+- When a scoring run executes, judge every settled Thread (no turn in the last hour) that has no existing `ThreadScore`.
+- Score each Thread against Zoe's four-axis contract: Resolved, Grounded, Tool success, No deflection.
+- Classify each failing Thread into exactly one Failure lane: `code_bug`, `agent_behaviour`, or `capability_gap`.
+- When a Thread scores below passing, create one frozen EvalCase capturing the conversation prefix up to the violating turn and the violated expectation.
+- Stamp every Zoe interaction with a composite Prompt version (router hash + brain hash).
+- The scoring run is idempotent — a Thread that already has a `ThreadScore` is not re-judged.
+- If the scoring run targets a non-local database, refuse to proceed unless an explicit confirmation flag is supplied.
+
+**Verify & calibrate (V2 — in QA)**
+
+- When an eval replay runs, regenerate only the violating turn's response from the candidate prompt and judge it against the stored expectation with the same versioned judge as live scoring.
+- While an eval replay runs, never execute real tools; capture tool invocations as intent only.
+- Instantiate the candidate prompt from the branch checked out in the `../mastra` working tree.
+- When a candidate is compared to a baseline, emit a pass-rate diff, per-case verdicts, and a regression list, and exit non-zero if any regression exists.
+- The admin dashboard presents Thread-score trends by agent, Failure lane, and Prompt version, with worst-Thread drilldown.
+- Track judge-vs-human directional agreement over the overlap set and gate autonomy on a configured threshold.
+
+**Autonomy (V3 — planned)**
+
+- While calibration is above threshold, auto-file confirmed failures to the tracker that owns each lane.
+- Cluster failures by failure mode so a single prompt patch can address a class of failures.
+- When AI proposes a prompt patch, open it as a PR only if evals improve with no regressions, and a human always merges.
+
+## Rollout
+
+**V1 — Measure & route (Level A) — SHIPPED / live.** Judge, `ThreadScore`/`EvalCase`, `promptVersion` stamping, `score-threads` CLI, ranked Level-A report. A human actions the report. (PR #175, merged 2026-06-11; follow-ups #183, #360.)
+
+**V2 — Verify & calibrate — IN QA.** Eval-replay runner, `eval-prompt` orchestrator (pass-rate diff), Thread-score analytics dashboard, calibration gate, and Level B lane-routed auto-filing. Built; being verified.
+
+**V3 — Autonomy (Level C) — PLANNED.** Failure clustering + eval-gated prompt-patch PRs, nightly `score-threads` cron, scheduled `file-failures` behind the gate, `eval-prompt`-as-CI evidence on `../mastra` PRs, periodic judge audit.
+
+## Where we are
+
+We are at **Level A, operating manually** — the loop's first rung and already delivering value. Phase 1 is live: `score-threads` judges the backlog against prod and prints the ranked report, and every failure is being distilled into the EvalCase suite. Phase 2's machinery (offline `eval-prompt` verification, the analytics dashboard, and the calibration gate) is built and sitting in QA. Nothing autonomous is switched on yet — that's gated on the calibration card reaching its agreement threshold, which in turn depends on us **rating responses as we use Zoe** to build ground truth.
+
+## Open questions
+
+- **What's the calibration threshold, exactly, and who owns declaring it met?** ADR-0012 sets ≥80% directional agreement over ≥10 overlap pairs as the gate; confirm the team is comfortable unlocking Level B/C at that bar. *(Owner: product)*
+- **How much do we invest in growing human ratings** to reach calibration faster, vs. letting it accumulate passively? Nothing autonomous unlocks without it. *(Owner: product)*
+- **Weekly cadence owner** — who runs the weekly `score-threads` + triage until the nightly cron lands? *(Owner: eng)*
+- **Judge-drift policy** — when we revise the judge prompt (bumping `JUDGE_VERSION`), how do we keep old vs new scores comparable in the dashboard? *(Owner: eng)*

--- a/scripts/score-threads.ts
+++ b/scripts/score-threads.ts
@@ -16,8 +16,14 @@
  *   npm run score-threads -- --limit 25        # cap this run
  *   npm run score-threads -- --yes             # required for a non-local DB host
  *
- * Requires ANTHROPIC_API_KEY for the judge.
+ * Requires ANTHROPIC_API_KEY for the judge. Prisma auto-loads .env (where
+ * DATABASE_URL lives), but not .env.local — so this script loads .env.local
+ * (then .env) itself before anything reads the environment. Values already set
+ * in the shell win, so `DATABASE_URL=… npm run score-threads` still overrides.
  */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { PrismaClient } from "@prisma/client";
 
 import {
@@ -28,6 +34,37 @@ import {
 } from "../src/server/services/AgentEvalService";
 
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "host.docker.internal"]);
+
+/**
+ * Load .env.local then .env into process.env without overriding anything the
+ * shell already set. Mirrors Next.js precedence (.env.local wins over .env)
+ * while leaving explicit shell/inline vars untouched. Kept dependency-free on
+ * purpose: dotenv is only a transitive dep here.
+ */
+function loadEnvFiles(): void {
+  for (const file of [".env.local", ".env"]) {
+    let contents: string;
+    try {
+      contents = readFileSync(resolve(process.cwd(), file), "utf8");
+    } catch {
+      continue; // absent file is fine
+    }
+    for (const line of contents.split("\n")) {
+      const match = /^\s*(?:export\s+)?([\w.-]+)\s*=\s*(.*)$/.exec(line);
+      const key = match?.[1];
+      if (key === undefined || process.env[key] !== undefined) continue;
+      let value = (match?.[2] ?? "").trim();
+      if (
+        value.length >= 2 &&
+        ((value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'")))
+      ) {
+        value = value.slice(1, -1);
+      }
+      process.env[key] = value;
+    }
+  }
+}
 
 function parseArgs(argv: string[]): { limit: number | undefined; yes: boolean } {
   const yes = argv.includes("--yes");
@@ -59,6 +96,7 @@ function oneLine(text: string, max = 160): string {
 }
 
 async function main(): Promise<void> {
+  loadEnvFiles();
   const { limit, yes } = parseArgs(process.argv.slice(2));
 
   const databaseUrl = process.env.DATABASE_URL;


### PR DESCRIPTION
### **User description**
## What

Three small things around the **agent-quality self-improvement loop**:

1. **`score-threads` DX fix** — the script read `ANTHROPIC_API_KEY` from the environment, but nothing loaded it. Prisma auto-loads `.env` (where `DATABASE_URL` lives) but **not** `.env.local`, where the key lives — so the judge started unauthenticated and every Thread failed with *"Could not resolve authentication method."* Added a tiny **dependency-free** loader that reads `.env.local` then `.env` without overriding shell/inline vars. The weekly `npm run score-threads -- --yes` now works with no manual env export.
2. **PRD mirrored into the repo** — `dev-docs/PRD_AGENT_QUALITY_SELF_IMPROVEMENT_LOOP.md`, with the Exponential feature as the **canonical source** (page + requirement rows linked at the top).
3. **Runbook pointer** — `AGENT_QUALITY_RUNBOOK.md` now links the PRD page + feature for team discussion.

## Why

Weekly quality review is a manual operator task; the env papercut made it fail on first run every time. And the loop had ADRs + a runbook but no PRD to discuss with the team — now it does.

## Precedence (loader)

`shell/inline vars` > `.env.local` > `.env`. So `DATABASE_URL=… npm run score-threads` still overrides. Verified against quoted values, `=` inside values, `export` prefix, comments, and empty values.

## Test plan

- [x] `eslint scripts/score-threads.ts` clean
- [x] `tsc --noEmit` clean
- [x] pre-commit unit tests pass
- [x] standalone verification of the loader's parsing + precedence

No schema/migration changes. Docs + one script.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Fix `score-threads` script failing due to missing `ANTHROPIC_API_KEY` env var

- Add dependency-free `.env.local` / `.env` loader with shell-var precedence

- Mirror Agent Quality Self-Improvement Loop PRD into repo as new doc

- Add PRD links to existing runbook for team discoverability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Shell / inline vars"]
  B[".env.local"]
  C[".env"]
  D["loadEnvFiles()"]
  E["score-threads main()"]
  F["ANTHROPIC_API_KEY resolved"]

  D -- "reads (no override)" --> B
  D -- "reads (no override)" --> C
  A -- "highest precedence" --> E
  D -- "sets missing vars" --> E
  E -- "judge authenticated" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>score-threads.ts</strong><dd><code>Add dependency-free .env.local loader to fix auth failures</code></dd></summary>
<hr>

scripts/score-threads.ts

<ul><li>Added <code>loadEnvFiles()</code> function that reads <code>.env.local</code> then <code>.env</code> without <br>overriding existing shell/inline vars<br> <li> Imported <code>readFileSync</code> and <code>resolve</code> from Node built-ins for <br>dependency-free env loading<br> <li> Called <code>loadEnvFiles()</code> at the start of <code>main()</code> before any env reads<br> <li> Updated file header comment to document the <code>.env.local</code> loading <br>behavior and precedence rules</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/397/files#diff-96816be1db5c1b49024c1c6b470448df9695c19642ef8a23e46aeb82f3ba0a16">+39/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENT_QUALITY_RUNBOOK.md</strong><dd><code>Add PRD links to agent quality runbook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dev-docs/AGENT_QUALITY_RUNBOOK.md

<ul><li>Added a paragraph pointing to the PRD page and feature in Exponential<br> <li> Added link to the new in-repo PRD mirror file</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/397/files#diff-2ba3a4557e05b2cc7d83ba02e047a1310c3ca1dd9ce14d443e21769ce052cdca">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PRD_AGENT_QUALITY_SELF_IMPROVEMENT_LOOP.md</strong><dd><code>Add in-repo PRD mirror for agent quality loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dev-docs/PRD_AGENT_QUALITY_SELF_IMPROVEMENT_LOOP.md

<ul><li>New file mirroring the Agent Quality Self-Improvement Loop PRD from <br>Exponential<br> <li> Documents problem statement, goals, non-goals, solution (5 parts), and <br>requirements (V1/V2/V3)<br> <li> Describes rollout stages and current status (Level A live, V2 in QA, <br>V3 planned)<br> <li> Lists open questions around calibration threshold, rating cadence, and <br>judge-drift policy</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/397/files#diff-3bfd2d3710201581b14efe19c29840a802e46e4949ef7bb46f273b31b94208bd">+111/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

