### PR TITLE
fix(migration): dedupe notification-prefs backfill (unblocks prod migrations)

### DIFF
--- a/prisma/migrations/20260722143827_migrate_notification_prefs_to_matrix/migration.sql
+++ b/prisma/migrations/20260722143827_migrate_notification_prefs_to_matrix/migration.sql
@@ -12,26 +12,39 @@
 --
 -- Always-on channels (Push, Email) keep the seeded defaults and are not written
 -- here. Idempotent: re-running only re-affirms enabled cells.
+--
+-- NOTE: the inner SELECT DISTINCT is required. Both dailySummary and
+-- weeklySummary map to the single 'summary' category, so a user with both
+-- enabled (or two integrations for the same provider) would otherwise yield two
+-- identical (userId, 'summary', channel) rows in one INSERT and trip
+-- "ON CONFLICT DO UPDATE command cannot affect row a second time" (SQLSTATE
+-- 21000). Deduping the logical key before assigning id/timestamps avoids it.
 
 INSERT INTO "NotificationChannelPreference" ("id", "userId", "category", "channel", "enabled", "createdAt", "updatedAt")
 SELECT
   gen_random_uuid()::text,
-  np."userId",
-  m.category,
-  i."provider",
+  d."userId",
+  d."category",
+  d."channel",
   true,
   now(),
   now()
-FROM "NotificationPreference" np
-JOIN "Integration" i
-  ON i."id" = np."integrationId"
-  AND i."provider" IN ('matrix', 'whatsapp', 'zulip')
-JOIN LATERAL (
-  VALUES
-    ('due_date', np."taskReminders"),
-    ('summary', np."dailySummary"),
-    ('summary', np."weeklySummary")
-) AS m(category, flag) ON m.flag = true
-WHERE np."integrationId" IS NOT NULL
+FROM (
+  SELECT DISTINCT
+    np."userId"  AS "userId",
+    m.category   AS "category",
+    i."provider" AS "channel"
+  FROM "NotificationPreference" np
+  JOIN "Integration" i
+    ON i."id" = np."integrationId"
+    AND i."provider" IN ('matrix', 'whatsapp', 'zulip')
+  JOIN LATERAL (
+    VALUES
+      ('due_date', np."taskReminders"),
+      ('summary', np."dailySummary"),
+      ('summary', np."weeklySummary")
+  ) AS m(category, flag) ON m.flag = true
+  WHERE np."integrationId" IS NOT NULL
+) d
 ON CONFLICT ("userId", "category", "channel")
 DO UPDATE SET "enabled" = true, "updatedAt" = now();


### PR DESCRIPTION
### **User description**
## Why

The `20260722143827_migrate_notification_prefs_to_matrix` data migration (from #406) **failed on production** and has been silently blocking every migration since, via Prisma **P3009**. When #410 (product logo) then shipped a Prisma client that `SELECT`s the not-yet-created `Product.logoUrl`, **all product queries started throwing** → the products page showed "No products yet."

## Root cause (deterministic, not transient)

Original failure from #406's deploy:
```
P3018 — SQLSTATE 21000
ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time
```

`dailySummary` and `weeklySummary` both map to the single `summary` category. A user with **both** enabled on an opt-in channel produces two identical `(userId, 'summary', channel)` rows in one `INSERT … ON CONFLICT DO UPDATE`, which Postgres rejects. Dev DBs had no such user, so it only ever failed on prod.

## Fix

Wrap the source rows in `SELECT DISTINCT (userId, category, channel)` before assigning `id`/timestamps, so no duplicate conflict keys reach the `INSERT`. Semantically identical, still idempotent.

Editing the migration in place is safe because it **never succeeded on any tracked DB** (prod failed; dev/develop never ran it through a migrate workflow) — no checksum-mismatch risk.

## Verification

Ran against a throwaway Postgres with representative data (a user with both summaries on matrix, a whatsapp single-summary user, plus ignored non-opt-in/no-integration users):

- Original SQL → **fails with 21000** (bug reproduced)
- Fixed SQL → **`INSERT 0 3`, succeeds**; re-run succeeds with no duplicates (idempotent)
- Correct rows: `u1 → due_date+summary/matrix`, `u2 → summary/whatsapp`; google-integration & no-integration users excluded

## Deploy / recovery (manual, against production `DATABASE_URL`)

After this merges so the corrected file is present:
```bash
npx prisma migrate resolve --rolled-back 20260722143827_migrate_notification_prefs_to_matrix
npx prisma migrate deploy   # re-applies corrected backfill + creates Product.logoUrl
```
This unblocks the queue, lands #406's notification backfill correctly, and restores the products page.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix production migration failure caused by duplicate `(userId, category, channel)` rows

- Wrap source rows in `SELECT DISTINCT` before assigning `id`/timestamps to prevent `ON CONFLICT` collision

- Root cause: `dailySummary` and `weeklySummary` both map to `summary` category, producing duplicate conflict keys

- Fix unblocks all subsequent migrations (P3009) and restores product queries broken by stalled migration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NotificationPreference rows"]
  B["JOIN Integration (matrix/whatsapp/zulip)"]
  C["LATERAL VALUES (due_date/summary)"]
  D["SELECT DISTINCT userId, category, channel"]
  E["INSERT NotificationChannelPreference"]
  F["ON CONFLICT DO UPDATE"]

  A -- "integrationId" --> B
  B -- "flag=true" --> C
  C -- "dedup logical key" --> D
  D -- "no duplicate conflict keys" --> E
  E -- "idempotent upsert" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>migration.sql</strong><dd><code>Deduplicate source rows in notification prefs backfill migration</code></dd></summary>
<hr>

prisma/migrations/20260722143827_migrate_notification_prefs_to_matrix/migration.sql

<ul><li>Wraps the source query in a <code>SELECT DISTINCT</code> subquery on <code>(userId, </code><br><code>category, channel)</code> before assigning <code>id</code>/timestamps<br> <li> Prevents duplicate conflict keys from reaching the <code>INSERT … ON </code><br><code>CONFLICT</code> when both <code>dailySummary</code> and <code>weeklySummary</code> map to the same <br><code>summary</code> category<br> <li> Adds explanatory comment documenting why <code>SELECT DISTINCT</code> is required<br> <li> Migration remains semantically identical and idempotent across re-runs</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/411/files#diff-ce98b59a8a28a8d7f4eb568b87a02a2bb81da60312b2e8e862df9ec36a9cfe4d">+27/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

