### PR TITLE
feat: workspace-scoped Sentry webhooks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,10 +41,15 @@
         "@tiptap/extension-placeholder": "^2.11.5",
         "@tiptap/extension-subscript": "^2.11.5",
         "@tiptap/extension-superscript": "^2.11.5",
+        "@tiptap/extension-table": "^2.11.5",
+        "@tiptap/extension-table-cell": "^2.11.5",
+        "@tiptap/extension-table-header": "^2.11.5",
+        "@tiptap/extension-table-row": "^2.11.5",
         "@tiptap/extension-task-item": "^2.27.2",
         "@tiptap/extension-task-list": "^2.27.2",
         "@tiptap/extension-text-align": "^2.11.5",
         "@tiptap/extension-underline": "^2.11.5",
+        "@tiptap/html": "^2.11.5",
         "@tiptap/react": "^2.11.5",
         "@tiptap/starter-kit": "^2.11.5",
         "@tiptap/suggestion": "2.11.5",
@@ -67,6 +72,7 @@
         "geist": "^1.3.0",
         "googleapis": "^155.0.1",
         "gray-matter": "^4.0.3",
+        "happy-dom": "^18.0.1",
         "html-to-image": "^1.11.13",
         "imapflow": "^1.2.9",
         "jsonwebtoken": "^9.0.2",
@@ -81,6 +87,7 @@
         "octokit": "^5.0.3",
         "openai": "^4.89.0",
         "pdf-parse": "^2.4.5",
+        "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -107,6 +114,7 @@
         "@types/node-cron": "^3.0.11",
         "@types/nodemailer": "^7.0.9",
         "@types/pdf-parse": "^1.1.5",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@types/web-push": "^3.6.4",
@@ -1058,6 +1066,14 @@
 
     "@tiptap/extension-superscript": ["@tiptap/extension-superscript@2.26.1", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, ""],
 
+    "@tiptap/extension-table": ["@tiptap/extension-table@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0", "@tiptap/pm": "^2.7.0" } }, "sha512-pDbhOpT5phZkcsyPjGBQlXv0+0hmdrvqHJ+dJjkGcCtlfy2pHiEIhmIItOFagc7wXy8G9iUFZ9Jie4zvDf+brg=="],
+
+    "@tiptap/extension-table-cell": ["@tiptap/extension-table-cell@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, "sha512-9Lk46MjZMFzVZfOj9Kd7VgC6Odt6vmEhlCYVumErShUY7EkFqCw3b2IYoUtQkntfOEx/Afnhff/okNQwPsJeUA=="],
+
+    "@tiptap/extension-table-header": ["@tiptap/extension-table-header@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, "sha512-ZEb6lbG0NbbodWLV0b4BS/QrDIPlUbCcuOsUxzqVvlMUY1Vg6Fj6fKwLaBcsIUDHi8sxZDBEgYEDw3BR/zcO6A=="],
+
+    "@tiptap/extension-table-row": ["@tiptap/extension-table-row@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, "sha512-Nw9+tA56Y5HtLVP01NGCZSUuTQhJPtfK9OfmDgGgcxynn2cRVdEtj+9FNZqRhQ1iRVaAI+Rd4xRvX9qYePMOxw=="],
+
     "@tiptap/extension-task-item": ["@tiptap/extension-task-item@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0", "@tiptap/pm": "^2.7.0" } }, "sha512-ZBSqj/dygB/Rp5K9qOxRVwASTZCmKVoTq8C59KvMgD/aFjJxhq/w2dZaWkCUEXEep+NmvJqo0kfeAEMY5UDnGg=="],
 
     "@tiptap/extension-task-list": ["@tiptap/extension-task-list@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, "sha512-5nupAewdzZ9F3599oAcaK0WkDH04wdACAVBPM4zG7InlIpkbho3txB7zWmm64OxfhCMIMGKiXY1q0bw9i0QBGQ=="],
@@ -1069,6 +1085,8 @@
     "@tiptap/extension-text-style": ["@tiptap/extension-text-style@2.26.1", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, ""],
 
     "@tiptap/extension-underline": ["@tiptap/extension-underline@2.26.1", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, ""],
+
+    "@tiptap/html": ["@tiptap/html@2.27.2", "", { "dependencies": { "zeed-dom": "^0.15.1" }, "peerDependencies": { "@tiptap/core": "^2.7.0", "@tiptap/pm": "^2.7.0" } }, "sha512-WiZgAvFjUprjyAczxAHLN9k++w7klwsCJ7EJDljtW/QXQ476Q0GqNtaHG4WRuW25cBH7c7AWZFptALeak2OE4Q=="],
 
     "@tiptap/pm": ["@tiptap/pm@2.26.1", "", { "dependencies": { "prosemirror-changeset": "^2.3.0", "prosemirror-collab": "^1.3.1", "prosemirror-commands": "^1.6.2", "prosemirror-dropcursor": "^1.8.1", "prosemirror-gapcursor": "^1.3.2", "prosemirror-history": "^1.4.1", "prosemirror-inputrules": "^1.4.0", "prosemirror-keymap": "^1.2.2", "prosemirror-markdown": "^1.13.1", "prosemirror-menu": "^1.2.4", "prosemirror-model": "^1.23.0", "prosemirror-schema-basic": "^1.2.3", "prosemirror-schema-list": "^1.4.1", "prosemirror-state": "^1.4.3", "prosemirror-tables": "^1.6.4", "prosemirror-trailing-node": "^3.0.0", "prosemirror-transform": "^1.10.2", "prosemirror-view": "^1.37.0" } }, ""],
 
@@ -1201,6 +1219,8 @@
     "@types/plist": ["@types/plist@3.0.5", "", { "dependencies": { "@types/node": "*", "xmlbuilder": ">=11.0.1" } }, "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA=="],
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, ""],
+
+    "@types/qrcode": ["@types/qrcode@1.5.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw=="],
 
     "@types/qs": ["@types/qs@6.14.0", "", {}, "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="],
 
@@ -1738,6 +1758,8 @@
 
     "didyoumean": ["didyoumean@1.2.2", "", {}, ""],
 
+    "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
+
     "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
 
     "dir-compare": ["dir-compare@3.3.0", "", { "dependencies": { "buffer-equal": "^1.0.0", "minimatch": "^3.0.4" } }, "sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg=="],
@@ -1814,7 +1836,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.24.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ=="],
 
-    "entities": ["entities@4.5.0", "", {}, ""],
+    "entities": ["entities@5.0.0", "", {}, "sha512-BeJFvFRJddxobhvEdm5GqHzRV/X+ACeuw0/BuuxsCh1EUZcAIz8+kYmBp/LrQuloy6K1f3a0M7+IhmZ7QnkISA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -2654,6 +2676,8 @@
 
     "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, ""],
 
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, ""],
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
@@ -2717,6 +2741,8 @@
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, ""],
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
+
+    "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, ""],
 
