### PR TITLE
chore(env): declare VAPID push keys in env schema + .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,15 @@ NOTION_REDIRECT_URI=""
 POSTMARK_SERVER_TOKEN=""
 AUTH_POSTMARK_FROM="noreply@exponential.im"
 
+# Web Push notifications (VAPID key pair).
+# Generate a pair with: npx web-push generate-vapid-keys
+# The public key is exposed to the browser as the applicationServerKey; the
+# private key stays server-side to sign outgoing pushes. Leave both blank to
+# disable push notifications (the feature degrades gracefully when unset).
+# NOTE: rotating these invalidates existing browser subscriptions.
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=""
+VAPID_PRIVATE_KEY=""
+
 # =============================================================================
 # AI & LLM
 # =============================================================================

--- a/src/env.js
+++ b/src/env.js
@@ -17,6 +17,10 @@ export const env = createEnv({
     MICROSOFT_ENTRA_ID_CLIENT_SECRET: z.string().optional(),
     MICROSOFT_ENTRA_ID_TENANT_ID: z.string().optional(),
     DATABASE_URL: z.string().url(),
+    // Web Push (VAPID) private key — server-only, pairs with
+    // NEXT_PUBLIC_VAPID_PUBLIC_KEY. Optional: push notifications degrade
+    // gracefully when unset (see WebPushService / pushSubscription router).
+    VAPID_PRIVATE_KEY: z.string().optional(),
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
@@ -35,6 +39,10 @@ export const env = createEnv({
       process.env.VERCEL_ENV === "production"
         ? z.string().url()
         : z.string().url().optional(),
+    // Web Push (VAPID) public key — exposed to the browser as the
+    // applicationServerKey for pushManager.subscribe(). Optional: push
+    // notifications degrade gracefully when unset.
+    NEXT_PUBLIC_VAPID_PUBLIC_KEY: z.string().optional(),
   },
 
   /**
@@ -49,8 +57,10 @@ export const env = createEnv({
     MICROSOFT_ENTRA_ID_CLIENT_SECRET: process.env.MICROSOFT_ENTRA_ID_CLIENT_SECRET,
     MICROSOFT_ENTRA_ID_TENANT_ID: process.env.MICROSOFT_ENTRA_ID_TENANT_ID,
     DATABASE_URL: process.env.DATABASE_URL,
+    VAPID_PRIVATE_KEY: process.env.VAPID_PRIVATE_KEY,
     NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    NEXT_PUBLIC_VAPID_PUBLIC_KEY: process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially


### PR DESCRIPTION
### **User description**
## What

- Declare `NEXT_PUBLIC_VAPID_PUBLIC_KEY` (client block) and `VAPID_PRIVATE_KEY` (server block) in `src/env.js`, wired through `runtimeEnv`.
- Document both in `.env.example` under the Email/Notifications section, with `npx web-push generate-vapid-keys` instructions and a rotation warning.

## Why

These two keys power Web Push notifications but were read via `process.env` directly — never declared in the T3 env schema, never listed in `.env.example`. A missing or empty key surfaced only as a runtime "Subscription failed" toast with **no build-time or setup-time signal**, and a new environment had no documented hint that the keys were needed.

This is the hardening follow-up to the push-subscription loop fix (`f04f0898` on main): that fix stopped a stale/rotated key from throwing `InvalidStateError` on every subscribe; this makes the keys themselves discoverable and validated.

## Design note: why `optional()`, not required

Push notifications degrade gracefully by design — `WebPushService` and the `pushSubscription` router throw a helpful runtime error only when actually invoked without keys. Declaring the vars **optional** documents and type-validates them while letting local dev, previews, and any non-push deploy boot normally. Making them required-in-production would mean rotating/removing the prod keys takes the whole app down at boot — strictly worse than push degrading.

## Verification

- `createEnv` constructs without throwing (no `NEXT_PUBLIC`-in-server structural error).
- App boots with VAPID vars **unset** — both resolve to `undefined`, graceful degradation preserved.
- `eslint src/env.js` clean; unit test suite green via pre-commit hook.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Declare `VAPID_PRIVATE_KEY` (server) and `NEXT_PUBLIC_VAPID_PUBLIC_KEY` (client) in T3 env schema

- Both keys wired through `runtimeEnv` as optional fields

- Document VAPID keys in `.env.example` with generation instructions and rotation warning


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["process.env (runtime)"] -- "VAPID_PRIVATE_KEY" --> B["server block (src/env.js)"]
  A -- "NEXT_PUBLIC_VAPID_PUBLIC_KEY" --> C["client block (src/env.js)"]
  B -- "optional, graceful degradation" --> D["WebPushService / pushSubscription router"]
  C -- "optional, graceful degradation" --> E["Browser pushManager.subscribe()"]
  F[".env.example"] -- "documents keys + generation instructions" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>env.js</strong><dd><code>Add VAPID keys to T3 env schema as optional fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/env.js

<ul><li>Added <code>VAPID_PRIVATE_KEY</code> as optional string in the server block with <br>explanatory comment<br> <li> Added <code>NEXT_PUBLIC_VAPID_PUBLIC_KEY</code> as optional string in the client <br>block with explanatory comment<br> <li> Wired both new keys into <code>runtimeEnv</code> via <code>process.env</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/402/files#diff-5fefa99495d6ed3e62e828ee33b4be377469032ec0a61c088bc0101e071c1172">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.example</strong><dd><code>Document VAPID key pair in .env.example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.env.example

<ul><li>Added <code>NEXT_PUBLIC_VAPID_PUBLIC_KEY</code> and <code>VAPID_PRIVATE_KEY</code> entries under <br>Email/Notifications section<br> <li> Included generation instructions (<code>npx web-push generate-vapid-keys</code>) <br>and rotation warning<br> <li> Noted graceful degradation behavior when keys are left blank</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/402/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

