### PR TITLE
feat: wire up Sentry error reporting end-to-end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,18 @@ GITHUB_PRIVATE_KEY=""
 GITHUB_APP_SLUG=""
 GITHUB_WEBHOOK_SECRET=""
 
+# Sentry error reporting (this app's own errors -> Sentry)
+# DSN is public and shipped to the browser. Required on Vercel production,
+# optional elsewhere; without it Sentry stays disabled.
+NEXT_PUBLIC_SENTRY_DSN=""
+# Build-time only: enable source-map upload so production stack traces are
+# readable. Set these in the Vercel build environment (SENTRY_AUTH_TOKEN is a
+# Sentry org auth token with project:releases scope). Builds succeed without
+# them — stack traces just stay minified.
+SENTRY_ORG=""
+SENTRY_PROJECT=""
+SENTRY_AUTH_TOKEN=""
+
 # Sentry -> Exponential bug webhook (/api/webhooks/sentry)
 # Client Secret of the Sentry internal integration; used to verify the
 # Sentry-Hook-Signature on incoming webhooks. If unset, verification is skipped.

--- a/dev-docs/OBSERVABILITY.md
+++ b/dev-docs/OBSERVABILITY.md
@@ -1,0 +1,57 @@
+# Observability
+
+How this app reports its own errors. (For the *inbound* Sentry→bug-ticket
+webhook, see ADR-0027 / ADR-0048 — that's a separate concern.)
+
+## Sentry
+
+`@sentry/nextjs` is initialized on **Vercel production and preview** deploys
+only; local dev never reports. Config lives in:
+
+- `sentry.server.config.ts` / `sentry.edge.config.ts` — server/edge runtime init
+- `src/instrumentation.ts` — loads the configs, exports `onRequestError`
+  (captures route-handler and RSC errors)
+- `src/instrumentation-client.ts` — browser init
+- `next.config.js` — `withSentryConfig` (source-map upload, `/monitoring`
+  tunnel route, Vercel cron monitors)
+
+Errors are always captured; `tracesSampleRate` only samples performance
+traces (10% in production, 100% in preview).
+
+### What gets captured
+
+| Surface | Mechanism |
+|---|---|
+| tRPC procedure errors | `onError` in `src/app/api/trpc/[trpc]/route.ts` — only `INTERNAL_SERVER_ERROR` (unexpected exceptions); expected client errors (UNAUTHORIZED, Zod failures…) are not reported |
+| Route handlers / RSC | `onRequestError` in `src/instrumentation.ts` |
+| Client render crashes (page level) | `error.tsx` in each route group → `SegmentErrorFallback` |
+| Client render crashes (root layout level) | `src/app/global-error.tsx` |
+| Component-level boundaries | `src/app/_components/ErrorBoundary.tsx` |
+| Vercel crons | `automaticVercelMonitors` in `next.config.js` creates Sentry cron monitors from `vercel.json` |
+
+### Environment variables
+
+| Var | Where | Purpose |
+|---|---|---|
+| `NEXT_PUBLIC_SENTRY_DSN` | Runtime (public) | Required on Vercel production; without it Sentry is disabled |
+| `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` | Vercel build env only | Source-map upload. Missing ⇒ build still succeeds, stack traces stay minified |
+
+The browser SDK posts events through the `/monitoring` tunnel route (rewritten
+to Sentry by `withSentryConfig`) so ad blockers can't drop them. That path is
+excluded from the auth middleware matcher in `src/middleware.ts`.
+
+### Verifying a change to this setup
+
+Deploy a preview and trigger any error (previews report with
+`environment: preview`, so production alerting is unaffected). Check the
+Sentry issue has a readable (non-minified) stack trace — if not, source-map
+upload is broken.
+
+## Other signals
+
+- **Vercel function logs** — tRPC internal errors are also `console.error`ed
+  in production for correlation.
+- **DB-backed job history** — ticket sync (`TicketSyncRun`,
+  `TicketSyncPushJob`), webhook deliveries (`WebhookLog`), AI calls
+  (`AiInteractionHistory`) record their own run/error state in Postgres with
+  admin UIs; Sentry complements rather than replaces these.

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@
  * for Docker builds.
  */
 import "./src/env.js";
+import { withSentryConfig } from "@sentry/nextjs";
 
 /** @type {import("next").NextConfig} */
 const config = {
@@ -33,4 +34,26 @@ const config = {
   },
 };
 
-export default config;
+export default withSentryConfig(config, {
+  // Source-map upload happens only when SENTRY_AUTH_TOKEN is set (Vercel
+  // build env). Without it the plugin logs a warning and the build still
+  // succeeds — but production stack traces stay minified.
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  silent: !process.env.CI,
+  // Upload a wider set of source maps so server-component and vendored
+  // frames symbolicate too.
+  widenClientFileUpload: true,
+  // Don't ship source maps to the public — delete them after upload.
+  sourcemaps: {
+    deleteSourcemapsAfterUpload: true,
+  },
+  // Proxy browser events through /monitoring so ad blockers can't drop them.
+  tunnelRoute: "/monitoring",
+  // Strip Sentry debug-logger calls from client bundles.
+  disableLogger: true,
+  telemetry: false,
+  // Create Sentry cron monitors for the vercel.json crons so silent cron
+  // failures become visible.
+  automaticVercelMonitors: true,
+});

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,11 @@ const config = {
   eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: true },
   experimental: {
+    // Keep the build inside Vercel's 8GB container: source-map emission
+    // raised webpack's footprint, and static-gen workers inherit the raised
+    // NODE_OPTIONS heap cap, so bound both.
+    webpackMemoryOptimizations: true,
+    cpus: 2,
     turbo: {
       resolveAlias: {
         "markdown-it": "markdown-it/dist/index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {
-    "build": "next build",
+    "build": "NODE_OPTIONS=\"--max-old-space-size=8192\" next build",
     "check": "NODE_OPTIONS=\"--max-old-space-size=4096\" next lint && tsc --noEmit",
     "db:generate": "prisma migrate dev",
     "db:migrate": "prisma migrate deploy",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {
-    "build": "NODE_OPTIONS=\"--max-old-space-size=8192\" next build",
+    "build": "NODE_OPTIONS=\"--max-old-space-size=6144\" next build",
     "check": "NODE_OPTIONS=\"--max-old-space-size=4096\" next lint && tsc --noEmit",
     "db:generate": "prisma migrate dev",
     "db:migrate": "prisma migrate deploy",

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,9 +1,14 @@
 import * as Sentry from "@sentry/nextjs";
 
-if (process.env.VERCEL_ENV === "production") {
+const vercelEnv = process.env.VERCEL_ENV;
+
+// Report from production AND preview deploys; local dev stays silent.
+if (vercelEnv === "production" || vercelEnv === "preview") {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-    tracesSampleRate: 1.0,
+    environment: vercelEnv,
+    // Errors are always captured — this rate only samples performance traces.
+    tracesSampleRate: vercelEnv === "production" ? 0.1 : 1.0,
     sendDefaultPii: false,
     release: process.env.VERCEL_GIT_COMMIT_SHA,
   });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,9 +1,14 @@
 import * as Sentry from "@sentry/nextjs";
 
-if (process.env.VERCEL_ENV === "production") {
+const vercelEnv = process.env.VERCEL_ENV;
+
+// Report from production AND preview deploys; local dev stays silent.
+if (vercelEnv === "production" || vercelEnv === "preview") {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-    tracesSampleRate: 1.0,
+    environment: vercelEnv,
+    // Errors are always captured — this rate only samples performance traces.
+    tracesSampleRate: vercelEnv === "production" ? 0.1 : 1.0,
     sendDefaultPii: false,
     release: process.env.VERCEL_GIT_COMMIT_SHA,
   });

--- a/src/app/(home)/error.tsx
+++ b/src/app/(home)/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+import { SegmentErrorFallback } from "~/app/_components/SegmentErrorFallback";
+
+export default SegmentErrorFallback;

--- a/src/app/(public)/error.tsx
+++ b/src/app/(public)/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+import { SegmentErrorFallback } from "~/app/_components/SegmentErrorFallback";
+
+export default SegmentErrorFallback;

--- a/src/app/(published)/error.tsx
+++ b/src/app/(published)/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+import { SegmentErrorFallback } from "~/app/_components/SegmentErrorFallback";
+
+export default SegmentErrorFallback;

--- a/src/app/(sidemenu)/error.tsx
+++ b/src/app/(sidemenu)/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+import { SegmentErrorFallback } from "~/app/_components/SegmentErrorFallback";
+
+export default SegmentErrorFallback;

--- a/src/app/(web3)/error.tsx
+++ b/src/app/(web3)/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+import { SegmentErrorFallback } from "~/app/_components/SegmentErrorFallback";
+
+export default SegmentErrorFallback;

--- a/src/app/_components/ErrorBoundary.tsx
+++ b/src/app/_components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as Sentry from '@sentry/nextjs';
 import React, { Component, type ErrorInfo, type ReactNode } from 'react';
 import { Paper, Text, Button, Stack, Alert, Group } from '@mantine/core';
 import { IconAlertTriangle, IconRefresh, IconBug } from '@tabler/icons-react';
@@ -40,6 +41,9 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('ErrorBoundary caught an error:', error, errorInfo);
+    Sentry.captureException(error, {
+      extra: { componentStack: errorInfo.componentStack },
+    });
     this.setState({
       errorInfo,
     });

--- a/src/app/_components/SegmentErrorFallback.tsx
+++ b/src/app/_components/SegmentErrorFallback.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+interface SegmentErrorFallbackProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Shared fallback for Next.js `error.tsx` boundaries. Reports the error to
+ * Sentry, then offers a retry. Deliberately dependency-free (no Mantine) so
+ * it renders even when providers are broken.
+ */
+export function SegmentErrorFallback({
+  error,
+  reset,
+}: SegmentErrorFallbackProps) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center">
+      <h2 className="text-xl font-semibold text-text-primary">
+        Something went wrong
+      </h2>
+      <p className="max-w-md text-sm text-text-secondary">
+        The error has been reported automatically.
+        {error.digest ? ` Reference: ${error.digest}` : ""}
+      </p>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-md border border-border-primary px-4 py-2 text-sm font-medium text-text-primary hover:bg-surface-hover"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/api/sentry-tracer-bullet/route.ts
+++ b/src/app/api/sentry-tracer-bullet/route.ts
@@ -1,8 +1,0 @@
-// TEMPORARY: tracer bullet for Sentry (GH issue 104). Hit this in production
-// to verify the first Sentry event arrives, then delete this route before
-// final merge.
-export async function GET() {
-  throw new Error(
-    "Sentry tracer bullet: deliberate production throw to verify ingestion (GH issue 104).",
-  );
-}

--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { type NextRequest } from "next/server";
 
@@ -25,14 +26,28 @@ const handler = (req: NextRequest) =>
     createContext: () => createContext(req),
     // Agent tools always POST, including to query procedures (ADR-0041).
     allowMethodOverride: true,
-    onError:
-      env.NODE_ENV === "development"
-        ? ({ path, error }) => {
-            console.error(
-              `❌ tRPC failed on ${path ?? "<no-path>"}: ${error.message}`
-            );
-          }
-        : undefined,
+    // tRPC catches procedure exceptions and turns them into HTTP responses,
+    // so Next's onRequestError hook never sees them — this is the only place
+    // they can be reported.
+    onError: ({ path, type, error }) => {
+      if (env.NODE_ENV === "development") {
+        console.error(
+          `❌ tRPC failed on ${path ?? "<no-path>"}: ${error.message}`
+        );
+        return;
+      }
+      // INTERNAL_SERVER_ERROR is what unexpected exceptions surface as;
+      // expected client errors (UNAUTHORIZED, NOT_FOUND, Zod input
+      // failures…) would only be noise in Sentry.
+      if (error.code === "INTERNAL_SERVER_ERROR") {
+        Sentry.captureException(error.cause ?? error, {
+          tags: { "trpc.path": path ?? "<no-path>", "trpc.type": type },
+        });
+        console.error(
+          `tRPC ${type} ${path ?? "<no-path>"} failed: ${error.message}`
+        );
+      }
+    },
   });
 
 export { handler as GET, handler as POST };

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import "~/styles/globals.css";
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+/**
+ * Last-resort boundary: catches errors thrown by the route-group root
+ * layouts themselves. Must render its own <html>/<body> because it replaces
+ * the entire tree.
+ */
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="en" data-mantine-color-scheme="dark">
+      <body className="bg-background-primary">
+        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
+          <h1 className="text-xl font-semibold text-text-primary">
+            Something went wrong
+          </h1>
+          <p className="max-w-md text-sm text-text-secondary">
+            The error has been reported automatically.
+            {error.digest ? ` Reference: ${error.digest}` : ""}
+          </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="rounded-md border border-border-primary px-4 py-2 text-sm font-medium text-text-primary hover:bg-surface-hover"
+          >
+            Reload page
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,9 +1,14 @@
 import * as Sentry from "@sentry/nextjs";
 
-if (process.env.NEXT_PUBLIC_VERCEL_ENV === "production") {
+const vercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV;
+
+// Report from production AND preview deploys; local dev stays silent.
+if (vercelEnv === "production" || vercelEnv === "preview") {
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-    tracesSampleRate: 1.0,
+    environment: vercelEnv,
+    // Errors are always captured — this rate only samples performance traces.
+    tracesSampleRate: vercelEnv === "production" ? 0.1 : 1.0,
     sendDefaultPii: false,
     release: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
   });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,6 +1,10 @@
 import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
+  // Never initialize during `next build`: each static-generation worker
+  // would load the full SDK (+OpenTelemetry) and OOM the build container.
+  // Runtime servers initialize normally.
+  if (process.env.NEXT_PHASE === "phase-production-build") return;
   const vercelEnv = process.env.VERCEL_ENV;
   if (vercelEnv !== "production" && vercelEnv !== "preview") return;
   if (process.env.NEXT_RUNTIME === "nodejs") {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,7 +1,8 @@
 import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
-  if (process.env.VERCEL_ENV !== "production") return;
+  const vercelEnv = process.env.VERCEL_ENV;
+  if (vercelEnv !== "production" && vercelEnv !== "preview") return;
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("../sentry.server.config");
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -67,11 +67,12 @@ export const config = {
     /*
      * Match all request paths except for the ones starting with:
      * - api (API routes)
+     * - monitoring (Sentry browser-event tunnel)
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      * - signin (login page)
      */
-    '/((?!api|_next/static|_next/image|favicon.ico|signin).*)',
+    '/((?!api|monitoring|_next/static|_next/image|favicon.ico|signin).*)',
   ],
 }; 

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -182,33 +182,13 @@ export const createCallerFactory = t.createCallerFactory;
 export const createTRPCRouter = t.router;
 
 /**
- * Middleware for timing procedure execution and adding an artificial delay in development.
- *
- * You can remove this if you don't like it, but it can help catch unwanted waterfalls by simulating
- * network latency that would occur in production but not in local development.
- */
-const timingMiddleware = t.middleware(async ({ next }) => {
-  // if (t._config.isDev) {
-  //   // artificial delay in dev
-  //   const waitMs = Math.floor(Math.random() * 400) + 100;
-  //   await new Promise((resolve) => setTimeout(resolve, waitMs));
-  // }
-
-  const result = await next();
-
-  // console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
-
-  return result;
-});
-
-/**
  * Public (unauthenticated) procedure
  *
  * This is the base piece you use to build new queries and mutations on your tRPC API. It does not
  * guarantee that a user querying is authorized, but you can still access user session data if they
  * are logged in.
  */
-export const publicProcedure = t.procedure.use(timingMiddleware);
+export const publicProcedure = t.procedure;
 
 /**
  * Protected (authenticated) procedure
@@ -219,7 +199,6 @@ export const publicProcedure = t.procedure.use(timingMiddleware);
  * @see https://trpc.io/docs/procedures
  */
 export const protectedProcedure = t.procedure
-  .use(timingMiddleware)
   .use(({ ctx, next }) => {
     if (!ctx.session?.user) {
       throw new TRPCError({ code: "UNAUTHORIZED" });


### PR DESCRIPTION
### **User description**
## Why

Sentry was installed and initialized, but the app's dominant traffic path bypassed it entirely: tRPC's `onError` was dev-gated, and tRPC swallows procedure exceptions before Next's `onRequestError` hook can see them — so **every production tRPC error was invisible**. Client render crashes were also unreported (no `error.tsx`/`global-error.tsx` anywhere), and without source-map upload, what did arrive was minified.

## What

- **tRPC errors reported**: `onError` in the tRPC route handler now captures `INTERNAL_SERVER_ERROR` (unexpected exceptions) to Sentry in production, tagged with procedure path/type, plus a `console.error` for Vercel log correlation. Expected client errors (UNAUTHORIZED, NOT_FOUND, Zod input failures) are deliberately not reported to keep noise out.
- **Source maps**: `next.config.js` is wrapped in `withSentryConfig` — uploads source maps when `SENTRY_ORG`/`SENTRY_PROJECT`/`SENTRY_AUTH_TOKEN` are set in the Vercel build env (build still succeeds without them), deletes them after upload, tunnels browser events through `/monitoring` so ad blockers can't drop them, and auto-creates Sentry cron monitors for the `vercel.json` crons.
- **Client error boundaries**: new `src/app/global-error.tsx` (catches root-layout crashes, renders its own html/body since the root layout is a passthrough) and an `error.tsx` in each of the five route groups, all reporting via a shared `SegmentErrorFallback` (dependency-free, semantic color tokens only). The hand-rolled `ErrorBoundary` component now reports to Sentry too.
- **Preview coverage**: Sentry now initializes on preview deploys as well, tagged `environment: preview`, so staging errors surface before production. Traces sampled at 10% in production (was 100% — quota hazard); errors are always captured.
- **Cleanup**: removed the dead `timingMiddleware` (fully commented-out body, still on every procedure) and the temporary `sentry-tracer-bullet` route (GH issue 104 said delete after verifying ingestion).
- **Docs**: `dev-docs/OBSERVABILITY.md` documents what's captured where, the env vars, and how to verify.

## Deploy notes

To get readable stack traces, set `SENTRY_ORG`, `SENTRY_PROJECT`, and `SENTRY_AUTH_TOKEN` (org token with `project:releases` scope) in the Vercel build environment. Nothing breaks without them — stack traces just stay minified.

## Validation

- `npx tsc --noEmit` clean (8GB heap)
- ESLint clean on all changed files
- Unit suite passed via pre-commit hook; full Vercel build passed via pre-push hook


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Wire up Sentry error reporting end-to-end across all surfaces

- Add client error boundaries (`global-error.tsx`, per-route `error.tsx`) with `SegmentErrorFallback`

- Fix tRPC `onError` to capture `INTERNAL_SERVER_ERROR` in production; was dev-gated

- Enable Sentry on preview deploys, reduce trace sample rate to 10% in production


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sentry Init\n(prod + preview)"] -- "server/edge" --> B["sentry.server.config.ts\nsentry.edge.config.ts"]
  A -- "browser" --> C["instrumentation-client.ts"]
  D["next.config.js\nwithSentryConfig"] -- "source maps + tunnel" --> E["Sentry Platform"]
  F["tRPC onError\nINTERNAL_SERVER_ERROR"] -- "captureException" --> E
  G["global-error.tsx\nerror.tsx (x5)"] -- "SegmentErrorFallback" --> E
  H["ErrorBoundary.tsx"] -- "captureException" --> E
  I["/monitoring tunnel"] -- "browser events" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>sentry.edge.config.ts</strong><dd><code>Enable Sentry on preview, reduce prod trace sample rate</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-0579713d2867dd7b0b73196db50bf4197fd89375775158de6670415dff599032">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sentry.server.config.ts</strong><dd><code>Enable Sentry on preview, reduce prod trace sample rate</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-1ab87e7d17ff99375cf43fd08d1fe605cff6b415d719ba8cb725ebd06f181cec">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>instrumentation-client.ts</strong><dd><code>Enable Sentry on preview, reduce prod trace sample rate</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-953d09c7a2fdd8e6944bb7f8a09dd7314f27ef8d5a8da2db18ece678a70c607f">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ErrorBoundary.tsx</strong><dd><code>Report caught component errors to Sentry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-3824dc10b7216f125b654392e0fb7136c22ceba16c5ef4ffe12c2f5c44ba3364">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SegmentErrorFallback.tsx</strong><dd><code>New shared error fallback component reporting to Sentry</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-b9509a26de7614dfcf424a3de41b92468f400e554be9d7d47bbb1d240498ca07">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>global-error.tsx</strong><dd><code>New root-layout error boundary reporting to Sentry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-65c11b515bcbbb7a9c0ec2b3c50a3f4547cab4d61cd54500f5e8337326764633">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>error.tsx</strong><dd><code>Add route-group error boundary using SegmentErrorFallback</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-93167c983529e6890ad9c2009606429946bed0a79fa90381005ccc62b247dfd0">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>error.tsx</strong><dd><code>Add route-group error boundary using SegmentErrorFallback</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-1c3a1f9d4866a3da80542844d4aa3ae363943dee692bde3742068d13e3586800">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>error.tsx</strong><dd><code>Add route-group error boundary using SegmentErrorFallback</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-d24cb2d01bc6e91dd8b2226df5d0d20a96071776834c60c901f880991309d6d7">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>error.tsx</strong><dd><code>Add route-group error boundary using SegmentErrorFallback</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-0209a8f1c7e0b664f470896ce907623daeaefdf6a584530f5f5c674720df3df6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>error.tsx</strong><dd><code>Add route-group error boundary using SegmentErrorFallback</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-9eb6f566ddfd8f80cee20e6f5556d8561a00b7677e8ff6280a62e914dd67840f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>instrumentation.ts</strong><dd><code>Skip Sentry init during build, enable preview deploys</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-1d5bbd60ea57ea5431ebe7f03e6a47d12e205b27e1b04d9e2a046fafde4bbb2c">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>route.ts</strong><dd><code>Capture tRPC INTERNAL_SERVER_ERROR to Sentry in production</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-fce65859056d89fe5e22c35d68da3be9526781e6efde03a3ad8ebf0f499dd895">+23/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>middleware.ts</strong><dd><code>Exclude /monitoring tunnel path from auth middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>route.ts</strong><dd><code>Remove temporary Sentry tracer-bullet test route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-36bac3daed9547d9eed476cdeab9505dd48efe3d67deb4d5b1687e6107a0bbd9">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>trpc.ts</strong><dd><code>Remove dead timingMiddleware from tRPC procedures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-d1873554bffe6aae1ccd90d4e0c7643119f59236073129fff81d21a049e77e91">+1/-22</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>next.config.js</strong><dd><code>Wrap config with withSentryConfig for source maps and tunnel</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-882b2c04b01b2e8b2cdcf1817c30ea503a8005f1c0d54cfff37053b6801fea85">+29/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong><dd><code>Cap build heap at 6GB to prevent OOM during source-map emission</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>.env.example</strong><dd><code>Document Sentry DSN and source-map upload env vars</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OBSERVABILITY.md</strong><dd><code>Add observability documentation for Sentry setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/462/files#diff-e608379e40bafc9cc6a526c79545546dac14663e40ebdbc6733813229078f1a6">+57/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

