### PR TITLE
feat: V5: Key rotation

### DIFF
--- a/dev-docs/ENCRYPTION_KEY_ROTATION.md
+++ b/dev-docs/ENCRYPTION_KEY_ROTATION.md
@@ -1,0 +1,46 @@
+# Encryption key rotation runbook
+
+`DATABASE_ENCRYPTION_KEY` encrypts every `IntegrationCredential.key` (string
+form, `v1:<base64(iv12+tag16+ct)>`, AES-256-GCM) and the CRM PII `Bytes`
+columns (`CrmContact` email/phone/socials, `CrmCommunication` from/to fields,
+`User.phone`). Rotation is supported via a decrypt-only fallback key:
+`DATABASE_ENCRYPTION_KEY_PREVIOUS`.
+
+Both keys are 32 bytes, raw or base64 (validated in `src/env.js`).
+
+## Rotation procedure
+
+1. **Add previous** — set `DATABASE_ENCRYPTION_KEY_PREVIOUS` to the *current*
+   key, and `DATABASE_ENCRYPTION_KEY` to the *new* key (generate with
+   `openssl rand -base64 32`), in every environment that talks to the DB.
+2. **Deploy** — all reads now try the new key first and fall back to the old
+   one; all writes use the new key. Nothing breaks mid-rotation.
+3. **Re-encrypt** — rewrite every stored row under the new key:
+
+   ```bash
+   npx tsx scripts/reencrypt-under-current-key.ts          # dry-run, review output
+   npx tsx scripts/reencrypt-under-current-key.ts --apply
+   ```
+
+   The script is idempotent (a second run reports zero changes) and exits
+   non-zero if any value failed to decrypt under either key — **do not
+   proceed to step 4 while failures remain**.
+4. **Drop previous** — remove `DATABASE_ENCRYPTION_KEY_PREVIOUS` and deploy
+   again. Rotation complete.
+
+## Observability
+
+Decrypt failures are reason-coded (`no_key` / `auth_failed` /
+`not_ciphertext`, see `DecryptFailureReason` in
+`src/server/utils/encryption.ts`). After a rotation, alert on `auth_failed`
+in logs: it means ciphertext that authenticates under *neither* key — a
+wrong key or skipped re-encrypt — and is deliberately distinguishable from an
+integration that was never configured.
+
+## Related
+
+- `scripts/census-credential-encryption.ts` — read-only state census (V4).
+- `scripts/backfill-credential-encryption.ts` — one-time plaintext backfill (V4).
+- `src/server/utils/credentialHelper.ts` — the only sanctioned read/write API
+  for credential secrets (`encryptCredential`, `resolveCredential`,
+  `decryptCredentialResult`).

--- a/scripts/reencrypt-under-current-key.ts
+++ b/scripts/reencrypt-under-current-key.ts
@@ -1,0 +1,178 @@
+/**
+ * Key-rotation re-encrypt: rewrite every encrypted row under the CURRENT
+ * DATABASE_ENCRYPTION_KEY (2026-07-30 integration-secrets audit, V5).
+ *
+ * Run with BOTH keys set — DATABASE_ENCRYPTION_KEY (new) and
+ * DATABASE_ENCRYPTION_KEY_PREVIOUS (old). Rows that decrypt under the
+ * previous key are re-encrypted under the current one; rows already under the
+ * current key are only rewritten when they lack the v1: version prefix
+ * (string form). Idempotent: a second run reports zero changes.
+ *
+ * Covers:
+ *   - IntegrationCredential.key (string ciphertext, isEncrypted = true)
+ *   - CrmContact PII Bytes columns (email/phone/linkedIn/telegram/twitter/github/bluesky)
+ *   - CrmCommunication Bytes columns (fromEmail/toEmail/fromTelegram/toTelegram)
+ *   - User.phone (Bytes)
+ *
+ * Usage:
+ *   npx tsx scripts/reencrypt-under-current-key.ts          # dry-run (default)
+ *   npx tsx scripts/reencrypt-under-current-key.ts --apply  # actually update
+ *
+ * Full runbook: dev-docs/ENCRYPTION_KEY_ROTATION.md
+ */
+
+import { PrismaClient } from "@prisma/client";
+import {
+  decryptFromBase64WithKeyInfo,
+  decryptBufferWithKeyInfo,
+  encryptToBase64,
+  encryptString,
+} from "../src/server/utils/encryption";
+
+const db = new PrismaClient();
+const apply = process.argv.includes("--apply");
+
+const counts = {
+  rewrittenFromPreviousKey: 0,
+  normalizedVersionPrefix: 0,
+  alreadyCurrent: 0,
+  failed: 0,
+};
+
+async function reencryptCredentials() {
+  const rows = await db.integrationCredential.findMany({
+    where: { isEncrypted: true },
+    select: { id: true, key: true, keyType: true },
+  });
+
+  for (const row of rows) {
+    const result = decryptFromBase64WithKeyInfo(row.key);
+    if (!result.ok) {
+      console.log(`  FAIL   credential ${row.id} (${row.keyType}): ${result.reason} — needs manual review`);
+      counts.failed++;
+      continue;
+    }
+    if (!result.usedPreviousKey && result.hadVersionPrefix) {
+      counts.alreadyCurrent++;
+      continue;
+    }
+    const label = result.usedPreviousKey ? "previous key" : "missing v1 prefix";
+    console.log(`  REWRITE credential ${row.id} (${row.keyType}): ${label}`);
+    if (apply) {
+      await db.integrationCredential.update({
+        where: { id: row.id },
+        data: { key: encryptToBase64(result.value) },
+      });
+    }
+    if (result.usedPreviousKey) counts.rewrittenFromPreviousKey++;
+    else counts.normalizedVersionPrefix++;
+  }
+}
+
+/** Re-encrypt one nullable Bytes field value; returns the new value or undefined when no rewrite is needed. */
+function reencryptBytes(
+  label: string,
+  value: Uint8Array | null,
+): Uint8Array<ArrayBuffer> | undefined {
+  if (!value || value.length === 0) return undefined;
+  try {
+    const result = decryptBufferWithKeyInfo(value);
+    if (result === null) {
+      console.log(`  FAIL   ${label}: not ciphertext — needs manual review`);
+      counts.failed++;
+      return undefined;
+    }
+    if (!result.usedPreviousKey) {
+      counts.alreadyCurrent++;
+      return undefined;
+    }
+    console.log(`  REWRITE ${label}: previous key`);
+    counts.rewrittenFromPreviousKey++;
+    return encryptString(result.value);
+  } catch {
+    console.log(`  FAIL   ${label}: does not decrypt under any available key — needs manual review`);
+    counts.failed++;
+    return undefined;
+  }
+}
+
+async function reencryptCrmContacts() {
+  const fields = ["email", "phone", "linkedIn", "telegram", "twitter", "github", "bluesky"] as const;
+  const rows = await db.crmContact.findMany({
+    select: Object.fromEntries([["id", true], ...fields.map((f) => [f, true])]) as Record<string, true>,
+  });
+  for (const row of rows as unknown as Array<Record<string, Uint8Array | string | null>>) {
+    const data: Record<string, Uint8Array<ArrayBuffer>> = {};
+    for (const f of fields) {
+      const updated = reencryptBytes(`CrmContact ${row.id as string}.${f}`, row[f] as Uint8Array | null);
+      if (updated) data[f] = updated;
+    }
+    if (Object.keys(data).length > 0 && apply) {
+      await db.crmContact.update({ where: { id: row.id as string }, data });
+    }
+  }
+}
+
+async function reencryptCrmCommunications() {
+  const fields = ["fromEmail", "toEmail", "fromTelegram", "toTelegram"] as const;
+  const rows = await db.crmCommunication.findMany({
+    select: Object.fromEntries([["id", true], ...fields.map((f) => [f, true])]) as Record<string, true>,
+  });
+  for (const row of rows as unknown as Array<Record<string, Uint8Array | string | null>>) {
+    const data: Record<string, Uint8Array<ArrayBuffer>> = {};
+    for (const f of fields) {
+      const updated = reencryptBytes(`CrmCommunication ${row.id as string}.${f}`, row[f] as Uint8Array | null);
+      if (updated) data[f] = updated;
+    }
+    if (Object.keys(data).length > 0 && apply) {
+      await db.crmCommunication.update({ where: { id: row.id as string }, data });
+    }
+  }
+}
+
+async function reencryptUserPhones() {
+  const rows = await db.user.findMany({
+    where: { phone: { not: null } },
+    select: { id: true, phone: true },
+  });
+  for (const row of rows) {
+    const updated = reencryptBytes(`User ${row.id}.phone`, row.phone);
+    if (updated && apply) {
+      await db.user.update({ where: { id: row.id }, data: { phone: updated } });
+    }
+  }
+}
+
+async function main() {
+  console.log(`Mode: ${apply ? "APPLY" : "DRY-RUN"}\n`);
+
+  if (!process.env.DATABASE_ENCRYPTION_KEY) {
+    throw new Error("DATABASE_ENCRYPTION_KEY is not set — nothing to re-encrypt under.");
+  }
+  if (!process.env.DATABASE_ENCRYPTION_KEY_PREVIOUS) {
+    console.warn(
+      "DATABASE_ENCRYPTION_KEY_PREVIOUS is not set — only v1-prefix normalization will happen; rows under an old key will FAIL.\n",
+    );
+  }
+
+  await reencryptCredentials();
+  await reencryptCrmContacts();
+  await reencryptCrmCommunications();
+  await reencryptUserPhones();
+
+  console.log(`\n== Summary (${apply ? "applied" : "dry-run"}) ==`);
+  console.table(counts);
+  if (counts.failed > 0) {
+    console.error(`\n${counts.failed} value(s) failed to decrypt — do NOT drop the previous key until resolved.`);
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    void db.$disconnect();
+  });

