### PR TITLE
feat: meeting provenance + duplicate warning on accept

### DIFF
--- a/prisma/migrations/20260726131326_add_feature_source_transcription/migration.sql
+++ b/prisma/migrations/20260726131326_add_feature_source_transcription/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Feature" ADD COLUMN     "sourceTranscriptionId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Feature_sourceTranscriptionId_idx" ON "Feature"("sourceTranscriptionId");
+
+-- AddForeignKey
+ALTER TABLE "Feature" ADD CONSTRAINT "Feature_sourceTranscriptionId_fkey" FOREIGN KEY ("sourceTranscriptionId") REFERENCES "TranscriptionSession"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1289,6 +1289,7 @@ model TranscriptionSession {
 
   actions           Action[]
   featureDrafts     MeetingFeatureDraft[]
+  sourcedFeatures   Feature[]                         @relation("FeatureSourceMeeting")
   screenshots       Screenshot[]
   project           Project?                          @relation(fields: [projectId], references: [id])
   sourceIntegration Integration?                      @relation(fields: [sourceIntegrationId], references: [id])
@@ -4050,48 +4051,55 @@ model Area {
 }
 
 model Feature {
-  id             String        @id @default(cuid())
-  productId      String
-  name           String
+  id                    String        @id @default(cuid())
+  productId             String
+  name                  String
   // PRD body - the scoped ADR-0017 exception (ADR-0024). `descriptionDoc` is the
   // canonical ProseMirror document the editor reads/writes; `description` is a
   // derived, write-only Markdown projection for off-island readers (CLI, agents,
   // card previews) and never read back into the editor. `docVersion` powers the
   // optimistic-concurrency stale-write guard for single-writer editing.
-  description    String?
-  descriptionDoc Json?
-  docVersion     Int           @default(0)
-  vision         String?
-  status         FeatureStatus @default(IDEA)
-  effort         Float?
-  priority       Int?
+  description           String?
+  descriptionDoc        Json?
+  docVersion            Int           @default(0)
+  vision                String?
+  status                FeatureStatus @default(IDEA)
+  effort                Float?
+  priority              Int?
   // Strategic alignment: optional link to a Goal (which may be an Objective in the OKR hierarchy)
-  goalId         Int?
+  goalId                Int?
   // Exclusive Area bucket (Features V2) - at most one per Feature, nullable
   // while unsorted.
-  areaId         String?
-  createdById    String
-  createdAt      DateTime      @default(now())
-  updatedAt      DateTime      @updatedAt
+  areaId                String?
+  // Provenance (Features V3): the meeting this Feature was ideated from, set at
+  // accept time by the meeting→features path. Nullable — hand-authored features
+  // have no originating meeting. SetNull on delete so purging a meeting doesn't
+  // cascade away the Features it produced; the back-link just goes quiet.
+  sourceTranscriptionId String?
+  createdById           String
+  createdAt             DateTime      @default(now())
+  updatedAt             DateTime      @updatedAt
 
-  product      Product          @relation(fields: [productId], references: [id], onDelete: Cascade)
-  createdBy    User             @relation("FeatureCreatedBy", fields: [createdById], references: [id])
-  goal         Goal?            @relation("FeatureGoal", fields: [goalId], references: [id], onDelete: SetNull)
-  area         Area?            @relation(fields: [areaId], references: [id], onDelete: SetNull)
-  scopes       FeatureScope[]
-  userStories  UserStory[]
-  requirements Requirement[]
-  insights     FeatureInsight[]
-  tickets      Ticket[]
-  tags         FeatureTag[]
-  comments     FeatureComment[]
-  pages        FeaturePage[]
+  product             Product               @relation(fields: [productId], references: [id], onDelete: Cascade)
+  createdBy           User                  @relation("FeatureCreatedBy", fields: [createdById], references: [id])
+  goal                Goal?                 @relation("FeatureGoal", fields: [goalId], references: [id], onDelete: SetNull)
+  area                Area?                 @relation(fields: [areaId], references: [id], onDelete: SetNull)
+  sourceTranscription TranscriptionSession? @relation("FeatureSourceMeeting", fields: [sourceTranscriptionId], references: [id], onDelete: SetNull)
+  scopes              FeatureScope[]
+  userStories         UserStory[]
+  requirements        Requirement[]
+  insights            FeatureInsight[]
+  tickets             Ticket[]
+  tags                FeatureTag[]
+  comments            FeatureComment[]
+  pages               FeaturePage[]
 
   @@index([productId])
   @@index([goalId])
   @@index([createdById])
   @@index([status])
   @@index([areaId])
+  @@index([sourceTranscriptionId])
 }
 
 /// A candidate Feature ideated from a meeting, held OUTSIDE the feature registry

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
@@ -28,6 +28,7 @@ import {
   IconFlag,
   IconFlame,
   IconMap2,
+  IconMicrophone,
   IconTag,
   IconTarget,
   IconTicket,
@@ -488,6 +489,24 @@ export default function FeatureDetailPage() {
             {new Date(feature.createdAt).toLocaleDateString()}
           </Text>
         </PropertyRow>
+
+        {/* Provenance (V3): a back-link to the meeting this feature was
+            ideated from. Absent for hand-authored features. */}
+        {feature.sourceTranscription && (
+          <PropertyRow icon={<IconMicrophone size={14} />} label="From meeting">
+            <Text
+              size="xs"
+              component={Link}
+              href={`/recording/${feature.sourceTranscription.id}`}
+              className="text-brand-primary hover:underline"
+              lineClamp={1}
+            >
+              {feature.sourceTranscription.title?.trim()
+                ? feature.sourceTranscription.title
+                : "Untitled meeting"}
+            </Text>
+          </PropertyRow>
+        )}
       </PropertiesSidebar>
 
       <MoveFeatureModal

--- a/src/app/_components/DraftFeaturesReviewCard.tsx
+++ b/src/app/_components/DraftFeaturesReviewCard.tsx
@@ -13,7 +13,8 @@ import {
   Text,
 } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
-import { IconPencil, IconTrash } from "@tabler/icons-react";
+import { IconAlertTriangle, IconPencil, IconTrash } from "@tabler/icons-react";
+import Link from "next/link";
 import { api, type RouterOutputs } from "~/trpc/react";
 import { EditDraftFeatureModal } from "./EditDraftFeatureModal";
 
@@ -60,6 +61,28 @@ export function DraftFeaturesReviewCard({
     { workspaceId: workspaceId ?? "" },
     { enabled: Boolean(workspaceId) },
   );
+
+  // Near-duplicate warning (V3): once a product is picked, flag drafts whose
+  // name already exists there. A warning only — accept is never blocked.
+  const { data: duplicateRows = [] } =
+    api.transcription.findDuplicateFeatures.useQuery(
+      { transcriptionId, productId: productId ?? "" },
+      { enabled: Boolean(productId) },
+    );
+  const duplicatesByDraft = new Map(
+    duplicateRows.map((row) => [row.draftId, row.matches]),
+  );
+
+  // Build the workspace/product-scoped link to an existing feature, or null if
+  // we can't (no workspace slug, or the product's slug isn't loaded) — the
+  // warning then still names the duplicate, just without a link.
+  const workspaceSlug = meeting?.workspace?.slug ?? null;
+  const selectedProductSlug =
+    products.find((product) => product.id === productId)?.slug ?? null;
+  const featureHref = (featureId: string): string | null =>
+    workspaceSlug && selectedProductSlug
+      ? `/w/${workspaceSlug}/products/${selectedProductSlug}/features/${featureId}`
+      : null;
 
   const invalidateQueries = useCallback(async () => {
     await Promise.all([
@@ -211,6 +234,42 @@ export function DraftFeaturesReviewCard({
                 />
                 <Stack gap={6} style={{ flex: 1, minWidth: 0 }}>
                   <Text fw={500}>{draft.name}</Text>
+                  {(duplicatesByDraft.get(draft.id) ?? []).length > 0 && (
+                    <Group gap={6} wrap="nowrap" align="center">
+                      <IconAlertTriangle
+                        size={14}
+                        className="text-brand-warning"
+                      />
+                      <Text size="xs" className="text-brand-warning">
+                        Possible duplicate of{" "}
+                        {(duplicatesByDraft.get(draft.id) ?? []).map(
+                          (match, index) => {
+                            const href = featureHref(match.id);
+                            return (
+                              <span key={match.id}>
+                                {index > 0 && ", "}
+                                {href ? (
+                                  <Text
+                                    span
+                                    component={Link}
+                                    href={href}
+                                    className="underline"
+                                  >
+                                    {match.name}
+                                  </Text>
+                                ) : (
+                                  <Text span fw={500}>
+                                    {match.name}
+                                  </Text>
+                                )}
+                              </span>
+                            );
+                          },
+                        )}
+                        . You can still accept it.
+                      </Text>
+                    </Group>
+                  )}
                   {draft.description && (
                     <Text size="sm" c="dimmed">
                       {draft.description}

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -386,6 +386,11 @@ export const featureRouter = createTRPCRouter({
             },
           },
           area: { select: { id: true, name: true } },
+          // Provenance (V3): the meeting this feature was ideated from, for the
+          // "From meeting" back-link. Null for hand-authored features.
+          sourceTranscription: {
+            select: { id: true, title: true, meetingDate: true },
+          },
           scopes: { orderBy: { displayOrder: "asc" } },
           userStories: { orderBy: { displayOrder: "asc" } },
           requirements: {

--- a/src/server/api/routers/__tests__/featureIdeation.test.ts
+++ b/src/server/api/routers/__tests__/featureIdeation.test.ts
@@ -520,4 +520,51 @@ describe("transcription router — feature ideation (mocked Prisma)", () => {
     expect(dbMock.feature.create).not.toHaveBeenCalled();
     expect(createTicketWithNumber).not.toHaveBeenCalled();
   });
+
+  // ── Near-duplicate warning (V3) ───────────────────────────────────
+  it("flags a draft whose normalized name matches an existing feature in the product", async () => {
+    stubOwnedSession(dbMock);
+    stubProductAccess(dbMock);
+    dbMock.meetingFeatureDraft.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "draft-1", name: "  Bulk   CSV Import " } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "draft-2", name: "Totally new idea" } as any,
+    ]);
+    dbMock.feature.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "feat-1", name: "bulk csv import" } as any,
+    ]);
+
+    const rows = await caller.transcription.findDuplicateFeatures({
+      transcriptionId,
+      productId,
+    });
+
+    // Only the matching draft is returned, linking the existing feature; the
+    // match is by normalized name, so whitespace and case differences still hit.
+    expect(rows).toEqual([
+      { draftId: "draft-1", matches: [{ id: "feat-1", name: "bulk csv import" }] },
+    ]);
+  });
+
+  it("returns no duplicate rows when nothing matches", async () => {
+    stubOwnedSession(dbMock);
+    stubProductAccess(dbMock);
+    dbMock.meetingFeatureDraft.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "draft-1", name: "Brand new capability" } as any,
+    ]);
+    dbMock.feature.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "feat-1", name: "Something unrelated" } as any,
+    ]);
+
+    const rows = await caller.transcription.findDuplicateFeatures({
+      transcriptionId,
+      productId,
+    });
+
+    expect(rows).toEqual([]);
+  });
 });