@@ -2816,6 +2842,8 @@
 
     "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
+    "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
+
     "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
@@ -2896,6 +2924,8 @@
 
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
+    "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
+
     "reselect": ["reselect@5.1.1", "", {}, ""],
 
     "resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, ""],
@@ -2967,6 +2997,8 @@
     "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "server-only": ["server-only@0.0.1", "", {}, ""],
+
+    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, ""],
 
@@ -3314,6 +3346,8 @@
 
     "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, ""],
 
+    "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
+
     "which-typed-array": ["which-typed-array@1.1.19", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, ""],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": "cli.js" }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
@@ -3347,6 +3381,8 @@
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, ""],
+
+    "zeed-dom": ["zeed-dom@0.15.1", "", { "dependencies": { "css-what": "^6.1.0", "entities": "^5.0.0" } }, "sha512-dtZ0aQSFyZmoJS0m06/xBN1SazUBPL5HpzlAcs/KcRW0rzadYw12deQBjeMhGKMMeGEp7bA9vmikMLaO4exBcg=="],
 
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
 
@@ -3560,6 +3596,8 @@
 
     "dockerode/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, ""],
+
     "effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, ""],
 
     "electron/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
@@ -3644,6 +3682,8 @@
 
     "markdown-it/argparse": ["argparse@2.0.1", "", {}, ""],
 
+    "markdown-it/entities": ["entities@4.5.0", "", {}, ""],
+
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -3681,6 +3721,8 @@
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, ""],
 
     "prosemirror-markdown/@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, ""],
+
+    "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -3936,6 +3978,8 @@
 
     "gtoken/jws/jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, ""],
 
+    "html-to-text/htmlparser2/entities": ["entities@4.5.0", "", {}, ""],
+
     "jszip/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "jszip/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
@@ -3965,6 +4009,14 @@
     "prosemirror-markdown/@types/markdown-it/@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, ""],
 
     "prosemirror-markdown/@types/markdown-it/@types/mdurl": ["@types/mdurl@2.0.0", "", {}, ""],
+
+    "qrcode/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "qrcode/yargs/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, ""],
 
@@ -4088,6 +4140,12 @@
 
     "octokit/@octokit/core/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 
+    "qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "qrcode/yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
     "@sentry/bundler-plugin-core/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "electron-builder-squirrel-windows/archiver/archiver-utils/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
@@ -4097,5 +4155,11 @@
     "electron-builder-squirrel-windows/archiver/zip-stream/archiver-utils/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "electron-builder-squirrel-windows/archiver/zip-stream/compress-commons/crc32-stream": ["crc32-stream@4.0.3", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^3.4.0" } }, "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw=="],
+
+    "qrcode/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, ""],
+
+    "qrcode/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "qrcode/yargs/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }
 }

--- a/docs/adr/0027-sentry-errors-as-bug-tickets.md
+++ b/docs/adr/0027-sentry-errors-as-bug-tickets.md
@@ -6,6 +6,12 @@ Accepted — 2026-06-19. Builds on the external-webhook-writes-to-Ticket pattern
 [ADR-0021](0021-pr-merge-promotes-ticket-via-app-webhook.md) and deviates, deliberately,
 from [ADR-0016](0016-agent-activity-writes-reuse-human-path.md) on attribution.
 
+**Amended by [ADR-0048](0048-workspace-scoped-sentry-integration.md) (2026-07-25):** decision
+point 2 below ("*not* an `Integration` row" / single global hook) is superseded — Sentry is now a
+workspace-scoped `Integration` with a per-tenant signed webhook. The global route described here
+remains as a fallback; the rest of this ADR (bug-as-Ticket, Errol authorship, `links` dedup, the
+shared ticket-create service) stands.
+
 ## Context
 
 Sentry (`@sentry/nextjs`, production-only) captures runtime errors but there was no path from

