### PR TITLE
fix: own the local-wiki turn loop — the librarian could not write

### DIFF
--- a/src/lib/chat/__tests__/streamLocalWikiChat.test.ts
+++ b/src/lib/chat/__tests__/streamLocalWikiChat.test.ts
@@ -6,164 +6,262 @@ import type { WikiClientTool } from '../../localWiki';
 
 /**
  * The local wiki is the one chat path that doesn't go through
- * `/api/chat/stream`, so it's also the one whose events nothing else exercises.
- * These tests feed synthetic client-js chunks through the adapter and assert the
- * `ChatStreamUpdate` sequence ManyChat would render — no network, no Mastra, no
- * UI. Same seam as `streamProtocol.test.ts` covers for the server transport.
+ * `/api/chat/stream`, so nothing else exercises it.
+ *
+ * These stubs replay chunk sequences shaped like the ones the *real* server
+ * sends — which is the lesson from the first version of this file. It asserted a
+ * `tool-result` event that this build never emits, so every test passed while
+ * the transport was broken in production: chips stuck on "running" and, worse,
+ * no turn ever looked like it had written anything, so nothing was committed. A
+ * tool's outcome now comes from the call we make ourselves, and the tests
+ * reflect that.
  */
 
-/** A stub agent that replays a fixed chunk sequence. */
-function agentEmitting(chunks: WikiStreamChunk[]) {
+/** One round of the model: what the server streams before it stops. */
+type Round = WikiStreamChunk[];
+
+/**
+ * Stub agent replaying one round per `stream()` call, recording the history and
+ * tools it was handed each time.
+ */
+function agentRounds(...rounds: Round[]) {
+  const calls: unknown[][] = [];
+  const toolsSeen: Record<string, unknown>[] = [];
+  let round = 0;
+
   return {
-    stream: vi.fn().mockResolvedValue({
-      processDataStream: async ({
-        onChunk,
-      }: {
-        onChunk: (chunk: WikiStreamChunk) => void | Promise<void>;
-      }) => {
-        for (const chunk of chunks) await onChunk(chunk);
-      },
-    }),
+    calls,
+    toolsSeen,
+    stream: vi
+      .fn()
+      .mockImplementation((messages: unknown[], opts: { clientTools: Record<string, unknown> }) => {
+        calls.push(messages);
+        toolsSeen.push(opts.clientTools);
+        const chunks = rounds[round++] ?? [];
+        return Promise.resolve({
+          processDataStream: async ({
+            onChunk,
+          }: {
+            onChunk: (chunk: WikiStreamChunk) => void | Promise<void>;
+          }) => {
+            for (const chunk of chunks) await onChunk(chunk);
+          },
+        });
+      }),
   };
 }
 
 const text = (t: string): WikiStreamChunk => ({ type: 'text-delta', payload: { text: t } });
-const call = (toolName: string, toolCallId: string, args?: Record<string, unknown>): WikiStreamChunk => ({
-  type: 'tool-call',
-  payload: { toolName, toolCallId, args },
-});
-const result = (toolName: string, toolCallId: string): WikiStreamChunk => ({
-  type: 'tool-result',
-  payload: { toolName, toolCallId, result: { ok: true } },
-});
+const call = (
+  toolName: string,
+  toolCallId: string,
+  args: Record<string, unknown> = {},
+): WikiStreamChunk => ({ type: 'tool-call', payload: { toolName, toolCallId, args } });
+
+function tool(id: string, execute = vi.fn().mockResolvedValue({ ok: true })): WikiClientTool {
+  return {
+    id,
+    description: id,
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    execute,
+  };
+}
 
 const NO_TOOLS: Record<string, WikiClientTool> = {};
-
-async function run(chunks: WikiStreamChunk[], options = {}) {
-  const updates: ChatStreamUpdate[] = [];
-  const final = await streamLocalWikiChat(
-    agentEmitting(chunks),
-    [{ role: 'user', content: 'hello' }],
-    NO_TOOLS,
-    { onUpdate: (u) => updates.push(structuredClone(u)), ...options },
-  );
-  return { final, updates };
-}
+const USER = [{ role: 'user' as const, content: 'what is in my wiki?' }];
 
 describe('text streaming', () => {
   it('accumulates deltas into the text ManyChat renders', async () => {
-    const { final, updates } = await run([text('There are '), text('three pages.')]);
+    const updates: ChatStreamUpdate[] = [];
+    const final = await streamLocalWikiChat(
+      agentRounds([text('There are '), text('three pages.')]),
+      USER,
+      NO_TOOLS,
+      { onUpdate: (u) => updates.push(structuredClone(u)) },
+    );
     expect(final.displayText).toBe('There are three pages.');
     expect(updates.map((u) => u.displayText)).toEqual(['There are ', 'There are three pages.']);
   });
 
+  it('carries text across rounds, since a turn is several requests', async () => {
+    const final = await streamLocalWikiChat(
+      agentRounds([text('Let me look. '), call('wiki_list_pages', 'c1')], [text('Three pages.')]),
+      USER,
+      { wiki_list_pages: tool('wiki_list_pages') },
+    );
+    expect(final.displayText).toBe('Let me look. Three pages.');
+  });
+
   it('counts raw bytes so a tool-only turn is not mistaken for empty', async () => {
-    // ManyChat reads rawLength to decide whether a failed turn "had content".
-    // A turn that only ran tools did real work — it may have touched the user's
-    // files — and must never be silently auto-retried.
-    const { final } = await run([call('wiki_write_page', 'c1'), result('wiki_write_page', 'c1')]);
+    // ManyChat reads rawLength to decide whether a failed turn "had content". A
+    // turn that only ran tools may have touched the user's files and must not be
+    // silently auto-retried.
+    const final = await streamLocalWikiChat(
+      agentRounds([call('wiki_write_page', 'c1')], []),
+      USER,
+      { wiki_write_page: tool('wiki_write_page') },
+    );
     expect(final.displayText).toBe('');
     expect(final.rawLength).toBeGreaterThan(0);
   });
 });
 
-describe('tool lifecycle', () => {
-  it('upgrades a running call to success rather than adding a second chip', async () => {
-    const { final } = await run([
-      call('wiki_list_pages', 'c1', { foo: 1 }),
-      result('wiki_list_pages', 'c1'),
-    ]);
+describe('the turn loop', () => {
+  it('executes the tool locally and continues the turn', async () => {
+    const execute = vi.fn().mockResolvedValue({ pages: [] });
+    const agent = agentRounds([call('wiki_list_pages', 'c1', { a: 1 })], [text('done')]);
+
+    const final = await streamLocalWikiChat(agent, USER, {
+      wiki_list_pages: tool('wiki_list_pages', execute),
+    });
+
+    expect(execute).toHaveBeenCalledWith({ a: 1 });
     expect(final.toolCalls).toEqual([
-      { id: 'c1', name: 'wiki_list_pages', args: { foo: 1 }, status: 'success' },
+      { id: 'c1', name: 'wiki_list_pages', args: { a: 1 }, status: 'success' },
     ]);
   });
 
-  it('keeps the call arguments when the result arrives', async () => {
-    // The result frame carries no args; losing them would blank the chip's
-    // detail halfway through the turn.
-    const { final } = await run([
-      call('wiki_read_page', 'c1', { path: 'index.md' }),
-      result('wiki_read_page', 'c1'),
-    ]);
-    expect(final.toolCalls[0]?.args).toEqual({ path: 'index.md' });
+  it('keeps the user message in the continuation', async () => {
+    // The bug this loop exists for. client-js's own continuation re-POSTs only
+    // what accumulated during the stream, dropping the user's message — so the
+    // model got a tool result with no idea what was asked and answered by
+    // introducing itself. Verified against the real server before the rewrite.
+    const agent = agentRounds([call('wiki_list_pages', 'c1')], [text('done')]);
+    await streamLocalWikiChat(agent, USER, { wiki_list_pages: tool('wiki_list_pages') });
+
+    expect(agent.calls).toHaveLength(2);
+    expect(agent.calls[1]).toContainEqual({ role: 'user', content: 'what is in my wiki?' });
   });
 
-  it('preserves first-seen order across interleaved calls', async () => {
-    const { final } = await run([
-      call('wiki_list_pages', 'c1'),
-      call('wiki_read_page', 'c2'),
-      result('wiki_read_page', 'c2'),
-      result('wiki_list_pages', 'c1'),
-    ]);
-    expect(final.toolCalls.map((t) => t.id)).toEqual(['c1', 'c2']);
-  });
+  it('sends the tool call and its result back so the model can use it', async () => {
+    const agent = agentRounds([call('wiki_read_page', 'c1', { path: 'index.md' })], [text('ok')]);
+    await streamLocalWikiChat(agent, USER, {
+      wiki_read_page: tool('wiki_read_page', vi.fn().mockResolvedValue({ content: '# Index' })),
+    });
 
-  it('marks a result carrying an error as failed, with its message', async () => {
-    const { final } = await run([
-      call('wiki_read_page', 'c1', { path: '../etc/passwd' }),
-      {
-        type: 'tool-result',
-        payload: {
-          toolName: 'wiki_read_page',
+    const second = agent.calls[1] as { role: string; content: unknown }[];
+    expect(second[1]).toEqual({
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
           toolCallId: 'c1',
-          isError: true,
-          error: { message: 'path is outside the wiki folder' },
+          toolName: 'wiki_read_page',
+          args: { path: 'index.md' },
         },
-      },
+      ],
+    });
+    expect(second[2]).toEqual({
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'c1',
+          toolName: 'wiki_read_page',
+          result: { content: '# Index' },
+        },
+      ],
+    });
+  });
+
+  it('hands the server schemas without execute, so it cannot drive the loop', async () => {
+    // Passing an executable tool is exactly what makes client-js take over the
+    // continuation, and its continuation is the broken one.
+    const agent = agentRounds([text('hi')]);
+    await streamLocalWikiChat(agent, USER, { wiki_list_pages: tool('wiki_list_pages') });
+
+    const declared = agent.toolsSeen[0]!.wiki_list_pages as Record<string, unknown>;
+    expect(declared).toHaveProperty('inputSchema');
+    expect(declared).not.toHaveProperty('execute');
+  });
+
+  it('runs several tools from one round before continuing', async () => {
+    const agent = agentRounds(
+      [call('wiki_read_page', 'c1'), call('wiki_read_page', 'c2')],
+      [text('done')],
+    );
+    const execute = vi.fn().mockResolvedValue({ content: '' });
+    const final = await streamLocalWikiChat(agent, USER, {
+      wiki_read_page: tool('wiki_read_page', execute),
+    });
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(final.toolCalls.map((t) => `${t.id}:${t.status}`)).toEqual(['c1:success', 'c2:success']);
+  });
+
+  it('stops after the round cap rather than looping on the user machine', async () => {
+    // Every round runs tools against their disk; a model stuck in a loop must
+    // not be able to keep going forever.
+    const forever: Round[] = Array.from({ length: 40 }, (_, i) => [
+      call('wiki_list_pages', `c${i}`),
     ]);
+    const agent = agentRounds(...forever);
+    await streamLocalWikiChat(agent, USER, { wiki_list_pages: tool('wiki_list_pages') });
+    expect(agent.stream.mock.calls.length).toBeLessThanOrEqual(20);
+  });
+
+  it('ignores chunk types it does not recognise', async () => {
+    const final = await streamLocalWikiChat(
+      agentRounds([
+        { type: 'start' },
+        { type: 'tool-call-input-streaming-start', payload: { toolCallId: 'c1' } },
+        text('fine'),
+        { type: 'step-finish' },
+      ]),
+      USER,
+      NO_TOOLS,
+    );
+    expect(final.displayText).toBe('fine');
+    expect(final.toolCalls).toHaveLength(0);
+  });
+});
+
+describe('tool failures', () => {
+  it('marks the chip failed and tells the model, without ending the turn', async () => {
+    // The model needs to know, so it can say the write failed rather than
+    // reporting success it never had.
+    const agent = agentRounds(
+      [call('wiki_write_page', 'c1', { path: '../escape.md' })],
+      [text('I could not write there.')],
+    );
+    const execute = vi.fn().mockRejectedValue('path is outside the wiki folder');
+
+    const final = await streamLocalWikiChat(agent, USER, {
+      wiki_write_page: tool('wiki_write_page', execute),
+    });
+
     expect(final.toolCalls[0]).toMatchObject({
       status: 'error',
       errorMsg: 'path is outside the wiki folder',
     });
-  });
-
-  it('handles a dedicated tool-error frame', async () => {
-    const { final } = await run([
-      call('wiki_write_page', 'c1'),
-      { type: 'tool-error', payload: { toolCallId: 'c1', error: 'disk full' } },
-    ]);
-    expect(final.toolCalls[0]).toMatchObject({ status: 'error', errorMsg: 'disk full' });
-  });
-
-  it('still shows a result for a call it never saw', async () => {
-    // Dropping it would hide work that actually touched the user's files.
-    const { final } = await run([result('wiki_write_page', 'orphan')]);
-    expect(final.toolCalls).toHaveLength(1);
-    expect(final.toolCalls[0]).toMatchObject({ name: 'wiki_write_page', status: 'success' });
-  });
-
-  it('ignores chunk types it does not recognise', async () => {
-    // The stream format is a moving target on a pinned snapshot build; an
-    // unfamiliar chunk must never cost the user their answer.
-    const { final } = await run([
-      { type: 'start-step' },
-      text('fine'),
-      { type: 'reasoning-delta', payload: { text: 'hmm' } },
-      { type: 'finish' },
-    ]);
-    expect(final.displayText).toBe('fine');
+    const second = agent.calls[1] as { content: { result?: unknown }[] }[];
+    expect(second[2]?.content[0]?.result).toEqual({ error: 'path is outside the wiki folder' });
+    expect(final.displayText).toBe('I could not write there.');
   });
 });
 
 describe('stream errors', () => {
   it('throws so the caller can reuse the existing failure handling', async () => {
     await expect(
-      run([text('partial'), { type: 'error', payload: { error: { message: 'model exploded' } } }]),
-    ).rejects.toThrow('model exploded');
+      streamLocalWikiChat(
+        agentRounds([text('partial'), { type: 'error', payload: { error: { message: 'boom' } } }]),
+        USER,
+        NO_TOOLS,
+      ),
+    ).rejects.toThrow('boom');
   });
 
-  it('throws something readable even when the payload has no message', async () => {
-    await expect(run([{ type: 'error', payload: {} }])).rejects.toThrow(
-      'The local wiki agent stream failed',
-    );
+  it('throws something readable when the payload has no message', async () => {
+    await expect(
+      streamLocalWikiChat(agentRounds([{ type: 'error', payload: {} }]), USER, NO_TOOLS),
+    ).rejects.toThrow('The local wiki agent stream failed');
   });
 
   it('still fails the turn if the stream library swallows callback errors', async () => {
     // We record the error and re-throw after the stream rather than throwing
-    // from inside onChunk. The pinned client-js build does propagate a throw,
-    // but it is an OM snapshot we pin because it moves — and if a future build
-    // caught and logged instead, the alternative would be a failed turn quietly
-    // resolving as a partial answer. This stub is that future build.
+    // from inside onChunk. The pinned build propagates a throw, but it is an OM
+    // snapshot we pin because it moves — and if a future build caught and logged
+    // instead, a failed turn would quietly resolve as a partial answer.
     const swallowing = {
       stream: vi.fn().mockResolvedValue({
         processDataStream: async ({
@@ -185,24 +283,19 @@ describe('stream errors', () => {
       }),
     };
 
-    await expect(
-      streamLocalWikiChat(swallowing, [{ role: 'user', content: 'hi' }], NO_TOOLS),
-    ).rejects.toThrow('model exploded');
+    await expect(streamLocalWikiChat(swallowing, USER, NO_TOOLS)).rejects.toThrow('model exploded');
   });
 
   it('stops folding chunks into the answer once the turn has failed', async () => {
-    // Whatever follows an error frame is not part of a reply the user should
-    // see. Deferring the throw to the end of the stream must not mean the rest
-    // of the stream keeps appending to the answer in the meantime.
     const updates: ChatStreamUpdate[] = [];
     await expect(
       streamLocalWikiChat(
-        agentEmitting([
+        agentRounds([
           text('before'),
           { type: 'error', payload: { error: { message: 'boom' } } },
           text('after'),
         ]),
-        [{ role: 'user', content: 'hi' }],
+        USER,
         NO_TOOLS,
         { onUpdate: (u) => updates.push(structuredClone(u)) },
       ),
@@ -215,20 +308,27 @@ describe('stream errors', () => {
 });
 
 describe('commit per turn', () => {
-  const writeTurn: WikiStreamChunk[] = [
-    call('wiki_write_page', 'c1', { path: 'people/ada.md' }),
-    result('wiki_write_page', 'c1'),
-    call('wiki_write_page', 'c2', { path: 'index.md' }),
-    result('wiki_write_page', 'c2'),
-    text('Filed it.'),
-  ];
+  /** A turn that files a page, links it from the index and logs it. */
+  const writingTurn = () =>
+    agentRounds(
+      [
+        call('wiki_write_page', 'c1', { path: 'people/ada.md' }),
+        call('wiki_write_page', 'c2', { path: 'index.md' }),
+        call('wiki_write_page', 'c3', { path: 'log.md' }),
+      ],
+      [text('Filed it.')],
+    );
 
   it('commits exactly once for a turn that wrote several pages', async () => {
-    // The whole point of commit-per-turn: filing a page and linking it from the
-    // index are one change. Two commits would let you revert the page and leave
-    // the index pointing at a file that no longer exists.
+    // Three commits would let you revert the page and leave the index pointing
+    // at a file that no longer exists.
     const onTurnWrote = vi.fn().mockResolvedValue(undefined);
-    await run(writeTurn, { onTurnWrote, turnSummary: 'Tell me about Ada' });
+    await streamLocalWikiChat(
+      writingTurn(),
+      USER,
+      { wiki_write_page: tool('wiki_write_page') },
+      { onTurnWrote, turnSummary: 'Tell me about Ada' },
+    );
     expect(onTurnWrote).toHaveBeenCalledTimes(1);
     expect(onTurnWrote).toHaveBeenCalledWith('Tell me about Ada');
   });
@@ -236,74 +336,79 @@ describe('commit per turn', () => {
   it('does not commit a turn that only read', async () => {
     // An empty commit every turn would bury the real ones.
     const onTurnWrote = vi.fn().mockResolvedValue(undefined);
-    await run(
-      [call('wiki_list_pages', 'c1'), result('wiki_list_pages', 'c1'), text('Three pages.')],
+    await streamLocalWikiChat(
+      agentRounds([call('wiki_list_pages', 'c1')], [text('Three pages.')]),
+      USER,
+      { wiki_list_pages: tool('wiki_list_pages') },
       { onTurnWrote },
     );
     expect(onTurnWrote).not.toHaveBeenCalled();
   });
 
   it('does not commit when the only write failed', async () => {
-    // A write the jail refused changed nothing on disk; committing for it would
-    // produce an empty commit implying otherwise.
+    // A write the jail refused changed nothing on disk.
     const onTurnWrote = vi.fn().mockResolvedValue(undefined);
-    await run(
-      [
-        call('wiki_write_page', 'c1', { path: '../escape.md' }),
-        {
-          type: 'tool-result',
-          payload: { toolName: 'wiki_write_page', toolCallId: 'c1', isError: true },
-        },
-      ],
+    await streamLocalWikiChat(
+      agentRounds([call('wiki_write_page', 'c1')], [text('could not')]),
+      USER,
+      { wiki_write_page: tool('wiki_write_page', vi.fn().mockRejectedValue(new Error('nope'))) },
       { onTurnWrote },
     );
     expect(onTurnWrote).not.toHaveBeenCalled();
   });
 
-  it('commits after the stream ends, not mid-turn', async () => {
-    // Client-js resumes a tool call by re-POSTing the turn, so writes can land
-    // across several rounds. Committing early would split one conversation into
-    // several commits.
+  it('commits after the whole turn, not after the round that wrote', async () => {
+    // Writes can land across several rounds; committing early would split one
+    // conversation into several commits.
     const seen: string[] = [];
-    const onTurnWrote = vi.fn().mockImplementation(async () => {
-      seen.push('commit');
-    });
-    await run(
-      [
-        call('wiki_write_page', 'c1'),
-        result('wiki_write_page', 'c1'),
-        { type: 'text-delta', payload: { text: 'done' } },
-      ],
+    await streamLocalWikiChat(
+      agentRounds([call('wiki_write_page', 'c1')], [call('wiki_write_page', 'c2')], [text('done')]),
+      USER,
       {
-        onTurnWrote,
-        onUpdate: () => seen.push('update'),
+        wiki_write_page: tool(
+          'wiki_write_page',
+          vi.fn().mockImplementation(() => {
+            seen.push('write');
+            return Promise.resolve({ ok: true });
+          }),
+        ),
+      },
+      {
+        onTurnWrote: async () => {
+          seen.push('commit');
+        },
       },
     );
-    expect(seen[seen.length - 1]).toBe('commit');
+    expect(seen).toEqual(['write', 'write', 'commit']);
+  });
+
+  it('does not commit a turn that failed mid-stream', async () => {
+    // Throwing before the commit is deliberate: a turn that died half-written
+    // should be inspectable in `git status`, not sealed into history as though
+    // it completed.
+    const onTurnWrote = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      streamLocalWikiChat(
+        agentRounds([
+          call('wiki_write_page', 'c1'),
+          { type: 'error', payload: { error: { message: 'boom' } } },
+        ]),
+        USER,
+        { wiki_write_page: tool('wiki_write_page') },
+        { onTurnWrote },
+      ),
+    ).rejects.toThrow('boom');
+    expect(onTurnWrote).not.toHaveBeenCalled();
   });
 
   it('falls back to an empty summary rather than failing the commit', async () => {
     const onTurnWrote = vi.fn().mockResolvedValue(undefined);
-    await run(writeTurn, { onTurnWrote });
+    await streamLocalWikiChat(
+      writingTurn(),
+      USER,
+      { wiki_write_page: tool('wiki_write_page') },
+      { onTurnWrote },
+    );
     expect(onTurnWrote).toHaveBeenCalledWith('');
-  });
-});
-
-describe('client tools', () => {
-  it('hands the tools to the agent so they execute on this device', async () => {
-    const tools: Record<string, WikiClientTool> = {
-      wiki_list_pages: {
-        id: 'wiki_list_pages',
-        description: 'list',
-        inputSchema: { type: 'object', properties: {} },
-        execute: vi.fn().mockResolvedValue({ pages: [] }),
-      },
-    };
-    const agent = agentEmitting([text('ok')]);
-    await streamLocalWikiChat(agent, [{ role: 'user', content: 'hi' }], tools);
-
-    expect(agent.stream).toHaveBeenCalledWith([{ role: 'user', content: 'hi' }], {
-      clientTools: tools,
-    });
   });
 });

--- a/src/lib/chat/streamLocalWikiChat.ts
+++ b/src/lib/chat/streamLocalWikiChat.ts
@@ -24,10 +24,29 @@ import { LOCAL_WIKI_AGENT_ID, WIKI_WRITE_TOOLS, type WikiClientTool } from '../l
  * requests, and `toolCalls` grows across them.
  */
 
+/**
+ * How many model↔tool rounds one turn may take before we stop.
+ *
+ * The tools run on the user's machine, so an agent that keeps calling them is
+ * spending their disk and their tokens. Matches the agent's own `maxSteps`.
+ */
+const MAX_TOOL_ROUNDS = 20;
+
+/**
+ * A message in the turn's history.
+ *
+ * Wider than `ChatStreamCoreMessage` because continuing a turn means sending
+ * back the assistant's tool calls and their results, which are structured parts
+ * rather than prose.
+ */
+export type WikiTurnMessage =
+  | ChatStreamCoreMessage
+  | { role: 'assistant' | 'tool'; content: Record<string, unknown>[] };
+
 /** Just enough of `@mastra/client-js` to stream a turn — injectable for tests. */
 export interface WikiAgentStreamer {
   stream: (
-    messages: ChatStreamCoreMessage[],
+    messages: WikiTurnMessage[],
     options: {
       clientTools: Record<string, WikiClientTool>;
     },
@@ -85,9 +104,6 @@ interface ToolCallPayload {
   toolName?: string;
   toolCallId?: string;
   args?: Record<string, unknown>;
-  result?: unknown;
-  error?: unknown;
-  isError?: boolean;
 }
 
 interface TextPayload {
@@ -102,13 +118,15 @@ function toolPayload(payload: unknown): ToolCallPayload {
   return (asRecord(payload) ?? {}) as ToolCallPayload;
 }
 
-/** Error text for a tool chip, without dumping an object into the UI. */
-function errorMessage(payload: ToolCallPayload): string | undefined {
-  const raw = payload.error;
-  if (typeof raw === 'string') return raw;
-  const record = asRecord(raw);
-  const message = record?.message;
-  return typeof message === 'string' ? message : undefined;
+/**
+ * Readable text for something a tool threw. The Rust side rejects with a plain
+ * string (`"path is outside the wiki folder"`), so that case matters most.
+ */
+function thrownMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  const message = asRecord(error)?.message;
+  return typeof message === 'string' ? message : 'The wiki tool failed';
 }
 
 /**
@@ -157,102 +175,140 @@ export async function streamLocalWikiChat(
     rawLength,
   });
 
-  const response = await agent.stream(messages, { clientTools });
+  // Tool schemas only — no `execute`.
+  //
+  // Handing client-js an executable tool makes it drive the continuation itself,
+  // and on this build that continuation re-POSTs only the messages accumulated
+  // during the stream: the user's own message is dropped. The model gets a tool
+  // result with no idea what was asked, and answers by introducing itself. So we
+  // declare the contract to the server and run the loop below ourselves, which
+  // is also the honest shape — the tools are ours, executing on this device.
+  const declaredTools = Object.fromEntries(
+    Object.entries(clientTools).map(([name, { execute: _execute, ...schema }]) => [name, schema]),
+  ) as Record<string, WikiClientTool>;
 
-  await response.processDataStream({
-    onChunk: (chunk) => {
-      // Once the turn has failed, stop folding later chunks into the answer —
-      // whatever follows an error frame is not part of a reply the user should
-      // see.
-      if (failure.error) return;
+  // A turn is a conversation, not a request. Bounded so a model that keeps
+  // calling tools cannot spin forever on the user's machine.
+  const history: WikiTurnMessage[] = [...messages];
 
-      switch (chunk.type) {
-        case 'text-delta': {
-          const text = (asRecord(chunk.payload) as TextPayload | null)?.text;
-          if (typeof text === 'string' && text) {
-            displayText += text;
-            rawLength += text.length;
+  for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
+    const pending: { id: string; name: string; args: Record<string, unknown> }[] = [];
+
+    const response = await agent.stream(history, { clientTools: declaredTools });
+    await response.processDataStream({
+      onChunk: (chunk) => {
+        if (failure.error) return;
+
+        switch (chunk.type) {
+          case 'text-delta': {
+            const text = (asRecord(chunk.payload) as TextPayload | null)?.text;
+            if (typeof text === 'string' && text) {
+              displayText += text;
+              rawLength += text.length;
+              onUpdate?.(snapshot());
+            }
+            return;
+          }
+          case 'tool-call': {
+            const payload = toolPayload(chunk.payload);
+            const name = payload.toolName ?? 'tool';
+            const id = payload.toolCallId ?? `${name}-${toolCallsById.size}`;
+            const args = payload.args ?? {};
+            pending.push({ id, name, args });
+            toolCallsById.set(id, { id, name, args, status: 'running' });
+            rawLength += 1;
             onUpdate?.(snapshot());
+            return;
           }
-          return;
-        }
-        case 'tool-call': {
-          const payload = toolPayload(chunk.payload);
-          const id = payload.toolCallId ?? payload.toolName ?? `tool-${toolCallsById.size}`;
-          toolCallsById.set(id, {
-            id,
-            name: payload.toolName ?? 'tool',
-            args: payload.args,
-            status: 'running',
-          });
-          rawLength += 1;
-          onUpdate?.(snapshot());
-          return;
-        }
-        case 'tool-result': {
-          const payload = toolPayload(chunk.payload);
-          const id = payload.toolCallId ?? payload.toolName ?? '';
-          const existing = toolCallsById.get(id);
-          // A result for a call we never saw still deserves a chip; dropping it
-          // would hide work that actually touched the user's files.
-          const failed = payload.isError === true || payload.error !== undefined;
-          const name = payload.toolName ?? existing?.name ?? 'tool';
-          if (!failed && WIKI_WRITE_TOOLS.has(name)) {
-            wroteSomething = true;
+          case 'error': {
+            // Ends the turn. Surfacing it as a rejection rather than resolving
+            // with half an answer is what lets the caller reuse the existing
+            // failure/retry handling.
+            const record = asRecord(chunk.payload);
+            const nested = asRecord(record?.error);
+            failure.error = new Error(
+              (typeof nested?.message === 'string' ? nested.message : undefined) ??
+                (typeof record?.message === 'string' ? record.message : undefined) ??
+                'The local wiki agent stream failed',
+            );
+            return;
           }
-          toolCallsById.set(id, {
-            id,
-            name,
-            args: existing?.args,
-            status: failed ? 'error' : 'success',
-            ...(failed ? { errorMsg: errorMessage(payload) } : {}),
-          });
-          rawLength += 1;
-          onUpdate?.(snapshot());
-          return;
+          default:
+            // Unrecognised chunk types are not our business.
+            return;
         }
-        case 'tool-error': {
-          const payload = toolPayload(chunk.payload);
-          const id = payload.toolCallId ?? payload.toolName ?? '';
-          const existing = toolCallsById.get(id);
-          toolCallsById.set(id, {
-            id,
-            name: payload.toolName ?? existing?.name ?? 'tool',
-            args: existing?.args,
-            status: 'error',
-            errorMsg: errorMessage(payload),
-          });
-          rawLength += 1;
-          onUpdate?.(snapshot());
-          return;
-        }
-        case 'error': {
-          // A stream-level error ends the turn. Surfacing it as a rejection
-          // rather than resolving with half an answer is what lets the caller
-          // reuse the existing failure/retry handling.
-          const record = asRecord(chunk.payload);
-          const nested = asRecord(record?.error);
-          const message =
-            (typeof nested?.message === 'string' ? nested.message : undefined) ??
-            (typeof record?.message === 'string' ? record.message : undefined) ??
-            'The local wiki agent stream failed';
-          failure.error = new Error(message);
-          return;
-        }
-        default:
-          // Unrecognised chunk types are not our business.
-          return;
+      },
+    });
+
+    if (failure.error) break;
+    // No tools asked for: the model has said its piece and the turn is done.
+    if (pending.length === 0) return await finish();
+
+    // Run them here, on this device, and fold the outcome in ourselves. The
+    // stream carries no `tool-result` event on this build — the result reaches
+    // the model only by going back up in the next request — so our own call is
+    // the single source of truth for whether a tool ran and what it returned.
+    const results: WikiTurnMessage[] = [];
+    for (const call of pending) {
+      let result: unknown;
+      let failed: unknown;
+      try {
+        result = await clientTools[call.name]?.execute(call.args);
+        if (WIKI_WRITE_TOOLS.has(call.name)) wroteSomething = true;
+      } catch (error) {
+        failed = error;
+        // The model is told, so it can apologise or try a different path rather
+        // than pretending the write happened.
+        result = { error: thrownMessage(error) };
       }
-    },
-  });
+      toolCallsById.set(call.id, {
+        id: call.id,
+        name: call.name,
+        args: call.args,
+        status: failed ? 'error' : 'success',
+        ...(failed ? { errorMsg: thrownMessage(failed) } : {}),
+      });
+      rawLength += 1;
+      onUpdate?.(snapshot());
 
-  if (failure.error) throw failure.error;
+      results.push({
+        role: 'tool',
+        content: [
+          { type: 'tool-result', toolCallId: call.id, toolName: call.name, result },
+        ],
+      });
+    }
 
-  // After the stream, so the commit captures every write the turn made — not
-  // just the ones that had landed when some intermediate round finished.
-  if (wroteSomething && onTurnWrote) {
-    await onTurnWrote(turnSummary?.trim() ?? '');
+    // Carry the whole conversation forward — crucially including the user's
+    // original message, which is exactly what the library's own continuation
+    // loses.
+    history.push({
+      role: 'assistant',
+      content: pending.map((call) => ({
+        type: 'tool-call',
+        toolCallId: call.id,
+        toolName: call.name,
+        args: call.args,
+      })),
+    });
+    history.push(...results);
   }
 
-  return snapshot();
+  return finish();
+
+  /**
+   * End the turn: surface any stream failure, then commit once if it wrote.
+   *
+   * Committing here rather than per write is what makes the history readable —
+   * filing a page, linking it from `index.md` and appending to `log.md` are one
+   * change, and splitting them would let you revert the page while leaving the
+   * index pointing at a file that no longer exists.
+   */
+  async function finish(): Promise<ChatStreamUpdate> {
+    if (failure.error) throw failure.error;
+    if (wroteSomething && onTurnWrote) {
+      await onTurnWrote(turnSummary?.trim() ?? '');
+    }
+    return snapshot();
+  }
 }


### PR DESCRIPTION
### **User description**
## What

Driving the merged V2 librarian against the deployed `localWikiAgent` for the first time turned up two bugs. **As merged, the librarian cannot write to the wiki at all** — which is half the feature.

Both were invisible to the unit tests, because those tests asserted a stream shape I invented rather than one the server actually sends. That's the real lesson here.

## Bug 1 — the turn lost the user's message

Handing `@mastra/client-js` an executable `clientTool` makes *it* drive the continuation, and on this pinned build that continuation re-POSTs only the messages accumulated during the stream. **The user's own message is dropped.** So the librarian would read `index.md`, then answer a question it could no longer see by introducing itself.

Confirmed with a discriminating test — asked for a page count *"and the word BANANA"*:

```
FINAL TEXT: "I see your wiki has three pages: a.md, b.md, and c.md. …
             How can I help you?"
keeps user message across the round-trip: false
```

It has the tool *result* (all three page names) and no idea what was asked.

**This also corrects the V2 spike's verdict.** The spike looked like a pass because a weather-shaped agent does something sensible with a location it was just handed. It was never evidence that context survived.

## Bug 2 — nothing was ever committed

There is no `tool-result` event on this build; results travel back only in the next request. So the handler that set the "this turn wrote something" flag was dead code — every wiki turn looked read-only, `wiki_commit_turn` never fired, and every tool chip sat on "running" forever.

## The fix

Both bugs come from one mistake: letting the library own a loop whose two critical facts — what the user asked, and what our own tools did — only we have.

The transport now declares tool schemas to the server **without** `execute`, runs the tools itself, and re-POSTs the full history (user message included) round by round, bounded to twenty so a looping model can't keep working the user's disk. A tool's outcome comes from the call we made, which is ground truth rather than an event that may not arrive.

## Verification

End to end against the deployed agent with a real git-backed wiki:

```
TURN 2  "We picked Postgres over DynamoDB … Remember this."
  [local] wiki_read_page  index.md / schema.md / log.md
  [local] wiki_write_page decisions/why-postgres.md
  [local] wiki_write_page index.md
  [local] wiki_write_page log.md
  [commit] committed=true sha=5a05a7f          ← three writes, ONE commit

TURN 3  "Why did we pick our database?"
  → "According to [[decisions/why-postgres]], you chose Postgres over DynamoDB…"

GIT LOG: 5a05a7f We picked Postgres over DynamoDB…
         ecafb5e seed
WORKING TREE: clean
```

The wiki compounds — turn 3 is grounded in a page filed in turn 2. That's the premise the whole foray is testing, working for the first time.

Tests rewritten around the real stream shape, and they now pin the two things that broke: the continuation carries the user message, and the server is handed schemas with no `execute`.

## Note for the V3 work

Ingest and lint (`smooth.dune`) build directly on this loop, so this wants to land first.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fix turn loop so user's message is preserved across tool-call rounds

- Transport now owns the tool execution loop instead of delegating to `client-js`

- Tool schemas sent to server without `execute` to prevent library from hijacking continuation

- Tests rewritten to reflect actual server stream shape (no `tool-result` event)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Message"] -- "sent with full history" --> B["agent.stream()"]
  B -- "tool-call chunk" --> C["Local Tool Execution"]
  C -- "result appended to history" --> D["history: user + assistant + tool"]
  D -- "next round (max 20)" --> B
  B -- "no pending tools" --> E["finish()"]
  E -- "wroteSomething?" --> F["onTurnWrote commit"]
  E --> G["ChatStreamUpdate"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>streamLocalWikiChat.ts</strong><dd><code>Own the tool execution loop to fix user message loss and enable writes</code></dd></summary>
<hr>

src/lib/chat/streamLocalWikiChat.ts

<ul><li>Added <code>MAX_TOOL_ROUNDS = 20</code> cap to prevent infinite loops on user's <br>machine<br> <li> Added <code>WikiTurnMessage</code> type to support structured assistant/tool <br>messages in history<br> <li> Transport now strips <code>execute</code> from tool schemas before sending to <br>server, preventing <code>client-js</code> from owning the continuation<br> <li> Replaced single <code>agent.stream()</code> call with a bounded round loop that <br>executes tools locally and maintains full conversation history<br> <li> Moved <code>finish()</code> logic into a local function that handles failure <br>surfacing and single commit-per-turn<br> <li> Removed handling of <code>tool-result</code> and <code>tool-error</code> stream events (they <br>don't exist on this build); tool outcomes now come from local <br>execution</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/461/files#diff-41a3f71390e43463cc1acb20823f082f67a752174f2bc4da45eff423ea1bc651">+154/-98</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>streamLocalWikiChat.test.ts</strong><dd><code>Rewrite tests to match real server stream shape and new turn loop</code></dd></summary>
<hr>

src/lib/chat/__tests__/streamLocalWikiChat.test.ts

<ul><li>Replaced <code>agentEmitting</code> stub with <code>agentRounds</code> that records calls and <br>tools seen per round<br> <li> Added tests verifying user message is preserved in continuation <br>requests<br> <li> Added tests verifying tool schemas sent without <code>execute</code> property<br> <li> Added tests for multi-round turns, round cap enforcement, and <br>cross-round text accumulation<br> <li> Rewrote commit-per-turn tests to use actual tool execution flow <br>instead of <code>tool-result</code> stream events<br> <li> Removed tests for <code>tool-result</code>/<code>tool-error</code> stream events that don't <br>exist on this build</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/461/files#diff-f9f4008b42b7e3e17114d74eba0e4ac534727f4894092578ebd69e67fb3e139d">+277/-172</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