--- a/src/server/api/routers/__tests__/featureIdeation.test.ts
+++ b/src/server/api/routers/__tests__/featureIdeation.test.ts
@@ -424,6 +424,8 @@ describe("transcription router — feature ideation (mocked Prisma)", () => {
         vision: "Nobody types a contact in by hand again.",
         status: "IDEA",
         createdById: callerId,
+        // Provenance (V3): the originating meeting is recorded on the Feature.
+        sourceTranscriptionId: transcriptionId,
       }),
     ]);
 

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -2039,6 +2039,9 @@ export const transcriptionRouter = createTRPCRouter({
             vision: draft.vision,
             status: "IDEA",
             createdById: userId,
+            // Provenance (V3): record the meeting this Feature came from, so the
+            // feature view can link back to it.
+            sourceTranscriptionId: input.transcriptionId,
           },
         });
         featureIds.push(feature.id);

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -10,7 +10,10 @@ import { uploadToBlob } from "~/lib/blob";
 import { FirefliesSyncService } from "~/server/services/FirefliesSyncService";
 import { TranscriptionProcessingService } from "~/server/services/TranscriptionProcessingService";
 import { FeatureIdeationService } from "~/server/services/FeatureIdeationService";
-import { parseProposedTickets } from "~/server/services/FeatureExtractionService";
+import {
+  parseProposedTickets,
+  normalizeFeatureName,
+} from "~/server/services/FeatureExtractionService";
 import { TICKET_TYPES } from "~/lib/ticket-types";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 import { loadProductWithAccess } from "~/plugins/product/server/routers/product";
