### PR TITLE
feat: Merged-PR turnaround metric

### DIFF
--- a/src/app/_components/metrics/MetricsDashboard.tsx
+++ b/src/app/_components/metrics/MetricsDashboard.tsx
@@ -6,6 +6,7 @@ import {
   IconCircleCheck,
   IconBolt,
   IconTrendingUp,
+  IconGitPullRequest,
 } from '@tabler/icons-react';
 import { api, type RouterOutputs } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
@@ -166,7 +167,7 @@ function ActiveCycleMetrics({ data }: { data: CycleMetrics }) {
         <span className="text-text-secondary font-medium">{data.sprintName}</span>
       </Text>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
         {/* Velocity — completed-action COUNT is the headline, points alongside */}
         <Card
           withBorder
@@ -224,8 +225,103 @@ function ActiveCycleMetrics({ data }: { data: CycleMetrics }) {
             />
           </Stack>
         </Card>
+
+        {/* Merged-PR turnaround */}
+        <PrTurnaroundCard />
       </div>
     </Stack>
+  );
+}
+
+/** Format a duration in hours as a compact, sensible unit. */
+function formatHours(hours: number): { value: string; unit: string } {
+  if (hours < 1) return { value: String(Math.max(1, Math.round(hours * 60))), unit: 'min' };
+  if (hours < 48) return { value: String(Math.round(hours)), unit: 'h' };
+  return { value: (hours / 24).toFixed(1), unit: 'd' };
+}
+
+function PrTurnaroundCard() {
+  const { workspaceId } = useWorkspace();
+  const { data, isLoading } =
+    api.sprintAnalytics.getActiveCyclePrTurnaround.useQuery(
+      { workspaceId: workspaceId ?? '' },
+      { enabled: !!workspaceId },
+    );
+
+  const header = (
+    <Group gap="xs">
+      <IconGitPullRequest size={16} className="text-text-muted" />
+      <Text size="sm" fw={500} className="text-text-secondary">
+        PR turnaround
+      </Text>
+    </Group>
+  );
+
+  let body: React.ReactNode;
+  if (isLoading) {
+    body = (
+      <div className="animate-pulse space-y-2">
+        <div className="h-10 w-1/2 rounded bg-surface-hover" />
+        <div className="h-3 w-2/3 rounded bg-surface-hover" />
+      </div>
+    );
+  } else if (!data || data.mergedPrCount === 0) {
+    body = (
+      <Text size="sm" className="text-text-muted">
+        No PRs merged this cycle yet.
+      </Text>
+    );
+  } else if (data.avgHours == null) {
+    // PRs merged, but no captured opened event to measure against.
+    body = (
+      <Stack gap="xs">
+        <Text className="text-4xl font-bold text-accent-indigo">
+          {data.mergedPrCount}
+        </Text>
+        <Text size="xs" className="text-text-muted">
+          {data.mergedPrCount === 1 ? 'PR' : 'PRs'} merged · turnaround
+          unavailable
+        </Text>
+      </Stack>
+    );
+  } else {
+    const avg = formatHours(data.avgHours);
+    body = (
+      <Stack gap="xs">
+        <Group align="baseline" gap={4}>
+          <Text className="text-4xl font-bold text-accent-indigo">
+            {avg.value}
+          </Text>
+          <Text size="lg" fw={600} className="text-accent-indigo">
+            {avg.unit}
+          </Text>
+          <Text size="sm" className="text-text-muted">
+            avg
+          </Text>
+        </Group>
+        <Text size="xs" className="text-text-muted">
+          {data.medianHours != null &&
+            (() => {
+              const med = formatHours(data.medianHours);
+              return `${med.value}${med.unit} median · `;
+            })()}
+          {data.mergedPrCount} {data.mergedPrCount === 1 ? 'PR' : 'PRs'} merged
+        </Text>
+      </Stack>
+    );
+  }
+
+  return (
+    <Card
+      withBorder
+      radius="md"
+      className="border-border-primary bg-surface-secondary"
+    >
+      <Stack gap="xs">
+        {header}
+        {body}
+      </Stack>
+    </Card>
   );
 }
 

