### PR TITLE
feat(sentry): allow supplying a custom webhook signing secret in the UI

### DIFF
--- a/src/app/_components/SentrySettings.tsx
+++ b/src/app/_components/SentrySettings.tsx
@@ -11,6 +11,7 @@ import {
   PasswordInput,
   Select,
   Stack,
+  Switch,
   Text,
   TextInput,
 } from "@mantine/core";
@@ -37,12 +38,19 @@ export function SentrySettings({ workspace, canManage }: SentrySettingsProps) {
   const [setupOpened, { open: openSetup, close: closeSetup }] =
     useDisclosure(false);
   const [productId, setProductId] = useState<string | null>(null);
+  // Optional: let the admin supply their own signing secret instead of having
+  // one generated (e.g. to reuse an existing Sentry Client Secret).
+  const [useOwnSecret, setUseOwnSecret] = useState(false);
+  const [ownSecret, setOwnSecret] = useState("");
   // Populated once, from the create response — the only time we ever hold the
   // plaintext secret client-side.
   const [created, setCreated] = useState<{
     webhookUrl: string;
     webhookSecret: string;
   } | null>(null);
+
+  // Mirror the server's `z.string().min(16)` rule so we can validate before submit.
+  const ownSecretTooShort = useOwnSecret && ownSecret.length < 16;
 
   const utils = api.useUtils();
 
@@ -76,6 +84,8 @@ export function SentrySettings({ workspace, canManage }: SentrySettingsProps) {
     // Keep `created` cleared so the secret isn't lingering in state after close.
     setCreated(null);
     setProductId(null);
+    setUseOwnSecret(false);
+    setOwnSecret("");
     createMutation.reset();
   }
 
@@ -206,6 +216,30 @@ export function SentrySettings({ workspace, canManage }: SentrySettingsProps) {
               searchable
             />
 
+            <div>
+              <Switch
+                checked={useOwnSecret}
+                onChange={(e) => setUseOwnSecret(e.currentTarget.checked)}
+                label="Provide my own signing secret"
+                description="Off by default — a strong secret is generated for you."
+              />
+              {useOwnSecret && (
+                <PasswordInput
+                  mt="sm"
+                  label="Signing secret"
+                  placeholder="At least 16 characters"
+                  value={ownSecret}
+                  onChange={(e) => setOwnSecret(e.currentTarget.value)}
+                  error={
+                    ownSecretTooShort
+                      ? "Must be at least 16 characters"
+                      : undefined
+                  }
+                  required
+                />
+              )}
+            </div>
+
             {createMutation.error && (
               <Alert color="red" icon={<IconX size={16} />}>
                 {createMutation.error.message}
@@ -218,12 +252,16 @@ export function SentrySettings({ workspace, canManage }: SentrySettingsProps) {
               </Button>
               <Button
                 loading={createMutation.isPending}
-                disabled={!productId}
+                disabled={!productId || ownSecretTooShort}
                 onClick={() => {
                   if (!productId) return;
                   createMutation.mutate({
                     workspaceId: workspace.id,
                     productId,
+                    // Only send a secret when the admin opted to supply one;
+                    // otherwise the server generates it.
+                    webhookSecret:
+                      useOwnSecret && ownSecret ? ownSecret : undefined,
                   });
                 }}
               >

--- a/src/server/api/routers/__tests__/sentryIntegration.integration.test.ts
+++ b/src/server/api/routers/__tests__/sentryIntegration.integration.test.ts
@@ -55,6 +55,52 @@ describe("integration router — Sentry", () => {
       expect(getDecryptedKey(secretCred[0]!)).toBe(result.webhookSecret);
     });
 
+    it("uses a caller-supplied secret when one is provided", async () => {
+      const owner = await createUser(db);
+      const workspace = await createWorkspace(db, { ownerId: owner.id });
+      const product = await createProduct(db, {
+        workspaceId: workspace.id,
+        createdById: owner.id,
+      });
+      const caller = createTestCaller(owner.id);
+
+      const provided = "my-own-super-secret-value";
+      const result = await caller.integration.createSentryIntegration({
+        workspaceId: workspace.id,
+        productId: product.id,
+        webhookSecret: provided,
+      });
+
+      expect(result.webhookSecret).toBe(provided);
+
+      const integration = await db.integration.findFirst({
+        where: { provider: "sentry", workspaceId: workspace.id },
+        include: { credentials: true },
+      });
+      const secretCred = integration!.credentials.find(
+        (c) => c.keyType === "WEBHOOK_SECRET",
+      );
+      expect(getDecryptedKey(secretCred!)).toBe(provided);
+    });
+
+    it("rejects a supplied secret shorter than 16 chars", async () => {
+      const owner = await createUser(db);
+      const workspace = await createWorkspace(db, { ownerId: owner.id });
+      const product = await createProduct(db, {
+        workspaceId: workspace.id,
+        createdById: owner.id,
+      });
+      const caller = createTestCaller(owner.id);
+
+      await expect(
+        caller.integration.createSentryIntegration({
+          workspaceId: workspace.id,
+          productId: product.id,
+          webhookSecret: "tooshort",
+        }),
+      ).rejects.toThrow();
+    });
+
     it("rejects a non-owner/admin member with FORBIDDEN", async () => {
       const owner = await createUser(db);
       const member = await createUser(db);


### PR DESCRIPTION
The backend already accepts an optional webhookSecret (min 16 chars); expose it in SentrySettings with a "Provide my own signing secret" toggle. Off by default — a strong secret is generated. Adds router tests for the provided-secret path and the min-length rejection.

Refs: wet.iris
Exponential-Ticket: cms09tnar0005ie04sir4rp1x

## Description
Brief description of what this PR does.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Database Changes
- [ ] This PR includes database schema changes (migrations)
- [ ] NO database changes in this PR

If migrations are included:
- Migration name(s): 
- Schema changes: 
- Coordinated with team: Yes/No

## Testing
- [ ] Tested locally
- [ ] Tested in preview deployment
- [ ] Added/updated tests
- [ ] All tests passing

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Database migrations tested on test database
- [ ] Coordinated with team on any migration conflicts

## Deployment Notes
Any special deployment considerations?

## Related Issues
Closes #