### PR TITLE
fix: GitHub PR/push webhooks dropped — matcher ignores WorkspaceRepository

### DIFF
--- a/src/server/services/GitHubActivityService.ts
+++ b/src/server/services/GitHubActivityService.ts
@@ -32,6 +32,7 @@ interface PullRequestEventData {
     title: string;
     state: string;
     html_url: string;
+    created_at: string;
     merged_at: string | null;
     user: {
       login: string;
@@ -85,6 +86,25 @@ async function findIntegrationForRepo(
   prisma: PrismaClient,
   repoFullName: string,
 ): Promise<{ integrationId: string; workspaceId: string } | null> {
+  // Preferred: the workspace GitHub App install (ADR-0020) tracks which repos a
+  // workspace follows in the WorkspaceRepository table. This is how repos
+  // connected via /settings/integrations are registered — the legacy
+  // github_metadata credential below is NOT written by that flow, so without
+  // this lookup every PR/push webhook for an App-installed repo was dropped and
+  // no GitHubActivity was ever recorded.
+  const tracked = await prisma.workspaceRepository.findFirst({
+    where: { fullName: repoFullName },
+    select: { workspaceId: true, integrationId: true },
+  });
+  if (tracked) {
+    return {
+      integrationId: tracked.integrationId,
+      workspaceId: tracked.workspaceId,
+    };
+  }
+
+  // Legacy fallback: per-repo github_metadata credential from the older
+  // project-level GitHub integration (issue-sync) flow.
   const integrations = await prisma.integration.findMany({
     where: { provider: "github", status: "ACTIVE" },
     include: {
@@ -135,7 +155,7 @@ function extractActionIdFromBranch(branchName: string): string | null {
 
 /**
  * Attempts to map an activity to an action via issue references in commit messages.
- * Looks for patterns like: fixes #123, closes #456, refs #789
+ * Looks for patterns like: "fixes #<n>", "closes #<n>", "refs #<n>".
  */
 function extractIssueNumbersFromMessage(message: string): number[] {
   const pattern = /(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?|refs?)\s+#(\d+)/gi;
@@ -264,7 +284,15 @@ export class GitHubActivityService {
         prMergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
         repoFullName,
         repoUrl: data.repository.html_url,
-        eventTimestamp: new Date(),
+        // Use the PR's real timestamps, not webhook-receipt time, so
+        // opened→merged turnaround (getPrTurnaround) is measured accurately
+        // even if a webhook is delivered late or replayed.
+        eventTimestamp:
+          data.action === "opened" && pr.created_at
+            ? new Date(pr.created_at)
+            : pr.merged_at
+              ? new Date(pr.merged_at)
+              : new Date(),
         actionId: mapping?.actionId ?? null,
         mappingMethod: mapping?.method ?? null,
         mappingConfidence: mapping?.confidence ?? null,


### PR DESCRIPTION
### **User description**
## Problem

No `GitHubActivity` is ever recorded for repos connected via the **workspace GitHub App install** (ADR-0020), so the activity feed and the metrics **PR-turnaround** card are permanently empty — even with repos installed and tracked (confirmed on CLEAR: clear-api/mvp/pipeline/website, nrc-find all tracked, zero activity).

**Root cause:** the webhook handler resolves repo→workspace via `findIntegrationForRepo`, which only checks a legacy per-repo **`github_metadata` credential** (`metadata.repository.fullName`). The App-install flow stores tracked repos in the **`WorkspaceRepository`** table and never writes that credential, so `findIntegrationForRepo` returns `null` and `processPullRequestEvent` / `processPushEvent` / `processPullRequestReviewEvent` drop every event at `if (!ctx) return;`.

## Fix

- `findIntegrationForRepo` now resolves `repoFullName → {workspaceId, integrationId}` via **`WorkspaceRepository`** first, keeping the legacy `github_metadata` credential path as a fallback.
- `processPullRequestEvent` stamps `eventTimestamp` from the PR's real **`created_at`** (opened) / `merged_at` instead of webhook-receipt time, so opened→merged turnaround (`getPrTurnaround`) is accurate even for delayed/replayed deliveries.

## Caveats

- **Forward-only**: this fixes ingestion for *new* events. Historical PRs won't appear without a separate one-time backfill.
- Requires the GitHub App's webhook to actually POST `pull_request` events to `/api/webhooks/github` (App-level config on github.com, not in this repo).

## Acceptance criteria

- [x] Webhooks for App-installed repos resolve to the tracking workspace and write `GitHubActivity`
- [x] Opened→merged turnaround uses real PR timestamps
- [x] Legacy `github_metadata` path still works (fallback)
- [x] `npm run check` passes; no hardcoded colors

---

Ships: delta.gecko


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix webhooks dropped for App-installed repos via `WorkspaceRepository` lookup

- `findIntegrationForRepo` now checks `WorkspaceRepository` table first, legacy fallback retained

- `processPullRequestEvent` uses real PR timestamps (`created_at`/`merged_at`) for accurate turnaround

- Minor comment/doc improvements in `GitHubActivityService`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  webhook["GitHub Webhook Event"]
  findIntegration["findIntegrationForRepo()"]
  wrLookup["WorkspaceRepository\n(App-install, ADR-0020)"]
  legacyLookup["github_metadata credential\n(legacy fallback)"]
  ctx["Resolved Context\n{workspaceId, integrationId}"]
  activity["GitHubActivity recorded"]
  timestamp["eventTimestamp\n(created_at / merged_at)"]

  webhook -- "repoFullName" --> findIntegration
  findIntegration -- "preferred lookup" --> wrLookup
  findIntegration -- "fallback" --> legacyLookup
  wrLookup -- "found" --> ctx
  legacyLookup -- "found" --> ctx
  ctx --> activity
  timestamp --> activity
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GitHubActivityService.ts</strong><dd><code>Fix webhook resolution and use real PR timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/GitHubActivityService.ts

<ul><li>Added <code>created_at</code> field to <code>PullRequestEventData</code> interface for real <br>timestamp access<br> <li> <code>findIntegrationForRepo</code> now queries <code>WorkspaceRepository</code> table first <br>(App-install path), with legacy <code>github_metadata</code> credential as fallback<br> <li> <code>processPullRequestEvent</code> sets <code>eventTimestamp</code> from PR's real <code>created_at</code> <br>or <code>merged_at</code> instead of webhook-receipt time<br> <li> Minor comment/doc fix in <code>extractIssueNumbersFromMessage</code> JSDoc</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/424/files#diff-49fbbae3723cb07f72097bdd871dc9efaa7447c9d5353f9634a5822ff7596fa2">+30/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

