### PR TITLE
fix: GitHub connect flow wipes the stored access token

### DIFF
--- a/src/server/services/__tests__/githubIntegrationUpdate.test.ts
+++ b/src/server/services/__tests__/githubIntegrationUpdate.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression test: re-running the GitHub connect flow must not wipe the
+ * stored access token (2026-07-30 integration-secrets audit, standalone bug).
+ *
+ * updateGithubIntegration used an UNSCOPED updateMany over every credential
+ * row of the integration, rewriting access_token into github_metadata and
+ * leaving N identical metadata rows. It must instead replace-in-place scoped
+ * by keyType (same pattern as upsertWorkspaceInstallation), storing the fresh
+ * token encrypted.
+ *
+ * Uses an in-memory credential store behind a mocked Prisma client — no real
+ * DB, ever (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.hoisted(() => {
+  // Raw 32-byte key (encryption.ts accepts raw or base64-encoded 32 bytes).
+  process.env.DATABASE_ENCRYPTION_KEY = "0".repeat(32);
+});
+
+interface Row {
+  id: string;
+  integrationId: string;
+  key: string;
+  keyType: string;
+  isEncrypted: boolean;
+}
+
+const store = vi.hoisted(() => ({ rows: [] as Row[], nextId: 1 }));
+
+vi.mock("~/server/db", () => ({
+  db: {
+    integration: {
+      update: vi.fn().mockResolvedValue({}),
+    },
+    integrationCredential: {
+      deleteMany: vi.fn(async ({ where }: { where: { integrationId: string; keyType?: { in: string[] } } }) => {
+        const before = store.rows.length;
+        store.rows = store.rows.filter(
+          (r) =>
+            r.integrationId !== where.integrationId ||
+            (where.keyType ? !where.keyType.in.includes(r.keyType) : false),
+        );
+        return { count: before - store.rows.length };
+      }),
+      createMany: vi.fn(async ({ data }: { data: Omit<Row, "id">[] }) => {
+        for (const d of data) {
+          store.rows.push({ ...d, id: `cred-${store.nextId++}` });
+        }
+        return { count: data.length };
+      }),
+      create: vi.fn(async ({ data }: { data: Omit<Row, "id"> }) => {
+        const row = { ...data, id: `cred-${store.nextId++}` };
+        store.rows.push(row);
+        return row;
+      }),
+      updateMany: vi.fn(async () => {
+        throw new Error(
+          "updateGithubIntegration must not use updateMany on credentials — an unscoped updateMany is exactly the bug this test guards against",
+        );
+      }),
+    },
+    workflow: { create: vi.fn().mockResolvedValue({}) },
+  },
+}));
+
+import { githubIntegrationService } from "~/server/services/github-integration";
+import { decryptCredential } from "~/server/utils/credentialHelper";
+
+const OAUTH_DATA = {
+  accessToken: "gho_fresh_token",
+  scopes: ["repo"],
+  githubUser: { id: 1, login: "octocat", avatar_url: "http://x" },
+  selectedRepository: {
+    id: 10,
+    name: "repo",
+    full_name: "octocat/repo",
+    private: false,
+    permissions: { push: true },
+  },
+  installationId: 42,
+};
+
+describe("updateGithubIntegration credential handling", () => {
+  beforeEach(() => {
+    store.rows = [
+      {
+        id: "cred-token",
+        integrationId: "int-1",
+        key: "gho_original_token",
+        keyType: "access_token",
+        isEncrypted: false,
+      },
+      {
+        id: "cred-meta",
+        integrationId: "int-1",
+        key: "{}",
+        keyType: "github_metadata",
+        isEncrypted: false,
+      },
+      {
+        id: "cred-other-int",
+        integrationId: "int-2",
+        key: "unrelated",
+        keyType: "access_token",
+        isEncrypted: false,
+      },
+    ];
+  });
+
+  it("preserves a usable access_token across repeated connects and does not accumulate metadata rows", async () => {
+    await githubIntegrationService.updateGithubIntegration("user-1", "int-1", OAUTH_DATA);
+    await githubIntegrationService.updateGithubIntegration("user-1", "int-1", OAUTH_DATA);
+
+    const mine = store.rows.filter((r) => r.integrationId === "int-1");
+    const tokens = mine.filter((r) => r.keyType === "access_token");
+    const metas = mine.filter((r) => r.keyType === "github_metadata");
+
+    expect(tokens).toHaveLength(1);
+    expect(metas).toHaveLength(1);
+    // The stored token is the fresh one, decryptable, and actually encrypted.
+    expect(decryptCredential(tokens[0]!.key, tokens[0]!.isEncrypted)).toBe("gho_fresh_token");
+
+    // Other integrations' credentials are untouched.
+    expect(store.rows.find((r) => r.id === "cred-other-int")).toBeDefined();
+  });
+});

--- a/src/server/services/github-integration.ts
+++ b/src/server/services/github-integration.ts
@@ -337,6 +337,7 @@ class GitHubIntegrationService {
     },
   ) {
     const {
+      accessToken,
       scopes,
       githubUser,
       selectedRepository,
@@ -359,30 +360,45 @@ class GitHubIntegrationService {
       },
     });
 
