### PR TITLE
fix: snapshot-aware echo suppression — stop stranding pending human edits

### DIFF
--- a/src/server/services/ticketSync/__tests__/roundTripProperty.test.ts
+++ b/src/server/services/ticketSync/__tests__/roundTripProperty.test.ts
@@ -24,18 +24,17 @@
  * reproducible: the thrown error carries the seed AND the full operation
  * sequence, and the seed alone re-runs the identical scenario.
  *
- * ── A REAL CONVERGENCE DEFECT THIS TEST FOUND ────────────────────────────────
- * ~18% of random sequences do NOT converge, all via one mechanism: a human edit
- * to field B of a Notion page that is still pending (unpulled) when an outbound
- * push writes a DIFFERENT field A to that same page flips the whole page's
- * "last edited by" to the integration bot; the next inbound pull then hits
- * engine.ts' row-level echo suppression (`if (row.lastEditedByBot) skip`) and
- * skips the page entirely, and the incremental `lastPulledAt` window advances
- * past the human's edit — so field B's remote change is never reconciled (a lost
- * remote update). This is NOT papered over: the exact seeds that hit it in the
- * property band are pinned in KNOWN_DEFECT_SEEDS and actively asserted to still
- * reproduce it, and `roundTripProperty.test.ts` carries a named deterministic
- * regression test at the bottom. See the PR body for the full write-up.
+ * ── A REAL CONVERGENCE DEFECT THIS TEST FOUND (fixed: smoky.wolf) ────────────
+ * Originally ~18% of random sequences did NOT converge, all via one mechanism:
+ * a human edit to field B of a Notion page that was still pending (unpulled)
+ * when an outbound push wrote a DIFFERENT field A to that same page flipped the
+ * whole page's "last edited by" to the integration bot; the old row-level echo
+ * suppression (`if (row.lastEditedByBot) skip`) then skipped the page entirely
+ * and the incremental `lastPulledAt` window advanced past the human's edit — a
+ * lost remote update. The engine now applies echo suppression snapshot-aware
+ * (a bot-edited row is only skipped while its remote fields match the last-
+ * synced base), the once-failing seeds run in the normal invariant band, and a
+ * named deterministic regression test at the bottom pins the minimal case.
  *
  * The engine imports createTicketWithNumber / the tag helpers / recordActivity
  * directly (not injectable), so — like engine.test.ts and roundTrip.test.ts —
@@ -412,50 +411,35 @@ async function runScenario(seed: number): Promise<void> {
 }
 
 /**
- * Seeds in the [1..40] property band that exercise the echo-suppression
- * convergence defect documented at the top of this file and reproduced
- * deterministically by the regression test below. They are NOT silently
- * skipped: the `it.each(KNOWN_DEFECT_SEEDS)` block asserts each one still fails
- * to converge, so if the engine is fixed (or the generator drifts) these tests
- * go red and force this list — and the regression test — to be revisited.
+ * All 40 seeds run the full invariant suite. Seeds 3, 6, 13, 18, 30 and 37
+ * originally exposed the echo-suppression lost-update defect (smoky.wolf) and
+ * were pinned as known-failing until the engine gained snapshot-aware echo
+ * suppression; they are deliberately kept in the band as regression sentinels.
  */
-const KNOWN_DEFECT_SEEDS = [3, 6, 13, 18, 30, 37];
-
 const ALL_SEEDS = Array.from({ length: 40 }, (_, i) => i + 1);
