### PR TITLE
ci: add "Migrations apply cleanly" merge gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,53 @@ jobs:
           SKIP_ENV_VALIDATION: true
           AUTH_SECRET: test-secret-for-ci
 
+  # Dedicated merge gate: apply every migration from scratch against a real
+  # Postgres. Fails the PR (once required in branch protection) if any migration
+  # errors — bad SQL, a reference to a not-yet-created column, ordering drift, or
+  # a checksum mismatch on an edited already-applied migration.
+  #
+  # Runs UNCONDITIONALLY on every PR (not path-filtered) so it is a reliable
+  # required status check — a path-filtered required check that gets skipped
+  # shows as "pending" and blocks merge forever. Applying the full history to an
+  # empty DB takes only a few seconds.
+  #
+  # COVERAGE LIMIT: this applies migrations to an EMPTY database, so it catches
+  # STRUCTURAL failures but NOT data-dependent ones (a data backfill that only
+  # trips on real rows — e.g. an ON CONFLICT dup that needs an existing row).
+  # Write data migrations defensively (dedupe before INSERT ... ON CONFLICT,
+  # guard against NULLs, etc.); an empty-DB apply cannot prove them safe on prod.
+  migration-apply:
+    name: Migrations apply cleanly
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: exponential_migrations
+        ports:
+          - 5434:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://test:test@localhost:5434/exponential_migrations
+      SKIP_ENV_VALIDATION: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Apply all migrations from scratch
+        run: npx prisma migrate deploy
+      - name: Verify no pending migrations / drift
+        run: npx prisma migrate status
+
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
### **User description**
## Why

Follow-up to the products outage. Root cause recap: #406's data migration failed on prod (SQLSTATE 21000), silently blocked every later migration (P3009), and once #410 shipped a client selecting the not-yet-created `Product.logoUrl`, all product queries threw.

Nothing stopped the broken migrations from merging because:
- **`main` has no branch protection** — CI can go red and a PR still merges.
- `migrate deploy` *does* already run inside `integration-tests`, but it's buried as a step and (being an empty-DB apply) can't catch data-dependent failures.

## What this adds

A dedicated **`Migrations apply cleanly`** job in `test.yml` that, on every PR:
- spins up Postgres, `npm ci`,
- `npx prisma migrate deploy` (applies the whole history from scratch),
- `npx prisma migrate status` (asserts no pending/drift).

It runs **unconditionally** (not path-filtered) so it's a reliable required check — a path-filtered required check that gets skipped shows "pending" and blocks merge forever.

## What it catches / doesn't

✅ Structural failures: bad SQL, references to not-yet-created columns/tables, ordering drift, checksum mismatch on an edited already-applied migration.

⚠️ **Not** data-dependent failures — it applies to an *empty* DB, so a backfill that only breaks on real rows (like the 21000 dup) won't trip it. That's documented inline; the mitigation is writing data migrations defensively (as #411 did with `SELECT DISTINCT`).

## Required manual step to actually enforce it

A workflow can't block a merge on its own. After this merges, enable branch protection on `main` and mark **`Migrations apply cleanly`** (ideally also `Lint & Typecheck`, `Unit Tests`, `Integration Tests`, `Build`) as **required status checks**. I can apply this via `gh api` on request — see the PR thread.


___

### **PR Type**
Enhancement, other


___

### **Description**
- Add dedicated `Migrations apply cleanly` CI job to `.github/workflows/test.yml`

- Spins up Postgres, runs `prisma migrate deploy` + `prisma migrate status` on every PR

- Catches structural migration failures: bad SQL, missing columns, ordering drift, checksum mismatches

- Runs unconditionally (no path filter) to be a reliable required status check


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PR["Pull Request"] -- "triggers" --> job["migration-apply job"]
  job -- "spins up" --> pg["Postgres (pgvector/pg16)"]
  job -- "npm ci" --> deps["Dependencies installed"]
  deps -- "prisma migrate deploy" --> apply["Full migration history applied"]
  apply -- "prisma migrate status" --> verify["No pending/drift verified"]
  verify -- "pass/fail" --> gate["Required status check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test.yml</strong><dd><code>Add unconditional migration apply CI merge gate job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/test.yml

<ul><li>Adds new <code>migration-apply</code> job with a dedicated Postgres service <br>container<br> <li> Runs <code>npx prisma migrate deploy</code> to apply full migration history from <br>scratch<br> <li> Runs <code>npx prisma migrate status</code> to assert no pending migrations or <br>drift<br> <li> Job runs unconditionally on every PR without path filtering for <br>reliability</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/412/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