--- a/src/server/api/routers/sprintAnalytics.ts
+++ b/src/server/api/routers/sprintAnalytics.ts
@@ -8,6 +8,7 @@ import {
   sprintAnalyticsService,
   type SprintMetricsResult,
   type VelocityHistoryPoint,
+  type PrTurnaroundResult,
 } from "~/server/services/SprintAnalyticsService";
 import { githubActivityService } from "~/server/services/GitHubActivityService";
 
@@ -89,6 +90,27 @@ export const sprintAnalyticsRouter = createTRPCRouter({
         input.workspaceId,
         input.count,
       );
+    }),
+
+  /**
+   * Metrics page (UI): merged-PR turnaround for the workspace's active cycle.
+   *
+   * Enforces workspace membership, resolves the active cycle, and returns the
+   * average/median opened→merged time for PRs merged in the cycle window
+   * (computed live from GitHubActivity). Returns `null` when there is no active
+   * cycle so the UI can render an empty state.
+   */
+  getActiveCyclePrTurnaround: protectedProcedure
+    .input(z.object({ workspaceId: z.string().min(1) }))
+    .query(async ({ ctx, input }): Promise<PrTurnaroundResult | null> => {
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, input.workspaceId);
+
+      const activeSprint = await sprintAnalyticsService.getActiveSprint(
+        input.workspaceId,
+      );
+      if (!activeSprint) return null;
+
+      return sprintAnalyticsService.getPrTurnaround(activeSprint.id);
     }),
 
   /**

--- a/src/server/services/SprintAnalyticsService.ts
+++ b/src/server/services/SprintAnalyticsService.ts
@@ -41,6 +41,15 @@ export interface DailySnapshotResult {
   actionsCompleted: number;
 }
 
+export interface PrTurnaroundResult {
+  /** PRs merged within the cycle window (deduped by repo + PR number). */
+  mergedPrCount: number;
+  /** Avg opened→merged time in hours, over PRs with a known opened event. Null when none are measurable. */
+  avgHours: number | null;
+  /** Median opened→merged time in hours. Null when none are measurable. */
+  medianHours: number | null;
+}
+
 export interface VelocityHistoryPoint {
   sprintId: string;
   sprintName: string;
@@ -450,6 +459,120 @@ export class SprintAnalyticsService {
       velocity: m.velocity,
       completionRate: m.completionRate,
     }));
