### PR TITLE
feat: Velocity trend across recent completed cycles

### DIFF
--- a/src/app/_components/metrics/MetricsDashboard.tsx
+++ b/src/app/_components/metrics/MetricsDashboard.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import { Card, Text, Group, Stack, Progress, Container } from '@mantine/core';
-import { IconChartBar, IconCircleCheck, IconBolt } from '@tabler/icons-react';
+import {
+  IconChartBar,
+  IconCircleCheck,
+  IconBolt,
+  IconTrendingUp,
+} from '@tabler/icons-react';
 import { api, type RouterOutputs } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 
@@ -47,8 +52,103 @@ export function MetricsDashboard() {
         ) : (
           <ActiveCycleMetrics data={data} />
         )}
+
+        <VelocityTrend workspaceId={workspaceId} />
       </Stack>
     </Container>
+  );
+}
+
+function VelocityTrend({ workspaceId }: { workspaceId: string | null }) {
+  const { data, isLoading } = api.sprintAnalytics.getVelocityTrend.useQuery(
+    { workspaceId: workspaceId ?? '', count: 8 },
+    { enabled: !!workspaceId },
+  );
+
+  if (isLoading || !workspaceId) {
+    return (
+      <Card
+        withBorder
+        radius="md"
+        className="border-border-primary bg-surface-secondary"
+      >
+        <div className="animate-pulse space-y-3">
+          <div className="h-4 w-1/4 rounded bg-surface-hover" />
+          <div className="h-24 rounded bg-surface-hover" />
+        </div>
+      </Card>
+    );
+  }
+
+  // Trend needs at least 2 completed cycles to be meaningful.
+  if (!data || data.length < 2) {
+    return (
+      <Card
+        withBorder
+        radius="md"
+        className="border-border-primary bg-surface-secondary"
+      >
+        <Group gap="xs" className="mb-2">
+          <IconTrendingUp size={16} className="text-text-muted" />
+          <Text size="sm" fw={500} className="text-text-secondary">
+            Velocity trend
+          </Text>
+        </Group>
+        <Text size="sm" className="text-text-muted">
+          Not enough completed cycles yet — the trend appears once at least two
+          cycles have completed.
+        </Text>
+      </Card>
+    );
+  }
+
+  // Service returns most-recent-first; show oldest → newest for a trend read.
+  const cycles = [...data].reverse();
+  const maxActions = Math.max(...cycles.map((c) => c.completedActions), 1);
+
+  return (
+    <Card
+      withBorder
+      radius="md"
+      className="border-border-primary bg-surface-secondary"
+    >
+      <Stack gap="md">
+        <Group gap="xs">
+          <IconTrendingUp size={16} className="text-text-muted" />
+          <Text size="sm" fw={500} className="text-text-secondary">
+            Velocity trend
+          </Text>
+          <Text size="xs" className="text-text-muted">
+            (last {cycles.length} completed cycles)
+          </Text>
+        </Group>
+
+        <Stack gap="sm">
+          {cycles.map((cycle) => (
+            <div key={cycle.sprintId}>
+              <Group justify="space-between" gap="xs" className="mb-1">
+                <Text size="xs" className="truncate text-text-secondary">
+                  {cycle.sprintName}
+                </Text>
+                <Text size="xs" className="text-text-muted">
+                  <span className="font-semibold text-text-primary">
+                    {cycle.completedActions}
+                  </span>{' '}
+                  {cycle.completedActions === 1 ? 'action' : 'actions'} ·{' '}
+                  {cycle.completedEffort} pts
+                </Text>
+              </Group>
+              <Progress
+                value={(cycle.completedActions / maxActions) * 100}
+                size="lg"
+                radius="sm"
+                color="indigo"
+              />
+            </div>
+          ))}
+        </Stack>
+      </Stack>
+    </Card>
   );
 }
 

--- a/src/server/api/routers/sprintAnalytics.ts
+++ b/src/server/api/routers/sprintAnalytics.ts
@@ -7,6 +7,7 @@ import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import {
   sprintAnalyticsService,
   type SprintMetricsResult,
+  type VelocityHistoryPoint,
 } from "~/server/services/SprintAnalyticsService";
 import { githubActivityService } from "~/server/services/GitHubActivityService";
 
