### PR TITLE
fix: V4: Encryption becomes mandatory

### DIFF
--- a/scripts/backfill-credential-encryption.ts
+++ b/scripts/backfill-credential-encryption.ts
@@ -1,0 +1,147 @@
+/**
+ * Backfill: encrypt plaintext secret credential rows and repair mislabelled
+ * ones (2026-07-30 integration-secrets audit, V4 — run AFTER the census,
+ * scripts/census-credential-encryption.ts, and BEFORE enforcement matters).
+ *
+ * Idempotent: a second run reports zero changes. Per row:
+ *   - allowlisted deliberate-plaintext keyTypes are never touched;
+ *   - isEncrypted=false secret rows are encrypted;
+ *   - isEncrypted=true rows that decrypt are left alone (already correct);
+ *   - isEncrypted=true rows that do NOT decrypt but look like a raw provider
+ *     token (xox…, ntn_…, secret_…, gh*_…, EAA…) are mislabelled plaintext —
+ *     re-encrypted properly;
+ *   - isEncrypted=true rows that neither decrypt nor look like raw tokens are
+ *     reported for manual review (could be ciphertext under a different key —
+ *     encrypting them again would destroy them).
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-credential-encryption.ts          # dry-run (default)
+ *   npx tsx scripts/backfill-credential-encryption.ts --apply  # actually update
+ */
+
+import { PrismaClient } from "@prisma/client";
+import {
+  decryptCredential,
+  encryptCredential,
+} from "../src/server/utils/credentialHelper";
+
+const db = new PrismaClient();
+const apply = process.argv.includes("--apply");
+
+/** keyTypes that are deliberately plaintext (labels, hosts, ids — not secrets). */
+const PLAINTEXT_ALLOWLIST = new Set(
+  [
+    "slack_metadata",
+    "notion_metadata",
+    "github_metadata",
+    "TEAM_ID",
+    "APP_ID",
+    "PHONE_NUMBER_ID",
+    "BUSINESS_ACCOUNT_ID",
+    "email_address",
+    "imap_host",
+    "smtp_host",
+    "from_address",
+    "SERVER_URL",
+    "BOT_EMAIL",
+    "DEFAULT_STREAM",
+    "DEFAULT_TOPIC",
+    "EMAIL",
+  ].map((t) => t.toLowerCase()),
+);
+
+function looksLikeRawProviderToken(value: string): boolean {
+  return (
+    value.startsWith("xox") ||
+    value.startsWith("secret_") ||
+    value.startsWith("ntn_") ||
+    /^gh[a-z]_/.test(value) ||
+    value.startsWith("EAA")
+  );
+}
+
+async function main() {
+  console.log(`Mode: ${apply ? "APPLY" : "DRY-RUN"}\n`);
+
+  if (!process.env.DATABASE_ENCRYPTION_KEY) {
+    throw new Error(
+      "DATABASE_ENCRYPTION_KEY is not set — refusing to run: the backfill would have nothing to encrypt with.",
+    );
+  }
+
+  const rows = await db.integrationCredential.findMany({
+    select: { id: true, key: true, keyType: true, isEncrypted: true },
+  });
+
+  const counts = {
+    allowlisted: 0,
+    alreadyEncrypted: 0,
+    encryptedPlaintext: 0,
+    repairedMislabelled: 0,
+    needsManualReview: 0,
+  };
+  const byKeyType = new Map<string, number>();
+  const bump = (keyType: string) =>
+    byKeyType.set(keyType, (byKeyType.get(keyType) ?? 0) + 1);
+
+  for (const row of rows) {
+    if (PLAINTEXT_ALLOWLIST.has(row.keyType.toLowerCase())) {
+      counts.allowlisted++;
+      continue;
+    }
+
+    if (row.isEncrypted) {
+      if (decryptCredential(row.key, true) !== null) {
+        counts.alreadyEncrypted++;
+        continue;
+      }
+      if (!looksLikeRawProviderToken(row.key)) {
+        console.log(
+          `  REVIEW ${row.id} (${row.keyType}): claims encrypted, does not decrypt, not a recognizable raw token — not touching`,
+        );
+        counts.needsManualReview++;
+        continue;
+      }
+      // Mislabelled: flag says encrypted but the value is a raw token.
+      const enc = encryptCredential(row.key);
+      console.log(`  FIX    ${row.id} (${row.keyType}): mislabelled plaintext token — re-encrypting`);
+      if (apply) {
+        await db.integrationCredential.update({
+          where: { id: row.id },
+          data: { key: enc.key, isEncrypted: enc.isEncrypted },
+        });
+      }
+      counts.repairedMislabelled++;
+      bump(row.keyType);
+      continue;
+    }
+
+    // Honest plaintext secret — encrypt it.
+    const enc = encryptCredential(row.key);
+    console.log(`  FIX    ${row.id} (${row.keyType}): plaintext secret — encrypting`);
+    if (apply) {
+      await db.integrationCredential.update({
+        where: { id: row.id },
+        data: { key: enc.key, isEncrypted: enc.isEncrypted },
+      });
+    }
+    counts.encryptedPlaintext++;
+    bump(row.keyType);
+  }
+
+  console.log(`\n== Summary (${apply ? "applied" : "dry-run"}) ==`);
+  console.table(counts);
+  if (byKeyType.size > 0) {
+    console.log("Changed rows by keyType:");
+    console.table(Object.fromEntries(byKeyType));
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    void db.$disconnect();
+  });