+  }
+
+  /**
+   * Merged-PR turnaround for a cycle: average (and median) opened→merged time
+   * for PRs merged within the cycle's [startDate, endDate] window.
+   *
+   * Computed **live** from the webhook-fed `GitHubActivity` event log — a PR's
+   * `opened`-event `eventTimestamp` joined to its `prMergedAt`. Nothing is
+   * persisted; `SprintMetrics.avgPrTurnaround` stays dormant per ADR-0047.
+   * Merged-PR turnaround only (no open-PR-age panel).
+   *
+   * Returns zeros/nulls gracefully when the cycle has no window or no merged
+   * PRs (no NaN from an empty average).
+   */
+  async getPrTurnaround(listId: string): Promise<PrTurnaroundResult> {
+    const empty: PrTurnaroundResult = {
+      mergedPrCount: 0,
+      avgHours: null,
+      medianHours: null,
+    };
+
+    const list = await this.prisma.list.findUniqueOrThrow({
+      where: { id: listId },
+      select: { startDate: true, endDate: true, workspaceId: true },
+    });
+
+    if (!list.startDate || !list.endDate || !list.workspaceId) return empty;
+
+    // PRs merged within the cycle window.
+    const mergedRows = await this.prisma.gitHubActivity.findMany({
+      where: {
+        workspaceId: list.workspaceId,
+        eventType: "pull_request",
+        prNumber: { not: null },
+        prMergedAt: { gte: list.startDate, lte: list.endDate },
+      },
+      select: { prNumber: true, repoFullName: true, prMergedAt: true },
+    });
+
+    // Dedup to one merged timestamp per (repo, PR number).
+    const mergedByPr = new Map<
+      string,
+      { prNumber: number; repoFullName: string; mergedAt: Date }
+    >();
+    for (const row of mergedRows) {
+      if (row.prNumber == null || !row.prMergedAt) continue;
+      const key = `${row.repoFullName}#${row.prNumber}`;
+      const existing = mergedByPr.get(key);
+      if (!existing || row.prMergedAt > existing.mergedAt) {
+        mergedByPr.set(key, {
+          prNumber: row.prNumber,
+          repoFullName: row.repoFullName,
+          mergedAt: row.prMergedAt,
+        });
+      }
+    }
+
+    if (mergedByPr.size === 0) return empty;
+
+    const merged = [...mergedByPr.values()];
+    const prNumbers = [...new Set(merged.map((m) => m.prNumber))];
+    const repoNames = [...new Set(merged.map((m) => m.repoFullName))];
+
+    // Opened events for those PRs → earliest opened timestamp per PR.
+    const openedRows = await this.prisma.gitHubActivity.findMany({
+      where: {
+        workspaceId: list.workspaceId,
+        eventType: "pull_request",
+        eventAction: "opened",
+        prNumber: { in: prNumbers },
+        repoFullName: { in: repoNames },
+      },
+      select: { prNumber: true, repoFullName: true, eventTimestamp: true },
+    });
+
+    const openedByPr = new Map<string, Date>();
+    for (const row of openedRows) {
+      if (row.prNumber == null) continue;
+      const key = `${row.repoFullName}#${row.prNumber}`;
+      const existing = openedByPr.get(key);
+      if (!existing || row.eventTimestamp < existing) {
+        openedByPr.set(key, row.eventTimestamp);
+      }
+    }
+
+    const durationsHours: number[] = [];
+    for (const [key, { mergedAt }] of mergedByPr) {
+      const openedAt = openedByPr.get(key);
+      if (!openedAt) continue; // no opened event captured → not measurable
+      const ms = mergedAt.getTime() - openedAt.getTime();
+      if (ms < 0) continue;
+      durationsHours.push(ms / (1000 * 60 * 60));
+    }
+
+    if (durationsHours.length === 0) {
+      // PRs merged in-window, but none had a captured opened event to measure.
+      return { mergedPrCount: mergedByPr.size, avgHours: null, medianHours: null };
+    }
+
+    const avgHours =
+      durationsHours.reduce((sum, h) => sum + h, 0) / durationsHours.length;
+
+    const sorted = [...durationsHours].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    const medianHours =
+      sorted.length % 2 === 0
+        ? (sorted[mid - 1]! + sorted[mid]!) / 2
+        : sorted[mid]!;
+
+    return {
+      mergedPrCount: mergedByPr.size,
+      avgHours,
+      medianHours,
+    };
   }
 }
 


### PR DESCRIPTION
### **User description**
## What

Adds merged-PR turnaround to the Metrics page. Independent of the velocity-trend slice; both build on the tracer bullet (`aqua.tulip`).

- **New live aggregation**: `SprintAnalyticsService.getPrTurnaround(listId)` over the webhook-fed `GitHubActivity` event log. For PRs **merged within the active cycle's window**, it joins each PR's `opened`-event `eventTimestamp` to its `prMergedAt` and computes **average and median** opened→merged time. Dedups by repo + PR number; guards the zero-merged and missing-opened-event cases (no NaN / empty-average crash). Nothing is persisted — `SprintMetrics.avgPrTurnaround` stays dormant per [ADR-0047](docs/adr/0047-metrics-page-live-computation.md). Merged-PR turnaround only — no live open-PR-age panel (out of v1).
- **API**: new `getActiveCyclePrTurnaround` `protectedProcedure` (workspaceId + `assertWorkspaceMember`).
- **UI**: turnaround stat card alongside velocity/completion — compact unit (min/h/d), median as a secondary figure, with a no-PRs-merged empty state.

