### PR TITLE
chore: V2 spike — clientTools round-trip + Mastra CORS (go)

### DIFF
--- a/src/app/api/dev/mastra-agent-token/route.ts
+++ b/src/app/api/dev/mastra-agent-token/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "~/server/auth";
+import { generateAgentJWT } from "~/server/utils/jwt";
+
+/**
+ * Dev-only: mint a short-lived agent JWT for the browser.
+ *
+ * Exists for the V2 transport spike (`/dev/mastra-client-tools`), which needs a
+ * token in the *browser* so it can stream straight to the Mastra server. The
+ * shipping version of this is a `mastra.mintAgentToken` tRPC procedure; this
+ * route is throwaway scaffolding and 404s outside development.
+ *
+ * A signed-in session is used when there is one. Without it — the usual case
+ * when poking at this from a scratch browser — it mints for a synthetic id
+ * instead. That is only tolerable because it is dev-gated and because the spike
+ * drives the weather demo agent, which touches no user data; never widen this to
+ * production or to an agent with real tools.
+ */
+export const dynamic = "force-dynamic";
+
+const SYNTHETIC_SPIKE_USER_ID = "spike-user";
+
+export async function GET(): Promise<NextResponse> {
+  if (process.env.NODE_ENV === "production") {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  const session = await auth();
+  const user = session?.user?.id
+    ? { id: session.user.id, email: session.user.email, name: session.user.name }
+    : { id: SYNTHETIC_SPIKE_USER_ID, email: null, name: "Spike" };
+
+  return NextResponse.json({
+    token: generateAgentJWT(user, 10),
+    userId: user.id,
+    synthetic: user.id === SYNTHETIC_SPIKE_USER_ID,
+    mastraUrl: process.env.MASTRA_API_URL ?? "http://localhost:4111",
+  });
+}

--- a/src/app/dev/mastra-client-tools/ClientToolsSpike.tsx
+++ b/src/app/dev/mastra-client-tools/ClientToolsSpike.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { MastraClient } from "@mastra/client-js";
+import { useRef, useState } from "react";
+
+/**
+ * V2 transport spike: can a browser stream a turn to the Mastra server and
+ * execute a tool *locally* mid-turn?
+ *
+ * The whole local-wiki design rests on yes. The librarian's file tools have to
+ * run on the user's machine, which means the model asks for a tool, the browser
+ * runs it, and the model carries on with the result — with the Exponential
+ * backend nowhere in the turn's data path.
+ *
+ * This page proves that end to end with the cheapest possible tool: an echo that
+ * runs here, in the page, and stamps the result so its output is unmistakably
+ * local. Everything it does with `clientTools` is what `streamLocalWikiChat`
+ * will do with the real wiki commands.
+ */
+
+/** One line of the transcript — the evidence the spike is actually about. */
+interface Event {
+  at: number;
+  kind: "info" | "tool-call" | "local-exec" | "text" | "error" | "done";
+  detail: string;
+}
+
+interface TokenResponse {
+  token: string;
+  userId: string;
+  synthetic: boolean;
+  mastraUrl: string;
+}
+
+/** Agent to drive. The weather demo agent touches no user data. */
+const SPIKE_AGENT_ID = "weatherAgent";
+
+/**
+ * A city the model cannot know without asking the local tool, and would never
+ * guess from the prompt. Seeing it in the final answer is the proof that the
+ * locally-produced result actually reached the model.
+ */
+const SECRET_LOCATION = "Reykjavik";
+
+/**
+ * Deliberately makes the turn need *both* kinds of tool: a local one to learn
+ * where the device is, then the agent's own server-side weather tool for that
+ * place. That is the exact shape V2 needs — local file tools composing with
+ * whatever the agent already has, inside one turn.
+ */
+const PROMPT =
+  "What is the weather where I am right now? " +
+  "You do not know my location — call `getDeviceLocation` first to find out, " +
+  "then look up the weather for whatever city it returns. " +
+  "Name the city in your answer.";
+
+export function ClientToolsSpike() {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [running, setRunning] = useState(false);
+  const executed = useRef(0);
+  // Mirrors the streamed answer outside React state, so the verdict below can
+  // read it without waiting for a re-render.
+  const answerRef = useRef("");
+
+  const log = (kind: Event["kind"], detail: string) =>
+    setEvents((prev) => [...prev, { at: Date.now(), kind, detail }]);
+
+  const run = async () => {
+    setEvents([]);
+    executed.current = 0;
+    answerRef.current = "";
+    setRunning(true);
+
+    try {
+      const res = await fetch("/api/dev/mastra-agent-token");
+      if (!res.ok) throw new Error(`token mint failed: ${res.status}`);
+      const { token, userId, synthetic, mastraUrl } = (await res.json()) as TokenResponse;
+      log("info", `minted agent JWT for ${userId}${synthetic ? " (synthetic)" : ""}`);
+      log("info", `streaming to ${mastraUrl} as ${SPIKE_AGENT_ID}`);
+
+      // Straight from the browser to Mastra — no Next.js route in between. If
+      // the server's CORS did not allow this origin plus the Authorization
+      // header, the request would never leave the page.
+      const client = new MastraClient({
+        baseUrl: mastraUrl,
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      const response = await client.getAgent(SPIKE_AGENT_ID).stream(PROMPT, {
+        clientTools: {
+          getDeviceLocation: {
+            id: "getDeviceLocation",
+            description:
+              "Returns the city this device is in. Runs on the user's device, not on the server.",
+            // Raw JSON Schema, deliberately not zod. `processClientTools` runs
+            // every zod-shaped `inputSchema` through a converter that mangles the
+            // app's zod build into `{"anyOf":[{},{"type":"null"}]}`, which OpenAI
+            // then rejects outright ("schema must be of type object"). Objects
+            // that don't look like zod are forwarded untouched, so handing over
+            // the JSON Schema directly sidesteps the converter entirely.
+            inputSchema: {
+              type: "object",
+              properties: {},
+              additionalProperties: false,
+            },
+            execute: async () => {
+              // The load-bearing line: this runs *here*, in the page.
+              executed.current += 1;
+              log("local-exec", `getDeviceLocation ran in the browser → ${SECRET_LOCATION}`);
+              return { city: SECRET_LOCATION };
+            },
+          },
+        },
+      });
+
+      await response.processDataStream({
+        onChunk: async (chunk: { type?: string; payload?: unknown }) => {
+          if (chunk.type === "tool-call") {
+            const payload = chunk.payload as { toolName?: string; args?: unknown };
+            log("tool-call", `model asked for ${payload?.toolName ?? "?"}`);
+          } else if (chunk.type === "text-delta") {
+            const payload = chunk.payload as { text?: string };
+            if (payload?.text) {
+              answerRef.current += payload.text;
+              log("text", payload.text);
+            }
+          } else if (chunk.type === "error") {
+            log("error", JSON.stringify(chunk.payload));
+          }
+        },
+      });
+
+      // Executing locally is only half of it. The result has to get *back* into
+      // the model's context, and the only honest evidence of that is the model
+      // repeating something it could not have known otherwise.
+      const answerSoFar = answerRef.current;
+      if (executed.current === 0) {
+        log("done", "NO LOCAL EXECUTION — the model never called the client tool");
+      } else if (answerSoFar.includes(SECRET_LOCATION)) {
+        log(
+          "done",
+          `ROUND-TRIP PROVEN — tool ran locally ${executed.current}×, and the model's answer ` +
+            `names ${SECRET_LOCATION}, which it could only have learned from the local result`,
+        );
+      } else {
+        log(
+          "done",
+          `PARTIAL — the tool ran locally ${executed.current}× and the turn continued, but the ` +
+            `answer never mentions ${SECRET_LOCATION}, so the result reaching the model is unproven`,
+        );
+      }
+    } catch (error) {
+      log("error", error instanceof Error ? error.message : String(error));
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const answer = events
+    .filter((e) => e.kind === "text")
+    .map((e) => e.detail)
+    .join("");
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-4 p-8 text-text-primary">
+      <div>
+        <h1 className="text-xl font-semibold">Mastra clientTools round-trip</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          Streams one turn from this page straight to the Mastra server, passing a
+          tool whose <code>execute()</code> runs in the browser. Proves the V2
+          local-wiki transport before any of it is built.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => void run()}
+        disabled={running}
+        className="w-fit rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+      >
+        {running ? "Running…" : "Run the round-trip"}
+      </button>
+
+      {events.length > 0 && (
+        <ol className="flex flex-col gap-1 rounded-md border border-border-primary bg-surface-secondary p-4 font-mono text-xs">
+          {events
+            .filter((e) => e.kind !== "text")
+            .map((event, i) => (
+              <li key={i} className={event.kind === "error" ? "text-red-500" : undefined}>
+                <span className="text-text-muted">{event.kind}</span> {event.detail}
+              </li>
+            ))}
+        </ol>
+      )}
+
+      {answer && (
+        <div className="rounded-md border border-border-primary p-4">
+          <p className="text-xs uppercase text-text-muted">Model&apos;s answer</p>
+          <p className="mt-1 text-sm">{answer}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dev/mastra-client-tools/page.tsx
+++ b/src/app/dev/mastra-client-tools/page.tsx
@@ -1,0 +1,14 @@
+import { notFound } from "next/navigation";
+
+import { ClientToolsSpike } from "./ClientToolsSpike";
+
+/**
+ * Dev-only harness for the V2 transport spike. Throwaway scaffolding — it exists
+ * to answer a go/no-go question, not to ship.
+ */
+export const dynamic = "force-dynamic";
+
+export default function Page() {
+  if (process.env.NODE_ENV === "production") notFound();
+  return <ClientToolsSpike />;
+}


### PR DESCRIPTION
### **User description**
## What

Answers the V2 go/no-go before anything is built on it: **can a browser stream a turn to Mastra and execute a tool locally, mid-turn?** The whole local-wiki design rests on yes — the librarian's file tools must run on the user's machine, with Vercel nowhere in the turn's data path.

**Verdict: GO.** Proved from a browser at `localhost:3000` against the deployed Mastra server on the pinned `@mastra/client-js@0.0.0-om-20260204032032`. No upgrade needed. Full write-up is on the ticket.

Ships a dev-only harness at `/dev/mastra-client-tools` (404s outside development) plus the throwaway token route it needs.

## The proof

The first attempt looked like a pass and wasn't. An `echo` tool executed locally and the turn completed — but the agent ignored the output, so all it proved was *continuation*, not that the result reached the model. The harness now asks for "the weather where I am", with a local `getDeviceLocation` returning a city the model cannot guess:

```
tool-call   model asked for getDeviceLocation
local-exec  getDeviceLocation ran in the browser → Reykjavik
tool-call   model asked for weatherTool          ← server-side tool, for a city it only learned locally
done        model's answer names Reykjavik
```

Local and server-side tools compose inside one turn — exactly the shape V2 needs.

## Two findings V2 has to carry

- **No zod in the tool contract.** A zod `inputSchema` is unusable on this build: `processClientTools` mangles this app's zod into `{"anyOf":[{},{"type":"null"}]}` and OpenAI rejects the turn outright. Non-zod objects pass through untouched, so wiki tool schemas must be raw JSON Schema — which happens to suit the PRD's brain-agnostic constraint.
- **CORS was never disabled.** The PRD's open question assumed it needed enabling; Mastra defaults to `origin: '*'` and always allows `Authorization`, so the browser reached the deployed server on the first try. The tightening (naming the app origins instead of answering everyone) is a separate PR in `../mastra` and needs a `railway up`; V2 is not blocked either way.

## Scope note

Both files here are throwaway. The token route mints for a synthetic id when there's no session — tolerable only because it is dev-gated and drives the weather demo agent, which touches no user data. The shipping replacement is the `mastra.mintAgentToken` procedure V2 adds; this should not outlive it.

## Acceptance criteria

- [x] A turn streamed from a browser context executes a client tool (call → local execute → result → model continues) against our deployed Mastra server
- [x] CORS from the app origins verified — already permissive; tightened in the companion `../mastra` PR
- [x] Go/no-go verdict and version constraints documented as a ticket comment

---

Ships: polar.eagle


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Adds dev-only V2 spike proving browser-to-Mastra `clientTools` round-trip

- Local tool execution (`getDeviceLocation`) composes with server-side tools in one turn

- Dev-only JWT token route mints short-lived agent tokens for browser use

- Both routes/pages return 404 in production, pure throwaway scaffolding


___

### Diagram Walkthrough


```mermaid
flowchart LR
  browser["Browser\n/dev/mastra-client-tools"]
  tokenRoute["API Route\n/api/dev/mastra-agent-token"]
  jwtUtil["generateAgentJWT"]
  mastraServer["Mastra Server\n(deployed)"]
  localTool["Local Tool\ngetDeviceLocation (browser)"]
  serverTool["Server-side Tool\nweatherAgent"]

  browser -- "fetch token" --> tokenRoute
  tokenRoute -- "calls" --> jwtUtil
  tokenRoute -- "returns JWT + mastraUrl" --> browser
  browser -- "stream turn + clientTools" --> mastraServer
  mastraServer -- "tool-call request" --> localTool
  localTool -- "result: Reykjavik" --> mastraServer
  mastraServer -- "tool-call request" --> serverTool
  serverTool -- "weather result" --> mastraServer
  mastraServer -- "final answer" --> browser
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Dev-only agent JWT minting route for V2 spike</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/dev/mastra-agent-token/route.ts

<ul><li>New dev-only API route that mints a short-lived agent JWT for browser <br>use<br> <li> Returns 404 in production; uses real session user or synthetic <br>fallback in dev<br> <li> Returns token, userId, synthetic flag, and <code>mastraUrl</code> to the caller</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/458/files#diff-4449de74918b52c846eb30aee6cb23c04494c528ea7fcc97c5fbe76b9d66f4b7">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ClientToolsSpike.tsx</strong><dd><code>Browser clientTools round-trip spike component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/dev/mastra-client-tools/ClientToolsSpike.tsx

<ul><li>New client component that streams a turn from the browser directly to <br>Mastra<br> <li> Registers a local <code>getDeviceLocation</code> clientTool using raw JSON Schema <br>(not zod)<br> <li> Logs a structured transcript showing tool-call, local-exec, and model <br>answer events<br> <li> Validates round-trip by checking if model's answer contains the secret <br>location</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/458/files#diff-13b3580903bf463445f5f6c20b8ac3b471b23a510b590d2a5ce4105899523e76">+204/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Dev-only page wrapper for clientTools spike</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/dev/mastra-client-tools/page.tsx

<ul><li>New dev-only Next.js page that renders <code>ClientToolsSpike</code><br> <li> Returns 404 via <code>notFound()</code> when <code>NODE_ENV</code> is production</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/458/files#diff-afff948d7129c160c1ca626bbc5c0a01db1a19135f9f8f7711f91b36ad83097c">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

