### PR TITLE
fix: accept the signed Notion webhook handshake during bootstrap

### DIFF
--- a/src/app/api/webhooks/__tests__/notionWebhook.test.ts
+++ b/src/app/api/webhooks/__tests__/notionWebhook.test.ts
@@ -126,15 +126,49 @@ describe("POST /api/webhooks/notion", () => {
     expect(runInboundMock).not.toHaveBeenCalled();
   });
 
-  it("acknowledges the unsigned subscription handshake with 200 and logs the token", async () => {
+  it("acknowledges the handshake during bootstrap (no secret configured) with 200 and logs the token", async () => {
+    // Notion signs the verification request keyed by the token itself, which
+    // the operator has not stored yet — so during bootstrap ANY handshake must
+    // be acknowledged or the subscription can never be created (the 503
+    // chicken-and-egg observed live).
+    delete process.env.NOTION_WEBHOOK_SECRET;
     const logSpy = vi.spyOn(console, "log");
     const raw = JSON.stringify({ verification_token: "verif_tok_xyz" });
 
-    const response = await POST(makeRequest(raw));
+    const response = await POST(
+      makeRequest(raw, { "x-notion-signature": sign(raw, "verif_tok_xyz") }),
+    );
 
     expect(response.status).toBe(200);
     expect(runInboundMock).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("verif_tok_xyz"));
+  });
+
+  it("acknowledges a correctly-signed handshake when the secret is configured", async () => {
+    const logSpy = vi.spyOn(console, "log");
+    const raw = JSON.stringify({ verification_token: "verif_tok_resend" });
+
+    const response = await POST(
+      makeRequest(raw, { "x-notion-signature": sign(raw) }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("verif_tok_resend"),
+    );
+  });
+
+  it("rejects an unsigned handshake once a secret is configured (log-poisoning guard)", async () => {
+    const logSpy = vi.spyOn(console, "log");
+    const raw = JSON.stringify({ verification_token: "attacker_token" });
+
+    const response = await POST(makeRequest(raw));
+
+    expect(response.status).toBe(401);
+    expect(runInboundMock).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("attacker_token"),
+    );
   });
 
   it("returns 200 no-op for a verified event whose database matches no config", async () => {

--- a/src/app/api/webhooks/notion/route.ts
+++ b/src/app/api/webhooks/notion/route.ts
@@ -40,23 +40,32 @@ export async function POST(request: NextRequest) {
       body = null;
     }
 
-    // Subscription-verification handshake: unsigned, carries only a
-    // verification_token. Log it clearly and acknowledge — this is the one
-    // request the signature check legitimately does not cover.
-    if (
-      !signature &&
-      body &&
-      typeof body === "object" &&
-      typeof (body as Record<string, unknown>).verification_token === "string"
-    ) {
-      const token = (body as Record<string, unknown>).verification_token;
-      console.log(
-        `[NotionWebhook] subscription verification_token (copy into Notion to confirm): ${String(token)}`,
-      );
-      return NextResponse.json({ ok: true }, { status: 200 });
-    }
-
     const secret = process.env.NOTION_WEBHOOK_SECRET;
+
+    // Subscription-verification handshake: carries a verification_token —
+    // and, in practice, Notion SIGNS it (keyed by that same token), so it
+    // cannot pass the normal signature check before the operator has stored
+    // the token as NOTION_WEBHOOK_SECRET. Bootstrap rule:
+    // - no secret configured yet → we cannot verify anything; log the token
+    //   for the operator and acknowledge (the whole point of the handshake);
+    // - secret configured → the handshake must verify like any other request
+    //   (an unsigned/forged token body must not be able to poison the logs
+    //   and trick the operator into rotating the secret).
+    const verificationToken =
+      body && typeof body === "object"
+        ? (body as Record<string, unknown>).verification_token
+        : undefined;
+    if (typeof verificationToken === "string") {
+      const trusted =
+        !secret || (signature !== null && verifySignature(raw, signature, secret));
+      if (trusted) {
+        console.log(
+          `[NotionWebhook] subscription verification_token (copy into Notion to confirm): ${verificationToken}`,
+        );
+        return NextResponse.json({ ok: true }, { status: 200 });
+      }
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
     // Fail closed: without the shared secret we cannot verify a single event,
     // so we must never process one.
     if (!secret) {


### PR DESCRIPTION
### **User description**
## What

Fixes the chicken-and-egg 503 observed while activating the webhook (#456 follow-up): Notion **signs** the subscription-verification request — keyed by the very token the operator hasn't stored yet — so it skipped the unsigned-only handshake branch and fell into the fail-closed secret check. Result: `Failed to send verification token with status 503` in the Notion UI, and no way to ever complete setup.

New rule for any body carrying `verification_token`:
- **Bootstrap** (no `NOTION_WEBHOOK_SECRET` configured): acknowledge + log the token — nothing is verifiable yet, and surfacing the token is the handshake's entire purpose.
- **Secret configured**: the handshake must pass the normal signature check; unsigned/forged token bodies get 401 and are *not* logged (log-poisoning guard — an attacker must not be able to plant a fake token and trick the operator into rotating the secret onto it).

28/28 webhook route tests green (3 new); tsc clean.

---

Follow-up to #456 (indigo.river)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix chicken-and-egg 503 blocking Notion webhook subscription setup

- Rework handshake logic: bootstrap (no secret) accepts any token body, secret-configured requires valid signature

- Add log-poisoning guard: unsigned token bodies rejected with 401 when secret is set

- Add 3 new tests covering bootstrap handshake, signed re-verification, and log-poisoning guard


___

### Diagram Walkthrough


```mermaid
flowchart LR
  request["POST /api/webhooks/notion"]
  hasToken["verification_token present?"]
  hasSecret["NOTION_WEBHOOK_SECRET set?"]
  sigValid["Signature valid?"]
  ack["200 OK + log token"]
  reject401["401 Unauthorized (no log)"]
  normalFlow["Normal HMAC verification flow"]

  request -- "parse body" --> hasToken
  hasToken -- "yes" --> hasSecret
  hasToken -- "no" --> normalFlow
  hasSecret -- "no (bootstrap)" --> ack
  hasSecret -- "yes" --> sigValid
  sigValid -- "valid" --> ack
  sigValid -- "invalid/missing" --> reject401
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Fix handshake bootstrap and add log-poisoning guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/webhooks/notion/route.ts

<ul><li>Removes the old unsigned-only handshake branch that caused 503 during <br>bootstrap<br> <li> Extracts <code>verificationToken</code> from body before the secret check<br> <li> Bootstrap (no secret): acknowledges and logs any token body with 200<br> <li> Secret configured: requires valid HMAC signature on token body; <br>unsigned/forged bodies return 401 without logging</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/460/files#diff-433dce6fe8fc0cd7088720c870c8b2337177da04f325bcc1637ed0d14bf8f625">+25/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>notionWebhook.test.ts</strong><dd><code>Add handshake bootstrap and log-poisoning guard tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/webhooks/__tests__/notionWebhook.test.ts

<ul><li>Renames existing handshake test to clarify bootstrap (no secret) <br>scenario<br> <li> Adds test: correctly-signed handshake acknowledged when secret is <br>configured<br> <li> Adds test: unsigned handshake rejected with 401 when secret is set <br>(log-poisoning guard)<br> <li> Verifies attacker token is never logged in the rejection case</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/460/files#diff-929053faeed45a21da427b3b02617fdfeef89302a673a14d095557565cc76ccb">+36/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

