### PR TITLE
fix: V3: Every credential read decrypts

### DIFF
--- a/scripts/fix-slack-oauth-credentials.ts
+++ b/scripts/fix-slack-oauth-credentials.ts
@@ -1,0 +1,107 @@
+/**
+ * Data-fix: repair Slack OAuth credentials mislabelled by the old callback.
+ *
+ * The Slack OAuth callback used to store the bot token in PLAINTEXT while
+ * claiming `isEncrypted: true`, under keyType 'access_token' (which no Slack
+ * consumer reads — they all read 'BOT_TOKEN'). Those rows both poison any
+ * audit that trusts the flag and return null from getDecryptedKey.
+ *
+ * For every credential row on a slack-provider integration with
+ * keyType 'access_token' (any casing):
+ *   - if the flag claims encrypted but the value does not decrypt and looks
+ *     like a raw Slack token (xox…), re-store it properly encrypted;
+ *   - if it is plaintext-labelled, encrypt it too;
+ *   - in all cases relabel keyType to 'BOT_TOKEN'.
+ * Rows that decrypt fine just get the keyType relabel.
+ *
+ * Usage:
+ *   npx tsx scripts/fix-slack-oauth-credentials.ts          # dry-run (default)
+ *   npx tsx scripts/fix-slack-oauth-credentials.ts --apply  # actually update
+ */
+
+import { PrismaClient } from "@prisma/client";
+import {
+  decryptCredential,
+  encryptCredential,
+} from "../src/server/utils/credentialHelper";
+
+const db = new PrismaClient();
+const apply = process.argv.includes("--apply");
+
+async function main() {
+  console.log(`Mode: ${apply ? "APPLY" : "DRY-RUN"}\n`);
+
+  const rows = await db.integrationCredential.findMany({
+    where: {
+      integration: { provider: "slack" },
+      keyType: { in: ["access_token", "ACCESS_TOKEN"] },
+    },
+    select: {
+      id: true,
+      key: true,
+      keyType: true,
+      isEncrypted: true,
+      integrationId: true,
+      integration: { select: { name: true } },
+    },
+  });
+
+  console.log(`Found ${rows.length} slack 'access_token' credential row(s)\n`);
+
+  let fixed = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    const decrypted = decryptCredential(row.key, row.isEncrypted);
+
+    let newKey = row.key;
+    let newIsEncrypted = row.isEncrypted;
+    let reason: string;
+
+    if (decrypted !== null && row.isEncrypted) {
+      // Genuinely encrypted — only the keyType label is wrong.
+      reason = "relabel keyType only (row decrypts fine)";
+    } else if (decrypted !== null && !row.isEncrypted) {
+      // Honest plaintext — encrypt it while we're here.
+      const enc = encryptCredential(decrypted);
+      newKey = enc.key;
+      newIsEncrypted = enc.isEncrypted;
+      reason = "encrypt plaintext row + relabel keyType";
+    } else if (row.key.startsWith("xox")) {
+      // Mislabelled: flag says encrypted but the value is a raw Slack token.
+      const enc = encryptCredential(row.key);
+      newKey = enc.key;
+      newIsEncrypted = enc.isEncrypted;
+      reason = "flag claimed encrypted but value is a raw xox… token — re-encrypt + relabel";
+    } else {
+      console.log(
+        `  SKIP ${row.id} (${row.integration.name}): claims encrypted, does not decrypt, does not look like a raw token — needs manual review`,
+      );
+      skipped++;
+      continue;
+    }
+
+    console.log(`  FIX  ${row.id} (${row.integration.name}): ${reason}`);
+
+    if (apply) {
+      await db.integrationCredential.update({
+        where: { id: row.id },
+        data: { key: newKey, keyType: "BOT_TOKEN", isEncrypted: newIsEncrypted },
+      });
+    }
+    fixed++;
+  }
+
+  console.log(
+    `\n${apply ? "Fixed" : "Would fix"} ${fixed} row(s), ${skipped} need manual review.`,
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    void db.$disconnect();
+  });

--- a/src/app/api/auth/slack/callback/route.ts
+++ b/src/app/api/auth/slack/callback/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { auth } from '~/server/auth';
 import { db } from '~/server/db';
