### PR TITLE
feat(ai-worker): run Claude Code directly against OpenRouter, add ai-buildable

### DIFF
--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -246,26 +246,35 @@ jobs:
         id: agent
         continue-on-error: true
         env:
-          # ANTHROPIC_AUTH_TOKEN (not ANTHROPIC_API_KEY) is the header the SDK
-          # sends to a custom base URL. ANTHROPIC_API_KEY is blanked explicitly
-          # so a leftover Anthropic key in repo secrets cannot win the race and
-          # silently bill the wrong account.
+          # Exactly ONE credential reaches the agent (AI_BUILDER_API_KEY); the
+          # run block exports it under the variable whose auth header the
+          # target endpoint expects. Anthropic direct authenticates with
+          # x-api-key, which the SDK sends from ANTHROPIC_API_KEY; every other
+          # Anthropic-compatible endpoint (OpenRouter included) takes
+          # Authorization: Bearer, sent from ANTHROPIC_AUTH_TOKEN. Both are
+          # pre-blanked here so a leftover key in repo settings can never win a
+          # precedence race and silently bill the wrong account.
           #
           # That precedence trap is not hypothetical: PR #436 traced a five-week
           # outage to claude-code-action PREFERRING claude_code_oauth_token when
           # both credentials were present. The subscription behind it had hit a
           # rolling usage cap and failed in ~250ms, and adding API-key credit
-          # changed nothing because the API key was never consulted. Exactly one
-          # credential reaches the agent here, and it is named explicitly.
+          # changed nothing because the API key was never consulted.
           ANTHROPIC_BASE_URL: ${{ env.AGENT_BASE_URL }}
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.AI_BUILDER_API_KEY }}
+          AI_BUILDER_API_KEY: ${{ secrets.AI_BUILDER_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ""
           ANTHROPIC_API_KEY: ""
           MAX_BUDGET_USD: ${{ vars.AI_BUILDER_MAX_USD || '2' }}
           DEBUG_OUTPUT: ${{ inputs.debug_output || false }}
         run: |
           set -euo pipefail
-          if [ -z "${ANTHROPIC_AUTH_TOKEN}" ]; then
+          if [ -z "${AI_BUILDER_API_KEY}" ]; then
             echo "::error::Missing AI_BUILDER_API_KEY secret"; exit 1
+          fi
+          if [ "${ANTHROPIC_BASE_URL%/}" = "https://api.anthropic.com" ]; then
+            export ANTHROPIC_API_KEY="$AI_BUILDER_API_KEY"
+          else
+            export ANTHROPIC_AUTH_TOKEN="$AI_BUILDER_API_KEY"
           fi
           # Pinned: this process holds the LLM key in its env, so a hijacked
           # release of the CLI would run holding that secret. Bump deliberately.

--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -283,8 +283,10 @@ jobs:
           # unavoidably in this process's env (the Read tool can see
           # /proc/self/environ), so: WebFetch/WebSearch are denied to close the
           # outbound-exfil channel; repo/API tokens are step-scoped OUT of this
-          # step; and later steps never execute agent-editable files (Finalize
-          # commits with --no-verify).
+          # step; later steps never execute agent-editable files (Finalize
+          # commits with --no-verify); and the guard rejects any edit under
+          # .github/ or .husky/ so agent-authored CI never reaches a
+          # `pull_request` run that holds secrets.
           # --max-budget-usd is a hard spend ceiling; unlike --max-turns it
           # bounds cost directly, which matters now billing is per-token rather
           # than a flat subscription fee.
@@ -312,15 +314,28 @@ jobs:
           fi
           exit "$AGENT_EXIT"
 
-      - name: Guard — no schema or migration edits
+      - name: Guard — no CI/hook edits; no schema edits (ai-buildable)
         id: guard
         continue-on-error: true
         run: |
           set -euo pipefail
-          # Features briefed via `ai-buildable` are told to STOP if they need a
-          # migration. That is an instruction, and a model can ignore an
-          # instruction — it cannot ignore a diff. Enforced only for the
-          # feature profile: an `ai-fixable` bug fix that legitimately needs a
+          # A model can ignore an instruction — it cannot ignore a diff.
+          #
+          # CI and hook paths are banned for BOTH profiles: they are the
+          # worker's own control plane. Finalize's `git add -A` commits, pushes
+          # and opens a PR from an in-repo branch, so `pull_request` workflows
+          # (test.yml, pr_agent.yml, …) would immediately EXECUTE an
+          # agent-authored workflow file with this repo's secrets, before any
+          # human review. Same for .husky/ hooks.
+          FORBIDDEN=$(git status --porcelain -- .github .husky)
+          if [ -n "$FORBIDDEN" ]; then
+            echo "::error::agent modified CI/hook files, which is never allowed"
+            echo "$FORBIDDEN"
+            exit 1
+          fi
+          # The schema/migration ban is `ai-buildable`-only. Features briefed
+          # via that label are told to STOP if they need a migration; this
+          # enforces it. An `ai-fixable` bug fix that legitimately needs a
           # schema change still goes through human review as before.
           #
           # Rationale: preview deploys run `next build` only, never
@@ -328,7 +343,7 @@ jobs:
           # database. The feature would look broken for reasons unrelated to
           # the agent's work.
           if [ "$TRIGGER_LABEL" != "ai-buildable" ]; then
-            echo "guard not applicable for '$TRIGGER_LABEL'"; exit 0
+            echo "guard (schema) not applicable for '$TRIGGER_LABEL'"; exit 0
           fi
           # --porcelain over `git diff` so NEW untracked migration directories
           # are caught too — a migration is almost always a new file, which a
@@ -415,7 +430,7 @@ jobs:
 
           if [ -n "$BAILED" ]; then fail "the agent flagged this as needing a human — ${BAILED}"; fi
           if [ "${{ steps.agent.outcome }}" != "success" ]; then abort "the coding agent step failed (log tail in the step above)"; fi
-          if [ "${{ steps.guard.outcome }}" != "success" ]; then fail "the agent changed the database schema, which ai-buildable forbids"; fi
+          if [ "${{ steps.guard.outcome }}" != "success" ]; then fail "the agent modified forbidden paths (CI/hook files, or schema/migrations under ai-buildable)"; fi
           if [ -z "$HAS_CHANGES" ]; then fail "the agent made no code changes"; fi
           if [ "${{ steps.validate.outcome }}" != "success" ]; then fail "validation (tsc/next lint) failed"; fi
 

--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -253,7 +253,7 @@ jobs:
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.AI_BUILDER_API_KEY }}
           ANTHROPIC_API_KEY: ""
         run: |
-          set -uo pipefail
+          set -euo pipefail
           if [ -z "${ANTHROPIC_AUTH_TOKEN}" ]; then
             echo "::error::Missing AI_BUILDER_API_KEY secret"; exit 1
           fi

--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -189,9 +189,11 @@ jobs:
       # model id). Clearing the var does NOT do that: `||` here cannot tell unset
       # from empty, so both fall back to the OpenRouter default.
       AGENT_BASE_URL: ${{ vars.AI_BUILDER_BASE_URL || 'https://openrouter.ai/api' }}
-      EXPONENTIAL_TOKEN: ${{ secrets.EXPONENTIAL_TOKEN }}
-      # Prefer a PAT so the PR triggers CI; fall back to the default token.
-      GH_TOKEN: ${{ secrets.AI_BUG_FIXER_GH_TOKEN || github.token }}
+      # EXPONENTIAL_TOKEN and GH_TOKEN are deliberately NOT job-level env:
+      # job env is inherited by EVERY step, including the agent process (whose
+      # Read tool can read /proc/self/environ) and Validate's `npx next lint`
+      # (which executes agent-editable JS config). They are step-scoped to the
+      # steps that actually use them instead.
     steps:
       - uses: actions/checkout@v4
         with:
@@ -204,6 +206,10 @@ jobs:
           cache: npm
 
       - name: Install deps + CLI
+        # The only step that needs the raw token in env — `auth login` stores
+        # credentials for the CLI, so later steps call it with no token in env.
+        env:
+          EXPONENTIAL_TOKEN: ${{ secrets.EXPONENTIAL_TOKEN }}
         run: |
           npm ci
           npm i -g exponential-cli
@@ -271,10 +277,14 @@ jobs:
           # carries Bash(...) allow rules that merge into the agent's
           # permissions on top of these flags. A deny beats every allow source,
           # so this is what actually keeps the agent from shelling out — the
-          # brief forbids git, the workflow owns commit/push/PR, and an agent
-          # that cannot shell out cannot read the API key from its env.
-          # WebFetch/WebSearch are denied too: the brief needs neither, and a
-          # file-editing agent has no business making outbound requests.
+          # brief forbids git, and the workflow owns commit/push/PR.
+          #
+          # Containment is layered, not a single wall. The LLM key is
+          # unavoidably in this process's env (the Read tool can see
+          # /proc/self/environ), so: WebFetch/WebSearch are denied to close the
+          # outbound-exfil channel; repo/API tokens are step-scoped OUT of this
+          # step; and later steps never execute agent-editable files (Finalize
+          # commits with --no-verify).
           # --max-budget-usd is a hard spend ceiling; unlike --max-turns it
           # bounds cost directly, which matters now billing is per-token rather
           # than a flat subscription fee.
@@ -354,6 +364,9 @@ jobs:
           GIT_AUTHOR_EMAIL: ai-bot@bots.exponential.im
           GIT_COMMITTER_NAME: exponential-ai-bot
           GIT_COMMITTER_EMAIL: ai-bot@bots.exponential.im
+          # Prefer a PAT so the PR triggers CI; fall back to the default token.
+          # Step-scoped (see the job env comment): only this step runs `gh`.
+          GH_TOKEN: ${{ secrets.AI_BUG_FIXER_GH_TOKEN || github.token }}
         run: |
           set -euo pipefail
 
@@ -422,7 +435,11 @@ jobs:
           Autonomous change for Exponential ticket #${TICKET_NUMBER}.
           Requires human review before merge.
           EOF
-            git commit -F .git-commit-msg
+            # --no-verify: the workflow owns this commit. Hooks under .husky/
+            # are tracked, agent-editable files (installed by npm ci's
+            # `prepare`), so running them here would execute agent-authored
+            # code in a step that holds tokens.
+            git commit --no-verify -F .git-commit-msg
             rm -f .git-commit-msg
           fi
 

--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -138,6 +138,14 @@ jobs:
           exponential tickets list \
             --product "$EXPONENTIAL_PRODUCT" --workspace "$EXPONENTIAL_WORKSPACE" \
             --status READY_TO_PLAN --label security --json > security.json
+          # Retry bound: a ticket that failed a previous attempt carries
+          # `ai-attempted` (added on release, below). Excluding it here stops a
+          # deterministically-failing ticket from burning metered budget every
+          # hour forever AND (selection is oldest-first) starving the queue
+          # behind it. A human re-arms the ticket by removing the label.
+          exponential tickets list \
+            --product "$EXPONENTIAL_PRODUCT" --workspace "$EXPONENTIAL_WORKSPACE" \
+            --status READY_TO_PLAN --label ai-attempted --json > attempted.json
 
       - name: Count open AI PRs (cap guard)
         id: prs
@@ -158,6 +166,7 @@ jobs:
             --candidates fixable.json  --candidate-label ai-fixable
             --candidates buildable.json --candidate-label ai-buildable
             --exclude security.json
+            --exclude attempted.json
             --open-prs "${{ steps.prs.outputs.open }}"
             --max-open-prs "${{ vars.AI_BUG_FIXER_MAX_OPEN_PRS || '3' }}"
           )
@@ -427,9 +436,13 @@ jobs:
             reason="$1"
             exponential tickets comment add --id "$TICKET_ID" \
               -m "🤖 Couldn't open a PR automatically: ${reason}. Releasing the ticket for a human. [Run log]($RUN_URL)." || true
-            # Releasing the status is essential; dropping the label is cosmetic.
+            # Releasing the status is essential; label ops are best-effort so a
+            # missing/flaky label can never strand the ticket.
             exponential tickets update --id "$TICKET_ID" --status READY_TO_PLAN --json || true
             exponential tickets update --id "$TICKET_ID" --remove-label ai-in-progress --json || true
