### PR TITLE
fix(ai-bug-fixer): grant id-token: write so the coding agent can authenticate

### DIFF
--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -30,6 +30,11 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  # Required by anthropics/claude-code-action, which authenticates via OIDC.
+  # Without it the agent step fails with "Could not fetch an OIDC token" —
+  # and because that step is `continue-on-error`, the run still goes GREEN
+  # while silently never producing a PR. Do not remove.
+  id-token: write
 
 env:
   EXPONENTIAL_API_URL: ${{ vars.EXPONENTIAL_API_URL }}


### PR DESCRIPTION
## The bug

`anthropics/claude-code-action@v1` authenticates via OIDC and requires `id-token: write`. The workflow granted only `contents: write` and `pull-requests: write`, so the agent step failed on every run:

```
Attempt 3 failed: Could not fetch an OIDC token. Did you remember to
add `id-token: write` to your workflow permissions?
##[error]Process completed with exit code 1
```

## Why nobody noticed

The agent step is `continue-on-error: true`. So when it failed, the workflow's `fail()` path ran exactly as designed — commented on the ticket, released it to `READY_TO_PLAN`, exited 0. **The run went green.**

225 green runs between 11–21 July. Zero PRs. It picked up the same Exponential ticket (`dry.comet`, "AI-fixer smoke test") and put it back down every hour for ten days.

## Still outstanding (not fixed here)

`AI_BUG_FIXER_GH_TOKEN` expired on **21 July** — set 21 June with the 30-day default. That's the clean break in the run history (green through the 21st, 100% failure from the 22nd). It now fails at `actions/checkout` before reaching the agent, masking this bug. Needs a rotated PAT; no code change.

## Verification

Can't be verified by CI — it needs a live run. Once the PAT is rotated, trigger `workflow_dispatch` against the `dry.comet` smoke-test ticket and confirm a PR appears.

## Worth considering separately

A run that claims a ticket and produces nothing shouldn't be green. The workflow already emits `::warning::` in that path; promoting it to a failure (or a notification) would have surfaced this in a day rather than five weeks. Deliberately not in this PR.

---

_Note: an earlier revision of this description referred to the Exponential ticket as `#204`. GitHub autolinked that to PR #204 (an unrelated, already-merged goals feature), which made the PR-Agent bot report a false "ticket compliance" failure. Exponential ticket numbers and GitHub issue/PR numbers share the `#N` namespace — referring to Exponential tickets by shortId avoids the collision._