### PR TITLE
feat: Notify meeting participants when notes are ready

### DIFF
--- a/src/app/api/webhooks/fireflies/route.ts
+++ b/src/app/api/webhooks/fireflies/route.ts
@@ -5,6 +5,8 @@ import { db } from '~/server/db';
 import { FirefliesService, type FirefliesTranscript } from '~/server/services/FirefliesService';
 import { getEmbeddingTriggerService } from '~/server/services/embedding';
 import { decryptFromBase64 } from '~/server/utils/encryption';
+import { emitNotification } from '~/server/services/notifications/emit/emitNotification';
+import { NOTIFICATION_CATEGORIES } from '~/server/services/notifications/emit/constants';
 // import { ActionProcessorFactory } from '~/server/services/processors/ActionProcessorFactory';
 // import { NotificationServiceFactory } from '~/server/services/notifications/NotificationServiceFactory';
 
@@ -464,6 +466,20 @@ async function handleTranscriptionCompleted(meetingId: string, clientReferenceId
       });
       
       console.log(`🔔 Created notification for new transcription: ${title}`);
+
+      // Also notify the meeting's team-member participants that the notes are
+      // ready (ADR-0045) — the scheduledNotification above only reaches the
+      // owner. Only fires when a summary actually landed and there are member
+      // (userId) participants; a freshly-imported meeting with none is a safe
+      // no-op. Owner is the actor and is dropped downstream. Fire-and-forget.
+      if (sessionData.summary) {
+        void emitNotification({
+          db,
+          category: NOTIFICATION_CATEGORIES.MEETING_READY,
+          actorUserId: user.id,
+          subject: { sessionId: transcriptionSession.id },
+        });
+      }
     }
 
     // 6. Trigger embedding for knowledge base (fire-and-forget)

--- a/src/server/services/meetings/ensureMeetingSummary.ts
+++ b/src/server/services/meetings/ensureMeetingSummary.ts
@@ -4,6 +4,8 @@ import {
   SummarizationNotConfiguredError,
 } from "~/server/services/TranscriptSummarizerService";
 import { recordActivity } from "~/server/services/activity/recordActivity";
+import { emitNotification } from "~/server/services/notifications/emit/emitNotification";
+import { NOTIFICATION_CATEGORIES } from "~/server/services/notifications/emit/constants";
 import {
   extractReadableTranscript,
   MAX_SUMMARY_TRANSCRIPT_CHARS,
@@ -142,6 +144,20 @@ export async function summarizeMeetingRow(
       entityId: meeting.id,
       action: "summarized",
       metadata: { title: meeting.title ?? undefined },
+    });
+  }
+
+  // Notify the meeting's team-member participants that the notes are ready
+  // (ADR-0045). Fires on the same idempotent null → value transition as the
+  // activity event, so a re-summarize/overwrite never re-notifies. The meeting
+  // owner is the actor and is dropped downstream — they don't need telling their
+  // own notes are ready. Fire-and-forget: never blocks summarization.
+  if (meeting.workspaceId) {
+    void emitNotification({
+      db,
+      category: NOTIFICATION_CATEGORIES.MEETING_READY,
+      actorUserId: meeting.userId ?? null,
+      subject: { sessionId: meeting.id },
     });
   }
 

--- a/src/server/services/notifications/emit/__tests__/emitNotification.test.ts
+++ b/src/server/services/notifications/emit/__tests__/emitNotification.test.ts
@@ -368,3 +368,54 @@ describe("emitNotification — Meeting participant added", () => {
     expect(db.notification.create).not.toHaveBeenCalled();
   });
 });