+            # Retry bound: mark the ticket attempted so the scan skips it from
+            # now on. A human re-arms it by removing `ai-attempted`.
+            exponential tickets update --id "$TICKET_ID" --add-label ai-attempted --json || true
           }
           fail() {
             echo "::warning::AI fix did not produce a PR: $1"

--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -249,7 +249,10 @@ jobs:
           # changed nothing.
           mkdir -p .ai-bug-fixer
           exponential tickets get "$TICKET_ID" --json > .ai-bug-fixer/ticket.json
-          node scripts/ai-bug-fixer/render-prompt.mjs --ticket .ai-bug-fixer/ticket.json --out .ai-bug-fixer/prompt.md
+          # --label: framing follows the ticket's type, but HARD RULES follow
+          # the trigger label — ai-buildable's brief must state the schema ban
+          # the guard enforces, whatever type the ticket is.
+          node scripts/ai-bug-fixer/render-prompt.mjs --ticket .ai-bug-fixer/ticket.json --out .ai-bug-fixer/prompt.md --label "$TRIGGER_LABEL"
 
       - name: Run coding agent
         id: agent

--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -184,8 +184,10 @@ jobs:
       # would be sent to OpenRouter, which does not know it.
       MODEL: ${{ inputs.model || vars.AI_BUILDER_MODEL || 'z-ai/glm-5.2' }}
       # OpenRouter's Anthropic-compatible endpoint. Note `/api`, NOT `/api/v1` —
-      # the Anthropic SDK appends its own path. Unset this var to talk to
-      # Anthropic directly instead (then MODEL must be an Anthropic model id).
+      # the Anthropic SDK appends its own path. To talk to Anthropic directly,
+      # SET the var to https://api.anthropic.com (then MODEL must be an Anthropic
+      # model id). Clearing the var does NOT do that: `||` here cannot tell unset
+      # from empty, so both fall back to the OpenRouter default.
       AGENT_BASE_URL: ${{ vars.AI_BUILDER_BASE_URL || 'https://openrouter.ai/api' }}
       EXPONENTIAL_TOKEN: ${{ secrets.EXPONENTIAL_TOKEN }}
       # Prefer a PAT so the PR triggers CI; fall back to the default token.
@@ -252,17 +254,27 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ env.AGENT_BASE_URL }}
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.AI_BUILDER_API_KEY }}
           ANTHROPIC_API_KEY: ""
+          MAX_BUDGET_USD: ${{ vars.AI_BUILDER_MAX_USD || '2' }}
+          DEBUG_OUTPUT: ${{ inputs.debug_output || false }}
         run: |
           set -euo pipefail
           if [ -z "${ANTHROPIC_AUTH_TOKEN}" ]; then
             echo "::error::Missing AI_BUILDER_API_KEY secret"; exit 1
           fi
-          npm i -g @anthropic-ai/claude-code
+          # Pinned: this process holds the LLM key in its env, so a hijacked
+          # release of the CLI would run holding that secret. Bump deliberately.
+          npm i -g @anthropic-ai/claude-code@2.1.186
 
-          # Tools are allow-listed rather than unrestricted. Bash is NOT granted:
-          # the brief already forbids the agent running git, the workflow owns
-          # commit/push/PR, and this process holds an API key in its env — in a
-          # public repo, an agent that cannot shell out cannot exfiltrate it.
+          # Tools are allow-listed AND Bash is explicitly denied. The deny is
+          # load-bearing, not belt-and-braces: --allowedTools only pre-approves,
+          # it does not restrict, and the checked-in .claude/settings.json
+          # carries Bash(...) allow rules that merge into the agent's
+          # permissions on top of these flags. A deny beats every allow source,
+          # so this is what actually keeps the agent from shelling out — the
+          # brief forbids git, the workflow owns commit/push/PR, and an agent
+          # that cannot shell out cannot read the API key from its env.
+          # WebFetch/WebSearch are denied too: the brief needs neither, and a
+          # file-editing agent has no business making outbound requests.
           # --max-budget-usd is a hard spend ceiling; unlike --max-turns it
           # bounds cost directly, which matters now billing is per-token rather
           # than a flat subscription fee.
@@ -270,9 +282,10 @@ jobs:
           claude -p "Read .ai-bug-fixer/prompt.md and implement what it describes. Edit the working tree only — do NOT run git, commit, push, or open a PR." \
             --model "$MODEL" \
             --max-turns 30 \
-            --max-budget-usd "${{ vars.AI_BUILDER_MAX_USD || '2' }}" \
+            --max-budget-usd "$MAX_BUDGET_USD" \
             --permission-mode acceptEdits \
             --allowedTools "Read,Write,Edit,Glob,Grep" \
+            --disallowedTools "Bash,WebFetch,WebSearch" \
             > .ai-bug-fixer/agent-output.txt 2>&1
           AGENT_EXIT=$?
           set -e
@@ -282,7 +295,7 @@ jobs:
           # opt-in. On failure we surface the tail regardless — a silent
           # failure is what made the previous incarnation of this step fail
           # green and unnoticed for five weeks.
-          if [ "${{ inputs.debug_output || false }}" = "true" ]; then
+          if [ "$DEBUG_OUTPUT" = "true" ]; then
             cat .ai-bug-fixer/agent-output.txt
           elif [ "$AGENT_EXIT" -ne 0 ]; then
             echo "::group::agent output (tail)"; tail -n 30 .ai-bug-fixer/agent-output.txt; echo "::endgroup::"
@@ -360,10 +373,13 @@ jobs:
 
           # `if` guards (not `[ ] && cmd`) so a false condition can't trip set -e.
           #
-          # `fail` = the agent couldn't do the job. Expected, not our problem to
-          # debug, so the run stays green. `abort` = OUR machinery broke (push,
-          # PR creation). That must go RED — a broken worker silently reporting
-          # success is how this workflow hid a total failure for five weeks.
+          # `fail` = the agent ran fine but its OUTPUT isn't shippable (bailed
+          # to needs-human, empty diff, guard trip, validation red). Expected,
+          # so the run stays green. `abort` = the machinery broke, and that
+          # must go RED. The agent PROCESS exiting non-zero (bad key, unknown
+          # model, crash) is machinery, not output — routing it to `fail` would
+          # recreate the exact green-run outage that went unnoticed for five
+          # weeks behind claude-code-action's continue-on-error.
           # Both release the ticket; neither may leave it stranded IN_PROGRESS.
           release_ticket() {
             reason="$1"
@@ -385,7 +401,7 @@ jobs:
           }
 
           if [ -n "$BAILED" ]; then fail "the agent flagged this as needing a human — ${BAILED}"; fi
-          if [ "${{ steps.agent.outcome }}" != "success" ]; then fail "the coding agent step failed"; fi
+          if [ "${{ steps.agent.outcome }}" != "success" ]; then abort "the coding agent step failed (log tail in the step above)"; fi
           if [ "${{ steps.guard.outcome }}" != "success" ]; then fail "the agent changed the database schema, which ai-buildable forbids"; fi
           if [ -z "$HAS_CHANGES" ]; then fail "the agent made no code changes"; fi
           if [ "${{ steps.validate.outcome }}" != "success" ]; then fail "validation (tsc/next lint) failed"; fi

--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -1,15 +1,24 @@
 name: AI Bug Fixer
 
-# Autonomous ticket worker. Polls Exponential for tickets a human has
-# explicitly marked `ai-fixable`, attempts the work, runs validation, and
-# opens a PR for HUMAN REVIEW. It never merges and never deploys. Ticket
-# close-out happens via the existing PR-merge webhook (ADR-0021).
+# Autonomous ticket worker. Polls Exponential for tickets a human (or the
+# ideation flow) has marked with a trigger label, attempts the work, runs
+# validation, and opens a PR for HUMAN REVIEW. It never merges and never
+# deploys. Ticket close-out happens via the existing PR-merge webhook (ADR-0021).
 #
-# NOT bug-only: there is no ticket-type filter. The pipeline is type-agnostic
-# and the human-applied label is the gate. The brief adapts its framing to the
-# ticket type (see scripts/ai-bug-fixer/render-prompt.mjs) — a feature briefed
-# with bug-fix framing produces a deliberate non-implementation.
-# The workflow file, job name and `ai-fixable`/`ai-bug-fixer` labels keep their
+# TWO trigger labels, two profiles:
+#   `ai-fixable`   — bugs. Narrow-fix framing. tsc + lint.
+#   `ai-buildable` — features. Build-what-it-says framing. tsc + lint, PLUS a
+#                    hard ban on schema/migration edits (see "Guard").
+# The pipeline is otherwise type-agnostic; the label is the gate. The brief
+# adapts its framing to the ticket type (scripts/ai-bug-fixer/render-prompt.mjs).
+#
+# The coding agent is the Claude Code CLI invoked DIRECTLY, not
+# anthropics/claude-code-action. Two reasons: (1) the model is served by
+# OpenRouter via its Anthropic-compatible endpoint, which the action does not
+# support; (2) the action's failures surfaced as a green run that silently
+# produced no PR — a direct call gives us a plain exit code.
+#
+# The workflow file, job name, script dir and `ai-bug-fixer` PR label keep their
 # historical names so existing runs, secrets and repo vars keep resolving.
 #
 # See docs/agents/ai-bug-fixer.md for setup, required secrets, and the marker
@@ -24,7 +33,7 @@ on:
         description: "Specific ticket CUID to attempt (optional; otherwise picks the oldest eligible)"
         required: false
       model:
-        description: "Override the coding-agent model (default: the AI_BUG_FIXER_MODEL repo var or claude-haiku-4-5)"
+        description: "Override the coding-agent model (default: the AI_BUILDER_MODEL repo var or z-ai/glm-5.2)"
         required: false
       debug_output:
         description: "Log the coding agent's full output. THIS REPO IS PUBLIC — the log is world-readable. Manual runs only, one at a time, and only when you need the agent's error message."
@@ -42,11 +51,10 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
-  # Required by anthropics/claude-code-action, which authenticates via OIDC.
-  # Without it the agent step fails with "Could not fetch an OIDC token" —
-  # and because that step is `continue-on-error`, the run still goes GREEN
-  # while silently never producing a PR. Do not remove.
-  id-token: write
+  # `id-token: write` used to live here for anthropics/claude-code-action's OIDC
+  # exchange. The agent is now the Claude Code CLI called directly, which
+  # authenticates with a plain API key, so no OIDC token is minted and the
+  # permission is deliberately gone. Do not re-add it without a reason.
 
 env:
   EXPONENTIAL_API_URL: ${{ vars.EXPONENTIAL_API_URL }}
@@ -69,6 +77,7 @@ jobs:
       ticket_number: ${{ steps.select.outputs.ticket_number }}
       ticket_title: ${{ steps.select.outputs.ticket_title }}
       branch_slug: ${{ steps.select.outputs.branch_slug }}
