### PR TITLE
feat(notifications): include action deep link in Matrix reminders

### DIFF
--- a/src/server/services/notifications/MatrixNotificationService.ts
+++ b/src/server/services/notifications/MatrixNotificationService.ts
@@ -1,9 +1,26 @@
+import { getPublicBaseUrlFromEnv } from '~/lib/urls';
 import {
   NotificationService,
   type NotificationPayload,
   type NotificationResult,
   type NotificationConfig,
 } from './NotificationService';
+
+// Same base-URL resolution the email channel uses, so deep links point at the
+// same origin in every channel. Safe outside a request scope (cron/workers).
+const BASE_URL = process.env.NEXTAUTH_URL ?? getPublicBaseUrlFromEnv();
+
+/**
+ * Append the absolute deep link to the message body so the Matrix DM is
+ * actionable — the gateway only forwards { title, message }, so the link has to
+ * ride along in the text (Matrix clients auto-linkify a bare URL). `deeplink` is
+ * a workspace-relative path (e.g. `/w/acme/actions/123`); no-op when absent.
+ */
+function appendDeeplink(message: string, meta: NotificationPayload['metadata']): string {
+  const deeplink = typeof meta?.deeplink === 'string' ? meta.deeplink : undefined;
+  if (!deeplink) return message;
+  return `${message}\n\nView action: ${BASE_URL}${deeplink}`;
+}
 
 /**
  * Delivers notifications to a user's Matrix DM with the Zoe bot (V2, ADR-0043).
@@ -46,7 +63,7 @@ export class MatrixNotificationService extends NotificationService {
         body: JSON.stringify({
           userId: this.config.userId,
           title: payload.title,
-          message: payload.message,
+          message: appendDeeplink(payload.message, payload.metadata),
         }),
       });
 

--- a/src/server/services/notifications/__tests__/MatrixNotificationService.test.ts
+++ b/src/server/services/notifications/__tests__/MatrixNotificationService.test.ts
@@ -41,6 +41,43 @@ describe("MatrixNotificationService", () => {
     });
   });
 
+  it("appends the deeplink as an absolute URL to the message body", async () => {
+    fetchMock.mockResolvedValue(OK({ delivered: true, roomId: "!dm:server" }));
+    const svc = new MatrixNotificationService({ userId: "u1" });
+
+    await svc.sendNotification({
+      title: "Reminder: Gather medical bills",
+      message: "Due in 1 hour",
+      metadata: { deeplink: "/w/acme/actions/a1" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string) as {
+      message: string;
+    };
+    // Original message is preserved and the workspace-relative path is turned
+    // into an absolute, clickable link. Origin comes from env-based resolution.
+    expect(body.message.startsWith("Due in 1 hour")).toBe(true);
+    expect(body.message).toMatch(/View action: https?:\/\/\S+\/w\/acme\/actions\/a1$/);
+  });
+
+  it("leaves the message untouched when there is no deeplink", async () => {
+    fetchMock.mockResolvedValue(OK({ delivered: true, roomId: "!dm:server" }));
+    const svc = new MatrixNotificationService({ userId: "u1" });
+
+    await svc.sendNotification({
+      title: "t",
+      message: "Due in 1 hour",
+      metadata: { category: "due_date" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string) as {
+      message: string;
+    };
+    expect(body.message).toBe("Due in 1 hour");
+  });
+
   it("fails cleanly when the gateway secret is missing (no fetch)", async () => {
     delete process.env.GATEWAY_SECRET;
     const svc = new MatrixNotificationService({ userId: "u1" });


### PR DESCRIPTION
### **User description**
## What
Matrix reminder notifications now deep-link back to the Action, matching the email channel.

## Why
Reminder content already carried a `deeplink` (`/w/<workspace>/actions/<id>`) that the Email channel uses, but `MatrixNotificationService` forwarded only `title` + `message` to the gateway and dropped it — so Matrix DMs had no link. Reported by James: Matrix reminders like "Gather Medical bills" had no way to jump to the Action.

## How
Append the absolute action URL to the Matrix message body, reusing the same base-URL resolution the email channel uses (`NEXTAUTH_URL` -> `NEXT_PUBLIC_APP_URL` -> prod). Matrix clients auto-linkify a bare URL, so no gateway change. No-op when there is no deeplink.

```text
Reminder: Gather Medical bills

Due in 1 hour

View action: https://www.exponential.im/w/<workspace>/actions/<id>
```

## Tests
- Matrix service tests: 8/8 (added 2 — link appended / untouched when absent)
- Full notifications suite: 52/52
- `tsc` clean on the change, source lints clean

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Append absolute deep link URL to Matrix notification message body

- Reuse same base-URL resolution (`NEXTAUTH_URL`/`NEXT_PUBLIC_APP_URL`) as email channel

- Add `appendDeeplink` helper; no-op when metadata has no `deeplink` field

- Add 2 new tests covering link-appended and link-absent scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  env["Environment Variables\n(NEXTAUTH_URL / NEXT_PUBLIC_APP_URL)"]
  base["BASE_URL\n(module-level constant)"]
  helper["appendDeeplink()\n(helper function)"]
  payload["NotificationPayload\n(metadata.deeplink)"]
  gateway["Matrix Gateway\n(message body)"]

  env -- "resolves" --> base
  base -- "used by" --> helper
  payload -- "deeplink path" --> helper
  helper -- "absolute URL appended" --> gateway
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MatrixNotificationService.ts</strong><dd><code>Append absolute deep link URL to Matrix message body</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/notifications/MatrixNotificationService.ts

<ul><li>Import <code>getPublicBaseUrlFromEnv</code> and resolve <code>BASE_URL</code> at module level<br> <li> Add <code>appendDeeplink()</code> helper that appends absolute URL to message when <br><code>metadata.deeplink</code> is present<br> <li> Pass <code>appendDeeplink(payload.message, payload.metadata)</code> instead of bare <br><code>payload.message</code> to gateway request body</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/426/files#diff-3a3cfcffc163e20868b9f309e683c4fbd33ccb4b835acb1fad1fdf765dc02545">+18/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MatrixNotificationService.test.ts</strong><dd><code>Add tests for deep link appending behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/notifications/__tests__/MatrixNotificationService.test.ts

<ul><li>Add test verifying deep link is appended as absolute URL when <br><code>metadata.deeplink</code> is set<br> <li> Add test verifying message is unchanged when no <code>deeplink</code> is present in <br>metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/426/files#diff-4af53391d8c04def32a570010fbde75a47250ae44a8f1f66e60fd7a95be2d075">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

