### PR TITLE
fix(nav): open Goals tab by default instead of OKRs

### DIFF
--- a/src/app/_components/layout/WorkspaceTopNav.tsx
+++ b/src/app/_components/layout/WorkspaceTopNav.tsx
@@ -31,7 +31,7 @@ const NAV_ITEMS: readonly NavItem[] = [
     label: 'Goals',
     icon: IconTarget,
     segment: 'goals',
-    href: 'goals?tab=okrs',
+    href: 'goals?tab=goals',
     matchSegments: ['goals', 'okrs'],
   },
   { label: 'Projects', icon: IconStack2, segment: 'projects' },


### PR DESCRIPTION
### **User description**
## What

The Goals link in the workspace top-nav pointed at `goals?tab=okrs`, so clicking **Goals** landed on the OKRs tab.

This changes the link to `goals?tab=goals` so the Goals tab opens by default — matching the intended `/w/<slug>/goals?tab=goals` destination. (The page already defaults to the Goals tab when no `tab` param is present.)

## Change

- `src/app/_components/layout/WorkspaceTopNav.tsx`: `goals?tab=okrs` → `goals?tab=goals`


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Goals nav link to open Goals tab by default

- Changed `href` from `goals?tab=okrs` to `goals?tab=goals`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WorkspaceTopNav Goals link"] -- "was pointing to" --> B["goals?tab=okrs (OKRs tab)"]
  A -- "now points to" --> C["goals?tab=goals (Goals tab)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WorkspaceTopNav.tsx</strong><dd><code>Fix Goals nav link default tab destination</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/layout/WorkspaceTopNav.tsx

<ul><li>Changed the <code>href</code> for the Goals nav item from <code>goals?tab=okrs</code> to <br><code>goals?tab=goals</code><br> <li> Ensures clicking Goals in the top nav opens the Goals tab by default</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/401/files#diff-6fbc08bc6bc74d11828ee72eea39735e7d15eba67b5787e966af1c888ef3d073">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

