### PR TITLE
fix: wire Matrix notification opt-in into the live /settings/notifications page

### DIFF
--- a/src/app/(sidemenu)/settings/notifications/page.tsx
+++ b/src/app/(sidemenu)/settings/notifications/page.tsx
@@ -11,9 +11,11 @@ import {
   Skeleton,
   Badge,
   Divider,
+  Switch,
+  Button,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import { IconBell, IconMail } from '@tabler/icons-react';
+import { IconBell, IconMail, IconMessageCircle } from '@tabler/icons-react';
 import { api } from '~/trpc/react';
 import { PushNotificationToggle } from '~/app/_components/PushNotificationToggle';
 
@@ -23,6 +25,58 @@ export default function NotificationSettingsPage() {
   const utils = api.useUtils();
 
   const { data, isLoading } = api.notification.getAllWorkspaceOverrides.useQuery();
+
+  // Matrix opt-in: only surfaced when the user has paired a Matrix account.
+  const { data: matrixOptIn } = api.notification.getMatrixOptIn.useQuery();
+  const { data: preferences } = api.notification.getPreferences.useQuery();
+
+  const updatePreferences = api.notification.updatePreferences.useMutation({
+    onSuccess: () => {
+      void utils.notification.getPreferences.invalidate();
+      notifications.show({
+        title: 'Notification preferences updated',
+        message: 'Your Matrix delivery preference has been saved.',
+        color: 'green',
+        autoClose: 3000,
+      });
+    },
+  });
+
+  const sendMatrixTest = api.notification.sendMatrixTest.useMutation({
+    onSuccess: () => {
+      notifications.show({
+        title: 'Test sent',
+        message: 'Check your Zoe DM in Matrix.',
+        color: 'green',
+        autoClose: 4000,
+      });
+    },
+    onError: (error) => {
+      notifications.show({
+        title: 'Test failed',
+        message: error.message,
+        color: 'red',
+        autoClose: 5000,
+      });
+    },
+  });
+
+  const matrixSelected =
+    !!matrixOptIn?.integrationId &&
+    preferences?.integrationId === matrixOptIn.integrationId;
+
+  function handleMatrixToggle(on: boolean) {
+    updatePreferences.mutate(
+      on
+        ? {
+            integrationId: matrixOptIn?.integrationId ?? undefined,
+            enabled: true,
+            dailySummary: true,
+            weeklySummary: true,
+          }
+        : { integrationId: undefined },
+    );
+  }
 
   const setOverrideMutation = api.notification.setWorkspaceOverride.useMutation({
     onSuccess: () => {
@@ -87,6 +141,41 @@ export default function NotificationSettingsPage() {
             <PushNotificationToggle />
           </Group>
         </Card>
+
+        {/* Matrix (Zoe DM) — only shown when the user has paired a Matrix account */}
+        {matrixOptIn?.available && (
+          <Card className="bg-surface-secondary border-border-primary" withBorder>
+            <Group justify="space-between" align="flex-start">
+              <Group gap="md">
+                <IconMessageCircle size={24} className="text-text-muted" />
+                <div>
+                  <Title order={4} className="text-text-primary">
+                    Matrix (Zoe DM)
+                  </Title>
+                  <Text size="sm" className="text-text-muted" maw={500}>
+                    Deliver your daily &amp; weekly task summaries to your direct
+                    message with the Zoe bot on Matrix.
+                  </Text>
+                  <Button
+                    variant="light"
+                    size="xs"
+                    mt="sm"
+                    loading={sendMatrixTest.isPending}
+                    onClick={() => sendMatrixTest.mutate()}
+                  >
+                    Send test message
+                  </Button>
+                </div>
+              </Group>
+              <Switch
+                checked={matrixSelected}
+                onChange={(e) => handleMatrixToggle(e.currentTarget.checked)}
+                disabled={updatePreferences.isPending}
+                aria-label="Deliver task summaries to Matrix"
+              />
+            </Group>
+          </Card>
+        )}
 
         <Divider />
 

--- a/src/server/api/routers/__tests__/notificationMatrixOptIn.test.ts
+++ b/src/server/api/routers/__tests__/notificationMatrixOptIn.test.ts
@@ -111,3 +111,19 @@ describe("notification.getMatrixOptIn", () => {
     });
   });
 });
+
+describe("notification.sendMatrixTest", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  it("refuses (PRECONDITION_FAILED) when the user has not paired Matrix", async () => {
+    dbMock.integration.findFirst.mockResolvedValue(MATRIX_INT as never);
+    dbMock.integrationUserMapping.findFirst.mockResolvedValue(null as never);
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(caller.notification.sendMatrixTest()).rejects.toThrow(/Connect Matrix first/);
+  });
+});

--- a/src/server/api/routers/notification.ts
+++ b/src/server/api/routers/notification.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
+import { MatrixNotificationService } from "~/server/services/notifications/MatrixNotificationService";
 
 export const notificationRouter = createTRPCRouter({
   // Get user notification preferences
@@ -50,6 +51,41 @@ export const notificationRouter = createTRPCRouter({
       available: !!mapping,
       integrationId: mapping ? integration.id : null,
     };
+  }),
+
+  // Deliver a test message to the user's Matrix DM *immediately* (bypasses the
+  // scheduler), so opt-in can be verified on the spot. Requires a Matrix mapping.
+  sendMatrixTest: protectedProcedure.mutation(async ({ ctx }) => {
+    const integration = await ctx.db.integration.findFirst({
+      where: { provider: "matrix", status: "ACTIVE", userId: null },
+    });
+    const mapping = integration
+      ? await ctx.db.integrationUserMapping.findFirst({
+          where: { userId: ctx.session.user.id, integrationId: integration.id },
+        })
+      : null;
+    if (!mapping) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Connect Matrix first (Settings → Assistant → Connect Matrix).",
+      });
+    }
+
+    const service = new MatrixNotificationService({
+      userId: ctx.session.user.id,
+      integrationId: integration!.id,
+    });
+    const result = await service.sendNotification({
+      title: "Test notification",
+      message: "✅ Your Exponential notifications are wired up to Matrix.",
+    });
+    if (!result.success) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: result.error ?? "Failed to deliver to Matrix",
+      });
+    }
+    return { success: true };
   }),
 
   // Update notification preferences


