### PR TITLE
feat: MatrixNotificationService — outbound notifications via the gateway (V2)

### DIFF
--- a/src/server/services/notifications/MatrixNotificationService.ts
+++ b/src/server/services/notifications/MatrixNotificationService.ts
@@ -1,0 +1,99 @@
+import {
+  NotificationService,
+  type NotificationPayload,
+  type NotificationResult,
+  type NotificationConfig,
+} from './NotificationService';
+
+/**
+ * Delivers notifications to a user's Matrix DM with the Zoe bot (V2, ADR-0043).
+ *
+ * Unlike Slack/WhatsApp/Zulip, this service holds NO per-user credential: the
+ * bot token lives only in the gateway. It POSTs { userId, title, message } to
+ * the gateway's `/notify` endpoint (gateway-secret guarded), and the gateway
+ * resolves the user's canonical DM room from its in-memory mapping. So the
+ * "destination" is just the userId — the same userId the gateway already maps.
+ */
+export class MatrixNotificationService extends NotificationService {
+  name = 'Matrix';
+  type = 'matrix';
+
+  constructor(config: NotificationConfig) {
+    super(config);
+  }
+
+  private gatewayUrl(): string {
+    return process.env.MATRIX_GATEWAY_URL ?? 'http://localhost:4114';
+  }
+
+  private gatewaySecret(): string | undefined {
+    return process.env.GATEWAY_SECRET ?? process.env.WHATSAPP_GATEWAY_SECRET;
+  }
+
+  async sendNotification(payload: NotificationPayload): Promise<NotificationResult> {
+    const secret = this.gatewaySecret();
+    if (!secret) {
+      return { success: false, error: 'Gateway secret not configured' };
+    }
+
+    try {
+      const res = await fetch(`${this.gatewayUrl()}/notify`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Gateway-Secret': secret,
+        },
+        body: JSON.stringify({
+          userId: this.config.userId,
+          title: payload.title,
+          message: payload.message,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        return {
+          success: false,
+          error: body.error ?? `Matrix gateway returned ${res.status}`,
+        };
+      }
+
+      const data = (await res.json()) as { delivered?: boolean; roomId?: string };
+      return { success: !!data.delivered, messageId: data.roomId };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
+  async validateConfig(): Promise<{ valid: boolean; errors: string[] }> {
+    const errors: string[] = [];
+    if (!this.config.userId) errors.push('userId is required');
+    if (!this.gatewaySecret()) errors.push('GATEWAY_SECRET is not configured');
+    if (!process.env.MATRIX_GATEWAY_URL) {
+      errors.push('MATRIX_GATEWAY_URL is not configured');
+    }
+    return { valid: errors.length === 0, errors };
+  }
+
+  async testConnection(): Promise<{ connected: boolean; error?: string }> {
+    try {
+      const res = await fetch(`${this.gatewayUrl()}/health`);
+      if (!res.ok) {
+        return { connected: false, error: `Health check returned ${res.status}` };
+      }
+      const data = (await res.json()) as { matrixConnected?: boolean };
+      return {
+        connected: !!data.matrixConnected,
+        error: data.matrixConnected ? undefined : 'Gateway is up but not connected to Matrix',
+      };
+    } catch (error) {
+      return {
+        connected: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+}

--- a/src/server/services/notifications/NotificationServiceFactory.ts
+++ b/src/server/services/notifications/NotificationServiceFactory.ts
@@ -2,9 +2,10 @@ import { type NotificationService, type NotificationConfig } from './Notificatio
 import { SlackNotificationService } from './SlackNotificationService';
 import { WhatsAppNotificationService } from './WhatsAppNotificationService';
 import { ZulipNotificationService } from './ZulipNotificationService';
+import { MatrixNotificationService } from './MatrixNotificationService';
 import { db } from '~/server/db';
 
-export type NotificationServiceType = 'slack' | 'email' | 'discord' | 'whatsapp' | 'zulip';
+export type NotificationServiceType = 'slack' | 'email' | 'discord' | 'whatsapp' | 'zulip' | 'matrix';
 
 export class NotificationServiceFactory {
   /**
@@ -61,6 +62,8 @@ export class NotificationServiceFactory {
         return new WhatsAppNotificationService(config);
       case 'zulip':
         return new ZulipNotificationService(config);
+      case 'matrix':
+        return new MatrixNotificationService(config);
       case 'email':
         // TODO: Implement EmailNotificationService
         return null;

--- a/src/server/services/notifications/__tests__/MatrixNotificationService.test.ts
+++ b/src/server/services/notifications/__tests__/MatrixNotificationService.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { MatrixNotificationService } from "~/server/services/notifications/MatrixNotificationService";
+
+const OK = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+const ERR = (status: number, body: unknown = {}) =>
+  ({ ok: false, status, json: async () => body }) as unknown as Response;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  process.env.GATEWAY_SECRET = "test-secret";
+  process.env.MATRIX_GATEWAY_URL = "https://gw.example.com";
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.GATEWAY_SECRET;
+  delete process.env.MATRIX_GATEWAY_URL;
+});
+
+describe("MatrixNotificationService", () => {
+  it("POSTs userId + payload to the gateway /notify with the gateway secret", async () => {
+    fetchMock.mockResolvedValue(OK({ delivered: true, roomId: "!dm:server" }));
+    const svc = new MatrixNotificationService({ userId: "u1" });
+
+    const result = await svc.sendNotification({ title: "Due soon", message: "Pay Malte" });
+
+    expect(result).toEqual({ success: true, messageId: "!dm:server" });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe("https://gw.example.com/notify");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as Record<string, Record<string, string>>).headers["X-Gateway-Secret"]).toBe("test-secret");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      userId: "u1",
+      title: "Due soon",
+      message: "Pay Malte",
+    });
+  });
+
+  it("fails cleanly when the gateway secret is missing (no fetch)", async () => {
+    delete process.env.GATEWAY_SECRET;
+    const svc = new MatrixNotificationService({ userId: "u1" });
+    const result = await svc.sendNotification({ title: "t", message: "m" });
+    expect(result.success).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 404 (unpaired user) as a failure with the gateway's error", async () => {
+    fetchMock.mockResolvedValue(ERR(404, { error: "User has no paired Matrix DM" }));
+    const svc = new MatrixNotificationService({ userId: "u1" });
+    const result = await svc.sendNotification({ title: "t", message: "m" });
+    expect(result).toEqual({ success: false, error: "User has no paired Matrix DM" });
+  });
+
+  it("reports success:false when the gateway says delivered:false", async () => {
+    fetchMock.mockResolvedValue(OK({ delivered: false }));
+    const svc = new MatrixNotificationService({ userId: "u1" });
+    const result = await svc.sendNotification({ title: "t", message: "m" });
+    expect(result.success).toBe(false);
+  });
+
+  it("validateConfig flags missing userId / secret / url", async () => {
+    delete process.env.MATRIX_GATEWAY_URL;
+    delete process.env.GATEWAY_SECRET;
+    const svc = new MatrixNotificationService({ userId: "" });
+    const { valid, errors } = await svc.validateConfig();
+    expect(valid).toBe(false);
+    expect(errors).toHaveLength(3);
+  });
+
+  it("testConnection reflects the gateway /health matrixConnected flag", async () => {
+    fetchMock.mockResolvedValue(OK({ status: "ok", matrixConnected: true }));
+    const svc = new MatrixNotificationService({ userId: "u1" });
+    await expect(svc.testConnection()).resolves.toEqual({ connected: true, error: undefined });
+
+    fetchMock.mockResolvedValue(OK({ status: "ok", matrixConnected: false }));
+    const down = await svc.testConnection();
+    expect(down.connected).toBe(false);
+  });
+});


### PR DESCRIPTION
### **User description**
## What

Registers a `matrix` channel in the notification factory (`NotificationServiceType` + `createService` switch). `MatrixNotificationService.sendNotification` POSTs `{ userId, title, message }` to the gateway's `/notify` (companion mastra PR positonic/mastra#54) with `X-Gateway-Secret` + `MATRIX_GATEWAY_URL` — no per-user credential, the bot token stays in the gateway, which resolves the user's canonical DM room.

First half of Matrix **V2 (outbound notifications)** — the delivery spine. Opt-in wiring (preference UI + scheduler branch) is the follow-up ticket.

## Design note (matches the explicit-opt-in decision)

Matrix is **deliberately not** added to the per-user `sendToAll` fan-out allowlists. The Matrix integration is a single shared system row (`userId: null`), so the per-user query wouldn't match it anyway — and more importantly, delivery is **explicit opt-in**: pairing Matrix for chat must never auto-enable notifications. `createService('matrix')` is wired for the opt-in scheduler + test paths that land next.

## Acceptance criteria
- [x] `MatrixNotificationService` registered in the factory; `sendNotification` hits the gateway `/notify` with the secret + userId
- [x] Clean failures: missing secret (no fetch), 404 unpaired, delivered:false, gateway down
- [x] `testConnection` reflects `/health` `matrixConnected`
- [x] Finding documented: factory `sendToAll` does NOT reach Matrix (shared/`userId:null` integration + opt-in by design) — so transcription-completed→Matrix is handled via opt-in in V2-2, not auto-fan-out
- [x] Unit tests (6, mocked fetch); full unit suite green; tsc + eslint clean

Ships: matrix-v2-outbound-delivery-spine


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds `MatrixNotificationService` for outbound Matrix DM notifications via gateway

- Service POSTs `{ userId, title, message }` to gateway `/notify` with `X-Gateway-Secret`

- Registers `matrix` as a new channel type in `NotificationServiceFactory`

- Includes 6 unit tests covering delivery, failures, and connection health checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  factory["NotificationServiceFactory"]
  matrix["MatrixNotificationService"]
  gateway["Matrix Gateway /notify"]
  health["Matrix Gateway /health"]

  factory -- "createService('matrix')" --> matrix
  matrix -- "POST userId+payload\nX-Gateway-Secret" --> gateway
  matrix -- "GET matrixConnected" --> health
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MatrixNotificationService.ts</strong><dd><code>New MatrixNotificationService delivering via gateway</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/notifications/MatrixNotificationService.ts

<ul><li>Implements <code>MatrixNotificationService</code> extending <code>NotificationService</code><br> <li> <code>sendNotification</code> POSTs <code>{ userId, title, message }</code> to gateway <code>/notify</code> <br>with <code>X-Gateway-Secret</code> header<br> <li> <code>testConnection</code> checks gateway <code>/health</code> for <code>matrixConnected</code> flag<br> <li> <code>validateConfig</code> validates <code>userId</code>, <code>GATEWAY_SECRET</code>, and <br><code>MATRIX_GATEWAY_URL</code> env vars<br> <li> No per-user credential stored; bot token lives only in the gateway</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/398/files#diff-3a3cfcffc163e20868b9f309e683c4fbd33ccb4b835acb1fad1fdf765dc02545">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NotificationServiceFactory.ts</strong><dd><code>Register matrix channel in notification factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/notifications/NotificationServiceFactory.ts

<ul><li>Adds <code>'matrix'</code> to <code>NotificationServiceType</code> union type<br> <li> Imports <code>MatrixNotificationService</code> and registers it in the <br><code>createService</code> switch</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/398/files#diff-8cce8801c5239b3a57f2a31c94403f1106ee9a31fa3d148c497d5696f74625ef">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MatrixNotificationService.test.ts</strong><dd><code>Unit tests for MatrixNotificationService</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/notifications/__tests__/MatrixNotificationService.test.ts

<ul><li>Adds 6 unit tests using <code>vitest</code> with mocked <code>fetch</code><br> <li> Tests cover: successful delivery, missing secret (no fetch), 404 <br>unpaired user, <code>delivered:false</code>, config validation errors, and <code>/health</code> <br><code>matrixConnected</code> flag<br> <li> Sets up/tears down env vars and global fetch mock in <br><code>beforeEach</code>/<code>afterEach</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/398/files#diff-4af53391d8c04def32a570010fbde75a47250ae44a8f1f66e60fd7a95be2d075">+84/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

