### PR TITLE
feat: V3 due-date reminders on the unified notification pipeline

### DIFF
--- a/src/app/api/cron/process-notifications/route.ts
+++ b/src/app/api/cron/process-notifications/route.ts
@@ -2,12 +2,13 @@ import { type NextRequest, NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { db } from "~/server/db";
 import { retryPendingDeliveries } from "~/server/services/notifications/emit/processNotifications";
+import { generateDueDateReminders } from "~/server/services/notifications/emit/dueDateReminders";
 
 /**
- * Cron endpoint (ADR-0045): the retry backstop for the unified notification
- * pipeline. Re-attempts any NotificationDelivery that hasn't succeeded (failed,
- * or orphaned-pending) under the attempt cap. Scheduled-notification generation
- * (summaries, due-date reminders) is added in later scopes; V1 is retry-only.
+ * Cron endpoint (ADR-0045) for the unified notification pipeline. Generates
+ * scheduled notifications as they come due (V3: due-date reminders; summaries in
+ * V4) and retries any NotificationDelivery that hasn't succeeded (failed, or
+ * orphaned-pending) under the attempt cap.
  *
  * Call via: GET /api/cron/process-notifications — Vercel cron, CRON_SECRET-protected.
  */
@@ -21,9 +22,12 @@ export async function GET(_request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const result = await retryPendingDeliveries(db);
+    // Scheduled generation: emit due-date reminders as their offsets are crossed.
+    const dueDate = await generateDueDateReminders(db);
+    // Retry backstop: re-attempt any delivery that hasn't succeeded.
+    const retry = await retryPendingDeliveries(db);
 
-    return NextResponse.json({ ok: true, ...result });
+    return NextResponse.json({ ok: true, dueDate, retry });
   } catch (error) {
     console.error("[cron/process-notifications] failed:", error);
     return NextResponse.json(

--- a/src/server/services/notifications/emit/__tests__/dueDateReminders.test.ts
+++ b/src/server/services/notifications/emit/__tests__/dueDateReminders.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import { generateDueDateReminders } from "~/server/services/notifications/emit/dueDateReminders";
+import { emitNotification } from "~/server/services/notifications/emit/emitNotification";
+
+vi.mock("~/server/services/notifications/emit/emitNotification", () => ({
+  emitNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+const db = mockDeep<PrismaClient>();
+const NOW = new Date("2026-07-22T12:00:00.000Z");
+const inMinutes = (m: number) => new Date(NOW.getTime() + m * 60_000);
+
+function action(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "a1",
+    name: "Ship the thing",
+    dueDate: inMinutes(60),
+    createdById: "creator1",
+    workspace: { id: "ws1", slug: "acme" },
+    project: null,
+    assignees: [{ userId: "assignee1" }],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockReset(db);
+  vi.clearAllMocks();
+});
+
+describe("generateDueDateReminders", () => {
+  it("emits one Due-date reminder to the assignee as the 60-min offset is crossed", async () => {
+    db.action.findMany.mockResolvedValue([action()] as never);
+
+    const result = await generateDueDateReminders(db, NOW);
+
+    expect(emitNotification).toHaveBeenCalledTimes(1);
+    expect(emitNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "due_date",
+        actorUserId: null,
+        subject: expect.objectContaining({
+          actionId: "a1",
+          ownerUserId: "assignee1",
+          offsetMinutes: 60,
+          workspaceId: "ws1",
+          workspaceSlug: "acme",
+        }),
+      }),
+    );
+    expect(result.emitted).toBe(1);
+  });
+
+  it("falls back to the creator as owner when there are no assignees", async () => {
+    db.action.findMany.mockResolvedValue([action({ assignees: [] })] as never);
+
+    await generateDueDateReminders(db, NOW);
+
+    expect(emitNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: expect.objectContaining({ ownerUserId: "creator1" }),
+      }),
+    );
+  });
+
+  it("does not fire before the offset boundary is reached", async () => {
+    // Due in 120 min → the 60-min reminder time is 60 min in the future.
+    db.action.findMany.mockResolvedValue([action({ dueDate: inMinutes(120) })] as never);
+
+    const result = await generateDueDateReminders(db, NOW);
+
+    expect(emitNotification).not.toHaveBeenCalled();
+    expect(result.emitted).toBe(0);
+  });
+
+  it("does not back-fill an offset that elapsed long before now", async () => {
+    // Due in 5 min → the 60-min reminder time is 55 min in the past (outside the
+    // lookback window), so we don't belatedly fire it.
+    db.action.findMany.mockResolvedValue([action({ dueDate: inMinutes(5) })] as never);
+
+    const result = await generateDueDateReminders(db, NOW);
+
+    expect(emitNotification).not.toHaveBeenCalled();
+    expect(result.emitted).toBe(0);
+  });
+
+  it("resolves the workspace via the project when the action has none directly", async () => {
+    db.action.findMany.mockResolvedValue([
+      action({ workspace: null, project: { workspace: { id: "ws2", slug: "beta" } } }),
+    ] as never);
+
+    await generateDueDateReminders(db, NOW);
+
+    expect(emitNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: expect.objectContaining({ workspaceId: "ws2", workspaceSlug: "beta" }),
+      }),
+    );
+  });
+});

