### PR TITLE
refactor: FakeNotion round-trip harness + quiescence tests for ticket sync

### DIFF
--- a/src/server/services/ticketSync/__tests__/harness/fakeNotion.ts
+++ b/src/server/services/ticketSync/__tests__/harness/fakeNotion.ts
@@ -1,0 +1,381 @@
+import type {
+  RemoteTicketRow,
+  TicketSyncRemoteAdapter,
+} from "../../engine";
+import type { TicketPushAdapter } from "../../push";
+import type { NotionDbSchema } from "../../outboundMapping";
+import type { TestClock } from "./testClock";
+
+/**
+ * FakeNotion — one in-memory Notion database implementing BOTH sync adapter
+ * seams ({@link TicketSyncRemoteAdapter} for the inbound engine and
+ * {@link TicketPushAdapter} for the outbound push), mirroring the production
+ * NotionTicketSyncAdapter which also implements both on one class.
+ *
+ * The point of a SHARED fake: pull and push in a test operate on the same page
+ * store, so round-trip properties (quiescence, echo suppression, no ping-pong)
+ * are exercised for real instead of against per-direction stubs. Pages track
+ * `lastEditedAt` and who edited them — writes through the push adapter are
+ * "bot" edits (surfaced as `lastEditedByBot` on query, which the engine's echo
+ * suppression keys on); `editAsHuman()` simulates a person editing in Notion.
+ *
+ * Every adapter write is appended to {@link FakeNotion.writes} so tests can
+ * assert zero-write quiescence precisely.
+ */
+
+export interface FakePage {
+  externalId: string;
+  url: string | null;
+  title: string;
+  rawStatus: string | null;
+  rawPriority: string | null;
+  rawType: string | null;
+  rawEffort: string | null;
+  labels: string[];
+  cycleName: string | null;
+  assigneeEmail: string | null;
+  lastEditedAt: Date;
+  lastEditedBy: "bot" | "human";
+  archived: boolean;
+  /** Properties written by the sync that the fake has no column for. */
+  extra: Record<string, unknown>;
+  /** Body blocks passed to createPage, kept for assertions. */
+  children: unknown[];
+}
+
+export interface NotionWrite {
+  method: "updatePage" | "createPage" | "archivePage";
+  externalId: string | null;
+  properties?: Record<string, unknown>;
+}
+
+/** Raw option names for each TicketStatus, matching DEFAULT_STATUS_MAP. */
+export const STATUS_TO_RAW: Record<string, string> = {
+  BACKLOG: "Backlog",
+  NEEDS_REFINEMENT: "Needs Refinement",
+  READY_TO_PLAN: "Ready to Plan",
+  COMMITTED: "Committed",
+  IN_PROGRESS: "In Progress",
+  BLOCKED: "Blocked",
+  QA: "In Review",
+  DONE: "Done",
+  DEPLOYED: "Shipped",
+  ARCHIVED: "Archived",
+};
+
+export const TYPE_TO_RAW: Record<string, string> = {
+  BUG: "Bug",
+  FEATURE: "Feature",
+  CHORE: "Chore",
+  IMPROVEMENT: "Improvement",
+  SPIKE: "Spike",
+  RESEARCH: "Research",
+};
+
+export const PRIORITY_TO_RAW: Record<number, string> = {
+  0: "0 - Critical",
+  1: "1 - High",
+  2: "2 - Medium",
+  3: "3 - Low",
+  4: "4 - Trivial",
+};
+
+export const POINTS_TO_RAW: Record<number, string> = {
+  1: "S (1pt)",
+  3: "M (3pts)",
+  5: "L (5pts)",
+  8: "XL (8pts)",
+};
+
+/**
+ * A schema whose options round-trip through mapping.ts for every value the
+ * raw-value tables above can produce — so outbound writes always find a
+ * matching option unless a test deliberately narrows the schema.
+ */
+export const DEFAULT_FAKE_SCHEMA: NotionDbSchema = {
+  Name: { type: "title" },
+  Status: { type: "status", options: Object.values(STATUS_TO_RAW) },
+  Priority: { type: "select", options: Object.values(PRIORITY_TO_RAW) },
+  Type: { type: "select", options: Object.values(TYPE_TO_RAW) },
+  Effort: { type: "select", options: Object.values(POINTS_TO_RAW) },
+  Label: { type: "multi_select", options: [] },
+  Cycles: { type: "relation" },
+  Assignee: { type: "people" },
+};
+
+/** Property-name → page-column roles, mirroring the default config names. */
+const DEFAULT_PROPERTY_NAMES = {
+  status: "Status",
+  priority: "Priority",
+  type: "Type",
+  effort: "Effort",
+  label: "Label",
+  cycle: "Cycles",
+  assignee: "Assignee",
+};
+
+/** The payload shapes mapFieldsToNotion / the engine hand to pages.update. */
+interface PropertyPayload {
+  title?: Array<{ text: { content: string } }>;
+  status?: { name?: string } | null;
+  select?: { name?: string } | null;
+  number?: number | null;
+  multi_select?: Array<{ name: string }>;
+  relation?: Array<{ id: string }>;
+  people?: Array<{ id: string }>;
+}
+
+export class FakeNotion implements TicketSyncRemoteAdapter, TicketPushAdapter {
+  readonly pages = new Map<string, FakePage>();
+  readonly writes: NotionWrite[] = [];
+  /** Set to make the next updatePage call throw (failure injection). */
+  updatePageError: Error | null = null;
+
+  /** Cycle relation pages: page id → cycle title. */
+  readonly cyclePagesById = new Map<string, string>();
+  /** Notion workspace people: email → person id. */
+  readonly peopleByEmail = new Map<string, string>();
+
+  private schema: NotionDbSchema;
+  private readonly propertyNames = { ...DEFAULT_PROPERTY_NAMES };
+  private pageCounter = 0;
+
+  constructor(
+    private readonly clock: TestClock,
+    opts: { schema?: NotionDbSchema } = {},
+  ) {
+    this.schema = opts.schema ?? DEFAULT_FAKE_SCHEMA;
+  }
+
+  setSchema(schema: NotionDbSchema): void {
+    this.schema = schema;
+  }
+
+  // ── seeding & simulated human activity ────────────────────────────────────
+
+  seedPage(overrides: Partial<FakePage> = {}): FakePage {
+    const id = overrides.externalId ?? `page-${++this.pageCounter}`;
+    const page: FakePage = {
+      externalId: id,
+      url: `https://notion.so/${id}`,
+      title: "Seeded row",
+      rawStatus: "In Progress",
+      rawPriority: "1 - High",
+      rawType: "Bug",
+      rawEffort: "L (5pts)",
+      labels: [],
+      cycleName: null,
+      assigneeEmail: null,
+      lastEditedAt: this.clock.now(),
+      lastEditedBy: "human",
+      archived: false,
+      extra: {},
+      children: [],
+      ...overrides,
+    };
+    this.pages.set(page.externalId, page);
+    return page;
+  }
+
+  /** Simulate a person editing the page in Notion. */
+  editAsHuman(
+    externalId: string,
+    patch: Partial<
+      Pick<
+        FakePage,
+        | "title"
+        | "rawStatus"
+        | "rawPriority"
+        | "rawType"
+        | "rawEffort"
+        | "labels"
+        | "cycleName"
+        | "assigneeEmail"
+        | "archived"
+      >
+    >,
+  ): FakePage {
+    const page = this.mustGet(externalId);
+    Object.assign(page, patch);
+    page.lastEditedAt = this.clock.advance();
+    page.lastEditedBy = "human";
+    return page;
+  }
+
+  /** Remove a page entirely, so getRow returns null (page 404s). */
+  deletePage(externalId: string): void {
+    this.pages.delete(externalId);
+  }
+
+  // ── TicketSyncRemoteAdapter (inbound / pull) ──────────────────────────────
+
+  queryRows(params: {
+    databaseId: string;
+    editedAfter?: Date;
+    relationScope?: { property: string; contains: string };
+  }): Promise<RemoteTicketRow[]> {
+    const rows = [...this.pages.values()]
+      .filter(
+        (p) =>
+          params.editedAfter === undefined ||
+          p.lastEditedAt.getTime() > params.editedAfter.getTime(),
+      )
+      .map((p) => this.toRow(p));
+    return Promise.resolve(rows);
+  }
+
+  getPageBody(externalId: string): Promise<string | null> {
+    const page = this.pages.get(externalId);
+    return Promise.resolve(page ? `Body of ${page.title}` : null);
+  }
+
+  // ── TicketPushAdapter (outbound / push) ───────────────────────────────────
+
+  getRow(externalId: string): Promise<RemoteTicketRow | null> {
+    const page = this.pages.get(externalId);
+    return Promise.resolve(page ? this.toRow(page) : null);
+  }
+
+  getWriteSchema(_databaseId: string): Promise<NotionDbSchema> {
+    return Promise.resolve(this.schema);
+  }
+
+  updatePage(
+    externalId: string,
+    properties: Record<string, unknown>,
+  ): Promise<void> {
+    if (this.updatePageError) {
+      const error = this.updatePageError;
+      this.updatePageError = null;
+      return Promise.reject(error);
+    }
+    const page = this.mustGet(externalId);
+    this.writes.push({ method: "updatePage", externalId, properties });
+    this.applyProperties(page, properties);
+    page.lastEditedAt = this.clock.advance();
+    page.lastEditedBy = "bot";
+    return Promise.resolve();
+  }
+
+  findCyclePageIdByName(
+    _databaseId: string,
+    _cycleProperty: string,
+    name: string,
+  ): Promise<string | null> {
+    for (const [id, title] of this.cyclePagesById) {
+      if (title === name) return Promise.resolve(id);
+    }
+    return Promise.resolve(null);
+  }
+
+  findPersonIdByEmail(email: string): Promise<string | null> {
+    return Promise.resolve(this.peopleByEmail.get(email) ?? null);
+  }
+
+  createPage(params: {
+    databaseId: string;
+    titleProperty: string | null;
+    properties: Record<string, unknown>;
+    children: unknown[];
+  }): Promise<{ externalId: string; url: string | null }> {
+    const page = this.seedPage({ title: "", children: params.children });
+    this.writes.push({
+      method: "createPage",
+      externalId: page.externalId,
+      properties: params.properties,
+    });
+    this.applyProperties(page, params.properties);
+    page.lastEditedAt = this.clock.advance();
+    page.lastEditedBy = "bot";
+    return Promise.resolve({ externalId: page.externalId, url: page.url });
+  }
+
+  archivePage(externalId: string): Promise<void> {
+    const page = this.mustGet(externalId);
+    this.writes.push({ method: "archivePage", externalId });
+    page.archived = true;
+    page.lastEditedAt = this.clock.advance();
+    page.lastEditedBy = "bot";
+    return Promise.resolve();
+  }
+
+  // ── internals ─────────────────────────────────────────────────────────────
+
+  private mustGet(externalId: string): FakePage {
+    const page = this.pages.get(externalId);
+    if (!page) throw new Error(`FakeNotion: no page ${externalId}`);
+    return page;
+  }
+
+  private toRow(page: FakePage): RemoteTicketRow {
+    return {
+      externalId: page.externalId,
+      url: page.url,
+      title: page.title,
+      rawStatus: page.rawStatus,
+      rawPriority: page.rawPriority,
+      rawType: page.rawType,
+      rawEffort: page.rawEffort,
+      labels: [...page.labels],
+      cycleName: page.cycleName,
+      assigneeEmail: page.assigneeEmail,
+      lastEditedAt: page.lastEditedAt,
+      lastEditedByBot: page.lastEditedBy === "bot",
+      archived: page.archived,
+    };
+  }
+
+  /**
+   * Apply a pages.update/pages.create `properties` payload onto the page's
+   * columns — the reverse of what the real Notion API does — so subsequent
+   * pulls read back exactly what the push wrote.
+   */
+  private applyProperties(
+    page: FakePage,
+    properties: Record<string, unknown>,
+  ): void {
+    for (const [name, raw] of Object.entries(properties)) {
+      const payload = raw as PropertyPayload;
+      if (this.schema[name]?.type === "title") {
+        page.title = payload.title?.map((t) => t.text.content).join("") ?? "";
+      } else if (name === this.propertyNames.status) {
+        page.rawStatus =
+          payload.status?.name ?? payload.select?.name ?? null;
+      } else if (name === this.propertyNames.priority) {
+        page.rawPriority = this.optionOrNumber(payload, (n) => `${n}`);
+      } else if (name === this.propertyNames.type) {
+        page.rawType = payload.select?.name ?? null;
+      } else if (name === this.propertyNames.effort) {
+        page.rawEffort = this.optionOrNumber(payload, (n) => `${n} pts`);
+      } else if (name === this.propertyNames.label) {
+        page.labels = (payload.multi_select ?? []).map((o) => o.name);
+      } else if (name === this.propertyNames.cycle) {
+        const id = payload.relation?.[0]?.id ?? null;
+        page.cycleName = id ? (this.cyclePagesById.get(id) ?? null) : null;
+      } else if (name === this.propertyNames.assignee) {
+        const id = payload.people?.[0]?.id ?? null;
+        page.assigneeEmail = id ? (this.emailForPersonId(id) ?? null) : null;
+      } else {
+        // Source marker / backlink / unknown — keep visible for assertions.
+        page.extra[name] = raw;
+      }
+    }
+  }
+
+  private optionOrNumber(
+    payload: PropertyPayload,
+    format: (n: number) => string,
+  ): string | null {
+    if ("number" in payload) {
+      return payload.number == null ? null : format(payload.number);
+    }
+    return payload.select?.name ?? null;
+  }
+
+  private emailForPersonId(id: string): string | null {
+    for (const [email, personId] of this.peopleByEmail) {
+      if (personId === id) return email;
+    }
+    return null;
+  }
+}

