### PR TITLE
feat: Metrics page — cycle selector (view any cycle)

### DIFF
--- a/src/app/_components/metrics/MetricsDashboard.tsx
+++ b/src/app/_components/metrics/MetricsDashboard.tsx
@@ -1,6 +1,15 @@
 'use client';
 
-import { Card, Text, Group, Stack, Progress, Container } from '@mantine/core';
+import { useMemo, useState } from 'react';
+import {
+  Card,
+  Text,
+  Group,
+  Stack,
+  Progress,
+  Container,
+  Select,
+} from '@mantine/core';
 import {
   IconChartBar,
   IconCircleCheck,
@@ -12,38 +21,79 @@ import { api, type RouterOutputs } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 
 /**
- * Metrics page dashboard (v1 tracer bullet).
+ * Metrics page dashboard.
  *
- * Renders the workspace's ACTIVE cycle: velocity (completed-action **count** as
- * the headline, summed effort/points alongside) and completion. All numbers are
- * computed live by `sprintAnalytics.getActiveCycleMetrics` — nothing is read
- * from the dormant `SprintMetrics` table. See ADR-0047.
- *
- * Trend across cycles (#2) and merged-PR turnaround (#3) are out of scope here.
+ * Renders the selected cycle (default: the workspace's ACTIVE cycle) — velocity
+ * (completed-ticket **count** as the headline, summed points alongside),
+ * completion, and merged-PR turnaround — plus a workspace-wide velocity trend.
+ * A cycle selector lets the user view any cycle. All numbers are computed live
+ * over the cycle's Tickets; nothing is read from the dormant `SprintMetrics`
+ * table. See ADR-0047 (incl. the Ticket-based amendment).
  */
 export function MetricsDashboard() {
   const { workspace, workspaceId } = useWorkspace();
 
-  const { data, isLoading } = api.sprintAnalytics.getActiveCycleMetrics.useQuery(
+  const { data: cycles } = api.sprintAnalytics.getCycles.useQuery(
     { workspaceId: workspaceId ?? '' },
     { enabled: !!workspaceId },
+  );
+
+  const [picked, setPicked] = useState<string | null>(null);
+
+  // Default the selection to the active cycle (else the most recent), but let
+  // an explicit pick win.
+  const defaultCycleId = useMemo(() => {
+    if (!cycles?.length) return null;
+    return (cycles.find((c) => c.status === 'ACTIVE') ?? cycles[0])?.id ?? null;
+  }, [cycles]);
+
+  const selectedCycleId = picked ?? defaultCycleId;
+
+  const { data, isLoading } = api.sprintAnalytics.getActiveCycleMetrics.useQuery(
+    { workspaceId: workspaceId ?? '', cycleId: selectedCycleId ?? undefined },
+    { enabled: !!workspaceId },
+  );
+
+  const cycleOptions = useMemo(
+    () =>
+      (cycles ?? []).map((c) => ({
+        value: c.id,
+        label:
+          c.status === 'ACTIVE' ? `${c.name} (active)` : c.name,
+      })),
+    [cycles],
   );
 
   return (
     <Container size="lg" className="w-full py-6">
       <Stack gap="lg">
-        <Group gap="sm">
-          <IconChartBar size={24} className="text-text-secondary" />
-          <div>
-            <Text fw={600} size="xl" className="text-text-primary">
-              Metrics
-            </Text>
-            <Text size="sm" className="text-text-secondary">
-              {workspace?.name
-                ? `Delivery metrics for ${workspace.name}`
-                : 'Delivery metrics'}
-            </Text>
-          </div>
+        <Group justify="space-between" align="flex-start" wrap="nowrap">
+          <Group gap="sm">
+            <IconChartBar size={24} className="text-text-secondary" />
+            <div>
+              <Text fw={600} size="xl" className="text-text-primary">
+                Metrics
+              </Text>
+              <Text size="sm" className="text-text-secondary">
+                {workspace?.name
+                  ? `Delivery metrics for ${workspace.name}`
+                  : 'Delivery metrics'}
+              </Text>
+            </div>
+          </Group>
+
+          {cycleOptions.length > 0 && (
+            <Select
+              aria-label="Select cycle"
+              data={cycleOptions}
+              value={selectedCycleId}
+              onChange={setPicked}
+              allowDeselect={false}
+              checkIconPosition="right"
+              w={220}
+              size="sm"
+            />
+          )}
         </Group>
 
         {isLoading || !workspaceId ? (
@@ -51,7 +101,7 @@ export function MetricsDashboard() {
         ) : !data ? (
           <EmptyState />
         ) : (
-          <ActiveCycleMetrics data={data} />
+          <ActiveCycleMetrics data={data} cycleId={selectedCycleId ?? undefined} />
         )}
 
         <VelocityTrend workspaceId={workspaceId} />
@@ -157,7 +207,13 @@ type CycleMetrics = NonNullable<
   RouterOutputs['sprintAnalytics']['getActiveCycleMetrics']
 >;
 
-function ActiveCycleMetrics({ data }: { data: CycleMetrics }) {
+function ActiveCycleMetrics({
+  data,
+  cycleId,
+}: {
+  data: CycleMetrics;
+  cycleId: string | undefined;
+}) {
   const completionRate = Math.round(data.completionRate);
 
   return (
@@ -226,7 +282,7 @@ function ActiveCycleMetrics({ data }: { data: CycleMetrics }) {
         </Card>
 
         {/* Merged-PR turnaround */}
-        <PrTurnaroundCard />
+        <PrTurnaroundCard cycleId={cycleId} />
       </div>
     </Stack>
   );
@@ -239,11 +295,11 @@ function formatHours(hours: number): { value: string; unit: string } {
   return { value: (hours / 24).toFixed(1), unit: 'd' };
 }
 
-function PrTurnaroundCard() {
+function PrTurnaroundCard({ cycleId }: { cycleId: string | undefined }) {
   const { workspaceId } = useWorkspace();
   const { data, isLoading } =
     api.sprintAnalytics.getActiveCyclePrTurnaround.useQuery(
-      { workspaceId: workspaceId ?? '' },
+      { workspaceId: workspaceId ?? '', cycleId },
       { enabled: !!workspaceId },
     );
 
@@ -267,7 +323,8 @@ function PrTurnaroundCard() {
   } else if (!data || data.mergedPrCount === 0) {
     body = (
       <Text size="sm" className="text-text-muted">
-        No PRs merged this cycle yet.
+        No merged-PR data for this cycle. Turnaround is computed from GitHub PR
+        webhook events; it stays empty until a connected repo sends them.
       </Text>
     );
   } else if (data.avgHours == null) {

--- a/src/server/api/routers/sprintAnalytics.ts
+++ b/src/server/api/routers/sprintAnalytics.ts
@@ -6,6 +6,7 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import {
   sprintAnalyticsService,
+  type CycleSummary,
   type CycleTicketMetricsResult,
   type CycleVelocityPoint,
   type PrTurnaroundResult,
@@ -37,6 +38,35 @@ async function assertWorkspaceMember(
 }
 
 /**
+ * Resolve which cycle the Metrics page should show: an explicit `cycleId`
+ * (verified to be a SPRINT list in this workspace, so no cross-workspace read),
+ * or the workspace's active cycle when none is given. Returns `null` when there
+ * is nothing to show (no active cycle and no explicit id).
+ */
+async function resolveCycleId(
+  db: Prisma.TransactionClient | typeof dbInstance,
+  workspaceId: string,
+  cycleId: string | undefined,
+): Promise<string | null> {
+  if (cycleId) {
+    const cycle = await db.list.findFirst({
+      where: { id: cycleId, workspaceId, listType: "SPRINT" },
+      select: { id: true },
+    });
+    if (!cycle) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Cycle not found in this workspace",
+      });
+    }
+    return cycle.id;
+  }
+
+  const active = await sprintAnalyticsService.getActiveSprint(workspaceId);
+  return active?.id ?? null;
+}
+
+/**
  * Sprint analytics tRPC router.
  *
  * Exposes SprintAnalyticsService + GitHubActivityService as API endpoints.
@@ -49,26 +79,44 @@ async function assertWorkspaceMember(
  */
 export const sprintAnalyticsRouter = createTRPCRouter({
   /**
-   * Metrics page (UI): active-cycle metrics for a workspace.
+   * Metrics page (UI): the workspace's cycles, for the cycle selector.
+   * Enforces workspace membership.
+   */
+  getCycles: protectedProcedure
+    .input(z.object({ workspaceId: z.string().min(1) }))
+    .query(async ({ ctx, input }): Promise<CycleSummary[]> => {
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, input.workspaceId);
+      return sprintAnalyticsService.getWorkspaceCycles(input.workspaceId);
+    }),
+
+  /**
+   * Metrics page (UI): cycle metrics for a workspace.
    *
-   * Enforces workspace membership, resolves the workspace's active cycle
-   * (List with listType=SPRINT, status=ACTIVE), and returns its live
-   * **Ticket-based** metrics (velocity/completion over the cycle's tickets).
-   * Returns `null` when the workspace has no active cycle so the UI can render
-   * an empty state. See ADR-0047 for why this is Ticket-based rather than
-   * Action-based like the agent-facing `getMetrics`.
+   * Enforces workspace membership, then resolves the target cycle — an explicit
+   * `cycleId` (workspace-verified) or the active cycle when omitted — and
+   * returns its live **Ticket-based** metrics (velocity/completion over the
+   * cycle's tickets). Returns `null` when there is no cycle to show so the UI
+   * can render an empty state. See ADR-0047 for why this is Ticket-based rather
+   * than Action-based like the agent-facing `getMetrics`.
    */
   getActiveCycleMetrics: protectedProcedure
-    .input(z.object({ workspaceId: z.string().min(1) }))
+    .input(
+      z.object({
+        workspaceId: z.string().min(1),
+        cycleId: z.string().optional(),
+      }),
+    )
     .query(async ({ ctx, input }): Promise<CycleTicketMetricsResult | null> => {
       await assertWorkspaceMember(ctx.db, ctx.session.user.id, input.workspaceId);
 
-      const activeSprint = await sprintAnalyticsService.getActiveSprint(
+      const cycleId = await resolveCycleId(
+        ctx.db,
         input.workspaceId,
+        input.cycleId,
       );
-      if (!activeSprint) return null;
+      if (!cycleId) return null;
 
-      return sprintAnalyticsService.getCycleTicketMetrics(activeSprint.id);
+      return sprintAnalyticsService.getCycleTicketMetrics(cycleId);
     }),
 
   /**
@@ -98,22 +146,30 @@ export const sprintAnalyticsRouter = createTRPCRouter({
   /**
    * Metrics page (UI): merged-PR turnaround for the workspace's active cycle.
    *
-   * Enforces workspace membership, resolves the active cycle, and returns the
-   * average/median opened→merged time for PRs merged in the cycle window
-   * (computed live from GitHubActivity). Returns `null` when there is no active
-   * cycle so the UI can render an empty state.
+   * Enforces workspace membership, resolves the target cycle (explicit
+   * `cycleId` or the active cycle), and returns the average/median opened→merged
+   * time for PRs merged in the cycle window (computed live from GitHubActivity).
+   * Returns `null` when there is no cycle to show so the UI can render an empty
+   * state.
    */
   getActiveCyclePrTurnaround: protectedProcedure
-    .input(z.object({ workspaceId: z.string().min(1) }))
+    .input(
+      z.object({
+        workspaceId: z.string().min(1),
+        cycleId: z.string().optional(),
+      }),
+    )
     .query(async ({ ctx, input }): Promise<PrTurnaroundResult | null> => {
       await assertWorkspaceMember(ctx.db, ctx.session.user.id, input.workspaceId);
 
-      const activeSprint = await sprintAnalyticsService.getActiveSprint(
+      const cycleId = await resolveCycleId(
+        ctx.db,
         input.workspaceId,
+        input.cycleId,
       );
-      if (!activeSprint) return null;
+      if (!cycleId) return null;
 
-      return sprintAnalyticsService.getPrTurnaround(activeSprint.id);
+      return sprintAnalyticsService.getPrTurnaround(cycleId);
     }),
 
   /**

--- a/src/server/services/SprintAnalyticsService.ts
+++ b/src/server/services/SprintAnalyticsService.ts
@@ -64,6 +64,14 @@ export interface CycleTicketMetricsResult {
   statusCounts: Record<string, number>;
 }
 
+export interface CycleSummary {
+  id: string;
+  name: string;
+  status: string; // ListStatus (ACTIVE / COMPLETED / PLANNED / …)
+  startDate: Date | null;
+  endDate: Date | null;
+}
+
 export interface CycleVelocityPoint {
   cycleId: string;
   cycleName: string;
@@ -611,6 +619,32 @@ export class SprintAnalyticsService {
       avgHours,
       medianHours,
     };
+  }
+
+  /**
+   * List a workspace's cycles (SPRINT lists) for the Metrics page selector.
+   * Ordered most-recent-first by start date (undated cycles last, by recency).
+   */
+  async getWorkspaceCycles(workspaceId: string): Promise<CycleSummary[]> {
+    const cycles = await this.prisma.list.findMany({
+      where: { workspaceId, listType: "SPRINT" },
+      orderBy: [{ startDate: "desc" }, { createdAt: "desc" }],
+      select: {
+        id: true,
+        name: true,
+        status: true,
+        startDate: true,
+        endDate: true,
+      },
+    });
+
+    return cycles.map((c) => ({
+      id: c.id,
+      name: c.name,
+      status: c.status,
+      startDate: c.startDate,
+      endDate: c.endDate,
+    }));
   }
 
   /**


### PR DESCRIPTION
### **User description**
## What

The Metrics page was hardwired to the workspace's **active** cycle. This adds a **cycle picker** so any cycle (active or completed) can be viewed.

- `getCycles` `protectedProcedure` lists the workspace's SPRINT cycles (id, name, status, dates) for the dropdown.
- `getActiveCycleMetrics` + `getActiveCyclePrTurnaround` now accept an optional `cycleId`; a shared `resolveCycleId()` **verifies the id is a SPRINT list in the workspace** (no cross-workspace read) or falls back to the active cycle.
- UI: a `Select` in the header, defaulting to the active cycle (else most recent); switching re-queries the velocity / completion / PR-turnaround cards. The velocity trend stays workspace-wide.

## Also: honest PR-turnaround empty state

While here, I diagnosed why PR turnaround always shows empty for CLEAR: it's computed from **GitHub PR webhook events** (`GitHubActivity`), and CLEAR has none captured — only 3/146 cycle tickets even have a `prUrl`. The PRs are real on GitHub but never flowed into the app. Not a computation bug — the empty-state copy now says so (stays empty until a connected repo sends webhook events). Feeding those events is a separate follow-up.

> Latent bug noted (not fixed here): `GitHubActivityService.processPullRequestEvent` stamps the `opened` event with `eventTimestamp: new Date()` (webhook-receipt time) instead of the PR's real `created_at`, so opened→merged turnaround is mismeasured even when events do flow.

## Acceptance criteria

- [x] Dropdown lists the workspace's cycles; selecting one updates the metric cards
- [x] Defaults to the active cycle; empty state when the workspace has no cycles
- [x] `cycleId` is workspace-verified server-side (no cross-workspace read)
- [x] `npm run check` passes; no hardcoded colors

---

Ships: light.penguin


___

### **PR Type**
Enhancement


___

### **Description**
- Add cycle selector dropdown to Metrics page for viewing any cycle

- New `getCycles` tRPC procedure lists workspace's SPRINT cycles for picker

- `getActiveCycleMetrics` and `getActiveCyclePrTurnaround` accept optional `cycleId` with workspace verification

- Improve PR-turnaround empty state with honest messaging about webhook dependency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["MetricsDashboard UI"]
  Selector["Cycle Select Dropdown"]
  getCycles["getCycles procedure"]
  resolveId["resolveCycleId()"]
  getMetrics["getActiveCycleMetrics"]
  getPrTurnaround["getActiveCyclePrTurnaround"]
  service["SprintAnalyticsService"]

  UI -- "renders" --> Selector
  Selector -- "calls" --> getCycles
  getCycles -- "getWorkspaceCycles()" --> service
  UI -- "selectedCycleId" --> getMetrics
  UI -- "selectedCycleId" --> getPrTurnaround
  getMetrics -- "verifies cycleId" --> resolveId
  getPrTurnaround -- "verifies cycleId" --> resolveId
  resolveId -- "getCycleTicketMetrics / getPrTurnaround" --> service
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MetricsDashboard.tsx</strong><dd><code>Add cycle selector UI and propagate cycleId to metric cards</code></dd></summary>
<hr>

src/app/_components/metrics/MetricsDashboard.tsx

<ul><li>Add <code>Select</code> dropdown for cycle picker, defaulting to active cycle or <br>most recent<br> <li> Introduce <code>picked</code> state and <code>selectedCycleId</code> derived from <code>getCycles</code> <br>query<br> <li> Pass <code>cycleId</code> prop down to <code>ActiveCycleMetrics</code> and <code>PrTurnaroundCard</code><br> <li> Update PR-turnaround empty state message to explain webhook dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/423/files#diff-1484d2a65a8e9ae596af83efe68b19d6858d822ba22144ebf69da067a9acbe85">+84/-27</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sprintAnalytics.ts</strong><dd><code>Add getCycles endpoint and optional cycleId to analytics procedures</code></dd></summary>
<hr>

src/server/api/routers/sprintAnalytics.ts

<ul><li>Add new <code>getCycles</code> protectedProcedure returning workspace's SPRINT <br>cycles<br> <li> Add shared <code>resolveCycleId()</code> helper that verifies cycleId belongs to <br>workspace or falls back to active cycle<br> <li> Extend <code>getActiveCycleMetrics</code> and <code>getActiveCyclePrTurnaround</code> inputs <br>with optional <code>cycleId</code><br> <li> Import <code>CycleSummary</code> type from service layer</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/423/files#diff-4a82f292b7c8e3544af99c137099a52a39d118b5beeaf18df20448bfe0823119">+75/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SprintAnalyticsService.ts</strong><dd><code>Add CycleSummary type and getWorkspaceCycles service method</code></dd></summary>
<hr>

src/server/services/SprintAnalyticsService.ts

<ul><li>Define and export new <code>CycleSummary</code> interface for cycle picker data<br> <li> Add <code>getWorkspaceCycles()</code> method querying SPRINT lists ordered by start <br>date descending</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/423/files#diff-2454525a76d9cb695ad024c76d06e4053d64b8b66e7285fc87c06550d17f0603">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