### PR DESCRIPTION
### **User description**
## Why

V2-2's Matrix opt-in picker was added to `NotificationPreferences.tsx` — which turns out to be **mounted nowhere** (orphaned component). So there was no reachable UI to enable Matrix notification delivery. The real page at `/settings/notifications` only had Push + per-workspace Email.

## What

Adds a **"Matrix (Zoe DM)"** card to the actual notifications settings page, shown only when the user has paired Matrix (`getMatrixOptIn.available`):
- **A switch** to route daily/weekly summaries to the Zoe DM (sets `NotificationPreference.integrationId` to the Matrix integration + enables the summaries).
- **A "Send test message" button** → new `notification.sendMatrixTest` mutation that delivers **immediately** via `MatrixNotificationService` (bypasses the scheduler), so opt-in is verifiable on the spot rather than waiting for the next scheduled run.

The stale/orphaned edit in `NotificationPreferences.tsx` from #399 is harmless (unmounted) and left as-is.

## Acceptance criteria
- [x] Live `/settings/notifications` shows the Matrix card once paired; hidden otherwise
- [x] Toggle routes summaries to Matrix (writes the preference)
- [x] "Send test message" delivers to the Zoe DM instantly; PRECONDITION_FAILED if not paired (unit test)
- [x] Full unit suite green (1574); tsc + eslint clean; semantic tokens only

Ships: matrix-v2-optin-scheduled-summaries


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add Matrix (Zoe DM) card to live `/settings/notifications` page

- New `sendMatrixTest` tRPC mutation for immediate Matrix delivery verification

- Matrix card shown only when user has paired a Matrix account

- Add unit test for `sendMatrixTest` PRECONDITION_FAILED guard


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User pairs Matrix account"]
  B["getMatrixOptIn\n(available: true)"]
  C["Matrix card shown\nin /settings/notifications"]
  D["Toggle switch\n(handleMatrixToggle)"]
  E["updatePreferences mutation\n(integrationId set)"]
  F["Send test message button"]
  G["sendMatrixTest mutation"]
  H["MatrixNotificationService"]
  I["Gateway /notify"]

  A -- "gates" --> B
  B -- "available=true" --> C
  C -- "user toggles on" --> D
  D -- "writes preference" --> E
  C -- "user clicks" --> F
  F -- "calls" --> G
  G -- "mapping check" --> H
  H -- "POST" --> I
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add Matrix opt-in card to live notifications settings page</code></dd></summary>
<hr>

src/app/(sidemenu)/settings/notifications/page.tsx

<ul><li>Adds <code>Switch</code> and <code>Button</code> imports from Mantine; adds <code>IconMessageCircle</code> <br>icon<br> <li> Fetches <code>matrixOptIn</code> and <code>preferences</code> queries; adds <code>updatePreferences</code> <br>and <code>sendMatrixTest</code> mutations<br> <li> Implements <code>handleMatrixToggle</code> to write Matrix delivery preference<br> <li> Renders a Matrix (Zoe DM) card with toggle switch and "Send test <br>message" button, gated on <code>matrixOptIn.available</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/400/files#diff-018720fe78dc56ffa9940056620a85fdca65f8b8eb614f8f794529f906b70707">+90/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>notification.ts</strong><dd><code>Add sendMatrixTest tRPC mutation for immediate Matrix delivery</code></dd></summary>
<hr>

src/server/api/routers/notification.ts

<ul><li>Imports <code>MatrixNotificationService</code><br> <li> Adds <code>sendMatrixTest</code> protected mutation that verifies Matrix pairing <br>and delivers an immediate test message<br> <li> Throws <code>PRECONDITION_FAILED</code> if no Matrix mapping exists; throws <br><code>INTERNAL_SERVER_ERROR</code> on delivery failure</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/400/files#diff-7a4d7ed5cb5604efb6f21f81571ba47677e6cd15dad28e7b7ae60d0a9df394b6">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>notificationMatrixOptIn.test.ts</strong><dd><code>Add unit test for sendMatrixTest PRECONDITION_FAILED guard</code></dd></summary>
<hr>

src/server/api/routers/__tests__/notificationMatrixOptIn.test.ts

<ul><li>Adds new <code>describe</code> block for <code>notification.sendMatrixTest</code><br> <li> Tests that <code>sendMatrixTest</code> rejects with <code>PRECONDITION_FAILED</code> when user <br>has no Matrix mapping</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/400/files#diff-cb19efe3f7e8ad0cffa0da24e165b9e06c16df6d74d95c7fa3108d7f97c3d6ac">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