--- a/docs/adr/0048-workspace-scoped-sentry-integration.md
+++ b/docs/adr/0048-workspace-scoped-sentry-integration.md
@@ -1,0 +1,90 @@
+# Sentry becomes a workspace-scoped Integration with a per-tenant signed webhook
+
+## Status
+
+Accepted — 2026-07-25. Amends decision point 2 of
+[ADR-0027](0027-sentry-errors-as-bug-tickets.md) (the "single global inbound hook, *not* an
+`Integration` row" stance). Everything else in ADR-0027 — bug-as-Ticket, Errol authorship,
+`links`-based dedup, the shared ticket-create service — stands unchanged. Builds on the
+workspace-scoped `Integration` pattern GitHub uses
+([ADR-0020](0020-agent-integration-callback-not-token.md)).
+
+## Context
+
+[ADR-0027](0027-sentry-errors-as-bug-tickets.md) shipped Sentry ingestion as a single global
+endpoint (`/api/webhooks/sentry`): one env secret (`SENTRY_WEBHOOK_SECRET`), one hardcoded
+destination Product (`SENTRY_BUG_PRODUCT_ID`, defaulting to the Exponential product). Every
+Sentry issue from every source lands in that one product. That was the right v1 — Exponential
+was Sentry's only tenant — but it cannot serve more than one: there is no way to authenticate a
+second Sentry source independently, nor to route different sources to different workspaces/products.
+
+The app already models exactly this shape for other providers. `Integration` carries
+`workspaceId`, a unique `webhookId`, and a `providerConfig` JSON blob; `IntegrationCredential`
+stores per-integration secrets, encrypted via `credentialHelper`. GitHub uses `providerConfig`
+for non-secret config and `IntegrationCredential` for its token, all scoped by `workspaceId`.
+Sentry used none of it. No schema change is needed to adopt it — `webhookId` and `providerConfig`
+already exist and (for `webhookId`) were previously unused.
+
+The one wrinkle: every existing webhook receiver in the app is a *static* route that reverse-maps
+the tenant from a globally-unique key in the payload (GitHub matches the repo full name). Sentry
+payloads carry no reliable workspace key, and Sentry lets the user set an arbitrary webhook URL —
+so the tenant has to travel in the URL, which means a dynamic route segment, a pattern the repo
+did not yet have for webhooks.
+
+## Decision
+
+1. **Sentry is a workspace-scoped `Integration`.** `createSentryIntegration` (owner/admin only,
+   transactional single-config-per-workspace replace, mirroring the Postmark procedures) creates
+   an `Integration` with `provider: "sentry"`, `workspaceId`, a generated unique `webhookId`, and
+   `providerConfig: { productId }` naming the destination Product (validated to belong to the
+   workspace). The signing secret is stored as an encrypted `IntegrationCredential`
+   (`keyType: "WEBHOOK_SECRET"`). `getWorkspaceSentryStatus` / `removeWorkspaceSentry` complete
+   the trio; status never returns the secret. No migration — reuses existing columns.
+
+2. **Per-tenant URL, not payload reverse-lookup.** A new dynamic route
+   `/api/webhooks/sentry/[webhookId]` resolves the integration by its unique `webhookId` (one
+   indexed lookup; unknown id or non-sentry provider → 404). Chosen over the GitHub-style
+   static-route reverse-lookup because Sentry payloads have no dependable workspace key and the
+   webhook URL is user-set. This is the first dynamic-segment webhook route in the app; the
+   trade-off is a new pattern, accepted because the alternative (parsing org/project slugs out of
+   the payload and hoping they map) is brittle.
+
+3. **Per-integration HMAC, no shared env secret.** The route verifies `Sentry-Hook-Signature`
+   against that integration's own decrypted secret (reusing `verifySentrySignature` from
+   ADR-0027). A configured integration always has a secret, so — unlike the global route — there
+   is no unauthenticated mode: a missing/undecryptable secret is a 401, not an open door.
+
+4. **Destination product per workspace.** `ingestSentryBug` gains an optional `productId`;
+   the dynamic route passes `providerConfig.productId`. Precedence is explicit-product →
+   `SENTRY_BUG_PRODUCT_ID` → hardcoded default, so the ingest path is shared and the global
+   route's behaviour is unchanged.
+
+5. **The global route stays as a fallback.** `/api/webhooks/sentry` (env secret → default
+   product, ADR-0027) is left intact. The change is purely additive: existing deployments keep
+   working, and workspaces opt in to their own hook when they want isolation. Errol authorship,
+   dedup, labels, and the Zulip announce are untouched.
+
+## Considered alternatives
+
+- **Keep the global hook, reverse-map by Sentry org/project slug** (the GitHub pattern).
+  Rejected: Sentry payloads don't reliably carry a stable workspace key, and matching on
+  org/project strings couples routing to Sentry's payload shape.
+- **A `TicketSyncConfig`-style model for richer per-product routing.** Deferred: one destination
+  product per workspace in `providerConfig` covers the need; the heavier model is the documented
+  upgrade if multi-product routing is ever wanted.
+- **Replace the global route outright.** Rejected for v1: additive-with-fallback avoids a
+  breaking change to the current single-tenant Sentry setup.
+- **Per-integration secret in `providerConfig`.** Rejected: secrets belong in
+  `IntegrationCredential` (encrypted via `credentialHelper`), not in the plaintext JSON blob.
+
+## Consequences
+
+- Sentry now has first-class connect/disconnect UI in workspace settings (`SentrySettings`),
+  showing a generated webhook URL and a one-time signing secret to paste into a Sentry internal
+  integration.
+- A dynamic-segment webhook route now exists; future per-tenant inbound webhooks can follow it
+  instead of the reverse-lookup pattern when the payload lacks a tenant key.
+- Two ingest paths coexist (global env fallback + per-workspace). `ingestSentryBug`'s `productId`
+  precedence is the single point that reconciles them.
+- No new env knobs and no migration; `webhookId` (previously unused) and `providerConfig` are now
+  load-bearing for Sentry.

--- a/src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx
@@ -45,6 +45,7 @@ import {
   IconShieldExclamation,
   IconSparkles,
   IconSend,
+  IconBug,
   type Icon as TablerIcon,
 } from '@tabler/icons-react';
 import { useRouter } from 'next/navigation';
@@ -57,6 +58,7 @@ import { PendingInvitationsTable } from '~/app/_components/PendingInvitationsTab
 import { WorkspaceTeamsSection } from '~/app/_components/WorkspaceTeamsSection';
 import { SlackChannelSettings } from '~/app/_components/SlackChannelSettings';
 import { ZulipSettings } from '~/app/_components/ZulipSettings';
+import { SentrySettings } from '~/app/_components/SentrySettings';
 import { FirefliesWizardModal } from '~/app/_components/integrations/FirefliesWizardModal';
 import { FirefliesIntegrationsList } from '~/app/_components/integrations/FirefliesIntegrationsList';
 import { EFFORT_UNIT_OPTIONS, type EffortUnit } from '~/types/effort';
@@ -1262,6 +1264,19 @@ export default function WorkspaceSettingsPage() {
                 <ZulipSettings
                   workspace={{ id: workspaceId, name: workspace.name }}
                   workspaceSlug={workspace.slug}
+                />
+              </SettingsSection>
+            )}
+
+            {workspaceId && (
+              <SettingsSection
+                icon={IconBug}
+                title="Sentry"
+                description="File Sentry issues as Bug tickets in a product of your choice. Generates a webhook URL and signing secret to paste into a Sentry internal integration."
+              >
+                <SentrySettings
+                  workspace={{ id: workspaceId, name: workspace.name }}
+                  canManage={canEdit}
                 />
               </SettingsSection>
             )}