-const CONVERGING_SEEDS = ALL_SEEDS.filter((s) => !KNOWN_DEFECT_SEEDS.includes(s));
 
 describe("round-trip convergence (property-based)", () => {
-  it.each(CONVERGING_SEEDS)(
+  it.each(ALL_SEEDS)(
     "seed %i converges, terminates, and invents nothing",
     async (seed) => {
       await runScenario(seed);
     },
   );
 
-  it.each(KNOWN_DEFECT_SEEDS)(
-    "seed %i still reproduces the known echo-suppression convergence defect",
-    async (seed) => {
-      // Documented, not ignored: assert the defect is still present. When the
-      // engine is fixed this rejects-expectation fails and the seed graduates
-      // to CONVERGING_SEEDS.
-      await expect(runScenario(seed)).rejects.toThrow(/did not converge/);
-    },
-  );
-
   /**
-   * KNOWN DEFECT — deterministic minimal reproduction (see the file header and
-   * the PR body for the full analysis).
+   * REGRESSION (smoky.wolf) — deterministic minimal case for the lost-update
+   * defect this suite originally found.
    *
    * A human changes field B (status) on a page; before any inbound pull applies
    * it, a local change to field A (priority) makes the next outbound push write
-   * to the same page, flipping its "last edited by" to the integration bot. The
-   * following inbound pull then hits row-level echo suppression and skips the
-   * whole page, and the `lastPulledAt` window advances past the human's edit —
-   * so the status change is stranded forever. Correct behavior would apply the
-   * remote-only status change locally; when that is fixed, the assertions marked
-   * "(would be … if fixed)" below flip and this test must be updated.
+   * to the same page, flipping its "last edited by" to the integration bot.
+   * Row-level echo suppression used to skip the whole page on the next pull and
+   * the `lastPulledAt` window advanced past the human's edit — stranding it
+   * forever. With snapshot-aware echo suppression the pull must detect that the
+   * remote row differs from the last-synced base, apply the pending status, and
+   * then go quiet.
    */
-  it("KNOWN DEFECT: a remote edit still pending at push time is stranded by row-level echo suppression", async () => {
+  it("REGRESSION: a remote edit still pending at push time survives the push's bot flip", async () => {
     const w = createRoundTripWorld();
     const { ticket, page } = w.seedSyncedTicket({
       status: "IN_PROGRESS",
@@ -470,31 +454,27 @@ describe("round-trip convergence (property-based)", () => {
     const pushes = await w.pushAll();
     expect(pushes.map((p) => p.action)).toEqual(["pushed"]);
     // Only priority is pushed; the status change is remote-ahead (push is
-    // outbound-only), yet the write still marks the whole page a bot edit.
+    // outbound-only), and the write marks the whole page a bot edit.
     expect(pushes[0]?.wrote).toEqual(["priority"]);
     expect(page.lastEditedBy).toBe("bot");
 
-    // Drive reconciling cycles; none can recover the stranded status.
-    let echoSuppressed = false;
-    for (let i = 0; i < 3; i++) {
-      const pull = await w.pull();
-      const item = pull.items.find((it2) => it2.externalId === page.externalId);
-      if (
-        item?.action === "skipped" &&
-        item.reason?.includes("echo suppression")
-      ) {
-        echoSuppressed = true;
-      }
-      await w.pushAll();
-    }
-
-    // The defect: echo suppression skipped the page and the status never applied.
-    expect(echoSuppressed).toBe(true);
-    expect(w.db.tickets.get(ticket.id)?.status).toBe("IN_PROGRESS"); // (would be DONE if fixed)
-    expect(page.rawStatus).toBe(STATUS_TO_RAW.DONE); // page keeps the human's value
-    // Ticket and page disagree on status — no convergence.
-    expect(RAW_TO_STATUS[page.rawStatus!]).not.toBe(
+    // The next pull must NOT treat the bot-edited row as a pure echo: the
+    // remote status differs from the snapshot, so the pending change applies.
+    const pull = await w.pull();
+    expect(pull.updated).toBe(1);
+    expect(w.db.tickets.get(ticket.id)?.status).toBe("DONE");
+    expect(w.db.tickets.get(ticket.id)?.priority).toBe(3);
+    expect(page.rawStatus).toBe(STATUS_TO_RAW.DONE);
+    expect(RAW_TO_STATUS[page.rawStatus!]).toBe(
       w.db.tickets.get(ticket.id)?.status,
     );
+
+    // And the exchange terminates: one more full cycle is a strict no-op.
+    w.clearWrites();
+    const cycle = await w.cycle();
+    expect(cycle.pull.updated).toBe(0);
+    expect(cycle.pushes.every((p) => p.action === "skipped")).toBe(true);
+    expect(w.ticketWrites()).toHaveLength(0);
+    expect(w.notionWrites()).toHaveLength(0);
   });
 });

--- a/src/server/services/ticketSync/engine.ts
+++ b/src/server/services/ticketSync/engine.ts
@@ -14,6 +14,7 @@ import {
   resolveCycleIdByName,
 } from "./resolvers";
 import {
+  fieldEquals,
   mergeSyncedFields,
   SYNCED_FIELD_KEYS,
   type SyncedFieldKey,
@@ -436,19 +437,22 @@ export async function runInboundTicketSync(
           continue;
         }
 
-        if (row.lastEditedByBot) {
+        const record = recordByExternalId.get(row.externalId);
+
+        // Echo suppression for rows we never linked stays row-level: an unseen
+        // bot-edited row can only be our own residue, never a pending human
+        // change. Linked rows are handled snapshot-aware below (smoky.wolf).
+        if (row.lastEditedByBot && !record) {
           counts.skipped++;
           items.push({
             externalId: row.externalId,
-            ticketId: recordByExternalId.get(row.externalId)?.ticketId ?? null,
+            ticketId: null,
             title: row.title,
             action: "skipped",
             reason: "last edit was ours (echo suppression)",
           });
           continue;
         }
-
-        const record = recordByExternalId.get(row.externalId);
 
         if (!record) {
           // ----------------------------------------------------------
@@ -627,6 +631,33 @@ export async function runInboundTicketSync(
         // ARCHIVED read as unchanged, so the remote status wins the merge.
         const restoring = record.tombstonedAt !== null;
         if (restoring) warnings.unshift("restored from Notion trash");
+
+        // Snapshot-aware echo suppression (smoky.wolf): our own last write is a
+        // pure echo only while every remote field still matches the last-synced
+        // base. A bot last-edit can mask a human change that was still unpulled
+        // when the push wrote (the push flips the page's editor); skipping the
+        // whole row would strand that change forever once the incremental
+        // window advances past it. A dirty or baseless row falls through to the
+        // merge, which reconciles it normally.
+        if (row.lastEditedByBot && !restoring) {
+          const base = (record.snapshot ?? null) as Partial<SyncedFields> | null;
+          const pureEcho =
+            base !== null &&
+            SYNCED_FIELD_KEYS.every((field) =>
+              fieldEquals(base[field], remote[field]),
+            );
+          if (pureEcho) {
+            counts.skipped++;
+            items.push({
+              externalId: row.externalId,
+              ticketId: ticket.id,
+              title: row.title,
+              action: "skipped",
+              reason: "last edit was ours (echo suppression)",
+            });
+            continue;
+          }
+        }
 
         const merged = mergeSyncedFields({
           base: (record.snapshot ?? null) as Partial<SyncedFields> | null,

--- a/src/server/services/ticketSync/merge.ts
+++ b/src/server/services/ticketSync/merge.ts
@@ -73,7 +73,7 @@ export interface MergeInput {
   remoteEditedAt: Date;
 }
 
-function fieldEquals(
+export function fieldEquals(
   a: SyncedFields[SyncedFieldKey] | undefined,
   b: SyncedFields[SyncedFieldKey] | undefined,
 ): boolean {


### PR DESCRIPTION
### **User description**
## What

Fixes the lost-remote-update defect found by the property-based convergence suite in #450 (~18% of random edit interleavings; Exponential ticket **smoky.wolf**).

**The bug:** a human edits field B of a linked Notion page; before the next pull, an outbound push writes a *different* field A to the same page, flipping the page's last-edited-by to the integration bot. The inbound pull's row-level echo suppression (`if (row.lastEditedByBot) skip`) then skipped the entire row — including the pending human edit — and the incremental `lastPulledAt` window advanced past it, so the edit was never reconciled.

**The fix:** echo suppression is now snapshot-aware for linked rows — a bot-edited row is only skipped while *every* remote field still matches the last-synced snapshot base (the pure-echo case). A dirty row falls through to the normal three-way merge, which applies the pending change; a baseless row (adopted ticket, no snapshot) also merges (LWW), as before. Unlinked bot-edited rows keep the row-level skip — they can only be our own residue.

`fieldEquals` is exported from `merge.ts` for the purity comparison; no behavior change there.

## Verification

- The six once-failing property seeds (3, 6, 13, 18, 30, 37) are graduated into the normal invariant band — all 40 seeds now converge, terminate, and invent nothing.
- The pinned deterministic repro is flipped into a true regression test: the pending status edit survives the push's bot flip, both sides converge, and one more full cycle is a strict no-op.
- Full ticket-sync surface green: 248 tests (engine, push, merge, mapping, scheduler, pushRunner, revert, outbound mapping/create, router, cron routes, round-trip, scenarios, property).
- `tsc --noEmit` clean.

---

Ships: smoky.wolf

[View in Exponential](https://www.exponential.im/w/syntrofi/products/exponential/tickets/426)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix snapshot-aware echo suppression to prevent stranded pending human edits

- Bot-edited linked rows now only skipped when remote fields match last-synced snapshot

- Export `fieldEquals` from `merge.ts` for purity comparison in engine

- Graduate all 40 property-based seeds to full invariant suite; flip regression test to assert correct behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  push["Outbound Push\n(field A written, bot flips page editor)"]
  pull["Inbound Pull\n(engine.ts runInboundTicketSync)"]
  snapshot["Snapshot Base\n(record.snapshot)"]
  fieldEquals["fieldEquals()\n(exported from merge.ts)"]
  pureEcho["Pure Echo Check\n(all remote fields == snapshot base?)"]
  skip["Skip Row\n(echo suppression)"]
  merge["Three-Way Merge\n(pending human edit applied)"]
  test["Property Test\n(all 40 seeds converge)"]

  push -- "marks page lastEditedByBot" --> pull
  pull -- "linked row?" --> snapshot
  snapshot -- "compared via" --> fieldEquals
  fieldEquals -- "drives" --> pureEcho
  pureEcho -- "yes (pure echo)" --> skip
  pureEcho -- "no (dirty row)" --> merge
  merge -- "reconciles pending field B" --> test
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>engine.ts</strong><dd><code>Snapshot-aware echo suppression for linked bot-edited rows</code></dd></summary>
<hr>

src/server/services/ticketSync/engine.ts

<ul><li>Move <code>record</code> lookup before the echo-suppression block so linked rows <br>are identified early<br> <li> Unlinked bot-edited rows keep row-level skip; linked rows proceed to <br>snapshot-aware check<br> <li> Add snapshot-aware echo suppression: bot-edited linked rows only <br>skipped when all remote fields match last-synced base<br> <li> Import <code>fieldEquals</code> from <code>merge.ts</code> for the purity comparison</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/452/files#diff-efe07be6916b5447498a2588f188ac30db90f9345dd6188473dea22c7866e658">+35/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merge.ts</strong><dd><code>Export fieldEquals for reuse in engine echo suppression</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/ticketSync/merge.ts

<ul><li>Export <code>fieldEquals</code> function (previously private) for use in <code>engine.ts</code><br> <li> No behavioral change to the function itself</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/452/files#diff-f1dacdc5a9888068212025d3f72f333857474c7a9243ee10692e28a72a7d098d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>roundTripProperty.test.ts</strong><dd><code>Graduate all seeds to full suite; flip regression to assert fix</code></dd></summary>
<hr>

src/server/services/ticketSync/__tests__/roundTripProperty.test.ts

<ul><li>Update file header comment to reflect defect is now fixed (smoky.wolf)<br> <li> Remove <code>KNOWN_DEFECT_SEEDS</code> list and separate failing-seed test block; <br>all 40 seeds now run the full invariant suite<br> <li> Flip deterministic regression test from asserting the defect exists to <br>asserting correct convergence behavior<br> <li> Regression test now verifies pending status survives push's bot flip <br>and exchange goes quiet after one cycle</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/452/files#diff-116a9fd717cf3654a9f9bd0568c1c4e2a522719ac939a8efb6bb92f4cafe6f48">+42/-62</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

