### PR TITLE
feat: Matrix notification opt-in + scheduled-summary delivery (V2)

### DIFF
--- a/src/app/_components/NotificationPreferences.tsx
+++ b/src/app/_components/NotificationPreferences.tsx
@@ -79,6 +79,12 @@ export function NotificationPreferences({ opened, onClose }: NotificationPrefere
     { enabled: opened }
   );
 
+  // Matrix opt-in: offered only when the user has paired a Matrix account.
+  const { data: matrixOptIn } = api.notification.getMatrixOptIn.useQuery(
+    undefined,
+    { enabled: opened }
+  );
+
   // Update preferences mutation
   const updatePreferences = api.notification.updatePreferences.useMutation({
     onSuccess: () => {
@@ -148,7 +154,7 @@ export function NotificationPreferences({ opened, onClose }: NotificationPrefere
             icon={<IconBell size={16} />}
             color="blue"
           >
-            Configure how and when you receive notifications via WhatsApp. 
+            Configure how and when you receive notifications on your connected channels.
             All times are in your selected timezone.
           </Alert>
 
@@ -163,15 +169,18 @@ export function NotificationPreferences({ opened, onClose }: NotificationPrefere
               />
 
               <Select
-                label="WhatsApp Integration"
-                placeholder="Select integration to use"
-                description="Choose which WhatsApp number to send from"
+                label="Notification channel"
+                placeholder="Select where notifications are delivered"
+                description="Where scheduled summaries are delivered"
                 data={[
                   { value: '', label: 'Use default' },
                   ...(integrations?.map(i => ({
                     value: i.id,
                     label: i.name,
                   })) || []),
+                  ...(matrixOptIn?.available && matrixOptIn.integrationId
+                    ? [{ value: matrixOptIn.integrationId, label: 'Matrix (Zoe DM)' }]
+                    : []),
                 ]}
                 {...form.getInputProps('integrationId')}
               />

--- a/src/server/api/routers/__tests__/notificationMatrixOptIn.test.ts
+++ b/src/server/api/routers/__tests__/notificationMatrixOptIn.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit test for notification.getMatrixOptIn (V2, ADR-0043).
+ *
+ * The opt-in gate: Matrix is offered as a notification channel ONLY when the
+ * user has paired (a mapping under the shared system "matrix" Integration).
+ * Pairing for chat is what creates the mapping; choosing Matrix here is still
+ * a separate explicit step (setting preference.integrationId to the returned id).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      /* noop */
+    }
+  },
+}));
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const USER_ID = "user-1";
+const MATRIX_INT = { id: "int-matrix", provider: "matrix", status: "ACTIVE" };
+
+describe("notification.getMatrixOptIn", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  it("is unavailable when no Matrix integration exists at all", async () => {
+    dbMock.integration.findFirst.mockResolvedValue(null as never);
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(caller.notification.getMatrixOptIn()).resolves.toEqual({
+      available: false,
+      integrationId: null,
+    });
+  });
+
+  it("is unavailable when the user has NOT paired (no mapping) — pairing is required", async () => {
+    dbMock.integration.findFirst.mockResolvedValue(MATRIX_INT as never);
+    dbMock.integrationUserMapping.findFirst.mockResolvedValue(null as never);
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(caller.notification.getMatrixOptIn()).resolves.toEqual({
+      available: false,
+      integrationId: null,
+    });
+  });
+
+  it("is available (and returns the integration id) once the user has a mapping", async () => {
+    dbMock.integration.findFirst.mockResolvedValue(MATRIX_INT as never);
+    dbMock.integrationUserMapping.findFirst.mockResolvedValue({
+      userId: USER_ID,
+      integrationId: "int-matrix",
+      externalUserId: "@james:syntro.fi",
+    } as never);
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(caller.notification.getMatrixOptIn()).resolves.toEqual({
+      available: true,
+      integrationId: "int-matrix",
+    });
+  });
+});

--- a/src/server/api/routers/notification.ts
+++ b/src/server/api/routers/notification.ts
@@ -32,6 +32,26 @@ export const notificationRouter = createTRPCRouter({
     return preferences;
   }),
 