--- a/src/server/services/ticketSync/__tests__/harness/fakeSyncDb.ts
+++ b/src/server/services/ticketSync/__tests__/harness/fakeSyncDb.ts
@@ -1,0 +1,426 @@
+import { Prisma } from "@prisma/client";
+import type { PrismaClient, TicketStatus, TicketType } from "@prisma/client";
+import type { SyncedFields } from "../../merge";
+import type { TestClock } from "./testClock";
+
+/**
+ * FakeSyncDb — a STATEFUL in-memory stand-in for the slice of Prisma the two
+ * sync runners touch (ticket, ticketSync, ticketSyncConfig, ticketSyncRun).
+ *
+ * The per-direction unit suites use `mockDeep<PrismaClient>` with canned
+ * returns; that can't express a round trip, where a pull's snapshot advance
+ * must be visible to the next push. This fake actually persists: writes mutate
+ * the stores, reads reflect them, and every mutation is appended to
+ * {@link FakeSyncDb.writeLog} so tests can assert zero-write quiescence.
+ *
+ * It implements ONLY the call shapes the runners make and throws loudly on
+ * anything else — an unsupported shape means the engine changed and the fake
+ * (not the assertion) needs extending.
+ */
+
+export interface FakeTicket {
+  id: string;
+  number: number;
+  title: string;
+  body: string | null;
+  status: TicketStatus;
+  type: TicketType;
+  priority: number | null;
+  points: number | null;
+  labels: string[];
+  cycleName: string | null;
+  assigneeEmail: string | null;
+  links: Record<string, unknown> | null;
+  updatedAt: Date;
+}
+
+export interface FakeSyncRecord {
+  id: string;
+  configId: string;
+  ticketId: string;
+  provider: string;
+  externalId: string;
+  externalUrl: string | null;
+  snapshot: Record<string, unknown> | null;
+  lastSyncedAt: Date | null;
+  tombstonedAt: Date | null;
+}
+
+export interface FakeConfig {
+  id: string;
+  productId: string;
+  provider: string;
+  integrationId: string | null;
+  databaseId: string;
+  enabled: boolean;
+  pushEnabled: boolean;
+  statusMap: Record<string, TicketStatus> | null;
+  propertyNames: Record<string, string> | null;
+  lastPulledAt: Date | null;
+  createdById: string;
+  product: {
+    id: string;
+    workspaceId: string;
+    slug: string;
+    workspace: { slug: string };
+  };
+}
+
+export interface DbWrite {
+  model: "ticket" | "ticketSync" | "ticketSyncConfig" | "ticketSyncRun";
+  op: "create" | "update" | "delete";
+  id: string | null;
+  data: unknown;
+}
+
+interface WhereById {
+  where: { id: string };
+}
+
+export class FakeSyncDb {
+  readonly tickets = new Map<string, FakeTicket>();
+  readonly syncs = new Map<string, FakeSyncRecord>();
+  readonly runs = new Map<string, Record<string, unknown>>();
+  readonly writeLog: DbWrite[] = [];
+  readonly config: FakeConfig;
+
+  private ticketCounter = 0;
+  private syncCounter = 0;
+  private runCounter = 0;
+
+  constructor(
+    private readonly clock: TestClock,
+    configOverrides: Partial<FakeConfig> = {},
+  ) {
+    this.config = {
+      id: "cfg1",
+      productId: "prod1",
+      provider: "notion",
+      integrationId: "int1",
+      databaseId: "db1",
+      enabled: true,
+      pushEnabled: true,
+      statusMap: null,
+      propertyNames: null,
+      lastPulledAt: null,
+      createdById: "user1",
+      product: {
+        id: "prod1",
+        workspaceId: "ws1",
+        slug: "prod",
+        workspace: { slug: "ws" },
+      },
+      ...configOverrides,
+    };
+  }
+
+  // ── seeding & simulated local (user) activity ─────────────────────────────
+
+  seedTicket(overrides: Partial<FakeTicket> = {}): FakeTicket {
+    const n = ++this.ticketCounter;
+    const ticket: FakeTicket = {
+      id: `t${n}`,
+      number: n,
+      title: "Seeded row",
+      body: null,
+      status: "IN_PROGRESS",
+      type: "BUG",
+      priority: 1,
+      points: 5,
+      labels: [],
+      cycleName: null,
+      assigneeEmail: null,
+      links: null,
+      updatedAt: this.clock.now(),
+      ...overrides,
+    };
+    this.tickets.set(ticket.id, ticket);
+    return ticket;
+  }
+
+  linkTicket(
+    ticketId: string,
+    externalId: string,
+    snapshot: Partial<SyncedFields> | null,
+  ): FakeSyncRecord {
+    const record: FakeSyncRecord = {
+      id: `sync${++this.syncCounter}`,
+      configId: this.config.id,
+      ticketId,
+      provider: this.config.provider,
+      externalId,
+      externalUrl: null,
+      snapshot: (snapshot as Record<string, unknown> | null) ?? null,
+      lastSyncedAt: snapshot ? this.clock.now() : null,
+      tombstonedAt: null,
+    };
+    this.syncs.set(record.id, record);
+    return record;
+  }
+
+  /** Simulate a user editing the ticket in Exponential (not a sync write). */
+  editTicketLocally(
+    ticketId: string,
+    patch: Partial<
+      Pick<
+        FakeTicket,
+        | "title"
+        | "status"
+        | "type"
+        | "priority"
+        | "points"
+        | "labels"
+        | "cycleName"
+        | "assigneeEmail"
+      >
+    >,
+  ): FakeTicket {
+    const ticket = this.mustGetTicket(ticketId);
+    Object.assign(ticket, patch);
+    ticket.updatedAt = this.clock.advance();
+    return ticket;
+  }
+
+  /** Sync-driven ticket field writes (the "local side writes" of a run). */
+  ticketWrites(): DbWrite[] {
+    return this.writeLog.filter((w) => w.model === "ticket" && w.op === "update");
+  }
+
+  clearWriteLog(): void {
+    this.writeLog.length = 0;
+  }
+
+  // ── the PrismaClient facade ───────────────────────────────────────────────
+
+  asPrismaClient(): PrismaClient {
+    const facade = {
+      ticketSyncConfig: {
+        findUniqueOrThrow: (args: WhereById) => {
+          if (args.where.id !== this.config.id) {
+            return Promise.reject(
+              new Error(`FakeSyncDb: unknown config ${args.where.id}`),
+            );
+          }
+          return Promise.resolve({ ...this.config });
+        },
+        update: (args: WhereById & { data: { lastPulledAt?: Date } }) => {
+          if (args.data.lastPulledAt !== undefined) {
+            this.config.lastPulledAt = args.data.lastPulledAt;
+          }
+          this.writeLog.push({
+            model: "ticketSyncConfig",
+            op: "update",
+            id: args.where.id,
+            data: args.data,
+          });
+          return Promise.resolve({ ...this.config });
+        },
+      },
+
+      ticketSyncRun: {
+        create: (args: { data: Record<string, unknown> }) => {
+          const id = `run${++this.runCounter}`;
+          this.runs.set(id, { id, ...args.data });
+          return Promise.resolve({ id });
+        },
+        update: (args: WhereById & { data: Record<string, unknown> }) => {
+          const run = this.runs.get(args.where.id);
+          if (!run) {
+            return Promise.reject(
+              new Error(`FakeSyncDb: unknown run ${args.where.id}`),
+            );
+          }
+          Object.assign(run, args.data);
+          return Promise.resolve({ ...run });
+        },
+      },
+
+      ticket: {
+        findMany: (args: { where?: Record<string, unknown> }) => {
+          // The only findMany the engine issues is the adoption scan
+          // (links set, no sync record for this config).
+          if (!args.where || !("links" in args.where)) {
+            return Promise.reject(
+              new Error("FakeSyncDb: unsupported ticket.findMany shape"),
+            );
+          }
+          const linkedTicketIds = new Set(
+            [...this.syncs.values()]
+              .filter((s) => s.configId === this.config.id)
+              .map((s) => s.ticketId),
+          );
+          const adoptable = [...this.tickets.values()]
+            .filter((t) => t.links !== null && !linkedTicketIds.has(t.id))
+            .map((t) => ({ id: t.id, title: t.title, links: t.links }));
+          return Promise.resolve(adoptable);
+        },
+        findUnique: (args: WhereById) => {
+          const t = this.tickets.get(args.where.id);
+          return Promise.resolve(t ? this.ticketView(t) : null);
+        },
+        update: (args: WhereById & { data: Record<string, unknown> }) => {
+          const t = this.mustGetTicket(args.where.id);
+          for (const key of [
+            "title",
+            "status",
+            "type",
+            "priority",
+            "points",
+          ] as const) {
+            if (key in args.data) {
+              (t as Record<string, unknown>)[key] = args.data[key];
+            }
+          }
+          if ("cycleId" in args.data || "assigneeId" in args.data) {
+            throw new Error(
+              "FakeSyncDb: relational id writes not supported yet — extend the fake",
+            );
+          }
+          t.updatedAt = this.clock.now();
+          this.writeLog.push({
+            model: "ticket",
+            op: "update",
+            id: t.id,
+            data: args.data,
+          });
+          return Promise.resolve(this.ticketView(t));
+        },
+      },
+
+      ticketSync: {
+        findMany: (_args: unknown) => {
+          const records = [...this.syncs.values()]
+            .filter((s) => s.configId === this.config.id)
+            .map((s) => ({ ...s }));
+          return Promise.resolve(records);
+        },
+        findUnique: (args: WhereById) => {
+          const s = this.syncs.get(args.where.id);
+          if (!s) return Promise.resolve(null);
+          const ticket = this.tickets.get(s.ticketId);
+          return Promise.resolve({
+            ...s,
+            config: { ...this.config },
+            ticket: ticket ? this.ticketView(ticket) : null,
+          });
+        },
+        create: (args: { data: Record<string, unknown> }) => {
+          const data = args.data;
+          const externalId = data.externalId as string;
+          const collision = [...this.syncs.values()].some(
+            (s) =>
+              (s.configId === data.configId && s.externalId === externalId) ||
+              (s.ticketId === data.ticketId && s.provider === data.provider),
+          );
+          if (collision) {
+            return Promise.reject(
+              new Error("FakeSyncDb: unique constraint violation on ticketSync"),
+            );
+          }
+          const record: FakeSyncRecord = {
+            id: `sync${++this.syncCounter}`,
+            configId: data.configId as string,
+            ticketId: data.ticketId as string,
+            provider: data.provider as string,
+            externalId,
+            externalUrl: (data.externalUrl as string | null) ?? null,
+            snapshot: this.normalizeSnapshot(data.snapshot),
+            lastSyncedAt: (data.lastSyncedAt as Date | undefined) ?? null,
+            tombstonedAt: null,
+          };
+          this.syncs.set(record.id, record);
+          this.writeLog.push({
+            model: "ticketSync",
+            op: "create",
+            id: record.id,
+            data,
+          });
+          return Promise.resolve({ ...record });
+        },
+        update: (args: WhereById & { data: Record<string, unknown> }) => {
+          const s = this.syncs.get(args.where.id);
+          if (!s) {
+            return Promise.reject(
+              new Error(`FakeSyncDb: unknown sync ${args.where.id}`),
+            );
+          }
+          const data = args.data;
+          if ("snapshot" in data) s.snapshot = this.normalizeSnapshot(data.snapshot);
+          if ("externalId" in data) s.externalId = data.externalId as string;
+          if ("externalUrl" in data && data.externalUrl !== undefined) {
+            s.externalUrl = data.externalUrl as string | null;
+          }
+          if ("lastSyncedAt" in data) s.lastSyncedAt = data.lastSyncedAt as Date;
+          if ("tombstonedAt" in data) {
+            s.tombstonedAt = data.tombstonedAt as Date | null;
+          }
+          this.writeLog.push({
+            model: "ticketSync",
+            op: "update",
+            id: s.id,
+            data,
+          });
+          return Promise.resolve({ ...s });
+        },
+        delete: (args: WhereById) => {
+          const existed = this.syncs.delete(args.where.id);
+          if (!existed) {
+            return Promise.reject(
+              new Error(`FakeSyncDb: unknown sync ${args.where.id}`),
+            );
+          }
+          this.writeLog.push({
+            model: "ticketSync",
+            op: "delete",
+            id: args.where.id,
+            data: null,
+          });
+          return Promise.resolve({});
+        },
+      },
+
+      // The runners only use the promise-array form; the fake's model methods
+      // execute eagerly, so awaiting the batch is all a "transaction" needs.
+      $transaction: (promises: Array<Promise<unknown>>) => Promise.all(promises),
+    };
+
+    return facade as unknown as PrismaClient;
+  }
+
+  // ── internals ─────────────────────────────────────────────────────────────
+
+  private mustGetTicket(id: string): FakeTicket {
+    const t = this.tickets.get(id);
+    if (!t) throw new Error(`FakeSyncDb: no ticket ${id}`);
+    return t;
+  }
+
+  /** The read shape both runners select (relations + tags as objects). */
+  private ticketView(t: FakeTicket) {
+    return {
+      id: t.id,
+      number: t.number,
+      title: t.title,
+      body: t.body,
+      status: t.status,
+      type: t.type,
+      priority: t.priority,
+      points: t.points,
+      updatedAt: t.updatedAt,
+      links: t.links,
+      cycle: t.cycleName ? { name: t.cycleName } : null,
+      assignee: t.assigneeEmail ? { email: t.assigneeEmail } : null,
+      tags: t.labels.map((name) => ({ tag: { name } })),
+    };
+  }
+
+  private normalizeSnapshot(value: unknown): Record<string, unknown> | null {
+    if (value === null || value === undefined) return null;
+    // Prisma.DbNull sentinel → stored NULL.
+    if (value === Prisma.DbNull) return null;
+    if (typeof value === "object" && !Array.isArray(value)) {
+      return { ...(value as Record<string, unknown>) };
+    }
+    return null;
+  }
+}