## Acceptance criteria

- [x] New service method computes avg (and median) opened→merged time for PRs merged in the cycle window, from `GitHubActivity`
- [x] Handles cycles with zero merged PRs gracefully (no NaN / empty-average crash)
- [x] Protected procedure enforces `assertWorkspaceMember`
- [x] Metrics page shows the turnaround stat with a sensible unit (hours/days) and empty state
- [x] No `SprintMetrics` writes; computed live
- [x] `npm run check` passes; no hardcoded colors

## Blocked by

- `aqua.tulip` (#417, merged) — the Metrics page shell + protected-procedure pattern

---

Ships: fiery.ocean


___

### **PR Type**
Enhancement


___

### **Description**
- Add merged-PR turnaround metric to the Metrics page

- New `getPrTurnaround` service method computes avg/median opened→merged time

- New `getActiveCyclePrTurnaround` protected tRPC procedure with auth guard

- `PrTurnaroundCard` UI component with compact unit formatting and empty states


___

### Diagram Walkthrough


```mermaid
flowchart LR
  card["PrTurnaroundCard\n(UI component)"]
  proc["getActiveCyclePrTurnaround\n(protectedProcedure)"]
  auth["assertWorkspaceMember"]
  svc["SprintAnalyticsService\n.getPrTurnaround(listId)"]
  db["GitHubActivity\nevent log"]
  result["PrTurnaroundResult\n(avg + median hours)"]

  card -- "calls" --> proc
  proc -- "enforces" --> auth
  proc -- "delegates to" --> svc
  svc -- "queries" --> db
  svc -- "returns" --> result
  result -- "renders" --> card
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MetricsDashboard.tsx</strong><dd><code>Add PR turnaround stat card to MetricsDashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/metrics/MetricsDashboard.tsx

<ul><li>Added <code>IconGitPullRequest</code> import from <code>@tabler/icons-react</code><br> <li> Changed grid layout from 2 to 3 columns to accommodate new card<br> <li> Added <code>PrTurnaroundCard</code> component alongside velocity and completion <br>cards<br> <li> Implemented <code>formatHours</code> helper for compact unit display (min/h/d)<br> <li> Implemented <code>PrTurnaroundCard</code> with loading skeleton, empty state, and <br>avg/median display</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/419/files#diff-1484d2a65a8e9ae596af83efe68b19d6858d822ba22144ebf69da067a9acbe85">+97/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sprintAnalytics.ts</strong><dd><code>Add getActiveCyclePrTurnaround protected tRPC procedure</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/sprintAnalytics.ts

<ul><li>Imported <code>PrTurnaroundResult</code> type from <code>SprintAnalyticsService</code><br> <li> Added <code>getActiveCyclePrTurnaround</code> protected procedure with <br><code>assertWorkspaceMember</code> guard<br> <li> Procedure resolves active sprint and delegates to <br><code>sprintAnalyticsService.getPrTurnaround</code><br> <li> Returns <code>null</code> when no active cycle exists for empty-state handling</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/419/files#diff-4a82f292b7c8e3544af99c137099a52a39d118b5beeaf18df20448bfe0823119">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SprintAnalyticsService.ts</strong><dd><code>Implement live PR turnaround aggregation in SprintAnalyticsService</code></dd></summary>
<hr>

src/server/services/SprintAnalyticsService.ts

<ul><li>Defined <code>PrTurnaroundResult</code> interface with <code>mergedPrCount</code>, <code>avgHours</code>, and <br><code>medianHours</code><br> <li> Implemented <code>getPrTurnaround(listId)</code> method querying <code>GitHubActivity</code> for <br>merged PRs in cycle window<br> <li> Deduplicates PRs by repo + PR number and joins to earliest <br>opened-event timestamp<br> <li> Computes average and median opened→merged duration in hours; guards <br>zero-merged and missing-event cases</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/419/files#diff-2454525a76d9cb695ad024c76d06e4053d64b8b66e7285fc87c06550d17f0603">+123/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

