### PR TITLE
fix: V2: Slack webhook fails closed

### DIFF
--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -11,6 +11,7 @@ interface CoreMessage {
 import { auth } from "~/server/auth";
 import { generateAgentJWT } from "~/server/utils/jwt";
 import { db } from "~/server/db";
+import { getDecryptedKey } from "~/server/utils/credentialHelper";
 import { sanitizeAIOutput } from "~/lib/sanitize-output";
 import { getAiInteractionLogger } from "~/server/services/AiInteractionLogger";
 import {
@@ -47,14 +48,15 @@ async function resolveSlackChannelId(
   try {
     const credential = await db.integrationCredential.findFirst({
       where: { integrationId, keyType: "BOT_TOKEN" },
-      select: { key: true },
+      select: { key: true, isEncrypted: true },
     });
-    if (!credential?.key) return null;
+    const botToken = credential ? getDecryptedKey(credential) : null;
+    if (!botToken) return null;
 
     const nameWithoutHash = channelName.replace(/^#/, "");
     const response = await fetch(
       "https://slack.com/api/conversations.list?types=public_channel,private_channel&exclude_archived=true&limit=1000",
-      { headers: { Authorization: `Bearer ${credential.key}` } }
+      { headers: { Authorization: `Bearer ${botToken}` } }
     );
     const data = await response.json() as { ok: boolean; channels?: Array<{ id: string; name: string }> };
     if (!data.ok || !data.channels) return null;

--- a/src/app/api/webhooks/slack/__tests__/route.test.ts
+++ b/src/app/api/webhooks/slack/__tests__/route.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for the Slack webhook's credential decryption and signature
+ * verification (2026-07-30 integration-secrets audit, V2).
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHmac } from "crypto";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  // Raw 32-byte key (encryption.ts accepts raw or base64-encoded 32 bytes).
+  process.env.DATABASE_ENCRYPTION_KEY = "0".repeat(32);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import type { NextRequest } from "next/server";
+import { POST } from "../route";
+import { encryptToBase64 } from "~/server/utils/encryption";
+
+const SIGNING_SECRET = "test-signing-secret";
+const TEAM_ID = "T0TESTTEAM";
+
+/**
+ * A payload the router doesn't recognize as event/command/interactive, so a
+ * verified request short-circuits to the "Received but not processed" fallback
+ * without touching any handler (handlers would need far deeper DB mocks).
+ */
+const NEUTRAL_BODY = JSON.stringify({ type: "unit_test_probe", team_id: TEAM_ID });
+
+function slackSignature(body: string, timestamp: string, secret: string): string {
+  return `v0=${createHmac("sha256", secret).update(`v0:${timestamp}:${body}`, "utf8").digest("hex")}`;
+}
+
+function makeRequest(opts: { body?: string; timestamp?: string | null; signature?: string | null }) {
+  const body = opts.body ?? NEUTRAL_BODY;
+  const headers = new Headers({ "content-type": "application/json" });
+  if (opts.timestamp) headers.set("x-slack-request-timestamp", opts.timestamp);
+  if (opts.signature) headers.set("x-slack-signature", opts.signature);
+  return new Request("http://localhost/api/webhooks/slack", {
+    method: "POST",
+    headers,
+    body,
+  }) as unknown as NextRequest;
+}
+
+function integrationRow(secretRow: { key: string; isEncrypted: boolean }) {
+  return {
+    id: "int-1",
+    provider: "slack",
+    status: "ACTIVE",
+    user: { id: "user-1" },
+    team: null,
+    credentials: [
+      { id: "cred-1", keyType: "SIGNING_SECRET", key: secretRow.key, isEncrypted: secretRow.isEncrypted },
+      { id: "cred-2", keyType: "BOT_TOKEN", key: "xoxb-not-used-here", isEncrypted: false },
+    ],
+  };
+}
+
+describe("Slack webhook signature verification", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+  });
+
+  function stubIntegration(secretRow: { key: string; isEncrypted: boolean }) {
+    db.integration.findFirst.mockResolvedValue(
+      integrationRow(secretRow) as unknown as Awaited<ReturnType<PrismaClient["integration"]["findFirst"]>>,
+    );
+  }
+
+  it("accepts a correctly signed request when the secret is stored encrypted", async () => {
+    stubIntegration({ key: encryptToBase64(SIGNING_SECRET), isEncrypted: true });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const res = await POST(
+      makeRequest({ timestamp, signature: slackSignature(NEUTRAL_BODY, timestamp, SIGNING_SECRET) }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true });
+  });
+
+  it("accepts a correctly signed request when the secret is stored plaintext", async () => {
+    stubIntegration({ key: SIGNING_SECRET, isEncrypted: false });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const res = await POST(
+      makeRequest({ timestamp, signature: slackSignature(NEUTRAL_BODY, timestamp, SIGNING_SECRET) }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true });
+  });
+});

--- a/src/app/api/webhooks/slack/__tests__/route.test.ts
+++ b/src/app/api/webhooks/slack/__tests__/route.test.ts
@@ -145,4 +145,43 @@ describe("Slack webhook signature verification", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ success: true });
   });
