### PR TITLE
fix: stop logging JWT payload PII on authenticated requests

### DIFF
--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -81,27 +81,29 @@ export const createTRPCContext = async (opts: { headers: Headers }) => {
           throw new Error('Invalid token: missing user identifier');
         }
 
-        console.log('🔐 [JWT DEBUG] Token decoded successfully', {
-          userId: userId,
-          userEmail: decoded.email,
-          tokenType: decoded.tokenType,
-          issuedAt: decoded.iat ? new Date(decoded.iat * 1000).toISOString() : 'not set',
-          expiresAt: decoded.exp ? new Date(decoded.exp * 1000).toISOString() : 'not set',
-          securityVersion: decoded.securityVersion
-        });
+        // PII (email, name) must never be logged here — this runs on every
+        // JWT-authenticated request, including production.
+        if (process.env.NODE_ENV === 'development') {
+          console.log('🔐 [JWT DEBUG] Token decoded successfully', {
+            userId: userId,
+            tokenType: decoded.tokenType,
+            issuedAt: decoded.iat ? new Date(decoded.iat * 1000).toISOString() : 'not set',
+            expiresAt: decoded.exp ? new Date(decoded.exp * 1000).toISOString() : 'not set',
+            securityVersion: decoded.securityVersion
+          });
+        }
 
         // Find the user
         const user = await db.user.findUnique({
           where: { id: userId }
         });
 
-        console.log('👤 [USER LOOKUP] Database user lookup', {
-          userId: userId,
-          userFound: !!user,
-          userEmail: user?.email || 'not found',
-          userName: user?.name || 'not found',
-          userCreatedAt: 'not available in token'
-        });
+        if (process.env.NODE_ENV === 'development') {
+          console.log('👤 [USER LOOKUP] Database user lookup', {
+            userId: userId,
+            userFound: !!user,
+          });
+        }
 
         if (user) {
           // Create a session-like object from the JWT token
@@ -127,7 +129,11 @@ export const createTRPCContext = async (opts: { headers: Headers }) => {
           };
         }
       } catch (error) {
-        console.error('JWT verification failed:', error);
+        // Log only the message — never the raw token or decoded payload.
+        console.error(
+          'JWT verification failed:',
+          error instanceof Error ? error.message : 'unknown error',
+        );
       }
     }
   }


### PR DESCRIPTION
### **User description**
## Summary

The JWT verification path in `createTRPCContext` (`src/server/api/trpc.ts`) unconditionally logged the decoded JWT payload (user id, **email**, token type, expiry) and the subsequent DB user lookup (**email**, **name**) on every JWT-authenticated request — including in production. That is PII in plain logs.

## Changes

- Gated the `🔐 [JWT DEBUG]` and `👤 [USER LOOKUP]` logs behind `NODE_ENV === 'development'`, and dropped the email/name fields entirely so PII is never logged even in dev (userId, token type, expiry, and `userFound` remain for debugging).
- The verification-failure `console.error` now logs only the error message, never the full error object — so a raw token or decoded payload can never leak through it.
- The `🚨 [JWT SECURITY]` warning is untouched (it contains no PII).

## Validation

- `npx tsc --noEmit` — clean
- `eslint src/server/api/trpc.ts` — clean
- Pre-commit unit test suite passed

No schema changes — safe for fast-track to main.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Gate JWT debug logs behind `NODE_ENV === 'development'` to prevent PII exposure in production

- Remove `email` and `name` fields from all debug log statements

- Limit `console.error` on JWT failure to error message only, never raw token or payload


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JWT Token Decoded"] -- "NODE_ENV check" --> B["Development Only Logging"]
  B -- "userId, tokenType, expiry only" --> C["🔐 JWT DEBUG log"]
  A -- "DB lookup" --> D["User Found"]
  D -- "NODE_ENV check" --> E["Development Only Logging"]
  E -- "userId, userFound only" --> F["👤 USER LOOKUP log"]
  A -- "on error" --> G["console.error"]
  G -- "message only" --> H["No token/payload leak"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>trpc.ts</strong><dd><code>Prevent PII logging in JWT authentication path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/trpc.ts

<ul><li>Gated <code>🔐 [JWT DEBUG]</code> log behind <code>process.env.NODE_ENV === 'development'</code> <br>check<br> <li> Removed <code>userEmail</code> field from JWT debug log to prevent PII exposure<br> <li> Gated <code>👤 [USER LOOKUP]</code> log behind <code>NODE_ENV === 'development'</code> and <br>removed <code>userEmail</code>/<code>userName</code> fields<br> <li> Changed <code>console.error</code> on JWT failure to log only <code>error.message</code> instead <br>of the full error object</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/463/files#diff-d1873554bffe6aae1ccd90d4e0c7643119f59236073129fff81d21a049e77e91">+22/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

