### PR TITLE
feat: Notify team members added as meeting participants

### DIFF
--- a/src/app/(sidemenu)/settings/notifications/NotificationChannelMatrix.tsx
+++ b/src/app/(sidemenu)/settings/notifications/NotificationChannelMatrix.tsx
@@ -19,6 +19,7 @@ const CATEGORY_ORDER = [
   'due_date',
   'summary',
   'meeting_ready',
+  'meeting_participant_added',
 ] as const;
 type Category = (typeof CATEGORY_ORDER)[number];
 
@@ -31,6 +32,7 @@ const CATEGORY_LABELS: Record<Category, string> = {
   due_date: 'Due-date reminders',
   summary: 'Summaries',
   meeting_ready: 'Meeting-ready',
+  meeting_participant_added: 'Added to a meeting',
 };
 
 const CHANNEL_LABELS: Record<Channel, string> = {

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -28,6 +28,8 @@ import {
   requireProjectAccess,
 } from "~/server/services/access";
 import { recordActivity } from "~/server/services/activity/recordActivity";
+import { emitNotification } from "~/server/services/notifications/emit/emitNotification";
+import { NOTIFICATION_CATEGORIES } from "~/server/services/notifications/emit/constants";
 import { encryptString, decryptBuffer } from "~/server/utils/encryption";
 import { createHash } from "crypto";
 
@@ -914,6 +916,21 @@ export const transcriptionRouter = createTRPCRouter({
         });
       }
 
+      // Notify workspace members tagged as participants (ADR-0045 pipeline).
+      // Only member (userId) participants are notifiable — CRM-contact /
+      // free-text people have no User account. The actor is dropped downstream.
+      const memberUserIds = participants
+        .map((p) => p.userId)
+        .filter((id): id is string => !!id);
+      if (session.workspaceId && memberUserIds.length > 0) {
+        void emitNotification({
+          db: ctx.db,
+          category: NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED,
+          actorUserId: ctx.session.user.id,
+          subject: { sessionId: session.id, participantUserIds: memberUserIds },
+        });
+      }
+
       return session;
     }),
 
@@ -974,6 +991,23 @@ export const transcriptionRouter = createTRPCRouter({
         await syncParticipantCount(tx, session.id);
         return row;
       });
+
+      // Notify the tagged workspace member (ADR-0045 pipeline). Only the member
+      // (userId) path is notifiable; CRM-contact / free-text adds resolve to a
+      // contact with no User account. Fire-and-forget; the actor is dropped
+      // downstream (self-adds don't self-notify).
+      if (input.userId) {
+        void emitNotification({
+          db: ctx.db,
+          category: NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED,
+          actorUserId: ctx.session.user.id,
+          subject: {
+            sessionId: session.id,
+            participantUserIds: [input.userId],
+          },
+        });
+      }
+
       return participant;
     }),
 

--- a/src/server/services/notifications/emit/__tests__/emitNotification.test.ts
+++ b/src/server/services/notifications/emit/__tests__/emitNotification.test.ts
@@ -301,3 +301,70 @@ describe("emitNotification — channel resolution", () => {
     });
   });
 });