@@ -65,6 +66,29 @@ export const sprintAnalyticsRouter = createTRPCRouter({
       if (!activeSprint) return null;
 
       return sprintAnalyticsService.getSprintMetrics(activeSprint.id);
+    }),
+
+  /**
+   * Metrics page (UI): velocity trend across recent completed cycles.
+   *
+   * Enforces workspace membership and returns the last N completed cycles with
+   * velocity (count + points) and completion, each recomputed live. Returned
+   * most-recent-first.
+   */
+  getVelocityTrend: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string().min(1),
+        count: z.number().int().min(1).max(20).optional(),
+      }),
+    )
+    .query(async ({ ctx, input }): Promise<VelocityHistoryPoint[]> => {
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, input.workspaceId);
+
+      return sprintAnalyticsService.getVelocityHistory(
+        input.workspaceId,
+        input.count,
+      );
     }),
 
   /**

--- a/src/server/services/SprintAnalyticsService.ts
+++ b/src/server/services/SprintAnalyticsService.ts
@@ -41,6 +41,18 @@ export interface DailySnapshotResult {
   actionsCompleted: number;
 }
 
+export interface VelocityHistoryPoint {
+  sprintId: string;
+  sprintName: string;
+  endDate: Date | null;
+  // Velocity, reported as both a count (headline) and points, consistent
+  // with the active-cycle metrics.
+  completedActions: number;
+  completedEffort: number;
+  velocity: number; // = completedEffort (points); kept for agent compatibility
+  completionRate: number;
+}
+
 const KANBAN_STATUSES: ActionStatus[] = [
   "BACKLOG",
   "TODO",
@@ -398,12 +410,22 @@ export class SprintAnalyticsService {
   }
 
   /**
-   * Get velocity history across past sprints for trend analysis.
+   * Get velocity history across recent completed sprints for trend analysis.
+   *
+   * Each cycle is **recomputed live** from its actions' current (final)
+   * kanbanStatus — the same computation as {@link getSprintMetrics} — rather
+   * than reading the dormant, never-written `SprintMetrics` rows (which made
+   * this method return all-zeros in practice). A completed cycle's actions are
+   * effectively immutable, so a live recompute is accurate and needs no stored
+   * snapshot. No `SprintMetrics` row is written and no cron is introduced.
+   * See ADR-0047.
+   *
+   * Returned most-recent-first (by `endDate` desc).
    */
   async getVelocityHistory(
     workspaceId: string,
     count = 5,
-  ): Promise<Array<{ sprintName: string; velocity: number; completionRate: number }>> {
+  ): Promise<VelocityHistoryPoint[]> {
     const completedSprints = await this.prisma.list.findMany({
       where: {
         workspaceId,
@@ -412,15 +434,21 @@ export class SprintAnalyticsService {
       },
       orderBy: { endDate: "desc" },
       take: count,
-      include: {
-        metrics: true,
-      },
+      select: { id: true },
     });
 
-    return completedSprints.map((sprint) => ({
-      sprintName: sprint.name,
-      velocity: sprint.metrics?.velocity ?? 0,
-      completionRate: sprint.metrics?.completionRate ?? 0,
+    const metrics = await Promise.all(
+      completedSprints.map((sprint) => this.getSprintMetrics(sprint.id)),
+    );
+
+    return metrics.map((m) => ({
+      sprintId: m.sprintId,
+      sprintName: m.sprintName,
+      endDate: m.endDate,
+      completedActions: m.completedActions,
+      completedEffort: m.completedEffort,
+      velocity: m.velocity,
+      completionRate: m.completionRate,
     }));
   }
 }


### PR DESCRIPTION
### **User description**
## What

Adds the cross-cycle velocity trend to the Metrics page. Builds on the tracer bullet (`aqua.tulip`).

- **Backend fix**: `SprintAnalyticsService.getVelocityHistory` previously read stored `SprintMetrics` rows — which nothing in the codebase ever writes — so it returned all-zeros. Rewritten to **recompute each recent completed cycle live** via `getSprintMetrics` (a completed cycle's actions' final `kanbanStatus` is stable, so a live recompute is accurate). No `SprintMetrics` persistence and no cron are introduced — those columns stay dormant per [ADR-0047](docs/adr/0047-metrics-page-live-computation.md). The return shape gains `completedActions` (count), `sprintId`, and `endDate`; `velocity` (points) and `completionRate` are preserved for agent compatibility.
- **API**: new `getVelocityTrend` `protectedProcedure` (workspaceId + `assertWorkspaceMember`), returning the last N completed cycles.
- **UI**: velocity-trend card on the Metrics page — count-based headline consistent with #1, bars scaled to the busiest cycle, oldest→newest.

## Acceptance criteria

- [x] `getVelocityHistory` returns real per-cycle velocity for completed cycles (no longer all-zeros), computed live
- [x] No `SprintMetrics` row writes and no scheduled job added
- [x] Protected procedure enforces `assertWorkspaceMember`
- [x] Metrics page shows a velocity trend across the last N completed cycles (count-based headline consistent with #1)
- [x] Sensible empty state when there are fewer than 2 completed cycles
- [x] `npm run check` passes; no hardcoded colors

## Blocked by

- `aqua.tulip` (#417, merged) — the Metrics page shell + protected-procedure pattern

---

Ships: inner.elk


___

### **PR Type**
Enhancement


___

### **Description**
- Rewrite `getVelocityHistory` to compute metrics live instead of reading dormant `SprintMetrics` rows

- Add `getVelocityTrend` protected tRPC procedure with workspace membership enforcement

- Add `VelocityTrend` UI card to Metrics page showing per-cycle bar chart (oldest→newest)

- Introduce `VelocityHistoryPoint` interface with `completedActions`, `completedEffort`, `sprintId`, `endDate`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ui["VelocityTrend\ncomponent"]
  proc["getVelocityTrend\n(protectedProcedure)"]
  auth["assertWorkspaceMember"]
  svc["SprintAnalyticsService\n.getVelocityHistory"]
  metrics["getSprintMetrics\n(live recompute per cycle)"]
  db["Prisma: completed\nSPRINT lists"]

  ui -- "calls" --> proc
  proc -- "enforces" --> auth
  proc -- "delegates to" --> svc
  svc -- "queries" --> db
  svc -- "recomputes live via" --> metrics
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MetricsDashboard.tsx</strong><dd><code>Add VelocityTrend card to MetricsDashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/metrics/MetricsDashboard.tsx

<ul><li>Added <code>VelocityTrend</code> component rendering a bar chart of completed <br>cycles (oldest→newest)<br> <li> Bars are scaled relative to the busiest cycle; count is the headline <br>metric with points alongside<br> <li> Loading skeleton and empty state shown when fewer than 2 completed <br>cycles exist<br> <li> <code>IconTrendingUp</code> imported and used as the section icon</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/418/files#diff-1484d2a65a8e9ae596af83efe68b19d6858d822ba22144ebf69da067a9acbe85">+101/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sprintAnalytics.ts</strong><dd><code>Add getVelocityTrend protected tRPC procedure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/sprintAnalytics.ts

<ul><li>Added <code>getVelocityTrend</code> <code>protectedProcedure</code> accepting <code>workspaceId</code> and <br>optional <code>count</code><br> <li> Enforces <code>assertWorkspaceMember</code> before delegating to <br><code>SprintAnalyticsService.getVelocityHistory</code><br> <li> Returns <code>VelocityHistoryPoint[]</code> most-recent-first<br> <li> Imported <code>VelocityHistoryPoint</code> type from the service</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/418/files#diff-4a82f292b7c8e3544af99c137099a52a39d118b5beeaf18df20448bfe0823119">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SprintAnalyticsService.ts</strong><dd><code>Rewrite getVelocityHistory with live per-cycle recomputation</code></dd></summary>
<hr>

src/server/services/SprintAnalyticsService.ts

<ul><li>Introduced <code>VelocityHistoryPoint</code> interface with <code>sprintId</code>, <code>sprintName</code>, <br><code>endDate</code>, <code>completedActions</code>, <code>completedEffort</code>, <code>velocity</code>, and <br><code>completionRate</code><br> <li> Rewrote <code>getVelocityHistory</code> to recompute each completed cycle live via <br><code>getSprintMetrics</code> instead of reading never-written <code>SprintMetrics</code> rows<br> <li> Removed <code>include: { metrics: true }</code> in favour of <code>select: { id: true }</code> <br>followed by <code>Promise.all</code> over <code>getSprintMetrics</code><br> <li> Return type updated from anonymous object array to <br><code>VelocityHistoryPoint[]</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/418/files#diff-2454525a76d9cb695ad024c76d06e4053d64b8b66e7285fc87c06550d17f0603">+37/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

