### PR TITLE
fix: surface unreadable cycle-relation pages instead of silently dropping them

### DIFF
--- a/src/server/services/ticketSync/__tests__/engine.test.ts
+++ b/src/server/services/ticketSync/__tests__/engine.test.ts
@@ -834,3 +834,70 @@ describe("runInboundTicketSync — revert-tombstoned links (ADR-0042)", () => {
     expect(item?.reason).toContain("tombstoned by revert");
   });
 });
+
+describe("runInboundTicketSync — unreadable cycle relation (frosty.flame)", () => {
+  it("does not clear the local cycle, surfaces the cause, and holds the window", async () => {
+    db.ticketSync.findMany.mockResolvedValue([
+      {
+        id: "s1",
+        ticketId: "t1",
+        externalId: "page-1",
+        snapshot: snapshotFor({ cycleName: "Sprint 1" }),
+        tombstonedAt: null,
+      },
+    ] as never);
+    db.ticket.findUnique.mockResolvedValue({
+      ...LINKED_TICKET,
+      cycle: { name: "Sprint 1" },
+    } as never);
+
+    const result = await runInboundTicketSync(
+      db,
+      fakeAdapter([row({ cycleName: null, cycleUnreadable: true })]),
+      { configId: "cfg1", trigger: "manual" },
+    );
+
+    expect(result.updated).toBe(0);
+    expect(db.ticket.update).not.toHaveBeenCalled();
+    expect(result.items[0]!.reason).toContain("cycle page unreadable");
+    // Window held: the row stays re-scannable so the cycle applies
+    // automatically once the Cycles database is shared.
+    expect(db.ticketSyncConfig.update).not.toHaveBeenCalled();
+  });
+
+  it("advances the window normally when no relation is unreadable", async () => {
+    db.ticketSync.findMany.mockResolvedValue([
+      {
+        id: "s1",
+        ticketId: "t1",
+        externalId: "page-1",
+        snapshot: snapshotFor(),
+        tombstonedAt: null,
+      },
+    ] as never);
+    db.ticket.findUnique.mockResolvedValue(LINKED_TICKET as never);
+
+    await runInboundTicketSync(db, fakeAdapter([row()]), {
+      configId: "cfg1",
+      trigger: "manual",
+    });
+
+    expect(db.ticketSyncConfig.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ lastPulledAt: expect.any(Date) }),
+      }),
+    );
+  });
+
+  it("a created row with an unreadable cycle carries the warning and holds the window", async () => {
+    const result = await runInboundTicketSync(
+      db,
+      fakeAdapter([row({ cycleUnreadable: true })]),
+      { configId: "cfg1", trigger: "manual" },
+    );
+
+    expect(result.created).toBe(1);
+    expect(result.items[0]!.reason).toContain("cycle page unreadable");
+    expect(db.ticketSyncConfig.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/ticketSync/__tests__/push.test.ts
+++ b/src/server/services/ticketSync/__tests__/push.test.ts
@@ -598,3 +598,48 @@ describe("runOutboundTicketPush — outbound archive", () => {
     expect(db.ticketSync.update).not.toHaveBeenCalled();
   });
 });
+
+describe("runOutboundTicketPush — unreadable cycle relation (frosty.flame)", () => {
+  it("neutralizes the unknown remote cycle: no write, no local clear, cause surfaced", async () => {
+    // Local ticket carries a cycle; the remote row reports the relation as
+    // unreadable (cycleName null + cycleUnreadable). Without neutralization
+    // the merge would read this as "remote cleared the cycle" and stage a
+    // phantom applyToLocal that clears it locally.
+    db.ticketSync.findUnique.mockResolvedValue(
+      syncRecord({
+        snapshot: snapshotFor({ cycleName: "Sprint 1" }),
+        ticket: { cycle: { name: "Sprint 1" } },
+      }) as never,
+    );
+    const adapter = fakeAdapter(
+      remoteRow({ cycleName: null, cycleUnreadable: true }),
+    );
+
+    const item = await runOutboundTicketPush(db, adapter, { syncId: "s1" });
+
+    expect(item.action).toBe("skipped");
+    expect(item.reason).toContain("cycle page unreadable");
+    expect(adapter.updates).toHaveLength(0);
+    // Nothing was written in either direction, so the snapshot stays put.
+    expect(db.ticketSync.update).not.toHaveBeenCalled();
+  });
+
+  it("still pushes unrelated scalar changes while the cycle is unreadable", async () => {
+    db.ticketSync.findUnique.mockResolvedValue(
+      syncRecord({
+        snapshot: snapshotFor({ cycleName: "Sprint 1", title: "Old" }),
+        ticket: { cycle: { name: "Sprint 1" }, title: "New title" },
+      }) as never,
+    );
+    const adapter = fakeAdapter(
+      remoteRow({ title: "Old", cycleName: null, cycleUnreadable: true }),
+    );
+
+    const item = await runOutboundTicketPush(db, adapter, { syncId: "s1" });
+
+    expect(item.action).toBe("pushed");
+    expect(item.wrote).toEqual(["title"]);
+    expect(item.reason).toContain("cycle page unreadable");
+    expect(adapter.updates).toHaveLength(1);
+  });
+});

--- a/src/server/services/ticketSync/engine.ts
+++ b/src/server/services/ticketSync/engine.ts
@@ -14,6 +14,7 @@ import {
   resolveCycleIdByName,
 } from "./resolvers";
 import {
+  CYCLE_UNREADABLE_WARNING,
   fieldEquals,
   mergeSyncedFields,
   SYNCED_FIELD_KEYS,
@@ -45,6 +46,12 @@ export interface RemoteTicketRow {
   labels: string[];
   /** Resolved title of the first page in the cycle relation, if any. */
   cycleName: string | null;
+  /**
+   * True when the cycle relation points at a page the connection cannot read
+   * (typically: the Cycles database is not shared with the integration). The
+   * remote cycle is then UNKNOWN — not empty — and must never be applied.
+   */
+  cycleUnreadable?: boolean;
   /** Email of the first person in the assignee property, if visible. */
   assigneeEmail: string | null;
   lastEditedAt: Date;
@@ -113,6 +120,7 @@ const SCALAR_FIELDS: SyncedFieldKey[] = [
   "type",
   "points",
 ];
+
 
 type StatusMap = Record<string, TicketStatus>;
 
@@ -276,6 +284,11 @@ export async function runInboundTicketSync(
   const items: SyncRunItem[] = [];
   const counts = { created: 0, updated: 0, skipped: 0, conflicts: 0, archived: 0, failed: 0 };
   const statusMap = (config.statusMap ?? null) as StatusMap | null;
+  // Set when any row's cycle relation could not be read. While true, the
+  // incremental window is NOT advanced, so the affected rows are re-scanned on
+  // every run and the pending cycle applies automatically once access is
+  // granted — no manual re-edit needed (frosty.flame).
+  let sawUnreadableRelation = false;
 
   try {
     // ------------------------------------------------------------------
@@ -462,6 +475,13 @@ export async function runInboundTicketSync(
             labels: row.labels,
           });
 
+          // Unknown remote cycle: create the ticket without one, but say so —
+          // and hold the window (flag) so the cycle lands once readable.
+          if (row.cycleUnreadable) {
+            warnings.push(CYCLE_UNREADABLE_WARNING);
+            sawUnreadableRelation = true;
+          }
+
           if (dryRun) {
             warnings.push(
               ...(await relationalPreviewWarnings(
@@ -625,6 +645,17 @@ export async function runInboundTicketSync(
         const { fields: remote, warnings } = rowToSyncedFields(row, statusMap, {
           labels: local.labels,
         });
+
+        // An unreadable cycle relation means the remote cycle is UNKNOWN, not
+        // empty. Neutralize it to the local value so the merge can neither
+        // clear the local cycle nor invent a change, surface the cause, and
+        // hold the incremental window (see sawUnreadableRelation) so the value
+        // applies automatically once the Cycles database is shared.
+        if (row.cycleUnreadable) {
+          remote.cycleName = local.cycleName;
+          warnings.push(CYCLE_UNREADABLE_WARNING);
+          sawUnreadableRelation = true;
+        }
 
         // A tombstoned record whose page is out of the trash re-links here:
         // the archive-time snapshot (status ARCHIVED) makes the ticket's
@@ -850,8 +881,11 @@ export async function runInboundTicketSync(
     });
 
     // Scoped runs saw only a subset — advancing the window would make the
-    // next full run silently skip everything else edited meanwhile.
-    if (!dryRun && !params.scope) {
+    // next full run silently skip everything else edited meanwhile. A run that
+    // hit unreadable cycle relations also holds the window: the affected rows
+    // must stay re-scannable so their cycles apply automatically once the
+    // Cycles database is shared, instead of requiring a manual re-edit.
+    if (!dryRun && !params.scope && !sawUnreadableRelation) {
       await db.ticketSyncConfig.update({
         where: { id: config.id },
         data: { lastPulledAt: startedAt },

--- a/src/server/services/ticketSync/merge.ts
+++ b/src/server/services/ticketSync/merge.ts
@@ -46,6 +46,14 @@ export const SYNCED_FIELD_KEYS: SyncedFieldKey[] = [
   "assigneeEmail",
 ];
 
+/**
+ * Surfaced on every row whose cycle relation cannot be read (frosty.flame).
+ * Lives here (the dependency-free module) so both engines can import it
+ * without dragging each other's runtime graphs into test files.
+ */
+export const CYCLE_UNREADABLE_WARNING =
+  "cycle page unreadable — share the Cycles database with the Notion connection";
+
 export interface MergeConflict {
   field: SyncedFieldKey;
   winner: "local" | "remote";

--- a/src/server/services/ticketSync/notionAdapter.ts
+++ b/src/server/services/ticketSync/notionAdapter.ts
@@ -134,7 +134,9 @@ export class NotionTicketSyncAdapter
       .map((page) => this.projectRow(page));
 
     // Resolve cycle relation ids → page titles, one concurrent lookup per
-    // unique cycle (resolvePageTitle already swallows per-page failures).
+    // unique cycle. An unreadable page (connection lacks access to the Cycles
+    // database) is flagged, NOT collapsed into "no cycle" — the engine treats
+    // the remote cycle as unknown and surfaces a warning (frosty.flame).
     const uniqueCycleIds = [
       ...new Set(
         rows
@@ -145,26 +147,34 @@ export class NotionTicketSyncAdapter
     const titleCache = new Map(
       await Promise.all(
         uniqueCycleIds.map(
-          async (id) => [id, await this.resolvePageTitle(id)] as const,
+          async (id) => [id, await this.resolveCycleTitle(id)] as const,
         ),
       ),
     );
     for (const row of rows) {
       if (!row.cycleRelationId) continue;
-      row.cycleName = titleCache.get(row.cycleRelationId) ?? null;
+      const resolved = titleCache.get(row.cycleRelationId);
+      row.cycleName = resolved?.title ?? null;
+      if (resolved?.unreadable) row.cycleUnreadable = true;
     }
 
     return rows;
   }
 
-  private async resolvePageTitle(pageId: string): Promise<string | null> {
+  private async resolveCycleTitle(
+    pageId: string,
+  ): Promise<{ title: string | null; unreadable: boolean }> {
     try {
       const page = (await this.notion.getPage(pageId)) as RawNotionPage;
-      return NotionService.extractTitleFromProperties(page.properties ?? {});
+      return {
+        title: NotionService.extractTitleFromProperties(page.properties ?? {}),
+        unreadable: false,
+      };
     } catch {
-      return null;
+      return { title: null, unreadable: true };
     }
   }
+
 
   private projectRow(
     page: RawNotionPage,
@@ -221,7 +231,9 @@ export class NotionTicketSyncAdapter
     }
     const row = this.projectRow(page);
     if (row.cycleRelationId) {
-      row.cycleName = await this.resolvePageTitle(row.cycleRelationId);
+      const resolved = await this.resolveCycleTitle(row.cycleRelationId);
+      row.cycleName = resolved.title;
+      if (resolved.unreadable) row.cycleUnreadable = true;
     }
     const { cycleRelationId: _cycleRelationId, ...rest } = row;
     return rest;

--- a/src/server/services/ticketSync/push.ts
+++ b/src/server/services/ticketSync/push.ts
@@ -1,6 +1,7 @@
 import type { Prisma, PrismaClient, TicketStatus, TicketType } from "@prisma/client";
 import { mapPoints, mapPriority, mapStatus, mapType } from "./mapping";
 import {
+  CYCLE_UNREADABLE_WARNING,
   mergeSyncedFields,
   SYNCED_FIELD_KEYS,
   type SyncedFieldKey,
@@ -358,6 +359,17 @@ export async function runOutboundTicketPush(
   }
 
   const remote = rowToRemoteFields(row, statusMap);
+
+  // An unreadable cycle relation means the remote cycle is UNKNOWN, not empty:
+  // neutralize it to the local value so the merge can neither clear the local
+  // cycle (a phantom applyToLocal) nor push over a value it cannot see. The
+  // cause is surfaced on the item; the inbound engine holds its window until
+  // access is restored (frosty.flame).
+  const cycleUnreadable = row.cycleUnreadable === true;
+  if (cycleUnreadable) {
+    remote.cycleName = local.cycleName;
+  }
+
   const merged = mergeSyncedFields({
     base: (sync.snapshot ?? null) as Partial<SyncedFields> | null,
     local,
@@ -370,6 +382,7 @@ export async function runOutboundTicketPush(
   const warnings: string[] = merged.conflicts.map(
     (c) => `conflict on ${c.field}: ${c.winner} wins`,
   );
+  if (cycleUnreadable) warnings.push(CYCLE_UNREADABLE_WARNING);
 
   // Nothing to push. Either fully in sync, or the only divergence is a
   // remote-only change (or a conflict the remote won) — both are the inbound
@@ -383,7 +396,7 @@ export async function runOutboundTicketPush(
       reason:
         merged.conflicts.length > 0
           ? warnings.join("; ")
-          : "in sync — nothing to push",
+          : ["in sync — nothing to push", ...warnings].join("; "),
     };
   }
 


### PR DESCRIPTION
### **User description**
## What

Fixes the silent cycle-sync gap found while testing the sandbox (Exponential ticket **frosty.flame**): the Cycles column relates to a *separate* Cycles database, and when the Notion connection can't read the related page, the adapter collapsed the failure into `cycleName: null` — indistinguishable from "no cycle set". Result observed live: 3 of 113 fluentsynth tickets had a cycle despite heavy Cycles usage in Notion, with zero surfaced errors.

Now the adapter flags the row (`cycleUnreadable`) and both engines treat the remote cycle as **unknown, not empty**:

- **Inbound**: remote cycle neutralized to the local value (no phantom clears, no invented changes), an actionable per-item warning ("cycle page unreadable — share the Cycles database with the Notion connection"), and the incremental window is **held** so affected rows stay re-scannable — the cycle applies automatically once access is granted, no manual re-edit needed.
- **Outbound**: same neutralization prevents a push merge from clearing the local cycle; unrelated field changes still push, with the warning on the item reason.
- **Creation** from an unreadable row proceeds without a cycle, with the same warning + window hold.

The warning constant lives in `merge.ts` (dependency-free) so both engines share it without cross-contaminating test module graphs.

## Verification

- 5 new unit tests: inbound no-clear + warning + window hold, window advances when healthy, creation-path warning, outbound no-clear/no-write + warning, unrelated-field push still works while unreadable.
- Full ticket-sync unit surface green (234 tests); `tsc --noEmit` clean.

---

Ships: frosty.flame

[View in Exponential](https://www.exponential.im/w/syntrofi/products/exponential/tickets/427)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix silent cycle-sync gap: unreadable cycle relations now flagged, not dropped

- Both inbound and outbound engines neutralize unknown remote cycles to local value

- Incremental sync window held when unreadable relations detected, enabling auto-recovery

- 5 new unit tests covering inbound/outbound unreadable cycle scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  notionAdapter["notionAdapter.ts"]
  merge["merge.ts"]
  engine["engine.ts"]
  push["push.ts"]
  engineTests["engine.test.ts"]
  pushTests["push.test.ts"]

  notionAdapter -- "resolveCycleTitle returns unreadable flag" --> engine
  notionAdapter -- "resolveCycleTitle returns unreadable flag" --> push
  merge -- "exports CYCLE_UNREADABLE_WARNING" --> engine
  merge -- "exports CYCLE_UNREADABLE_WARNING" --> push
  engine -- "neutralizes remote cycle, holds window" --> engineTests
  push -- "neutralizes remote cycle, surfaces warning" --> pushTests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merge.ts</strong><dd><code>Add shared CYCLE_UNREADABLE_WARNING constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/ticketSync/merge.ts

<ul><li>Adds <code>CYCLE_UNREADABLE_WARNING</code> constant exported from the <br>dependency-free module<br> <li> Constant is shared by both inbound and outbound engines without <br>cross-contaminating test graphs</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/454/files#diff-f1dacdc5a9888068212025d3f72f333857474c7a9243ee10692e28a72a7d098d">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>notionAdapter.ts</strong><dd><code>Flag unreadable cycle pages instead of collapsing to null</code></dd></summary>
<hr>

src/server/services/ticketSync/notionAdapter.ts

<ul><li>Renames <code>resolvePageTitle</code> to <code>resolveCycleTitle</code>, returning <code>{ title, </code><br><code>unreadable }</code> instead of <code>string | null</code><br> <li> Propagates <code>cycleUnreadable: true</code> onto <code>RemoteTicketRow</code> when the cycle <br>page fetch fails<br> <li> Updates both batch and single-row fetch paths to use the new return <br>shape</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/454/files#diff-01ccbdc7c270905dc6d098bdec52026e3fadd76ea2f3d33c301bece929bc8e5d">+19/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>engine.ts</strong><dd><code>Neutralize unreadable remote cycles and hold sync window</code>&nbsp; </dd></summary>
<hr>

src/server/services/ticketSync/engine.ts

<ul><li>Imports <code>CYCLE_UNREADABLE_WARNING</code> from <code>merge.ts</code><br> <li> Adds <code>cycleUnreadable</code> field to <code>RemoteTicketRow</code> interface<br> <li> Neutralizes remote <code>cycleName</code> to local value when <code>cycleUnreadable</code> is <br>set during update path<br> <li> Adds warning and sets <code>sawUnreadableRelation</code> flag on creation path when <br>cycle is unreadable<br> <li> Holds incremental window (<code>lastPulledAt</code> not advanced) when <br><code>sawUnreadableRelation</code> is true</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/454/files#diff-efe07be6916b5447498a2588f188ac30db90f9345dd6188473dea22c7866e658">+36/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>push.ts</strong><dd><code>Prevent phantom cycle clears in outbound push</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/ticketSync/push.ts

<ul><li>Imports <code>CYCLE_UNREADABLE_WARNING</code> from <code>merge.ts</code><br> <li> Neutralizes remote <code>cycleName</code> to local value when <code>cycleUnreadable</code> is <br>true before merge<br> <li> Appends <code>CYCLE_UNREADABLE_WARNING</code> to item warnings/reason when cycle is <br>unreadable<br> <li> Ensures unrelated scalar changes still push while cycle is unreadable</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/454/files#diff-0504c91c3575b6a06d16df56910f78c731ff2ea60dda0fd1cb9363d23690afaa">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>engine.test.ts</strong><dd><code>Add inbound unreadable cycle relation unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/ticketSync/__tests__/engine.test.ts

<ul><li>Adds test suite for unreadable cycle relation inbound scenarios<br> <li> Tests: no local cycle clear + warning + window hold, window advances <br>when healthy, creation-path warning + window hold</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/454/files#diff-1842eb3834aa6ce71989236566db12f9f93564ac1c6d3b83951c371c66f41899">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>push.test.ts</strong><dd><code>Add outbound unreadable cycle relation unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/ticketSync/__tests__/push.test.ts

<ul><li>Adds test suite for unreadable cycle relation outbound scenarios<br> <li> Tests: no write/no local clear + cause surfaced, unrelated scalar <br>changes still push while cycle unreadable</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/454/files#diff-5a8e270b8e45e16f0ee895e07876de657ce70698fffc22cb529906dd82ddfe9b">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