+      trigger_label: ${{ steps.select.outputs.trigger_label }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -83,8 +92,15 @@ jobs:
           if [ -z "${EXPONENTIAL_TOKEN}" ]; then
             echo "::error::Missing EXPONENTIAL_TOKEN secret"; exit 1
           fi
+          # Checked in the CHEAP job: without it the fix job would claim a
+          # ticket, flip it to IN_PROGRESS, and only then discover it cannot run
+          # the agent. Fail before anything is claimed.
+          if [ -z "${AI_BUILDER_API_KEY}" ]; then
+            echo "::error::Missing AI_BUILDER_API_KEY secret (OpenRouter key)"; exit 1
+          fi
         env:
           EXPONENTIAL_TOKEN: ${{ secrets.EXPONENTIAL_TOKEN }}
+          AI_BUILDER_API_KEY: ${{ secrets.AI_BUILDER_API_KEY }}
 
       - name: Install + auth Exponential CLI
         run: |
@@ -100,13 +116,21 @@ jobs:
           # wrong workspace, missing label) must fail the scan loudly rather than
           # leave the worker silently idle. An unused-but-existing label resolves
           # cleanly to {tickets:[]}; only a genuine misconfig errors out.
-          # Eligible: any ai-fixable ticket that is fully specified
+          # Eligible: any ticket carrying a trigger label that is fully specified
           # (READY_TO_PLAN). Deliberately NOT filtered by type — the pipeline
           # (claim, brief, agent, validate, PR) is type-agnostic, and the
-          # human-applied `ai-fixable` label is the real gate.
+          # trigger label is the real gate.
+          #
+          # ONE QUERY PER LABEL, on purpose: `--label` is repeatable but ANDs,
+          # so a single call cannot express "ai-fixable OR ai-buildable".
+          # select-candidate.mjs merges the two files and remembers which query
+          # produced each ticket.
           exponential tickets list \
             --product "$EXPONENTIAL_PRODUCT" --workspace "$EXPONENTIAL_WORKSPACE" \
-            --status READY_TO_PLAN --label ai-fixable --json > candidates.json
+            --status READY_TO_PLAN --label ai-fixable --json > fixable.json
+          exponential tickets list \
+            --product "$EXPONENTIAL_PRODUCT" --workspace "$EXPONENTIAL_WORKSPACE" \
+            --status READY_TO_PLAN --label ai-buildable --json > buildable.json
           # Safety exclusion set: anything also tagged `security`. MUST use the
           # same filters as the candidate query above (minus the label) — if
           # this one is narrower, a ticket can be in candidates but missing from
@@ -131,7 +155,8 @@ jobs:
           ONLY_TICKET: ${{ inputs.ticket_id }}
         run: |
           args=(
-            --candidates candidates.json
+            --candidates fixable.json  --candidate-label ai-fixable
+            --candidates buildable.json --candidate-label ai-buildable
             --exclude security.json
             --open-prs "${{ steps.prs.outputs.open }}"
             --max-open-prs "${{ vars.AI_BUG_FIXER_MAX_OPEN_PRS || '3' }}"
@@ -153,7 +178,15 @@ jobs:
       TICKET_TITLE: ${{ needs.scan.outputs.ticket_title }}
       BRANCH: ai/ticket-${{ needs.scan.outputs.ticket_number }}-${{ needs.scan.outputs.branch_slug }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      MODEL: ${{ inputs.model || vars.AI_BUG_FIXER_MODEL || 'claude-haiku-4-5' }}
+      TRIGGER_LABEL: ${{ needs.scan.outputs.trigger_label }}
+      # Deliberately a NEW var name rather than reusing AI_BUG_FIXER_MODEL: that
+      # one named an Anthropic model, and a stale value left in repo settings
+      # would be sent to OpenRouter, which does not know it.
+      MODEL: ${{ inputs.model || vars.AI_BUILDER_MODEL || 'z-ai/glm-5.2' }}
+      # OpenRouter's Anthropic-compatible endpoint. Note `/api`, NOT `/api/v1` —
+      # the Anthropic SDK appends its own path. Unset this var to talk to
+      # Anthropic directly instead (then MODEL must be an Anthropic model id).
+      AGENT_BASE_URL: ${{ vars.AI_BUILDER_BASE_URL || 'https://openrouter.ai/api' }}
       EXPONENTIAL_TOKEN: ${{ secrets.EXPONENTIAL_TOKEN }}
       # Prefer a PAT so the PR triggers CI; fall back to the default token.
       GH_TOKEN: ${{ secrets.AI_BUG_FIXER_GH_TOKEN || github.token }}
@@ -204,21 +237,79 @@ jobs:
       - name: Run coding agent
         id: agent
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
-        with:
-          # Two auth paths, because the two credential types are NOT
-          # interchangeable: a subscription OAuth token (`claude setup-token`,
-          # `sk-ant-oat…`) goes in CLAUDE_CODE_OAUTH_TOKEN, a console API key
-          # (`sk-ant-api…`) goes in ANTHROPIC_API_KEY. Passing the wrong one
-          # fails in ~2s with `is_error: true` and no usable message. Whichever
-          # secret is set wins; an unset secret renders as empty and is ignored.
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Off by default. See the debug_output input — this repo is public, so
-          # the agent's full output lands in a world-readable log.
-          show_full_output: ${{ inputs.debug_output || false }}
-          prompt: "Read .ai-bug-fixer/prompt.md and implement the narrow fix it describes. Edit the working tree only — do NOT run git, commit, push, or open a PR."
-          claude_args: "--model ${{ inputs.model || vars.AI_BUG_FIXER_MODEL || 'claude-haiku-4-5' }} --max-turns 30"
+        env:
+          # ANTHROPIC_AUTH_TOKEN (not ANTHROPIC_API_KEY) is the header the SDK
+          # sends to a custom base URL. ANTHROPIC_API_KEY is blanked explicitly
+          # so a leftover Anthropic key in repo secrets cannot win the race and
+          # silently bill the wrong account.
+          ANTHROPIC_BASE_URL: ${{ env.AGENT_BASE_URL }}
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.AI_BUILDER_API_KEY }}
+          ANTHROPIC_API_KEY: ""
+        run: |
+          set -uo pipefail
+          if [ -z "${ANTHROPIC_AUTH_TOKEN}" ]; then
+            echo "::error::Missing AI_BUILDER_API_KEY secret"; exit 1
+          fi
+          npm i -g @anthropic-ai/claude-code
+
+          # Tools are allow-listed rather than unrestricted. Bash is NOT granted:
+          # the brief already forbids the agent running git, the workflow owns
+          # commit/push/PR, and this process holds an API key in its env — in a
+          # public repo, an agent that cannot shell out cannot exfiltrate it.
+          # --max-budget-usd is a hard spend ceiling; unlike --max-turns it
+          # bounds cost directly, which matters now billing is per-token rather
+          # than a flat subscription fee.
+          set +e
+          claude -p "Read .ai-bug-fixer/prompt.md and implement what it describes. Edit the working tree only — do NOT run git, commit, push, or open a PR." \
+            --model "$MODEL" \
+            --max-turns 30 \
+            --max-budget-usd "${{ vars.AI_BUILDER_MAX_USD || '2' }}" \
+            --permission-mode acceptEdits \
+            --allowedTools "Read,Write,Edit,Glob,Grep" \
+            > .ai-bug-fixer/agent-output.txt 2>&1
+          AGENT_EXIT=$?
+          set -e
+
+          # THIS REPO IS PUBLIC and Actions logs are world-readable, so the
+          # agent's output is written to a file and only echoed on explicit
+          # opt-in. On failure we surface the tail regardless — a silent
+          # failure is what made the previous incarnation of this step fail
+          # green and unnoticed for five weeks.
+          if [ "${{ inputs.debug_output || false }}" = "true" ]; then
+            cat .ai-bug-fixer/agent-output.txt
+          elif [ "$AGENT_EXIT" -ne 0 ]; then
+            echo "::group::agent output (tail)"; tail -n 30 .ai-bug-fixer/agent-output.txt; echo "::endgroup::"
+          fi
+          exit "$AGENT_EXIT"
+
+      - name: Guard — no schema or migration edits
+        id: guard
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          # Features briefed via `ai-buildable` are told to STOP if they need a
+          # migration. That is an instruction, and a model can ignore an
+          # instruction — it cannot ignore a diff. Enforced only for the
+          # feature profile: an `ai-fixable` bug fix that legitimately needs a
+          # schema change still goes through human review as before.
+          #
+          # Rationale: preview deploys run `next build` only, never
+          # `prisma migrate deploy`, so a schema change never reaches a preview
+          # database. The feature would look broken for reasons unrelated to
+          # the agent's work.
+          if [ "$TRIGGER_LABEL" != "ai-buildable" ]; then
+            echo "guard not applicable for '$TRIGGER_LABEL'"; exit 0
+          fi
+          # --porcelain over `git diff` so NEW untracked migration directories
+          # are caught too — a migration is almost always a new file, which a
+          # plain diff against HEAD would not see.
+          CHANGED=$(git status --porcelain -- prisma/schema.prisma prisma/migrations)
+          if [ -n "$CHANGED" ]; then
+            echo "::error::agent modified prisma schema/migrations, which ai-buildable forbids"
+            echo "$CHANGED"
+            exit 1
+          fi
+          echo "no schema or migration changes"
 
       - name: Validate (typecheck + lint)
         id: validate
@@ -288,6 +379,7 @@ jobs:
 
           if [ -n "$BAILED" ]; then fail "the agent flagged this as needing a human — ${BAILED}"; fi
           if [ "${{ steps.agent.outcome }}" != "success" ]; then fail "the coding agent step failed"; fi
+          if [ "${{ steps.guard.outcome }}" != "success" ]; then fail "the agent changed the database schema, which ai-buildable forbids"; fi
           if [ -z "$HAS_CHANGES" ]; then fail "the agent made no code changes"; fi
           if [ "${{ steps.validate.outcome }}" != "success" ]; then fail "validation (tsc/next lint) failed"; fi
 
@@ -295,41 +387,39 @@ jobs:
           gh label create ai-bug-fixer --color BFD4F2 --description "Opened by the AI bug-fixer" --force >/dev/null 2>&1 || true
           # Commit staged edits if the agent left them uncommitted; if the action
           # already committed to the branch, this is a no-op and we just push.
+          # Conventional-commit prefix follows the profile, so a feature build
+          # does not land as `fix:` and pollute the changelog.
+          PREFIX="fix"
+          if [ "$TRIGGER_LABEL" = "ai-buildable" ]; then PREFIX="feat"; fi
+
           if ! git diff --cached --quiet; then
             cat > .git-commit-msg <<EOF
-          fix: ${TICKET_TITLE} (ticket #${TICKET_NUMBER})
+          ${PREFIX}: ${TICKET_TITLE} (ticket #${TICKET_NUMBER})
 
-          Autonomous fix for Exponential ticket #${TICKET_NUMBER}.
+          Autonomous change for Exponential ticket #${TICKET_NUMBER}.
           Requires human review before merge.
           EOF
             git commit -F .git-commit-msg
             rm -f .git-commit-msg
           fi
 
-          # claude-code-action rewrites remote.origin.url to embed its OWN
-          # (claude[bot]) token — it logs "Updating remote URL with
-          # authentication". That silently replaces the credential
-          # actions/checkout installed, so this push authenticates as the bot
-          # and dies with "Invalid username or token".
-          #
-          # Reset the remote to the PLAIN url — no token. actions/checkout's
-          # own `http.https://github.com/.extraheader` credential is still in
-          # .git/config at this point (it is only unset by the checkout Post
-          # step, which runs after this one) and applies to that url, so the
-          # push authenticates as us again. Deliberately NOT re-embedding a
-          # token in the url or in git config: this repo is public and Actions
-          # logs are world-readable, so a token in the remote would leak via
-          # `git remote -v`, `git config --list`, or a git error that echoes
-          # the url. Nothing to leak if nothing is stored.
-          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          # The remote is left exactly as actions/checkout configured it. The
+          # previous incarnation had to reset remote.origin.url here because
+          # claude-code-action rewrote it to embed its own claude[bot] token,
+          # breaking the push. The CLI does not touch git at all (it has no
+          # Bash tool), so there is nothing to undo. Deliberately NOT embedding
+          # a token in the url: this repo is public and Actions logs are
+          # world-readable, so a token there would leak via `git remote -v` or
+          # any git error that echoes the url.
           if ! git push origin "$BRANCH"; then abort "could not push the branch"; fi
 
           cat > .pr-body.md <<EOF
-          ## 🤖 Autonomous bug fix — needs human review
+          ## 🤖 Autonomous change — needs human review
 
           Implements Exponential ticket **#${TICKET_NUMBER}** — ${TICKET_TITLE}.
 
-          Generated by the AI bug-fixer ([run log]($RUN_URL)) using \`${MODEL}\`.
+          Triggered by the \`${TRIGGER_LABEL}\` label. Generated by the AI worker
+          ([run log]($RUN_URL)) using \`${MODEL}\`.
           Validation (\`tsc --noEmit\` + \`next lint\`) passed.
 
           **A human must review and merge this PR.** On merge, the existing PR-merge
@@ -338,7 +428,7 @@ jobs:
 
           if ! PR_URL=$(gh pr create \
             --base main --head "$BRANCH" \
-            --title "fix: ${TICKET_TITLE} (ticket #${TICKET_NUMBER})" \
+            --title "${PREFIX}: ${TICKET_TITLE} (ticket #${TICKET_NUMBER})" \
             --label ai-bug-fixer \
             --body-file .pr-body.md); then
             abort "pushed the branch but could not open the PR"

--- a/.github/workflows/ai-bug-fixer.yml
+++ b/.github/workflows/ai-bug-fixer.yml
@@ -296,9 +296,14 @@ jobs:
           # commits with --no-verify); and the guard rejects any edit under
           # .github/ or .husky/ so agent-authored CI never reaches a
           # `pull_request` run that holds secrets.
-          # --max-budget-usd is a hard spend ceiling; unlike --max-turns it
-          # bounds cost directly, which matters now billing is per-token rather
-          # than a flat subscription fee.
+          # --max-budget-usd bounds cost directly — but only if the CLI can
+          # price the model. It computes spend from an internal per-model
+          # pricing table, and a proxy-served id it does not know (e.g.
+          # z-ai/glm-5.2 via OpenRouter) may cost out at $0.00, in which case
+          # the ceiling never binds and --max-turns is the only real bound.
+          # Keep a key-level spend limit configured at the provider as the
+          # backstop. The flag stays: it is harmless when inert and correct if
+          # pricing metadata arrives later.
           set +e
           claude -p "Read .ai-bug-fixer/prompt.md and implement what it describes. Edit the working tree only — do NOT run git, commit, push, or open a PR." \
             --model "$MODEL" \

--- a/docs/adr/0029-ai-bug-fixer-workflow.md
+++ b/docs/adr/0029-ai-bug-fixer-workflow.md
@@ -116,7 +116,11 @@ everything else — still exactly one credential secret either way.
 
 *Consequence, and it is a real one:* the flat-fee subscription token named as a
 cost control above is gone. Billing is per-token. `--max-budget-usd` was added as
-a hard per-run ceiling to compensate. Rejected: keeping the subscription for bugs
+a per-run ceiling to compensate — with a caveat: the CLI prices spend from an
+internal per-model table, and for a proxy-served model id it does not know the
+computed cost can be $0.00, leaving `--max-turns` and a provider-side key spend
+limit as the real bounds (see the *Cost controls* caveat in
+[docs/agents/ai-bug-fixer.md](../agents/ai-bug-fixer.md)). Rejected: keeping the subscription for bugs
 and OpenRouter for features — two auth paths and two failure modes to keep alive,
 for a worker with almost no track record to protect.
 

--- a/docs/adr/0029-ai-bug-fixer-workflow.md
+++ b/docs/adr/0029-ai-bug-fixer-workflow.md
@@ -109,7 +109,10 @@ profiles, not just features. OpenRouter's Anthropic-compatible endpoint
 provider" collapses to a model string: OpenAI and Anthropic models are reachable
 the same way. Set `AI_BUILDER_BASE_URL` to `https://api.anthropic.com` to talk to
 Anthropic directly — clearing it merely restores the OpenRouter default, since an
-Actions `||` expression cannot tell an unset variable from an empty one.
+Actions `||` expression cannot tell an unset variable from an empty one. The
+workflow picks the auth header per endpoint: `x-api-key` (`ANTHROPIC_API_KEY`)
+for Anthropic direct, `Authorization: Bearer` (`ANTHROPIC_AUTH_TOKEN`) for
+everything else — still exactly one credential secret either way.
 
 *Consequence, and it is a real one:* the flat-fee subscription token named as a
 cost control above is gone. Billing is per-token. `--max-budget-usd` was added as

--- a/docs/adr/0029-ai-bug-fixer-workflow.md
+++ b/docs/adr/0029-ai-bug-fixer-workflow.md
@@ -36,19 +36,20 @@ Add one scheduled **GitHub Actions** workflow (`.github/workflows/ai-bug-fixer.y
 plus two small helper scripts (`scripts/ai-bug-fixer/`). **No app code, no schema
 changes, no new tRPC procedures.**
 
-- **Marker:** a human opts a bug in by adding the **`ai-fixable`** label to a
-  `type = BUG` ticket in `READY_TO_PLAN`. Exclusions are enforced in the worker:
-  any ticket also tagged `security`, or with `priority = 0` (critical), is never
-  attempted. Reuses the existing tag system — no new field.
+- **Marker:** a human opts work in by adding a **trigger label** to a ticket in
+  `READY_TO_PLAN` — **`ai-fixable`** for bugs, **`ai-buildable`** for features
+  (see *Amendment*). Exclusions are enforced in the worker: any ticket also
+  tagged `security`, or with `priority = 0` (critical), is never attempted.
+  Reuses the existing tag system — no new field.
 - **Trigger:** the workflow polls hourly (`schedule`) plus `workflow_dispatch`.
   Polling is used because **no outbound event path from Exponential exists today**;
   a `repository_dispatch` upgrade is left as future work.
 - **Orchestration is GitHub Actions** because the fix needs a repo checkout, a
   coding agent, and a PR — all native to Actions, and the repo already
   standardises on Actions. No new queue/worker infrastructure.
-- **Coding agent:** `anthropics/claude-code-action`, authenticated with a Claude
-  subscription token (`CLAUDE_CODE_OAUTH_TOKEN`, a flat fee) and defaulting to a
-  cheap model (`claude-haiku-4-5`). Model and auth are configurable via repo vars.
+- **Coding agent:** the Claude Code CLI, called directly (see *Amendment*;
+  originally `anthropics/claude-code-action` with a Claude subscription token).
+  Model, endpoint and spend ceiling are configurable via repo vars.
 - **Worker interface is the `exponential` CLI + a bot JWT** (`EXPONENTIAL_TOKEN`),
   mirroring `setup-merge-hook`. Zero new API surface.
 - **Soft lock:** a single-runner `concurrency` group plus a `READY_TO_PLAN →
@@ -79,5 +80,49 @@ hourly / manual → scan (CLI only): pick oldest eligible bug, minus security/cr
 - If validation fails, the agent makes no change, or the agent flags the bug as
   needing a human, the ticket is **released back to `READY_TO_PLAN`** with an
   explanatory comment — never left silently stuck in `IN_PROGRESS`.
+
+## Amendment (2026-07-30): OpenRouter, a second label, and a direct CLI call
+
+Three changes. The shape of the decision above — Actions, CLI-as-interface, PR
+for human review, no app code — is unchanged.
+
+**1. The coding agent is the Claude Code CLI, called directly.** Not
+`anthropics/claude-code-action`. The action authenticates via OIDC against
+Anthropic and does not support a third-party endpoint, which the model change
+below requires. It also rewrote `remote.origin.url` to embed its own bot token,
+which the workflow had to undo before every push. Decisively: the action step is
+`continue-on-error`, so its failures surfaced as a **green run that produced no
+PR** — a total outage went unnoticed for five weeks. A direct call yields a plain
+exit code. The `id-token: write` permission and the remote-URL workaround are
+both gone. The agent is allow-listed to `Read,Write,Edit,Glob,Grep`; **Bash is
+withheld**, so an agent holding an API key in a public repo's runner cannot shell
+out.
+
+**2. The model is served by OpenRouter, defaulting to `z-ai/glm-5.2`.** Both
+profiles, not just features. OpenRouter's Anthropic-compatible endpoint
+(`https://openrouter.ai/api` — note `/api`, not `/api/v1`) means "which
+provider" collapses to a model string: OpenAI and Anthropic models are reachable
+the same way. `AI_BUILDER_BASE_URL` can be cleared to talk to Anthropic directly.
+
+*Consequence, and it is a real one:* the flat-fee subscription token named as a
+cost control above is gone. Billing is per-token. `--max-budget-usd` was added as
+a hard per-run ceiling to compensate. Rejected: keeping the subscription for bugs
+and OpenRouter for features — two auth paths and two failure modes to keep alive,
+for a worker with almost no track record to protect.
+
+**3. A second trigger label, `ai-buildable`, for features.** `--label` on the CLI
+ANDs, so "either label" cannot be one query; the scan runs one list per label and
+`select-candidate.mjs` merges them, recording which query matched. A ticket with
+both is worked as `ai-fixable` — the stricter profile. `ai-buildable` adds one
+gate: **schema and migration edits are rejected by diff**, not by prompt.
+Rationale — preview deploys run `next build` only, never `prisma migrate deploy`,
+so a schema change cannot reach a preview database and the feature would appear
+broken for reasons unrelated to the agent.
+
+**Deliberately still not done:** no per-workspace provider configuration in the
+app, and no stored LLM credentials. Each repo holds its own key in its own GitHub
+secrets. Considered and rejected: storing customer keys and shipping them to a
+runner at run time — it would make the app a key-distribution service and break
+the standing invariant that decrypted credentials never leave the server process.
 
 See [docs/agents/ai-bug-fixer.md](../agents/ai-bug-fixer.md) for setup and operations.

--- a/docs/adr/0029-ai-bug-fixer-workflow.md
+++ b/docs/adr/0029-ai-bug-fixer-workflow.md
@@ -93,16 +93,23 @@ below requires. It also rewrote `remote.origin.url` to embed its own bot token,
 which the workflow had to undo before every push. Decisively: the action step is
 `continue-on-error`, so its failures surfaced as a **green run that produced no
 PR** — a total outage went unnoticed for five weeks. A direct call yields a plain
-exit code. The `id-token: write` permission and the remote-URL workaround are
-both gone. The agent is allow-listed to `Read,Write,Edit,Glob,Grep`; **Bash is
-withheld**, so an agent holding an API key in a public repo's runner cannot shell
-out.
+exit code, and the workflow turns a non-zero agent exit into a **red** run (only
+an honest "couldn't do it" — bail, empty diff, failed validation — stays green).
+The `id-token: write` permission and the remote-URL workaround are both gone.
+The agent is allow-listed to `Read,Write,Edit,Glob,Grep` and **Bash is
+explicitly denied** (`--disallowedTools`). The deny is what does the work: an
+allow-list alone does not restrict, and the repo's checked-in
+`.claude/settings.json` would otherwise merge its own `Bash(...)` allow rules
+into the agent's permissions. With the deny in place, an agent holding an API
+key in a public repo's runner cannot shell out.
 
 **2. The model is served by OpenRouter, defaulting to `z-ai/glm-5.2`.** Both
 profiles, not just features. OpenRouter's Anthropic-compatible endpoint
 (`https://openrouter.ai/api` — note `/api`, not `/api/v1`) means "which
 provider" collapses to a model string: OpenAI and Anthropic models are reachable
-the same way. `AI_BUILDER_BASE_URL` can be cleared to talk to Anthropic directly.
+the same way. Set `AI_BUILDER_BASE_URL` to `https://api.anthropic.com` to talk to
+Anthropic directly — clearing it merely restores the OpenRouter default, since an
+Actions `||` expression cannot tell an unset variable from an empty one.
 
 *Consequence, and it is a real one:* the flat-fee subscription token named as a
 cost control above is gone. Billing is per-token. `--max-budget-usd` was added as
@@ -113,7 +120,10 @@ for a worker with almost no track record to protect.
 **3. A second trigger label, `ai-buildable`, for features.** `--label` on the CLI
 ANDs, so "either label" cannot be one query; the scan runs one list per label and
 `select-candidate.mjs` merges them, recording which query matched. A ticket with
-both is worked as `ai-fixable` — the stricter profile. `ai-buildable` adds one
+both is worked as `ai-fixable` — the narrow-fix profile. (Deliberate consequence:
+the diff gate below is keyed to the `ai-buildable` trigger, so a both-labelled
+ticket is not diff-gated; its schema edits reach human review like any bug
+fix's.) `ai-buildable` adds one
 gate: **schema and migration edits are rejected by diff**, not by prompt.
 Rationale — preview deploys run `next build` only, never `prisma migrate deploy`,
 so a schema change cannot reach a preview database and the feature would appear

--- a/docs/agents/ai-bug-fixer.md
+++ b/docs/agents/ai-bug-fixer.md
@@ -1,46 +1,79 @@
 # AI Bug Fixer
 
-An autonomous worker that fixes bugs you explicitly hand it. When a `type = BUG`
-ticket is marked `ai-fixable` and is `READY_TO_PLAN`, a scheduled GitHub Action
-picks it up, writes a narrow fix, validates it, and opens a **pull request for
-human review**. It never merges and never deploys.
+An autonomous worker that does work you explicitly hand it. When a ticket carries
+a **trigger label** and is `READY_TO_PLAN`, a scheduled GitHub Action picks it up,
+writes the change, validates it, and opens a **pull request for human review**. It
+never merges and never deploys.
 
 Design rationale: [ADR-0029](../adr/0029-ai-bug-fixer-workflow.md). Close-out (PR
 merge → ticket `DONE`) is handled by the existing webhook in
 [ADR-0021](../adr/0021-pr-merge-promotes-ticket-via-app-webhook.md).
 
-## How a bug becomes eligible
+## The two profiles
+
+| | `ai-fixable` | `ai-buildable` |
+| --- | --- | --- |
+| For | bugs | features |
+| Brief framing | smallest change that fixes it | build what the ticket describes |
+| Validation | `tsc` + `next lint` | `tsc` + `next lint`, **plus no schema/migration edits** |
+| Commit prefix | `fix:` | `feat:` |
+
+Both profiles share everything else: the same scan, claim, agent, PR and release
+logic. The label is the gate, not the ticket type — `type` only steers the brief's
+wording.
+
+The schema ban on `ai-buildable` is mechanical (a `git status` check), not an
+instruction the model can ignore. It exists because preview deploys run
+`next build` only, never `prisma migrate deploy`, so a schema change can never
+reach a preview database — the feature would look broken for reasons unrelated
+to the agent's work. A bug fix that legitimately needs a migration is still
+allowed under `ai-fixable`, and still goes through human review.
+
+## How a ticket becomes eligible
 
 A ticket is attempted only when **all** of these hold:
 
 | Condition | Why |
 | --- | --- |
-| `type = BUG` | only bugs, not features/chores |
 | `status = READY_TO_PLAN` | the documented "ready for an AFK agent" state |
-| has the **`ai-fixable`** label | explicit human opt-in |
+| has **`ai-fixable`** or **`ai-buildable`** | explicit opt-in |
 | **not** labelled `security` | safety: humans handle security |
 | `priority` is not `0` (critical) | safety: humans handle critical |
 
-To hand a bug to the worker: write a clear reproduction in the ticket body, then
+To hand work to the worker: write a clear ticket body, then
 
 ```bash
-exponential tickets update --id <ticket-cuid> --status READY_TO_PLAN --add-label ai-fixable
+exponential tickets update --id <ticket-cuid> --status READY_TO_PLAN --add-label ai-buildable
 ```
 
-The worker picks the **oldest** eligible ticket each run (FIFO).
+The worker picks the **oldest** eligible ticket each run (FIFO). A ticket carrying
+both labels is worked as `ai-fixable` — the stricter profile.
+
+> `--label` on the CLI ANDs, so "either label" cannot be one query. The scan runs
+> one list per label and `select-candidate.mjs` merges them, remembering which
+> query produced each ticket.
 
 ## What the worker does
 
-1. **Scan** (cheap, CLI only): list eligible bugs, subtract `security`, drop
-   `priority 0`, respect the open-PR cap, pick the oldest.
+1. **Scan** (cheap, CLI only): one list per trigger label, merge, subtract
+   `security`, drop `priority 0`, respect the open-PR cap, pick the oldest.
 2. **Claim:** move the ticket to `IN_PROGRESS`, add `ai-in-progress`, comment.
-3. **Brief + fix:** render the ticket into `.ai-bug-fixer/prompt.md` and run
-   `claude-code-action` against it on a new `ai/bug-<n>-<slug>` branch.
-4. **Validate:** `npx tsc --noEmit` + `npx next lint` (same checks as CI).
-5. **Open PR** (labelled `ai-bug-fixer`), set the ticket to `QA`, link `prUrl` +
+3. **Brief + build:** render the ticket into `.ai-bug-fixer/prompt.md` and run
+   the Claude Code CLI against it on a new `ai/ticket-<n>-<slug>` branch. The
+   agent is allow-listed to `Read,Write,Edit,Glob,Grep` — **no Bash**, so it
+   cannot run git, and cannot shell out with an API key in its environment.
+4. **Guard** (`ai-buildable` only): fail if `prisma/schema.prisma` or
+   `prisma/migrations` changed.
+5. **Validate:** `npx tsc --noEmit` + `npx next lint` (same checks as CI).
+6. **Open PR** (labelled `ai-bug-fixer`), set the ticket to `QA`, link `prUrl` +
    `branchName`, remove `ai-in-progress`, comment with the PR link. **Never merges.**
-6. If the fix fails, is empty, or the agent flags it as needing a human, the
-   ticket is **released back to `READY_TO_PLAN`** with an explanatory comment.
+7. If the work fails, is empty, trips the guard, or the agent flags it as needing
+   a human, the ticket is **released back to `READY_TO_PLAN`** with an
+   explanatory comment.
+
+The agent's output is written to a file, not the log — this repo is public and
+Actions logs are world-readable. On failure the last 30 lines are surfaced so a
+broken worker cannot fail silently; `debug_output` prints everything.
 
 A human reviews and merges the PR. On merge, the ADR-0021 webhook flips the ticket
 `QA → DONE`.
@@ -52,18 +85,43 @@ A human reviews and merges the PR. On merge, the ADR-0021 webhook flips the tick
 | Secret | Required | Purpose |
 | --- | --- | --- |
 | `EXPONENTIAL_TOKEN` | yes | Bot JWT for the CLI. Get it with `exponential auth show --token`. Prefer a dedicated service-account user over a personal token. |
-| `CLAUDE_CODE_OAUTH_TOKEN` | yes | Claude Pro/Max subscription token for the coding agent (flat fee). Alternatively switch the action to `anthropic_api_key`. |
+| `AI_BUILDER_API_KEY` | yes | The LLM key. An OpenRouter key by default; an Anthropic key if you clear `AI_BUILDER_BASE_URL`. Checked in the cheap scan job so a missing key fails **before** a ticket is claimed. |
 | `AI_BUG_FIXER_GH_TOKEN` | optional | A PAT used to push the branch and open the PR. Set this so the PR **triggers CI** — PRs opened by the default `GITHUB_TOKEN` do not. Falls back to `GITHUB_TOKEN`. |
+
+`CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` are **no longer used** by this
+workflow. The agent is the Claude Code CLI called directly against a configurable
+endpoint; it reads `AI_BUILDER_API_KEY` only, and blanks `ANTHROPIC_API_KEY` in
+its environment so a leftover Anthropic key cannot silently bill the wrong
+account.
 
 ### Repository variables (`gh variable set …`)
 
 | Variable | Required | Default | Purpose |
 | --- | --- | --- | --- |
 | `EXPONENTIAL_API_URL` | yes | — | e.g. `https://www.exponential.im` |
-| `EXPONENTIAL_PRODUCT` | yes | — | Product slug or CUID whose bug backlog to scan |
+| `EXPONENTIAL_PRODUCT` | yes | — | Product slug or CUID whose backlog to scan |
 | `EXPONENTIAL_WORKSPACE` | yes | — | Workspace slug or CUID (e.g. `syntrofi`). Required — the CLI resolves `--label` slugs against the workspace, so label filtering fails without it even with a CUID product. |
-| `AI_BUG_FIXER_MODEL` | no | `claude-haiku-4-5` | Coding-agent model |
-| `AI_BUG_FIXER_MAX_OPEN_PRS` | no | `3` | Skip new fixes while this many AI PRs are open |
+| `AI_BUILDER_MODEL` | no | `z-ai/glm-5.2` | Coding-agent model, as the endpoint names it |
+| `AI_BUILDER_BASE_URL` | no | `https://openrouter.ai/api` | Anthropic-compatible endpoint. Note `/api`, **not** `/api/v1` — the SDK appends its own path. Set to empty to talk to Anthropic directly (then `AI_BUILDER_MODEL` must be an Anthropic model id). |
+| `AI_BUILDER_MAX_USD` | no | `2` | Hard per-run spend ceiling passed to `--max-budget-usd` |
+| `AI_BUG_FIXER_MAX_OPEN_PRS` | no | `3` | Skip new work while this many AI PRs are open |
+
+The old `AI_BUG_FIXER_MODEL` variable is deliberately **not** read any more: it
+named an Anthropic model, and a stale value left in repo settings would be sent
+to OpenRouter, which does not know it. Delete it if it is set.
+
+### Using a different provider
+
+Any endpoint that speaks the Anthropic Messages protocol works. OpenRouter's
+covers OpenAI and Anthropic models too, so "which provider" is usually just a
+different `AI_BUILDER_MODEL` string rather than a different endpoint.
+
+### Using this in another repo
+
+Copy `.github/workflows/ai-bug-fixer.yml` plus `scripts/ai-bug-fixer/` into the
+target repo and set the secrets and variables above. **No credential is stored in
+Exponential** — each repo holds its own LLM key in its own GitHub secrets, and the
+app never sees it.
 
 ### Running it
 
@@ -73,16 +131,23 @@ A human reviews and merges the PR. On merge, the ADR-0021 webhook flips the tick
 
 ## Cost controls
 
-The biggest levers, all already wired in: the opt-in `ai-fixable` tag (nothing is
-touched unless tagged), **one ticket per run**, the **open-PR cap**, an **hourly**
-cadence, a **cheap default model**, a `--max-turns 30` ceiling, and the
-**subscription token** (flat fee rather than metered). Candidate scanning is
-free — agent tokens are only spent once a real ticket is claimed.
+The biggest levers, all wired in: the opt-in labels (nothing is touched unless
+tagged), **one ticket per run**, the **open-PR cap**, an **hourly** cadence, a
+**cheap default model**, a `--max-turns 30` ceiling, and a hard
+`--max-budget-usd` ceiling per run. Candidate scanning is free — tokens are only
+spent once a real ticket is claimed.
+
+**Billing is now metered, not flat.** ADR-0029 originally leaned on a Claude
+subscription token (flat fee). Moving to OpenRouter trades that for per-token
+billing, which is why `--max-budget-usd` was added. At GLM 5.2's rates
+(~$0.63/M input, ~$1.97/M output) a run costs cents, but it is no longer free.
 
 ## Safety guarantees
 
 - Never auto-merges, never auto-deploys — only opens PRs.
 - Never attempts `security`-labelled or `priority 0` (critical) tickets.
+- The agent has **no Bash tool** — it edits files and nothing else.
+- `ai-buildable` cannot change the database schema (enforced by diff, not prompt).
 - The brief instructs a **narrow** fix and tells the agent to bail (writing
   `.ai-bug-fixer/needs-human.txt`) if the fix would be broad or risky.
 - A failed/empty/bailed attempt releases the ticket back to `READY_TO_PLAN`

--- a/docs/agents/ai-bug-fixer.md
+++ b/docs/agents/ai-bug-fixer.md
@@ -120,7 +120,7 @@ silently bill the wrong account.
 | `EXPONENTIAL_WORKSPACE` | yes | — | Workspace slug or CUID (e.g. `syntrofi`). Required — the CLI resolves `--label` slugs against the workspace, so label filtering fails without it even with a CUID product. |
 | `AI_BUILDER_MODEL` | no | `z-ai/glm-5.2` | Coding-agent model, as the endpoint names it |
 | `AI_BUILDER_BASE_URL` | no | `https://openrouter.ai/api` | Anthropic-compatible endpoint. Note `/api`, **not** `/api/v1` — the SDK appends its own path. Set to `https://api.anthropic.com` to talk to Anthropic directly (then `AI_BUILDER_MODEL` must be an Anthropic model id, and the workflow switches the auth header to `x-api-key` automatically); clearing the var just restores the OpenRouter default. |
-| `AI_BUILDER_MAX_USD` | no | `2` | Hard per-run spend ceiling passed to `--max-budget-usd` |
+| `AI_BUILDER_MAX_USD` | no | `2` | Per-run spend ceiling passed to `--max-budget-usd`. Binds only if the CLI can price the model (see *Cost controls*) |
 | `AI_BUG_FIXER_MAX_OPEN_PRS` | no | `3` | Skip new work while this many AI PRs are open |
 
 The old `AI_BUG_FIXER_MODEL` variable is deliberately **not** read any more: it
@@ -150,14 +150,22 @@ app never sees it.
 
 The biggest levers, all wired in: the opt-in labels (nothing is touched unless
 tagged), **one ticket per run**, the **open-PR cap**, an **hourly** cadence, a
-**cheap default model**, a `--max-turns 30` ceiling, and a hard
-`--max-budget-usd` ceiling per run. Candidate scanning is free — tokens are only
-spent once a real ticket is claimed.
+**cheap default model**, a `--max-turns 30` ceiling, and a `--max-budget-usd`
+ceiling per run. Candidate scanning is free — tokens are only spent once a real
+ticket is claimed.
 
 **Billing is now metered, not flat.** ADR-0029 originally leaned on a Claude
 subscription token (flat fee). Moving to OpenRouter trades that for per-token
 billing, which is why `--max-budget-usd` was added. At GLM 5.2's rates
 (~$0.63/M input, ~$1.97/M output) a run costs cents, but it is no longer free.
+
+**Caveat: `--max-budget-usd` binds only if the CLI can price the model.** Claude
+Code computes spend from an internal per-model pricing table; a proxy-served id
+it does not know (like `z-ai/glm-5.2` through OpenRouter) may report `$0.00`
+total cost, in which case the ceiling never triggers and `--max-turns` is the
+only real per-run bound. Until a run has confirmed a non-zero `total_cost_usd`
+for your model, treat the flag as best-effort and **set a key-level spend limit
+on the OpenRouter key** — that one is enforced by the provider regardless.
 
 ## Safety guarantees
 

--- a/docs/agents/ai-bug-fixer.md
+++ b/docs/agents/ai-bug-fixer.md
@@ -42,6 +42,7 @@ A ticket is attempted only when **all** of these hold:
 | `status = READY_TO_PLAN` | the documented "ready for an AFK agent" state |
 | has **`ai-fixable`** or **`ai-buildable`** | explicit opt-in |
 | **not** labelled `security` | safety: humans handle security |
+| **not** labelled `ai-attempted` | retry bound: a prior run already failed on it (see below) |
 | `priority` is not `0` (critical) | safety: humans handle critical |
 
 To hand work to the worker: write a clear ticket body, then
@@ -81,7 +82,12 @@ not run for a both-labelled ticket.
    `branchName`, remove `ai-in-progress`, comment with the PR link. **Never merges.**
 7. If the work fails, is empty, trips the guard, or the agent flags it as needing
    a human, the ticket is **released back to `READY_TO_PLAN`** with an
-   explanatory comment.
+   explanatory comment — and labelled **`ai-attempted`**, which the scan
+   excludes. Without that bound, a deterministically-failing ticket (say, a
+   feature that genuinely needs a migration) would be retried every hour
+   forever at per-token cost, and — selection being oldest-first — starve every
+   newer ticket behind it. **To re-arm a ticket** after fixing whatever made it
+   fail: `exponential tickets update --id <cuid> --remove-label ai-attempted`.
 
 The agent's output is written to a file, not the log — this repo is public and
 Actions logs are world-readable. If the agent process itself fails, the last 30
@@ -122,6 +128,14 @@ silently bill the wrong account.
 | `AI_BUILDER_BASE_URL` | no | `https://openrouter.ai/api` | Anthropic-compatible endpoint. Note `/api`, **not** `/api/v1` — the SDK appends its own path. Set to `https://api.anthropic.com` to talk to Anthropic directly (then `AI_BUILDER_MODEL` must be an Anthropic model id, and the workflow switches the auth header to `x-api-key` automatically); clearing the var just restores the OpenRouter default. |
 | `AI_BUILDER_MAX_USD` | no | `2` | Per-run spend ceiling passed to `--max-budget-usd`. Binds only if the CLI can price the model (see *Cost controls*) |
 | `AI_BUG_FIXER_MAX_OPEN_PRS` | no | `3` | Skip new work while this many AI PRs are open |
+
+### Labels (must exist in the workspace)
+
+The CLI **errors on an unknown label slug**, and the scan deliberately does not
+swallow CLI errors — so every label the workflow queries or applies must exist
+in the workspace before the workflow runs: `ai-fixable`, `ai-buildable`,
+`security`, `ai-in-progress`, and `ai-attempted`. Create any missing one with
+`exponential labels create --workspace <ws> --name <slug>`.
 
 The old `AI_BUG_FIXER_MODEL` variable is deliberately **not** read any more: it
 named an Anthropic model, and a stale value left in repo settings would be sent

--- a/docs/agents/ai-bug-fixer.md
+++ b/docs/agents/ai-bug-fixer.md
@@ -14,13 +14,16 @@ merge → ticket `DONE`) is handled by the existing webhook in
 | | `ai-fixable` | `ai-buildable` |
 | --- | --- | --- |
 | For | bugs | features |
-| Brief framing | smallest change that fixes it | build what the ticket describes |
 | Validation | `tsc` + `next lint` | `tsc` + `next lint`, **plus no schema/migration edits** |
 | Commit prefix | `fix:` | `feat:` |
 
 Both profiles share everything else: the same scan, claim, agent, PR and release
-logic. The label is the gate, not the ticket type — `type` only steers the brief's
-wording.
+logic. The label is the gate. The **brief's framing follows the ticket's `type`
+field, not the label** (`scripts/ai-bug-fixer/render-prompt.mjs`): a BUG-type
+ticket is told "smallest change that fixes it", anything else "build what the
+ticket describes". So a FEATURE-type ticket labelled `ai-fixable` gets the build
+framing but the `fix:` prefix and **no schema guard** — label tickets to match
+their type.
 
 The schema ban on `ai-buildable` is mechanical (a `git status` check), not an
 instruction the model can ignore. It exists because preview deploys run
@@ -47,7 +50,9 @@ exponential tickets update --id <ticket-cuid> --status READY_TO_PLAN --add-label
 ```
 
 The worker picks the **oldest** eligible ticket each run (FIFO). A ticket carrying
-both labels is worked as `ai-fixable` — the stricter profile.
+both labels is worked as `ai-fixable`, the narrow-fix profile — note that the
+schema/migration diff guard is keyed to the `ai-buildable` trigger, so it does
+not run for a both-labelled ticket.
 
 > `--label` on the CLI ANDs, so "either label" cannot be one query. The scan runs
 > one list per label and `select-candidate.mjs` merges them, remembering which
@@ -60,8 +65,10 @@ both labels is worked as `ai-fixable` — the stricter profile.
 2. **Claim:** move the ticket to `IN_PROGRESS`, add `ai-in-progress`, comment.
 3. **Brief + build:** render the ticket into `.ai-bug-fixer/prompt.md` and run
    the Claude Code CLI against it on a new `ai/ticket-<n>-<slug>` branch. The
-   agent is allow-listed to `Read,Write,Edit,Glob,Grep` — **no Bash**, so it
-   cannot run git, and cannot shell out with an API key in its environment.
+   agent is allow-listed to `Read,Write,Edit,Glob,Grep` with **Bash explicitly
+   denied** — the deny overrides the `Bash(...)` allow rules that the repo's
+   checked-in `.claude/settings.json` would otherwise merge in, so the agent
+   cannot run git or shell out with an API key in its environment.
 4. **Guard** (`ai-buildable` only): fail if `prisma/schema.prisma` or
    `prisma/migrations` changed.
 5. **Validate:** `npx tsc --noEmit` + `npx next lint` (same checks as CI).
@@ -72,8 +79,10 @@ both labels is worked as `ai-fixable` — the stricter profile.
    explanatory comment.
 
 The agent's output is written to a file, not the log — this repo is public and
-Actions logs are world-readable. On failure the last 30 lines are surfaced so a
-broken worker cannot fail silently; `debug_output` prints everything.
+Actions logs are world-readable. If the agent process itself fails, the last 30
+lines are surfaced **and the run goes red** — a broken worker cannot fail
+silently or green; `debug_output` prints everything. (An honest non-result —
+bail, empty diff, tripped guard, failed validation — stays green.)
 
 A human reviews and merges the PR. On merge, the ADR-0021 webhook flips the ticket
 `QA → DONE`.
@@ -85,7 +94,7 @@ A human reviews and merges the PR. On merge, the ADR-0021 webhook flips the tick
 | Secret | Required | Purpose |
 | --- | --- | --- |
 | `EXPONENTIAL_TOKEN` | yes | Bot JWT for the CLI. Get it with `exponential auth show --token`. Prefer a dedicated service-account user over a personal token. |
-| `AI_BUILDER_API_KEY` | yes | The LLM key. An OpenRouter key by default; an Anthropic key if you clear `AI_BUILDER_BASE_URL`. Checked in the cheap scan job so a missing key fails **before** a ticket is claimed. |
+| `AI_BUILDER_API_KEY` | yes | The LLM key. An OpenRouter key by default; an Anthropic key if you point `AI_BUILDER_BASE_URL` at Anthropic. Checked in the cheap scan job so a missing key fails **before** a ticket is claimed. |
 | `AI_BUG_FIXER_GH_TOKEN` | optional | A PAT used to push the branch and open the PR. Set this so the PR **triggers CI** — PRs opened by the default `GITHUB_TOKEN` do not. Falls back to `GITHUB_TOKEN`. |
 
 `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` are **no longer used** by this
@@ -102,7 +111,7 @@ account.
 | `EXPONENTIAL_PRODUCT` | yes | — | Product slug or CUID whose backlog to scan |
 | `EXPONENTIAL_WORKSPACE` | yes | — | Workspace slug or CUID (e.g. `syntrofi`). Required — the CLI resolves `--label` slugs against the workspace, so label filtering fails without it even with a CUID product. |
 | `AI_BUILDER_MODEL` | no | `z-ai/glm-5.2` | Coding-agent model, as the endpoint names it |
-| `AI_BUILDER_BASE_URL` | no | `https://openrouter.ai/api` | Anthropic-compatible endpoint. Note `/api`, **not** `/api/v1` — the SDK appends its own path. Set to empty to talk to Anthropic directly (then `AI_BUILDER_MODEL` must be an Anthropic model id). |
+| `AI_BUILDER_BASE_URL` | no | `https://openrouter.ai/api` | Anthropic-compatible endpoint. Note `/api`, **not** `/api/v1` — the SDK appends its own path. Set to `https://api.anthropic.com` to talk to Anthropic directly (then `AI_BUILDER_MODEL` must be an Anthropic model id); clearing the var just restores the OpenRouter default. |
 | `AI_BUILDER_MAX_USD` | no | `2` | Hard per-run spend ceiling passed to `--max-budget-usd` |
 | `AI_BUG_FIXER_MAX_OPEN_PRS` | no | `3` | Skip new work while this many AI PRs are open |
 
@@ -146,7 +155,9 @@ billing, which is why `--max-budget-usd` was added. At GLM 5.2's rates
 
 - Never auto-merges, never auto-deploys — only opens PRs.
 - Never attempts `security`-labelled or `priority 0` (critical) tickets.
-- The agent has **no Bash tool** — it edits files and nothing else.
+- The agent has **Bash explicitly denied** (a deny rule beats every allow
+  source, including the repo's checked-in settings) — it edits files and
+  nothing else.
 - `ai-buildable` cannot change the database schema (enforced by diff, not prompt).
 - The brief instructs a **narrow** fix and tells the agent to bail (writing
   `.ai-bug-fixer/needs-human.txt`) if the fix would be broad or risky.

--- a/docs/agents/ai-bug-fixer.md
+++ b/docs/agents/ai-bug-fixer.md
@@ -102,11 +102,14 @@ A human reviews and merges the PR. On merge, the ADR-0021 webhook flips the tick
 | `AI_BUILDER_API_KEY` | yes | The LLM key. An OpenRouter key by default; an Anthropic key if you point `AI_BUILDER_BASE_URL` at Anthropic. Checked in the cheap scan job so a missing key fails **before** a ticket is claimed. |
 | `AI_BUG_FIXER_GH_TOKEN` | optional | A PAT used to push the branch and open the PR. Set this so the PR **triggers CI** — PRs opened by the default `GITHUB_TOKEN` do not. Falls back to `GITHUB_TOKEN`. |
 
-`CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` are **no longer used** by this
-workflow. The agent is the Claude Code CLI called directly against a configurable
-endpoint; it reads `AI_BUILDER_API_KEY` only, and blanks `ANTHROPIC_API_KEY` in
-its environment so a leftover Anthropic key cannot silently bill the wrong
-account.
+`CLAUDE_CODE_OAUTH_TOKEN` and any `ANTHROPIC_API_KEY` repo secret are **no
+longer used** by this workflow. The agent is the Claude Code CLI called directly
+against a configurable endpoint; the only credential it sees is
+`AI_BUILDER_API_KEY`, exported under whichever variable matches the target's
+auth header — `ANTHROPIC_API_KEY` (`x-api-key`) when the base URL is
+`https://api.anthropic.com`, `ANTHROPIC_AUTH_TOKEN` (`Authorization: Bearer`)
+for every other endpoint. The unused one is blanked so a leftover key cannot
+silently bill the wrong account.
 
 ### Repository variables (`gh variable set …`)
 
@@ -116,7 +119,7 @@ account.
 | `EXPONENTIAL_PRODUCT` | yes | — | Product slug or CUID whose backlog to scan |
 | `EXPONENTIAL_WORKSPACE` | yes | — | Workspace slug or CUID (e.g. `syntrofi`). Required — the CLI resolves `--label` slugs against the workspace, so label filtering fails without it even with a CUID product. |
 | `AI_BUILDER_MODEL` | no | `z-ai/glm-5.2` | Coding-agent model, as the endpoint names it |
-| `AI_BUILDER_BASE_URL` | no | `https://openrouter.ai/api` | Anthropic-compatible endpoint. Note `/api`, **not** `/api/v1` — the SDK appends its own path. Set to `https://api.anthropic.com` to talk to Anthropic directly (then `AI_BUILDER_MODEL` must be an Anthropic model id); clearing the var just restores the OpenRouter default. |
+| `AI_BUILDER_BASE_URL` | no | `https://openrouter.ai/api` | Anthropic-compatible endpoint. Note `/api`, **not** `/api/v1` — the SDK appends its own path. Set to `https://api.anthropic.com` to talk to Anthropic directly (then `AI_BUILDER_MODEL` must be an Anthropic model id, and the workflow switches the auth header to `x-api-key` automatically); clearing the var just restores the OpenRouter default. |
 | `AI_BUILDER_MAX_USD` | no | `2` | Hard per-run spend ceiling passed to `--max-budget-usd` |
 | `AI_BUG_FIXER_MAX_OPEN_PRS` | no | `3` | Skip new work while this many AI PRs are open |
 

--- a/docs/agents/ai-bug-fixer.md
+++ b/docs/agents/ai-bug-fixer.md
@@ -15,6 +15,7 @@ merge → ticket `DONE`) is handled by the existing webhook in
 | --- | --- | --- |
 | For | bugs | features |
 | Validation | `tsc` + `next lint` | `tsc` + `next lint`, **plus no schema/migration edits** |
+| Forbidden paths | `.github/`, `.husky/` | `.github/`, `.husky/`, `prisma/schema.prisma`, `prisma/migrations` |
 | Commit prefix | `fix:` | `feat:` |
 
 Both profiles share everything else: the same scan, claim, agent, PR and release
@@ -69,7 +70,11 @@ not run for a both-labelled ticket.
    denied** — the deny overrides the `Bash(...)` allow rules that the repo's
    checked-in `.claude/settings.json` would otherwise merge in, so the agent
    cannot run git or shell out with an API key in its environment.
-4. **Guard** (`ai-buildable` only): fail if `prisma/schema.prisma` or
+4. **Guard:** for **both** profiles, fail if anything under `.github/` or
+   `.husky/` changed — those are the worker's own control plane, and an
+   agent-authored workflow file would be *executed* by `pull_request` CI (with
+   repo secrets) the moment the branch is pushed, before any human review.
+   Additionally (`ai-buildable` only): fail if `prisma/schema.prisma` or
    `prisma/migrations` changed.
 5. **Validate:** `npx tsc --noEmit` + `npx next lint` (same checks as CI).
 6. **Open PR** (labelled `ai-bug-fixer`), set the ticket to `QA`, link `prUrl` +
@@ -158,6 +163,9 @@ billing, which is why `--max-budget-usd` was added. At GLM 5.2's rates
 - The agent has **Bash explicitly denied** (a deny rule beats every allow
   source, including the repo's checked-in settings) — it edits files and
   nothing else.
+- Neither profile can touch `.github/` or `.husky/` (enforced by diff): CI and
+  hook files are executed by later steps and by `pull_request` workflows, so
+  agent-authored code there would run with secrets before human review.
 - `ai-buildable` cannot change the database schema (enforced by diff, not prompt).
 - The brief instructs a **narrow** fix and tells the agent to bail (writing
   `.ai-bug-fixer/needs-human.txt`) if the fix would be broad or risky.

--- a/docs/agents/ai-bug-fixer.md
+++ b/docs/agents/ai-bug-fixer.md
@@ -20,11 +20,14 @@ merge → ticket `DONE`) is handled by the existing webhook in
 
 Both profiles share everything else: the same scan, claim, agent, PR and release
 logic. The label is the gate. The **brief's framing follows the ticket's `type`
-field, not the label** (`scripts/ai-bug-fixer/render-prompt.mjs`): a BUG-type
-ticket is told "smallest change that fixes it", anything else "build what the
-ticket describes". So a FEATURE-type ticket labelled `ai-fixable` gets the build
-framing but the `fix:` prefix and **no schema guard** — label tickets to match
-their type.
+field** (`scripts/ai-bug-fixer/render-prompt.mjs`): a BUG-type ticket is told
+"smallest change that fixes it", anything else "build what the ticket
+describes". The brief's **hard rules follow the trigger label**: an
+`ai-buildable` ticket's brief states the schema/migration ban explicitly
+(whatever the ticket's type), telling the agent to bail rather than trip the
+guard. A FEATURE-type ticket labelled `ai-fixable` still gets the build framing
+but the `fix:` prefix and **no schema guard** — label tickets to match their
+type.
 
 The schema ban on `ai-buildable` is mechanical (a `git status` check), not an
 instruction the model can ignore. It exists because preview deploys run

--- a/scripts/ai-bug-fixer/render-prompt.mjs
+++ b/scripts/ai-bug-fixer/render-prompt.mjs
@@ -8,7 +8,15 @@
  * in the workflow ("read this file and fix it") and put all the ticket context
  * here, so the YAML stays clean and the brief is auditable in the run logs.
  *
- * Usage: node render-prompt.mjs --ticket ticket.json --out .ai-bug-fixer/prompt.md
+ * Usage: node render-prompt.mjs --ticket ticket.json --out .ai-bug-fixer/prompt.md \
+ *          [--label ai-buildable]
+ *
+ * FRAMING follows the ticket's `type` (BUG → narrow fix, else build-the-ticket);
+ * HARD RULES follow the trigger label (`--label`), because the workflow keys its
+ * mechanical gates to the label: `ai-buildable` bans schema/migration edits by
+ * diff, so the brief must say so no matter what type the ticket is — a BUG-type
+ * ticket labelled `ai-buildable` would otherwise never be told to bail, trip
+ * the guard, and fail the attempt.
  *
  * `buildBrief` is exported and pure so the framing logic can be tested without
  * a filesystem or a live ticket — see render-prompt.test.ts. The CLI wrapper at
@@ -24,9 +32,11 @@ function arg(name, fallback) {
 
 /**
  * @param {Record<string, any>} ticket  parsed `exponential tickets get --json`
+ * @param {string} [triggerLabel]  the trigger label that selected this ticket
+ *   (`ai-fixable` / `ai-buildable`); absent keeps the label-agnostic brief
  * @returns {string} the Markdown brief the coding agent reads
  */
-export function buildBrief(ticket) {
+export function buildBrief(ticket, triggerLabel = "") {
 const comments = Array.isArray(ticket.comments) ? ticket.comments : [];
 const commentBlock = comments.length
   ? comments
@@ -95,7 +105,15 @@ ${actionBlock}
 5. If the ticket body is empty or too vague to act on, do **not** guess — STOP
    and write \`.ai-bug-fixer/needs-human.txt\` saying what you'd need to know.
 6. Do **not** run git, commit, push, or open a PR — the workflow handles that.
-   Just edit the working tree.
+   Just edit the working tree.${
+    triggerLabel === "ai-buildable"
+      ? `
+7. This task may **NOT** touch \`prisma/schema.prisma\` or \`prisma/migrations\`
+   — the workflow rejects such changes mechanically, whatever this brief says.
+   If the ticket cannot be done without a schema change, **STOP** and write
+   \`.ai-bug-fixer/needs-human.txt\` explaining that, making no code changes.`
+      : ""
+  }
 
 When done, the workflow runs \`npx tsc --noEmit\` and \`npx next lint\`; your change
 must pass both.
@@ -108,7 +126,7 @@ must pass both.
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
   const ticket = JSON.parse(readFileSync(arg("ticket"), "utf8"));
   const out = arg("out", ".ai-bug-fixer/prompt.md");
-  const brief = buildBrief(ticket);
+  const brief = buildBrief(ticket, arg("label", ""));
   mkdirSync(dirname(out), { recursive: true });
   writeFileSync(out, brief);
   console.log(`[ai-bug-fixer] wrote prompt for #${ticket.number ?? "?"} → ${out} (${brief.length} chars)`);

--- a/scripts/ai-bug-fixer/render-prompt.test.ts
+++ b/scripts/ai-bug-fixer/render-prompt.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { buildBrief } from "./render-prompt.mjs";
+
+const bugTicket = {
+  id: "c1",
+  number: 12,
+  title: "Fix the thing",
+  type: "BUG",
+  body: "It breaks.",
+};
+
+const featureTicket = {
+  id: "c2",
+  number: 13,
+  title: "Build the thing",
+  type: "FEATURE",
+  body: "Please build it.",
+};
+
+describe("buildBrief framing (keyed on ticket type)", () => {
+  it("gives BUG tickets the narrow-fix framing", () => {
+    const brief = buildBrief(bugTicket);
+    expect(brief).toContain("Bug fix task");
+    expect(brief).toContain("smallest change");
+  });
+
+  it("gives non-BUG tickets the build-the-ticket framing", () => {
+    const brief = buildBrief(featureTicket);
+    expect(brief).toContain("Implementation task");
+    expect(brief).toContain("Implement **only** what this ticket describes");
+  });
+
+  it("defaults missing type to BUG", () => {
+    const brief = buildBrief({ ...bugTicket, type: undefined });
+    expect(brief).toContain("Bug fix task");
+  });
+});
+
+describe("buildBrief hard rules (keyed on trigger label)", () => {
+  it("omits the schema ban when no label is given (existing behavior)", () => {
+    expect(buildBrief(featureTicket)).not.toContain("prisma/schema.prisma");
+    expect(buildBrief(featureTicket, "ai-fixable")).not.toContain(
+      "prisma/schema.prisma",
+    );
+  });
+
+  it("states the schema ban for ai-buildable, whatever the ticket type", () => {
+    // The guard is keyed to the label, not the type — a BUG-type ticket
+    // labelled ai-buildable must still be told to bail on schema changes.
+    for (const ticket of [bugTicket, featureTicket]) {
+      const brief = buildBrief(ticket, "ai-buildable");
+      expect(brief).toContain("prisma/schema.prisma");
+      expect(brief).toContain("needs-human.txt");
+    }
+  });
+});

--- a/scripts/ai-bug-fixer/select-candidate.mjs
+++ b/scripts/ai-bug-fixer/select-candidate.mjs
@@ -30,8 +30,9 @@
  *
  * Writes the chosen ticket to `chosen.json` (cwd) and, when running under GitHub
  * Actions, emits `found`, `ticket_id`, `ticket_number`, `ticket_title`,
- * `branch_slug`, `trigger_label` to $GITHUB_OUTPUT. Exit code is always 0 —
- * "nothing to do" is a normal outcome, not a failure.
+ * `branch_slug`, `trigger_label` to $GITHUB_OUTPUT. "Nothing to do" is a
+ * normal outcome (exit 0); mispaired --candidates/--candidate-label flags are
+ * an invocation bug and exit 1.
  */
 import { readFileSync, writeFileSync, appendFileSync } from "node:fs";
 
@@ -77,6 +78,16 @@ function slugify(title) {
 // is worked as `ai-fixable`, the stricter (narrow-fix) profile.
 const candidateFiles = args("candidates");
 const candidateLabels = args("candidate-label");
+// The two repeatable flags pair by index; a mismatch would stamp tickets with
+// an empty triggerLabel, which downstream reads as "no profile" and would skip
+// profile-specific gates (e.g. the ai-buildable schema/migration guard). That
+// is an invocation bug, not "nothing to do" — fail the scan loudly.
+if (candidateFiles.length !== candidateLabels.length) {
+  console.error(
+    `[ai-bug-fixer] --candidates (${candidateFiles.length}) and --candidate-label (${candidateLabels.length}) must be paired 1:1`,
+  );
+  process.exit(1);
+}
 /** @type {Map<string, any>} */
 const byId = new Map();
 candidateFiles.forEach((file, i) => {

--- a/scripts/ai-bug-fixer/select-candidate.mjs
+++ b/scripts/ai-bug-fixer/select-candidate.mjs
@@ -9,7 +9,10 @@
  * Eligibility (server-side filters are applied by the CLI before this runs):
  *   - status = READY_TO_PLAN and one of the trigger labels (the candidates sets)
  * Exclusions (applied here — the safety gate):
- *   - any ticket also carrying the `security` label  (the exclude set)
+ *   - any ticket in an exclude set: `security`-labelled, or `ai-attempted`
+ *     (a prior run failed on it — retrying hourly at per-token cost would burn
+ *     budget forever AND, because selection is oldest-first, starve every
+ *     newer ticket behind it; a human re-arms by removing the label)
  *   - any ticket with priority 0 (critical)
  *   - if the number of already-open AI PRs is at/above the cap, select nothing
  *
@@ -28,7 +31,8 @@
  *   node select-candidate.mjs \
  *     --candidates fixable.json  --candidate-label ai-fixable \
  *     --candidates buildable.json --candidate-label ai-buildable \
- *     --exclude sec.json [--open-prs 1] [--max-open-prs 3] [--only-ticket <id>]
+ *     --exclude sec.json --exclude attempted.json \
+ *     [--open-prs 1] [--max-open-prs 3] [--only-ticket <id>]
  *
  * Writes the chosen ticket to `chosen.json` (cwd) and, when running under GitHub
  * Actions, emits `found`, `ticket_id`, `ticket_number`, `ticket_title`,
@@ -104,7 +108,9 @@ candidateFiles.forEach((file, i) => {
   }
 });
 const candidates = [...byId.values()];
-const excludeIds = new Set(readTickets(arg("exclude")).map((t) => t.id));
+// `--exclude` is repeatable like `--candidates`: one file per exclusion query
+// (security-labelled, ai-attempted). Union of every file's ids.
+const excludeIds = new Set(args("exclude").flatMap((f) => readTickets(f).map((t) => t.id)));
 const onlyTicket = arg("only-ticket"); // manual workflow_dispatch override
 const openPrs = parseInt(arg("open-prs", "0"), 10) || 0;
 const maxOpenPrs = parseInt(arg("max-open-prs", "3"), 10) || 0;
@@ -115,7 +121,7 @@ function pickReason() {
   }
 
   let pool = candidates.filter((t) => {
-    if (excludeIds.has(t.id)) return false; // `security`-labelled
+    if (excludeIds.has(t.id)) return false; // `security`-labelled or `ai-attempted`
     if (t.priority === 0) return false; // critical
     return true;
   });
@@ -130,7 +136,7 @@ function pickReason() {
   if (pool.length === 0) {
     return {
       chosen: null,
-      reason: `no eligible tickets (${candidateLabels.join("/") || "no labels queried"} + READY_TO_PLAN, minus security/critical)`,
+      reason: `no eligible tickets (${candidateLabels.join("/") || "no labels queried"} + READY_TO_PLAN, minus security/ai-attempted/critical)`,
     };
   }
 

--- a/scripts/ai-bug-fixer/select-candidate.mjs
+++ b/scripts/ai-bug-fixer/select-candidate.mjs
@@ -20,7 +20,9 @@
  * and passes each file here. `--candidates` is therefore REPEATABLE, and each
  * one is paired with the `--candidate-label` of the same index so the chosen
  * ticket can report which profile it matched. A ticket carrying both labels is
- * deduped to its first (bug-fix) match, which is the stricter profile.
+ * deduped to its first (bug-fix) match — the narrow-fix profile. Note the
+ * schema/migration diff guard is keyed to the `ai-buildable` trigger, so it
+ * does not run for a both-labelled ticket.
  *
  * Usage:
  *   node select-candidate.mjs \
@@ -75,7 +77,7 @@ function slugify(title) {
 
 // Merge every --candidates file, stamping each ticket with the label whose
 // query produced it. First match wins on dedupe: a ticket carrying BOTH labels
-// is worked as `ai-fixable`, the stricter (narrow-fix) profile.
+// is worked as `ai-fixable`, the narrow-fix profile.
 const candidateFiles = args("candidates");
 const candidateLabels = args("candidate-label");
 // The two repeatable flags pair by index; a mismatch would stamp tickets with
@@ -88,7 +90,13 @@ if (candidateFiles.length !== candidateLabels.length) {
   );
   process.exit(1);
 }
-/** @type {Map<string, any>} */
+/**
+ * A ticket row from `exponential tickets list --json`, stamped with the trigger
+ * label whose query produced it.
+ * @typedef {{id: string, number?: number, title?: string, priority?: number,
+ *            createdAt: string, triggerLabel: string}} Candidate
+ */
+/** @type {Map<string, Candidate>} */
 const byId = new Map();
 candidateFiles.forEach((file, i) => {
   for (const t of readTickets(file)) {

--- a/scripts/ai-bug-fixer/select-candidate.mjs
+++ b/scripts/ai-bug-fixer/select-candidate.mjs
@@ -7,22 +7,31 @@
  * calls, decides which single bug (if any) the worker should attempt this run.
  *
  * Eligibility (server-side filters are applied by the CLI before this runs):
- *   - type = BUG, status = READY_TO_PLAN, label = `ai-fixable`  (the candidates set)
+ *   - status = READY_TO_PLAN and one of the trigger labels (the candidates sets)
  * Exclusions (applied here — the safety gate):
  *   - any ticket also carrying the `security` label  (the exclude set)
  *   - any ticket with priority 0 (critical)
  *   - if the number of already-open AI PRs is at/above the cap, select nothing
  *
- * Among survivors, picks the OLDEST by createdAt (FIFO — oldest bug waiting longest).
+ * Among survivors, picks the OLDEST by createdAt (FIFO — oldest waiting longest).
+ *
+ * TWO trigger labels, not one. `--label` on the CLI is AND-only, so "ai-fixable
+ * OR ai-buildable" cannot be one query — the workflow runs one list per label
+ * and passes each file here. `--candidates` is therefore REPEATABLE, and each
+ * one is paired with the `--candidate-label` of the same index so the chosen
+ * ticket can report which profile it matched. A ticket carrying both labels is
+ * deduped to its first (bug-fix) match, which is the stricter profile.
  *
  * Usage:
- *   node select-candidate.mjs --candidates cand.json --exclude sec.json \
- *     [--open-prs 1] [--max-open-prs 3] [--only-ticket <id>]
+ *   node select-candidate.mjs \
+ *     --candidates fixable.json  --candidate-label ai-fixable \
+ *     --candidates buildable.json --candidate-label ai-buildable \
+ *     --exclude sec.json [--open-prs 1] [--max-open-prs 3] [--only-ticket <id>]
  *
  * Writes the chosen ticket to `chosen.json` (cwd) and, when running under GitHub
  * Actions, emits `found`, `ticket_id`, `ticket_number`, `ticket_title`,
- * `branch_slug` to $GITHUB_OUTPUT. Exit code is always 0 — "nothing to do" is a
- * normal outcome, not a failure.
+ * `branch_slug`, `trigger_label` to $GITHUB_OUTPUT. Exit code is always 0 —
+ * "nothing to do" is a normal outcome, not a failure.
  */
 import { readFileSync, writeFileSync, appendFileSync } from "node:fs";
 
@@ -30,6 +39,16 @@ import { readFileSync, writeFileSync, appendFileSync } from "node:fs";
 function arg(name, fallback) {
   const i = process.argv.indexOf(`--${name}`);
   return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+/** All values of a repeatable flag, in the order given. @param {string} name */
+function args(name) {
+  /** @type {string[]} */
+  const out = [];
+  process.argv.forEach((a, i) => {
+    if (a === `--${name}` && process.argv[i + 1]) out.push(process.argv[i + 1]);
+  });
+  return out;
 }
 
 /** Tolerate both `[...]` and `{ tickets: [...] }` shapes from the CLI. */
@@ -53,7 +72,19 @@ function slugify(title) {
     .slice(0, 40) || "fix";
 }
 
-const candidates = readTickets(arg("candidates"));
+// Merge every --candidates file, stamping each ticket with the label whose
+// query produced it. First match wins on dedupe: a ticket carrying BOTH labels
+// is worked as `ai-fixable`, the stricter (narrow-fix) profile.
+const candidateFiles = args("candidates");
+const candidateLabels = args("candidate-label");
+/** @type {Map<string, any>} */
+const byId = new Map();
+candidateFiles.forEach((file, i) => {
+  for (const t of readTickets(file)) {
+    if (!byId.has(t.id)) byId.set(t.id, { ...t, triggerLabel: candidateLabels[i] ?? "" });
+  }
+});
+const candidates = [...byId.values()];
 const excludeIds = new Set(readTickets(arg("exclude")).map((t) => t.id));
 const onlyTicket = arg("only-ticket"); // manual workflow_dispatch override
 const openPrs = parseInt(arg("open-prs", "0"), 10) || 0;
@@ -78,7 +109,10 @@ function pickReason() {
   }
 
   if (pool.length === 0) {
-    return { chosen: null, reason: "no eligible bugs (ai-fixable + READY_TO_PLAN, minus security/critical)" };
+    return {
+      chosen: null,
+      reason: `no eligible tickets (${candidateLabels.join("/") || "no labels queried"} + READY_TO_PLAN, minus security/critical)`,
+    };
   }
 
   pool.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
@@ -100,4 +134,7 @@ setOutput("ticket_id", chosen.id);
 setOutput("ticket_number", String(chosen.number ?? ""));
 setOutput("ticket_title", String(chosen.title ?? "").replace(/\n/g, " "));
 setOutput("branch_slug", slugify(chosen.title));
-console.log(`[ai-bug-fixer] chosen: #${chosen.number ?? "?"} ${chosen.title} (${chosen.id})`);
+setOutput("trigger_label", String(chosen.triggerLabel ?? ""));
+console.log(
+  `[ai-bug-fixer] chosen: #${chosen.number ?? "?"} ${chosen.title} (${chosen.id}) via ${chosen.triggerLabel || "?"}`,
+);


### PR DESCRIPTION
Swaps the autonomous ticket worker onto OpenRouter (default `z-ai/glm-5.2`) and adds a second trigger label for features. **No app code, no schema change, no stored credentials.**

Amends [ADR-0029](docs/adr/0029-ai-bug-fixer-workflow.md) rather than superseding it — the shape of that decision (Actions, CLI-as-interface, PR for human review) is unchanged.

## 1. Claude Code CLI called directly, not `claude-code-action`

The action can't target a third-party endpoint, which the model change requires. It also rewrote `remote.origin.url` to embed its own bot token, which the workflow had to undo before every push. Decisively: its step is `continue-on-error`, so failures surfaced as a **green run that produced no PR** — a total outage went unnoticed for five weeks. A direct call gives a plain exit code.

Drops `id-token: write` and the remote-URL workaround. The agent is allow-listed to `Read,Write,Edit,Glob,Grep` and **Bash is explicitly denied** via `--disallowedTools` (an allow-list alone doesn't restrict — the checked-in `.claude/settings.json` would merge its own `Bash(...)` allow rules in), so an agent holding an API key in a public repo's runner can't shell out. Output goes to a file, never the log, with the tail surfaced on failure.

## 2. OpenRouter, default `z-ai/glm-5.2`, for bugs and features alike

Via OpenRouter's Anthropic-compatible endpoint, so "which provider" collapses to a model string. `AI_BUILDER_BASE_URL` can be set to `https://api.anthropic.com` to talk to Anthropic directly (clearing it just restores the OpenRouter default — Actions `||` can't tell unset from empty).

**Billing is now metered, not a flat subscription fee** — that was listed as a cost control in ADR-0029 and is genuinely gone. `--max-budget-usd` (default $2/run) was added as a hard ceiling to compensate.

`AI_BUG_FIXER_MODEL` is deliberately no longer read: it named an Anthropic model, and a stale value would be sent to an endpoint that doesn't know it.

## 3. `ai-buildable` as a second trigger label

`--label` ANDs, so "either label" can't be one query — the scan runs one list per label and `select-candidate.mjs` merges them, recording which matched. A ticket with both is worked as `ai-fixable` (stricter profile).

`ai-buildable` adds one gate: **schema and migration edits are rejected by diff, not by prompt.** Preview deploys run `next build` only, never `prisma migrate deploy`, so a schema change can't reach a preview database — the feature would look broken for reasons unrelated to the agent.

## Required before merge

```bash
gh secret set AI_BUILDER_API_KEY -R positonic/exponential   # OpenRouter key
```

The `ai-buildable` label has already been created in `syntrofi`. This was load-bearing: the CLI errors on an unknown label slug and the scan doesn't swallow errors, so merging without it would fail the job hourly.

Optional cleanup — nothing reads these any more:
```bash
gh secret delete CLAUDE_CODE_OAUTH_TOKEN -R positonic/exponential
```

## Testing

- `select-candidate.mjs` exercised over merge, both-labels dedupe, security exclusion, and PR cap
- Workflow YAML parsed; step order and job outputs confirmed
- `--max-turns` verified still valid despite being undocumented in 2.1.186 (unknown flags are rejected instantly; this one isn't). `--max-budget-usd` confirmed present.

**Not yet verified:** that GLM 5.2 actually drives Claude Code's tool loop end to end — no OpenRouter key was available. That's a 30-second check once the secret is set, and only the model default depends on it; the runner change stands either way.