+
+describe("emitNotification — Meeting notes ready", () => {
+  beforeEach(() => {
+    // Recipients are the meeting's member (userId) participants.
+    db.transcriptionSessionParticipant.findMany.mockResolvedValue([
+      { userId: "member1" },
+      { userId: "member2" },
+    ] as never);
+    // Content resolves the meeting to a title + workspace.
+    db.transcriptionSession.findUnique.mockResolvedValue({
+      title: "Weekly sync",
+      workspace: WORKSPACE,
+    } as never);
+  });
+
+  it("notifies member participants (excluding the actor/owner) when notes land", async () => {
+    await emitNotification({
+      category: NOTIFICATION_CATEGORIES.MEETING_READY,
+      actorUserId: "member2", // the owner/actor is dropped
+      subject: { sessionId: "m1" },
+      db,
+    });
+
+    expect(db.notification.create).toHaveBeenCalledTimes(1);
+    expect(db.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "member1",
+          category: "meeting_ready",
+          title: "Meeting notes are ready",
+          message: "Weekly sync",
+          deeplink: "/recording/m1",
+          dedupeKey: "meeting_ready:m1:member1",
+        }),
+      }),
+    );
+  });
+
+  it("is a no-op when the meeting has no member participants", async () => {
+    db.transcriptionSessionParticipant.findMany.mockResolvedValue([] as never);
+
+    await emitNotification({
+      category: NOTIFICATION_CATEGORIES.MEETING_READY,
+      actorUserId: null,
+      subject: { sessionId: "m1" },
+      db,
+    });
+
+    expect(db.notification.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/notifications/emit/content.ts
+++ b/src/server/services/notifications/emit/content.ts
@@ -115,6 +115,36 @@ export async function buildContent(
         dedupeKey: `meeting_participant_added:${sessionId}:${recipientId}`,
       };
     }
+    case NOTIFICATION_CATEGORIES.MEETING_READY: {
+      const { sessionId } = input.subject;
+
+      const session = await db.transcriptionSession.findUnique({
+        where: { id: sessionId },
+        select: {
+          title: true,
+          workspace: { select: { id: true, slug: true, name: true } },
+        },
+      });
+      if (!session?.workspace) return null;
+
+      const meetingTitle = session.title ?? "a meeting";
+
+      return {
+        category: NOTIFICATION_CATEGORIES.MEETING_READY,
+        title: "Meeting notes are ready",
+        message: meetingTitle,
+        deeplink: `/recording/${sessionId}`,
+        metadata: {
+          sessionId,
+          transcriptionId: sessionId,
+          workspaceId: session.workspace.id,
+          workspaceSlug: session.workspace.slug,
+          workspaceName: session.workspace.name,
+        },
+        workspaceId: session.workspace.id,
+        dedupeKey: `meeting_ready:${sessionId}:${recipientId}`,
+      };
+    }
     case NOTIFICATION_CATEGORIES.MENTION:
       return buildMentionContent(input, recipientId);
     default:

--- a/src/server/services/notifications/emit/recipients.ts
+++ b/src/server/services/notifications/emit/recipients.ts
@@ -22,6 +22,24 @@ export async function resolveRecipients(
       return Promise.resolve(
         Array.from(new Set(input.subject.participantUserIds)),
       );
+    case NOTIFICATION_CATEGORIES.MEETING_READY: {
+      // Meeting notes ready → the meeting's team-member (userId) participants.
+      // CRM-contact / free-text participants have no User account and are skipped.
+      const rows = await input.db.transcriptionSessionParticipant.findMany({
+        where: {
+          transcriptionSessionId: input.subject.sessionId,
+          userId: { not: null },
+        },
+        select: { userId: true },
+      });
+      return Array.from(
+        new Set(
+          rows
+            .map((r) => r.userId)
+            .filter((id): id is string => id !== null),
+        ),
+      );
+    }
     default:
       return Promise.resolve([]);
   }

--- a/src/server/services/notifications/emit/types.ts
+++ b/src/server/services/notifications/emit/types.ts
@@ -25,6 +25,15 @@ export interface MeetingParticipantAddedSubject {
 }
 
 /**
+ * Meeting notes ready: a meeting (TranscriptionSession) whose summary just
+ * landed (null → value). Recipients are the meeting's team-member (userId)
+ * participants, resolved from the participant rows by the resolver.
+ */
+export interface MeetingReadySubject {
+  sessionId: string;
+}
+
+/**
  * Mention (V2): a comment on some target (action / feature / scope), already
  * resolved to its workspace + display name + deep-link. Recipients are parsed
  * from the `@[Name](id)` markup and membership-filtered by the resolver.
@@ -67,6 +76,10 @@ export type EmitNotificationInput = {
   | {
       category: typeof NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED;
       subject: MeetingParticipantAddedSubject;
+    }
+  | {
+      category: typeof NOTIFICATION_CATEGORIES.MEETING_READY;
+      subject: MeetingReadySubject;
     }
 );
 


### PR DESCRIPTION
### **User description**
## What

Notify a meeting's **team-member participants** when its notes/summary become available, via the unified notification pipeline (**ADR-0045**). Completes the half-seeded `meeting_ready` category (it already had a matrix row + settings toggle, but no subject/resolver/content/trigger).

Wires the category end to end and fires it from the two points a summary lands:

- **AI summarization** — `ensureMeetingSummary`, on the idempotent `summary: null → value` transition (next to the existing `summarized` activity event), so a re-summarize/overwrite never re-notifies.
- **Fireflies webhook** — alongside the owner's existing "transcription ready" notification, so member participants are reached too (a safe no-op when a freshly-imported meeting has no member participants yet).

Recipients are **member (`userId`) participants only** — CRM-contact / free-text people are skipped. The meeting **owner is the actor and is dropped** (no "your own notes are ready"). Deep-links to `/recording/<id>`; delivery channels (push/email/Matrix/WhatsApp/Zulip) come from the pipeline, gated by each user's preference matrix.

## Acceptance criteria

- [ ] When a meeting's AI summary is generated (empty→populated), team-member participants are notified once.
- [ ] When a summary arrives via the Fireflies webhook, member participants are notified (not only the owner).
- [ ] Reuses the ADR-0045 pipeline (same channels + gating, incl. Matrix opt-in).
- [ ] No duplicate "notes ready" on re-summarization/overwrite (dedupeKey + null→value guard).
- [ ] CRM-contact / free-text participants are not notified.

## Verification

- New unit tests in `emit/__tests__/emitNotification.test.ts` (member-only recipients, actor drop, deeplink/dedupeKey, no-participants no-op).
- Full suite: 1656 unit tests pass · tsc 0 errors · eslint clean.

---

Ships: magic.creek (Exponential ticket cmrw0s72w000fjr04qrjwdwf9)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Wire `meeting_ready` notification category end-to-end (ADR-0045)

- Add recipient resolver, content builder, and type definitions for `MEETING_READY`

- Fire notifications from AI summarization and Fireflies webhook triggers

- Add unit tests covering member-only recipients, actor drop, and no-op cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ensureMeetingSummary\n(null→value transition)"] -- "emitNotification\nMEETING_READY" --> D["emitNotification()"]
  B["Fireflies webhook\nhandleTranscriptionCompleted"] -- "emitNotification\nMEETING_READY" --> D
  D -- "resolveRecipients" --> E["recipients.ts\n(userId participants only)"]
  D -- "buildContent" --> F["content.ts\n(title, deeplink, dedupeKey)"]
  E -- "drops actor/owner" --> G["Notification created\nper member participant"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Trigger meeting_ready notification from Fireflies webhook</code></dd></summary>
<hr>

src/app/api/webhooks/fireflies/route.ts

<ul><li>Import <code>emitNotification</code> and <code>NOTIFICATION_CATEGORIES</code><br> <li> Fire <code>MEETING_READY</code> notification for member participants after <br>Fireflies transcription completes, guarded by <code>sessionData.summary</code> <br>presence<br> <li> Fire-and-forget (void), safe no-op when no member participants exist</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/415/files#diff-c4c34f72b689901ef5fe32a75fe9caad19b2881508d1421ecd0a559625c0b865">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ensureMeetingSummary.ts</strong><dd><code>Trigger meeting_ready notification on AI summarization</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/meetings/ensureMeetingSummary.ts

<ul><li>Import <code>emitNotification</code> and <code>NOTIFICATION_CATEGORIES</code><br> <li> Fire <code>MEETING_READY</code> notification on idempotent <code>null → value</code> summary <br>transition, gated by <code>meeting.workspaceId</code><br> <li> Fire-and-forget to never block summarization</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/415/files#diff-56c1c9e23e500523fe259d19ae0128df84375644f912995bc52f7e44142c07d5">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>recipients.ts</strong><dd><code>Resolve member participants as meeting_ready recipients</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/notifications/emit/recipients.ts

<ul><li>Add <code>MEETING_READY</code> case to <code>resolveRecipients</code><br> <li> Queries <code>transcriptionSessionParticipant</code> for rows with non-null <code>userId</code><br> <li> Skips CRM-contact and free-text participants; deduplicates results</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/415/files#diff-c616ea57fdf8a4feae06c77a500c0a62a10d0403df65ee59010046d6bea507cf">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>content.ts</strong><dd><code>Build notification content for meeting_ready category</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/notifications/emit/content.ts

<ul><li>Add <code>MEETING_READY</code> case to <code>buildContent</code><br> <li> Fetches session title and workspace; builds title, message, deeplink, <br>metadata<br> <li> Sets per-recipient <code>dedupeKey</code> as <code>meeting_ready:<sessionId>:<recipientId></code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/415/files#diff-0de1681e5e2c85a302ddd3eccff0dae2a5a1f1079bad2ef656209b66c900ab21">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add MeetingReadySubject type and input union variant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/notifications/emit/types.ts

<ul><li>Add <code>MeetingReadySubject</code> interface with <code>sessionId</code> field<br> <li> Add <code>MEETING_READY</code> discriminated union variant to <code>EmitNotificationInput</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/415/files#diff-24cf961c0fa36a7d78a25dacb5751507ecb95553fd1e062c713fe311a4341972">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>emitNotification.test.ts</strong><dd><code>Add unit tests for meeting_ready notification emission</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/notifications/emit/__tests__/emitNotification.test.ts

<ul><li>Add <code>emitNotification — Meeting notes ready</code> describe block<br> <li> Test notifies member participants excluding the actor/owner<br> <li> Test is a no-op when meeting has no member participants<br> <li> Verifies correct <code>category</code>, <code>title</code>, <code>message</code>, <code>deeplink</code>, and <code>dedupeKey</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/415/files#diff-43bcf0ed5c1ff3d9e21c6810ff69d3e458908d8b716251c68ac819911bc9d47a">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

