### PR TITLE
fix(pages): restore list markers on published pages

### DIFF
--- a/src/app/(published)/p/[slugId]/page.tsx
+++ b/src/app/(published)/p/[slugId]/page.tsx
@@ -250,8 +250,13 @@ export default async function PublishedPage({
             <TypographyStylesProvider>
               {/* Server-generated from the schema-constrained ProseMirror doc
                   after the ADR-0038 sanitization pass — the deliberate, narrow
-                  exception to the no-dangerouslySetInnerHTML rule. */}
-              <div dangerouslySetInnerHTML={{ __html: html }} />
+                  exception to the no-dangerouslySetInnerHTML rule.
+                  `prd-document` is the same class the in-app editor/viewer sets:
+                  Tailwind Preflight strips list markers and list padding, and
+                  TypographyStylesProvider has no ul/ol rules to put them back, so
+                  without it bullets and numbers vanish on the public render (it
+                  also carries the table and task-list styling). */}
+              <div className="prd-document" dangerouslySetInnerHTML={{ __html: html }} />
             </TypographyStylesProvider>
           ) : page.body ? (
             <MarkdownRenderer content={page.body} variant="prose" />


### PR DESCRIPTION
Bullets and numbered lists rendered fine in the workspace page view but disappeared on the published `/p/[slugId]` version.

## Cause

The published route renders the Tiptap `bodyDoc` to static HTML and drops it into a bare `<div>` inside `TypographyStylesProvider`:

```tsx
<div dangerouslySetInnerHTML={{ __html: html }} />
```

Two things combine:

- Tailwind Preflight resets `ol, ul, menu { list-style: none; margin: 0; padding: 0 }`.
- Mantine `TypographyStylesProvider` styles headings, paragraphs, links, tables, `hr`, `pre`, `kbd`, `mark` — but has **no** `ul`/`ol` rules, so nothing puts the markers back.

The in-app viewer/editor looked correct because `RichDocEditor` sets `className="prd-document"`, and `globals.css` restores markers, padding and `::marker` colour under that class.

Confirmed against the live page — the markup is there, unstyled:

```html
<ul class="tight" data-tight="true"><li><p><strong>A single owner per responsibility</strong>…
```

## Fix

Set `prd-document` on the public render so it picks up the same rules as the in-app view.

This also fixes tables and task lists on published pages. `globals.css` already wrote those rules for the headless `generateHTML` output —

```css
/* In the editable editor prosemirror-tables wraps the table in `.tableWrapper`…
   the headless public render (`generateHTML`) emits a bare <table>, so styling
   covers both. */
```

— but they never applied, because nothing on the public route was inside a `.prd-document` container.

## Verification

- Compiled `globals.css` through Tailwind and checked the cascade: Preflight `list-style: none` lands at line 463, `.prd-document ul:not([data-type="taskList"])` at line 7506 — later in the cascade and higher specificity, so the marker rules win.
- `npx tsc --noEmit` clean.
- `npm run test` — 182 files, 1741 tests passing.
- ESLint clean on the changed file.

No schema changes, no migration.