+
+describe("emitNotification — Meeting participant added", () => {
+  beforeEach(() => {
+    // The content builder resolves the meeting to a title + workspace.
+    db.transcriptionSession.findUnique.mockResolvedValue({
+      title: "Weekly sync",
+      workspace: WORKSPACE,
+    } as never);
+  });
+
+  it("notifies each tagged member (excluding the actor) with a /recording deeplink", async () => {
+    await emitNotification({
+      category: NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED,
+      actorUserId: "actor1",
+      subject: { sessionId: "m1", participantUserIds: ["member1", "actor1"] },
+      db,
+    });
+
+    // Actor excluded → exactly one recipient.
+    expect(db.notification.create).toHaveBeenCalledTimes(1);
+    expect(db.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "member1",
+          category: "meeting_participant_added",
+          message: "Weekly sync",
+          deeplink: "/recording/m1",
+          dedupeKey: "meeting_participant_added:m1:member1",
+        }),
+      }),
+    );
+    expect(sendNotificationSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Actor added you to a meeting" }),
+    );
+  });
+
+  it("delivers to Matrix when the opt-in cell is enabled for the category", async () => {
+    db.notificationChannelPreference.findMany.mockResolvedValue([
+      { channel: "push", enabled: false },
+      { channel: "matrix", enabled: true },
+    ] as never);
+
+    await emitNotification({
+      category: NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED,
+      actorUserId: "actor1",
+      subject: { sessionId: "m1", participantUserIds: ["member1"] },
+      db,
+    });
+
+    expect(NotificationServiceFactory.createService).toHaveBeenCalledWith("matrix", {
+      userId: "member1",
+    });
+  });
+
+  it("skips the emit when the meeting can no longer be resolved", async () => {
+    db.transcriptionSession.findUnique.mockResolvedValue(null as never);
+
+    await emitNotification({
+      category: NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED,
+      actorUserId: "actor1",
+      subject: { sessionId: "gone", participantUserIds: ["member1"] },
+      db,
+    });
+
+    expect(db.notification.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/notifications/emit/constants.ts
+++ b/src/server/services/notifications/emit/constants.ts
@@ -14,6 +14,7 @@ export const NOTIFICATION_CATEGORIES = {
   DUE_DATE: "due_date",
   SUMMARY: "summary",
   MEETING_READY: "meeting_ready",
+  MEETING_PARTICIPANT_ADDED: "meeting_participant_added",
 } as const;
 
 export type NotificationCategory =
@@ -69,6 +70,7 @@ export const CATEGORY_LIST = [
   NOTIFICATION_CATEGORIES.DUE_DATE,
   NOTIFICATION_CATEGORIES.SUMMARY,
   NOTIFICATION_CATEGORIES.MEETING_READY,
+  NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED,
 ] as const;
 
 /** All channels, in stable delivery / matrix-column order. */
@@ -97,4 +99,5 @@ export const DEFAULT_MATRIX: Record<
   [NOTIFICATION_CATEGORIES.DUE_DATE]: { push: true, email: true, matrix: false, whatsapp: false, zulip: false },
   [NOTIFICATION_CATEGORIES.SUMMARY]: { push: false, email: true, matrix: false, whatsapp: false, zulip: false },
   [NOTIFICATION_CATEGORIES.MEETING_READY]: { push: true, email: true, matrix: false, whatsapp: false, zulip: false },
+  [NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED]: { push: true, email: true, matrix: false, whatsapp: false, zulip: false },
 };

--- a/src/server/services/notifications/emit/content.ts
+++ b/src/server/services/notifications/emit/content.ts
@@ -71,6 +71,50 @@ export async function buildContent(
         dedupeKey: `assignment:${actionId}:${recipientId}`,
       };
     }
+    case NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED: {
+      const { sessionId } = input.subject;
+
+      const [session, actor] = await Promise.all([
+        db.transcriptionSession.findUnique({
+          where: { id: sessionId },
+          select: {
+            title: true,
+            workspace: { select: { id: true, slug: true, name: true } },
+          },
+        }),
+        input.actorUserId
+          ? db.user.findUnique({
+              where: { id: input.actorUserId },
+              select: { name: true, email: true },
+            })
+          : Promise.resolve(null),
+      ]);
+
+      // Participants require a workspace (see createManualTranscription), so a
+      // meeting with none can't have members to notify — skip if it's gone.
+      if (!session?.workspace) return null;
+
+      const adderName = actor?.name ?? actor?.email ?? "Someone";
+      const meetingTitle = session.title ?? "a meeting";
+
+      return {
+        category: NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED,
+        title: `${adderName} added you to a meeting`,
+        message: meetingTitle,
+        deeplink: `/recording/${sessionId}`,
+        metadata: {
+          sessionId,
+          // Mirrors the notificationDeepLink metadata shape used elsewhere.
+          transcriptionId: sessionId,
+          workspaceId: session.workspace.id,
+          workspaceSlug: session.workspace.slug,
+          workspaceName: session.workspace.name,
+          adderName,
+        },
+        workspaceId: session.workspace.id,
+        dedupeKey: `meeting_participant_added:${sessionId}:${recipientId}`,
+      };
+    }
     case NOTIFICATION_CATEGORIES.MENTION:
       return buildMentionContent(input, recipientId);
     default:

--- a/src/server/services/notifications/emit/recipients.ts
+++ b/src/server/services/notifications/emit/recipients.ts
@@ -17,6 +17,11 @@ export async function resolveRecipients(
     case NOTIFICATION_CATEGORIES.MENTION:
       // Mention → parsed, membership-filtered mentioned users.
       return resolveMentionRecipients(input);
+    case NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED:
+      // Meeting participant added → the members just linked. De-dup defensively.
+      return Promise.resolve(
+        Array.from(new Set(input.subject.participantUserIds)),
+      );
     default:
       return Promise.resolve([]);
   }

--- a/src/server/services/notifications/emit/types.ts
+++ b/src/server/services/notifications/emit/types.ts
@@ -15,6 +15,16 @@ export interface AssignmentSubject {
 }
 
 /**
+ * Meeting participant added: a meeting (TranscriptionSession) and the workspace
+ * members just linked to it as participants. Only member (userId) participants
+ * are notifiable — CRM-contact / free-text people have no User account.
+ */
+export interface MeetingParticipantAddedSubject {
+  sessionId: string;
+  participantUserIds: string[];
+}
+
+/**
  * Mention (V2): a comment on some target (action / feature / scope), already
  * resolved to its workspace + display name + deep-link. Recipients are parsed
  * from the `@[Name](id)` markup and membership-filtered by the resolver.
@@ -53,6 +63,10 @@ export type EmitNotificationInput = {
   | {
       category: typeof NOTIFICATION_CATEGORIES.MENTION;
       subject: MentionSubject;
+    }
+  | {
+      category: typeof NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED;
+      subject: MeetingParticipantAddedSubject;
     }
 );
 


### PR DESCRIPTION
### **User description**
## What

When a workspace **team member** is tagged as a meeting participant, notify them — via the unified notification pipeline (**ADR-0045**), not the removed `sendAssignmentNotifications` fan-out.

- Adds a new **`meeting_participant_added`** notification category, wired through `emit/{constants,types,recipients,content}` + the settings channel matrix.
- Fires `emitNotification(...)` fire-and-forget from **`createManualTranscription`** (member participants attached at create) and **`addParticipant`** (single member add on the detail page).
- Delivery to **push, email, Matrix, WhatsApp, Zulip** comes from the pipeline for free. Defaults: push + email **on**; Matrix/WhatsApp/Zulip **opt-in off** (users enable Matrix per-category in notification settings, per ADR-0045).
- Only **member (`userId`) participants** are notified — CRM-contact / free-text people have no `User` account and are skipped. The actor is never notified about their own add. Deep-links to `/recording/<id>`.

> Note: this supersedes the ticket's original "build a reusable Matrix helper" plan — ADR-0045 (which landed after the ticket was written) makes Matrix a first-class channel, so no custom helper is needed.

## Acceptance criteria

- [ ] Adding a team member to a meeting (Add Meeting modal OR detail page) notifies that member.
- [ ] Notifications respect the user's channel-preference matrix + per-workspace email override.
- [ ] Delivery covers push, email, and Matrix (Matrix only when the user has enabled that cell).
- [ ] CRM-contact / free-text participants are not notified and cause no errors.
- [ ] Fire-and-forget: a delivery failure never fails the participant-add mutation.

## Verification

- New unit tests in `emit/__tests__/emitNotification.test.ts` (recipient exclusion, deeplink/dedupeKey, Matrix delivery, meeting-gone skip).
- Full suite: 1654 unit tests pass · tsc 0 errors · eslint clean.
- Not driven end-to-end against live push/Matrix (needs a connected workspace).

---

Ships: alpha.nova (Exponential ticket cmrw0ruyv000bjr04s8lez00a)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds `meeting_participant_added` notification category to unified pipeline

- Fires notifications when workspace members are added as meeting participants
  - Triggered from both `createManualTranscription` and `addParticipant`
  - Actor excluded from notifications; CRM-contact/free-text participants skipped

- Wires new category through constants, types, recipients, content, and settings UI

- Adds unit tests covering recipient exclusion, deeplink, Matrix delivery, and missing meeting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["transcription.ts\n(createManualTranscription\n/ addParticipant)"] -- "emitNotification()" --> B["emitNotification\npipeline"]
  B -- "resolveRecipients()" --> C["recipients.ts\nMEETING_PARTICIPANT_ADDED"]
  B -- "buildContent()" --> D["content.ts\ntitle + deeplink + dedupeKey"]
  B -- "channel matrix" --> E["constants.ts\nDEFAULT_MATRIX\npush+email on"]
  E -- "UI label" --> F["NotificationChannelMatrix.tsx\n'Added to a meeting'"]
  B -- "deliver" --> G["push / email / Matrix\n/ WhatsApp / Zulip"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>constants.ts</strong><dd><code>Add MEETING_PARTICIPANT_ADDED category, list entry, and default matrix </code><br><code>row</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/414/files#diff-7f56b9da0271816ad3c913492a3db101a4463bb1e7858f9f68bd83aebe2d64fe">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Add MeetingParticipantAddedSubject interface and union discriminant</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/414/files#diff-24cf961c0fa36a7d78a25dacb5751507ecb95553fd1e062c713fe311a4341972">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>recipients.ts</strong><dd><code>Resolve participant userIds as recipients for new category</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/414/files#diff-c616ea57fdf8a4feae06c77a500c0a62a10d0403df65ee59010046d6bea507cf">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>content.ts</strong><dd><code>Build notification content with deeplink and dedupeKey for meeting </code><br><code>participant</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/414/files#diff-0de1681e5e2c85a302ddd3eccff0dae2a5a1f1079bad2ef656209b66c900ab21">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transcription.ts</strong><dd><code>Fire meeting_participant_added notification on create and </code><br><code>addParticipant</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/414/files#diff-14d6aec7ca6f74348adfbedb772dd759262f6da276ab98b75041752d8d7ea06b">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NotificationChannelMatrix.tsx</strong><dd><code>Add meeting_participant_added category to settings channel matrix UI</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/414/files#diff-3eb32e1021dc9790885dd3cf015720c483e7f3ac4505ba9c3ed3576d5ee17e09">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>emitNotification.test.ts</strong><dd><code>Add tests for meeting participant notification recipient and delivery </code><br><code>logic</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/414/files#diff-43bcf0ed5c1ff3d9e21c6810ff69d3e458908d8b716251c68ac819911bc9d47a">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

