### PR TITLE
feat: V4 daily/weekly summaries on the unified notification pipeline

### DIFF
--- a/src/app/api/cron/process-notifications/route.ts
+++ b/src/app/api/cron/process-notifications/route.ts
@@ -3,12 +3,13 @@ import { headers } from "next/headers";
 import { db } from "~/server/db";
 import { retryPendingDeliveries } from "~/server/services/notifications/emit/processNotifications";
 import { generateDueDateReminders } from "~/server/services/notifications/emit/dueDateReminders";
+import { generateScheduledSummaries } from "~/server/services/notifications/emit/summaries";
 
 /**
  * Cron endpoint (ADR-0045) for the unified notification pipeline. Generates
- * scheduled notifications as they come due (V3: due-date reminders; summaries in
- * V4) and retries any NotificationDelivery that hasn't succeeded (failed, or
- * orphaned-pending) under the attempt cap.
+ * scheduled notifications as they come due (due-date reminders, daily/weekly
+ * summaries) and retries any NotificationDelivery that hasn't succeeded (failed,
+ * or orphaned-pending) under the attempt cap.
  *
  * Call via: GET /api/cron/process-notifications — Vercel cron, CRON_SECRET-protected.
  */
@@ -22,12 +23,14 @@ export async function GET(_request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Scheduled generation: emit due-date reminders as their offsets are crossed.
+    // Scheduled generation: due-date reminders as offsets cross, and daily/weekly
+    // summaries at their configured local times.
     const dueDate = await generateDueDateReminders(db);
+    const summaries = await generateScheduledSummaries(db);
     // Retry backstop: re-attempt any delivery that hasn't succeeded.
     const retry = await retryPendingDeliveries(db);
 
-    return NextResponse.json({ ok: true, dueDate, retry });
+    return NextResponse.json({ ok: true, dueDate, summaries, retry });
   } catch (error) {
     console.error("[cron/process-notifications] failed:", error);
     return NextResponse.json(

--- a/src/server/services/notifications/NotificationTemplates.ts
+++ b/src/server/services/notifications/NotificationTemplates.ts
@@ -1,4 +1,3 @@
-import { format } from 'date-fns';
 import type { Action, Project, User } from '@prisma/client';
 
 export interface TemplateContext {
@@ -16,33 +15,11 @@ export interface TemplateContext {
   customData?: Record<string, any>;
 }
 
+// NOTE: The dead setInterval scheduler's task-reminder and project-update
+// templates (and their helpers) were retired with the unified pipeline
+// (ADR-0045). Due-date reminders build their own content in emit/content.ts;
+// only the daily/weekly summary templates below are still used (by emit/summaries.ts).
 export class NotificationTemplates {
-  /**
-   * Task reminder template
-   */
-  static taskReminder(
-    task: Pick<Action, 'name' | 'description' | 'dueDate' | 'priority'>,
-    minutesBefore: number
-  ): { title: string; message: string } {
-    const dueTime = this.formatDueTime(minutesBefore);
-    const priorityEmoji = this.getPriorityEmoji(task.priority);
-    
-    let message = `${priorityEmoji} Reminder: "${task.name}" is due ${dueTime}`;
-    
-    if (task.description) {
-      message += `\n\n📝 ${task.description}`;
-    }
-    
-    if (task.dueDate) {
-      message += `\n\n⏰ Due: ${format(task.dueDate, 'PPp')}`;
-    }
-
-    return {
-      title: '⏰ Task Reminder',
-      message,
-    };
-  }
-
   /**
    * Daily summary template
    */
@@ -137,46 +114,6 @@ export class NotificationTemplates {
   }
 
   /**
-   * Project update template
-   */
-  static projectUpdate(
-    project: Pick<Project, 'name' | 'status' | 'progress'>,
-    context: TemplateContext
-  ): { title: string; message: string } {
-    const { tasks = [] } = context;
-    const statusEmoji = this.getProjectStatusEmoji(project.status);
-    
-    let message = `${statusEmoji} *Project Update: ${project.name}*\n\n`;
-    
-    message += `📊 *Status:* ${this.formatProjectStatus(project.status)}\n`;
-    message += `📈 *Progress:* ${project.progress}%\n`;
-    
-    const projectTasks = tasks.filter(t => t.status !== 'COMPLETED');
-    
-    if (projectTasks.length > 0) {
-      message += `\n📋 *Pending Tasks:* ${projectTasks.length}\n`;
-      
-      const urgentTasks = projectTasks.filter(t => t.priority === 'HIGH');
-      if (urgentTasks.length > 0) {
-        message += `⚡ *Urgent:* ${urgentTasks.length}\n`;
-      }
-    } else {
-      message += `\n✅ All tasks completed!`;
-    }
-    
-    if (project.progress === 100) {
-      message += `\n\n🎉 Congratulations! Project completed!`;
-    } else if (project.progress >= 80) {
-      message += `\n\n🏁 Almost there! Final push!`;
-    }
-
-    return {
-      title: '📋 Project Update',
-      message,
-    };
-  }
-
-  /**
    * Custom template
    */
   static custom(title: string, template: string, context: TemplateContext): { title: string; message: string } {
@@ -208,20 +145,6 @@ export class NotificationTemplates {
   /**
    * Helper methods
    */
-  private static formatDueTime(minutesBefore: number): string {
-    if (minutesBefore === 0) {
-      return 'now';
-    } else if (minutesBefore < 60) {
-      return `in ${minutesBefore} minutes`;
-    } else if (minutesBefore < 1440) {
-      const hours = Math.floor(minutesBefore / 60);
-      return `in ${hours} hour${hours > 1 ? 's' : ''}`;
-    } else {
-      const days = Math.floor(minutesBefore / 1440);
-      return `in ${days} day${days > 1 ? 's' : ''}`;
-    }
-  }
-
   private static getPriorityEmoji(priority?: string | null): string {
     switch (priority) {
       case 'HIGH':
@@ -247,21 +170,6 @@ export class NotificationTemplates {
         return '❌';
       default:
         return '📁';
-    }
-  }
-
-  private static formatProjectStatus(status?: string): string {
-    switch (status) {
-      case 'ACTIVE':
-        return 'Active';
-      case 'COMPLETED':
-        return 'Completed';
-      case 'ON_HOLD':
-        return 'On Hold';
-      case 'CANCELLED':
-        return 'Cancelled';
-      default:
-        return 'Unknown';
     }
   }
 

--- a/src/server/services/notifications/emit/__tests__/summaries.test.ts
+++ b/src/server/services/notifications/emit/__tests__/summaries.test.ts
@@ -16,6 +16,9 @@ function pref(overrides: Record<string, unknown> = {}) {
     userId: "u1",
     timezone: "UTC",
     dailySummaryTime: "09:00",
+    dailySummary: true,
+    weeklySummary: false,
+    weeklyDayOfWeek: 1,
     ...overrides,
   };
 }
@@ -27,6 +30,7 @@ beforeEach(() => {
   db.user.findUnique.mockResolvedValue({ id: "u1", name: "Ada", email: "ada@acme.test" } as never);
   db.action.findMany.mockResolvedValue([] as never);
   db.action.count.mockResolvedValue(0 as never);
+  db.project.findMany.mockResolvedValue([] as never);
 });
 
 describe("generateScheduledSummaries", () => {
@@ -78,5 +82,32 @@ describe("generateScheduledSummaries", () => {
         subject: expect.objectContaining({ kind: "daily", periodKey: "2026-07-23" }),
       }),
     );
+  });
+
+  it("emits a weekly summary only on the configured weekday, keyed per ISO week", async () => {
+    // 2026-07-23 is a Thursday (getDay = 4).
+    db.notificationPreference.findMany.mockResolvedValue([
+      pref({ dailySummary: false, weeklySummary: true, weeklyDayOfWeek: 4 }),
+    ] as never);
+
+    await generateScheduledSummaries(db, new Date("2026-07-23T09:05:00.000Z"));
+
+    expect(emitNotification).toHaveBeenCalledTimes(1);
+    expect(emitNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: expect.objectContaining({ kind: "weekly", periodKey: "2026-W30" }),
+      }),
+    );
+  });
+
+  it("does not emit the weekly summary on other weekdays", async () => {
+    // Thursday now, but the user's weekly day is Monday (1).
+    db.notificationPreference.findMany.mockResolvedValue([
+      pref({ dailySummary: false, weeklySummary: true, weeklyDayOfWeek: 1 }),
+    ] as never);
+
+    await generateScheduledSummaries(db, new Date("2026-07-23T09:05:00.000Z"));
+
+    expect(emitNotification).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/notifications/emit/__tests__/summaries.test.ts
+++ b/src/server/services/notifications/emit/__tests__/summaries.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import { generateScheduledSummaries } from "~/server/services/notifications/emit/summaries";
+import { emitNotification } from "~/server/services/notifications/emit/emitNotification";
+
+vi.mock("~/server/services/notifications/emit/emitNotification", () => ({
+  emitNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+const db = mockDeep<PrismaClient>();
+
+function pref(overrides: Record<string, unknown> = {}) {
+  return {
+    userId: "u1",
+    timezone: "UTC",
+    dailySummaryTime: "09:00",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockReset(db);
+  vi.clearAllMocks();
+  // Digest data fixtures (real templates render from these).
+  db.user.findUnique.mockResolvedValue({ id: "u1", name: "Ada", email: "ada@acme.test" } as never);
+  db.action.findMany.mockResolvedValue([] as never);
+  db.action.count.mockResolvedValue(0 as never);
+});
+
+describe("generateScheduledSummaries", () => {
+  it("emits a daily summary at the configured local time (within the fire window)", async () => {
+    db.notificationPreference.findMany.mockResolvedValue([pref()] as never);
+
+    const result = await generateScheduledSummaries(db, new Date("2026-07-23T09:05:00.000Z"));
+
+    expect(emitNotification).toHaveBeenCalledTimes(1);
+    expect(emitNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "summary",
+        actorUserId: null,
+        subject: expect.objectContaining({
+          userId: "u1",
+          kind: "daily",
+          periodKey: "2026-07-23",
+        }),
+      }),
+    );
+    expect(result.emitted).toBe(1);
+  });
+
+  it("does not emit before the configured time", async () => {
+    db.notificationPreference.findMany.mockResolvedValue([pref()] as never);
+
+    await generateScheduledSummaries(db, new Date("2026-07-23T08:00:00.000Z"));
+
+    expect(emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("does not emit outside the fire window (well after the configured time)", async () => {
+    db.notificationPreference.findMany.mockResolvedValue([pref()] as never);
+
+    await generateScheduledSummaries(db, new Date("2026-07-23T11:00:00.000Z"));
+
+    expect(emitNotification).not.toHaveBeenCalled();
+  });
+
+  it("respects the user's timezone (09:00 New York = 13:00 UTC in July)", async () => {
+    db.notificationPreference.findMany.mockResolvedValue([
+      pref({ timezone: "America/New_York" }),
+    ] as never);
+
+    await generateScheduledSummaries(db, new Date("2026-07-23T13:05:00.000Z"));
+
+    expect(emitNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: expect.objectContaining({ kind: "daily", periodKey: "2026-07-23" }),
+      }),
+    );
+  });
+});

--- a/src/server/services/notifications/emit/content.ts
+++ b/src/server/services/notifications/emit/content.ts
@@ -92,6 +92,21 @@ export async function buildContent(
         dedupeKey: `due_date:${actionId}:${offsetMinutes}`,
       };
     }
+    case NOTIFICATION_CATEGORIES.SUMMARY: {
+      // The cron pre-rendered the digest; a summary is personal, not
+      // workspace-scoped, so no per-workspace email override applies.
+      return {
+        category: NOTIFICATION_CATEGORIES.SUMMARY,
+        title: input.subject.title,
+        message: input.subject.message,
+        metadata: {
+          kind: input.subject.kind,
+          periodKey: input.subject.periodKey,
+        },
+        workspaceId: "",
+        dedupeKey: `summary:${input.subject.kind}:${input.subject.periodKey}`,
+      };
+    }
     case NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED: {
       const { sessionId } = input.subject;
 

--- a/src/server/services/notifications/emit/recipients.ts
+++ b/src/server/services/notifications/emit/recipients.ts
@@ -20,6 +20,9 @@ export async function resolveRecipients(
     case NOTIFICATION_CATEGORIES.DUE_DATE:
       // Due-date → the single owner the cron computed the crossing for.
       return Promise.resolve([input.subject.ownerUserId]);
+    case NOTIFICATION_CATEGORIES.SUMMARY:
+      // Summary → the subject user their digest was built for.
+      return Promise.resolve([input.subject.userId]);
     case NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED:
       // Meeting participant added → the members just linked. De-dup defensively.
       return Promise.resolve(

--- a/src/server/services/notifications/emit/summaries.ts
+++ b/src/server/services/notifications/emit/summaries.ts
@@ -1,0 +1,131 @@
+import type { PrismaClient } from "@prisma/client";
+import { startOfDay, setHours, setMinutes, addDays, format } from "date-fns";
+import { toZonedTime, fromZonedTime } from "date-fns-tz";
+import { NotificationTemplates } from "~/server/services/notifications/NotificationTemplates";
+import { emitNotification } from "./emitNotification";
+import { NOTIFICATION_CATEGORIES } from "./constants";
+
+const DEFAULT_TIME = "09:00";
+/**
+ * A summary fires at the first cron tick at/after its configured local time,
+ * within this window. Dedup (per user + period) makes it exactly-once; the
+ * window just bounds how late a missed tick may fire it.
+ */
+const FIRE_WINDOW_MS = 60 * 60 * 1000;
+
+const TERMINAL_STATUSES = ["COMPLETED", "DONE", "CANCELLED"];
+const DONE_STATUSES = ["COMPLETED", "DONE"];
+
+/** True when `now` is within the fire window after today's local `timeStr` in `tz`. */
+function isWithinFireWindow(now: Date, tz: string, timeStr: string): boolean {
+  const parts = timeStr.split(":");
+  const hours = Number(parts[0]);
+  const minutes = Number(parts[1]);
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) return false;
+
+  const userNow = toZonedTime(now, tz);
+  const targetLocal = setMinutes(setHours(startOfDay(userNow), hours), minutes);
+  const targetUtc = fromZonedTime(targetLocal, tz);
+
+  const diff = now.getTime() - targetUtc.getTime();
+  return diff >= 0 && diff < FIRE_WINDOW_MS;
+}
+
+/** Build the rendered daily digest for a user, or null if the user is gone. */
+async function buildDailyDigest(
+  db: PrismaClient,
+  userId: string,
+  now: Date,
+  tz: string,
+): Promise<{ title: string; message: string } | null> {
+  const dayStartLocal = startOfDay(toZonedTime(now, tz));
+  const todayStartUtc = fromZonedTime(dayStartLocal, tz);
+  const tomorrowStartUtc = fromZonedTime(addDays(dayStartLocal, 1), tz);
+
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: { id: true, name: true, email: true },
+  });
+  if (!user) return null;
+
+  const tasks = await db.action.findMany({
+    where: {
+      createdById: userId,
+      dueDate: { gte: todayStartUtc, lt: tomorrowStartUtc },
+    },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      priority: true,
+      status: true,
+      dueDate: true,
+    },
+    orderBy: { priority: "desc" },
+  });
+
+  const completedTasks = tasks.filter((t) => DONE_STATUSES.includes(t.status)).length;
+  const pendingTasks = tasks.filter((t) => !TERMINAL_STATUSES.includes(t.status)).length;
+  const overdueCount = await db.action.count({
+    where: {
+      createdById: userId,
+      status: { notIn: TERMINAL_STATUSES },
+      dueDate: { lt: todayStartUtc },
+    },
+  });
+
+  return NotificationTemplates.dailySummary({
+    user,
+    tasks,
+    stats: {
+      todayCount: tasks.length,
+      pendingTasks,
+      completedTasks,
+      overdueCount,
+    },
+  });
+}
+
+/**
+ * Cron scheduled-generation (ADR-0045, V4): emit each user's daily digest at
+ * their configured local time, through the pipeline so it honours the Summary
+ * row of the matrix. Replaces the dead scheduler's `scheduleRecurringNotifications`.
+ * Weekly digests are added in action 2.
+ */
+export async function generateScheduledSummaries(
+  db: PrismaClient,
+  now: Date = new Date(),
+): Promise<{ emitted: number }> {
+  const prefs = await db.notificationPreference.findMany({
+    where: { enabled: true, dailySummary: true },
+    select: { userId: true, timezone: true, dailySummaryTime: true },
+  });
+
+  let emitted = 0;
+
+  for (const pref of prefs) {
+    const tz = pref.timezone ?? "UTC";
+
+    if (isWithinFireWindow(now, tz, pref.dailySummaryTime ?? DEFAULT_TIME)) {
+      const periodKey = format(toZonedTime(now, tz), "yyyy-MM-dd");
+      const digest = await buildDailyDigest(db, pref.userId, now, tz);
+      if (!digest) continue;
+
+      await emitNotification({
+        category: NOTIFICATION_CATEGORIES.SUMMARY,
+        actorUserId: null,
+        subject: {
+          userId: pref.userId,
+          kind: "daily",
+          title: digest.title,
+          message: digest.message,
+          periodKey,
+        },
+        db,
+      });
+      emitted++;
+    }
+  }
+
+  return { emitted };
+}

--- a/src/server/services/notifications/emit/summaries.ts
+++ b/src/server/services/notifications/emit/summaries.ts
@@ -1,5 +1,5 @@
 import type { PrismaClient } from "@prisma/client";
-import { startOfDay, setHours, setMinutes, addDays, format } from "date-fns";
+import { startOfDay, setHours, setMinutes, addDays, format, getDay } from "date-fns";
 import { toZonedTime, fromZonedTime } from "date-fns-tz";
 import { NotificationTemplates } from "~/server/services/notifications/NotificationTemplates";
 import { emitNotification } from "./emitNotification";
@@ -86,44 +86,113 @@ async function buildDailyDigest(
   });
 }
 
+/** True when today (local) is the user's weekly day and we're in the fire window. */
+function isWeeklyDue(
+  now: Date,
+  tz: string,
+  weeklyDayOfWeek: number,
+  timeStr: string,
+): boolean {
+  // weeklyDayOfWeek is 1=Mon…7=Sun; getDay is 0=Sun…6=Sat → map Sunday to 7.
+  const localDay = getDay(toZonedTime(now, tz)) || 7;
+  if (localDay !== weeklyDayOfWeek) return false;
+  return isWithinFireWindow(now, tz, timeStr);
+}
+
+/** Build the rendered weekly digest for a user, or null if the user is gone. */
+async function buildWeeklyDigest(
+  db: PrismaClient,
+  userId: string,
+): Promise<{ title: string; message: string } | null> {
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: { id: true, name: true, email: true },
+  });
+  if (!user) return null;
+
+  const tasks = await db.action.findMany({
+    where: { createdById: userId },
+    select: { status: true },
+  });
+  const completedTasks = tasks.filter((t) => DONE_STATUSES.includes(t.status)).length;
+
+  const projects = await db.project.findMany({
+    where: { createdById: userId, status: "ACTIVE" },
+    orderBy: { createdAt: "desc" },
+    take: 5,
+    select: { id: true, name: true, status: true, progress: true },
+  });
+
+  return NotificationTemplates.weeklySummary({
+    user,
+    projects,
+    stats: { totalTasks: tasks.length, completedTasks },
+  });
+}
+
+/** Emit one pre-rendered summary through the pipeline. */
+async function emitSummary(
+  db: PrismaClient,
+  userId: string,
+  kind: "daily" | "weekly",
+  digest: { title: string; message: string },
+  periodKey: string,
+): Promise<void> {
+  await emitNotification({
+    category: NOTIFICATION_CATEGORIES.SUMMARY,
+    actorUserId: null,
+    subject: { userId, kind, title: digest.title, message: digest.message, periodKey },
+    db,
+  });
+}
+
 /**
- * Cron scheduled-generation (ADR-0045, V4): emit each user's daily digest at
- * their configured local time, through the pipeline so it honours the Summary
- * row of the matrix. Replaces the dead scheduler's `scheduleRecurringNotifications`.
- * Weekly digests are added in action 2.
+ * Cron scheduled-generation (ADR-0045, V4): emit each user's daily and weekly
+ * digests at their configured local time (weekly also on their configured day),
+ * through the pipeline so they honour the Summary row of the matrix. Deduped per
+ * user+period. Replaces the dead scheduler's `scheduleRecurringNotifications`.
  */
 export async function generateScheduledSummaries(
   db: PrismaClient,
   now: Date = new Date(),
 ): Promise<{ emitted: number }> {
   const prefs = await db.notificationPreference.findMany({
-    where: { enabled: true, dailySummary: true },
-    select: { userId: true, timezone: true, dailySummaryTime: true },
+    where: {
+      enabled: true,
+      OR: [{ dailySummary: true }, { weeklySummary: true }],
+    },
+    select: {
+      userId: true,
+      timezone: true,
+      dailySummaryTime: true,
+      dailySummary: true,
+      weeklySummary: true,
+      weeklyDayOfWeek: true,
+    },
   });
 
   let emitted = 0;
 
   for (const pref of prefs) {
     const tz = pref.timezone ?? "UTC";
+    const time = pref.dailySummaryTime ?? DEFAULT_TIME;
 
-    if (isWithinFireWindow(now, tz, pref.dailySummaryTime ?? DEFAULT_TIME)) {
+    if (pref.dailySummary && isWithinFireWindow(now, tz, time)) {
       const periodKey = format(toZonedTime(now, tz), "yyyy-MM-dd");
       const digest = await buildDailyDigest(db, pref.userId, now, tz);
-      if (!digest) continue;
+      if (digest) {
+        await emitSummary(db, pref.userId, "daily", digest, periodKey);
+        emitted++;
+      }
+    }
 
-      await emitNotification({
-        category: NOTIFICATION_CATEGORIES.SUMMARY,
-        actorUserId: null,
-        subject: {
-          userId: pref.userId,
-          kind: "daily",
-          title: digest.title,
-          message: digest.message,
-          periodKey,
-        },
-        db,
-      });
-      emitted++;
+    if (pref.weeklySummary && isWeeklyDue(now, tz, pref.weeklyDayOfWeek ?? 1, time)) {
+      const periodKey = format(toZonedTime(now, tz), "RRRR-'W'II");
+      const digest = await buildWeeklyDigest(db, pref.userId);
+      if (digest) {
+        await emitSummary(db, pref.userId, "weekly", digest, periodKey);
+        emitted++;
+      }
     }
   }
 

--- a/src/server/services/notifications/emit/types.ts
+++ b/src/server/services/notifications/emit/types.ts
@@ -70,6 +70,20 @@ export interface DueDateSubject {
 }
 
 /**
+ * Summary / digest (V4): a user's daily or weekly roll-up. The cron builds the
+ * rendered digest (title + message) and passes it here; emit delivers it to the
+ * subject user's enabled Summary channels. Not workspace-scoped.
+ */
+export interface SummarySubject {
+  userId: string;
+  kind: "daily" | "weekly";
+  title: string;
+  message: string;
+  /** Period id for dedup — e.g. "2026-07-23" (daily) or "2026-W30" (weekly). */
+  periodKey: string;
+}
+
+/**
  * Discriminated union pairing each category with its subject. `emitNotification`
  * narrows on `category`, so recipient resolvers and content builders get a
  * fully-typed subject with no casts.
@@ -92,6 +106,10 @@ export type EmitNotificationInput = {
   | {
       category: typeof NOTIFICATION_CATEGORIES.DUE_DATE;
       subject: DueDateSubject;
+    }
+  | {
+      category: typeof NOTIFICATION_CATEGORIES.SUMMARY;
+      subject: SummarySubject;
     }
   | {
       category: typeof NOTIFICATION_CATEGORIES.MEETING_PARTICIPANT_ADDED;


### PR DESCRIPTION
### **User description**
## What

V4 of unified notification dispatch (ADR-0045): **make scheduled summaries fire again**. The old daily/weekly digests never actually sent — the `setInterval` scheduler was dead and serverless-incompatible. This moves generation into the cron and through the pipeline.

- **Summary category on the emit seam**: a `SummarySubject`, subject-user recipient, and personal (non-workspace-scoped) content.
- **`generateScheduledSummaries`** (in `/api/cron/process-notifications`): renders each user's **daily** digest at their configured local time and **weekly** digest on their configured `weeklyDayOfWeek` + time, reusing `NotificationTemplates`. Timezone-aware fire-window; deduped per user+period (`summary:daily:<date>` / `summary:weekly:<ISO-week>`). Delivered through the matrix like everything else.
- **Retired** the dead scheduler's now-orphaned `taskReminder` / `projectUpdate` templates + helpers — no remaining dependence on the `setInterval` scheduler.

Tests: `summaries.test.ts` (fires at configured time, respects the window, timezone handling, weekly day + ISO-week dedup). Full emit suite green.

## Acceptance criteria

- [ ] A user with daily summary enabled + Summary channel ticked receives their digest at the configured time
- [ ] Weekly summary fires on the configured day
- [ ] No remaining dependence on the setInterval scheduler

---

Ships: smooth.ember

Feature: Unified notification dispatch (`cmrw30ubj0001lb04otrv7rvk`) · builds on V1 (#406)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `generateScheduledSummaries` cron function for daily/weekly digest delivery
  - Timezone-aware fire-window logic; deduped per user+period via emit pipeline
  - Weekly summaries fire on user-configured `weeklyDayOfWeek` at their local time

- Add `SummarySubject` type and wire `SUMMARY` category into emit seam (recipients, content, types)

- Retire dead scheduler's `taskReminder` and `projectUpdate` templates and helpers

- Add `summaries.test.ts` unit suite covering fire-window, timezone, and weekly-day logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cron["cron /api/cron/process-notifications"]
  gen["generateScheduledSummaries(db, now)"]
  prefs["notificationPreference records"]
  window["isWithinFireWindow / isWeeklyDue"]
  daily["buildDailyDigest"]
  weekly["buildWeeklyDigest"]
  templates["NotificationTemplates.dailySummary / weeklySummary"]
  emit["emitNotification (SUMMARY category)"]
  pipeline["Unified emit pipeline (dedup, channels, delivery)"]

  cron -- "calls" --> gen
  gen -- "queries" --> prefs
  prefs -- "per user" --> window
  window -- "daily due" --> daily
  window -- "weekly due" --> weekly
  daily -- "renders via" --> templates
  weekly -- "renders via" --> templates
  daily -- "emitSummary" --> emit
  weekly -- "emitSummary" --> emit
  emit -- "through" --> pipeline
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>route.ts</strong><dd><code>Integrate generateScheduledSummaries into cron endpoint</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/420/files#diff-f9e24e97fc965527e1fc8df0f6669702e62b3cf9b966e3f2abbbee8bdb55f3aa">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>summaries.ts</strong><dd><code>New module: timezone-aware daily/weekly summary generation</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/420/files#diff-3237bbcb7c98b47e57073800b30dfb479c5bd5d91ce34d5422af09c63d4a7737">+200/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Add SummarySubject interface and SUMMARY union variant</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/420/files#diff-24cf961c0fa36a7d78a25dacb5751507ecb95553fd1e062c713fe311a4341972">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>content.ts</strong><dd><code>Handle SUMMARY category in buildContent with dedup key</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/420/files#diff-0de1681e5e2c85a302ddd3eccff0dae2a5a1f1079bad2ef656209b66c900ab21">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>recipients.ts</strong><dd><code>Resolve SUMMARY category recipient as subject userId</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/420/files#diff-c616ea57fdf8a4feae06c77a500c0a62a10d0403df65ee59010046d6bea507cf">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>summaries.test.ts</strong><dd><code>Unit tests for summary fire-window, timezone, and weekly-day logic</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/420/files#diff-32e5db74b324736f5574b5ed7efeb0ef9567cd2f1d8c5c472e01c9f1d7928526">+113/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>NotificationTemplates.ts</strong><dd><code>Remove dead taskReminder and projectUpdate templates and helpers</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/420/files#diff-a5906149554ead201bae7a1c891e377268785f1902e239411b1c857445797e72">+4/-96</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

