### PR TITLE
feat: Tickets accordion on the feature detail page and peek

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx
@@ -51,6 +51,7 @@ import { CollapsibleSection } from "~/app/_components/product/CollapsibleSection
 import { FeatureDocsSection } from "~/app/_components/product/FeatureDocsSection";
 import { FeatureScopesSection } from "~/app/_components/product/FeatureScopesSection";
 import { FeatureRequirementsSection } from "~/app/_components/product/FeatureRequirementsSection";
+import { FeatureTicketsSection } from "~/app/_components/product/FeatureTicketsSection";
 import { FeatureActivitySection } from "~/app/_components/product/FeatureActivitySection";
 import {
   FEATURE_STATUS_OPTIONS,
@@ -311,6 +312,22 @@ export default function FeatureDetailPage() {
               requirements={feature.requirements}
               scopes={feature.scopes}
               userStories={feature.userStories}
+            />
+          </CollapsibleSection>
+
+          {/* Tickets - the delivery work implementing this feature. The
+              properties sidebar has always shown a ticket count; this is
+              where it resolves to actual rows. */}
+          <CollapsibleSection
+            title="Tickets"
+            meta={feature._count.tickets > 0 ? String(feature._count.tickets) : undefined}
+          >
+            <FeatureTicketsSection
+              featureId={featureId}
+              productId={feature.product.id}
+              productName={feature.product.name}
+              funTicketIds={feature.product.funTicketIds}
+              ticketsPath={`/w/${workspace?.slug}/products/${productSlug}/tickets`}
             />
           </CollapsibleSection>
 

--- a/src/app/_components/product/FeatureTicketsSection.tsx
+++ b/src/app/_components/product/FeatureTicketsSection.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import Link from "next/link";
+import { Avatar, Badge, Skeleton, Text } from "@mantine/core";
+import { api } from "~/trpc/react";
+import { PriorityIcon } from "~/app/_components/product/PriorityIcon";
+import { BlockedIndicator } from "~/app/_components/product/TicketDependenciesSection";
+import { NotionSyncBadge } from "~/app/_components/product/NotionSyncBadge";
+import { generateLinearId, ticketUrlId } from "~/lib/fun-ids";
+import { STATUS_COLORS, STATUS_LABELS } from "~/lib/ticket-statuses";
+
+/**
+ * The Tickets block for a feature - the delivery work linked to it. Both the
+ * feature detail page and the feature peek promised a ticket count in their
+ * meta/properties but had no way to see the tickets themselves; this is that
+ * list.
+ *
+ * Scoped by `featureId` exactly like the count on `feature.getById`
+ * (`_count.tickets`), so the number in the section header and the rows below
+ * it can never disagree. Rows follow the same reading order as the product
+ * tickets list (ID, status, title, blockers, sync, priority, assignee).
+ */
+export function FeatureTicketsSection({
+  featureId,
+  productId,
+  productName,
+  funTicketIds,
+  ticketsPath,
+}: {
+  featureId: string;
+  productId: string;
+  productName: string;
+  /** Product setting: prefer the fun shortId over the Linear-style ID. */
+  funTicketIds: boolean;
+  /** Base href of the product's ticket pages (`.../products/<slug>/tickets`). */
+  ticketsPath: string;
+}) {
+  const { data: tickets, isLoading } = api.product.ticket.list.useQuery(
+    { productId, featureId },
+    { enabled: !!productId && !!featureId },
+  );
+
+  if (isLoading) {
+    return (
+      <div className="border border-border-primary rounded-lg overflow-hidden">
+        {[0, 1].map((i) => (
+          <div
+            key={i}
+            className={`px-3 py-2.5 ${i === 0 ? "border-b border-border-primary" : ""}`}
+          >
+            <Skeleton height={16} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!tickets || tickets.length === 0) {
+    return (
+      <Text size="xs" className="text-text-muted">
+        No tickets yet - tickets are the delivery work that implements this
+        feature.
+      </Text>
+    );
+  }
+
+  return (
+    // The container-list grammar (see DESIGN.md): one bordered container,
+    // divider-separated rows - same as Scopes, Requirements, and Docs.
+    <div className="border border-border-primary rounded-lg overflow-hidden">
+      {tickets.map((ticket, i) => {
+        const displayId =
+          funTicketIds && ticket.shortId
+            ? ticket.shortId
+            : ticket.number > 0
+              ? generateLinearId(productName, ticket.number)
+              : null;
+
+        return (
+          <Link
+            key={ticket.id}
+            href={`${ticketsPath}/${ticketUrlId(ticket)}`}
+            className={`flex items-center gap-3 px-3 py-2.5 no-underline transition-colors hover:bg-surface-hover ${i < tickets.length - 1 ? "border-b border-border-primary" : ""}`}
+          >
+            <Text size="xs" className="text-text-muted font-mono w-14 shrink-0" lineClamp={1}>
+              {displayId}
+            </Text>
+            <Badge
+              size="xs"
+              variant="filled"
+              color={STATUS_COLORS[ticket.status] ?? "gray"}
+              className="shrink-0"
+              styles={{ label: { color: "var(--mantine-color-dark-9)" } }}
+            >
+              {STATUS_LABELS[ticket.status] ?? ticket.status}
+            </Badge>
+            <Text size="sm" className="text-text-primary flex-1 min-w-0" lineClamp={1}>
+              {ticket.title}
+            </Text>
+            <BlockedIndicator
+              openBlockerCount={ticket.openBlockerCount}
+              isBlocked={ticket.isBlocked}
+            />
+            <NotionSyncBadge syncs={ticket.syncs} size={14} />
+            <div className="shrink-0">
+              <PriorityIcon priority={ticket.priority} size={14} />
+            </div>
+            {ticket.assignee && (
+              <Avatar size="xs" radius="xl" src={ticket.assignee.image} className="shrink-0">
+                {(ticket.assignee.name ?? "?")[0]?.toUpperCase()}
+              </Avatar>
+            )}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/_components/product/peek/FeaturePeek.tsx
+++ b/src/app/_components/product/peek/FeaturePeek.tsx
@@ -29,6 +29,7 @@ import { PropertyPill, PillRow, pillClassName, ColorDot } from "~/app/_component
 import { FeatureScopesSection } from "~/app/_components/product/FeatureScopesSection";
 import { FeatureRequirementsSection } from "~/app/_components/product/FeatureRequirementsSection";
 import { FeatureDocsSection } from "~/app/_components/product/FeatureDocsSection";
+import { FeatureTicketsSection } from "~/app/_components/product/FeatureTicketsSection";
 import { PriorityIcon, PRIORITY_LABELS } from "~/app/_components/product/PriorityIcon";
 import { LabelsCombobox } from "~/app/_components/product/LabelsCombobox";
 import { CollapsibleSection } from "~/app/_components/product/CollapsibleSection";
@@ -467,6 +468,24 @@ export function FeaturePeek({ featureId, basePath }: { featureId: string; basePa
             requirements={feature.requirements}
             scopes={feature.scopes}
             userStories={feature.userStories}
+          />
+        </CollapsibleSection>
+      </div>
+
+      {/* Tickets - the delivery work implementing this feature. The pill
+          strip above has always advertised a ticket count; this is where it
+          resolves to actual rows. */}
+      <div className="pt-2">
+        <CollapsibleSection
+          title="Tickets"
+          meta={feature._count.tickets > 0 ? String(feature._count.tickets) : undefined}
+        >
+          <FeatureTicketsSection
+            featureId={featureId}
+            productId={feature.product.id}
+            productName={feature.product.name}
+            funTicketIds={feature.product.funTicketIds}
+            ticketsPath={`${basePath}/tickets`}
           />
         </CollapsibleSection>
       </div>

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -374,7 +374,17 @@ export const featureRouter = createTRPCRouter({
       const feature = await ctx.db.feature.findUnique({
         where: { id: input.id },
         include: {
-          product: { select: { id: true, slug: true, workspaceId: true, name: true } },
+          // funTicketIds rides along so the Tickets section can render each
+          // ticket's display ID without a second product fetch.
+          product: {
+            select: {
+              id: true,
+              slug: true,
+              workspaceId: true,
+              name: true,
+              funTicketIds: true,
+            },
+          },
           createdBy: { select: { id: true, name: true, image: true } },
           goal: {
             select: {


### PR DESCRIPTION
### **User description**
## Problem

Both feature views advertised a ticket count but gave you no way to see the tickets:

- the peek's meta strip — `N tickets · M scopes`
- the detail page's `Tickets` property row

The count was a dead end.

## Change

A shared `FeatureTicketsSection`, wired into both views between **Requirements** and **Docs** (spec first, then delivery, then reference docs).

- **No new server endpoint.** `product.ticket.list` already accepted a `featureId` filter, and the feature payload already carries `product.id`.
- **Scoped by `featureId` exactly like the `_count.tickets`** that produced the advertised number, so the section header and its rows can never disagree. Tickets attached only to a scope (`Ticket.scopeId` with no `featureId`) are excluded — same as the count.
- Rows follow the product tickets list reading order (ID, status, title, blockers, Notion sync, priority, assignee) inside the container-list grammar shared by Scopes, Requirements, and Docs. Skeleton while loading, explanatory empty state when there are none.
- `feature.getById` now selects `product.funTicketIds` so display IDs render without a second product fetch.

## Files

- `src/app/_components/product/FeatureTicketsSection.tsx` (new)
- `src/app/_components/product/peek/FeaturePeek.tsx`
- `src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx`
- `src/plugins/product/server/routers/feature.ts`

## Verification

`tsc --noEmit` and ESLint clean across the repo; unit suite passes via the pre-commit hook; the feature detail route compiles and serves 200 under `next dev`.

**Not visually confirmed** — the local dev server redirects to sign-in and the OAuth flow wasn't completable in that session, so the rendered accordion still wants a human eyeball.


___

### **PR Type**
Enhancement


___

### **Description**
- New `FeatureTicketsSection` component renders linked delivery tickets

- Wired into both feature detail page and feature peek between Requirements and Docs

- `feature.getById` now selects `product.funTicketIds` for display ID rendering

- Ticket rows follow product list order: ID, status, title, blockers, sync, priority, assignee


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["feature.getById (router)"] -- "adds funTicketIds" --> B["feature payload"]
  B -- "featureId + productId" --> C["FeatureTicketsSection"]
  C -- "ticket.list query" --> D["ticket rows"]
  D -- "rendered in" --> E["Feature Detail Page"]
  D -- "rendered in" --> F["Feature Peek"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FeatureTicketsSection.tsx</strong><dd><code>New shared FeatureTicketsSection component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/product/FeatureTicketsSection.tsx

<ul><li>New shared client component that queries <code>product.ticket.list</code> filtered <br>by <code>featureId</code><br> <li> Renders skeleton while loading and empty state when no tickets exist<br> <li> Displays ticket rows with ID, status badge, title, blockers, Notion <br>sync, priority, and assignee avatar<br> <li> Follows the container-list grammar (bordered container, <br>divider-separated rows) consistent with Scopes, Requirements, and Docs</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/464/files#diff-e361ac5873136c52b0119462eb2641f6da7d58580c2e91462c1dcc208e6462f5">+118/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Wire FeatureTicketsSection into feature detail page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/features/[featureId]/page.tsx

<ul><li>Imports <code>FeatureTicketsSection</code> component<br> <li> Adds a <code>CollapsibleSection</code> titled "Tickets" with count meta between <br>Requirements and Docs sections<br> <li> Passes <code>featureId</code>, <code>productId</code>, <code>productName</code>, <code>funTicketIds</code>, and <br><code>ticketsPath</code> props</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/464/files#diff-30bd7d0f07bc8f48110c19f68c3c57fff8b280851aecfd51bb848b25bce2af6b">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FeaturePeek.tsx</strong><dd><code>Wire FeatureTicketsSection into feature peek</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/product/peek/FeaturePeek.tsx

<ul><li>Imports <code>FeatureTicketsSection</code> component<br> <li> Adds a <code>CollapsibleSection</code> titled "Tickets" with count meta between <br>Requirements and Docs sections in the peek panel<br> <li> Passes required props including <code>basePath</code>-derived <code>ticketsPath</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/464/files#diff-a6cc95e9b0a30c251ca8e13f2a0b0746f5fd2695da89277190dbee3829c0ded1">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>feature.ts</strong><dd><code>Add funTicketIds to feature.getById product select</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/routers/feature.ts

<ul><li>Extends <code>product</code> select in <code>feature.getById</code> to include <code>funTicketIds</code><br> <li> Allows the Tickets section to render display IDs without an additional <br>product fetch</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/464/files#diff-bff1a29f77efa7f846d655a0106c96302d007305d09f09ecb53ab204ef97d03d">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