--- a/src/server/services/notifications/emit/__tests__/dueDateReminders.test.ts
+++ b/src/server/services/notifications/emit/__tests__/dueDateReminders.test.ts
@@ -77,14 +77,35 @@ describe("generateDueDateReminders", () => {
   });
 
   it("does not back-fill an offset that elapsed long before now", async () => {
-    // Due in 5 min → the 60-min reminder time is 55 min in the past (outside the
-    // lookback window), so we don't belatedly fire it.
+    // Owner configured only the 60-min offset; the action is due in 5 min, so
+    // that offset's reminder time is 55 min in the past (outside the lookback
+    // window) and must not be belatedly fired.
+    db.notificationPreference.findUnique.mockResolvedValue({
+      reminderMinutesBefore: [60],
+    } as never);
     db.action.findMany.mockResolvedValue([action({ dueDate: inMinutes(5) })] as never);
 
     const result = await generateDueDateReminders(db, NOW);
 
     expect(emitNotification).not.toHaveBeenCalled();
     expect(result.emitted).toBe(0);
+  });
+
+  it("uses the owner's configured reminderMinutesBefore offsets", async () => {
+    // Owner wants a single 30-min reminder; action due in 30 min → fires it.
+    db.notificationPreference.findUnique.mockResolvedValue({
+      reminderMinutesBefore: [30],
+    } as never);
+    db.action.findMany.mockResolvedValue([action({ dueDate: inMinutes(30) })] as never);
+
+    await generateDueDateReminders(db, NOW);
+
+    expect(emitNotification).toHaveBeenCalledTimes(1);
+    expect(emitNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: expect.objectContaining({ offsetMinutes: 30 }),
+      }),
+    );
   });
 
   it("resolves the workspace via the project when the action has none directly", async () => {

--- a/src/server/services/notifications/emit/__tests__/emitNotification.test.ts
+++ b/src/server/services/notifications/emit/__tests__/emitNotification.test.ts
@@ -301,3 +301,54 @@ describe("emitNotification — channel resolution", () => {
     });
   });
 });
