### PR TITLE
fix(ai-bug-fixer): support API-key auth and add opt-in agent debug output

### DIFF
--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -19,6 +19,11 @@ on:
       model:
         description: "Override the coding-agent model (default: the AI_BUG_FIXER_MODEL repo var or claude-haiku-4-5)"
         required: false
+      debug_output:
+        description: "Log the coding agent's full output. THIS REPO IS PUBLIC — the log is world-readable. Manual runs only, one at a time, and only when you need the agent's error message."
+        required: false
+        type: boolean
+        default: false
 
 # One run at a time. The status flip READY_TO_PLAN -> IN_PROGRESS is the soft
 # lock; this guarantees runs queue rather than overlap, so two workers can't
@@ -179,7 +184,17 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
+          # Two auth paths, because the two credential types are NOT
+          # interchangeable: a subscription OAuth token (`claude setup-token`,
+          # `sk-ant-oat…`) goes in CLAUDE_CODE_OAUTH_TOKEN, a console API key
+          # (`sk-ant-api…`) goes in ANTHROPIC_API_KEY. Passing the wrong one
+          # fails in ~2s with `is_error: true` and no usable message. Whichever
+          # secret is set wins; an unset secret renders as empty and is ignored.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Off by default. See the debug_output input — this repo is public, so
+          # the agent's full output lands in a world-readable log.
+          show_full_output: ${{ inputs.debug_output || false }}
           prompt: "Read .ai-bug-fixer/prompt.md and implement the narrow fix it describes. Edit the working tree only — do NOT run git, commit, push, or open a PR."
           claude_args: "--model ${{ inputs.model || vars.AI_BUG_FIXER_MODEL || 'claude-haiku-4-5' }} --max-turns 30"
 


### PR DESCRIPTION
### **User description**
Follow-up to #427. That fix let the agent step launch for the first time — which immediately exposed a second failure behind it.

## What the agent actually returns now

```json
{ "subtype": "success", "is_error": true,
  "duration_ms": 1949, "num_turns": 1, "total_cost_usd": 0 }
```

1.9 seconds, one turn. That is a request being rejected, not a model deciding there is nothing to fix. The message itself is suppressed:

> Running Claude Code via SDK (full output hidden for security)...

## Changes

**1. Accept either credential type.** A subscription OAuth token (`claude setup-token`, `sk-ant-oat…`) and a console API key (`sk-ant-api…`) are not interchangeable. The workflow only ever passed `claude_code_oauth_token`, so an API key placed in that secret fails in ~2s with exactly the signature above. Both inputs are now passed; an unset secret renders as empty and is ignored.

**2. `debug_output` dispatch input**, wiring `show_full_output`.

Deliberately **not** hardcoded to `true`. **This repository is public**, so Actions logs are world-readable, and the agent's full output can include file contents and environment detail — which is why the action hides it by default. As an opt-in input it stays off for every scheduled run, and a human can enable it for a single manual run when they need the error.

## Verification

Needs a live run; CI cannot exercise this. After merge, either rotate the credential and re-run normally, or dispatch with `debug_output: true` against the `dry.comet` smoke-test ticket to read the underlying error.

Note that the smoke-test ticket describes no actual bug ("No real fix expected"), so it can prove the agent *runs* but can never produce a PR. Proving the full path to a PR needs a ticket with a real, small fix in it.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `anthropic_api_key` input to support API-key auth alongside OAuth token

- Add opt-in `debug_output` dispatch input wiring `show_full_output` for agent

- Both credential types now passed; unset secrets render empty and are ignored


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["workflow_dispatch inputs"] -- "new: debug_output boolean" --> B["Run coding agent step"]
  C["CLAUDE_CODE_OAUTH_TOKEN secret"] -- "OAuth token path" --> B
  D["ANTHROPIC_API_KEY secret"] -- "new: API key path" --> B
  B -- "show_full_output" --> E["Agent full log output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ai-bug-fixer.yml</strong><dd><code>Add API-key auth and opt-in debug output to agent step</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ai-bug-fixer.yml

<ul><li>Added <code>debug_output</code> boolean dispatch input with public-repo warning in <br>description<br> <li> Added <code>anthropic_api_key</code> input to the agent step to support console API <br>key auth<br> <li> Wired <code>show_full_output</code> to <code>inputs.debug_output || false</code>, defaulting off <br>for scheduled runs<br> <li> Added inline comments explaining the two credential types and why <br><code>show_full_output</code> is opt-in</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/428/files#diff-a0f87d7b9ca1fd245c24137fba57d0f173dbe6c565a61e3ef5d64e7a1450e381">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

