### PR TITLE
refactor: cron route handler tests for ticket-sync sweeps

### DIFF
--- a/src/app/api/cron/__tests__/ticketSyncRoutes.test.ts
+++ b/src/app/api/cron/__tests__/ticketSyncRoutes.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment node
+/**
+ * Route-handler tests for the two ticket-sync cron entry points — the
+ * production surfaces that run the sync every 10 minutes (inbound pull sweep)
+ * and every 2 minutes (outbound push-queue drain).
+ *
+ * The routes' whole job is auth + dispatch: fail closed without CRON_SECRET,
+ * reject bad bearers with a timing-safe compare, invoke the right runner, and
+ * report failures without leaking internals. The runners themselves are
+ * covered by scheduler.test.ts / pushRunner.test.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const { headersMock, runDueTicketSyncsMock, runOutboundPushSweepMock } =
+  vi.hoisted(() => ({
+    headersMock: vi.fn(),
+    runDueTicketSyncsMock: vi.fn(),
+    runOutboundPushSweepMock: vi.fn(),
+  }));
+
+vi.mock("next/headers", () => ({ headers: headersMock }));
+vi.mock("~/server/db", () => ({ db: { __stub: "db" } }));
+vi.mock("~/server/services/ticketSync/scheduler", () => ({
+  runDueTicketSyncs: runDueTicketSyncsMock,
+}));
+vi.mock("~/server/services/ticketSync/pushRunner", () => ({
+  runOutboundPushSweep: runOutboundPushSweepMock,
+}));
+
+import { GET as pullRoute } from "../ticket-sync/route";
+import { GET as pushRoute } from "../ticket-sync-push/route";
+
+const request = {} as NextRequest;
+
+function authHeader(value: string | null) {
+  headersMock.mockResolvedValue(
+    new Headers(value === null ? {} : { authorization: value }),
+  );
+}
+
+const ROUTES = [
+  {
+    name: "ticket-sync (pull sweep)",
+    route: pullRoute,
+    runner: runDueTicketSyncsMock,
+    runnerResult: { due: 0, ran: 0, skipped: 0, items: [] },
+  },
+  {
+    name: "ticket-sync-push (push drain)",
+    route: pushRoute,
+    runner: runOutboundPushSweepMock,
+    runnerResult: { claimed: 0, pushed: 0, failed: 0, items: [] },
+  },
+] as const;
+
+describe.each(ROUTES)("/api/cron/$name", ({ route, runner, runnerResult }) => {
+  const originalSecret = process.env.CRON_SECRET;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    process.env.CRON_SECRET = "test-secret";
+    runner.mockResolvedValue(runnerResult);
+    authHeader("Bearer test-secret");
+  });
+
+  afterEach(() => {
+    process.env.CRON_SECRET = originalSecret;
+    vi.restoreAllMocks();
+  });
+
+  it("fails closed with 503 when CRON_SECRET is not configured", async () => {
+    delete process.env.CRON_SECRET;
+
+    const response = await route(request);
+
+    expect(response.status).toBe(503);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for a wrong bearer token without invoking the runner", async () => {
+    authHeader("Bearer wrong-secret");
+
+    const response = await route(request);
+
+    expect(response.status).toBe(401);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the authorization header is missing", async () => {
+    authHeader(null);
+
+    const response = await route(request);
+
+    expect(response.status).toBe(401);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it("runs the sweep and reports its summary on a valid bearer", async () => {
+    const response = await route(request);
+
+    expect(response.status).toBe(200);
+    expect(runner).toHaveBeenCalledTimes(1);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.success).toBe(true);
+    for (const [key, value] of Object.entries(runnerResult)) {
+      expect(body[key]).toEqual(value);
+    }
+  });
+
+  it("returns 500 with the message only when the runner throws", async () => {
+    runner.mockRejectedValue(new Error("sweep exploded"));
+
+    const response = await route(request);
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body).toEqual({ error: "sweep exploded" });
+  });
+});
+
+describe("runner wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    process.env.CRON_SECRET = "test-secret";
+    authHeader("Bearer test-secret");
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    vi.restoreAllMocks();
+  });
+
+  it("pull route invokes runDueTicketSyncs with the db and the current time", async () => {
+    runDueTicketSyncsMock.mockResolvedValue({ due: 0, ran: 0, items: [] });
+
+    await pullRoute(request);
+
+    expect(runDueTicketSyncsMock).toHaveBeenCalledWith(
+      { __stub: "db" },
+      expect.any(Date),
+    );
+    expect(runOutboundPushSweepMock).not.toHaveBeenCalled();
+  });
+
+  it("push route invokes runOutboundPushSweep with the cron trigger", async () => {
+    runOutboundPushSweepMock.mockResolvedValue({ claimed: 0, failed: 0 });
+
+    await pushRoute(request);
+
+    expect(runOutboundPushSweepMock).toHaveBeenCalledWith(
+      { __stub: "db" },
+      expect.any(Date),
+      { trigger: "cron" },
+    );
+    expect(runDueTicketSyncsMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### **User description**
## What

Unit tests for the two ticket-sync cron API routes — previously zero coverage on the entry points that run the sync in production every 10 minutes (inbound pull sweep) and every 2 minutes (outbound push-queue drain).

Both routes are tested for: fail-closed auth (503 when `CRON_SECRET` is unset, runner never reached), 401 on wrong/missing bearer, the 200 happy path reporting the sweep summary, and a 500 message-only response when the runner throws. Runner wiring is asserted explicitly (`runDueTicketSyncs(db, now)` for pull; `runOutboundPushSweep(db, now, {trigger: "cron"})` for push).

## Acceptance criteria

- [x] Both cron routes covered: 503 fail-closed, 401 bad token, 200 happy path, runner-throw path
- [x] Runner invocation asserted with correct arguments (trigger source for push sweep)
- [x] Unit tests only, run in `npm run test`; typecheck clean

---

Ships: giddy.hornet

[View in Exponential](https://www.exponential.im/w/syntrofi/products/exponential/tickets/422)


___

### **PR Type**
Tests


___

### **Description**
- Add unit tests for two ticket-sync cron route handlers

- Cover auth fail-closed (503), 401 bad/missing token, 200 happy path, 500 on runner throw

- Assert correct runner wiring: `runDueTicketSyncs` for pull, `runOutboundPushSweep` with `{trigger: "cron"}` for push


___

### Diagram Walkthrough


```mermaid
flowchart LR
  testFile["ticketSyncRoutes.test.ts"]
  pullRoute["/api/cron/ticket-sync route"]
  pushRoute["/api/cron/ticket-sync-push route"]
  runDueTicketSyncs["runDueTicketSyncs runner"]
  runOutboundPushSweep["runOutboundPushSweep runner"]

  testFile -- "tests auth + dispatch" --> pullRoute
  testFile -- "tests auth + dispatch" --> pushRoute
  pullRoute -- "wiring assertion" --> runDueTicketSyncs
  pushRoute -- "wiring assertion with trigger:cron" --> runOutboundPushSweep
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ticketSyncRoutes.test.ts</strong><dd><code>Unit tests for ticket-sync cron route auth and dispatch</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/cron/__tests__/ticketSyncRoutes.test.ts

<ul><li>New test file covering both cron route handlers (<code>ticket-sync</code> pull <br>sweep and <code>ticket-sync-push</code> drain)<br> <li> Parameterized <code>describe.each</code> tests for 503 fail-closed, 401 bad/missing <br>token, 200 happy path, and 500 runner-throw scenarios<br> <li> Dedicated <code>runner wiring</code> describe block asserting correct arguments <br>passed to each runner<br> <li> Mocks <code>next/headers</code>, <code>~/server/db</code>, <code>scheduler</code>, and <code>pushRunner</code> via <br><code>vi.hoisted</code> and <code>vi.mock</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/448/files#diff-700947e5e2475cf75dd5b7575c7d959315166d5f0e26502a54973e7165d985f8">+161/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

