### PR TITLE
feat: announce new Sentry bugs in Matrix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,12 @@ SENTRY_BOT_NAME="Errol"
 # falls back to the workspace Zulip integration's default; the topic to "Sentry bugs".
 SENTRY_ZULIP_STREAM=""
 SENTRY_ZULIP_TOPIC=""
+# Optional: Matrix announcement for new Sentry bugs. All three must be set to
+# enable; otherwise a silent no-op. The room must be UNENCRYPTED and the bot
+# must be joined to it. Room id is the internal id (!abc:server), not an alias.
+MATRIX_HOMESERVER_URL=""
+MATRIX_BOT_ACCESS_TOKEN=""
+MATRIX_SENTRY_ROOM_ID=""
 
 # Slack
 SLACK_CLIENT_ID=""

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ db-backups/
 .impeccable/
 .claude/skills/impeccable/
 .claude/skills/verify/
+.env*

--- a/dev-docs/OBSERVABILITY.md
+++ b/dev-docs/OBSERVABILITY.md
@@ -47,6 +47,16 @@ Deploy a preview and trigger any error (previews report with
 Sentry issue has a readable (non-minified) stack trace — if not, source-map
 upload is broken.
 
+## Alerting
+
+New Sentry issues flow through the inbound webhook
+(`/api/webhooks/sentry`) → bug Ticket (authored by Errol) → best-effort
+announcements to **Zulip** (`sentryZulip.ts`) and **Matrix**
+(`sentryMatrix.ts`). The Matrix leg needs `MATRIX_HOMESERVER_URL`,
+`MATRIX_BOT_ACCESS_TOKEN`, and `MATRIX_SENTRY_ROOM_ID` set (see
+`.env.example`); the room must be unencrypted and the bot joined. Recurring
+errors that dedup onto an existing ticket do not re-notify.
+
 ## Other signals
 
 - **Vercel function logs** — tRPC internal errors are also `console.error`ed

--- a/src/server/services/sentry/SentryBugService.ts
+++ b/src/server/services/sentry/SentryBugService.ts
@@ -3,6 +3,7 @@ import { createTicketWithNumber } from "~/plugins/product/server/services/create
 import { ticketUrlId } from "~/lib/fun-ids";
 import { buildBugBody, type SentryBug } from "./sentryPayload";
 import { notifyZulipOfSentryBug } from "./sentryZulip";
+import { notifyMatrixOfSentryBug } from "./sentryMatrix";
 
 /**
  * Ingests a normalized {@link SentryBug} as a Bug Ticket in Exponential.
@@ -154,13 +155,15 @@ export async function ingestSentryBug(
   // Only on creation — recurring errors that dedup above do not re-notify.
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://www.exponential.im";
   const ticketUrl = `${baseUrl}/w/${product.workspace.slug}/products/${product.slug}/tickets/${ticketUrlId(ticket)}`;
-  await notifyZulipOfSentryBug(db, {
+  const bugNotification = {
     workspaceId: product.workspaceId,
     authorId: errol.id,
     title: bug.title,
     ticketUrl,
     sentryUrl: bug.url,
-  });
+  };
+  await notifyZulipOfSentryBug(db, bugNotification);
+  await notifyMatrixOfSentryBug(bugNotification);
 
   return { created: true, ticketId: ticket.id };
 }

--- a/src/server/services/sentry/sentryMatrix.ts
+++ b/src/server/services/sentry/sentryMatrix.ts
@@ -1,0 +1,81 @@
+import type { SentryBugNotification } from "./sentryZulip";
+
+/**
+ * Post a Matrix message announcing a newly-filed Sentry bug, with deep links
+ * to the created Ticket and back into Sentry. Sends via the raw Matrix
+ * client-server API using a bot account's access token — no SDK, no session
+ * state.
+ *
+ * Best-effort, mirroring sentryZulip: a silent no-op unless all three env
+ * vars are set, and any send failure is swallowed so it can never break the
+ * webhook. Called only when a *new* ticket was created (recurring errors that
+ * dedup onto an existing ticket do not re-notify).
+ *
+ * The target room must be UNENCRYPTED — this posts plain events and cannot
+ * participate in E2E encryption.
+ *
+ * Env:
+ * - MATRIX_HOMESERVER_URL   e.g. https://matrix.syntro.fi
+ * - MATRIX_BOT_ACCESS_TOKEN access token of the posting bot account
+ * - MATRIX_SENTRY_ROOM_ID   internal room id (!abc123:syntro.fi), not an alias
+ */
+export async function notifyMatrixOfSentryBug(
+  notification: SentryBugNotification,
+): Promise<void> {
+  const homeserver = process.env.MATRIX_HOMESERVER_URL;
+  const token = process.env.MATRIX_BOT_ACCESS_TOKEN;
+  const roomId = process.env.MATRIX_SENTRY_ROOM_ID;
+  if (!homeserver || !token || !roomId) return;
+
+  try {
+    const htmlLinks = [
+      `<a href="${notification.ticketUrl}">Open ticket</a>`,
+    ];
+    const textLinks = [notification.ticketUrl];
+    if (notification.sentryUrl) {
+      htmlLinks.push(`<a href="${notification.sentryUrl}">View in Sentry</a>`);
+      textLinks.push(notification.sentryUrl);
+    }
+
+    const body = `🐛 New Sentry bug: ${notification.title}\n${textLinks.join("\n")}`;
+    const formattedBody = `🐛 <strong>New Sentry bug:</strong> ${escapeHtml(
+      notification.title,
+    )}<br/>${htmlLinks.join(" · ")}`;
+
+    // PUT with a txn id makes retries idempotent on the homeserver side.
+    const txnId = crypto.randomUUID();
+    const url = `${homeserver.replace(/\/+$/, "")}/_matrix/client/v3/rooms/${encodeURIComponent(
+      roomId,
+    )}/send/m.room.message/${txnId}`;
+
+    const res = await fetch(url, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        msgtype: "m.text",
+        body,
+        format: "org.matrix.custom.html",
+        formatted_body: formattedBody,
+      }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      console.error(
+        `[sentry webhook] Matrix notify failed: ${res.status} ${detail}`,
+      );
+    }
+  } catch (error) {
+    console.error("[sentry webhook] Matrix notify error:", error);
+  }
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}