--- a/src/app/_components/SentrySettings.tsx
+++ b/src/app/_components/SentrySettings.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import {
+  Alert,
+  Badge,
+  Button,
+  CopyButton,
+  Group,
+  List,
+  Modal,
+  PasswordInput,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { IconCheck, IconCopy, IconX } from "@tabler/icons-react";
+import { useState } from "react";
+import { api } from "~/trpc/react";
+
+interface SentrySettingsProps {
+  workspace: { id: string; name: string };
+  /** Only owners/admins may connect or remove (the server enforces this too). */
+  canManage: boolean;
+}
+
+/**
+ * Workspace-scoped Sentry webhook configuration.
+ *
+ * Lets an owner/admin pick a destination Product and generates a per-workspace
+ * webhook URL + signing secret to paste into a Sentry internal integration. The
+ * secret is shown exactly once (right after connecting) — it is never returned
+ * again by the status query.
+ */
+export function SentrySettings({ workspace, canManage }: SentrySettingsProps) {
+  const [setupOpened, { open: openSetup, close: closeSetup }] =
+    useDisclosure(false);
+  const [productId, setProductId] = useState<string | null>(null);
+  // Populated once, from the create response — the only time we ever hold the
+  // plaintext secret client-side.
+  const [created, setCreated] = useState<{
+    webhookUrl: string;
+    webhookSecret: string;
+  } | null>(null);
+
+  const utils = api.useUtils();
+
+  const statusQuery = api.integration.getWorkspaceSentryStatus.useQuery({
+    workspaceId: workspace.id,
+  });
+
+  const productsQuery = api.product.product.list.useQuery(
+    { workspaceId: workspace.id },
+    { enabled: setupOpened },
+  );
+
+  const createMutation = api.integration.createSentryIntegration.useMutation({
+    onSuccess: (data) => {
+      void utils.integration.getWorkspaceSentryStatus.invalidate();
+      setCreated({
+        webhookUrl: data.webhookUrl,
+        webhookSecret: data.webhookSecret,
+      });
+    },
+  });
+
+  const removeMutation = api.integration.removeWorkspaceSentry.useMutation({
+    onSuccess: () => {
+      void utils.integration.getWorkspaceSentryStatus.invalidate();
+    },
+  });
+
+  function handleClose() {
+    closeSetup();
+    // Keep `created` cleared so the secret isn't lingering in state after close.
+    setCreated(null);
+    setProductId(null);
+    createMutation.reset();
+  }
+
+  const status = statusQuery.data;
+
+  // Connected state.
+  if (status?.configured && !setupOpened) {
+    return (
+      <Stack gap="sm">
+        <Group
+          gap="sm"
+          className="rounded-md border border-border-primary bg-surface-primary p-3"
+        >
+          <Badge color="green" variant="dot">
+            Connected
+          </Badge>
+          {status.productName && (
+            <Text size="sm" className="text-text-secondary">
+              Bugs file to{" "}
+              <span className="text-text-primary">{status.productName}</span>
+            </Text>
+          )}
+          {canManage && (
+            <Button
+              variant="subtle"
+              color="red"
+              size="xs"
+              ml="auto"
+              loading={removeMutation.isPending}
+              onClick={() =>
+                removeMutation.mutate({ workspaceId: workspace.id })
+              }
+            >
+              Remove
+            </Button>
+          )}
+        </Group>
+
+        <WebhookField label="Webhook URL" value={status.webhookUrl} />
+        <Text size="xs" className="text-text-muted">
+          The signing secret is shown only once, when you connect. Remove and
+          reconnect to generate a new one.
+        </Text>
+      </Stack>
+    );
+  }
+
+  // Not configured (or mid-setup).
+  return (
+    <>
+      {canManage ? (
+        <Button variant="light" onClick={openSetup}>
+          Connect Sentry
+        </Button>
+      ) : (
+        <Text size="sm" className="text-text-muted">
+          Sentry is not configured. Ask a workspace owner or admin to connect it.
+        </Text>
+      )}
+
+      <Modal
+        opened={setupOpened}
+        onClose={handleClose}
+        title="Connect Sentry"
+        size="lg"
+      >
+        {created ? (
+          // Post-create: show the URL + secret to copy into Sentry.
+          <Stack gap="md">
+            <Alert color="green" icon={<IconCheck size={16} />}>
+              Sentry is connected. Copy these into a Sentry internal integration
+              now — the secret won&apos;t be shown again.
+            </Alert>
+
+            <div>
+              <Text size="sm" fw={600} className="text-text-primary" mb={4}>
+                Set up in Sentry
+              </Text>
+              <List size="sm" spacing={4} className="text-text-secondary">
+                <List.Item>
+                  In Sentry: Settings &rarr; Developer Settings &rarr; New
+                  Internal Integration.
+                </List.Item>
+                <List.Item>
+                  Set the <b>Webhook URL</b> to the URL below and paste the{" "}
+                  <b>secret</b> as the integration&apos;s Client Secret.
+                </List.Item>
+                <List.Item>
+                  Under Webhooks, enable the <b>issue</b> resource (and
+                  optionally <b>alert</b>).
+                </List.Item>
+              </List>
+            </div>
+
+            <WebhookField label="Webhook URL" value={created.webhookUrl} />
+            <WebhookField
+              label="Signing Secret"
+              value={created.webhookSecret}
+              secret
+            />
+
+            <Group justify="flex-end">
+              <Button onClick={handleClose}>Done</Button>
+            </Group>
+          </Stack>
+        ) : (
+          // Pre-create: pick the destination product.
+          <Stack gap="md">
+            <Text size="sm" className="text-text-muted">
+              Incoming Sentry issues will be filed as Bug tickets in the product
+              you choose.
+            </Text>
+
+            <Select
+              label="Destination product"
+              placeholder="Select a product"
+              required
+              value={productId}
+              onChange={setProductId}
+              disabled={productsQuery.isLoading}
+              data={
+                productsQuery.data?.map((p) => ({
+                  value: p.id,
+                  label: p.name,
+                })) ?? []
+              }
+              nothingFoundMessage="No products in this workspace"
+              searchable
+            />
+
+            {createMutation.error && (
+              <Alert color="red" icon={<IconX size={16} />}>
+                {createMutation.error.message}
+              </Alert>
+            )}
+
+            <Group justify="flex-end" gap="sm">
+              <Button variant="subtle" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button
+                loading={createMutation.isPending}
+                disabled={!productId}
+                onClick={() => {
+                  if (!productId) return;
+                  createMutation.mutate({
+                    workspaceId: workspace.id,
+                    productId,
+                  });
+                }}
+              >
+                Connect
+              </Button>
+            </Group>
+          </Stack>
+        )}
+      </Modal>
+    </>
+  );
+}
+
+/** Read-only field with a copy button, for a webhook URL or secret. */
+function WebhookField({
+  label,
+  value,
+  secret,
+}: {
+  label: string;
+  value: string;
+  secret?: boolean;
+}) {
+  const inputProps = {
+    label,
+    value,
+    readOnly: true,
+    styles: { input: { fontFamily: "monospace" } },
+    rightSection: (
+      <CopyButton value={value} timeout={2000}>
+        {({ copied, copy }) => (
+          <Button
+            size="compact-xs"
+            variant="subtle"
+            color={copied ? "teal" : "gray"}
+            onClick={copy}
+            leftSection={
+              copied ? <IconCheck size={14} /> : <IconCopy size={14} />
+            }
+          >
+            {copied ? "Copied" : "Copy"}
+          </Button>
+        )}
+      </CopyButton>
+    ),
+    rightSectionWidth: 92,
+  };
+
+  return secret ? (
+    <PasswordInput {...inputProps} />
+  ) : (
+    <TextInput {...inputProps} />
+  );
+}

--- a/src/app/api/webhooks/sentry/[webhookId]/__tests__/route.test.ts
+++ b/src/app/api/webhooks/sentry/[webhookId]/__tests__/route.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the workspace-scoped Sentry webhook route. Mirrors the global
+ * route's test style: a tiny fake request, with `~/server/db` and the ingest
+ * service mocked so the route is tested in isolation. Credentials use
+ * `isEncrypted: false` so `getDecryptedKey` returns the secret verbatim — no
+ * encryption key needed in the test env.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import crypto from "crypto";
+import type { NextRequest } from "next/server";
+
+vi.hoisted(() => {
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+const { ingestSentryBug, findUnique } = vi.hoisted(() => ({
+  ingestSentryBug: vi.fn(),
+  findUnique: vi.fn(),
+}));
+vi.mock("~/server/db", () => ({
+  db: { integration: { findUnique } },
+}));
+vi.mock("~/server/services/sentry/SentryBugService", () => ({
+  ingestSentryBug,
+}));
+
+import { POST } from "../route";
+
+const SECRET = "workspace-secret";
+const WEBHOOK_ID = "wh_test_1";
+
+function sign(body: string): string {
+  return crypto.createHmac("sha256", SECRET).update(body, "utf8").digest("hex");
+}
+
+function fakeRequest(opts: {
+  body: string;
+  resource?: string;
+  signature?: string;
+}): NextRequest {
+  const headers = new Map<string, string>();
+  if (opts.signature !== undefined)
+    headers.set("sentry-hook-signature", opts.signature);
+  if (opts.resource !== undefined)
+    headers.set("sentry-hook-resource", opts.resource);
+  return {
+    headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+    text: () => Promise.resolve(opts.body),
+  } as unknown as NextRequest;
+}
+
+const ctx = { params: Promise.resolve({ webhookId: WEBHOOK_ID }) };
+
+function integrationRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "int-1",
+    provider: "sentry",
+    status: "ACTIVE",
+    providerConfig: { productId: "prod-1" },
+    credentials: [{ key: SECRET, isEncrypted: false }],
+    ...overrides,
+  };
+}
+
+const issueBody = JSON.stringify({
+  action: "created",
+  data: { issue: { id: "42", title: "Boom" } },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ingestSentryBug.mockResolvedValue({ created: true, ticketId: "ticket-1" });
+  findUnique.mockResolvedValue(integrationRow());
+});
+
+describe("POST /api/webhooks/sentry/[webhookId]", () => {
+  it("files a bug into the integration's product for a valid signed issue", async () => {
+    const res = await POST(
+      fakeRequest({ body: issueBody, resource: "issue", signature: sign(issueBody) }),
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    expect(ingestSentryBug).toHaveBeenCalledTimes(1);
+    // Routed to the per-workspace product, not the global default.
+    expect(ingestSentryBug.mock.calls[0]![2]).toEqual({ productId: "prod-1" });
+  });
+
+  it("returns 404 for an unknown webhookId and does not ingest", async () => {
+    findUnique.mockResolvedValue(null);
+    const res = await POST(
+      fakeRequest({ body: issueBody, resource: "issue", signature: sign(issueBody) }),
+      ctx,
+    );
+    expect(res.status).toBe(404);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the integration is not a sentry provider", async () => {
+    findUnique.mockResolvedValue(integrationRow({ provider: "slack" }));
+    const res = await POST(
+      fakeRequest({ body: issueBody, resource: "issue", signature: sign(issueBody) }),
+      ctx,
+    );
+    expect(res.status).toBe(404);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing signature with 401", async () => {
+    const res = await POST(
+      fakeRequest({ body: issueBody, resource: "issue" }),
+      ctx,
+    );
+    expect(res.status).toBe(401);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid signature with 401", async () => {
+    const res = await POST(
+      fakeRequest({ body: issueBody, resource: "issue", signature: "deadbeef" }),
+      ctx,
+    );
+    expect(res.status).toBe(401);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the integration has no usable secret", async () => {
+    findUnique.mockResolvedValue(integrationRow({ credentials: [] }));
+    const res = await POST(
+      fakeRequest({ body: issueBody, resource: "issue", signature: sign(issueBody) }),
+      ctx,
+    );
+    expect(res.status).toBe(401);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the integration has no destination product", async () => {
+    findUnique.mockResolvedValue(integrationRow({ providerConfig: {} }));
+    const res = await POST(
+      fakeRequest({ body: issueBody, resource: "issue", signature: sign(issueBody) }),
+      ctx,
+    );
+    expect(res.status).toBe(500);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 and ingests nothing for a valid signed non-bug event", async () => {
+    const body = JSON.stringify({ action: "resolved", data: { issue: { id: "42" } } });
+    const res = await POST(
+      fakeRequest({ body, resource: "issue", signature: sign(body) }),
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/webhooks/sentry/[webhookId]/route.ts
+++ b/src/app/api/webhooks/sentry/[webhookId]/route.ts
@@ -1,0 +1,121 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { db } from "~/server/db";
+import { ingestSentryBug } from "~/server/services/sentry/SentryBugService";
+import {
+  normalizeSentryPayload,
+  verifySentrySignature,
+} from "~/server/services/sentry/sentryPayload";
+import { getDecryptedKey } from "~/server/utils/credentialHelper";
+
+/**
+ * Workspace-scoped Sentry → Exponential bug webhook.
+ *
+ * The per-workspace counterpart to the global `/api/webhooks/sentry` route: each
+ * workspace configures a Sentry integration (see `createSentryIntegration`) and
+ * gets its own URL segment (`webhookId`) plus its own signing secret. This route
+ * looks the integration up by `webhookId`, verifies the HMAC against *that*
+ * integration's stored secret, and files the issue as a Bug Ticket in the
+ * workspace's chosen destination Product (`providerConfig.productId`).
+ *
+ * Unlike the global route, there is no shared env secret and no unauthenticated
+ * mode — a configured integration always has a secret, so every request must
+ * carry a valid `Sentry-Hook-Signature`.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ webhookId: string }> },
+) {
+  try {
+    const { webhookId } = await params;
+    const signature = request.headers.get("sentry-hook-signature");
+    const resource = request.headers.get("sentry-hook-resource");
+    const rawBody = await request.text();
+
+    // Resolve the tenant from the URL. A single indexed lookup on the unique
+    // `webhookId`; unknown ids (or a non-sentry integration) are a 404.
+    const integration = await db.integration.findUnique({
+      where: { webhookId },
+      select: {
+        id: true,
+        provider: true,
+        status: true,
+        providerConfig: true,
+        credentials: {
+          where: { keyType: "WEBHOOK_SECRET" },
+          select: { key: true, isEncrypted: true },
+        },
+      },
+    });
+
+    if (!integration || integration.provider !== "sentry") {
+      return NextResponse.json(
+        { error: "Unknown Sentry webhook" },
+        { status: 404 },
+      );
+    }
+
+    // Verify the signature against this integration's own secret.
+    const secretCred = integration.credentials[0];
+    const secret = secretCred ? getDecryptedKey(secretCred) : null;
+    if (!secret) {
+      // Integration exists but its secret is missing/undecryptable — treat as
+      // misconfigured rather than silently accepting unsigned traffic.
+      console.error(
+        `[sentry webhook ${webhookId}] no usable signing secret on integration ${integration.id}`,
+      );
+      return NextResponse.json(
+        { error: "Integration misconfigured" },
+        { status: 401 },
+      );
+    }
+
+    if (!signature || !verifySentrySignature(rawBody, signature, secret)) {
+      console.error(`[sentry webhook ${webhookId}] invalid signature`);
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    }
+
+    if (integration.status !== "ACTIVE") {
+      return NextResponse.json(
+        { error: "Integration is not active" },
+        { status: 403 },
+      );
+    }
+
+    if (!resource) {
+      return NextResponse.json(
+        { error: "Missing Sentry-Hook-Resource header" },
+        { status: 400 },
+      );
+    }
+
+    const bug = normalizeSentryPayload(resource, JSON.parse(rawBody) as unknown);
+    if (!bug) {
+      // Not an event we file as a bug (installation, comment, resolved, etc.).
+      return NextResponse.json({ message: `Ignored Sentry ${resource} event` });
+    }
+
+    const config = integration.providerConfig as { productId?: string } | null;
+    const productId = config?.productId;
+    if (!productId) {
+      console.error(
+        `[sentry webhook ${webhookId}] integration ${integration.id} has no destination product`,
+      );
+      return NextResponse.json(
+        { error: "Integration has no destination product" },
+        { status: 500 },
+      );
+    }
+
+    const result = await ingestSentryBug(db, bug, { productId });
+    console.log(
+      `[sentry webhook ${webhookId}] issue ${bug.issueId} -> ticket ${result.ticketId} (created=${result.created})`,
+    );
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("[sentry webhook] processing error:", error);
+    return NextResponse.json(
+      { error: "Webhook processing failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/server/api/routers/__tests__/sentryIntegration.integration.test.ts
+++ b/src/server/api/routers/__tests__/sentryIntegration.integration.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { getTestDb } from "~/test/test-db";
+import { createTestCaller } from "~/test/trpc-helpers";
+import {
+  createUser,
+  createWorkspace,
+  addWorkspaceMember,
+  createProduct,
+} from "~/test/factories";
+import { getDecryptedKey } from "~/server/utils/credentialHelper";
+
+describe("integration router — Sentry", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  describe("createSentryIntegration", () => {
+    it("owner connects Sentry: persists integration, encrypted secret, and product config", async () => {
+      const owner = await createUser(db);
+      const workspace = await createWorkspace(db, { ownerId: owner.id });
+      const product = await createProduct(db, {
+        workspaceId: workspace.id,
+        createdById: owner.id,
+      });
+      const caller = createTestCaller(owner.id);
+
+      const result = await caller.integration.createSentryIntegration({
+        workspaceId: workspace.id,
+        productId: product.id,
+      });
+
+      expect(result.configured).toBe(true);
+      expect(result.productName).toBe(product.name);
+      expect(result.webhookUrl).toContain(`/api/webhooks/sentry/${result.webhookId}`);
+      expect(result.webhookSecret).toBeTruthy();
+
+      const integration = await db.integration.findFirst({
+        where: { provider: "sentry", workspaceId: workspace.id },
+        include: { credentials: true },
+      });
+      expect(integration).not.toBeNull();
+      expect(integration!.webhookId).toBe(result.webhookId);
+      expect(
+        (integration!.providerConfig as { productId?: string }).productId,
+      ).toBe(product.id);
+
+      // Exactly one secret credential, and it round-trips to the returned value.
+      const secretCred = integration!.credentials.filter(
+        (c) => c.keyType === "WEBHOOK_SECRET",
+      );
+      expect(secretCred).toHaveLength(1);
+      expect(getDecryptedKey(secretCred[0]!)).toBe(result.webhookSecret);
+    });
+
+    it("rejects a non-owner/admin member with FORBIDDEN", async () => {
+      const owner = await createUser(db);
+      const member = await createUser(db);
+      const workspace = await createWorkspace(db, { ownerId: owner.id });
+      await addWorkspaceMember(db, workspace.id, member.id, "member");
+      const product = await createProduct(db, {
+        workspaceId: workspace.id,
+        createdById: owner.id,
+      });
+      const caller = createTestCaller(member.id);
+
+      await expect(
+        caller.integration.createSentryIntegration({
+          workspaceId: workspace.id,
+          productId: product.id,
+        }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it("rejects a destination product from another workspace", async () => {
+      const owner = await createUser(db);
+      const workspace = await createWorkspace(db, { ownerId: owner.id });
+      const otherWorkspace = await createWorkspace(db, { ownerId: owner.id });
+      const foreignProduct = await createProduct(db, {
+        workspaceId: otherWorkspace.id,
+        createdById: owner.id,
+      });
+      const caller = createTestCaller(owner.id);
+
+      await expect(
+        caller.integration.createSentryIntegration({
+          workspaceId: workspace.id,
+          productId: foreignProduct.id,
+        }),
+      ).rejects.toThrow(/product not found/i);
+    });
+
+    it("re-connecting replaces the prior config transactionally (no orphans)", async () => {
+      const owner = await createUser(db);
+      const workspace = await createWorkspace(db, { ownerId: owner.id });
+      const product = await createProduct(db, {
+        workspaceId: workspace.id,
+        createdById: owner.id,
+      });
+      const caller = createTestCaller(owner.id);
+
+      const first = await caller.integration.createSentryIntegration({
+        workspaceId: workspace.id,
+        productId: product.id,
+      });
+      const second = await caller.integration.createSentryIntegration({
+        workspaceId: workspace.id,
+        productId: product.id,
+      });
+
+      expect(second.webhookId).not.toBe(first.webhookId);
+
+      const integrations = await db.integration.findMany({
+        where: { provider: "sentry", workspaceId: workspace.id },
+      });
+      expect(integrations).toHaveLength(1);
+
+      // Exactly one secret remains, tied to the surviving integration — the
+      // replaced integration's credential was cascade-deleted with it.
+      const allSecretCreds = await db.integrationCredential.findMany({
+        where: { keyType: "WEBHOOK_SECRET" },
+      });
+      expect(allSecretCreds).toHaveLength(1);
+      expect(allSecretCreds[0]!.integrationId).toBe(integrations[0]!.id);
+    });
+  });
+
+  describe("getWorkspaceSentryStatus", () => {
+    it("reports configured + product, and never leaks the secret", async () => {
+      const owner = await createUser(db);
+      const workspace = await createWorkspace(db, { ownerId: owner.id });
+      const product = await createProduct(db, {
+        workspaceId: workspace.id,
+        createdById: owner.id,
+      });
+      const caller = createTestCaller(owner.id);
+
+      await caller.integration.createSentryIntegration({
+        workspaceId: workspace.id,
+        productId: product.id,
+      });
+
+      const status = await caller.integration.getWorkspaceSentryStatus({
+        workspaceId: workspace.id,
+      });
+
+      expect(status.configured).toBe(true);
+      if (status.configured) {
+        expect(status.productId).toBe(product.id);
+        expect(status.productName).toBe(product.name);
+        expect(status.webhookUrl).toContain("/api/webhooks/sentry/");
+        // The secret must not appear anywhere in the status payload.
+        expect(JSON.stringify(status)).not.toMatch(/webhookSecret/i);
+      }
+    });
+
+    it("returns not-configured when nothing is set up", async () => {
+      const owner = await createUser(db);
+      const workspace = await createWorkspace(db, { ownerId: owner.id });
+      const caller = createTestCaller(owner.id);
+
+      const status = await caller.integration.getWorkspaceSentryStatus({
+        workspaceId: workspace.id,
+      });
+      expect(status.configured).toBe(false);
+    });
+  });
+
+  describe("removeWorkspaceSentry", () => {
+    it("removes the integration and cascades its credentials", async () => {
+      const owner = await createUser(db);
+      const workspace = await createWorkspace(db, { ownerId: owner.id });
+      const product = await createProduct(db, {
+        workspaceId: workspace.id,
+        createdById: owner.id,
+      });
+      const caller = createTestCaller(owner.id);
+
+      await caller.integration.createSentryIntegration({
+        workspaceId: workspace.id,
+        productId: product.id,
+      });
+      await caller.integration.removeWorkspaceSentry({
+        workspaceId: workspace.id,
+      });
+
+      const integrations = await db.integration.findMany({
+        where: { provider: "sentry", workspaceId: workspace.id },
+      });
+      expect(integrations).toHaveLength(0);
+
+      const creds = await db.integrationCredential.findMany({
+        where: { keyType: "WEBHOOK_SECRET" },
+      });
+      expect(creds).toHaveLength(0);
+    });
+  });
+});

--- a/src/server/api/routers/integration.ts
+++ b/src/server/api/routers/integration.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import { z } from "zod";
 import {
   createTRPCRouter,
@@ -3768,6 +3769,182 @@ export const integrationRouter = createTRPCRouter({
           integrationId: input.integrationId,
           userId: input.userId,
         },
+      });
+      return { success: true };
+    }),
+
+  // ==================== SENTRY INTEGRATION ====================
+  // Workspace-scoped Sentry webhook config. Each workspace gets its own inbound
+  // URL (`/api/webhooks/sentry/{webhookId}`) and its own signing secret, and
+  // routes filed bugs to a chosen destination Product (`providerConfig.productId`).
+  // The receiver (dynamic route) looks the integration up by `webhookId` and
+  // verifies the HMAC against the stored secret. The legacy global env-based
+  // `/api/webhooks/sentry` route stays as a fallback. Modeled on Postmark:
+  // transactional single-config-per-workspace replace, owner/admin guarded.
+
+  createSentryIntegration: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        productId: z.string(),
+        // Optional: let the caller supply their own secret (e.g. to rotate to a
+        // known value); otherwise we generate a strong random one.
+        webhookSecret: z.string().min(16).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Only workspace owners/admins can wire up an inbound webhook.
+      const membership = await ctx.db.workspaceUser.findFirst({
+        where: {
+          workspaceId: input.workspaceId,
+          userId: ctx.session.user.id,
+          role: { in: ["owner", "admin"] },
+        },
+      });
+      if (!membership) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only workspace owners or admins can configure Sentry.",
+        });
+      }
+
+      // The destination product must live in this workspace — otherwise a member
+      // could route another workspace's bugs into their own product.
+      const product = await ctx.db.product.findFirst({
+        where: { id: input.productId, workspaceId: input.workspaceId },
+        select: { id: true, name: true },
+      });
+      if (!product) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Destination product not found in this workspace.",
+        });
+      }
+
+      // `webhookId` is the public, unguessable URL segment; `secret` signs the
+      // payload (HMAC-SHA256), matching what the Sentry receiver verifies.
+      const webhookId = crypto.randomUUID();
+      const secret =
+        input.webhookSecret ?? crypto.randomBytes(32).toString("hex");
+      const encryptedSecret = encryptCredential(secret);
+
+      // One config per workspace: replace transactionally so a failure can't
+      // leave an integration row with no secret (which the receiver would treat
+      // as misconfigured) or a secret with no integration.
+      await ctx.db.$transaction(async (tx) => {
+        await tx.integration.deleteMany({
+          where: { provider: "sentry", workspaceId: input.workspaceId },
+        });
+
+        const integration = await tx.integration.create({
+          data: {
+            name: "Sentry",
+            type: "WEBHOOK",
+            provider: "sentry",
+            description: "Files Sentry issues as Bug Tickets in this workspace",
+            userId: ctx.session.user.id,
+            workspaceId: input.workspaceId,
+            webhookId,
+            providerConfig: { productId: input.productId },
+            status: "ACTIVE",
+          },
+        });
+
+        await tx.integrationCredential.create({
+          data: {
+            key: encryptedSecret.key,
+            keyType: "WEBHOOK_SECRET",
+            isEncrypted: encryptedSecret.isEncrypted,
+            integrationId: integration.id,
+          },
+        });
+      });
+
+      const baseUrl =
+        process.env.NEXT_PUBLIC_APP_URL ?? "https://www.exponential.im";
+      return {
+        configured: true as const,
+        webhookId,
+        webhookUrl: `${baseUrl}/api/webhooks/sentry/${webhookId}`,
+        // Returned exactly once, for the user to copy into Sentry. Never exposed
+        // again by `getWorkspaceSentryStatus`.
+        webhookSecret: secret,
+        productId: product.id,
+        productName: product.name,
+      };
+    }),
+
+  // Workspace Sentry status. Returns the (non-secret) webhook URL + destination
+  // so the settings UI can render the connected state; never returns the secret.
+  getWorkspaceSentryStatus: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const membership = await ctx.db.workspaceUser.findFirst({
+        where: { workspaceId: input.workspaceId, userId: ctx.session.user.id },
+      });
+      if (!membership) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You are not a member of this workspace.",
+        });
+      }
+
+      const integration = await ctx.db.integration.findFirst({
+        where: {
+          provider: "sentry",
+          status: "ACTIVE",
+          workspaceId: input.workspaceId,
+        },
+        select: { id: true, webhookId: true, providerConfig: true },
+      });
+
+      if (!integration?.webhookId) return { configured: false as const };
+
+      const config = integration.providerConfig as {
+        productId?: string;
+      } | null;
+      const productId = config?.productId ?? null;
+      let productName: string | null = null;
+      if (productId) {
+        const product = await ctx.db.product.findUnique({
+          where: { id: productId },
+          select: { name: true },
+        });
+        productName = product?.name ?? null;
+      }
+
+      const baseUrl =
+        process.env.NEXT_PUBLIC_APP_URL ?? "https://www.exponential.im";
+      return {
+        configured: true as const,
+        integrationId: integration.id,
+        webhookId: integration.webhookId,
+        webhookUrl: `${baseUrl}/api/webhooks/sentry/${integration.webhookId}`,
+        productId,
+        productName,
+      };
+    }),
+
+  removeWorkspaceSentry: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const membership = await ctx.db.workspaceUser.findFirst({
+        where: {
+          workspaceId: input.workspaceId,
+          userId: ctx.session.user.id,
+          role: { in: ["owner", "admin"] },
+        },
+      });
+      if (!membership) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only workspace owners or admins can remove Sentry.",
+        });
+      }
+
+      // Credentials cascade-delete with the integration.
+      await ctx.db.integration.deleteMany({
+        where: { provider: "sentry", workspaceId: input.workspaceId },
       });
       return { success: true };
     }),

--- a/src/server/services/sentry/SentryBugService.ts
+++ b/src/server/services/sentry/SentryBugService.ts
@@ -95,8 +95,16 @@ export interface IngestResult {
 export async function ingestSentryBug(
   db: PrismaClient,
   bug: SentryBug,
+  options?: { productId?: string },
 ): Promise<IngestResult> {
-  const productId = process.env.SENTRY_BUG_PRODUCT_ID ?? DEFAULT_BUG_PRODUCT_ID;
+  // Destination precedence: an explicit per-workspace product (from a
+  // workspace-scoped Sentry integration) wins; otherwise fall back to the
+  // global env default, then the hardcoded Exponential product. This keeps the
+  // legacy global `/api/webhooks/sentry` route working unchanged.
+  const productId =
+    options?.productId ??
+    process.env.SENTRY_BUG_PRODUCT_ID ??
+    DEFAULT_BUG_PRODUCT_ID;
   const product = await db.product.findUnique({
     where: { id: productId },
     select: {


### PR DESCRIPTION
## What

Adds per-workspace Sentry webhook support to Exponential — each workspace configures its own Sentry integration (encrypted per-integration secret, dynamic webhook URL) that files incoming Sentry issues as Bug Tickets into a workspace-chosen destination Product. Purely additive: the existing global env-based `/api/webhooks/sentry` hook stays as a fallback. No DB migration — reuses `Integration` (`webhookId`, `providerConfig`) + `IntegrationCredential`.

Design recorded in **ADR-0048** (amends decision point 2 of ADR-0027).

### Slices (one commit each)

- **`wet.iris`** — tRPC `createSentryIntegration` / `getWorkspaceSentryStatus` / `removeWorkspaceSentry` (owner/admin guarded, transactional replace, modeled on Postmark) + `SentrySettings` UI in workspace settings (product picker, copy webhook-URL/secret).
- **`peppy.dove`** — dynamic receiver `/api/webhooks/sentry/[webhookId]`: looks up the integration by `webhookId`, verifies its own HMAC secret, routes the bug to `providerConfig.productId`. `ingestSentryBug` gains an optional `productId` (explicit → `SENTRY_BUG_PRODUCT_ID` → default).
- **`deep.fox`** — ADR-0048 + ADR-0027 cross-link.

## How it routes

Per-integration URL (not payload reverse-lookup): Sentry payloads carry no reliable workspace key and the webhook URL is user-set, so the tenant travels in the URL. First dynamic-segment webhook route in the app.

## Testing

- `sentryIntegration.integration.test.ts` — 7 tests: owner connect (persist + encrypted secret round-trip), non-admin FORBIDDEN, foreign-product BAD_REQUEST, transactional replace (no orphans), status redaction, remove cascade.
- `[webhookId]/route.test.ts` — 8 tests: signed issue → bug in the right product, unknown webhookId → 404, non-sentry → 404, missing/invalid signature → 401, missing secret → 401, no destination product → 500, non-bug event → 200 no-op.
- Full suite: typecheck 0 errors; 1730 unit tests pass; new tests green.

## Acceptance criteria

- [x] Owner/admin connects Sentry, choosing a destination Product in the workspace
- [x] UI shows a unique webhook URL + signing secret, each copyable (secret shown once)
- [x] Integration persisted with `provider:"sentry"`, `workspaceId`, `webhookId`, `providerConfig.productId`, encrypted `WEBHOOK_SECRET`
- [x] Re-connecting replaces transactionally (no orphans)
- [x] Non-owner/admin rejected; non-members cannot configure
- [x] Status never leaks the secret; disconnect removes integration + credential
- [x] Signed POST files a bug into the chosen product; bad signature 401; unknown id 404; dedup holds
- [x] Global `/api/webhooks/sentry` still works (fallback)

---

Ships: wet.iris
Ships: peppy.dove
Ships: deep.fox