+import { encryptCredential } from '~/server/utils/credentialHelper';
 import { z } from 'zod';
 
 const callbackSchema = z.object({
@@ -89,13 +90,17 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Store access token as encrypted credential
+    // Store the bot token actually encrypted — never claim isEncrypted for a
+    // value we did not encrypt. keyType is BOT_TOKEN because that is what
+    // every Slack consumer (webhook, notification service) reads; the old
+    // 'access_token' label left OAuth-created integrations inert.
+    const encryptedBotToken = encryptCredential(tokenData.access_token);
     await db.integrationCredential.create({
       data: {
         integrationId: integration.id,
-        key: tokenData.access_token,
-        keyType: 'access_token',
-        isEncrypted: true,
+        key: encryptedBotToken.key,
+        keyType: 'BOT_TOKEN',
+        isEncrypted: encryptedBotToken.isEncrypted,
       },
     });
 

--- a/src/app/api/webhooks/fireflies/route.ts
+++ b/src/app/api/webhooks/fireflies/route.ts
@@ -5,6 +5,7 @@ import { db } from '~/server/db';
 import { FirefliesService, type FirefliesTranscript } from '~/server/services/FirefliesService';
 import { getEmbeddingTriggerService } from '~/server/services/embedding';
 import { decryptFromBase64 } from '~/server/utils/encryption';
+import { resolveCredential } from '~/server/utils/credentialHelper';
 import { emitNotification } from '~/server/services/notifications/emit/emitNotification';
 import { NOTIFICATION_CATEGORIES } from '~/server/services/notifications/emit/constants';
 // import { ActionProcessorFactory } from '~/server/services/processors/ActionProcessorFactory';
@@ -308,20 +309,22 @@ async function getFirefliesIntegration(userId: string): Promise<{ apiKey: string
       },
       include: {
         credentials: {
-          where: {
-            keyType: 'API_KEY',
-          },
-          take: 1,
+          select: { key: true, keyType: true, isEncrypted: true },
         },
       },
     });
 
-    if (!integration || integration.credentials.length === 0) {
+    if (!integration) {
+      return null;
+    }
+
+    const apiKey = await resolveCredential(integration.credentials, ['API_KEY']);
+    if (!apiKey) {
       return null;
     }
 
     return {
-      apiKey: integration.credentials[0]!.key,
+      apiKey,
       integrationId: integration.id,
     };
   } catch (error) {

--- a/src/server/api/routers/integration.ts
+++ b/src/server/api/routers/integration.ts
@@ -1988,17 +1988,17 @@ export const integrationRouter = createTRPCRouter({
       }
 
       if (integration.provider === "monday") {
-        const apiKeyCredential = integration.credentials.find(
-          (c) => c.keyType === "API_KEY",
-        );
-        if (!apiKeyCredential) {
+        const mondayApiKey = await resolveCredential(integration.credentials, [
+          "API_KEY",
+        ]);
+        if (!mondayApiKey) {
           throw new TRPCError({
             code: "NOT_FOUND",
-            message: "No API key found for this Monday.com integration",
+            message: "No usable API key found for this Monday.com integration",
           });
         }
 
-        const result = await testMondayConnection(apiKeyCredential.key);
+        const result = await testMondayConnection(mondayApiKey);
         if (!result.success) {
           return {
             success: result.success,
@@ -2008,7 +2008,7 @@ export const integrationRouter = createTRPCRouter({
         }
 
         // Also fetch boards with columns for Monday.com
-        const mondayService = new MondayService(apiKeyCredential.key);
+        const mondayService = new MondayService(mondayApiKey);
         let boardsWithColumns: Array<any> = [];
         try {
           boardsWithColumns = await mondayService.getBoardsWithColumns();

--- a/src/server/api/routers/integration.ts
+++ b/src/server/api/routers/integration.ts
@@ -8,7 +8,7 @@ import {
 import { TRPCError } from "@trpc/server";
 import { MondayService } from "~/server/services/MondayService";
 import { WhatsAppVerificationService } from "~/server/services/whatsapp/VerificationService";
-import { encryptCredential, getDecryptedKey } from "~/server/utils/credentialHelper";
+import { encryptCredential, getDecryptedKey, resolveCredential } from "~/server/utils/credentialHelper";
 import {
   testZulipConnection,
   fetchZulipUsers,
@@ -472,25 +472,14 @@ export const integrationRouter = createTRPCRouter({
         });
       }
 
-      const tokenCredential = integration.credentials.find(
-        (c) =>
-          c.keyType === "access_token" ||
-          c.keyType === "ACCESS_TOKEN" ||
-          c.keyType === "API_KEY",
-      );
-
-      if (!tokenCredential) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "No access token found for this Notion integration",
-        });
-      }
-
-      const accessToken = getDecryptedKey(tokenCredential);
+      const accessToken = await resolveCredential(integration.credentials, [
+        "access_token",
+        "api_key",
+      ]);
       if (!accessToken) {
         throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Failed to decrypt Notion access token",
+          code: "NOT_FOUND",
+          message: "No usable access token found for this Notion integration",
         });
       }
 
@@ -535,25 +524,14 @@ export const integrationRouter = createTRPCRouter({
         });
       }
 
-      const tokenCredential = integration.credentials.find(
-        (c) =>
-          c.keyType === "access_token" ||
-          c.keyType === "ACCESS_TOKEN" ||
-          c.keyType === "API_KEY",
-      );
-
-      if (!tokenCredential) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "No access token found for this Notion integration",
-        });
-      }
-
-      const accessToken = getDecryptedKey(tokenCredential);
+      const accessToken = await resolveCredential(integration.credentials, [
+        "access_token",
+        "api_key",
+      ]);
       if (!accessToken) {
         throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Failed to decrypt Notion access token",
+          code: "NOT_FOUND",
+          message: "No usable access token found for this Notion integration",
         });
       }
 