### PR DESCRIPTION
### **User description**
## Why

New Sentry issues already become bug Tickets (Errol) with a Zulip announcement. The team also wants a ping in Matrix when Sentry opens a new issue.

## What

- `src/server/services/sentry/sentryMatrix.ts` — posts to a Matrix room via the raw client-server API (bot access token, `PUT /send` with txn id for idempotent retries). Mirrors the `sentryZulip` contract exactly: best-effort, silent no-op unless configured, failures swallowed so the webhook can never break, fires only on new-ticket creation (deduped recurring errors stay quiet).
- Wired in `SentryBugService` right after the Zulip announce.
- Env (all three required to enable; see `.env.example`): `MATRIX_HOMESERVER_URL`, `MATRIX_BOT_ACCESS_TOKEN`, `MATRIX_SENTRY_ROOM_ID`. Target room must be **unencrypted** and the bot joined.
- Documented in `dev-docs/OBSERVABILITY.md` (new Alerting section).

## Validation

ESLint + `tsc --noEmit` clean; unit suite via pre-commit; Vercel build via pre-push.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add Matrix room notification for new Sentry bugs

- New `sentryMatrix.ts` mirrors `sentryZulip` best-effort pattern

- Requires three env vars; silent no-op if unset, failures swallowed

- Documented in `OBSERVABILITY.md` and `.env.example`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  webhook["Sentry Webhook\n/api/webhooks/sentry"]
  service["SentryBugService\ningestSentryBug()"]
  ticket["Bug Ticket\n(Errol)"]
  zulip["sentryZulip.ts\nZulip Announce"]
  matrix["sentryMatrix.ts\nMatrix Announce"]
  envvars["Env Vars\nMATRIX_HOMESERVER_URL\nMATRIX_BOT_ACCESS_TOKEN\nMATRIX_SENTRY_ROOM_ID"]

  webhook -- "normalized bug" --> service
  service -- "creates" --> ticket
  service -- "notifyZulipOfSentryBug" --> zulip
  service -- "notifyMatrixOfSentryBug" --> matrix
  envvars -- "required to enable" --> matrix
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sentryMatrix.ts</strong><dd><code>Add Matrix notification service for Sentry bugs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/sentry/sentryMatrix.ts

<ul><li>New file implementing <code>notifyMatrixOfSentryBug</code> function<br> <li> Posts to a Matrix room via raw client-server API using a bot access <br>token<br> <li> Uses <code>PUT /send/{txnId}</code> for idempotent retries; silent no-op if env <br>vars missing<br> <li> Swallows send failures to avoid breaking the webhook; includes HTML <br>escaping helper</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/465/files#diff-1656d96f5600936bf7b92a2e145ec4bd353a298e49d475277326bcc38d383154">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SentryBugService.ts</strong><dd><code>Wire Matrix notification into SentryBugService</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/sentry/SentryBugService.ts

<ul><li>Imports <code>notifyMatrixOfSentryBug</code> from new <code>sentryMatrix.ts</code><br> <li> Refactors notification args into shared <code>bugNotification</code> object<br> <li> Calls <code>notifyMatrixOfSentryBug</code> after existing Zulip notification</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/465/files#diff-0dde9dcd8c1aed7f46faacd632832d501d8a805f9f8bb05920ab17f981832881">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.example</strong><dd><code>Document new Matrix env vars in example config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.env.example

<ul><li>Adds three new optional env vars: <code>MATRIX_HOMESERVER_URL</code>, <br><code>MATRIX_BOT_ACCESS_TOKEN</code>, <code>MATRIX_SENTRY_ROOM_ID</code><br> <li> Documents that all three must be set to enable Matrix notifications<br> <li> Notes room must be unencrypted and bot must be joined</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/465/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OBSERVABILITY.md</strong><dd><code>Document Matrix alerting in observability guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dev-docs/OBSERVABILITY.md

<ul><li>Adds new "Alerting" section describing the Sentry → Ticket → <br>Zulip/Matrix flow<br> <li> Documents required env vars and room constraints for Matrix <br>integration<br> <li> Notes that recurring/deduped errors do not re-notify</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/465/files#diff-e608379e40bafc9cc6a526c79545546dac14663e40ebdbc6733813229078f1a6">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