-    // Store GitHub user info and metadata with only the selected repository
-    await db.integrationCredential.updateMany({
+    // Replace-in-place, scoped by keyType (same pattern as
+    // upsertWorkspaceInstallation): the previous unscoped updateMany turned
+    // EVERY credential row — including access_token — into github_metadata,
+    // silently bricking the integration on reconnect.
+    const encryptedToken = encryptCredential(accessToken);
+    await db.integrationCredential.deleteMany({
       where: {
         integrationId: integrationId,
+        keyType: { in: ["access_token", "github_metadata"] },
       },
-      data: {
-        integrationId: integrationId,
-        key: JSON.stringify({
-          githubUserId: githubUser.id,
-          githubUsername: githubUser.login,
-          avatarUrl: githubUser.avatar_url,
-          scopes,
-          installationId,
-          repository: {
-            id: selectedRepository?.id,
-            name: selectedRepository?.name,
-            fullName: selectedRepository?.full_name,
-            private: selectedRepository?.private,
-            permissions: selectedRepository?.permissions,
-          },
-        }),
-        keyType: "github_metadata",
-        isEncrypted: false,
-      },
+    });
+    await db.integrationCredential.createMany({
+      data: [
+        {
+          integrationId: integrationId,
+          key: encryptedToken.key,
+          keyType: "access_token",
+          isEncrypted: encryptedToken.isEncrypted,
+        },
+        {
+          integrationId: integrationId,
+          key: JSON.stringify({
+            githubUserId: githubUser.id,
+            githubUsername: githubUser.login,
+            avatarUrl: githubUser.avatar_url,
+            scopes,
+            installationId,
+            repository: {
+              id: selectedRepository?.id,
+              name: selectedRepository?.name,
+              fullName: selectedRepository?.full_name,
+              private: selectedRepository?.private,
+              permissions: selectedRepository?.permissions,
+            },
+          }),
+          keyType: "github_metadata",
+          isEncrypted: false,
+        },
+      ],
     });
   }
 


### PR DESCRIPTION
### **User description**
## What

Fixes the standalone bug from the 2026-07-30 integration-secrets audit (feature `cms8lpaf60001jl048uxkjsfe`): `updateGithubIntegration` ran an **unscoped** `updateMany` over every credential row of the integration, setting `keyType: "github_metadata"` on all of them — re-running the GitHub connect flow rewrote the `access_token` row into metadata JSON, silently bricking the integration and accumulating duplicate metadata rows.

Replaced with the keyType-scoped delete-and-create pattern already used by `upsertWorkspaceInstallation` in the same file. As a bonus, the reconnect now stores the fresh OAuth token (encrypted via `encryptCredential`) instead of discarding it.

The regression test runs the flow twice against an in-memory credential store and asserts exactly one decryptable `access_token`, one `github_metadata` row, untouched credentials on other integrations, and that any `updateMany` on credentials throws.

Note: the production damage census (integrations with `github_metadata` but no `access_token`) could not be run from this session (prod DB access is permission-blocked); the ready-to-run read-only query is on the ticket. Damaged integrations recover by reconnecting through the fixed flow.

## Acceptance criteria

- [x] Re-running the GitHub connect flow leaves `access_token` intact
- [x] No duplicate `github_metadata` rows accumulate across repeated connects
- [ ] Count of already-damaged production integrations recorded as a ticket comment (query provided on the ticket — needs a manual run against prod)
- [x] `npm run check` passes

---

Ships: snowy.hornet

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cms8ltv8l0009jp046izu6y7u)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix unscoped `updateMany` that overwrote `access_token` with `github_metadata`

- Replace with keyType-scoped delete-and-create pattern, storing fresh encrypted token

- Add regression test asserting exactly one `access_token` and one `github_metadata` row after repeated connects


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Connect Flow"] -- "old: unscoped updateMany" --> B["All credential rows\nrewritten as github_metadata"]
  B -- "result" --> C["access_token destroyed\n(integration bricked)"]
  A -- "new: scoped deleteMany + createMany" --> D["Delete only access_token\n& github_metadata rows"]
  D -- "then" --> E["Create fresh encrypted\naccess_token row"]
  D -- "then" --> F["Create github_metadata row"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github-integration.ts</strong><dd><code>Fix credential update to use scoped delete-and-create pattern</code></dd></summary>
<hr>

src/server/services/github-integration.ts

<ul><li>Remove unscoped <code>updateMany</code> that rewrote all credential rows to <br><code>github_metadata</code><br> <li> Add <code>accessToken</code> to destructured parameters in <code>updateGithubIntegration</code><br> <li> Replace with keyType-scoped <code>deleteMany</code> (targeting <code>access_token</code> and <br><code>github_metadata</code>) followed by <code>createMany</code><br> <li> Store fresh OAuth token encrypted via <code>encryptCredential</code> alongside <br>metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/442/files#diff-550cef423d4e8fa784d20e672c89758ac9c9cfe850c585e550d8b01b7b1e8a24">+37/-21</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>githubIntegrationUpdate.test.ts</strong><dd><code>Add regression test for GitHub connect credential handling</code></dd></summary>
<hr>

src/server/services/__tests__/githubIntegrationUpdate.test.ts

<ul><li>Add regression test for <code>updateGithubIntegration</code> credential handling<br> <li> Mock Prisma client with in-memory credential store; <code>updateMany</code> throws <br>to guard against regression<br> <li> Assert exactly one <code>access_token</code> and one <code>github_metadata</code> row after two <br>consecutive connect calls<br> <li> Verify stored token is decryptable and other integrations' credentials <br>are untouched</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/442/files#diff-aaf29a2ca44fcabb81a1ef4ac9b0ff45a4c90bd8e722ed4c517b7d0860cda1bf">+128/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