--- a/src/env.js
+++ b/src/env.js
@@ -43,6 +43,15 @@ export const env = createEnv({
       message:
         "DATABASE_ENCRYPTION_KEY must be 32 bytes (raw) or base64-encoded 32 bytes",
     }),
+    // Decrypt-only fallback during key rotation (see
+    // dev-docs/ENCRYPTION_KEY_ROTATION.md). Optional everywhere.
+    DATABASE_ENCRYPTION_KEY_PREVIOUS: z
+      .string()
+      .optional()
+      .refine((val) => val === undefined || isValidDatabaseEncryptionKey(val), {
+        message:
+          "DATABASE_ENCRYPTION_KEY_PREVIOUS must be 32 bytes (raw) or base64-encoded 32 bytes",
+      }),
     // Web Push (VAPID) private key — server-only, pairs with
     // NEXT_PUBLIC_VAPID_PUBLIC_KEY. Optional: push notifications degrade
     // gracefully when unset (see WebPushService / pushSubscription router).
@@ -84,6 +93,7 @@ export const env = createEnv({
     MICROSOFT_ENTRA_ID_TENANT_ID: process.env.MICROSOFT_ENTRA_ID_TENANT_ID,
     DATABASE_URL: process.env.DATABASE_URL,
     DATABASE_ENCRYPTION_KEY: process.env.DATABASE_ENCRYPTION_KEY,
+    DATABASE_ENCRYPTION_KEY_PREVIOUS: process.env.DATABASE_ENCRYPTION_KEY_PREVIOUS,
     VAPID_PRIVATE_KEY: process.env.VAPID_PRIVATE_KEY,
     NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/src/server/api/routers/crmApi.ts
+++ b/src/server/api/routers/crmApi.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { createTRPCRouter } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
-import { encryptString, decryptBuffer } from "~/server/utils/encryption";
+import { encryptString, decryptBufferSafe } from "~/server/utils/encryption";
 import { Prisma } from "@prisma/client";
 import type { CrmContact, PrismaClient } from "@prisma/client";
 import { getProjectAccess, hasProjectAccess } from "~/server/services/access";
@@ -30,13 +30,13 @@ type DecryptedContact<T extends CrmContact> = Omit<
 function decryptContactPII<T extends CrmContact>(contact: T): DecryptedContact<T> {
   return {
     ...contact,
-    email: decryptBuffer(contact.email) ?? null,
-    phone: decryptBuffer(contact.phone) ?? null,
-    linkedIn: decryptBuffer(contact.linkedIn) ?? null,
-    telegram: decryptBuffer(contact.telegram) ?? null,
-    twitter: decryptBuffer(contact.twitter) ?? null,
-    github: decryptBuffer(contact.github) ?? null,
-    bluesky: decryptBuffer(contact.bluesky) ?? null,
+    email: decryptBufferSafe(contact.email) ?? null,
+    phone: decryptBufferSafe(contact.phone) ?? null,
+    linkedIn: decryptBufferSafe(contact.linkedIn) ?? null,
+    telegram: decryptBufferSafe(contact.telegram) ?? null,
+    twitter: decryptBufferSafe(contact.twitter) ?? null,
+    github: decryptBufferSafe(contact.github) ?? null,
+    bluesky: decryptBufferSafe(contact.bluesky) ?? null,
   };
 }
 

--- a/src/server/api/routers/crmContact.ts
+++ b/src/server/api/routers/crmContact.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
-import { encryptString, decryptBuffer } from "~/server/utils/encryption";
+import { encryptString, decryptBufferSafe } from "~/server/utils/encryption";
 import type { Prisma, CrmContact, PrismaClient } from "@prisma/client";
 import { ContactSyncService } from "~/server/services/ContactSyncService";
 import { ConnectionStrengthCalculator } from "~/server/services/ConnectionStrengthCalculator";
@@ -63,13 +63,13 @@ function decryptContactPII<T extends CrmContact>(
 ): DecryptedContact<T> {
   return {
     ...contact,
-    email: decryptBuffer(contact.email) ?? null,
-    phone: decryptBuffer(contact.phone) ?? null,
-    linkedIn: decryptBuffer(contact.linkedIn) ?? null,
-    telegram: decryptBuffer(contact.telegram) ?? null,
-    twitter: decryptBuffer(contact.twitter) ?? null,
-    github: decryptBuffer(contact.github) ?? null,
-    bluesky: decryptBuffer(contact.bluesky) ?? null,
+    email: decryptBufferSafe(contact.email) ?? null,
+    phone: decryptBufferSafe(contact.phone) ?? null,
+    linkedIn: decryptBufferSafe(contact.linkedIn) ?? null,
+    telegram: decryptBufferSafe(contact.telegram) ?? null,
+    twitter: decryptBufferSafe(contact.twitter) ?? null,
+    github: decryptBufferSafe(contact.github) ?? null,
+    bluesky: decryptBufferSafe(contact.bluesky) ?? null,
   };
 }
 
@@ -977,7 +977,7 @@ export const crmContactRouter = createTRPCRouter({
 
       let contactEmail: string | null = null;
       try {
-        contactEmail = decryptBuffer(contact.email) ?? null;
+        contactEmail = decryptBufferSafe(contact.email) ?? null;
       } catch (e) {
         console.error("PII decryption failed for contact", contactId, e);
       }

--- a/src/server/api/routers/integration.ts
+++ b/src/server/api/routers/integration.ts
@@ -8,7 +8,7 @@ import {
 import { TRPCError } from "@trpc/server";
 import { MondayService } from "~/server/services/MondayService";
 import { WhatsAppVerificationService } from "~/server/services/whatsapp/VerificationService";
-import { encryptCredential, getDecryptedKey, resolveCredential } from "~/server/utils/credentialHelper";
+import { encryptCredential, getDecryptedKey, decryptCredentialResult, resolveCredential } from "~/server/utils/credentialHelper";
 import {
   testZulipConnection,
   fetchZulipUsers,
@@ -1909,15 +1909,21 @@ export const integrationRouter = createTRPCRouter({
           });
         }
 
-        const apiKey = getDecryptedKey(apiKeyCredential);
-        if (!apiKey) {
+        const apiKeyResult = decryptCredentialResult(
+          apiKeyCredential.key,
+          apiKeyCredential.isEncrypted,
+        );
+        if (!apiKeyResult.ok) {
           throw new TRPCError({
             code: "INTERNAL_SERVER_ERROR",
-            message: "Failed to decrypt API key",
+            message:
+              apiKeyResult.reason === "auth_failed"
+                ? "Fireflies API key failed to decrypt (wrong or rotated encryption key?)"
+                : "Fireflies API key is stored but unusable (reason: " + apiKeyResult.reason + ")",
           });
         }
 
-        const result = await testFirefliesConnection(apiKey);
+        const result = await testFirefliesConnection(apiKeyResult.value);
         return {
           success: result.success,
           error: result.error,
@@ -1936,15 +1942,21 @@ export const integrationRouter = createTRPCRouter({
           });
         }
 
-        const botToken = getDecryptedKey(botTokenCredential);
-        if (!botToken) {
+        const botTokenResult = decryptCredentialResult(
+          botTokenCredential.key,
+          botTokenCredential.isEncrypted,
+        );
+        if (!botTokenResult.ok) {
           throw new TRPCError({
             code: "INTERNAL_SERVER_ERROR",
-            message: "Failed to decrypt Slack bot token",
+            message:
+              botTokenResult.reason === "auth_failed"
+                ? "Slack bot token failed to decrypt (wrong or rotated encryption key?)"
+                : "Slack bot token is stored but unusable (reason: " + botTokenResult.reason + ")",
           });
         }
 
-        const result = await testSlackConnection(botToken);
+        const result = await testSlackConnection(botTokenResult.value);
         return {
           success: result.success,
           error: result.error,

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -13,7 +13,7 @@ import crypto from "crypto";
 import { testFirefliesConnection } from "./integration";
 import { pageRouter } from "./page";
 import { GoogleCalendarService } from "~/server/services/GoogleCalendarService";
-import { decryptBuffer, encryptString, encryptToBase64 } from "~/server/utils/encryption";
+import { decryptBufferSafe, encryptString, encryptToBase64 } from "~/server/utils/encryption";
 import { encryptCredential, getDecryptedKey } from "~/server/utils/credentialHelper";
 import { addDays, startOfDay, endOfDay } from "date-fns";
 import { getCalendarService, getEventsMultiCalendar, checkProviderConnection } from "~/server/services";
@@ -2327,8 +2327,8 @@ export const mastraRouter = createTRPCRouter({
             id: contact.id,
             firstName: contact.firstName,
             lastName: contact.lastName,
-            email: decryptBuffer(contact.email) ?? null,
-            phone: decryptBuffer(contact.phone) ?? null,
+            email: decryptBufferSafe(contact.email) ?? null,
+            phone: decryptBufferSafe(contact.phone) ?? null,
           },
         };
       } catch (e) {
@@ -2606,8 +2606,8 @@ export const mastraRouter = createTRPCRouter({
             id: c.id,
             firstName: c.firstName,
             lastName: c.lastName,
-            email: decryptBuffer(c.email) ?? null,
-            phone: decryptBuffer(c.phone) ?? null,
+            email: decryptBufferSafe(c.email) ?? null,
+            phone: decryptBufferSafe(c.phone) ?? null,
             tags: c.tags,
             organizationName: c.organization?.name ?? null,
             organizationId: c.organizationId,
@@ -2667,12 +2667,12 @@ export const mastraRouter = createTRPCRouter({
           id: contact.id,
           firstName: contact.firstName,
           lastName: contact.lastName,
-          email: decryptBuffer(contact.email) ?? null,
-          phone: decryptBuffer(contact.phone) ?? null,
-          linkedIn: decryptBuffer(contact.linkedIn) ?? null,
-          telegram: decryptBuffer(contact.telegram) ?? null,
-          twitter: decryptBuffer(contact.twitter) ?? null,
-          github: decryptBuffer(contact.github) ?? null,
+          email: decryptBufferSafe(contact.email) ?? null,
+          phone: decryptBufferSafe(contact.phone) ?? null,
+          linkedIn: decryptBufferSafe(contact.linkedIn) ?? null,
+          telegram: decryptBufferSafe(contact.telegram) ?? null,
+          twitter: decryptBufferSafe(contact.twitter) ?? null,
+          github: decryptBufferSafe(contact.github) ?? null,
           about: contact.about,
           skills: contact.skills,
           tags: contact.tags,
@@ -2866,7 +2866,7 @@ export const mastraRouter = createTRPCRouter({
         id: contact.id,
         firstName: contact.firstName,
         lastName: contact.lastName,
-        email: updateData.email !== undefined ? (updateData.email ?? null) : (decryptBuffer(contact.email) ?? null),
+        email: updateData.email !== undefined ? (updateData.email ?? null) : (decryptBufferSafe(contact.email) ?? null),
         updated: true,
       };
     }),

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -41,7 +41,7 @@ import {
 import { recordActivity } from "~/server/services/activity/recordActivity";
 import { emitNotification } from "~/server/services/notifications/emit/emitNotification";
 import { NOTIFICATION_CATEGORIES } from "~/server/services/notifications/emit/constants";
-import { encryptString, decryptBuffer } from "~/server/utils/encryption";
+import { encryptString, decryptBufferSafe } from "~/server/utils/encryption";
 import { createHash } from "crypto";
 
 // Keep in-memory store for development/debugging
@@ -296,7 +296,7 @@ async function upsertMeetingParticipant(
     name =
       [contact.firstName, contact.lastName].filter(Boolean).join(" ") || null;
 
-    const existingEmail = decryptBuffer(contact.email);
+    const existingEmail = decryptBufferSafe(contact.email);
     if (existingEmail) {
       email = existingEmail;
     } else if (person.email) {

--- a/src/server/services/crm/automation/steps/SendEmailStep.ts
+++ b/src/server/services/crm/automation/steps/SendEmailStep.ts
@@ -5,7 +5,7 @@ import {
   type StepContext,
 } from "~/server/services/workflows/steps/IStepExecutor";
 import { EmailService } from "~/server/services/EmailService";
-import { encryptString, decryptBuffer } from "~/server/utils/encryption";
+import { encryptString, decryptBufferSafe } from "~/server/utils/encryption";
 import {
   buildContactTemplateData,
   renderInline,
@@ -51,7 +51,7 @@ export class SendEmailStep implements IStepExecutor {
       throw new Error(`send_email: contact ${contactId} not found`);
     }
 
-    const toEmail = decryptBuffer(contact.email);
+    const toEmail = decryptBufferSafe(contact.email);
     if (!toEmail) {
       throw new Error(
         `send_email: contact ${contactId} has no email address`,

--- a/src/server/services/crm/crmContactMemberResolver.ts
+++ b/src/server/services/crm/crmContactMemberResolver.ts
@@ -1,6 +1,6 @@
 import { type PrismaClient } from "@prisma/client";
 
-import { decryptBuffer } from "~/server/utils/encryption";
+import { decryptBufferSafe } from "~/server/utils/encryption";
 import {
   CRM_CONTACT_MEMBER_TYPE,
   type MemberTypeResolver,
@@ -46,7 +46,7 @@ export class CrmContactMemberResolver implements MemberTypeResolver {
 
     const resolved: ResolvedMember[] = [];
     for (const c of contacts) {
-      const email = decryptBuffer(c.email);
+      const email = decryptBufferSafe(c.email);
       if (!email) continue; // unmailable — cannot be a recipient
 
       const firstName = c.firstName ?? "";

--- a/src/server/services/notifications/ZulipNotificationService.ts
+++ b/src/server/services/notifications/ZulipNotificationService.ts
@@ -5,7 +5,7 @@ import {
   type NotificationConfig,
 } from "./NotificationService";
 import { db } from "~/server/db";
-import { getDecryptedKey } from "~/server/utils/credentialHelper";
+import { decryptCredentialResult } from "~/server/utils/credentialHelper";
 
 interface ZulipCredentials {
   serverUrl: string;
@@ -83,11 +83,17 @@ export class ZulipNotificationService extends NotificationService {
       return null;
     }
 
-    const apiToken = getDecryptedKey(apiTokenCred);
-    if (!apiToken) {
+    const tokenResult = decryptCredentialResult(apiTokenCred.key, apiTokenCred.isEncrypted);
+    if (!tokenResult.ok) {
+      // A wrong/rotated DATABASE_ENCRYPTION_KEY must be distinguishable in
+      // logs from "this workspace never configured Zulip".
+      console.error(
+        `[ZulipNotificationService] Zulip API token exists but cannot be decrypted (reason: ${tokenResult.reason}) for integration ${integration.id}`,
+      );
       this.cachedCredentials = null;
       return null;
     }
+    const apiToken = tokenResult.value;
 
     this.cachedCredentials = {
       serverUrl: serverUrlCred.key.replace(/\/+$/, ""),

--- a/src/server/services/ticketSync/notionAdapter.ts
+++ b/src/server/services/ticketSync/notionAdapter.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 import { NotionService } from "../NotionService";
-import { getDecryptedKey } from "~/server/utils/credentialHelper";
+import { decryptCredentialResult } from "~/server/utils/credentialHelper";
 import { firstOptionName, readOptionNames } from "./mapping";
 import type { RemoteTicketRow, TicketSyncRemoteAdapter } from "./engine";
 import type { TicketPushAdapter } from "./push";
@@ -409,10 +409,24 @@ export async function createNotionTicketSyncAdapter(
     return { ok: false, error: "No access token on the Notion integration" };
   }
 
-  const accessToken = getDecryptedKey(tokenCredential);
-  if (!accessToken) {
-    return { ok: false, error: "Failed to decrypt the Notion access token" };
+  const tokenResult = decryptCredentialResult(tokenCredential.key, tokenCredential.isEncrypted);
+  if (!tokenResult.ok) {
+    // Distinguish a key problem from a missing credential — a wrong/rotated
+    // DATABASE_ENCRYPTION_KEY must be alertable, not read as "not configured".
+    console.error(
+      `[notionAdapter] Notion access token exists but cannot be decrypted (reason: ${tokenResult.reason}) for integration ${integration.id}`,
+    );
+    return {
+      ok: false,
+      error:
+        tokenResult.reason === 'auth_failed'
+          ? "Notion access token failed to decrypt (wrong or rotated encryption key?)"
+          : tokenResult.reason === 'no_key'
+            ? "Notion access token is encrypted but DATABASE_ENCRYPTION_KEY is not set"
+            : "Notion access token row is not valid ciphertext",
+    };
   }
+  const accessToken = tokenResult.value;
 
   let botId: string | null = null;
   const metadataCredential = integration.credentials.find(

--- a/src/server/utils/__tests__/credentialHelper.test.ts
+++ b/src/server/utils/__tests__/credentialHelper.test.ts
@@ -19,12 +19,39 @@ vi.mock("~/server/db", () => ({
 }));
 
 import {
+  decryptCredentialResult,
   encryptCredential,
   findCredential,
   getDecryptedKey,
   resolveCredential,
 } from "~/server/utils/credentialHelper";
 import { encryptToBase64 } from "~/server/utils/encryption";
+
+describe("decryptCredentialResult", () => {
+  it("passes plaintext rows through", () => {
+    expect(decryptCredentialResult("plain", false)).toEqual({ ok: true, value: "plain" });
+  });
+
+  it("decrypts real ciphertext", () => {
+    expect(decryptCredentialResult(encryptToBase64("s3cret"), true)).toEqual({
+      ok: true,
+      value: "s3cret",
+    });
+  });
+
+  it("reports auth_failed for plausible ciphertext under the wrong key", () => {
+    // 44 random bytes: structurally valid (>= iv12+tag16) but never authentic.
+    const forged = Buffer.alloc(44, 7).toString("base64");
+    expect(decryptCredentialResult(forged, true)).toEqual({ ok: false, reason: "auth_failed" });
+  });
+
+  it("reports not_ciphertext for values too short to be ciphertext", () => {
+    expect(decryptCredentialResult("xoxb-raw-token", true)).toEqual({
+      ok: false,
+      reason: "not_ciphertext",
+    });
+  });
+});
 
 describe("encryptCredential", () => {
   it("encrypts for real and round-trips through getDecryptedKey", () => {

--- a/src/server/utils/__tests__/credentialHelperEnforcement.test.ts
+++ b/src/server/utils/__tests__/credentialHelperEnforcement.test.ts
@@ -14,12 +14,19 @@ vi.hoisted(() => {
   delete process.env.DATABASE_ENCRYPTION_KEY;
 });
 
-import { encryptCredential } from "~/server/utils/credentialHelper";
+import { encryptCredential, decryptCredentialResult } from "~/server/utils/credentialHelper";
 
 describe("encryptCredential without DATABASE_ENCRYPTION_KEY", () => {
   it("throws instead of returning plaintext", () => {
     expect(() => encryptCredential("super-secret")).toThrow(
       /DATABASE_ENCRYPTION_KEY is not set/,
     );
+  });
+
+  it("decryptCredentialResult reports no_key for encrypted rows", () => {
+    expect(decryptCredentialResult("v1:whatever", true)).toEqual({
+      ok: false,
+      reason: "no_key",
+    });
   });
 });

--- a/src/server/utils/__tests__/encryption.test.ts
+++ b/src/server/utils/__tests__/encryption.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for string-form ciphertext versioning (2026-07-30 audit, V5).
+ *
+ * New writes are `v1:<base64(iv12+tag16+ct)>`; legacy unprefixed base64 must
+ * keep decrypting as v1 so rotation lands without a big-bang rewrite.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.hoisted(() => {
+  // Raw 32-byte key (encryption.ts accepts raw or base64-encoded 32 bytes).
+  process.env.DATABASE_ENCRYPTION_KEY = "0".repeat(32);
+});
+
+import {
+  encryptString,
+  encryptToBase64,
+  decryptFromBase64,
+} from "~/server/utils/encryption";
+
+describe("versioned string ciphertext", () => {
+  it("writes a v1: prefix and round-trips", () => {
+    const ct = encryptToBase64("hello-secret");
+    expect(ct.startsWith("v1:")).toBe(true);
+    expect(decryptFromBase64(ct)).toBe("hello-secret");
+  });
+
+  it("still decrypts legacy unprefixed ciphertext as v1", () => {
+    const legacy = Buffer.from(encryptString("legacy-secret")).toString("base64");
+    expect(legacy.startsWith("v1:")).toBe(false);
+    expect(decryptFromBase64(legacy)).toBe("legacy-secret");
+  });
+
+  it("returns null for garbage input", () => {
+    expect(decryptFromBase64("not-ciphertext-at-all")).toBeNull();
+    expect(decryptFromBase64("v1:AAAA")).toBeNull();
+    expect(decryptFromBase64(null)).toBeNull();
+  });
+});

--- a/src/server/utils/__tests__/encryptionRotation.test.ts
+++ b/src/server/utils/__tests__/encryptionRotation.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Key-rotation test (2026-07-30 audit, V5): a credential written under the
+ * OLD key must still decrypt after rotation, given
+ * DATABASE_ENCRYPTION_KEY_PREVIOUS. Lives in its own file because
+ * encryption.ts captures both keys at module load.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import crypto from "crypto";
+
+const OLD_KEY = "1".repeat(32);
+const NEW_KEY = "2".repeat(32);
+
+vi.hoisted(() => {
+  process.env.DATABASE_ENCRYPTION_KEY = "2".repeat(32);
+  process.env.DATABASE_ENCRYPTION_KEY_PREVIOUS = "1".repeat(32);
+});
+
+import {
+  encryptToBase64,
+  decryptFromBase64,
+  decryptFromBase64WithKeyInfo,
+  decryptBufferWithKeyInfo,
+} from "~/server/utils/encryption";
+
+/** Produce iv12+tag16+ct ciphertext under an arbitrary raw 32-byte key. */
+function encryptUnder(key: string, plaintext: string): Buffer {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", Buffer.from(key), iv);
+  const ct = Buffer.concat([cipher.update(Buffer.from(plaintext, "utf8")), cipher.final()]);
+  return Buffer.concat([iv, cipher.getAuthTag(), ct]);
+}
+
+describe("key rotation with DATABASE_ENCRYPTION_KEY_PREVIOUS", () => {
+  it("decrypts old-key ciphertext via the previous-key fallback and reports it", () => {
+    const legacyCiphertext = encryptUnder(OLD_KEY, "written-before-rotation").toString("base64");
+
+    expect(decryptFromBase64(legacyCiphertext)).toBe("written-before-rotation");
+
+    const info = decryptFromBase64WithKeyInfo(`v1:${legacyCiphertext}`);
+    expect(info).toMatchObject({ ok: true, value: "written-before-rotation", usedPreviousKey: true });
+  });
+
+  it("decrypts current-key ciphertext without the fallback", () => {
+    const info = decryptFromBase64WithKeyInfo(encryptToBase64("written-after-rotation"));
+    expect(info).toMatchObject({ ok: true, value: "written-after-rotation", usedPreviousKey: false });
+  });
+
+  it("applies the fallback to binary (CRM Bytes) ciphertext too", () => {
+    const oldBinary = encryptUnder(OLD_KEY, "pii-under-old-key");
+    expect(decryptBufferWithKeyInfo(oldBinary)).toEqual({
+      value: "pii-under-old-key",
+      usedPreviousKey: true,
+    });
+  });
+
+  it("still fails (auth_failed) when neither key matches", () => {
+    const foreign = encryptUnder("3".repeat(32), "unreachable").toString("base64");
+    expect(decryptFromBase64WithKeyInfo(foreign)).toEqual({ ok: false, reason: "auth_failed" });
+  });
+
+  it("round-trips new writes under the new key", () => {
+    expect(decryptFromBase64(encryptToBase64(NEW_KEY + "-payload"))).toBe(NEW_KEY + "-payload");
+  });
+});

--- a/src/server/utils/__tests__/encryptionRotation.test.ts
+++ b/src/server/utils/__tests__/encryptionRotation.test.ts
@@ -21,6 +21,7 @@ import {
   decryptFromBase64,
   decryptFromBase64WithKeyInfo,
   decryptBufferWithKeyInfo,
+  decryptBufferSafe,
 } from "~/server/utils/encryption";
 
 /** Produce iv12+tag16+ct ciphertext under an arbitrary raw 32-byte key. */
@@ -57,6 +58,12 @@ describe("key rotation with DATABASE_ENCRYPTION_KEY_PREVIOUS", () => {
   it("still fails (auth_failed) when neither key matches", () => {
     const foreign = encryptUnder("3".repeat(32), "unreachable").toString("base64");
     expect(decryptFromBase64WithKeyInfo(foreign)).toEqual({ ok: false, reason: "auth_failed" });
+  });
+
+  it("decryptBufferSafe degrades to null on a wrong key instead of throwing (CRM PII paths)", () => {
+    const foreign = encryptUnder("3".repeat(32), "pii-under-unknown-key");
+    expect(() => decryptBufferSafe(foreign)).not.toThrow();
+    expect(decryptBufferSafe(foreign)).toBeNull();
   });
 
   it("round-trips new writes under the new key", () => {

--- a/src/server/utils/credentialHelper.ts
+++ b/src/server/utils/credentialHelper.ts
@@ -1,4 +1,9 @@
-import { encryptToBase64, decryptFromBase64, isEncryptionAvailable } from './encryption';
+import {
+  encryptToBase64,
+  decryptFromBase64Result,
+  isEncryptionAvailable,
+  type DecryptResult,
+} from './encryption';
 
 /**
  * Helper for managing integration credentials with encryption support.
@@ -26,27 +31,38 @@ export function encryptCredential(plaintext: string): { key: string; isEncrypted
 }
 
 /**
- * Decrypt a credential value.
+ * Decrypt a credential value, reporting WHY on failure.
  * Handles both encrypted and plaintext credentials based on isEncrypted flag.
  */
-export function decryptCredential(key: string, isEncrypted: boolean): string | null {
+export function decryptCredentialResult(key: string, isEncrypted: boolean): DecryptResult {
   if (!isEncrypted) {
-    // Plaintext credential (legacy or encryption unavailable)
-    return key;
+    // Plaintext credential (legacy) — the flag decides, never the caller.
+    return { ok: true, value: key };
   }
+  return decryptFromBase64Result(key);
+}
 
-  try {
-    const decrypted = decryptFromBase64(key);
-    if (decrypted === null) {
-      // Decryption failed - might be corrupted or wrong key
-      console.error('Failed to decrypt credential - returning null');
-      return null;
-    }
-    return decrypted;
-  } catch (error) {
-    console.error('Credential decryption error:', error);
+/**
+ * Decrypt a credential value, collapsing failures to null (after logging the
+ * reason). Prefer decryptCredentialResult where the caller can surface the
+ * distinction — an `auth_failed` here usually means a wrong or rotated
+ * DATABASE_ENCRYPTION_KEY, which must be alertable, not mistaken for an
+ * unconfigured integration.
+ */
+export function decryptCredential(key: string, isEncrypted: boolean): string | null {
+  const result = decryptCredentialResult(key, isEncrypted);
+  if (!result.ok) {
+    console.error(
+      `[credentialHelper] Failed to decrypt credential (reason: ${result.reason})` +
+        (result.reason === 'auth_failed'
+          ? ' — ciphertext did not authenticate; check DATABASE_ENCRYPTION_KEY (wrong or rotated key?)'
+          : result.reason === 'no_key'
+            ? ' — DATABASE_ENCRYPTION_KEY is not set'
+            : ' — value is not ciphertext (mislabelled row?)'),
+    );
     return null;
   }
+  return result.value;
 }
 
 /**

--- a/src/server/utils/encryption.ts
+++ b/src/server/utils/encryption.ts
@@ -48,25 +48,38 @@ export function decryptBuffer(buf: Buffer | Uint8Array | null | undefined): stri
 }
 
 /**
- * Encrypt a string and return it as a base64-encoded string.
+ * Version prefix for string-form ciphertext. Written on every encrypt so a
+ * future scheme change (new algorithm, key id) has something to dispatch on;
+ * legacy unprefixed values are treated as v1.
+ */
+const CIPHERTEXT_V1_PREFIX = 'v1:';
+
+/**
+ * Encrypt a string and return it as version-prefixed base64 (`v1:<base64>`).
  * Useful for storing encrypted data in String database fields.
  */
 export function encryptToBase64(plaintext: string): string {
   const encrypted = encryptString(plaintext);
-  return Buffer.from(encrypted).toString('base64');
+  return CIPHERTEXT_V1_PREFIX + Buffer.from(encrypted).toString('base64');
 }
 
 /**
- * Decrypt a base64-encoded encrypted string.
- * Useful for reading encrypted data from String database fields.
+ * Decrypt a (possibly version-prefixed) base64-encoded encrypted string.
+ * Accepts both `v1:<base64>` and legacy unprefixed `<base64>` (treated as v1).
  */
 export function decryptFromBase64(base64Encrypted: string | null | undefined): string | null {
   if (!base64Encrypted) return null;
+  const base64 = base64Encrypted.startsWith(CIPHERTEXT_V1_PREFIX)
+    ? base64Encrypted.slice(CIPHERTEXT_V1_PREFIX.length)
+    : base64Encrypted;
   try {
-    const buf = Buffer.from(base64Encrypted, 'base64');
+    const buf = Buffer.from(base64, 'base64');
     return decryptBuffer(buf);
   } catch {
-    // If decryption fails, the value might be stored in plaintext (legacy)
+    // NOTE: Buffer.from(x, 'base64') does not throw on non-base64 input — it
+    // decodes what it can. What lands here is the GCM auth-tag failure from
+    // decryptBuffer (wrong key, corruption, or a plaintext value that
+    // happened to be long enough to attempt).
     return null;
   }
 }

--- a/src/server/utils/encryption.ts
+++ b/src/server/utils/encryption.ts
@@ -5,18 +5,35 @@ if (!KEY_ENV) {
   console.warn('DATABASE_ENCRYPTION_KEY not set - encryption will not be available in production');
 }
 
-// Expect the key to be base64 or raw 32-byte string. Normalize to Buffer of length 32.
-function getKey(): Buffer {
-  if (!KEY_ENV) throw new Error('DATABASE_ENCRYPTION_KEY is not defined');
+/**
+ * Decrypt-only fallback for key rotation: set DATABASE_ENCRYPTION_KEY to the
+ * NEW key and DATABASE_ENCRYPTION_KEY_PREVIOUS to the old one, deploy, run
+ * scripts/reencrypt-under-current-key.ts, then drop the previous key. See
+ * dev-docs/ENCRYPTION_KEY_ROTATION.md. Never used for encryption.
+ */
+const KEY_PREVIOUS_ENV = process.env.DATABASE_ENCRYPTION_KEY_PREVIOUS || '';
+
+// Expect a key to be base64 or raw 32-byte string. Normalize to Buffer of length 32.
+function normalizeKey(envValue: string, name: string): Buffer {
+  if (!envValue) throw new Error(`${name} is not defined`);
   try {
-    const buf = Buffer.from(KEY_ENV, 'base64');
+    const buf = Buffer.from(envValue, 'base64');
     if (buf.length === 32) return buf;
   } catch {
     // fallthrough - try raw encoding
   }
-  const raw = Buffer.from(KEY_ENV);
+  const raw = Buffer.from(envValue);
   if (raw.length === 32) return raw;
-  throw new Error('DATABASE_ENCRYPTION_KEY must be 32 bytes (raw) or base64-encoded 32 bytes');
+  throw new Error(`${name} must be 32 bytes (raw) or base64-encoded 32 bytes`);
+}
+
+function getKey(): Buffer {
+  return normalizeKey(KEY_ENV, 'DATABASE_ENCRYPTION_KEY');
+}
+
+function getPreviousKey(): Buffer | null {
+  if (!KEY_PREVIOUS_ENV) return null;
+  return normalizeKey(KEY_PREVIOUS_ENV, 'DATABASE_ENCRYPTION_KEY_PREVIOUS');
 }
 
 export function encryptString(plaintext: string): Uint8Array<ArrayBuffer> {
@@ -33,18 +50,45 @@ export function encryptString(plaintext: string): Uint8Array<ArrayBuffer> {
   return out;
 }
 
-export function decryptBuffer(buf: Buffer | Uint8Array | null | undefined): string | null {
-  if (!buf) return null;
-  const data = Buffer.from(buf);
-  if (data.length < 28) return null; // iv(12) + tag(16) at least
+function decryptDataWithKey(data: Buffer, key: Buffer): string {
   const iv = data.slice(0, 12);
   const tag = data.slice(12, 28);
   const encrypted = data.slice(28);
-  const key = getKey();
   const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
   decipher.setAuthTag(tag);
   const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
   return decrypted.toString('utf8');
+}
+
+/**
+ * Decrypt binary ciphertext, reporting which key succeeded. Tries the current
+ * DATABASE_ENCRYPTION_KEY first, then DATABASE_ENCRYPTION_KEY_PREVIOUS (if
+ * set) as a decrypt-only fallback during rotation. Throws on auth failure of
+ * every available key (see decryptBuffer for the null-collapsing form).
+ */
+export function decryptBufferWithKeyInfo(
+  buf: Buffer | Uint8Array | null | undefined,
+): { value: string; usedPreviousKey: boolean } | null {
+  if (!buf) return null;
+  const data = Buffer.from(buf);
+  if (data.length < 28) return null; // iv(12) + tag(16) at least
+  try {
+    return { value: decryptDataWithKey(data, getKey()), usedPreviousKey: false };
+  } catch (error) {
+    const previousKey = getPreviousKey();
+    if (!previousKey) throw error;
+    try {
+      return { value: decryptDataWithKey(data, previousKey), usedPreviousKey: true };
+    } catch {
+      // Report the current-key failure — that's the actionable one.
+      throw error;
+    }
+  }
+}
+
+export function decryptBuffer(buf: Buffer | Uint8Array | null | undefined): string | null {
+  const result = decryptBufferWithKeyInfo(buf);
+  return result === null ? null : result.value;
 }
 
 /**
@@ -79,16 +123,21 @@ export type DecryptResult =
 
 /**
  * Decrypt a (possibly version-prefixed) base64-encoded encrypted string,
- * reporting WHY on failure. Accepts both `v1:<base64>` and legacy unprefixed
- * `<base64>` (treated as v1).
+ * reporting WHY on failure and WHICH key succeeded. Accepts both
+ * `v1:<base64>` and legacy unprefixed `<base64>` (treated as v1).
+ * `usedPreviousKey` / `hadVersionPrefix` drive the rotation re-encrypt
+ * script (scripts/reencrypt-under-current-key.ts).
  */
-export function decryptFromBase64Result(
+export function decryptFromBase64WithKeyInfo(
   base64Encrypted: string | null | undefined,
-): DecryptResult {
+):
+  | { ok: true; value: string; usedPreviousKey: boolean; hadVersionPrefix: boolean }
+  | { ok: false; reason: DecryptFailureReason } {
   if (!base64Encrypted) return { ok: false, reason: 'not_ciphertext' };
   if (!KEY_ENV) return { ok: false, reason: 'no_key' };
 
-  const base64 = base64Encrypted.startsWith(CIPHERTEXT_V1_PREFIX)
+  const hadVersionPrefix = base64Encrypted.startsWith(CIPHERTEXT_V1_PREFIX);
+  const base64 = hadVersionPrefix
     ? base64Encrypted.slice(CIPHERTEXT_V1_PREFIX.length)
     : base64Encrypted;
 
@@ -98,13 +147,24 @@ export function decryptFromBase64Result(
   if (buf.length < 28) return { ok: false, reason: 'not_ciphertext' }; // iv(12) + tag(16)
 
   try {
-    const value = decryptBuffer(buf);
-    if (value === null) return { ok: false, reason: 'not_ciphertext' };
-    return { ok: true, value };
+    const result = decryptBufferWithKeyInfo(buf);
+    if (result === null) return { ok: false, reason: 'not_ciphertext' };
+    return { ok: true, value: result.value, usedPreviousKey: result.usedPreviousKey, hadVersionPrefix };
   } catch {
-    // GCM auth-tag verification failure (or an invalid key).
+    // GCM auth-tag verification failure under every available key.
     return { ok: false, reason: 'auth_failed' };
   }
+}
+
+/**
+ * Decrypt a (possibly version-prefixed) base64-encoded encrypted string,
+ * reporting WHY on failure.
+ */
+export function decryptFromBase64Result(
+  base64Encrypted: string | null | undefined,
+): DecryptResult {
+  const result = decryptFromBase64WithKeyInfo(base64Encrypted);
+  return result.ok ? { ok: true, value: result.value } : result;
 }
 
 /**

--- a/src/server/utils/encryption.ts
+++ b/src/server/utils/encryption.ts
@@ -64,24 +64,58 @@ export function encryptToBase64(plaintext: string): string {
 }
 
 /**
- * Decrypt a (possibly version-prefixed) base64-encoded encrypted string.
- * Accepts both `v1:<base64>` and legacy unprefixed `<base64>` (treated as v1).
+ * Why a decrypt failed. `no_key` — DATABASE_ENCRYPTION_KEY absent;
+ * `not_ciphertext` — the value cannot be iv12+tag16+ct (too short / empty);
+ * `auth_failed` — structurally plausible ciphertext whose GCM auth tag did
+ * not verify: wrong/rotated key, corruption, or mislabelled plaintext.
+ * The distinction is what makes a key-rotation mistake alertable instead of
+ * looking like "the user never configured this integration".
  */
-export function decryptFromBase64(base64Encrypted: string | null | undefined): string | null {
-  if (!base64Encrypted) return null;
+export type DecryptFailureReason = 'no_key' | 'auth_failed' | 'not_ciphertext';
+
+export type DecryptResult =
+  | { ok: true; value: string }
+  | { ok: false; reason: DecryptFailureReason };
+
+/**
+ * Decrypt a (possibly version-prefixed) base64-encoded encrypted string,
+ * reporting WHY on failure. Accepts both `v1:<base64>` and legacy unprefixed
+ * `<base64>` (treated as v1).
+ */
+export function decryptFromBase64Result(
+  base64Encrypted: string | null | undefined,
+): DecryptResult {
+  if (!base64Encrypted) return { ok: false, reason: 'not_ciphertext' };
+  if (!KEY_ENV) return { ok: false, reason: 'no_key' };
+
   const base64 = base64Encrypted.startsWith(CIPHERTEXT_V1_PREFIX)
     ? base64Encrypted.slice(CIPHERTEXT_V1_PREFIX.length)
     : base64Encrypted;
+
+  // NOTE: Buffer.from(x, 'base64') does not throw on non-base64 input — it
+  // decodes what it can, so length is the only structural signal here.
+  const buf = Buffer.from(base64, 'base64');
+  if (buf.length < 28) return { ok: false, reason: 'not_ciphertext' }; // iv(12) + tag(16)
+
   try {
-    const buf = Buffer.from(base64, 'base64');
-    return decryptBuffer(buf);
+    const value = decryptBuffer(buf);
+    if (value === null) return { ok: false, reason: 'not_ciphertext' };
+    return { ok: true, value };
   } catch {
-    // NOTE: Buffer.from(x, 'base64') does not throw on non-base64 input — it
-    // decodes what it can. What lands here is the GCM auth-tag failure from
-    // decryptBuffer (wrong key, corruption, or a plaintext value that
-    // happened to be long enough to attempt).
-    return null;
+    // GCM auth-tag verification failure (or an invalid key).
+    return { ok: false, reason: 'auth_failed' };
   }
+}
+
+/**
+ * Decrypt a (possibly version-prefixed) base64-encoded encrypted string.
+ * Accepts both `v1:<base64>` and legacy unprefixed `<base64>` (treated as v1).
+ * Collapses all failures to null — prefer decryptFromBase64Result where the
+ * failure reason matters.
+ */
+export function decryptFromBase64(base64Encrypted: string | null | undefined): string | null {
+  const result = decryptFromBase64Result(base64Encrypted);
+  return result.ok ? result.value : null;
 }
 
 /**

--- a/src/server/utils/encryption.ts
+++ b/src/server/utils/encryption.ts
@@ -92,6 +92,24 @@ export function decryptBuffer(buf: Buffer | Uint8Array | null | undefined): stri
 }
 
 /**
+ * decryptBuffer that never throws: a wrong/rotated key degrades to null
+ * (logged) instead of 500ing the caller. Use for display paths — CRM contact
+ * PII in particular — where a page rendering with blank fields beats an
+ * error page. Keep decryptBuffer for callers that must fail loudly.
+ */
+export function decryptBufferSafe(buf: Buffer | Uint8Array | null | undefined): string | null {
+  try {
+    return decryptBuffer(buf);
+  } catch (error) {
+    console.error(
+      '[encryption] decryptBufferSafe: value did not authenticate under any available key — check DATABASE_ENCRYPTION_KEY (wrong or rotated?)',
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+}
+
+/**
  * Version prefix for string-form ciphertext. Written on every encrypt so a
  * future scheme change (new algorithm, key id) has something to dispatch on;
  * legacy unprefixed values are treated as v1.


### PR DESCRIPTION
### **User description**
## What

Makes `DATABASE_ENCRYPTION_KEY` rotatable (feature `cms8lpaf60001jl048uxkjsfe`, scope V5, from the 2026-07-30 integration-secrets audit). Previously ciphertext carried no version, every decrypt failure collapsed to `null`, and a rotation would have looked like a silent per-integration outage — while the CRM's unguarded `decryptBuffer` calls would 500 every contact query.

1. **Versioned ciphertext** — string writes are now `v1:<base64(iv12+tag16+ct)>`; decryption accepts legacy unprefixed values as v1.
2. **Discriminated decrypt result** — `decryptCredentialResult` / `decryptFromBase64Result` return `{ok:false, reason: 'no_key' | 'auth_failed' | 'not_ciphertext'}`, so a wrong/rotated key (`auth_failed`) is loggable and alertable, distinct from an unconfigured integration. The cited callers (integration `testConnection`, Zulip service, ticketSync notionAdapter) surface reason-specific errors.
3. **Rotation support** — `DATABASE_ENCRYPTION_KEY_PREVIOUS` is a decrypt-only fallback (string + Bytes paths), validated in `src/env.js`. `scripts/reencrypt-under-current-key.ts` (dry-run by default, idempotent, non-zero exit on failures) rewrites `IntegrationCredential`, CRM PII, `CrmCommunication` and `User.phone` under the current key and normalizes legacy unprefixed ciphertext. Runbook: `dev-docs/ENCRYPTION_KEY_ROTATION.md` — add previous → deploy → re-encrypt → drop previous.
4. **CRM fail-soft** — new `decryptBufferSafe` degrades to logged `null` on a bad key; all contact-PII read paths converted (crmContact, crmApi, transcription, SendEmailStep, crmContactMemberResolver, mastra CRM endpoints), so the contact list renders with blank PII instead of 500ing.

Also corrects the misleading `catch` comment in `encryption.ts` — `Buffer.from(x, 'base64')` never throws; that catch fires on the GCM auth-tag error.

## Acceptance criteria

- [x] A credential written today decrypts after the key is rotated, given `DATABASE_ENCRYPTION_KEY_PREVIOUS`
- [x] Legacy unprefixed ciphertext still decrypts
- [x] A wrong-key failure is distinguishable in logs from a missing credential
- [x] With a deliberately wrong key, the CRM contact list renders with null PII instead of returning 500
- [x] Re-encrypt script is idempotent and reports counts
- [x] `npm run check` passes

---

Ships: rainy.pine

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cms8lttas0005jp04bosx7698)


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Add versioned ciphertext (`v1:<base64>`) and discriminated decrypt results for key rotation support

- Introduce `DATABASE_ENCRYPTION_KEY_PREVIOUS` as a decrypt-only fallback during rotation

- Replace throwing `decryptBuffer` with safe `decryptBufferSafe` across all CRM PII read paths

- Add re-encrypt migration script, runbook, and comprehensive test coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ENV["DATABASE_ENCRYPTION_KEY\n+ _PREVIOUS (optional)"]
  ENC["encryption.ts\n(versioned v1: prefix,\ndiscriminated results,\nprevious-key fallback)"]
  CRED["credentialHelper.ts\n(decryptCredentialResult)"]
  CRM["CRM PII paths\n(decryptBufferSafe)"]
  CALLERS["integration.ts\nZulipService\nnotionAdapter"]
  SCRIPT["scripts/reencrypt-under-current-key.ts"]
  RUNBOOK["dev-docs/ENCRYPTION_KEY_ROTATION.md"]

  ENV -- "normalizeKey()" --> ENC
  ENC -- "DecryptResult / KeyInfo" --> CRED
  ENC -- "decryptBufferSafe" --> CRM
  CRED -- "reason-specific errors" --> CALLERS
  SCRIPT -- "dry-run / --apply" --> ENC
  RUNBOOK -- "documents" --> SCRIPT
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>encryption.ts</strong><dd><code>Versioned ciphertext, discriminated results, and previous-key fallback</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-58be3afc57e720cc00b373b4d9af5cf359f82452cb81bf7cfb2bc390307e29bf">+146/-21</a></td>

</tr>

<tr>
  <td><strong>credentialHelper.ts</strong><dd><code>Add decryptCredentialResult with reason-coded failure reporting</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-1c6f8be75c6b3a912aabd6dcd400f0b40759babe16455d163c44ed81144987f5">+31/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>reencrypt-under-current-key.ts</strong><dd><code>Idempotent re-encryption script for key rotation migration</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-8f1880fac28e53c55e4ea9959ab741dac1bd7bd0d3ec6ef314716e0771e3c4d1">+178/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>env.js</strong><dd><code>Validate and expose DATABASE_ENCRYPTION_KEY_PREVIOUS env var</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-5fefa99495d6ed3e62e828ee33b4be377469032ec0a61c088bc0101e071c1172">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ENCRYPTION_KEY_ROTATION.md</strong><dd><code>Runbook documenting the full key rotation procedure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-607390f1355f3272593db9ee4f002b440ff189d6b84a10988e0329bea41824f1">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>crmApi.ts</strong><dd><code>Replace decryptBuffer with decryptBufferSafe for contact PII</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-5a0e60d29e34a8b4a14c8286db30121f20477f6f47479aa3b31553831ff6f0b4">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>crmContact.ts</strong><dd><code>Replace decryptBuffer with decryptBufferSafe for contact PII</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-4365e036b2514a8aa3f9962c34aadb646c4e6e06b1223a39744976340d8b07a9">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mastra.ts</strong><dd><code>Replace decryptBuffer with decryptBufferSafe across CRM endpoints</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-afd76ed5d04839b106766464d541d99c9b1d0e8b28477ea826c7dcf52db960bb">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>transcription.ts</strong><dd><code>Replace decryptBuffer with decryptBufferSafe for participant email</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-14d6aec7ca6f74348adfbedb772dd759262f6da276ab98b75041752d8d7ea06b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SendEmailStep.ts</strong><dd><code>Replace decryptBuffer with decryptBufferSafe for contact email</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-4041a8296460e14d669a2d94d5e05d2389e424e3b236dcaecf19858e2b4fc6f4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>crmContactMemberResolver.ts</strong><dd><code>Replace decryptBuffer with decryptBufferSafe for member email</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-9779fce80954af81b70c791024515b0901a888ad8ecae0a83a79c22b5566c40a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>integration.ts</strong><dd><code>Surface reason-specific errors for Fireflies and Slack key failures</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-c77c1944f43c90e73f35e8df34be0e27e5c7ef596a4380d6e731f974acb89b3f">+21/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ZulipNotificationService.ts</strong><dd><code>Log auth_failed reason when Zulip API token cannot be decrypted</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-5bf32241bc22b4062fdfb55d26d9ec88d1d881fd8683d900236ff244682c5ba7">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notionAdapter.ts</strong><dd><code>Return reason-specific errors for Notion token decryption failures</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-01ccbdc7c270905dc6d098bdec52026e3fadd76ea2f3d33c301bece929bc8e5d">+18/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>encryption.test.ts</strong><dd><code>Unit tests for versioned ciphertext and legacy compatibility</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-91928eba7a2a036dcd93c09bbbf98d4b53eb69ea18c5e819cc5a3b2725caafc4">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>encryptionRotation.test.ts</strong><dd><code>Tests for previous-key fallback and decryptBufferSafe degradation</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-413cac2dad57a1c35b449cba28793e0c68295b2964590abf5bb688be7cf4f0b1">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>credentialHelper.test.ts</strong><dd><code>Tests for decryptCredentialResult with various credential states</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-5b9970bb29a94d16f4a7a66df3a24abb73528a884570d3b7167cb0a6b5f8e0c0">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>credentialHelperEnforcement.test.ts</strong><dd><code>Test no_key reason when DATABASE_ENCRYPTION_KEY is absent</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/444/files#diff-570c35f58e5f58454eb24fd43f9e2465d776b5a7158a41ae0439b0b893457f6c">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

