### PR TITLE
fix(ci): stop Exponential merge hook dying on PRs with no #-refs

### DIFF
--- a/.github/workflows/exponential-promote.yml
+++ b/.github/workflows/exponential-promote.yml
@@ -41,7 +41,7 @@ jobs:
           {
             echo "$PR_URL"
             git log "$BASE_SHA..$HEAD_SHA" --format=%B \
-              | grep -oE '#[0-9]+' | tr -d '#' | sort -u \
+              | { grep -oE '#[0-9]+' || true; } | tr -d '#' | sort -u \
               | sed "s@^@${REPO_URL}/pull/@"
           } | sort -u > /tmp/prs
           jq -R -s -c 'split("\n") | map(select(length > 0))' /tmp/prs > /tmp/prs.json

--- a/.github/workflows/exponential-requirements.yml
+++ b/.github/workflows/exponential-requirements.yml
@@ -50,7 +50,7 @@ jobs:
           {
             echo "$PR_URL"
             git log "$BASE_SHA..$HEAD_SHA" --format=%B \
-              | grep -oE '#[0-9]+' | tr -d '#' | sort -u \
+              | { grep -oE '#[0-9]+' || true; } | tr -d '#' | sort -u \
               | sed "s@^@${REPO_URL}/pull/@"
           } | sort -u > /tmp/prs
           jq -R -s -c 'split("\n") | map(select(length > 0))' /tmp/prs > /tmp/prs.json


### PR DESCRIPTION
### **User description**
## The bug

Both merge-hook workflows (`exponential-promote.yml`, `exponential-requirements.yml`) share a **Resolve merged PR → Tickets** step running under `set -euo pipefail`. It pipes the merged PR's commit log through `grep -oE '#[0-9]+'` to find child-PR references (rollup handling).

On an ordinary feature PR the commits carry **no** `#123` refs, so `grep` exits 1 → `pipefail` propagates → `set -e` kills the step before any Exponential call runs. **Every non-rollup merge failed silently green** — no ticket promoted, no requirement ticked, across 16 merged PRs (the tickets sat stuck in QA).

## The fix

```diff
- | grep -oE '#[0-9]+' | tr -d '#' | sort -u
+ | { grep -oE '#[0-9]+' || true; } | tr -d '#' | sort -u
```

Verified locally against a real merged PR (#420): the step now resolves the PR to its ticket instead of aborting.

## Not included here

The tickets stranded in QA while the hook was broken are being backfilled separately — this PR only unbreaks *future* merges.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix CI merge hook crashing on PRs with no `#`-refs in commits

- Wrap `grep` in `{ ... || true; }` to prevent `pipefail` propagation

- Affects both `exponential-promote.yml` and `exponential-requirements.yml`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  commits["git log commit messages"]
  grep["grep -oE '#[0-9]+'"]
  guard["{ grep ... || true; }"]
  pipeline["tr | sort | sed → /tmp/prs"]
  exponential["exponential tickets list"]

  commits -- "pipe" --> guard
  guard -- "no match: exits 0" --> pipeline
  guard -- "match: outputs refs" --> pipeline
  pipeline -- "PR URLs" --> exponential
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exponential-promote.yml</strong><dd><code>Guard grep from failing promote workflow on no refs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/exponential-promote.yml

<ul><li>Wrap <code>grep -oE '#[0-9]+'</code> in <code>{ ... || true; }</code> so a no-match exit code <br>does not propagate through <code>pipefail</code> and kill the step<br> <li> Ensures ticket promotion runs even when the merged PR's commits <br>contain no <code>#NNN</code> references</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/422/files#diff-0581d2c5686027e1b22a2ba6bbadb773740ed3f38b6ae602b15c3ae389bd8144">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>exponential-requirements.yml</strong><dd><code>Guard grep from failing requirements workflow on no refs</code>&nbsp; </dd></summary>
<hr>

.github/workflows/exponential-requirements.yml

<ul><li>Apply the same <code>{ grep -oE '#[0-9]+' || true; }</code> guard as in the promote <br>workflow<br> <li> Prevents the requirements-tick step from silently aborting on ordinary <br>feature PRs</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/422/files#diff-5de434c4737cd8ac2f831f78e81b18c105dc1d64650ff8ce7356c11247e1f54f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