+
+  it("rejects an unsigned request with 401", async () => {
+    stubIntegration({ key: SIGNING_SECRET, isEncrypted: false });
+    const res = await POST(makeRequest({ timestamp: null, signature: null }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a request signed under the wrong secret with 401", async () => {
+    stubIntegration({ key: SIGNING_SECRET, isEncrypted: false });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const res = await POST(
+      makeRequest({ timestamp, signature: slackSignature(NEUTRAL_BODY, timestamp, "wrong-secret") }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a signed request when the integration has no signing secret", async () => {
+    db.integration.findFirst.mockResolvedValue({
+      ...integrationRow({ key: SIGNING_SECRET, isEncrypted: false }),
+      credentials: [{ id: "cred-2", keyType: "BOT_TOKEN", key: "xoxb-not-used-here", isEncrypted: false }],
+    } as unknown as Awaited<ReturnType<PrismaClient["integration"]["findFirst"]>>);
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const res = await POST(
+      makeRequest({ timestamp, signature: slackSignature(NEUTRAL_BODY, timestamp, SIGNING_SECRET) }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a request whose secret row is undecryptable ciphertext", async () => {
+    // Valid-looking base64 that is not a real AES-GCM payload under the test
+    // key — getDecryptedKey returns null, the record omits SIGNING_SECRET,
+    // and verification must fail closed.
+    stubIntegration({ key: Buffer.from("garbage-ciphertext-that-wont-decrypt").toString("base64"), isEncrypted: true });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const res = await POST(
+      makeRequest({ timestamp, signature: slackSignature(NEUTRAL_BODY, timestamp, SIGNING_SECRET) }),
+    );
+    expect(res.status).toBe(401);
+  });
 });

--- a/src/app/api/webhooks/slack/route.ts
+++ b/src/app/api/webhooks/slack/route.ts
@@ -6,6 +6,7 @@ import { createCallerFactory } from '~/server/api/trpc';
 import { appRouter } from '~/server/api/root';
 import { parseActionInput } from '~/server/services/parsing';
 import { SlackChannelResolver } from '~/server/services/SlackChannelResolver';
+import { getDecryptedKey } from '~/server/utils/credentialHelper';
 import { PRODUCT_NAME } from '~/lib/brand';
 import { getPublicBaseUrlFromEnv } from '~/lib/urls';
 
@@ -321,8 +322,14 @@ async function findSlackIntegrationByTeam(teamId: string, appId?: string) {
       });
 
       if (integrationWithAppId) {
-        const credentials = integrationWithAppId.credentials.reduce((acc: Record<string, string>, cred: any) => {
-          acc[cred.keyType as string] = cred.key;
+        // Decrypt at the boundary: downstream consumers (signature check, bot
+        // API calls) always see plaintext. An undecryptable credential is
+        // omitted so verification fails closed rather than using ciphertext.
+        const credentials = integrationWithAppId.credentials.reduce((acc: Record<string, string>, cred) => {
+          const value = getDecryptedKey(cred);
+          if (value !== null) {
+            acc[cred.keyType] = value;
+          }
           return acc;
         }, {} as Record<string, string>);
 
@@ -364,8 +371,11 @@ async function findSlackIntegrationByTeam(teamId: string, appId?: string) {
       return null;
     }
 
-    const credentials = integration.credentials.reduce((acc: Record<string, string>, cred: any) => {
-      acc[cred.keyType as string] = cred.key;
+    const credentials = integration.credentials.reduce((acc: Record<string, string>, cred) => {
+      const value = getDecryptedKey(cred);
+      if (value !== null) {
+        acc[cred.keyType] = value;
+      }
       return acc;
     }, {} as Record<string, string>);
 

--- a/src/app/api/webhooks/slack/route.ts
+++ b/src/app/api/webhooks/slack/route.ts
@@ -544,16 +544,30 @@ export async function POST(request: NextRequest) {
     }
     
 
-    // Verify signature if we have signing secret
-    if (timestamp && signature && integrationData.credentials.SIGNING_SECRET) {
-      const isValid = verifySlackSignature(body, timestamp, signature, integrationData.credentials.SIGNING_SECRET);
-      if (!isValid) {
-        console.error('❌ Invalid Slack signature');
-        return NextResponse.json(
-          { error: 'Invalid signature' },
-          { status: 401 }
-        );
-      }
+    // Signature verification is mandatory — fail closed. A missing header or
+    // missing/undecryptable signing secret must never let a payload through
+    // (an unsigned POST with a forged team_id would otherwise be processed as
+    // genuine Slack traffic).
+    if (!integrationData.credentials.SIGNING_SECRET) {
+      console.error('❌ No usable Slack signing secret for team:', teamId);
+      return NextResponse.json(
+        { error: 'Integration misconfigured' },
+        { status: 401 }
+      );
+    }
+    if (!timestamp || !signature) {
+      console.error('❌ Missing Slack signature headers');
+      return NextResponse.json(
+        { error: 'Missing signature' },
+        { status: 401 }
+      );
+    }
+    if (!verifySlackSignature(body, timestamp, signature, integrationData.credentials.SIGNING_SECRET)) {
+      console.error('❌ Invalid Slack signature');
+      return NextResponse.json(
+        { error: 'Invalid signature' },
+        { status: 401 }
+      );
     }
 
 

--- a/src/server/api/routers/integration.ts
+++ b/src/server/api/routers/integration.ts
@@ -2320,15 +2320,16 @@ export const integrationRouter = createTRPCRouter({
       const botTokenCredential = integration.credentials.find(
         (c) => c.keyType === "BOT_TOKEN",
       );
-      if (!botTokenCredential) {
+      const botToken = botTokenCredential ? getDecryptedKey(botTokenCredential) : null;
+      if (!botToken) {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "No bot token found for this Slack integration",
+          message: "No usable bot token found for this Slack integration",
         });
       }
 
       // Test the connection and get latest team info
-      const testResult = await testSlackConnection(botTokenCredential.key);
+      const testResult = await testSlackConnection(botToken);
       if (!testResult.success) {
         throw new TRPCError({
           code: "BAD_REQUEST",

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -14,6 +14,7 @@ import { testFirefliesConnection } from "./integration";
 import { pageRouter } from "./page";
 import { GoogleCalendarService } from "~/server/services/GoogleCalendarService";
 import { decryptBuffer, encryptString, encryptToBase64 } from "~/server/utils/encryption";
+import { getDecryptedKey } from "~/server/utils/credentialHelper";
 import { addDays, startOfDay, endOfDay } from "date-fns";
 import { getCalendarService, getEventsMultiCalendar, checkProviderConnection } from "~/server/services";
 import { userEmailService } from "~/server/services/UserEmailService";
@@ -451,14 +452,15 @@ export const mastraRouter = createTRPCRouter({
           if (!projectSlackChannelId) {
             const credential = await ctx.db.integrationCredential.findFirst({
               where: { integrationId: projectSlackConfig.integrationId, keyType: "BOT_TOKEN" },
-              select: { key: true },
+              select: { key: true, isEncrypted: true },
             });
-            if (credential?.key) {
+            const botToken = credential ? getDecryptedKey(credential) : null;
+            if (botToken) {
               try {
                 const nameWithoutHash = projectSlackConfig.slackChannel.replace(/^#/, "");
                 const slackRes = await fetch(
                   "https://slack.com/api/conversations.list?types=public_channel,private_channel&exclude_archived=true&limit=1000",
-                  { headers: { Authorization: `Bearer ${credential.key}` } }
+                  { headers: { Authorization: `Bearer ${botToken}` } }
                 );
                 const slackData = await slackRes.json() as { ok: boolean; channels?: Array<{ id: string; name: string }> };
                 const match = slackData.ok && slackData.channels?.find((ch) => ch.name === nameWithoutHash);

--- a/src/server/api/routers/slack.ts
+++ b/src/server/api/routers/slack.ts
@@ -220,6 +220,9 @@ export const slackRouter = createTRPCRouter({
         include: {
           credentials: {
             where: { keyType: "BOT_TOKEN" },
+            // Presence check only — SlackNotificationService does its own
+            // decrypted read; never fetch the secret here.
+            select: { id: true },
             take: 1,
           },
         },
@@ -317,6 +320,9 @@ export const slackRouter = createTRPCRouter({
         include: {
           credentials: {
             where: { keyType: "BOT_TOKEN" },
+            // Presence check only — SlackNotificationService does its own
+            // decrypted read; never fetch the secret here.
+            select: { id: true },
             take: 1,
           },
         },

--- a/src/server/services/SlackChannelResolver.ts
+++ b/src/server/services/SlackChannelResolver.ts
@@ -193,9 +193,9 @@ export class SlackChannelResolver {
         status: 'ACTIVE'
       },
       include: {
-        credentials: {
-          where: { keyType: 'BOT_TOKEN' }
-        },
+        // No credentials here on purpose: no caller uses them, results flow to
+        // the client (weeklyReview/slack routers), and secrets must not ride
+        // along. Token consumers decrypt their own scoped read.
         slackChannelConfigs: {
           include: {
             project: true,

--- a/src/server/services/notifications/FeedbackDigestService.ts
+++ b/src/server/services/notifications/FeedbackDigestService.ts
@@ -311,10 +311,13 @@ export class FeedbackDigestService {
               status: "ACTIVE",
             },
             include: {
+              // Presence check only — SlackNotificationService does its own
+              // decrypted read; never fetch the secret here.
               credentials: {
                 where: {
                   keyType: "BOT_TOKEN",
                 },
+                select: { id: true },
                 take: 1,
               },
             },

--- a/src/server/services/notifications/SlackNotificationService.ts
+++ b/src/server/services/notifications/SlackNotificationService.ts
@@ -1,5 +1,6 @@
 import { NotificationService, type NotificationPayload, type NotificationResult, type NotificationConfig } from './NotificationService';
 import { db } from '~/server/db';
+import { getDecryptedKey } from '~/server/utils/credentialHelper';
 
 interface SlackChannel {
   id: string;
@@ -54,7 +55,13 @@ export class SlackNotificationService extends NotificationService {
       return null;
     }
 
-    this.botToken = integration.credentials[0]!.key;
+    const token = getDecryptedKey(integration.credentials[0]!);
+    if (!token) {
+      console.error('[SlackNotificationService] Failed to decrypt bot token for integration', integration.id);
+      return null;
+    }
+
+    this.botToken = token;
     return this.botToken;
   }
 

--- a/src/server/services/notifications/ThreadScoreDigestService.ts
+++ b/src/server/services/notifications/ThreadScoreDigestService.ts
@@ -175,7 +175,9 @@ export class ThreadScoreDigestService {
           integrations: {
             where: { provider: "slack", status: "ACTIVE" },
             include: {
-              credentials: { where: { keyType: "BOT_TOKEN" }, take: 1 },
+              // Presence check only — SlackNotificationService does its own
+              // decrypted read; never fetch the secret here.
+              credentials: { where: { keyType: "BOT_TOKEN" }, select: { id: true }, take: 1 },
             },
           },
         },

--- a/src/server/services/processors/SlackActionProcessor.ts
+++ b/src/server/services/processors/SlackActionProcessor.ts
@@ -193,6 +193,8 @@ export class SlackActionProcessor extends ActionProcessor {
             where: {
               keyType: 'BOT_TOKEN',
             },
+            // Presence check only — never fetch the secret itself here.
+            select: { id: true },
             take: 1,
           },
         },


### PR DESCRIPTION
### **User description**
## What

Makes the Slack webhook fail closed (feature `cms8lpaf60001jl048uxkjsfe`, scope V2, from the 2026-07-30 integration-secrets audit). Previously an unsigned POST with a forged `team_id` skipped signature verification entirely and was processed as genuine Slack traffic.

Ordered as decrypt-first, then fail-closed, so encrypted secrets don't 401 legitimate traffic:

1. **Decrypt at the boundary** — the webhook's `Record<keyType, key>` is now built through `getDecryptedKey` (both lookup paths); an undecryptable credential is omitted so verification fails closed instead of HMACing with ciphertext.
2. **Signature verification mandatory** — missing/undecryptable signing secret, missing `x-slack-signature`/timestamp headers, or a bad signature each return 401 before any handler runs.
3. **Remaining raw Slack bot-token reads decrypted** — `SlackNotificationService.getBotToken` (the funnel for every digest), the chat/stream channel resolver and mastra channel backfill (both also now select `isEncrypted`), and `integration.updateSlackTeamInfo`. Presence-only fetches (SlackActionProcessor, digest admin lookups, slack channel listings) no longer fetch the secret at all, and `SlackChannelResolver.getUserSlackIntegrations` dropped its unused BOT_TOKEN include (its results flow to the client).

Tests: signed requests succeed against encrypted and plaintext secret rows; unsigned, forged-signature, secretless, and undecryptable-ciphertext requests all 401.

## Acceptance criteria

- [x] An unsigned POST to `/api/webhooks/slack` returns 401 and reaches no handler
- [x] A POST with a signature computed under the wrong secret returns 401
- [x] A correctly signed POST still succeeds against an integration whose secret is stored encrypted, and against one stored plaintext
- [x] No `credentials.<KEY>`/`credential.key` is used as a Slack bearer token or HMAC key without passing through `getDecryptedKey`
- [x] `npm run check` passes

---

Ships: dusty.melon

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cms8ls57o000tjl04jghd8ox6)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Slack webhook now fails closed: signature verification is mandatory

- Credential decryption via `getDecryptedKey` applied at all Slack token read boundaries

- Presence-only DB fetches no longer retrieve secret values unnecessarily

- New unit tests cover encrypted/plaintext secrets, unsigned, forged, and undecryptable requests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Incoming POST /api/webhooks/slack"] -- "lookup integration" --> B["findSlackIntegrationByTeam"]
  B -- "getDecryptedKey per credential" --> C["credentials Record (plaintext)"]
  C -- "missing SIGNING_SECRET?" --> D["401 Integration misconfigured"]
  C -- "missing headers?" --> E["401 Missing signature"]
  C -- "bad signature?" --> F["401 Invalid signature"]
  C -- "valid signature" --> G["Event/Command/Interactive Handler"]
  H["SlackNotificationService.getBotToken"] -- "getDecryptedKey" --> I["Decrypted bot token"]
  J["chat/stream route & mastra backfill"] -- "select isEncrypted + getDecryptedKey" --> I
  K["Presence-only fetches"] -- "select id only" --> L["No secret exposed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>route.ts</strong><dd><code>Mandatory signature verification and decrypt-at-boundary for </code><br><code>credentials</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/440/files#diff-0112c377b18661439c25e9e2133560b7c08f68b4631187cfd312ddbda38d5a73">+38/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SlackNotificationService.ts</strong><dd><code>Decrypt bot token via getDecryptedKey in getBotToken</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/440/files#diff-39627f1c73f6a00260d95fa6cb1a35c95d921fed410a77a7a612e8304a185406">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>route.ts</strong><dd><code>Decrypt Slack bot token before Slack API call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/440/files#diff-44aee62d94edbf4662fd83225c2eecc607c675caf170aa4a280ab60ebe45f226">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mastra.ts</strong><dd><code>Decrypt bot token for Slack channel backfill in mastra router</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/440/files#diff-afd76ed5d04839b106766464d541d99c9b1d0e8b28477ea826c7dcf52db960bb">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>integration.ts</strong><dd><code>Decrypt bot token before testSlackConnection in updateSlackTeamInfo</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/440/files#diff-c77c1944f43c90e73f35e8df34be0e27e5c7ef596a4380d6e731f974acb89b3f">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>route.test.ts</strong><dd><code>New unit tests for webhook signature verification scenarios</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/440/files#diff-4e9dfa9b4d0f4cd62c727385398e7101340e955014551ed1375a09ec062c950f">+187/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>slack.ts</strong><dd><code>Restrict credential fetch to presence-only (select id) for BOT_TOKEN</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/440/files#diff-1c634e640761a2eba75834d0ed1770b4b71d3a0edb5fa82e6c6f9dd4f97ae697">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SlackChannelResolver.ts</strong><dd><code>Remove BOT_TOKEN credential include from getUserSlackIntegrations</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/440/files#diff-5ee4df8c675e785a938424805be763d539c7c333a1017a042e5fbecb6768c59a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FeedbackDigestService.ts</strong><dd><code>Restrict credential fetch to presence-only for digest admin lookups</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/440/files#diff-eb9d261776c4669518819341deaf460745a852a334a2112359ad18829b8ace88">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ThreadScoreDigestService.ts</strong><dd><code>Restrict credential fetch to presence-only for thread score digest</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/440/files#diff-04afbf0865fb65ee7e615d65e185a900f4e7040ac75bcd57826bf0823e5b3ff4">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SlackActionProcessor.ts</strong><dd><code>Restrict credential fetch to presence-only in validateConfig</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/440/files#diff-052f47cd9a451bf5498f99319b112095a3c6bb6e6ffa0260538edc105924816d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