+
+describe("emitNotification — Due-date reminder dedup", () => {
+  const dueSubject = {
+    actionId: "a1",
+    actionName: "Ship the thing",
+    ownerUserId: "owner1",
+    offsetMinutes: 60,
+    dueDate: new Date("2026-07-22T13:00:00.000Z"),
+    workspaceId: "ws1",
+    workspaceSlug: "acme",
+  };
+
+  it("emits one reminder to the owner keyed per (action, offset)", async () => {
+    await emitNotification({
+      category: NOTIFICATION_CATEGORIES.DUE_DATE,
+      actorUserId: null,
+      subject: dueSubject,
+      db,
+    });
+
+    expect(db.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "owner1",
+          category: "due_date",
+          dedupeKey: "due_date:a1:60",
+        }),
+      }),
+    );
+  });
+
+  it("does not re-send on the next cron tick (same action+offset already emitted)", async () => {
+    db.notification.findUnique.mockResolvedValue({ id: "existing" } as never);
+
+    await emitNotification({
+      category: NOTIFICATION_CATEGORIES.DUE_DATE,
+      actorUserId: null,
+      subject: dueSubject,
+      db,
+    });
+
+    expect(db.notification.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          dedupeKey_userId: { dedupeKey: "due_date:a1:60", userId: "owner1" },
+        },
+      }),
+    );
+    expect(db.notification.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/notifications/emit/access.ts
+++ b/src/server/services/notifications/emit/access.ts
@@ -14,6 +14,9 @@ function resolveResource(
   switch (input.category) {
     case NOTIFICATION_CATEGORIES.ASSIGNMENT:
       return { type: "action", id: input.subject.actionId };
+    case NOTIFICATION_CATEGORIES.DUE_DATE:
+      // Don't remind an owner who has lost access to the action.
+      return { type: "action", id: input.subject.actionId };
     default:
       return null;
   }

--- a/src/server/services/notifications/emit/content.ts
+++ b/src/server/services/notifications/emit/content.ts
@@ -71,9 +71,42 @@ export async function buildContent(
         dedupeKey: `assignment:${actionId}:${recipientId}`,
       };
     }
+    case NOTIFICATION_CATEGORIES.DUE_DATE: {
+      const { actionId, actionName, offsetMinutes, workspaceSlug, workspaceId } =
+        input.subject;
+      return {
+        category: NOTIFICATION_CATEGORIES.DUE_DATE,
+        title: `Reminder: ${actionName}`,
+        message: `Due ${dueLabel(offsetMinutes)}`,
+        deeplink: `/w/${workspaceSlug}/actions/${actionId}`,
+        metadata: {
+          actionId,
+          workspaceId,
+          workspaceSlug,
+          offsetMinutes,
+          dueDate: input.subject.dueDate.toISOString(),
+        },
+        workspaceId,
+        // Per (action, offset); combined with the recipient (owner) via the
+        // unique (dedupeKey, userId) index → one reminder per action/offset/owner.
+        dedupeKey: `due_date:${actionId}:${offsetMinutes}`,
+      };
+    }
     case NOTIFICATION_CATEGORIES.MENTION:
       return buildMentionContent(input, recipientId);
     default:
       return null;
   }