--- a/src/server/services/ticketSync/__tests__/harness/testClock.ts
+++ b/src/server/services/ticketSync/__tests__/harness/testClock.ts
@@ -1,0 +1,22 @@
+/**
+ * Deterministic-but-monotonic clock for round-trip sync tests.
+ *
+ * The engine stamps `lastPulledAt`/`startedAt` with the REAL `new Date()`, so a
+ * purely fake epoch would put every simulated edit "before" the pull window and
+ * silently exclude it. Instead the clock rides on real time plus a monotonic
+ * offset: `advance()` moves strictly past anything the engine has stamped so
+ * far, keeping edit ordering unambiguous without mocking global time.
+ */
+export class TestClock {
+  private offsetMs = 0;
+
+  now(): Date {
+    return new Date(Date.now() + this.offsetMs);
+  }
+
+  /** Move time forward (default 1s) and return the new now. */
+  advance(ms = 1000): Date {
+    this.offsetMs += ms;
+    return this.now();
+  }
+}

--- a/src/server/services/ticketSync/__tests__/harness/world.ts
+++ b/src/server/services/ticketSync/__tests__/harness/world.ts
@@ -1,0 +1,163 @@
+import type { PrismaClient, TicketStatus, TicketType } from "@prisma/client";
+import {
+  runInboundTicketSync,
+  type InboundSyncResult,
+} from "../../engine";
+import {
+  runOutboundTicketPush,
+  type OutboundPushItem,
+} from "../../push";
+import {
+  FakeNotion,
+  POINTS_TO_RAW,
+  PRIORITY_TO_RAW,
+  STATUS_TO_RAW,
+  TYPE_TO_RAW,
+  type FakePage,
+  type NotionWrite,
+} from "./fakeNotion";
+import {
+  FakeSyncDb,
+  type DbWrite,
+  type FakeConfig,
+  type FakeSyncRecord,
+  type FakeTicket,
+} from "./fakeSyncDb";
+import { TestClock } from "./testClock";
+
+/**
+ * The round-trip world: one FakeNotion + one FakeSyncDb sharing a TestClock,
+ * with drivers for full sync cycles.
+ *
+ * NOTE for test files: the engine imports `createTicketWithNumber`,
+ * the tag helpers, and `recordActivity` directly (not injectable), so any test
+ * importing this harness must vi.mock those three modules exactly as
+ * engine.test.ts does — see roundTrip.test.ts for the canonical block.
+ */
+
+export interface SeededLink {
+  ticket: FakeTicket;
+  page: FakePage;
+  sync: FakeSyncRecord;
+}
+
+export interface RoundTripWorld {
+  clock: TestClock;
+  notion: FakeNotion;
+  db: FakeSyncDb;
+  prisma: PrismaClient;
+  /** One inbound run (Notion → Exponential). */
+  pull(opts?: { dryRun?: boolean }): Promise<InboundSyncResult>;
+  /** Push every sync record once (Exponential → Notion). */
+  pushAll(opts?: { dryRun?: boolean }): Promise<OutboundPushItem[]>;
+  /** One full cycle: pull, then push everything. */
+  cycle(): Promise<{ pull: InboundSyncResult; pushes: OutboundPushItem[] }>;
+  /**
+   * Seed a ticket + Notion page holding the SAME values, linked with a
+   * converged snapshot — the steady state a healthy sync leaves behind.
+   */
+  seedSyncedTicket(overrides?: {
+    title?: string;
+    status?: TicketStatus;
+    type?: TicketType;
+    priority?: number | null;
+    points?: number | null;
+  }): SeededLink;
+  /** Adapter writes + sync-driven ticket writes since the last clear. */
+  notionWrites(): NotionWrite[];
+  ticketWrites(): DbWrite[];
+  clearWrites(): void;
+}
+
+export function createRoundTripWorld(opts?: {
+  config?: Partial<FakeConfig>;
+}): RoundTripWorld {
+  const clock = new TestClock();
+  const notion = new FakeNotion(clock);
+  const db = new FakeSyncDb(clock, opts?.config);
+  const prisma = db.asPrismaClient();
+
+  const pull = (pullOpts?: { dryRun?: boolean }) =>
+    runInboundTicketSync(prisma, notion, {
+      configId: db.config.id,
+      trigger: "manual",
+      dryRun: pullOpts?.dryRun,
+    });
+
+  const pushAll = async (pushOpts?: { dryRun?: boolean }) => {
+    const items: OutboundPushItem[] = [];
+    for (const sync of [...db.syncs.values()]) {
+      items.push(
+        await runOutboundTicketPush(prisma, notion, {
+          syncId: sync.id,
+          dryRun: pushOpts?.dryRun,
+        }),
+      );
+    }
+    return items;
+  };
+
+  const seedSyncedTicket: RoundTripWorld["seedSyncedTicket"] = (
+    overrides = {},
+  ) => {
+    const title = overrides.title ?? "Seeded row";
+    const status = overrides.status ?? "IN_PROGRESS";
+    const type = overrides.type ?? "BUG";
+    const priority = overrides.priority !== undefined ? overrides.priority : 1;
+    const points = overrides.points !== undefined ? overrides.points : 5;
+
+    const rawStatus = STATUS_TO_RAW[status];
+    const rawType = TYPE_TO_RAW[type];
+    const rawPriority = priority === null ? null : PRIORITY_TO_RAW[priority];
+    const rawEffort = points === null ? null : POINTS_TO_RAW[points];
+    if (rawStatus === undefined || rawType === undefined) {
+      throw new Error("seedSyncedTicket: unmapped status/type");
+    }
+    if (rawPriority === undefined || rawEffort === undefined) {
+      throw new Error(
+        "seedSyncedTicket: use priority 0-4 and points 1/3/5/8 (or null)",
+      );
+    }
+
+    const ticket = db.seedTicket({ title, status, type, priority, points });
+    const page = notion.seedPage({
+      title,
+      rawStatus,
+      rawType,
+      rawPriority,
+      rawEffort,
+    });
+    const sync = db.linkTicket(ticket.id, page.externalId, {
+      title,
+      status,
+      priority,
+      type,
+      points,
+      labels: [],
+      cycleName: null,
+      assigneeEmail: null,
+    });
+    return { ticket, page, sync };
+  };
+
+  return {
+    clock,
+    notion,
+    db,
+    prisma,
+    pull,
+    pushAll,
+    cycle: async () => {
+      const pullResult = await pull();
+      const pushes = await pushAll();
+      return { pull: pullResult, pushes };
+    },
+    seedSyncedTicket,
+    notionWrites: () => [...notion.writes],
+    ticketWrites: () => db.ticketWrites(),
+    clearWrites: () => {
+      notion.writes.length = 0;
+      db.clearWriteLog();
+    },
+  };
+}

