### PR TITLE
test: round-trip coverage for cycle and assignee relation paths

### DIFF
--- a/src/server/services/ticketSync/__tests__/harness/fakeNotion.ts
+++ b/src/server/services/ticketSync/__tests__/harness/fakeNotion.ts
@@ -37,6 +37,15 @@ export interface FakePage {
   lastEditedAt: Date;
   lastEditedBy: "bot" | "human";
   archived: boolean;
+  /**
+   * Simulates the Cycles database not being shared with the connection: the
+   * page still HAS a cycle (cycleName stays stored as hidden truth), but rows
+   * emitted to the sync report cycleName null + cycleUnreadable, exactly like
+   * the real adapter when the related page 403s. Flip back to false to
+   * simulate access being granted — deliberately WITHOUT bumping
+   * lastEditedAt, since self-healing must not require a re-edit.
+   */
+  cycleUnreadable?: boolean;
   /** Properties written by the sync that the fake has no column for. */
   extra: Record<string, unknown>;
   /** Body blocks passed to createPage, kept for assertions. */
@@ -192,6 +201,7 @@ export class FakeNotion implements TicketSyncRemoteAdapter, TicketPushAdapter {
         | "cycleName"
         | "assigneeEmail"
         | "archived"
+        | "cycleUnreadable"
       >
     >,
   ): FakePage {
@@ -317,7 +327,10 @@ export class FakeNotion implements TicketSyncRemoteAdapter, TicketPushAdapter {
       rawType: page.rawType,
       rawEffort: page.rawEffort,
       labels: [...page.labels],
-      cycleName: page.cycleName,
+      // Unreadable mode mirrors the real adapter: the relation exists but the
+      // page can't be fetched, so the row reports null + the flag.
+      cycleName: page.cycleUnreadable ? null : page.cycleName,
+      ...(page.cycleUnreadable ? { cycleUnreadable: true } : {}),
       assigneeEmail: page.assigneeEmail,
       lastEditedAt: page.lastEditedAt,
       lastEditedByBot: page.lastEditedBy === "bot",

--- a/src/server/services/ticketSync/__tests__/harness/fakeSyncDb.ts
+++ b/src/server/services/ticketSync/__tests__/harness/fakeSyncDb.ts
@@ -67,10 +67,18 @@ export interface FakeConfig {
 }
 
 export interface DbWrite {
-  model: "ticket" | "ticketSync" | "ticketSyncConfig" | "ticketSyncRun";
+  model: "ticket" | "ticketSync" | "ticketSyncConfig" | "ticketSyncRun" | "list";
   op: "create" | "update" | "delete";
   id: string | null;
   data: unknown;
+}
+
+/** Same slug rule as resolvers.ts, so slug-clash lookups behave identically. */
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
 }
 
 interface WhereById {
@@ -81,12 +89,18 @@ export class FakeSyncDb {
   readonly tickets = new Map<string, FakeTicket>();
   readonly syncs = new Map<string, FakeSyncRecord>();
   readonly runs = new Map<string, Record<string, unknown>>();
+  /** Workspace cycles (Prisma `List` rows, listType SPRINT): id → row. */
+  readonly cyclesById = new Map<string, { name: string; slug: string }>();
+  /** Workspace members: userId → email. */
+  readonly membersById = new Map<string, string>();
   readonly writeLog: DbWrite[] = [];
   readonly config: FakeConfig;
 
   private ticketCounter = 0;
   private syncCounter = 0;
   private runCounter = 0;
+  private cycleCounter = 0;
+  private memberCounter = 0;
 
   constructor(
     private readonly clock: TestClock,
@@ -156,6 +170,20 @@ export class FakeSyncDb {
     };
     this.syncs.set(record.id, record);
     return record;
+  }
+
+  /** Register a workspace cycle (SPRINT list) the resolvers can find. */
+  seedCycle(name: string): string {
+    const id = `cycle${++this.cycleCounter}`;
+    this.cyclesById.set(id, { name, slug: slugify(name) });
+    return id;
+  }
+
+  /** Register a workspace member the assignee resolver can match. */
+  seedMember(email: string): string {
+    const id = `member${++this.memberCounter}`;
+    this.membersById.set(id, email);
+    return id;
   }
 
   /** Simulate a user editing the ticket in Exponential (not a sync write). */
@@ -271,10 +299,32 @@ export class FakeSyncDb {
               (t as Record<string, unknown>)[key] = args.data[key];
             }
           }
-          if ("cycleId" in args.data || "assigneeId" in args.data) {
-            throw new Error(
-              "FakeSyncDb: relational id writes not supported yet — extend the fake",
-            );
+          // Relational id writes store back as name/email (the shape the rest
+          // of the fake reads), resolved through the registered cycle/member
+          // tables — mirroring what ticketView would render after a real write.
+          if ("cycleId" in args.data) {
+            const cycleId = args.data.cycleId as string | null;
+            if (cycleId === null) {
+              t.cycleName = null;
+            } else {
+              const cycle = this.cyclesById.get(cycleId);
+              if (!cycle) {
+                throw new Error(`FakeSyncDb: unknown cycle ${cycleId}`);
+              }
+              t.cycleName = cycle.name;
+            }
+          }
+          if ("assigneeId" in args.data) {
+            const assigneeId = args.data.assigneeId as string | null;
+            if (assigneeId === null) {
+              t.assigneeEmail = null;
+            } else {
+              const email = this.membersById.get(assigneeId);
+              if (!email) {
+                throw new Error(`FakeSyncDb: unknown member ${assigneeId}`);
+              }
+              t.assigneeEmail = email;
+            }
           }
           t.updatedAt = this.clock.now();
           this.writeLog.push({
@@ -376,6 +426,65 @@ export class FakeSyncDb {
             data: null,
           });
           return Promise.resolve({});
+        },
+      },
+
+      // Cycles are Prisma `List` rows (listType SPRINT); the resolvers look
+      // them up by insensitive name / unique slug and auto-create on miss.
+      list: {
+        findFirst: (args: {
+          where: { name?: { equals: string } };
+        }) => {
+          const wanted = args.where.name?.equals.toLowerCase();
+          if (wanted === undefined) {
+            return Promise.reject(
+              new Error("FakeSyncDb: unsupported list.findFirst shape"),
+            );
+          }
+          for (const [id, cycle] of this.cyclesById) {
+            if (cycle.name.toLowerCase() === wanted) {
+              return Promise.resolve({ id });
+            }
+          }
+          return Promise.resolve(null);
+        },
+        findUnique: (args: {
+          where: { workspaceId_slug: { slug: string } };
+        }) => {
+          for (const [id, cycle] of this.cyclesById) {
+            if (cycle.slug === args.where.workspaceId_slug.slug) {
+              return Promise.resolve({ id });
+            }
+          }
+          return Promise.resolve(null);
+        },
+        create: (args: { data: { name: string; slug: string } }) => {
+          const id = `cycle${++this.cycleCounter}`;
+          this.cyclesById.set(id, {
+            name: args.data.name,
+            slug: args.data.slug,
+          });
+          this.writeLog.push({
+            model: "list",
+            op: "create",
+            id,
+            data: args.data,
+          });
+          return Promise.resolve({ id });
+        },
+      },
+
+      workspaceUser: {
+        findFirst: (args: {
+          where: { user: { email: { equals: string } } };
+        }) => {
+          const wanted = args.where.user.email.equals.toLowerCase();
+          for (const [userId, email] of this.membersById) {
+            if (email.toLowerCase() === wanted) {
+              return Promise.resolve({ userId });
+            }
+          }
+          return Promise.resolve(null);
         },
       },
 

--- a/src/server/services/ticketSync/__tests__/roundTripRelations.test.ts
+++ b/src/server/services/ticketSync/__tests__/roundTripRelations.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Round-trip coverage for the RELATIONAL sync paths (cycle, assignee) — the
+ * coverage hole that let the live cycle-sync gap (frosty.flame) go unnoticed:
+ * the harness previously rejected relational writes by design, so no test ever
+ * drove a cycle through pull or push.
+ *
+ * Same shared FakeNotion + FakeSyncDb world as roundTrip.test.ts /
+ * roundTripScenarios.test.ts; every scenario ends with the standard
+ * zero-write quiescence check. The final block proves the frosty.flame
+ * self-heal end-to-end: an unreadable cycle warns and holds the window, then
+ * applies WITHOUT a re-edit once access is restored.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+const { createTicketMock, resolveTagsMock, attachTagsMock, recordActivityMock } =
+  vi.hoisted(() => ({
+    createTicketMock: vi.fn(),
+    resolveTagsMock: vi.fn(),
+    attachTagsMock: vi.fn(),
+    recordActivityMock: vi.fn(),
+  }));
+
+vi.mock("~/plugins/product/server/services/createTicket", () => ({
+  createTicketWithNumber: createTicketMock,
+}));
+
+vi.mock("../../notionTicketImport", () => ({
+  resolveOrCreateWorkspaceTags: resolveTagsMock,
+  attachTicketTags: attachTagsMock,
+}));
+
+vi.mock("~/server/services/activity/recordActivity", () => ({
+  recordActivity: recordActivityMock,
+}));
+
+import { createRoundTripWorld, type RoundTripWorld } from "./harness/world";
+
+recordActivityMock.mockResolvedValue(true);
+createTicketMock.mockRejectedValue(
+  new Error("unexpected ticket creation in a relation round-trip test"),
+);
+
+/** Assert a full pull+push cycle writes nothing on either side. */
+async function expectQuiescence(w: RoundTripWorld): Promise<void> {
+  w.clearWrites();
+  const cycle = await w.cycle();
+  expect(cycle.pull.updated).toBe(0);
+  expect(cycle.pull.conflicts).toBe(0);
+  expect(cycle.pushes.every((p) => p.action === "skipped")).toBe(true);
+  expect(w.ticketWrites()).toHaveLength(0);
+  expect(w.notionWrites()).toHaveLength(0);
+}
+
+describe("round-trip cycle relation", () => {
+  it("inbound: a cycle set in Notion auto-creates the local cycle and applies", async () => {
+    const w = createRoundTripWorld();
+    const { ticket, page } = w.seedSyncedTicket({});
+
+    w.notion.editAsHuman(page.externalId, { cycleName: "Cycle 3" });
+
+    const pull = await w.pull();
+    expect(pull.updated).toBe(1);
+    expect(w.db.tickets.get(ticket.id)?.cycleName).toBe("Cycle 3");
+    // The resolver auto-created the workspace cycle (SPRINT list).
+    expect(
+      [...w.db.cyclesById.values()].some((c) => c.name === "Cycle 3"),
+    ).toBe(true);
+
+    await expectQuiescence(w);
+  });
+
+  it("inbound: matches an existing local cycle case-insensitively, no duplicate", async () => {
+    const w = createRoundTripWorld();
+    const { ticket, page } = w.seedSyncedTicket({});
+    w.db.seedCycle("cycle three");
+
+    w.notion.editAsHuman(page.externalId, { cycleName: "Cycle Three" });
+
+    const pull = await w.pull();
+    expect(pull.updated).toBe(1);
+    expect(w.db.tickets.get(ticket.id)?.cycleName).toBe("cycle three");
+    expect(w.db.cyclesById.size).toBe(1);
+    expect(
+      w.db.writeLog.filter((e) => e.model === "list" && e.op === "create"),
+    ).toHaveLength(0);
+
+    await expectQuiescence(w);
+  });
+
+  it("outbound: a locally-assigned cycle pushes when a matching Notion page exists", async () => {
+    const w = createRoundTripWorld();
+    const { ticket, page } = w.seedSyncedTicket({});
+    w.notion.cyclePagesById.set("cycle-page-1", "Cycle 3");
+
+    w.db.editTicketLocally(ticket.id, { cycleName: "Cycle 3" });
+
+    const pushes = await w.pushAll();
+    expect(pushes.map((p) => p.action)).toEqual(["pushed"]);
+    expect(pushes[0]?.wrote).toContain("cycleName");
+    expect(page.cycleName).toBe("Cycle 3");
+
+    await expectQuiescence(w);
+  });
+
+  it("outbound: no matching Notion cycle page warns, skips, and stays pending", async () => {
+    const w = createRoundTripWorld();
+    const { ticket, page } = w.seedSyncedTicket({});
+
+    w.db.editTicketLocally(ticket.id, { cycleName: "Cycle 9" });
+
+    const pushes = await w.pushAll();
+    expect(pushes.map((p) => p.action)).toEqual(["skipped"]);
+    expect(pushes[0]?.reason).toContain('no Notion cycle page named "Cycle 9"');
+    expect(page.cycleName).toBeNull();
+    // Pending outbound, never reverted: the local value survives quiet cycles.
+    await expectQuiescence(w);
+    expect(w.db.tickets.get(ticket.id)?.cycleName).toBe("Cycle 9");
+
+    // Once the cycle page appears in Notion, the next push ships it.
+    w.notion.cyclePagesById.set("cycle-page-9", "Cycle 9");
+    const retry = await w.pushAll();
+    expect(retry.map((p) => p.action)).toEqual(["pushed"]);
+    expect(page.cycleName).toBe("Cycle 9");
+    await expectQuiescence(w);
+  });
+});
+
+describe("round-trip assignee relation", () => {
+  it("inbound: an assignee set in Notion applies when the email matches a member", async () => {
+    const w = createRoundTripWorld();
+    const { ticket, page } = w.seedSyncedTicket({});
+    w.db.seedMember("dev@example.com");
+
+    w.notion.editAsHuman(page.externalId, { assigneeEmail: "dev@example.com" });
+
+    const pull = await w.pull();
+    expect(pull.updated).toBe(1);
+    expect(w.db.tickets.get(ticket.id)?.assigneeEmail).toBe("dev@example.com");
+
+    await expectQuiescence(w);
+  });
+
+  it("outbound: a local assignee pushes when the email matches a Notion person", async () => {
+    const w = createRoundTripWorld();
+    const { ticket, page } = w.seedSyncedTicket({});
+    w.notion.peopleByEmail.set("dev@example.com", "person-1");
+
+    w.db.editTicketLocally(ticket.id, { assigneeEmail: "dev@example.com" });
+
+    const pushes = await w.pushAll();
+    expect(pushes.map((p) => p.action)).toEqual(["pushed"]);
+    expect(pushes[0]?.wrote).toContain("assigneeEmail");
+    expect(page.assigneeEmail).toBe("dev@example.com");
+
+    await expectQuiescence(w);
+  });
+});
+
+describe("round-trip unreadable cycle relation (frosty.flame self-heal)", () => {
+  it("warns, holds the window, never clears — then applies once access is restored, without a re-edit", async () => {
+    const w = createRoundTripWorld();
+    const { ticket, page } = w.seedSyncedTicket({});
+
+    // A human sets a cycle the connection cannot read.
+    w.notion.editAsHuman(page.externalId, {
+      cycleName: "Cycle 3",
+      cycleUnreadable: true,
+    });
+
+    const pull = await w.pull();
+    expect(pull.updated).toBe(0);
+    const item = pull.items.find((i) => i.externalId === page.externalId);
+    expect(item?.reason).toContain("cycle page unreadable");
+    expect(w.db.tickets.get(ticket.id)?.cycleName).toBeNull();
+    // Window held: lastPulledAt must NOT advance while relations are unreadable.
+    expect(w.db.config.lastPulledAt).toBeNull();
+
+    // The push direction must not clear the (unknown) remote cycle either.
+    const pushes = await w.pushAll();
+    expect(pushes.every((p) => p.action === "skipped")).toBe(true);
+    expect(w.notionWrites()).toHaveLength(0);
+
+    // Access is granted — NO page edit, no timestamp bump. Because the window
+    // was held, the very next pull re-scans the row and applies the cycle.
+    page.cycleUnreadable = false;
+    const healed = await w.pull();
+    expect(healed.updated).toBe(1);
+    expect(w.db.tickets.get(ticket.id)?.cycleName).toBe("Cycle 3");
+    // Healthy again: the window advances normally from here.
+    expect(w.db.config.lastPulledAt).not.toBeNull();
+
+    await expectQuiescence(w);
+  });
+});


### PR DESCRIPTION
### **User description**
## What

Closes the coverage hole that let the live cycle-sync gap (frosty.flame, #454) go unnoticed: the round-trip harness deliberately rejected relational ticket writes, so no test ever drove a cycle through pull or push.

**Harness**: FakeSyncDb gains registered cycle/member tables with seed helpers, relational id writes that store back as name/email, and the resolver call shapes (`list.findFirst` insensitive-name, `list.findUnique` by slug, `list.create`, `workspaceUser.findFirst`). FakeNotion gains a `cycleUnreadable` page mode mirroring the real adapter when the Cycles database isn't shared — and flipping it back deliberately does *not* bump `lastEditedAt`, because self-healing must not require a re-edit.

**Seven scenarios**, each ending in zero-write quiescence:
- inbound cycle auto-creates the local cycle; case-insensitive match creates no duplicate
- outbound cycle pushes when a matching Notion page exists; warns/skips/stays-pending and ships on retry when the page appears later
- assignee inbound + outbound happy paths
- **frosty.flame end-to-end self-heal**: unreadable cycle warns + holds the window + clears nothing, then applies *without a re-edit* once access is restored

## Verification

Full ticket-sync unit surface green (241 tests); `tsc --noEmit` clean.

---

Ships: dark.squid

[View in Exponential](https://www.exponential.im/w/syntrofi/products/exponential/tickets/428)


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Add round-trip test coverage for cycle and assignee relational sync paths

- Extend `FakeNotion` with `cycleUnreadable` page mode mirroring real adapter behavior

- Extend `FakeSyncDb` with cycle/member tables, seed helpers, and relational id write support

- Add 7 end-to-end scenarios including frosty.flame self-heal without re-edit


___

### Diagram Walkthrough


```mermaid
flowchart LR
  fakeNotion["FakeNotion\n(cycleUnreadable mode)"]
  fakeSyncDb["FakeSyncDb\n(cycle/member tables)"]
  roundTripTests["roundTripRelations.test.ts\n(7 scenarios)"]
  world["RoundTripWorld\nharness"]

  fakeNotion -- "emits null + cycleUnreadable flag" --> world
  fakeSyncDb -- "resolves relational id writes" --> world
  world -- "pull + push cycles" --> roundTripTests
  roundTripTests -- "frosty.flame self-heal" --> roundTripTests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fakeNotion.ts</strong><dd><code>Add cycleUnreadable page mode to FakeNotion harness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/ticketSync/__tests__/harness/fakeNotion.ts

<ul><li>Adds optional <code>cycleUnreadable</code> field to <code>FakePage</code> interface with <br>detailed JSDoc<br> <li> Updates <code>editAsHuman</code> to accept <code>cycleUnreadable</code> as a settable property<br> <li> Row emission now returns <code>cycleName: null</code> and <code>cycleUnreadable: true</code> <br>when flag is set, mirroring real adapter behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/455/files#diff-ba2ee470ae82b0459adeef15836eb7fcdc170645e4f786d721308dde159c25cf">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fakeSyncDb.ts</strong><dd><code>Extend FakeSyncDb with cycle and member relational support</code></dd></summary>
<hr>

src/server/services/ticketSync/__tests__/harness/fakeSyncDb.ts

<ul><li>Adds <code>cyclesById</code> and <code>membersById</code> maps plus <code>seedCycle</code>/<code>seedMember</code> helpers<br> <li> Replaces blanket relational-write error with proper <code>cycleId</code>/<code>assigneeId</code> <br>resolution through registered tables<br> <li> Adds <code>list</code> model (findFirst, findUnique, create) and <br><code>workspaceUser.findFirst</code> implementations<br> <li> Adds <code>slugify</code> helper matching production resolver logic; extends <br><code>DbWrite</code> model union with <code>"list"</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/455/files#diff-7e8f44663eff57a2c12148523a201fc582eb2bfb4235277a76441722ff878db0">+114/-5</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>roundTripRelations.test.ts</strong><dd><code>Add relational round-trip tests including frosty.flame self-heal</code></dd></summary>
<hr>

src/server/services/ticketSync/__tests__/roundTripRelations.test.ts

<ul><li>New test file with 7 round-trip scenarios for cycle and assignee <br>relational sync paths<br> <li> Covers inbound auto-create, case-insensitive dedup, outbound push, <br>missing-page skip/retry<br> <li> Covers assignee inbound and outbound happy paths<br> <li> Proves frosty.flame self-heal: unreadable cycle holds window and <br>applies without re-edit once access restored</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/455/files#diff-897e720d2480e6f5fe55f657193e8d12b4a377f28a13a42f83e7b3730b26ac80">+195/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