+}
+
+/** Human label for a reminder offset, e.g. 60 → "in 1 hour". */
+function dueLabel(offsetMinutes: number): string {
+  if (offsetMinutes <= 0) return "now";
+  if (offsetMinutes < 60) return `in ${offsetMinutes} minutes`;
+  if (offsetMinutes < 1440) {
+    const hours = Math.round(offsetMinutes / 60);
+    return `in ${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  const days = Math.round(offsetMinutes / 1440);
+  return `in ${days} day${days === 1 ? "" : "s"}`;
 }

--- a/src/server/services/notifications/emit/dueDateReminders.ts
+++ b/src/server/services/notifications/emit/dueDateReminders.ts
@@ -15,9 +15,40 @@ const LOOKBACK_MS = 15 * 60 * 1000;
 
 const TERMINAL_STATUSES = ["COMPLETED", "DONE", "CANCELLED"];
 
-// V3 action 1 tracer: a single offset. Action 2 replaces this with each owner's
-// configured reminderMinutesBefore.
-const TRACER_OFFSETS = [60];
+/** Fallback reminder offsets (minutes) when a user has no NotificationPreference. */
+const DEFAULT_OFFSETS = [15, 60, 1440];
+
+/**
+ * The Owner of an action — its assignees if any, else its creator (CONTEXT:
+ * Owner). The reusable recipient rule for owner-scoped notifications.
+ */
+export function resolveOwnerIds(action: {
+  createdById: string;
+  assignees: { userId: string }[];
+}): string[] {
+  return action.assignees.length > 0
+    ? [...new Set(action.assignees.map((a) => a.userId))]
+    : [action.createdById];
+}
+
+/** A user's configured reminder offsets, cached within a cron run. */
+async function getUserOffsets(
+  db: PrismaClient,
+  userId: string,
+  cache: Map<string, number[]>,
+): Promise<number[]> {
+  const cached = cache.get(userId);
+  if (cached) return cached;
+
+  const pref = await db.notificationPreference.findUnique({
+    where: { userId },
+    select: { reminderMinutesBefore: true },
+  });
+  // A row with an explicit (even empty) list wins; no row → defaults.
+  const offsets = pref?.reminderMinutesBefore ?? DEFAULT_OFFSETS;
+  cache.set(userId, offsets);
+  return offsets;
+}
 
 /**
  * Cron scheduled-generation (ADR-0045, V3): scan upcoming owned actions and emit
@@ -47,20 +78,18 @@ export async function generateDueDateReminders(
   });
 
   let emitted = 0;
+  const offsetCache = new Map<string, number[]>();
 
   for (const action of actions) {
     if (!action.dueDate) continue;
     const ws = action.workspace ?? action.project?.workspace;
     if (!ws) continue;
 
-    // Owner = assignees if any, else the creator.
-    const ownerIds =
-      action.assignees.length > 0
-        ? [...new Set(action.assignees.map((a) => a.userId))]
-        : [action.createdById];
+    const ownerIds = resolveOwnerIds(action);
 
     for (const ownerId of ownerIds) {
-      for (const offset of TRACER_OFFSETS) {
+      const offsets = await getUserOffsets(db, ownerId, offsetCache);
+      for (const offset of offsets) {
         const reminderMs = action.dueDate.getTime() - offset * 60_000;
         // Fire only as the boundary is crossed (within the last window).
         if (reminderMs > now.getTime()) continue;

--- a/src/server/services/notifications/emit/dueDateReminders.ts
+++ b/src/server/services/notifications/emit/dueDateReminders.ts
@@ -1,0 +1,91 @@
+import type { PrismaClient } from "@prisma/client";
+import { emitNotification } from "./emitNotification";
+import { NOTIFICATION_CATEGORIES } from "./constants";
+import type { DueDateSubject } from "./types";
+
+/** How far ahead to scan for upcoming due dates (covers the largest offset). */
+const SCAN_HORIZON_MS = 8 * 24 * 60 * 60 * 1000;
+/**
+ * A reminder fires only as its offset boundary is crossed — within this window
+ * of "now". Larger than the cron cadence so a missed tick still catches the
+ * crossing, but small enough that offsets which elapsed before we noticed the
+ * action are never back-filled. Dedup makes re-fires within the window harmless.
+ */
+const LOOKBACK_MS = 15 * 60 * 1000;
+
+const TERMINAL_STATUSES = ["COMPLETED", "DONE", "CANCELLED"];
+
+// V3 action 1 tracer: a single offset. Action 2 replaces this with each owner's
+// configured reminderMinutesBefore.
+const TRACER_OFFSETS = [60];
+
+/**
+ * Cron scheduled-generation (ADR-0045, V3): scan upcoming owned actions and emit
+ * a Due-date reminder to the owner as each reminder offset is crossed. Dedup
+ * (per action, offset, owner) makes it safe to run every tick.
+ */
+export async function generateDueDateReminders(
+  db: PrismaClient,
+  now: Date = new Date(),
+): Promise<{ emitted: number }> {
+  const horizon = new Date(now.getTime() + SCAN_HORIZON_MS);
+
+  const actions = await db.action.findMany({
+    where: {
+      dueDate: { gt: now, lte: horizon },
+      status: { notIn: TERMINAL_STATUSES },
+    },
+    select: {
+      id: true,
+      name: true,
+      dueDate: true,
+      createdById: true,
+      workspace: { select: { id: true, slug: true } },
+      project: { select: { workspace: { select: { id: true, slug: true } } } },
+      assignees: { select: { userId: true } },
+    },
+  });
+
+  let emitted = 0;
+
+  for (const action of actions) {
+    if (!action.dueDate) continue;
+    const ws = action.workspace ?? action.project?.workspace;
+    if (!ws) continue;
+
+    // Owner = assignees if any, else the creator.
+    const ownerIds =
+      action.assignees.length > 0
+        ? [...new Set(action.assignees.map((a) => a.userId))]
+        : [action.createdById];
+
+    for (const ownerId of ownerIds) {
+      for (const offset of TRACER_OFFSETS) {
+        const reminderMs = action.dueDate.getTime() - offset * 60_000;
+        // Fire only as the boundary is crossed (within the last window).
+        if (reminderMs > now.getTime()) continue;
+        if (reminderMs <= now.getTime() - LOOKBACK_MS) continue;
+
+        const subject: DueDateSubject = {
+          actionId: action.id,
+          actionName: action.name,
+          ownerUserId: ownerId,
+          offsetMinutes: offset,
+          dueDate: action.dueDate,
+          workspaceId: ws.id,
+          workspaceSlug: ws.slug,
+        };
+
+        await emitNotification({
+          category: NOTIFICATION_CATEGORIES.DUE_DATE,
+          actorUserId: null,
+          subject,
+          db,
+        });
+        emitted++;
+      }
+    }
+  }
+
+  return { emitted };
+}

--- a/src/server/services/notifications/emit/recipients.ts
+++ b/src/server/services/notifications/emit/recipients.ts
@@ -17,6 +17,9 @@ export async function resolveRecipients(
     case NOTIFICATION_CATEGORIES.MENTION:
       // Mention → parsed, membership-filtered mentioned users.
       return resolveMentionRecipients(input);
+    case NOTIFICATION_CATEGORIES.DUE_DATE:
+      // Due-date → the single owner the cron computed the crossing for.
+      return Promise.resolve([input.subject.ownerUserId]);
     default:
       return Promise.resolve([]);
   }

--- a/src/server/services/notifications/emit/types.ts
+++ b/src/server/services/notifications/emit/types.ts
@@ -35,6 +35,22 @@ export interface MentionSubject {
 }
 
 /**
+ * Due-date reminder (V3): a specific owned action, a single reminder offset, and
+ * the owner it fires for. The cron computes the (action, offset, owner) tuple
+ * and its crossing; emit just delivers to that owner.
+ */
+export interface DueDateSubject {
+  actionId: string;
+  actionName: string;
+  ownerUserId: string;
+  /** Which reminderMinutesBefore offset this reminder is for (part of the dedup key). */
+  offsetMinutes: number;
+  dueDate: Date;
+  workspaceId: string;
+  workspaceSlug: string;
+}
+
+/**
  * Discriminated union pairing each category with its subject. `emitNotification`
  * narrows on `category`, so recipient resolvers and content builders get a
  * fully-typed subject with no casts.
@@ -53,6 +69,10 @@ export type EmitNotificationInput = {
   | {
       category: typeof NOTIFICATION_CATEGORIES.MENTION;
       subject: MentionSubject;
+    }
+  | {
+      category: typeof NOTIFICATION_CATEGORIES.DUE_DATE;
+      subject: DueDateSubject;
     }
 );
 


### PR DESCRIPTION
### **User description**
## What

V3 of unified notification dispatch (ADR-0045): the first genuinely new trigger — **due-date reminders**, generated by the cron.

- **Due-date category on the emit seam**: a `DueDateSubject`, an owner recipient (the cron computes the tuple; emit delivers to that owner), a content builder, and an access-filter arm (don't remind an owner who lost access).
- **`generateDueDateReminders`**: the cron scans upcoming non-terminal owned actions and, for each **Owner** (assignee-else-creator), emits a reminder as each of the owner's configured `reminderMinutesBefore` offsets is crossed — firing only within a lookback window so elapsed offsets aren't back-filled.
- **Dedup** per `(action, offset, owner)` via `dedupeKey = due_date:<action>:<offset>` + the unique `(dedupeKey, userId)` index → not re-sent on the next tick.
- Wired into **`/api/cron/process-notifications`** ahead of the retry pass.

Tests: `dueDateReminders.test.ts` (crossing/back-fill/owner-fallback/per-owner offsets/workspace-via-project) + due-date dedup cases in `emitNotification.test.ts`. Full emit suite green.

Merged latest `main` (picks up the meeting-notification categories added in #414/#415); resolved the additive emit-seam overlaps.

## Acceptance criteria

- [ ] An owned action due within an offset emits one Due-date reminder to the owner
- [ ] Not re-sent on subsequent cron ticks (offset dedup)

---

Ships: lime.swan

Feature: Unified notification dispatch (`cmrw30ubj0001lb04otrv7rvk`) · builds on V1 (#406)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds V3 due-date reminders to the unified notification pipeline (ADR-0045)
  - New `generateDueDateReminders` cron function scans upcoming owned actions
  - Fires reminders per owner's configured `reminderMinutesBefore` offsets
  - Dedup via `due_date:<actionId>:<offsetMinutes>` key prevents re-sends

- Wires `DUE_DATE` category through types, recipients, content, and access filter

- Integrates reminder generation into `/api/cron/process-notifications` before retry pass

- Adds unit tests for crossing logic, back-fill prevention, owner fallback, and dedup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cron["cron /api/cron/process-notifications"] -- "generateDueDateReminders()" --> gen["dueDateReminders.ts"]
  gen -- "scan upcoming actions" --> db["PrismaClient\n(action.findMany)"]
  gen -- "resolveOwnerIds()" --> owners["assignees or creator"]
  gen -- "getUserOffsets()" --> prefs["NotificationPreference\n(reminderMinutesBefore)"]
  gen -- "offset boundary crossed?" --> emit["emitNotification()\ncategory: DUE_DATE"]
  emit -- "resolveRecipients" --> rec["recipients.ts\nownerUserId"]
  emit -- "buildContent" --> content["content.ts\ntitle + deeplink + dedupeKey"]
  emit -- "access filter" --> access["access.ts\naction resource check"]
  emit -- "dedup check" --> dedup["Notification.dedupeKey_userId\nunique index"]
  cron -- "retryPendingDeliveries()" --> retry["processNotifications.ts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>route.ts</strong><dd><code>Wire generateDueDateReminders into cron before retry pass</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/416/files#diff-f9e24e97fc965527e1fc8df0f6669702e62b3cf9b966e3f2abbbee8bdb55f3aa">+10/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dueDateReminders.ts</strong><dd><code>New cron function generating due-date reminder notifications</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/416/files#diff-b5e52940a6cf1c6ea00d406b21a9a0b94b568be163d24de69bb3b294eab6f5ad">+120/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Add DueDateSubject interface and DUE_DATE union discriminant</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/416/files#diff-24cf961c0fa36a7d78a25dacb5751507ecb95553fd1e062c713fe311a4341972">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>recipients.ts</strong><dd><code>Resolve ownerUserId as sole recipient for DUE_DATE category</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/416/files#diff-c616ea57fdf8a4feae06c77a500c0a62a10d0403df65ee59010046d6bea507cf">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>content.ts</strong><dd><code>Build due-date reminder content with deeplink and dedupeKey</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/416/files#diff-0de1681e5e2c85a302ddd3eccff0dae2a5a1f1079bad2ef656209b66c900ab21">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>access.ts</strong><dd><code>Add DUE_DATE action access filter to prevent stale reminders</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/416/files#diff-980ce655c6efb18bef080794dd1c5182164140eb04bd0ee70b314695eb3b0a9c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>dueDateReminders.test.ts</strong><dd><code>Unit tests for due-date reminder generation and owner logic</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/416/files#diff-51d69ae297365c823000c153246ac6c6488aee32ec0d4a67c2839e89a4a47da0">+124/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>emitNotification.test.ts</strong><dd><code>Add due-date reminder dedup tests to emitNotification suite</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/416/files#diff-43bcf0ed5c1ff3d9e21c6810ff69d3e458908d8b716251c68ac819911bc9d47a">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