--- a/scripts/census-credential-encryption.ts
+++ b/scripts/census-credential-encryption.ts
@@ -1,0 +1,87 @@
+/**
+ * Read-only census of IntegrationCredential encryption state (2026-07-30
+ * integration-secrets audit, V4 — run BEFORE the backfill and paste the
+ * output on ticket scarlet.glyph).
+ *
+ * Reports, by keyType:
+ *   - plaintext vs marked-encrypted row counts
+ *   - "impossible ciphertext": rows claiming isEncrypted = true whose value is
+ *     too short to be base64(iv12 + tag16 + ct)
+ * and separately the mislabel class: plaintext provider tokens (xox…, ntn_…,
+ * gh*_…, EAA…, secret_…) flagged isEncrypted = true.
+ *
+ * Makes NO writes. Usage:
+ *   npx tsx scripts/census-credential-encryption.ts
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const db = new PrismaClient();
+
+async function main() {
+  const byKeyType = await db.$queryRaw<
+    Array<{
+      keyType: string;
+      total: bigint;
+      plaintext: bigint;
+      marked_encrypted: bigint;
+      impossible_ciphertext: bigint;
+    }>
+  >`
+    SELECT "keyType",
+           COUNT(*)                                                            AS total,
+           COUNT(*) FILTER (WHERE "isEncrypted" = false)                       AS plaintext,
+           COUNT(*) FILTER (WHERE "isEncrypted" = true)                        AS marked_encrypted,
+           COUNT(*) FILTER (WHERE "isEncrypted" = true AND length("key") < 40) AS impossible_ciphertext
+    FROM "IntegrationCredential"
+    GROUP BY "keyType"
+    ORDER BY plaintext DESC, total DESC;
+  `;
+
+  const mislabelled = await db.$queryRaw<
+    Array<{ provider: string; keyType: string; count: bigint }>
+  >`
+    SELECT i.provider, c."keyType", COUNT(*) AS count
+    FROM "IntegrationCredential" c
+    JOIN "Integration" i ON i.id = c."integrationId"
+    WHERE c."isEncrypted" = true
+      AND (c."key" LIKE 'xox%'
+        OR c."key" LIKE 'secret_%' OR c."key" LIKE 'ntn_%'
+        OR c."key" LIKE 'gh%_%'
+        OR c."key" LIKE 'EAA%')
+    GROUP BY 1, 2 ORDER BY 3 DESC;
+  `;
+
+  console.log("== 1. Encryption state by keyType ==");
+  console.table(
+    byKeyType.map((r) => ({
+      keyType: r.keyType,
+      total: Number(r.total),
+      plaintext: Number(r.plaintext),
+      marked_encrypted: Number(r.marked_encrypted),
+      impossible_ciphertext: Number(r.impossible_ciphertext),
+    })),
+  );
+
+  console.log("\n== 2. Plaintext provider tokens flagged isEncrypted = true ==");
+  if (mislabelled.length === 0) {
+    console.log("(none)");
+  } else {
+    console.table(
+      mislabelled.map((r) => ({
+        provider: r.provider,
+        keyType: r.keyType,
+        count: Number(r.count),
+      })),
+    );
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    void db.$disconnect();
+  });

--- a/src/env.js
+++ b/src/env.js
@@ -1,6 +1,21 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
+/**
+ * DATABASE_ENCRYPTION_KEY must be 32 bytes, raw or base64 (mirrors
+ * `getKey()` in src/server/utils/encryption.ts). Guarded so the check also
+ * works in runtimes without a global Buffer.
+ */
+const isValidDatabaseEncryptionKey = (/** @type {string} */ val) => {
+  if (typeof Buffer === "undefined") return val.length >= 32;
+  try {
+    if (Buffer.from(val, "base64").length === 32) return true;
+  } catch {
+    // fall through to the raw check
+  }
+  return Buffer.byteLength(val) === 32;
+};
+
 export const env = createEnv({
   /**
    * Specify your server-side environment variables schema here. This way you can ensure the app
@@ -17,6 +32,17 @@ export const env = createEnv({
     MICROSOFT_ENTRA_ID_CLIENT_SECRET: z.string().optional(),
     MICROSOFT_ENTRA_ID_TENANT_ID: z.string().optional(),
     DATABASE_URL: z.string().url(),
+    // AES-256-GCM key for IntegrationCredential storage. Required in
+    // production so a misconfigured deploy fails at boot rather than at the
+    // first credential write; in dev/test `encryptCredential` still throws at
+    // write time when it is missing (encryption is mandatory everywhere).
+    DATABASE_ENCRYPTION_KEY: (process.env.NODE_ENV === "production"
+      ? z.string()
+      : z.string().optional()
+    ).refine((val) => val === undefined || isValidDatabaseEncryptionKey(val), {
+      message:
+        "DATABASE_ENCRYPTION_KEY must be 32 bytes (raw) or base64-encoded 32 bytes",
+    }),
     // Web Push (VAPID) private key — server-only, pairs with
     // NEXT_PUBLIC_VAPID_PUBLIC_KEY. Optional: push notifications degrade
     // gracefully when unset (see WebPushService / pushSubscription router).
@@ -57,6 +83,7 @@ export const env = createEnv({
     MICROSOFT_ENTRA_ID_CLIENT_SECRET: process.env.MICROSOFT_ENTRA_ID_CLIENT_SECRET,
     MICROSOFT_ENTRA_ID_TENANT_ID: process.env.MICROSOFT_ENTRA_ID_TENANT_ID,
     DATABASE_URL: process.env.DATABASE_URL,
+    DATABASE_ENCRYPTION_KEY: process.env.DATABASE_ENCRYPTION_KEY,
     VAPID_PRIVATE_KEY: process.env.VAPID_PRIVATE_KEY,
     NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/src/server/utils/__tests__/credentialHelper.test.ts
+++ b/src/server/utils/__tests__/credentialHelper.test.ts
@@ -19,10 +19,21 @@ vi.mock("~/server/db", () => ({
 }));
 
 import {
+  encryptCredential,
   findCredential,
+  getDecryptedKey,
   resolveCredential,
 } from "~/server/utils/credentialHelper";
 import { encryptToBase64 } from "~/server/utils/encryption";
+
+describe("encryptCredential", () => {
+  it("encrypts for real and round-trips through getDecryptedKey", () => {
+    const stored = encryptCredential("super-secret");
+    expect(stored.isEncrypted).toBe(true);
+    expect(stored.key).not.toContain("super-secret");
+    expect(getDecryptedKey(stored)).toBe("super-secret");
+  });
+});
 
 describe("findCredential", () => {
   const rows = [

--- a/src/server/utils/__tests__/credentialHelperEnforcement.test.ts
+++ b/src/server/utils/__tests__/credentialHelperEnforcement.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Enforcement test (2026-07-30 audit, V4): encryption is mandatory.
+ * `encryptCredential` must THROW when DATABASE_ENCRYPTION_KEY is absent —
+ * the old behavior silently degraded to `{ isEncrypted: false }`, so a
+ * misconfigured deploy stored every secret in plaintext.
+ *
+ * Lives in its own file because encryption.ts captures the key at module
+ * load: this file's env setup runs with the key deleted before import.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.hoisted(() => {
+  delete process.env.DATABASE_ENCRYPTION_KEY;
+});
+
+import { encryptCredential } from "~/server/utils/credentialHelper";
+
+describe("encryptCredential without DATABASE_ENCRYPTION_KEY", () => {
+  it("throws instead of returning plaintext", () => {
+    expect(() => encryptCredential("super-secret")).toThrow(
+      /DATABASE_ENCRYPTION_KEY is not set/,
+    );
+  });
+});

--- a/src/server/utils/credentialHelper.ts
+++ b/src/server/utils/credentialHelper.ts
@@ -6,22 +6,23 @@ import { encryptToBase64, decryptFromBase64, isEncryptionAvailable } from './enc
  */
 
 /**
- * Encrypt a credential value for storage if encryption is available.
- * Returns the encrypted value and encryption status.
+ * Encrypt a credential value for storage. Encryption is MANDATORY: a missing
+ * or invalid DATABASE_ENCRYPTION_KEY throws rather than silently degrading to
+ * plaintext (the old fallback meant a misconfigured deploy stored every
+ * secret in the clear — see the 2026-07-30 integration-secrets audit).
  */
 export function encryptCredential(plaintext: string): { key: string; isEncrypted: boolean } {
   if (!isEncryptionAvailable()) {
-    console.warn('DATABASE_ENCRYPTION_KEY not set - storing credential in plaintext');
-    return { key: plaintext, isEncrypted: false };
+    throw new Error(
+      'DATABASE_ENCRYPTION_KEY is not set — refusing to store a credential in plaintext. ' +
+        'Set a 32-byte key (raw or base64) in the environment.',
+    );
   }
 
-  try {
-    const encrypted = encryptToBase64(plaintext);
-    return { key: encrypted, isEncrypted: true };
-  } catch (error) {
-    console.error('Encryption failed, falling back to plaintext:', error);
-    return { key: plaintext, isEncrypted: false };
-  }
+  // encryptToBase64 throws on an invalid key or cipher failure — let it
+  // propagate; a failed write is the correct outcome.
+  const encrypted = encryptToBase64(plaintext);
+  return { key: encrypted, isEncrypted: true };
 }
 
 /**


### PR DESCRIPTION
### **User description**
## What

Encryption becomes mandatory (feature `cms8lpaf60001jl048uxkjsfe`, scope V4, from the 2026-07-30 integration-secrets audit). Lands after V2 (#440) and V3 (#441) on purpose — every read now decrypts, so enforcing encryption no longer converts plaintext storage into an outage.

Census → backfill → enforce:

1. **Census** — `scripts/census-credential-encryption.ts` (read-only): plaintext vs marked-encrypted by keyType, impossible-ciphertext rows, and plaintext provider tokens flagged `isEncrypted = true`.
2. **Backfill** — `scripts/backfill-credential-encryption.ts` (dry-run by default, `--apply`): encrypts honest-plaintext secret rows, re-encrypts mislabelled raw tokens, skips rows that already decrypt (idempotent — second run reports zero changes), never touches the deliberate-plaintext allowlist, and flags undecryptable non-token values for manual review instead of double-encrypting.
3. **Enforce** — `encryptCredential` now throws instead of returning `{ isEncrypted: false }`, and `DATABASE_ENCRYPTION_KEY` joins the server env schema (required in production → misconfigured deploys fail at boot; 32 bytes raw or base64, mirroring `encryption.getKey`). Dev/test without the key fail loudly at the first credential write.

### Operational steps (manual — this session cannot reach the prod DB)

- **Before relying on enforcement**: run the census against production and paste the output on ticket `scarlet.glyph`.
- **Then**: run the backfill dry-run, review, then `--apply`. Re-run the census — query 2 must return zero rows.
- Deploy safety checked: `DATABASE_ENCRYPTION_KEY` is already set in Vercel Development/Preview/Production, so boot-time validation will pass and enforcement cannot fire spuriously. Local dev environments without the key will now fail on credential writes until one is set (see `.env.example`).

## Acceptance criteria

- [ ] Census output for production recorded as a ticket comment (manual run — script provided)
- [x] Backfill is idempotent — a second run reports zero changes — and leaves every allowlisted `keyType` untouched
- [ ] After backfill, query 2 of the census returns zero rows (manual run)
- [x] Booting without `DATABASE_ENCRYPTION_KEY` fails loudly at startup (production env schema)
- [x] Creating an integration with the key unset throws rather than silently storing plaintext
- [ ] Every integration still functions post-backfill (spot-check Slack, WhatsApp, Notion, GitHub — after the manual backfill)

---

Ships: scarlet.glyph

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cms8ltrb00001jp04ckk5mqbe)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- `encryptCredential` now throws instead of silently storing plaintext when `DATABASE_ENCRYPTION_KEY` is missing

- `DATABASE_ENCRYPTION_KEY` added to server env schema, required in production for boot-time validation

- New `scripts/census-credential-encryption.ts` (read-only) audits plaintext vs encrypted credential rows

- New `scripts/backfill-credential-encryption.ts` idempotently encrypts/repairs plaintext and mislabelled credential rows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["encryptCredential()"] -- "DATABASE_ENCRYPTION_KEY missing" --> B["throws Error (fail closed)"]
  A -- "key present" --> C["encryptToBase64()"]
  C -- "success" --> D["{ key: ciphertext, isEncrypted: true }"]
  C -- "cipher failure" --> E["throws (propagated)"]
  F["src/env.js"] -- "production: required" --> G["DATABASE_ENCRYPTION_KEY validated at boot"]
  H["census-credential-encryption.ts"] -- "read-only audit" --> I["plaintext / mislabelled row report"]
  J["backfill-credential-encryption.ts"] -- "dry-run or --apply" --> K["encrypt plaintext rows, repair mislabelled rows"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>credentialHelper.ts</strong><dd><code>Make encryptCredential throw instead of silently storing plaintext</code></dd></summary>
<hr>

src/server/utils/credentialHelper.ts

<ul><li><code>encryptCredential</code> now throws <code>Error</code> when <code>DATABASE_ENCRYPTION_KEY</code> is <br>missing instead of returning <code>{ isEncrypted: false }</code><br> <li> Removed try/catch fallback that silently degraded to plaintext on <br>cipher failure; errors now propagate<br> <li> Updated JSDoc to reflect mandatory encryption policy</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/443/files#diff-1c6f8be75c6b3a912aabd6dcd400f0b40759babe16455d163c44ed81144987f5">+12/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>env.js</strong><dd><code>Add DATABASE_ENCRYPTION_KEY to env schema, required in production</code></dd></summary>
<hr>

src/env.js

<ul><li>Added <code>DATABASE_ENCRYPTION_KEY</code> to server env schema with a custom <br>32-byte validator (raw or base64)<br> <li> Required in production so misconfigured deploys fail at boot; optional <br>in dev/test<br> <li> Added <code>isValidDatabaseEncryptionKey</code> helper that works in runtimes <br>without a global <code>Buffer</code><br> <li> Wired <code>DATABASE_ENCRYPTION_KEY</code> into <code>runtimeEnv</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/443/files#diff-5fefa99495d6ed3e62e828ee33b4be377469032ec0a61c088bc0101e071c1172">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>census-credential-encryption.ts</strong><dd><code>New read-only census script for credential encryption state</code></dd></summary>
<hr>

scripts/census-credential-encryption.ts

<ul><li>New read-only script that reports plaintext vs marked-encrypted counts <br>by <code>keyType</code><br> <li> Detects "impossible ciphertext" rows (<code>isEncrypted=true</code> but value too <br>short)<br> <li> Detects mislabelled plaintext provider tokens flagged as encrypted<br> <li> Makes no writes; intended to be run before the backfill</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/443/files#diff-598b17340cae83477f3704390722d07b2904ca4461d906dcef3f8e91499bc0ff">+87/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backfill-credential-encryption.ts</strong><dd><code>New idempotent backfill script to encrypt plaintext credential rows</code></dd></summary>
<hr>

scripts/backfill-credential-encryption.ts

<ul><li>New idempotent backfill script (dry-run by default, <code>--apply</code> to write)<br> <li> Encrypts honest-plaintext secret rows and re-encrypts mislabelled raw <br>provider tokens<br> <li> Skips allowlisted deliberate-plaintext <code>keyType</code>s (labels, hosts, IDs)<br> <li> Flags undecryptable non-token rows for manual review instead of <br>double-encrypting</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/443/files#diff-402d894fc31044614052f18c9b7bc99393aac7cba83a5a39926e7530f4a1f7e7">+147/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>credentialHelper.test.ts</strong><dd><code>Add encryptCredential round-trip test to credentialHelper suite</code></dd></summary>
<hr>

src/server/utils/__tests__/credentialHelper.test.ts

<ul><li>Added <code>encryptCredential</code> import and <code>getDecryptedKey</code> import<br> <li> New <code>encryptCredential</code> test: verifies round-trip encryption via <br><code>getDecryptedKey</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/443/files#diff-5b9970bb29a94d16f4a7a66df3a24abb73528a884570d3b7167cb0a6b5f8e0c0">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>credentialHelperEnforcement.test.ts</strong><dd><code>New enforcement test: encryptCredential throws without encryption key</code></dd></summary>
<hr>

src/server/utils/__tests__/credentialHelperEnforcement.test.ts

<ul><li>New isolated test file that deletes <code>DATABASE_ENCRYPTION_KEY</code> before <br>module import<br> <li> Verifies <code>encryptCredential</code> throws with a descriptive error when the <br>key is absent<br> <li> Isolated to its own file because <code>encryption.ts</code> captures the key at <br>module load time</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/443/files#diff-570c35f58e5f58454eb24fd43f9e2465d776b5a7158a41ae0439b0b893457f6c">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