--- a/src/server/services/ticketSync/__tests__/roundTrip.test.ts
+++ b/src/server/services/ticketSync/__tests__/roundTrip.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Round-trip quiescence tests: pull and push driven against ONE shared
+ * FakeNotion + FakeSyncDb, proving the system converges and then goes quiet.
+ *
+ * The per-direction suites (engine.test.ts, push.test.ts) prove each runner's
+ * behavior in isolation; these tests prove the emergent two-way properties —
+ * no ping-pong, no phantom writes, echo suppression end-to-end — that only
+ * show up when both directions share state.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+const { createTicketMock, resolveTagsMock, attachTagsMock, recordActivityMock } =
+  vi.hoisted(() => ({
+    createTicketMock: vi.fn(),
+    resolveTagsMock: vi.fn(),
+    attachTagsMock: vi.fn(),
+    recordActivityMock: vi.fn(),
+  }));
+
+vi.mock("~/plugins/product/server/services/createTicket", () => ({
+  createTicketWithNumber: createTicketMock,
+}));
+
+vi.mock("../../notionTicketImport", () => ({
+  resolveOrCreateWorkspaceTags: resolveTagsMock,
+  attachTicketTags: attachTagsMock,
+}));
+
+vi.mock("~/server/services/activity/recordActivity", () => ({
+  recordActivity: recordActivityMock,
+}));
+
+import { createRoundTripWorld } from "./harness/world";
+
+recordActivityMock.mockResolvedValue(true);
+// The quiescence scenarios never create tickets from Notion; a call here means
+// the sync invented a row out of nothing — fail loudly.
+createTicketMock.mockRejectedValue(
+  new Error("unexpected ticket creation in a round-trip quiescence test"),
+);
+
+describe("round-trip quiescence", () => {
+  it("steady state: a full pull+push cycle performs zero writes on either side", async () => {
+    const w = createRoundTripWorld();
+    w.seedSyncedTicket({});
+
+    const pull = await w.pull();
+    expect(pull.created).toBe(0);
+    expect(pull.updated).toBe(0);
+    expect(pull.failed).toBe(0);
+    expect(w.ticketWrites()).toHaveLength(0);
+    expect(w.notionWrites()).toHaveLength(0);
+
+    const pushes = await w.pushAll();
+    expect(pushes.map((p) => p.action)).toEqual(["skipped"]);
+    expect(pushes[0]?.reason).toContain("in sync");
+    expect(w.notionWrites()).toHaveLength(0);
+  });
+
+  it("local edit: exactly one Notion write, then the system goes quiet", async () => {
+    const w = createRoundTripWorld();
+    const { ticket, page } = w.seedSyncedTicket({});
+
+    w.db.editTicketLocally(ticket.id, { title: "Renamed locally" });
+
+    const pushes = await w.pushAll();
+    expect(pushes.map((p) => p.action)).toEqual(["pushed"]);
+    expect(pushes[0]?.wrote).toEqual(["title"]);
+    expect(w.notionWrites()).toHaveLength(1);
+    expect(page.title).toBe("Renamed locally");
+
+    // Cycle 2: the pull sees only our own write (echo) and applies nothing;
+    // the push finds everything converged and writes nothing.
+    w.clearWrites();
+    const cycle2 = await w.cycle();
+    expect(cycle2.pull.updated).toBe(0);
+    expect(
+      cycle2.pull.items.every(
+        (i) => i.action === "skipped" || i.action === "adopted",
+      ),
+    ).toBe(true);
+    expect(cycle2.pushes.map((p) => p.action)).toEqual(["skipped"]);
+    expect(w.ticketWrites()).toHaveLength(0);
+    expect(w.notionWrites()).toHaveLength(0);
+
+    // Cycle 3: still quiet.
+    const cycle3 = await w.cycle();
+    expect(cycle3.pull.updated).toBe(0);
+    expect(cycle3.pushes.map((p) => p.action)).toEqual(["skipped"]);
+    expect(w.ticketWrites()).toHaveLength(0);
+    expect(w.notionWrites()).toHaveLength(0);
+
+    // The local edit survived the whole exchange.
+    expect(w.db.tickets.get(ticket.id)?.title).toBe("Renamed locally");
+    expect(page.title).toBe("Renamed locally");
+  });
+
+  it("remote human edit: applied locally exactly once, then the system goes quiet", async () => {
+    const w = createRoundTripWorld();
+    const { ticket, page } = w.seedSyncedTicket({});
+
+    w.notion.editAsHuman(page.externalId, {
+      rawStatus: "Done",
+    });
+
+    const pull = await w.pull();
+    expect(pull.updated).toBe(1);
+    expect(pull.conflicts).toBe(0);
+    expect(w.db.tickets.get(ticket.id)?.status).toBe("DONE");
+    expect(w.ticketWrites()).toHaveLength(1);
+    // Strictly read-only against Notion on the inbound path.
+    expect(w.notionWrites()).toHaveLength(0);
+
+    // The applied inbound change must NOT be echoed back to Notion.
+    w.clearWrites();
+    const pushes = await w.pushAll();
+    expect(pushes.map((p) => p.action)).toEqual(["skipped"]);
+    expect(w.notionWrites()).toHaveLength(0);
+
+    const cycle2 = await w.cycle();
+    expect(cycle2.pull.updated).toBe(0);
+    expect(cycle2.pushes.map((p) => p.action)).toEqual(["skipped"]);
+    expect(w.ticketWrites()).toHaveLength(0);
+    expect(w.notionWrites()).toHaveLength(0);
+  });
+
+  it("echo suppression keys on the editor: bot rows are skipped, human rows apply", async () => {
+    const w = createRoundTripWorld();
+    const { ticket, page } = w.seedSyncedTicket({});
+
+    // Our own push makes the page's last edit a bot edit …
+    w.db.editTicketLocally(ticket.id, { title: "Renamed locally" });
+    await w.pushAll();
+
+    const echoPull = await w.pull();
+    const echoItem = echoPull.items.find(
+      (i) => i.externalId === page.externalId,
+    );
+    expect(echoItem?.action).toBe("skipped");
+    expect(echoItem?.reason).toContain("echo suppression");
+
+    // … but a subsequent HUMAN edit is no longer suppressed and applies,
+    // without reverting the pushed title.
+    w.notion.editAsHuman(page.externalId, { rawStatus: "Blocked" });
+    w.clearWrites();
+    const humanPull = await w.pull();
+    expect(humanPull.updated).toBe(1);
+    expect(w.db.tickets.get(ticket.id)?.status).toBe("BLOCKED");
+    expect(w.db.tickets.get(ticket.id)?.title).toBe("Renamed locally");
+    expect(page.title).toBe("Renamed locally");
+
+    // And the exchange still terminates.
+    w.clearWrites();
+    const cycle = await w.cycle();
+    expect(cycle.pull.updated).toBe(0);
+    expect(cycle.pushes.map((p) => p.action)).toEqual(["skipped"]);
+    expect(w.ticketWrites()).toHaveLength(0);
+    expect(w.notionWrites()).toHaveLength(0);
+  });
+
+  it("a pushed field later edited by a human applies cleanly — no spurious conflict", async () => {
+    // This is the observable value of snapshot advancement after a push: with
+    // a stale snapshot the remote edit would read as a two-sided change and
+    // surface as a conflict; with the advanced snapshot it is a clean
+    // remote-only change. (Deliberately mutation-sensitive: disabling the
+    // ticketSync.update after updatePage in push.ts makes this fail.)
+    const w = createRoundTripWorld();
+    const { ticket, page } = w.seedSyncedTicket({});
+
+    w.db.editTicketLocally(ticket.id, { title: "Renamed locally" });
+    await w.pushAll();
+
+    w.notion.editAsHuman(page.externalId, { title: "Renamed in Notion" });
+
+    const pull = await w.pull();
+    expect(pull.conflicts).toBe(0);
+    expect(pull.updated).toBe(1);
+    expect(w.db.tickets.get(ticket.id)?.title).toBe("Renamed in Notion");
+
+    w.clearWrites();
+    const cycle = await w.cycle();
+    expect(cycle.pull.updated).toBe(0);
+    expect(cycle.pushes.map((p) => p.action)).toEqual(["skipped"]);
+    expect(w.ticketWrites()).toHaveLength(0);
+    expect(w.notionWrites()).toHaveLength(0);
+  });
+
+  it("edits on both sides of different fields converge within one cycle, then quiesce", async () => {
+    const w = createRoundTripWorld();
+    const { ticket, page } = w.seedSyncedTicket({});
+
+    w.db.editTicketLocally(ticket.id, { priority: 2 });
+    w.notion.editAsHuman(page.externalId, { rawStatus: "Done" });
+
+    const cycle1 = await w.cycle();
+    // Pull applies the remote status; push ships the local priority.
+    expect(cycle1.pull.updated).toBe(1);
+    expect(cycle1.pull.conflicts).toBe(0);
+    expect(cycle1.pushes.map((p) => p.action)).toEqual(["pushed"]);
+    expect(cycle1.pushes[0]?.wrote).toEqual(["priority"]);
+
+    expect(w.db.tickets.get(ticket.id)?.status).toBe("DONE");
+    expect(w.db.tickets.get(ticket.id)?.priority).toBe(2);
+    expect(page.rawStatus).toBe("Done");
+    expect(page.rawPriority).toBe("2 - Medium");
+
+    w.clearWrites();
+    const cycle2 = await w.cycle();
+    expect(cycle2.pull.updated).toBe(0);
+    expect(cycle2.pushes.map((p) => p.action)).toEqual(["skipped"]);
+    expect(w.ticketWrites()).toHaveLength(0);
+    expect(w.notionWrites()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### **User description**
## What

A shared in-memory fake Notion for the ticket sync test suite, plus the first set of round-trip tests that drive BOTH sync directions against the same fake state.

Today the ticket sync unit tests exercise pull (`runInboundTicketSync`) and push (`runOutboundPushSweep`/`runOutboundTicketPush`) separately against per-test fakes. Nothing proves the system converges when both directions run against shared state — which is where two-way syncs rot (ping-pong loops, phantom updates, lost edits).

`FakeNotion` implements both adapter seams — `TicketSyncRemoteAdapter` (engine) and `TicketPushAdapter` (push) — over an in-memory page store tracking per-page last-edited time and editor (bot vs human), so echo suppression is exercised for real. `FakeSyncDb` is a stateful stand-in for the Prisma slice the runners touch, with a write log for zero-write quiescence assertions.

Six round-trip scenarios, all ending in a quiescence check; the spurious-conflict scenario is mutation-sensitive to removing the post-push snapshot advance in push.ts (verified during development).

## Acceptance criteria

- [x] `FakeNotion` implements both `TicketSyncRemoteAdapter` and `TicketPushAdapter` and is importable by other test files in the ticket sync test suite
- [x] Fake tracks last-edited time and last-edited-by per page; engine echo suppression path is exercised by at least one test (bot-authored edit is skipped, human-authored is not)
- [x] Quiescence tests pass and fail meaningfully if snapshot advancement after push is removed (verified by temporarily breaking it during development)
- [x] All tests are plain unit tests (`*.test.ts`), run in `npm run test`, no Docker required
- [x] `npm run check` passes (tsc clean; new files are in eslint-ignored `__tests__/**`)

---

Ships: violet.daisy

[View in Exponential](https://www.exponential.im/w/syntrofi/products/exponential/tickets/419)


___

### **PR Type**
Tests


___

### **Description**
- Add shared `FakeNotion` implementing both sync adapter seams over one in-memory page store

- Add stateful `FakeSyncDb` as a Prisma stand-in with write log for quiescence assertions

- Add `TestClock` for deterministic-but-monotonic time ordering in round-trip tests

- Add six round-trip quiescence tests covering steady state, echo suppression, and convergence


___

### Diagram Walkthrough


```mermaid
flowchart LR
  TestClock["TestClock\n(monotonic clock)"]
  FakeNotion["FakeNotion\n(TicketSyncRemoteAdapter\n+ TicketPushAdapter)"]
  FakeSyncDb["FakeSyncDb\n(Prisma facade\n+ write log)"]
  World["RoundTripWorld\n(world.ts)"]
  Tests["roundTrip.test.ts\n(6 quiescence tests)"]

  TestClock -- "shared clock" --> FakeNotion
  TestClock -- "shared clock" --> FakeSyncDb
  FakeNotion -- "notion adapter" --> World
  FakeSyncDb -- "prisma facade" --> World
  World -- "pull() + pushAll() + cycle()" --> Tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fakeNotion.ts</strong><dd><code>Shared in-memory FakeNotion implementing both sync adapter seams</code></dd></summary>
<hr>

src/server/services/ticketSync/__tests__/harness/fakeNotion.ts

<ul><li>Implements both <code>TicketSyncRemoteAdapter</code> and <code>TicketPushAdapter</code> over a <br>single in-memory page store<br> <li> Tracks <code>lastEditedAt</code> and <code>lastEditedBy</code> (bot vs human) per page to <br>exercise echo suppression<br> <li> Exposes <code>writes</code> array for zero-write quiescence assertions; supports <br><code>seedPage</code>, <code>editAsHuman</code>, <code>deletePage</code><br> <li> Provides mapping tables (<code>STATUS_TO_RAW</code>, <code>TYPE_TO_RAW</code>, etc.) and <br><code>DEFAULT_FAKE_SCHEMA</code> for round-trip property mapping</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/447/files#diff-ba2ee470ae82b0459adeef15836eb7fcdc170645e4f786d721308dde159c25cf">+381/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fakeSyncDb.ts</strong><dd><code>Stateful FakeSyncDb Prisma facade with write log</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/ticketSync/__tests__/harness/fakeSyncDb.ts

<ul><li>Stateful in-memory stand-in for the Prisma slice touched by both sync <br>runners<br> <li> Implements <code>ticket</code>, <code>ticketSync</code>, <code>ticketSyncConfig</code>, <code>ticketSyncRun</code> facades <br>with real persistence<br> <li> Appends every mutation to <code>writeLog</code> enabling precise zero-write <br>quiescence assertions<br> <li> Exposes <code>seedTicket</code>, <code>linkTicket</code>, <code>editTicketLocally</code> helpers and <br><code>asPrismaClient()</code> facade</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/447/files#diff-7e8f44663eff57a2c12148523a201fc582eb2bfb4235277a76441722ff878db0">+426/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>testClock.ts</strong><dd><code>Monotonic TestClock for deterministic round-trip time ordering</code></dd></summary>
<hr>

src/server/services/ticketSync/__tests__/harness/testClock.ts

<ul><li>Provides a deterministic-but-monotonic clock riding on real time plus <br>an offset<br> <li> <code>advance()</code> moves time strictly forward to keep edit ordering <br>unambiguous without mocking global time</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/447/files#diff-47aa49ef416b2f010de5788894984cdf728e2838c27d206e204236abe7faa51d">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>world.ts</strong><dd><code>RoundTripWorld composer wiring harness components together</code></dd></summary>
<hr>

src/server/services/ticketSync/__tests__/harness/world.ts

<ul><li>Composes <code>FakeNotion</code>, <code>FakeSyncDb</code>, and <code>TestClock</code> into a single <br><code>RoundTripWorld</code> object<br> <li> Exposes <code>pull()</code>, <code>pushAll()</code>, <code>cycle()</code> drivers and <code>seedSyncedTicket()</code> for <br>converged initial state<br> <li> Provides <code>notionWrites()</code>, <code>ticketWrites()</code>, and <code>clearWrites()</code> for <br>quiescence assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/447/files#diff-0e6d49a519144b350ec18baa358274ca082f8b9c99e00a67fc7a791c7ad58437">+163/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>roundTrip.test.ts</strong><dd><code>Six round-trip quiescence tests for two-way ticket sync</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/ticketSync/__tests__/roundTrip.test.ts

<ul><li>Six round-trip quiescence tests covering steady state, local edit, <br>remote human edit, echo suppression, spurious conflict prevention, and <br>dual-field convergence<br> <li> Tests are mutation-sensitive: disabling post-push snapshot advancement <br>in <code>push.ts</code> fails the spurious-conflict test<br> <li> Uses <code>vi.mock</code> for <code>createTicketWithNumber</code>, tag helpers, and <br><code>recordActivity</code> to isolate sync logic</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/447/files#diff-41e0745f1bfddbd16a4dc275783e0ad54bff29c9967eeb98a2b8efa638ac7b53">+215/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