+  // Whether the user can pick Matrix as their notification channel — true only
+  // when they've paired a Matrix account (a mapping under the shared system
+  // "matrix" Integration). Returns that integration's id to set as the
+  // preference's integrationId. Opt-in: pairing for chat does not enable this
+  // by itself; the user must choose Matrix here. (V2, ADR-0043)
+  getMatrixOptIn: protectedProcedure.query(async ({ ctx }) => {
+    const integration = await ctx.db.integration.findFirst({
+      where: { provider: "matrix", status: "ACTIVE", userId: null },
+    });
+    if (!integration) return { available: false, integrationId: null };
+
+    const mapping = await ctx.db.integrationUserMapping.findFirst({
+      where: { userId: ctx.session.user.id, integrationId: integration.id },
+    });
+    return {
+      available: !!mapping,
+      integrationId: mapping ? integration.id : null,
+    };
+  }),
+
   // Update notification preferences
   updatePreferences: protectedProcedure
     .input(

--- a/src/server/services/notifications/NotificationScheduler.ts
+++ b/src/server/services/notifications/NotificationScheduler.ts
@@ -2,6 +2,7 @@ import { db } from '~/server/db';
 import { type Prisma } from '@prisma/client';
 import { WhatsAppNotificationService } from './WhatsAppNotificationService';
 import { ZulipNotificationService } from './ZulipNotificationService';
+import { MatrixNotificationService } from './MatrixNotificationService';
 import { NotificationTemplates } from './NotificationTemplates';
 import { sendPushToUser } from './WebPushService';
 import { notificationDeepLink } from './notificationDeepLink';
@@ -209,6 +210,30 @@ export class NotificationScheduler {
           }
         } catch (zulipError) {
           console.error(`[Zulip] Failed for notification ${notification.id}:`, zulipError);
+        }
+      }
+
+      // Also send via Matrix if the user chose it as their channel (V2, ADR-0043).
+      // The MatrixNotificationService posts { userId } to the gateway, which
+      // resolves the user's canonical DM room — no per-user credential here.
+      if (notification.integration?.provider === 'matrix') {
+        try {
+          const matrixService = new MatrixNotificationService({
+            userId: notification.userId,
+            integrationId: notification.integrationId!,
+          });
+          const matrixResult = await matrixService.sendNotification({
+            title: notification.title,
+            message: notification.message,
+          });
+          if (matrixResult.success) {
+            delivered = true;
+            console.log(`💬 Matrix sent for notification ${notification.id}`);
+          } else {
+            console.error(`[Matrix] Not delivered for ${notification.id}: ${matrixResult.error}`);
+          }
+        } catch (matrixError) {
+          console.error(`[Matrix] Failed for notification ${notification.id}:`, matrixError);
         }
       }
 


### PR DESCRIPTION
### **User description**
## What

Completes Matrix **V2 (outbound notifications)** — the opt-in half. Three pieces:

1. **Opt-in resolver** — `notification.getMatrixOptIn` surfaces the shared system `matrix` Integration's id **only when the user has paired** (has a mapping). Pairing for chat creates the mapping; choosing Matrix here is still a separate explicit step.
2. **Picker UI** — `NotificationPreferences` offers "Matrix (Zoe DM)" in the channel select when available; the WhatsApp-specific label/copy is generalized to channel-agnostic.
3. **Delivery** — a Matrix branch in `NotificationScheduler.sendNotification` (mirrors the Zulip branch) delivers daily/weekly summaries via `MatrixNotificationService` → the gateway `/notify` (shipped in the spine PR + mastra #54).

## Design (honors the explicit-opt-in decision)

Matrix is intentionally **not** on the factory `sendToAll` fan-out — that path queries per-user integrations and can't reach the shared (`userId:null`) Matrix row, and auto-firing would violate opt-in. Delivery is gated on the user selecting Matrix as their `NotificationPreference.integrationId`.

**Deferred (documented follow-up):** transcription-completed notifications use `sendToAll` directly, so they don't reach Matrix yet — they need the same opt-in routing. Filed as follow-up; not in this slice.

## Acceptance criteria
- [x] User can select Matrix as their notification channel — only when they have a Matrix mapping (`getMatrixOptIn` gated on the mapping; 3 unit tests)
- [x] Daily/weekly summaries delivered to the Zoe DM for a user who chose Matrix (scheduler branch → MatrixNotificationService → gateway /notify)
- [x] Pairing for chat alone does NOT start notifications (opt-in: mapping exists but preference must point at Matrix)
- [x] Transcription-completed: documented follow-up (sendToAll can't reach the shared integration)
- [x] Full unit suite green (1573); tsc + eslint clean

Ships: matrix-v2-optin-scheduled-summaries


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add Matrix notification opt-in resolver (`getMatrixOptIn` tRPC procedure)

- Deliver scheduled summaries via Matrix when user selects it as channel

- Generalize notification UI copy from WhatsApp-specific to channel-agnostic

- Add 3 unit tests covering Matrix opt-in gate logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User pairs Matrix account"]
  B["integrationUserMapping created"]
  C["getMatrixOptIn query"]
  D["NotificationPreferences UI\n(Matrix option shown)"]
  E["User selects Matrix channel"]
  F["NotificationScheduler.sendNotification"]
  G["MatrixNotificationService"]
  H["Gateway /notify"]

  A -- "creates" --> B
  B -- "gates" --> C
  C -- "available: true + integrationId" --> D
  D -- "user picks Matrix" --> E
  E -- "preference.integrationId set" --> F
  F -- "provider === 'matrix'" --> G
  G -- "POST userId" --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>notification.ts</strong><dd><code>Add getMatrixOptIn tRPC procedure gated on user pairing</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/notification.ts

<ul><li>Adds <code>getMatrixOptIn</code> protected tRPC query procedure<br> <li> Looks up shared system <code>matrix</code> Integration (userId: null, ACTIVE)<br> <li> Checks for a user mapping; returns <code>{ available, integrationId }</code> based <br>on pairing status</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/399/files#diff-7a4d7ed5cb5604efb6f21f81571ba47677e6cd15dad28e7b7ae60d0a9df394b6">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NotificationScheduler.ts</strong><dd><code>Add Matrix delivery branch in NotificationScheduler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/notifications/NotificationScheduler.ts

<ul><li>Imports <code>MatrixNotificationService</code><br> <li> Adds Matrix delivery branch in <code>sendNotification</code> when <br><code>integration.provider === 'matrix'</code><br> <li> Mirrors existing Zulip branch pattern; posts <code>{ userId }</code> to gateway via <br><code>MatrixNotificationService</code><br> <li> Logs success/failure for Matrix delivery attempts</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/399/files#diff-069ac62a784750f64f52e7a1248412d118b5a2b031c5aee5296e2057485b4d7b">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NotificationPreferences.tsx</strong><dd><code>Add Matrix option to notification channel picker UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/NotificationPreferences.tsx

<ul><li>Fetches <code>matrixOptIn</code> via new <code>getMatrixOptIn</code> query when modal is open<br> <li> Appends "Matrix (Zoe DM)" option to channel select when <br><code>matrixOptIn.available</code> is true<br> <li> Generalizes UI labels and description copy from WhatsApp-specific to <br>channel-agnostic</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/399/files#diff-b207e58d62fc00482b139615b931332bf2687ca32fb593d4fdf75efa42492766">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>notificationMatrixOptIn.test.ts</strong><dd><code>Unit tests for Matrix opt-in gate logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/__tests__/notificationMatrixOptIn.test.ts

<ul><li>New test file with 3 unit tests for <code>notification.getMatrixOptIn</code><br> <li> Tests: no integration exists, integration exists but no mapping, <br>integration + mapping present<br> <li> Sets up deep Prisma mock and environment variable stubs for isolated <br>testing</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/399/files#diff-cb19efe3f7e8ad0cffa0da24e165b9e06c16df6d74d95c7fa3108d7f97c3d6ac">+113/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