@@ -1976,21 +1954,16 @@ export const integrationRouter = createTRPCRouter({
       }
 
       if (integration.provider === "notion") {
-        const accessTokenCredential = integration.credentials.find(
-          (c) => c.keyType === "ACCESS_TOKEN" || c.keyType === "API_KEY",
+        // Case-insensitive aliases: the OAuth flow writes lowercase
+        // "access_token" while manual setup writes "ACCESS_TOKEN"/"API_KEY".
+        const notionAccessToken = await resolveCredential(
+          integration.credentials,
+          ["access_token", "api_key"],
         );
-        if (!accessTokenCredential) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "No access token found for this Notion integration",
-          });
-        }
-
-        const notionAccessToken = getDecryptedKey(accessTokenCredential);
         if (!notionAccessToken) {
           throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Failed to decrypt Notion access token",
+            code: "NOT_FOUND",
+            message: "No usable access token found for this Notion integration",
           });
         }
 
@@ -2004,9 +1977,7 @@ export const integrationRouter = createTRPCRouter({
         }
 
         // Also fetch databases for Notion
-        const databasesResult = await fetchNotionDatabases(
-          accessTokenCredential.key,
-        );
+        const databasesResult = await fetchNotionDatabases(notionAccessToken);
         return {
           success: result.success,
           error: result.error,
@@ -2106,14 +2077,15 @@ export const integrationRouter = createTRPCRouter({
       }
 
       // Get access token
-      const accessTokenCredential = integration.credentials.find(
-        (c) => c.keyType === "access_token" || c.keyType === "ACCESS_TOKEN",
+      const notionAccessToken = await resolveCredential(
+        integration.credentials,
+        ["access_token", "api_key"],
       );
 
-      if (!accessTokenCredential) {
+      if (!notionAccessToken) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: "No access token found for this Notion integration",
+          message: "No usable access token found for this Notion integration",
         });
       }
 
@@ -2124,7 +2096,7 @@ export const integrationRouter = createTRPCRouter({
           {
             method: "POST",
             headers: {
-              Authorization: `Bearer ${accessTokenCredential.key}`,
+              Authorization: `Bearer ${notionAccessToken}`,
               "Notion-Version": "2022-06-28",
               "Content-Type": "application/json",
             },

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -14,6 +14,7 @@ import { testFirefliesConnection } from "./integration";
 import { pageRouter } from "./page";
 import { GoogleCalendarService } from "~/server/services/GoogleCalendarService";
 import { decryptBuffer, encryptString, encryptToBase64 } from "~/server/utils/encryption";
+import { encryptCredential } from "~/server/utils/credentialHelper";
 import { addDays, startOfDay, endOfDay } from "date-fns";
 import { getCalendarService, getEventsMultiCalendar, checkProviderConnection } from "~/server/services";
 import { userEmailService } from "~/server/services/UserEmailService";
@@ -1896,12 +1897,13 @@ export const mastraRouter = createTRPCRouter({
         },
       });
 
-      // Create the credential
+      // Create the credential (encrypted at rest)
+      const encryptedApiKey = encryptCredential(input.apiKey);
       await ctx.db.integrationCredential.create({
         data: {
-          key: input.apiKey,
+          key: encryptedApiKey.key,
           keyType: 'API_KEY',
-          isEncrypted: false, // TODO: implement encryption
+          isEncrypted: encryptedApiKey.isEncrypted,
           integrationId: integration.id,
         },
       });
@@ -1967,12 +1969,13 @@ export const mastraRouter = createTRPCRouter({
         where: { integrationId: integration.id },
       });
 
-      // Create new API key credential
+      // Create new API key credential (encrypted at rest)
+      const rotatedApiKey = encryptCredential(input.apiKey);
       await ctx.db.integrationCredential.create({
         data: {
-          key: input.apiKey,
+          key: rotatedApiKey.key,
           keyType: 'API_KEY',
-          isEncrypted: false,
+          isEncrypted: rotatedApiKey.isEncrypted,
           integrationId: integration.id,
         },
       });

--- a/src/server/api/routers/whatsapp.ts
+++ b/src/server/api/routers/whatsapp.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { resolveCredential } from "~/server/utils/credentialHelper";
 import { TRPCError } from "@trpc/server";
 import { WhatsAppNotificationService } from "~/server/services/whatsapp/WhatsAppNotificationService";
 import { db } from "~/server/db";
@@ -92,8 +93,8 @@ export const whatsappRouter = createTRPCRouter({
       }
 
       // Get credentials
-      const accessToken = integration.credentials.find((c: any) => c.keyType === 'ACCESS_TOKEN')?.key;
-      const phoneNumberId = integration.credentials.find((c: any) => c.keyType === 'PHONE_NUMBER_ID')?.key;
+      const accessToken = await resolveCredential(integration.credentials, ['ACCESS_TOKEN']);
+      const phoneNumberId = await resolveCredential(integration.credentials, ['PHONE_NUMBER_ID']);
 
       if (!accessToken || !phoneNumberId) {
         throw new TRPCError({
@@ -195,8 +196,8 @@ export const whatsappRouter = createTRPCRouter({
       }
 
       // Get credentials
-      const accessToken = integration.credentials.find((c: any) => c.keyType === 'ACCESS_TOKEN')?.key;
-      const phoneNumberId = integration.credentials.find((c: any) => c.keyType === 'PHONE_NUMBER_ID')?.key;
+      const accessToken = await resolveCredential(integration.credentials, ['ACCESS_TOKEN']);
+      const phoneNumberId = await resolveCredential(integration.credentials, ['PHONE_NUMBER_ID']);
 
       if (!accessToken || !phoneNumberId) {
         throw new TRPCError({
@@ -393,7 +394,7 @@ export const whatsappRouter = createTRPCRouter({
       });
 
       // Submit template to WhatsApp for approval
-      const accessToken = integration.credentials.find(c => c.keyType === 'ACCESS_TOKEN')?.key;
+      const accessToken = await resolveCredential(integration.credentials, ['ACCESS_TOKEN']);
       const businessAccountId = integration.whatsappConfig.businessAccountId;
 
       if (accessToken && businessAccountId) {
@@ -563,8 +564,10 @@ export const whatsappRouter = createTRPCRouter({
 
       // If template has WhatsApp ID, delete from WhatsApp
       if (template.whatsappTemplateId) {
-        const accessToken = template.whatsappConfig.integration.credentials
-          .find(c => c.keyType === 'ACCESS_TOKEN')?.key;
+        const accessToken = await resolveCredential(
+          template.whatsappConfig.integration.credentials,
+          ['ACCESS_TOKEN'],
+        );
         
         if (accessToken) {
           try {

--- a/src/server/services/github-integration.ts
+++ b/src/server/services/github-integration.ts
@@ -6,7 +6,7 @@ import type {
   Prisma,
   Workflow,
 } from "@prisma/client";
-import { encryptCredential } from "~/server/utils/credentialHelper";
+import { encryptCredential, resolveCredential } from "~/server/utils/credentialHelper";
 import {
   GITHUB_INSTALLATION_PROVIDER,
   GITHUB_INSTALLATION_TYPE,
@@ -70,15 +70,15 @@ class GitHubIntegrationService {
   private async getAccessToken(
     integration: GitHubIntegration,
   ): Promise<string> {
-    const tokenCredential = integration.credentials.find(
-      (cred) => cred.keyType === "access_token",
-    );
+    const accessToken = await resolveCredential(integration.credentials, [
+      "access_token",
+    ]);
 
-    if (!tokenCredential) {
-      throw new Error("GitHub access token not found");
+    if (!accessToken) {
+      throw new Error("GitHub access token not found or undecryptable");
     }
 
-    return tokenCredential.key;
+    return accessToken;
   }
 
   private async makeGitHubRequest(

--- a/src/server/services/monday-sync.ts
+++ b/src/server/services/monday-sync.ts
@@ -1,5 +1,6 @@
 import { db } from '~/server/db';
 import { MondayService } from './MondayService';
+import { resolveCredential } from '~/server/utils/credentialHelper';
 import type { Workflow, Action } from '@prisma/client';
 
 interface MondayTodo {
@@ -54,12 +55,14 @@ export class MondaySyncService {
       throw new Error('Integration not found');
     }
 
-    const apiKeyCredential = integration.credentials.find(c => c.keyType === 'api_key');
-    if (!apiKeyCredential) {
-      throw new Error('Monday.com API key not found');
+    // Case-insensitive: the write path stores "API_KEY" (projectWorkflow.ts)
+    // while this lookup historically searched 'api_key' and never matched.
+    const apiKey = await resolveCredential(integration.credentials, ['API_KEY']);
+    if (!apiKey) {
+      throw new Error('Monday.com API key not found or undecryptable');
     }
 
-    const mondayService = new MondayService(apiKeyCredential.key);
+    const mondayService = new MondayService(apiKey);
     const todos: MondayTodo[] = [];
 
     // Get items from all configured boards

--- a/src/server/services/notifications/WhatsAppNotificationService.ts
+++ b/src/server/services/notifications/WhatsAppNotificationService.ts
@@ -1,4 +1,5 @@
 import { NotificationService, type NotificationPayload, type NotificationResult, type NotificationConfig } from './NotificationService';
+import { resolveCredential } from '~/server/utils/credentialHelper';
 import { db } from '~/server/db';
 
 
@@ -84,9 +85,9 @@ export class WhatsAppNotificationService extends NotificationService {
     }
 
     // Get credentials from the integration
-    const accessTokenCred = integration.credentials.find(c => c.keyType === 'ACCESS_TOKEN');
+    const accessToken = await resolveCredential(integration.credentials, ['ACCESS_TOKEN']);
 
-    if (!accessTokenCred) {
+    if (!accessToken) {
       return null;
     }
 
@@ -95,7 +96,7 @@ export class WhatsAppNotificationService extends NotificationService {
       return null;
     }
 
-    this.accessToken = accessTokenCred.key;
+    this.accessToken = accessToken;
     this.phoneNumberId = integration.whatsappConfig.phoneNumberId;
     this.businessAccountId = integration.whatsappConfig.businessAccountId;
 
@@ -474,7 +475,7 @@ export class WhatsAppNotificationService extends NotificationService {
       }
 
       // Get credentials
-      const accessToken = config.integration.credentials.find(c => c.keyType === 'ACCESS_TOKEN')?.key;
+      const accessToken = await resolveCredential(config.integration.credentials, ['ACCESS_TOKEN']);
       if (!accessToken) {
         return {
           success: false,

--- a/src/server/services/notion-integration.ts
+++ b/src/server/services/notion-integration.ts
@@ -1,6 +1,6 @@
 import { db } from '~/server/db';
 import type { Integration, IntegrationCredential } from '@prisma/client';
-import { encryptCredential } from '~/server/utils/credentialHelper';
+import { encryptCredential, resolveCredential } from '~/server/utils/credentialHelper';
 
 interface NotionIntegration extends Integration {
   credentials: IntegrationCredential[];
@@ -26,15 +26,16 @@ interface NotionDatabase {
 
 class NotionIntegrationService {
   private async getAccessToken(integration: NotionIntegration): Promise<string> {
-    const tokenCredential = integration.credentials.find(
-      cred => cred.keyType === 'access_token'
-    );
-    
-    if (!tokenCredential) {
-      throw new Error('Notion access token not found');
+    const accessToken = await resolveCredential(integration.credentials, [
+      'access_token',
+      'api_key',
+    ]);
+
+    if (!accessToken) {
+      throw new Error('Notion access token not found or undecryptable');
     }
 
-    return tokenCredential.key;
+    return accessToken;
   }
 
   private async makeNotionRequest(

--- a/src/server/services/notion-sync.ts
+++ b/src/server/services/notion-sync.ts
@@ -1,6 +1,7 @@
 import { db } from '~/server/db';
 import type { Workflow, Action, ActionStatus } from '@prisma/client';
 import { resolveNotionConfig } from './notion-config-resolver';
+import { resolveCredential } from '~/server/utils/credentialHelper';
 
 interface NotionTodo {
   id: string;
@@ -315,10 +316,13 @@ export class NotionSyncService {
    * Get pages from a specific Notion database
    */
   private async getDatabasePages(integration: any, databaseId: string) {
-    const accessToken = integration.credentials.find((c: any) => c.keyType === 'access_token')?.key;
-    
+    const accessToken = await resolveCredential(
+      (integration.credentials ?? []) as Array<{ key: string; keyType: string; isEncrypted: boolean }>,
+      ['access_token', 'api_key'],
+    );
+
     if (!accessToken) {
-      throw new Error('Notion access token not found');
+      throw new Error('Notion access token not found or undecryptable');
     }
 
     const response = await fetch(`https://api.notion.com/v1/databases/${databaseId}/query`, {
@@ -350,10 +354,13 @@ export class NotionSyncService {
    * Get database information
    */
   private async getDatabaseInfo(integration: any, databaseId: string) {
-    const accessToken = integration.credentials.find((c: any) => c.keyType === 'access_token')?.key;
-    
+    const accessToken = await resolveCredential(
+      (integration.credentials ?? []) as Array<{ key: string; keyType: string; isEncrypted: boolean }>,
+      ['access_token', 'api_key'],
+    );
+
     if (!accessToken) {
-      throw new Error('Notion access token not found');
+      throw new Error('Notion access token not found or undecryptable');
     }
 
     const response = await fetch(`https://api.notion.com/v1/databases/${databaseId}`, {

--- a/src/server/services/processors/MondayActionProcessor.ts
+++ b/src/server/services/processors/MondayActionProcessor.ts
@@ -1,6 +1,7 @@
 import { ActionProcessor, type ParsedActionItem, type ActionProcessorResult, type ActionProcessorConfig } from './ActionProcessor';
 import { MondayService, type CreateItemParams } from '../MondayService';
 import { db } from '~/server/db';
+import { resolveCredential } from '~/server/utils/credentialHelper';
 
 export interface MondayProcessorConfig {
   boardId: string;
@@ -36,18 +37,22 @@ export class MondayActionProcessor extends ActionProcessor {
         where: { id: this.config.integrationId },
         include: {
           credentials: {
-            where: { keyType: 'API_KEY' },
-            take: 1,
+            select: { key: true, keyType: true, isEncrypted: true },
           },
         },
       });
 
-      if (!integration || integration.credentials.length === 0) {
+      if (!integration) {
+        return { valid: false, errors: ['Monday.com integration not found'] };
+      }
+
+      const apiKey = await resolveCredential(integration.credentials, ['API_KEY']);
+      if (!apiKey) {
         return { valid: false, errors: ['Monday.com integration or API key not found'] };
       }
 
       // Initialize Monday service
-      this.mondayService = new MondayService(integration.credentials[0]!.key);
+      this.mondayService = new MondayService(apiKey);
 
       // Test connection
       const connectionTest = await this.mondayService.testConnection();

--- a/src/server/services/whatsapp/WhatsAppNotificationService.ts
+++ b/src/server/services/whatsapp/WhatsAppNotificationService.ts
@@ -1,4 +1,5 @@
 import { db } from "~/server/db";
+import { resolveCredential } from '~/server/utils/credentialHelper';
 
 export class WhatsAppNotificationService {
   private static instance: WhatsAppNotificationService;
@@ -39,9 +40,7 @@ export class WhatsAppNotificationService {
         };
       }
 
-      const accessToken = integration.credentials.find(
-        (c) => c.keyType === 'ACCESS_TOKEN'
-      )?.key;
+      const accessToken = await resolveCredential(integration.credentials, ['ACCESS_TOKEN']);
       const phoneNumberId = integration.whatsappConfig.phoneNumberId;
 
       if (!accessToken || !phoneNumberId) {
@@ -121,9 +120,7 @@ export class WhatsAppNotificationService {
         };
       }
 
-      const accessToken = integration.credentials.find(
-        (c) => c.keyType === 'ACCESS_TOKEN'
-      )?.key;
+      const accessToken = await resolveCredential(integration.credentials, ['ACCESS_TOKEN']);
       const phoneNumberId = integration.whatsappConfig.phoneNumberId;
 
       if (!accessToken || !phoneNumberId) {
@@ -217,9 +214,7 @@ export class WhatsAppNotificationService {
         };
       }
 
-      const accessToken = integration.credentials.find(
-        (c) => c.keyType === 'ACCESS_TOKEN'
-      )?.key;
+      const accessToken = await resolveCredential(integration.credentials, ['ACCESS_TOKEN']);
 
       if (!accessToken) {
         return {

--- a/src/server/utils/__tests__/credentialHelper.test.ts
+++ b/src/server/utils/__tests__/credentialHelper.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the shared credential resolver (2026-07-30 audit, V3).
+ *
+ * `keyType` is a free string with mixed-case spellings in production
+ * (`ACCESS_TOKEN` vs `access_token`), and rows may be stored encrypted or
+ * plaintext — the `isEncrypted` flag decides, never the caller.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.hoisted(() => {
+  // Raw 32-byte key (encryption.ts accepts raw or base64-encoded 32 bytes).
+  process.env.DATABASE_ENCRYPTION_KEY = "0".repeat(32);
+});
+
+const findManyMock = vi.hoisted(() => vi.fn());
+vi.mock("~/server/db", () => ({
+  db: { integrationCredential: { findMany: findManyMock } },
+}));
+
+import {
+  findCredential,
+  resolveCredential,
+} from "~/server/utils/credentialHelper";
+import { encryptToBase64 } from "~/server/utils/encryption";
+
+describe("findCredential", () => {
+  const rows = [
+    { keyType: "notion_metadata", key: "{}", isEncrypted: false },
+    { keyType: "access_token", key: "oauth-token", isEncrypted: false },
+    { keyType: "API_KEY", key: "manual-key", isEncrypted: false },
+  ];
+
+  it("matches keyType case-insensitively", () => {
+    expect(findCredential(rows, ["ACCESS_TOKEN"])?.key).toBe("oauth-token");
+    expect(findCredential(rows, ["api_key"])?.key).toBe("manual-key");
+  });
+
+  it("respects alias priority order", () => {
+    expect(findCredential(rows, ["ACCESS_TOKEN", "API_KEY"])?.key).toBe("oauth-token");
+    expect(findCredential(rows, ["API_KEY", "ACCESS_TOKEN"])?.key).toBe("manual-key");
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(findCredential(rows, ["BOT_TOKEN"])).toBeNull();
+  });
+});
+
+describe("resolveCredential", () => {
+  it("decrypts an encrypted row", async () => {
+    const rows = [
+      { keyType: "ACCESS_TOKEN", key: encryptToBase64("secret-token"), isEncrypted: true },
+    ];
+    await expect(resolveCredential(rows, ["access_token"])).resolves.toBe("secret-token");
+  });
+
+  it("passes through a plaintext row", async () => {
+    const rows = [{ keyType: "access_token", key: "plain-token", isEncrypted: false }];
+    await expect(resolveCredential(rows, ["ACCESS_TOKEN"])).resolves.toBe("plain-token");
+  });
+
+  it("returns null for an undecryptable row instead of returning ciphertext", async () => {
+    const rows = [
+      {
+        keyType: "ACCESS_TOKEN",
+        key: Buffer.from("garbage-that-will-not-decrypt").toString("base64"),
+        isEncrypted: true,
+      },
+    ];
+    await expect(resolveCredential(rows, ["ACCESS_TOKEN"])).resolves.toBeNull();
+  });
+
+  it("returns null when no alias matches", async () => {
+    const rows = [{ keyType: "EMAIL", key: "a@b.c", isEncrypted: false }];
+    await expect(resolveCredential(rows, ["ACCESS_TOKEN"])).resolves.toBeNull();
+  });
+
+  it("fetches rows by integrationId with a scoped select", async () => {
+    findManyMock.mockResolvedValueOnce([
+      { keyType: "access_token", key: "from-db", isEncrypted: false },
+    ]);
+    await expect(resolveCredential("int-1", ["ACCESS_TOKEN"])).resolves.toBe("from-db");
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: { integrationId: "int-1" },
+      select: { key: true, keyType: true, isEncrypted: true },
+    });
+  });
+});

--- a/src/server/utils/credentialHelper.ts
+++ b/src/server/utils/credentialHelper.ts
@@ -55,3 +55,59 @@ export function decryptCredential(key: string, isEncrypted: boolean): string | n
 export function getDecryptedKey(credential: { key: string; isEncrypted: boolean }): string | null {
   return decryptCredential(credential.key, credential.isEncrypted);
 }
+
+export interface CredentialRow {
+  key: string;
+  keyType: string;
+  isEncrypted: boolean;
+}
+
+/**
+ * Find a credential row by keyType, matching aliases case-insensitively.
+ *
+ * `keyType` is a free-form string with both `ACCESS_TOKEN`/`access_token` and
+ * `API_KEY`/`api_key` spellings live in production, so exact-match lookups
+ * silently miss rows written by a differently-cased writer. Aliases are tried
+ * in order — put the canonical spelling first.
+ */
+export function findCredential<T extends { keyType: string }>(
+  credentials: readonly T[],
+  aliases: readonly string[],
+): T | null {
+  for (const alias of aliases) {
+    const lowered = alias.toLowerCase();
+    const match = credentials.find((c) => c.keyType.toLowerCase() === lowered);
+    if (match) return match;
+  }
+  return null;
+}
+
+/**
+ * Resolve a credential to its decrypted value.
+ *
+ * The single supported way to read a secret out of `IntegrationCredential`:
+ * pass either an `integrationId` (scoped select of `key`/`keyType`/
+ * `isEncrypted` — never fetch more) or already-loaded rows, plus the keyType
+ * aliases to match (case-insensitive, in priority order). Returns `null` when
+ * no row matches or the matched row fails to decrypt — callers must treat
+ * `null` as "no usable secret" and fail closed.
+ */
+export async function resolveCredential(
+  source: string | readonly CredentialRow[],
+  aliases: readonly string[],
+): Promise<string | null> {
+  let rows: readonly CredentialRow[];
+  if (typeof source === 'string') {
+    // Imported lazily to keep this module usable in contexts that stub the db.
+    const { db } = await import('~/server/db');
+    rows = await db.integrationCredential.findMany({
+      where: { integrationId: source },
+      select: { key: true, keyType: true, isEncrypted: true },
+    });
+  } else {
+    rows = source;
+  }
+
+  const match = findCredential(rows, aliases);
+  return match ? getDecryptedKey(match) : null;
+}


### PR DESCRIPTION
### **User description**
## What

Every credential read now decrypts (feature `cms8lpaf60001jl048uxkjsfe`, scope V3, from the 2026-07-30 integration-secrets audit). ~15 read paths used `credential.key` raw while their write paths encrypt — Notion, WhatsApp, GitHub, Monday and the Fireflies webhook only worked in production because their secrets were stored plaintext. This is the precondition for V4 making encryption mandatory.

- **New shared resolver** — `resolveCredential(integrationId | rows, aliases)` in `credentialHelper.ts`: scoped select of `key`/`keyType`/`isEncrypted`, case-insensitive alias matching in priority order, decrypted return, `null` (fail closed) on no-match or decrypt failure. This also kills the `keyType` case-mismatch class (`ACCESS_TOKEN` vs `access_token`, `API_KEY` vs `api_key`).
- **Notion** converted end-to-end as the tracer — including the `testConnection` miss where only uppercase spellings matched while OAuth writes lowercase `access_token`, so "Test connection" reported no token for every OAuth-created Notion integration (and passed raw ciphertext to `fetchNotionDatabases`).
- **WhatsApp** — nine raw `ACCESS_TOKEN` reads across the router and both notification services.
- **GitHub + Monday** — including the dead `monday-sync` lookup that searched `'api_key'` while the write path stores `"API_KEY"` (never found a key at all).
- **Fireflies webhook** — raw `credentials[0].key` read.
- **Write-path honesty** — the two mastra.ts plaintext writes (`isEncrypted: false // TODO`) now encrypt; the Slack OAuth callback stored the token **plaintext with `isEncrypted: true`** under `keyType 'access_token'` (which no Slack consumer reads — OAuth-created Slack integrations were inert); it now encrypts and writes `BOT_TOKEN`.
- **Data-fix** — `scripts/fix-slack-oauth-credentials.ts` (dry-run by default, `--apply` to write) repairs existing mislabelled rows. **Run manually after merge.**

Slack read paths are deliberately untouched — V2 (#440) owns those files.

## Acceptance criteria

- [x] Every remaining `credential.key` / `credentials[0].key` read outside Slack goes through the shared resolver
- [x] Each converted provider works against a row stored encrypted **and** a row stored plaintext (the flag decides, not the caller)
- [x] Notion "Test connection" succeeds for an OAuth-created integration
- [x] `monday-sync` finds the API key it is looking for
- [x] No write path stores a secret without `encryptCredential`; no write path claims `isEncrypted: true` for a value it did not encrypt
- [x] `npm run check` passes

---

Ships: cold.raven

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cms8ls75g000xjl04kc1qmmu1)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- New `resolveCredential()` helper decrypts credentials at every read boundary

- All Slack, Notion, WhatsApp, GitHub, Monday, and Fireflies credential reads now decrypt via shared resolver

- Slack OAuth callback now properly encrypts and labels bot token as `BOT_TOKEN`

- New unit tests cover `findCredential` and `resolveCredential` (encrypted, plaintext, undecryptable, missing)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["resolveCredential()"] -- "case-insensitive alias match" --> B["findCredential()"]
  B -- "row found" --> C["getDecryptedKey()"]
  C -- "decrypts OK" --> D["Plaintext secret returned"]
  C -- "decrypt fails" --> E["null (fail closed)"]
  B -- "no match" --> E
  F["Notion / WhatsApp / GitHub\nMonday / Fireflies / Slack"] -- "all reads now use" --> A
  G["Slack OAuth callback"] -- "encryptCredential + keyType BOT_TOKEN" --> H["DB: encrypted BOT_TOKEN"]
  I["scripts/fix-slack-oauth-credentials.ts"] -- "data-fix: relabel + re-encrypt" --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>credentialHelper.ts</strong><dd><code>Add findCredential and resolveCredential shared helpers</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-1c6f8be75c6b3a912aabd6dcd400f0b40759babe16455d163c44ed81144987f5">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>credentialHelper.test.ts</strong><dd><code>Unit tests for findCredential and resolveCredential</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-5b9970bb29a94d16f4a7a66df3a24abb73528a884570d3b7167cb0a6b5f8e0c0">+88/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>route.ts</strong><dd><code>Encrypt bot token and use BOT_TOKEN keyType in OAuth callback</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-1cedca3c33d421a898eb6f8a6c88c952da90d7f4b85635810d539c643c915a8c">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fix-slack-oauth-credentials.ts</strong><dd><code>Data-fix script to relabel and re-encrypt Slack OAuth credentials</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-533825fb56e195462c28c9eb08d0abed47c554db5e0f8ece8186e509acbf0430">+107/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>notion-integration.ts</strong><dd><code>Resolve Notion access token via resolveCredential</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-0f5350323c621899598be4375080b22fc28fa1b25f47ae1c0d517569a1396c8c">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notion-sync.ts</strong><dd><code>Decrypt Notion credentials in getDatabasePages and getDatabaseInfo</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-e79306cf7304542cd8228b6b8fd8b5979dc71d4d2df1feba64c6e7674f864908">+13/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>integration.ts</strong><dd><code>Replace raw credential reads with resolveCredential for Notion and </code><br><code>Monday</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-c77c1944f43c90e73f35e8df34be0e27e5c7ef596a4380d6e731f974acb89b3f">+34/-62</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>whatsapp.ts</strong><dd><code>Decrypt WhatsApp ACCESS_TOKEN and PHONE_NUMBER_ID via </code><br><code>resolveCredential</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-17fa1855d55c9c2fe079240310296b3e1be3ce6f0e0ac7fbb3cac5cda431897d">+10/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WhatsAppNotificationService.ts</strong><dd><code>Decrypt WhatsApp access token via resolveCredential in notification </code><br><code>service</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-2144e1dbefafb6ce9ec5a093aff15ff6ab35e52b1d87edde8ade54266f8723a4">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WhatsAppNotificationService.ts</strong><dd><code>Decrypt WhatsApp access token via resolveCredential</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-99613bf4444d01a95d570dfe020b59ddcf4acab8ddf1dedcd9364676bebd662e">+4/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>github-integration.ts</strong><dd><code>Resolve GitHub access token via resolveCredential</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-550cef423d4e8fa784d20e672c89758ac9c9cfe850c585e550d8b01b7b1e8a24">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>monday-sync.ts</strong><dd><code>Fix case-insensitive Monday API_KEY lookup via resolveCredential</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-d725dda4eacb200ea6000898a96a4929a5bfa2a9940dd4691fb0774776f5c93a">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MondayActionProcessor.ts</strong><dd><code>Decrypt Monday API key via resolveCredential in validateConfig</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-8cd5b5fac753d1c48e2b0f4c2be919ba927ec8df6986e54a75a88f1e6da7f6a5">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>route.ts</strong><dd><code>Decrypt Fireflies API key via resolveCredential</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-c4c34f72b689901ef5fe32a75fe9caad19b2881508d1421ecd0a559625c0b865">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mastra.ts</strong><dd><code>Encrypt Fireflies API key at rest instead of storing plaintext</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/441/files#diff-afd76ed5d04839b106766464d541d99c9b1d0e8b28477ea826c7dcf52db960bb">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