@@ -1984,6 +1987,60 @@ export const transcriptionRouter = createTRPCRouter({
         vision: draft.vision,
         tickets: parseProposedTickets(draft.tickets),
       }));
+    }),
+
+  // Near-duplicate check (V3), run when the card has a target product picked.
+  // For each draft, find existing features in that product whose normalized
+  // name matches — a warning surface, NOT a gate: the accept mutation does not
+  // consult this and creates the Feature regardless. Deliberately narrow per
+  // the scope: exact normalized-name match, same product only, no embeddings,
+  // no cross-product comparison.
+  findDuplicateFeatures: protectedProcedure
+    .input(z.object({ transcriptionId: z.string(), productId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const session = await loadTranscriptionForAccess(
+        ctx.db,
+        input.transcriptionId,
+      );
+      await ensureTranscriptionAccess(
+        ctx.db,
+        ctx.session.user.id,
+        session,
+        "view",
+      );
+      const product = await loadProductWithAccess(
+        ctx.db,
+        ctx.session.user.id,
+        input.productId,
+      );
+
+      const drafts = await ctx.db.meetingFeatureDraft.findMany({
+        where: { transcriptionSessionId: input.transcriptionId },
+        select: { id: true, name: true },
+      });
+      const existing = await ctx.db.feature.findMany({
+        where: { productId: product.id },
+        select: { id: true, name: true },
+      });
+
+      // Index existing features by normalized name once, then look each draft up.
+      const byNormalized = new Map<string, { id: string; name: string }[]>();
+      for (const feature of existing) {
+        const key = normalizeFeatureName(feature.name);
+        const bucket = byNormalized.get(key);
+        if (bucket) {
+          bucket.push(feature);
+        } else {
+          byNormalized.set(key, [feature]);
+        }
+      }
+
+      return drafts
+        .map((draft) => ({
+          draftId: draft.id,
+          matches: byNormalized.get(normalizeFeatureName(draft.name)) ?? [],
+        }))
+        .filter((row) => row.matches.length > 0);
     }),
 
   publishSelectedDraftFeatures: protectedProcedure


### PR DESCRIPTION
## What

The final scope of **Meeting → product features & backlog tickets** (ticket `pale.lily`, V3). Closes the loop between a Feature and the meeting it came from, and warns on the obvious duplicate before it lands.

## Acceptance criteria

- [x] The originating meeting is recorded on each created Feature
- [x] The feature view links back to the meeting the feature came from
- [x] Accepting a draft whose normalized name closely matches an existing feature in the target product shows a warning naming and linking that feature
- [x] The warning does not block — accepting anyway still creates the Feature
- [x] The migration is written but run by the user, not by the agent

## Provenance (action 1)

- `Feature.sourceTranscriptionId` — nullable (hand-authored features have no meeting), indexed, FK `onDelete: SetNull` so purging a meeting doesn't cascade away the Features it produced; the back-link just goes quiet.
- Written at accept time in `publishSelectedDraftFeatures`.
- `feature.getById` includes it; the feature detail view renders a **"From meeting"** back-link, absent when there's no source.

## Duplicate warning (action 2)

- `transcription.findDuplicateFeatures`: for each draft, existing features in the chosen product whose **normalized** name matches — the same normalizer the extractor dedupes with, so case/whitespace differences still hit. Deliberately narrow per the scope: exact normalized-name match, same product only, **no embeddings, no cross-product comparison**.
- The card runs it once a product is picked and shows **"Possible duplicate of &lt;feature&gt;. You can still accept it."** per match, linking the existing feature. A warning, not a gate — the accept mutation never consults it and creates the Feature regardless.

## Migration

`add_feature_source_transcription` — additive: one nullable column, its index, and the FK. No existing column altered.

## Notes for review

- The duplicate check is a **read-side query the card calls**, not a branch inside the accept mutation — keeping "warn" and "write" as separate concerns means the warning can never accidentally become a gate.
- With this merged, the V1 double-accept gap noted on #429 is now closeable in principle (provenance exists), but this PR does **not** add re-ideation dedup on the button path — that wasn't in the V3 scope. Flagging so it's a conscious follow-up, not an assumed fix.

---

Ships: pale.lily
