### PR TITLE
feat: near-real-time inbound Notion ticket sync via webhook

### DIFF
--- a/src/app/api/webhooks/__tests__/notionWebhook.test.ts
+++ b/src/app/api/webhooks/__tests__/notionWebhook.test.ts
@@ -1,0 +1,212 @@
+// @vitest-environment node
+/**
+ * Route-handler tests for the Notion inbound-sync webhook — POST
+ * /api/webhooks/notion. The route is a verified doorbell: it authenticates the
+ * event, resolves which sync config the event's database ids belong to, and
+ * fires the SAME inbound pull the cron sweep runs (trigger `webhook`), always
+ * answering 200 fast. The engine itself is covered by engine.test.ts; here we
+ * pin the auth + dispatch contract.
+ */
+
+import { createHmac } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const { runInboundMock, adapterFactoryMock, findManyMock, findFirstMock } =
+  vi.hoisted(() => ({
+    runInboundMock: vi.fn(),
+    adapterFactoryMock: vi.fn(),
+    findManyMock: vi.fn(),
+    findFirstMock: vi.fn(),
+  }));
+
+vi.mock("~/server/db", () => ({
+  db: {
+    ticketSyncConfig: { findMany: findManyMock },
+    ticketSyncRun: { findFirst: findFirstMock },
+  },
+}));
+vi.mock("~/server/services/ticketSync/engine", () => ({
+  runInboundTicketSync: runInboundMock,
+}));
+vi.mock("~/server/services/ticketSync/notionAdapter", () => ({
+  createNotionTicketSyncAdapter: adapterFactoryMock,
+}));
+
+import { POST } from "../notion/route";
+
+const SECRET = "whsec_test";
+const DB_ID_DASHED = "11111111-2222-3333-4444-555555555555";
+const DB_ID_BARE = DB_ID_DASHED.replace(/-/g, "");
+
+function sign(raw: string, secret = SECRET): string {
+  return `sha256=${createHmac("sha256", secret).update(raw).digest("hex")}`;
+}
+
+function makeRequest(
+  rawBody: string,
+  headers: Record<string, string> = {},
+): NextRequest {
+  return {
+    text: async () => rawBody,
+    headers: new Headers(headers),
+  } as unknown as NextRequest;
+}
+
+/** A verified event body naming `databaseId` via data.parent.database_id. */
+function eventFor(databaseId: string): string {
+  return JSON.stringify({
+    id: "evt_1",
+    type: "page.content_updated",
+    entity: { id: "page_abc", type: "page" },
+    data: { parent: { type: "database", database_id: databaseId } },
+  });
+}
+
+function enabledConfig(databaseId: string) {
+  return {
+    id: "cfg_1",
+    productId: "prod_1",
+    integrationId: "int_1",
+    propertyNames: null,
+    databaseId,
+  };
+}
+
+describe("POST /api/webhooks/notion", () => {
+  const originalSecret = process.env.NOTION_WEBHOOK_SECRET;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    process.env.NOTION_WEBHOOK_SECRET = SECRET;
+    findManyMock.mockResolvedValue([]);
+    findFirstMock.mockResolvedValue(null);
+    adapterFactoryMock.mockResolvedValue({ ok: true, adapter: { queryRows: vi.fn() } });
+    runInboundMock.mockResolvedValue({ runId: "run_1" });
+  });
+
+  afterEach(() => {
+    process.env.NOTION_WEBHOOK_SECRET = originalSecret;
+    vi.restoreAllMocks();
+  });
+
+  it("fails closed with 503 when NOTION_WEBHOOK_SECRET is not configured", async () => {
+    delete process.env.NOTION_WEBHOOK_SECRET;
+    const raw = eventFor(DB_ID_DASHED);
+
+    const response = await POST(
+      makeRequest(raw, { "x-notion-signature": sign(raw) }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(findManyMock).not.toHaveBeenCalled();
+    expect(runInboundMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for a bad signature without resolving any config", async () => {
+    const raw = eventFor(DB_ID_DASHED);
+
+    const response = await POST(
+      makeRequest(raw, { "x-notion-signature": "sha256=deadbeef" }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(findManyMock).not.toHaveBeenCalled();
+    expect(runInboundMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the signature header is missing (non-handshake body)", async () => {
+    const raw = eventFor(DB_ID_DASHED);
+
+    const response = await POST(makeRequest(raw));
+
+    expect(response.status).toBe(401);
+    expect(runInboundMock).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges the unsigned subscription handshake with 200 and logs the token", async () => {
+    const logSpy = vi.spyOn(console, "log");
+    const raw = JSON.stringify({ verification_token: "verif_tok_xyz" });
+
+    const response = await POST(makeRequest(raw));
+
+    expect(response.status).toBe(200);
+    expect(runInboundMock).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("verif_tok_xyz"));
+  });
+
+  it("returns 200 no-op for a verified event whose database matches no config", async () => {
+    findManyMock.mockResolvedValue([enabledConfig("99999999-0000-0000-0000-000000000000")]);
+    const raw = eventFor(DB_ID_DASHED);
+
+    const response = await POST(
+      makeRequest(raw, { "x-notion-signature": sign(raw) }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { matched: number };
+    expect(body.matched).toBe(0);
+    expect(adapterFactoryMock).not.toHaveBeenCalled();
+    expect(runInboundMock).not.toHaveBeenCalled();
+  });
+
+  it("fires the inbound run with trigger webhook for a matching config (dash-normalized)", async () => {
+    // Config stores the id BARE; the event carries it DASHED — must still match.
+    findManyMock.mockResolvedValue([enabledConfig(DB_ID_BARE)]);
+    const adapter = { queryRows: vi.fn() };
+    adapterFactoryMock.mockResolvedValue({ ok: true, adapter });
+    const raw = eventFor(DB_ID_DASHED);
+
+    const response = await POST(
+      makeRequest(raw, { "x-notion-signature": sign(raw) }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runInboundMock).toHaveBeenCalledTimes(1);
+    expect(runInboundMock).toHaveBeenCalledWith(expect.anything(), adapter, {
+      configId: "cfg_1",
+      trigger: "webhook",
+    });
+  });
+
+  it("still returns 200 (no crash) when the fire-and-forget run rejects", async () => {
+    findManyMock.mockResolvedValue([enabledConfig(DB_ID_DASHED)]);
+    runInboundMock.mockRejectedValue(new Error("engine exploded"));
+    const raw = eventFor(DB_ID_DASHED);
+
+    const response = await POST(
+      makeRequest(raw, { "x-notion-signature": sign(raw) }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runInboundMock).toHaveBeenCalledTimes(1);
+    // Let the rejected promise's .catch settle so no unhandled rejection leaks.
+    await Promise.resolve();
+  });
+
+  it("debounces: skips the run when a recent run for the config is in flight", async () => {
+    findManyMock.mockResolvedValue([enabledConfig(DB_ID_DASHED)]);
+    findFirstMock.mockResolvedValue({
+      id: "run_prev",
+      status: "running",
+      startedAt: new Date(),
+    });
+    const raw = eventFor(DB_ID_DASHED);
+
+    const response = await POST(
+      makeRequest(raw, { "x-notion-signature": sign(raw) }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      matched: number;
+      items: Array<{ outcome: string }>;
+    };
+    expect(body.matched).toBe(1);
+    expect(body.items[0]?.outcome).toBe("skipped-running");
+    expect(adapterFactoryMock).not.toHaveBeenCalled();
+    expect(runInboundMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/webhooks/notion/route.ts
+++ b/src/app/api/webhooks/notion/route.ts
@@ -1,0 +1,111 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { type NextRequest, NextResponse } from "next/server";
+
+import { db } from "~/server/db";
+import {
+  extractDatabaseCandidateIds,
+  triggerWebhookInboundSync,
+} from "~/server/services/ticketSync/webhookTrigger";
+
+/**
+ * Webhook receiver: POST /api/webhooks/notion.
+ *
+ * A doorbell for the inbound Notion → ticket sync. Notion sends a thin event
+ * (ids only) when a subscribed database changes; this route verifies it and
+ * fires the SAME inbound pull the 10-minute cron runs (trigger `webhook`),
+ * turning that sync near-real-time WITHOUT touching the sync engine. It never
+ * processes event *content* — only the ids needed to resolve which sync
+ * config to pull — and always answers 200 fast (the run is fire-and-forget).
+ *
+ * Auth model (developers.notion.com/reference/webhooks):
+ * - Signature: `X-Notion-Signature: sha256=<hex>` is HMAC-SHA256 of the RAW
+ *   request body keyed by NOTION_WEBHOOK_SECRET; verified with a timing-safe
+ *   compare. Missing secret → 503 (fail closed); bad/missing signature → 401.
+ * - Subscription handshake: when a subscription is first created Notion POSTs
+ *   a body containing `verification_token` and no signature header. We log the
+ *   token (so the operator can copy it from the Vercel logs into Notion to
+ *   confirm the subscription) and return 200. Per the docs the signature check
+ *   does not apply to that initial unsigned handshake; every other request
+ *   MUST be signed.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const raw = await request.text();
+    const signature = request.headers.get("x-notion-signature");
+
+    let body: unknown = null;
+    try {
+      body = JSON.parse(raw) as unknown;
+    } catch {
+      body = null;
+    }
+
+    // Subscription-verification handshake: unsigned, carries only a
+    // verification_token. Log it clearly and acknowledge — this is the one
+    // request the signature check legitimately does not cover.
+    if (
+      !signature &&
+      body &&
+      typeof body === "object" &&
+      typeof (body as Record<string, unknown>).verification_token === "string"
+    ) {
+      const token = (body as Record<string, unknown>).verification_token;
+      console.log(
+        `[NotionWebhook] subscription verification_token (copy into Notion to confirm): ${String(token)}`,
+      );
+      return NextResponse.json({ ok: true }, { status: 200 });
+    }
+
+    const secret = process.env.NOTION_WEBHOOK_SECRET;
+    // Fail closed: without the shared secret we cannot verify a single event,
+    // so we must never process one.
+    if (!secret) {
+      console.error(
+        "[NotionWebhook] NOTION_WEBHOOK_SECRET is not configured — refusing to process events",
+      );
+      return NextResponse.json(
+        { error: "NOTION_WEBHOOK_SECRET is not configured" },
+        { status: 503 },
+      );
+    }
+
+    if (!signature || !verifySignature(raw, signature, secret)) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Verified. Read ONLY ids from the payload — never its content.
+    const candidateIds = extractDatabaseCandidateIds(body);
+    if (candidateIds.length === 0) {
+      // A verified event we can't tie to any database (thin/unknown shape) is
+      // a no-op, not an error.
+      return NextResponse.json({ ok: true, matched: 0 }, { status: 200 });
+    }
+
+    const result = await triggerWebhookInboundSync(db, new Date(), candidateIds);
+    return NextResponse.json(
+      { ok: true, matched: result.matched, items: result.items },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("[NotionWebhook] handler failed:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * Timing-safe check that `X-Notion-Signature` (`sha256=<hex>`) equals the
+ * HMAC-SHA256 of the raw body under the shared secret. A bare hex value (no
+ * prefix) is tolerated so a differing header convention can't strand events.
+ */
+function verifySignature(raw: string, header: string, secret: string): boolean {
+  const expected = `sha256=${createHmac("sha256", secret).update(raw).digest("hex")}`;
+  const provided = header.includes("=") ? header : `sha256=${header}`;
+
+  const expectedBuf = Buffer.from(expected);
+  const providedBuf = Buffer.from(provided);
+  if (expectedBuf.length !== providedBuf.length) return false;
+  return timingSafeEqual(expectedBuf, providedBuf);
+}

--- a/src/server/services/ticketSync/engine.ts
+++ b/src/server/services/ticketSync/engine.ts
@@ -249,7 +249,7 @@ export async function runInboundTicketSync(
   adapter: TicketSyncRemoteAdapter,
   params: {
     configId: string;
-    trigger: "manual" | "cron" | "agent";
+    trigger: "manual" | "cron" | "agent" | "webhook";
     dryRun?: boolean;
     /** Acting user for the run ledger; null for cron/agent triggers. */
     triggeredById?: string | null;

--- a/src/server/services/ticketSync/webhookTrigger.ts
+++ b/src/server/services/ticketSync/webhookTrigger.ts
@@ -1,0 +1,202 @@
+import type { PrismaClient } from "@prisma/client";
+import { runInboundTicketSync, type TicketSyncRemoteAdapter } from "./engine";
+import { createNotionTicketSyncAdapter } from "./notionAdapter";
+
+/**
+ * ticketSync/webhookTrigger — turn a verified Notion webhook event into an
+ * inbound pull.
+ *
+ * The webhook is a doorbell, not a sync engine: it resolves which enabled
+ * sync config(s) the event's database ids belong to and fires the SAME
+ * inbound run the cron sweep runs, with trigger `webhook`. It deliberately
+ * reuses the scheduler's overlap/debounce guard instead of inventing a queue —
+ * a burst of Notion edits collapses into at most one run per config per
+ * {@link WEBHOOK_DEBOUNCE_MS} window, and never overlaps an in-flight run.
+ *
+ * The engine run is fire-and-forget: this returns as soon as every matched
+ * config has either been skipped (guarded) or had its run kicked off, so the
+ * route can answer 200 fast. Errors are logged; the engine records its own
+ * errored run record.
+ */
+
+/**
+ * Collapse a burst: a config whose newest run is still `running`, or started
+ * within this window, is skipped rather than piling a redundant run on top.
+ * Matches the intent of the scheduler's overlap guard at webhook cadence.
+ */
+export const WEBHOOK_DEBOUNCE_MS = 15_000;
+
+export interface WebhookTriggerItem {
+  configId: string;
+  productId: string;
+  outcome: "triggered" | "skipped-running" | "error";
+  detail?: string;
+}
+
+export interface WebhookTriggerResult {
+  matched: number;
+  items: WebhookTriggerItem[];
+}
+
+type AdapterFactory = (
+  db: PrismaClient,
+  config: { integrationId: string; propertyNames: unknown },
+) => Promise<
+  { ok: true; adapter: TicketSyncRemoteAdapter } | { ok: false; error: string }
+>;
+
+type SyncRunner = typeof runInboundTicketSync;
+
+/** Notion ids arrive both dashed (UUID) and bare (32 hex) — compare canonically. */
+export function normalizeNotionId(id: string): string {
+  return id.replace(/-/g, "").toLowerCase();
+}
+
+/**
+ * Pull every id from an event JSON that could name the affected database.
+ * Notion's payloads are thin and their shape varies by event type, so we
+ * gather all plausible carriers (`data.parent.database_id`, a database-typed
+ * `data.parent.id`, `entity.id`, top-level `database_id`) and let the config
+ * lookup decide which one is real. Nothing beyond ids is ever read.
+ */
+export function extractDatabaseCandidateIds(body: unknown): string[] {
+  if (!body || typeof body !== "object") return [];
+  const b = body as Record<string, unknown>;
+  const data = (b.data ?? null) as Record<string, unknown> | null;
+  const parent = (data?.parent ?? null) as Record<string, unknown> | null;
+  const entity = (b.entity ?? null) as Record<string, unknown> | null;
+
+  const candidates: unknown[] = [
+    parent?.database_id,
+    // A page/database event whose parent IS a database carries the id under
+    // `parent.id` with `parent.type === "database"`.
+    parent && parent.type === "database" ? parent.id : null,
+    entity?.id,
+    b.database_id,
+    data?.database_id,
+  ];
+
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const c of candidates) {
+    if (typeof c !== "string" || c.length === 0) continue;
+    const norm = normalizeNotionId(c);
+    if (seen.has(norm)) continue;
+    seen.add(norm);
+    ids.push(norm);
+  }
+  return ids;
+}
+
+/**
+ * Resolve the enabled configs a webhook event touches and kick off an inbound
+ * run for each, guarded by the debounce/overlap window. Fire-and-forget: the
+ * returned promise settles once runs are dispatched, not once they finish.
+ */
+export async function triggerWebhookInboundSync(
+  db: PrismaClient,
+  now: Date,
+  candidateDatabaseIds: string[],
+  deps?: { adapterFactory?: AdapterFactory; runSync?: SyncRunner },
+): Promise<WebhookTriggerResult> {
+  const adapterFactory = deps?.adapterFactory ?? createNotionTicketSyncAdapter;
+  const runSync = deps?.runSync ?? runInboundTicketSync;
+
+  const wanted = new Set(candidateDatabaseIds);
+  if (wanted.size === 0) return { matched: 0, items: [] };
+
+  // Disconnected configs (null integration link, ADR-0042) can't sync — same
+  // filter the cron sweep uses. Match by normalized databaseId locally so a
+  // dashed/bare mismatch never causes a miss.
+  const configs = (
+    await db.ticketSyncConfig.findMany({
+      where: { enabled: true, integrationId: { not: null } },
+      select: {
+        id: true,
+        productId: true,
+        integrationId: true,
+        propertyNames: true,
+        databaseId: true,
+      },
+    })
+  ).filter(
+    (config): config is typeof config & { integrationId: string } =>
+      config.integrationId !== null &&
+      wanted.has(normalizeNotionId(config.databaseId)),
+  );
+
+  const items: WebhookTriggerItem[] = [];
+  const debounceBefore = new Date(now.getTime() - WEBHOOK_DEBOUNCE_MS);
+
+  for (const config of configs) {
+    try {
+      // Overlap + debounce: the newest run being in flight, or having started
+      // within the debounce window, means this doorbell is redundant.
+      const recent = await db.ticketSyncRun.findFirst({
+        where: { configId: config.id },
+        orderBy: { startedAt: "desc" },
+        select: { id: true, status: true, startedAt: true },
+      });
+      if (
+        recent &&
+        (recent.status === "running" || recent.startedAt > debounceBefore)
+      ) {
+        items.push({
+          configId: config.id,
+          productId: config.productId,
+          outcome: "skipped-running",
+          detail:
+            recent.status === "running"
+              ? `run ${recent.id} still in flight`
+              : `run ${recent.id} started <${WEBHOOK_DEBOUNCE_MS / 1000}s ago`,
+        });
+        continue;
+      }
+
+      const adapterResult = await adapterFactory(db, config);
+      if (!adapterResult.ok) {
+        console.error(
+          `[NotionWebhook] adapter unavailable for config ${config.id}: ${adapterResult.error}`,
+        );
+        items.push({
+          configId: config.id,
+          productId: config.productId,
+          outcome: "error",
+          detail: adapterResult.error,
+        });
+        continue;
+      }
+
+      // Fire-and-forget: the engine owns its own run record + error handling,
+      // so a failed run never blocks the 200. Never await the run here.
+      void runSync(db, adapterResult.adapter, {
+        configId: config.id,
+        trigger: "webhook",
+      }).catch((error: unknown) => {
+        console.error(
+          `[NotionWebhook] inbound run failed for config ${config.id}:`,
+          error,
+        );
+      });
+
+      items.push({
+        configId: config.id,
+        productId: config.productId,
+        outcome: "triggered",
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : "unknown error";
+      console.error(
+        `[NotionWebhook] failed to dispatch config ${config.id}: ${detail}`,
+      );
+      items.push({
+        configId: config.id,
+        productId: config.productId,
+        outcome: "error",
+        detail,
+      });
+    }
+  }
+
+  return { matched: configs.length, items };
+}


### PR DESCRIPTION
### **User description**
## What

A webhook doorbell that makes the inbound Notion → ticket sync near-real-time **without touching the sync engine** (Exponential ticket **indigo.river**). Notion edits now land in seconds-to-a-minute instead of waiting for the 10-minute cron, which stays in place as the reconciliation net.

- **`POST /api/webhooks/notion`** — fail-closed auth (503 without `NOTION_WEBHOOK_SECRET`), timing-safe HMAC-SHA256 signature verification of the raw body, and the one-time subscription-verification handshake (unsigned, token-only body → token logged for the operator, 200). Everything else unsigned → 401, never processed.
- **`webhookTrigger`** — reads ONLY ids from the verified event, resolves enabled + connected `TicketSyncConfig` rows by normalized `databaseId`, and fires the same `runInboundTicketSync` the cron uses with `trigger: "webhook"`, guarded by an overlap/debounce window (newest run in-flight or started within the window → skipped). Unknown databases are a 200 no-op.
- `trigger` is a plain String column — no migration.

Implemented by an agentbox sandbox agent (via the fixed relay — branch landed host-side with `agentbox git push --host-only`), rebased onto current main (post-#454) and re-validated host-side: 272 tests green including 8 new route tests; `tsc --noEmit` clean.

## Operator setup (after merge)

1. Vercel → Settings → Environment Variables: `NOTION_WEBHOOK_SECRET` = the signing secret Notion shows for the subscription (endpoint returns 503 until set).
2. Notion integration settings → Webhooks → add `https://www.exponential.im/api/webhooks/notion`.
3. Notion sends the unsigned handshake — copy the `verification_token` from Vercel logs (`[NotionWebhook] subscription verification_token`) back into Notion to confirm.
4. Subscribe the integration to the synced database(s) with page/property-update events.

---

Ships: indigo.river

[View in Exponential](https://www.exponential.im/w/syntrofi/products/exponential/tickets/429)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add near-real-time Notion webhook receiver (`POST /api/webhooks/notion`)

- Implement HMAC-SHA256 signature verification with fail-closed auth

- Add `webhookTrigger.ts` with debounce/overlap guard for inbound sync dispatch

- Widen `trigger` union in engine to include `"webhook"` value


___

### Diagram Walkthrough


```mermaid
flowchart LR
  notionWebhook["POST /api/webhooks/notion"]
  webhookTrigger["webhookTrigger.ts"]
  engine["engine.ts (runInboundTicketSync)"]
  db["DB (TicketSyncConfig / TicketSyncRun)"]
  notionAdapter["notionAdapter.ts"]
  tests["notionWebhook.test.ts"]

  notionWebhook -- "verifies HMAC-SHA256 signature" --> webhookTrigger
  webhookTrigger -- "resolves configs by databaseId" --> db
  webhookTrigger -- "debounce/overlap guard" --> db
  webhookTrigger -- "creates adapter" --> notionAdapter
  webhookTrigger -- "fire-and-forget trigger=webhook" --> engine
  tests -- "pins auth + dispatch contract" --> notionWebhook
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Add Notion webhook route with HMAC auth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/webhooks/notion/route.ts

<ul><li>Adds <code>POST /api/webhooks/notion</code> route handler<br> <li> Implements timing-safe HMAC-SHA256 signature verification against <br><code>NOTION_WEBHOOK_SECRET</code><br> <li> Handles unsigned subscription handshake by logging <code>verification_token</code> <br>and returning 200<br> <li> Fails closed with 503 when secret is unconfigured; returns 401 for <br>bad/missing signatures</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/456/files#diff-433dce6fe8fc0cd7088720c870c8b2337177da04f325bcc1637ed0d14bf8f625">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>webhookTrigger.ts</strong><dd><code>Add webhook trigger dispatcher with debounce guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/ticketSync/webhookTrigger.ts

<ul><li>Adds <code>extractDatabaseCandidateIds</code> to parse database ids from thin <br>Notion event payloads<br> <li> Adds <code>normalizeNotionId</code> to canonicalize dashed/bare UUID formats for <br>matching<br> <li> Implements <code>triggerWebhookInboundSync</code> with debounce/overlap guard (15s <br>window)<br> <li> Dispatches fire-and-forget inbound sync runs with <code>trigger: "webhook"</code> <br>per matched config</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/456/files#diff-6162a06a2a4f2f03bc087dad7f47a2549ef21d9d207d91359f01a12142e670b8">+202/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>engine.ts</strong><dd><code>Extend trigger union type to include webhook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/ticketSync/engine.ts

- Widens `trigger` parameter union to include `"webhook"` value


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/456/files#diff-efe07be6916b5447498a2588f188ac30db90f9345dd6188473dea22c7866e658">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>notionWebhook.test.ts</strong><dd><code>Add webhook route auth and dispatch unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/webhooks/__tests__/notionWebhook.test.ts

<ul><li>Adds 8 route-handler tests covering auth, dispatch, and debounce <br>contract<br> <li> Tests: 503 without secret, 401 bad/missing signature, 200 handshake, <br>no-op unmatched DB<br> <li> Tests: matched config fires inbound run with <code>trigger: "webhook"</code>, crash <br>resilience, debounce skip</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/456/files#diff-929053faeed45a21da427b3b02617fdfeef89302a673a14d095557565cc76ccb">+212/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

