### PR TITLE
fix(products): add page padding to New product screen

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/new/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/new/page.tsx
@@ -73,73 +73,75 @@ export default function NewProductPage() {
   };
 
   return (
-    <Stack gap="lg" maw={640}>
-      <div>
-        <Title order={2} className="text-text-primary">
-          New product
-        </Title>
-        <Text className="text-text-muted">
-          A product is a container for features, tickets, research, and cycles.
-        </Text>
-      </div>
+    <div className="px-8 py-6">
+      <Stack gap="lg" maw={640}>
+        <div>
+          <Title order={2} className="text-text-primary">
+            New product
+          </Title>
+          <Text className="text-text-muted">
+            A product is a container for features, tickets, research, and cycles.
+          </Text>
+        </div>
 
-      <Card className="border border-border-primary bg-surface-secondary">
-        <form onSubmit={onSubmit}>
-          <Stack gap="md">
-            <TextInput
-              label="Name"
-              placeholder={`e.g. ${PRODUCT_NAME} Core`}
-              value={name}
-              onChange={(e) => onNameChange(e.currentTarget.value)}
-              required
-              maxLength={120}
-            />
-            <TextInput
-              label="Slug"
-              placeholder="exponential-core"
-              description="URL-safe identifier. Lowercase letters, numbers, and hyphens only."
-              value={slug}
-              onChange={(e) => {
-                setSlug(e.currentTarget.value);
-                setSlugEdited(true);
-              }}
-              required
-              maxLength={60}
-            />
-            <Textarea
-              label="Description"
-              placeholder="Briefly describe what this product is and who it's for."
-              value={description}
-              onChange={(e) => setDescription(e.currentTarget.value)}
-              autosize
-              minRows={3}
-              maxLength={2000}
-            />
-            {error && (
-              <Text size="sm" className="text-text-error">
-                {error}
-              </Text>
-            )}
-            <Group justify="flex-end">
-              <Button
-                variant="subtle"
-                component={Link}
-                href={`/w/${workspace.slug}/products`}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                color="brand"
-                loading={createProduct.isPending}
-                disabled={!name.trim() || !slug.trim()}
-              >
-                Create product
-              </Button>
-            </Group>
-          </Stack>
-        </form>
-      </Card>
-    </Stack>
+        <Card className="border border-border-primary bg-surface-secondary">
+          <form onSubmit={onSubmit}>
+            <Stack gap="md">
+              <TextInput
+                label="Name"
+                placeholder={`e.g. ${PRODUCT_NAME} Core`}
+                value={name}
+                onChange={(e) => onNameChange(e.currentTarget.value)}
+                required
+                maxLength={120}
+              />
+              <TextInput
+                label="Slug"
+                placeholder="exponential-core"
+                description="URL-safe identifier. Lowercase letters, numbers, and hyphens only."
+                value={slug}
+                onChange={(e) => {
+                  setSlug(e.currentTarget.value);
+                  setSlugEdited(true);
+                }}
+                required
+                maxLength={60}
+              />
+              <Textarea
+                label="Description"
+                placeholder="Briefly describe what this product is and who it's for."
+                value={description}
+                onChange={(e) => setDescription(e.currentTarget.value)}
+                autosize
+                minRows={3}
+                maxLength={2000}
+              />
+              {error && (
+                <Text size="sm" className="text-text-error">
+                  {error}
+                </Text>
+              )}
+              <Group justify="flex-end">
+                <Button
+                  variant="subtle"
+                  component={Link}
+                  href={`/w/${workspace.slug}/products`}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  color="brand"
+                  loading={createProduct.isPending}
+                  disabled={!name.trim() || !slug.trim()}
+                >
+                  Create product
+                </Button>
+              </Group>
+            </Stack>
+          </form>
+        </Card>
+      </Stack>
+    </div>
   );
 }


### PR DESCRIPTION
### **User description**
## Problem

The **New product** screen (`/w/[workspaceSlug]/products/new`) rendered flush against the viewport edges — the heading, subtitle, and form card had no left/top gutter.

## Cause

The workspace layout wrapper (`WorkspaceLayout.module.css`) uses negative margins to cancel `<main>`'s padding so the `WorkspaceTopbar` can sit edge-to-edge. Pages under `ProductLayout` re-add a `px-10` gutter, but `products/new/page.tsx` renders as a plain sibling after the topbar with only a `<Stack maw={640}>` — no horizontal padding of its own.

## Fix

Wrap the form in a `px-8 py-6` container, matching the 32px horizontal gutter used across the products area (`ProductsViewTabs` top bar). Pure layout change — no logic touched.

## Test

- Visit **Products → New product**; content now has proper padding from the edges.


___

### **PR Type**
Bug fix


___

### **Description**
- Wrap New product page content in `px-8 py-6` container div

- Fixes flush rendering against viewport edges on `/products/new`

- Matches 32px horizontal gutter used across the products area


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["products/new/page.tsx"] -- "wrap with" --> B["div.px-8.py-6"]
  B -- "contains" --> C["Stack maw=640"]
  C -- "contains" --> D["Title + Text + Card/Form"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add px-8 py-6 padding wrapper to New product page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/products/new/page.tsx

<ul><li>Wrapped the existing <code>Stack</code> component in a new <code>div</code> with <code>px-8 py-6</code> <br>Tailwind classes<br> <li> Adds horizontal (32px) and vertical (24px) padding to the New product <br>page<br> <li> No logic or form behavior changed; purely a layout fix</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/409/files#diff-5645af402f63dcc26b4a920212dedda9090b6bb3b426889260a9bd0dd7565aba">+69/-67</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

