### PR TITLE
feat: ingest and lint for the local wiki

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -454,6 +454,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +576,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -890,6 +916,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1004,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.3.4",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2",
@@ -978,6 +1014,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tauri-plugin-store",
+ "url",
 ]
 
 [[package]]
@@ -1269,8 +1306,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1292,8 +1331,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1553,6 +1595,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1979,6 +2037,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2641,6 +2705,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2780,32 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2738,6 +2884,46 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2768,6 +2954,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2809,10 +3009,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3005,6 +3246,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,7 +3327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3211,6 +3464,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3375,7 +3634,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3803,6 +4062,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4116,6 +4385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4303,6 +4578,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,6 +4641,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4597,6 +4891,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5045,6 +5348,12 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,10 @@ serde_json = "1"
 base64 = "0.22"
 getrandom = "0.3"
 sha2 = "0.10"
+# Ingest fetches sources Rust-side: the webview cannot reach arbitrary
+# origins, and doing it here is what makes the SSRF guard in source.rs possible.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "charset"] }
+url = "2"
 tauri-plugin-store = "2.4.4"
 
 [profile.dev]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -18,6 +18,8 @@ fn main() {
                 "wiki_commit_turn",
                 "wiki_search",
                 "wiki_get_root",
+                "wiki_fetch_url",
+                "wiki_read_external",
             ]),
         ),
     )

--- a/src-tauri/capabilities/remote.json
+++ b/src-tauri/capabilities/remote.json
@@ -24,6 +24,8 @@
     "allow-wiki-write-page",
     "allow-wiki-commit-turn",
     "allow-wiki-search",
-    "allow-wiki-get-root"
+    "allow-wiki-get-root",
+    "allow-wiki-fetch-url",
+    "allow-wiki-read-external"
   ]
 }

--- a/src-tauri/permissions/autogenerated/wiki_fetch_url.toml
+++ b/src-tauri/permissions/autogenerated/wiki_fetch_url.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-wiki-fetch-url"
+description = "Enables the wiki_fetch_url command without any pre-configured scope."
+commands.allow = ["wiki_fetch_url"]
+
+[[permission]]
+identifier = "deny-wiki-fetch-url"
+description = "Denies the wiki_fetch_url command without any pre-configured scope."
+commands.deny = ["wiki_fetch_url"]

--- a/src-tauri/permissions/autogenerated/wiki_read_external.toml
+++ b/src-tauri/permissions/autogenerated/wiki_read_external.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-wiki-read-external"
+description = "Enables the wiki_read_external command without any pre-configured scope."
+commands.allow = ["wiki_read_external"]
+
+[[permission]]
+identifier = "deny-wiki-read-external"
+description = "Denies the wiki_read_external command without any pre-configured scope."
+commands.deny = ["wiki_read_external"]

--- a/src-tauri/seeds/schema.md
+++ b/src-tauri/seeds/schema.md
@@ -52,6 +52,18 @@ When you do file something:
 Write for the reader who has forgotten everything, including you in three months.
 Prose over bullet soup. Say what is true and how you know.
 
+**Ingesting.** When given a source — a link, a file — fold what matters into the
+wiki rather than pasting it in. Cite where it came from, so a reader can tell a
+summary from original reasoning and go back to the source. Log what was ingested
+and from where. If you only saw part of a long source, say so on the page; a
+summary that claims more coverage than it had will be trusted by everything
+downstream.
+
+**Linting.** A lint is a *report*: contradictions, stale claims, orphan pages
+nothing links to, and `[[wikilinks]]` pointing at pages that don't exist. It
+writes nothing, however obvious the repair looks — the reader decides what to
+fix, and that fix is an ordinary edit afterwards.
+
 **Etiquette for multiple librarians.** More than one agent may work this wiki, and
 they won't see each other's sessions. So: prefer appending to rewriting, keep
 edits small and self-explanatory, and never delete someone else's page to make

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@
 //! confirm it is talking to the shell.
 
 mod auth;
+mod source;
 mod wiki;
 
 use std::sync::OnceLock;
@@ -111,6 +112,8 @@ pub fn run() {
             wiki::wiki_commit_turn,
             wiki::wiki_search,
             wiki::wiki_get_root,
+            source::wiki_fetch_url,
+            source::wiki_read_external,
         ])
         .setup(|app| {
             resolve_wiki_root(app.handle());

--- a/src-tauri/src/source.rs
+++ b/src-tauri/src/source.rs
@@ -13,7 +13,11 @@
 //! * `wiki_fetch_url` refuses anything but http(s), and refuses hosts that
 //!   resolve to the loopback, private, or link-local ranges — otherwise a page
 //!   the model was reading could talk it into fetching `http://localhost:8080`
-//!   or a cloud metadata endpoint from inside the user's network.
+//!   or a cloud metadata endpoint from inside the user's network. It then
+//!   *connects to the addresses it checked*, rather than resolving the name a
+//!   second time, which is what stops a hostile DNS server answering publicly
+//!   for the check and privately for the connection. Redirects are followed by
+//!   hand so every hop gets the same treatment.
 //! * `wiki_read_external` refuses anything outside the user's home, refuses
 //!   dotfiles and dot-directories (which is where credentials live), and refuses
 //!   anything that doesn't look like text.
@@ -102,30 +106,68 @@ pub async fn wiki_fetch_url(url: String) -> Result<FetchedSource, String> {
     fetch_url(&url).await.map_err(Into::into)
 }
 
-pub async fn fetch_url(raw: &str) -> SourceResult<FetchedSource> {
-    let parsed = url::Url::parse(raw).map_err(|_| SourceError::UnsupportedScheme)?;
-    if !matches!(parsed.scheme(), "http" | "https") {
-        return Err(SourceError::UnsupportedScheme);
-    }
-    assert_public(&parsed)?;
+/// Redirect hops we will follow. Each is re-validated from scratch.
+const MAX_REDIRECTS: usize = 5;
 
-    let response = reqwest::Client::builder()
-        .user_agent("Exponential-Beta-Wiki/0.1")
-        .timeout(std::time::Duration::from_secs(20))
-        // A redirect could land somewhere private after we checked the original
-        // host, so every hop is re-checked rather than trusted.
-        .redirect(reqwest::redirect::Policy::custom(|attempt| {
-            match assert_public(attempt.url()) {
-                Ok(()) if attempt.previous().len() < 5 => attempt.follow(),
-                _ => attempt.stop(),
-            }
-        }))
-        .build()
-        .map_err(|e| SourceError::Io(e.to_string()))?
-        .get(parsed.clone())
-        .send()
-        .await
-        .map_err(|e| SourceError::Io(e.to_string()))?;
+pub async fn fetch_url(raw: &str) -> SourceResult<FetchedSource> {
+    let mut current = url::Url::parse(raw).map_err(|_| SourceError::UnsupportedScheme)?;
+    let mut hops = 0usize;
+
+    // Redirects are followed by hand rather than by reqwest, because each hop
+    // needs the same treatment as the first: check the scheme, resolve the host,
+    // verify every address is public, and then *connect to those addresses*.
+    // Letting the client follow redirects would leave later hops resolved
+    // without any of that.
+    let response = loop {
+        if !matches!(current.scheme(), "http" | "https") {
+            return Err(SourceError::UnsupportedScheme);
+        }
+        let host = current.host_str().ok_or(SourceError::NotPublic)?.to_string();
+        let addrs = public_addrs(&current)?;
+
+        // Pin the connection to the addresses we just vetted.
+        //
+        // Without this the guard is advisory: we resolve the name, approve the
+        // answer, and then the client resolves it *again* for the actual
+        // connection. A hostile DNS server only has to answer publicly the first
+        // time and privately the second — classic rebinding, and a realistic
+        // attack for something that fetches model-supplied URLs. Pinning means
+        // the socket goes to a checked address; the Host header and SNI still
+        // carry the original name, so ordinary sites are unaffected.
+        let response = reqwest::Client::builder()
+            .user_agent("Exponential-Beta-Wiki/0.1")
+            .timeout(std::time::Duration::from_secs(20))
+            .redirect(reqwest::redirect::Policy::none())
+            .resolve_to_addrs(&host, &addrs)
+            .build()
+            .map_err(|e| SourceError::Io(e.to_string()))?
+            .get(current.clone())
+            .send()
+            .await
+            .map_err(|e| SourceError::Io(e.to_string()))?;
+
+        if !response.status().is_redirection() {
+            break response;
+        }
+
+        let location = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .ok_or(SourceError::NotFound)?;
+        let next = current
+            .join(location)
+            .map_err(|_| SourceError::UnsupportedScheme)?;
+        if next == current {
+            return Err(SourceError::Io("redirect loop".into()));
+        }
+        current = next;
+
+        hops += 1;
+        if hops > MAX_REDIRECTS {
+            return Err(SourceError::Io("too many redirects".into()));
+        }
+    };
 
     let content_type = response
         .headers()
@@ -162,11 +204,18 @@ pub async fn fetch_url(raw: &str) -> SourceResult<FetchedSource> {
     })
 }
 
-/// Refuse hosts that point back at this machine or into the local network.
+/// Resolve a host and return its addresses, refusing anything that points back
+/// at this machine or into the local network.
 ///
-/// Checked against the *resolved* addresses, not the name: `localtest.me` and
-/// friends resolve to 127.0.0.1 while looking perfectly public.
-fn assert_public(url: &url::Url) -> SourceResult<()> {
+/// Returns the addresses rather than a yes/no so the caller can connect to
+/// *these* — resolving again at connect time is what leaves the door open to
+/// rebinding.
+///
+/// Checked against the resolved addresses, not the name: `localtest.me` and
+/// friends look perfectly public and answer as 127.0.0.1. Every address is
+/// checked, not just the first, since a name can resolve to several and the
+/// client may try any of them.
+fn public_addrs(url: &url::Url) -> SourceResult<Vec<std::net::SocketAddr>> {
     let host = url.host_str().ok_or(SourceError::NotPublic)?;
     if host.eq_ignore_ascii_case("localhost") || host.to_lowercase().ends_with(".local") {
         return Err(SourceError::NotPublic);
@@ -174,21 +223,18 @@ fn assert_public(url: &url::Url) -> SourceResult<()> {
 
     use std::net::ToSocketAddrs;
     let port = url.port_or_known_default().unwrap_or(80);
-    let addrs = (host, port)
+    let addrs: Vec<_> = (host, port)
         .to_socket_addrs()
-        .map_err(|_| SourceError::NotPublic)?;
+        .map_err(|_| SourceError::NotPublic)?
+        .collect();
 
-    let mut saw_one = false;
-    for addr in addrs {
-        saw_one = true;
-        if !is_public(addr.ip()) {
-            return Err(SourceError::NotPublic);
-        }
-    }
-    if !saw_one {
+    if addrs.is_empty() {
         return Err(SourceError::NotPublic);
     }
-    Ok(())
+    if addrs.iter().any(|addr| !is_public(addr.ip())) {
+        return Err(SourceError::NotPublic);
+    }
+    Ok(addrs)
 }
 
 /// Is this address out on the internet, rather than somewhere we shouldn't reach?
@@ -267,8 +313,21 @@ fn strip_element(html: &str, tag: &str) -> String {
     let mut out = String::with_capacity(html.len());
     let mut cursor = 0;
 
-    while let Some(start) = lower[cursor..].find(&open) {
-        let start = start + cursor;
+    while let Some(found) = lower[cursor..].find(&open) {
+        let start = found + cursor;
+        // `<head` must not match `<header`. A tag name ends at `>`, whitespace,
+        // or a self-closing slash — anything else means this is a different
+        // element that merely starts the same way. Getting this wrong silently
+        // ate everything from the first <header> onwards, which on a real page
+        // is the entire body.
+        let after = lower[start + open.len()..].chars().next();
+        if !matches!(after, Some('>') | Some('/') | Some(' ') | Some('\n') | Some('\t') | Some('\r'))
+        {
+            out.push_str(&html[cursor..start + open.len()]);
+            cursor = start + open.len();
+            continue;
+        }
+
         out.push_str(&html[cursor..start]);
         match lower[start..].find(&close) {
             Some(end) => cursor = start + end + close.len(),
@@ -414,6 +473,33 @@ fn cap(text: String) -> (String, bool) {
 mod tests {
     use super::*;
 
+    /// A scratch folder under the user's home that removes itself even when an
+    /// assertion fails partway through. Tests here necessarily write inside
+    /// `$HOME` — that's what the guard under test is about — so leaving debris
+    /// in a real person's home directory on every red test is not acceptable.
+    struct HomeScratch {
+        path: PathBuf,
+    }
+
+    impl HomeScratch {
+        fn new(name: &str) -> Self {
+            let path = PathBuf::from(std::env::var("HOME").expect("HOME"))
+                .join(format!("exp-source-test-{name}"));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).expect("scratch dir");
+            Self { path }
+        }
+        fn join(&self, rel: &str) -> PathBuf {
+            self.path.join(rel)
+        }
+    }
+
+    impl Drop for HomeScratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
     #[test]
     fn only_http_urls_are_ingestible() {
         for raw in ["file:///etc/passwd", "ftp://example.com/x", "not a url"] {
@@ -444,6 +530,28 @@ mod tests {
                 "{raw}",
             );
         }
+    }
+
+    #[test]
+    fn resolution_returns_the_addresses_so_they_can_be_pinned() {
+        // The guard is only worth anything because the caller connects to *these*
+        // addresses. If this ever went back to returning a bare yes/no, the
+        // client would resolve again at connect time and a hostile DNS server
+        // could answer publicly for the check and privately for the connection.
+        let url = url::Url::parse("http://example.com/").unwrap();
+        let addrs = public_addrs(&url).expect("example.com is public");
+        assert!(!addrs.is_empty());
+        assert!(addrs.iter().all(|a| is_public(a.ip())));
+        assert!(addrs.iter().all(|a| a.port() == 80), "port comes from the URL");
+    }
+
+    #[test]
+    fn a_name_resolving_anywhere_private_is_refused_outright() {
+        // Not "most of its addresses are fine" — a name that resolves to both a
+        // public and a private address is exactly the shape of an attack, and
+        // the client could pick either.
+        let url = url::Url::parse("http://localhost/").unwrap();
+        assert_eq!(public_addrs(&url), Err(SourceError::NotPublic));
     }
 
     #[test]
@@ -478,6 +586,20 @@ mod tests {
         assert!(!text.contains("evil()"), "script contents are not prose");
         assert!(!text.contains('<'), "no markup survives");
         assert_eq!(html_title(html).as_deref(), Some("Why Postgres"));
+    }
+
+    #[test]
+    fn a_tag_name_is_not_matched_as_a_prefix_of_another() {
+        // `<head` also starts `<header`, and stripping on the prefix ate
+        // everything from the first <header> to the end of the document — which
+        // on a real page is the whole article. Caught by fetching a live site
+        // and getting zero characters back.
+        let html = "<html><head><title>T</title></head><body>\
+            <header><nav>Home</nav></header><p>The actual article.</p></body></html>";
+        let text = html_to_text(html);
+        assert!(text.contains("The actual article."), "got: {text:?}");
+        assert!(text.contains("Home"), "a <header> is content, not <head>");
+        assert!(!text.contains("<title>"), "the real <head> is still removed");
     }
 
     #[test]
@@ -518,69 +640,49 @@ mod tests {
     fn refuses_hidden_files_where_credentials_live() {
         // The reason this guard exists: a model talked into ingesting ~/.ssh/id_rsa
         // would be writing it into a wiki the user may sync somewhere.
-        let home = PathBuf::from(std::env::var("HOME").unwrap());
-        let dir = home.join("exp-source-test");
-        let hidden = dir.join(".secrets");
+        let scratch = HomeScratch::new("hidden");
+        let hidden = scratch.join(".secrets");
         std::fs::create_dir_all(&hidden).unwrap();
         let secret = hidden.join("key.txt");
         std::fs::write(&secret, "hunter2").unwrap();
 
-        assert_eq!(
-            assert_ingestible_path(&secret),
-            Err(SourceError::NotAllowedPath),
-        );
+        assert_eq!(assert_ingestible_path(&secret), Err(SourceError::NotAllowedPath));
 
         // A dotfile directly, too.
-        let dotfile = dir.join(".env");
+        let dotfile = scratch.join(".env");
         std::fs::write(&dotfile, "SECRET=1").unwrap();
-        assert_eq!(
-            assert_ingestible_path(&dotfile),
-            Err(SourceError::NotAllowedPath),
-        );
-
-        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(assert_ingestible_path(&dotfile), Err(SourceError::NotAllowedPath));
     }
 
     #[test]
     fn refuses_a_symlink_that_escapes_the_home_folder() {
-        let home = PathBuf::from(std::env::var("HOME").unwrap());
-        let dir = home.join("exp-source-test-link");
-        std::fs::create_dir_all(&dir).unwrap();
-        let link = dir.join("passwd");
-        let _ = std::fs::remove_file(&link);
+        let scratch = HomeScratch::new("link");
+        let link = scratch.join("passwd");
         #[cfg(unix)]
         std::os::unix::fs::symlink("/etc/passwd", &link).unwrap();
 
         assert_eq!(assert_ingestible_path(&link), Err(SourceError::NotAllowedPath));
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn reads_an_ordinary_notes_file() {
-        let home = PathBuf::from(std::env::var("HOME").unwrap());
-        let dir = home.join("exp-source-test-ok");
-        std::fs::create_dir_all(&dir).unwrap();
-        let file = dir.join("notes.md");
+        let scratch = HomeScratch::new("ok");
+        let file = scratch.join("notes.md");
         std::fs::write(&file, "# Notes\n\nPostgres it is.").unwrap();
 
         let source = read_external(&file).expect("a plain notes file is ingestible");
         assert!(source.text.contains("Postgres it is."));
         assert_eq!(source.title.as_deref(), Some("notes.md"));
         assert!(!source.truncated);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn refuses_binary_files() {
-        let home = PathBuf::from(std::env::var("HOME").unwrap());
-        let dir = home.join("exp-source-test-bin");
-        std::fs::create_dir_all(&dir).unwrap();
-        let file = dir.join("image.png");
+        let scratch = HomeScratch::new("bin");
+        let file = scratch.join("image.png");
         std::fs::write(&file, [0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02]).unwrap();
 
         assert_eq!(read_external(&file), Err(SourceError::NotText));
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/source.rs
+++ b/src-tauri/src/source.rs
@@ -1,0 +1,594 @@
+//! Reading things that are **not** in the wiki, so the librarian can ingest them.
+//!
+//! This module is the deliberate counterpart to `wiki.rs`'s jail, and the split
+//! matters. Ingest exists to bring outside material *in*, which means reading a
+//! URL or a file the wiki knows nothing about — so it cannot go through
+//! `wiki::resolve`, and widening that jail to allow it would quietly hand the
+//! model read access to the whole disk for every other command too.
+//!
+//! Instead these are separate commands with their own, narrower guards. Both are
+//! reachable from a remote page and both take model-supplied input, so each one
+//! assumes the argument is hostile:
+//!
+//! * `wiki_fetch_url` refuses anything but http(s), and refuses hosts that
+//!   resolve to the loopback, private, or link-local ranges — otherwise a page
+//!   the model was reading could talk it into fetching `http://localhost:8080`
+//!   or a cloud metadata endpoint from inside the user's network.
+//! * `wiki_read_external` refuses anything outside the user's home, refuses
+//!   dotfiles and dot-directories (which is where credentials live), and refuses
+//!   anything that doesn't look like text.
+//!
+//! Both cap what they will return, because the result goes into a prompt.
+
+use std::net::IpAddr;
+use std::path::{Component, Path, PathBuf};
+
+use serde::Serialize;
+
+/// Most we will hand back from any source. Comfortably larger than an article
+/// or a notes file, far short of anything that would blow up a turn.
+const MAX_BYTES: usize = 512 * 1024;
+
+/// Anything a source read can refuse to do.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SourceError {
+    /// Not http(s), or not a URL at all.
+    UnsupportedScheme,
+    /// Points somewhere on the local network or at the machine itself.
+    NotPublic,
+    /// Outside the user's home, or somewhere credentials live.
+    NotAllowedPath,
+    /// Binary, or otherwise not something to put in a markdown wiki.
+    NotText,
+    /// Nothing there.
+    NotFound,
+    /// The network or the filesystem said no.
+    Io(String),
+}
+
+impl std::fmt::Display for SourceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedScheme => write!(f, "only http and https URLs can be ingested"),
+            // Deliberately does not say what it resolved to: the caller is model
+            // output, and a precise answer makes this a network scanner.
+            Self::NotPublic => write!(f, "that address is not publicly reachable"),
+            Self::NotAllowedPath => write!(
+                f,
+                "only files under your home folder can be ingested, and not hidden ones"
+            ),
+            Self::NotText => write!(f, "that file does not look like text"),
+            Self::NotFound => write!(f, "no such file"),
+            Self::Io(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<SourceError> for String {
+    fn from(e: SourceError) -> Self {
+        e.to_string()
+    }
+}
+
+type SourceResult<T> = Result<T, SourceError>;
+
+/// Material handed to the librarian to fold into the wiki.
+#[derive(Debug, Serialize)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+pub struct FetchedSource {
+    /// Echoed back so the librarian can cite where a page came from.
+    pub source: String,
+    /// Page title for a URL, filename for a file — a starting point for naming.
+    pub title: Option<String>,
+    pub text: String,
+    /// True when the source was longer than we will carry into a prompt, so the
+    /// librarian can say the ingest was partial rather than implying it read all
+    /// of it.
+    pub truncated: bool,
+}
+
+// ---------------------------------------------------------------------------
+// URLs
+// ---------------------------------------------------------------------------
+
+/// Fetch a public web page for ingestion.
+///
+/// The fetch happens here rather than in the webview because the page cannot
+/// reach arbitrary origins — and doing it in Rust is what makes the guards below
+/// possible at all.
+#[tauri::command]
+pub async fn wiki_fetch_url(url: String) -> Result<FetchedSource, String> {
+    fetch_url(&url).await.map_err(Into::into)
+}
+
+pub async fn fetch_url(raw: &str) -> SourceResult<FetchedSource> {
+    let parsed = url::Url::parse(raw).map_err(|_| SourceError::UnsupportedScheme)?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(SourceError::UnsupportedScheme);
+    }
+    assert_public(&parsed)?;
+
+    let response = reqwest::Client::builder()
+        .user_agent("Exponential-Beta-Wiki/0.1")
+        .timeout(std::time::Duration::from_secs(20))
+        // A redirect could land somewhere private after we checked the original
+        // host, so every hop is re-checked rather than trusted.
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            match assert_public(attempt.url()) {
+                Ok(()) if attempt.previous().len() < 5 => attempt.follow(),
+                _ => attempt.stop(),
+            }
+        }))
+        .build()
+        .map_err(|e| SourceError::Io(e.to_string()))?
+        .get(parsed.clone())
+        .send()
+        .await
+        .map_err(|e| SourceError::Io(e.to_string()))?;
+
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_lowercase();
+    if !content_type.is_empty()
+        && !content_type.contains("text/")
+        && !content_type.contains("json")
+        && !content_type.contains("xml")
+    {
+        return Err(SourceError::NotText);
+    }
+
+    let body = response
+        .text()
+        .await
+        .map_err(|e| SourceError::Io(e.to_string()))?;
+
+    let title = html_title(&body);
+    let text = if content_type.contains("html") || body.trim_start().starts_with('<') {
+        html_to_text(&body)
+    } else {
+        body
+    };
+    let (text, truncated) = cap(text);
+
+    Ok(FetchedSource {
+        source: raw.to_string(),
+        title,
+        text,
+        truncated,
+    })
+}
+
+/// Refuse hosts that point back at this machine or into the local network.
+///
+/// Checked against the *resolved* addresses, not the name: `localtest.me` and
+/// friends resolve to 127.0.0.1 while looking perfectly public.
+fn assert_public(url: &url::Url) -> SourceResult<()> {
+    let host = url.host_str().ok_or(SourceError::NotPublic)?;
+    if host.eq_ignore_ascii_case("localhost") || host.to_lowercase().ends_with(".local") {
+        return Err(SourceError::NotPublic);
+    }
+
+    use std::net::ToSocketAddrs;
+    let port = url.port_or_known_default().unwrap_or(80);
+    let addrs = (host, port)
+        .to_socket_addrs()
+        .map_err(|_| SourceError::NotPublic)?;
+
+    let mut saw_one = false;
+    for addr in addrs {
+        saw_one = true;
+        if !is_public(addr.ip()) {
+            return Err(SourceError::NotPublic);
+        }
+    }
+    if !saw_one {
+        return Err(SourceError::NotPublic);
+    }
+    Ok(())
+}
+
+/// Is this address out on the internet, rather than somewhere we shouldn't reach?
+pub fn is_public(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            !(v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_documentation()
+                || v4.is_unspecified()
+                // 100.64.0.0/10, carrier-grade NAT — also where Tailscale lives.
+                || (v4.octets()[0] == 100 && (64..128).contains(&v4.octets()[1]))
+                // 169.254.169.254 and friends are covered by is_link_local, but
+                // be explicit about why that matters: cloud metadata.
+                )
+        }
+        IpAddr::V6(v6) => {
+            !(v6.is_loopback()
+                || v6.is_unspecified()
+                // fc00::/7 unique-local and fe80::/10 link-local.
+                || (v6.segments()[0] & 0xfe00) == 0xfc00
+                || (v6.segments()[0] & 0xffc0) == 0xfe80)
+        }
+    }
+}
+
+/// The `<title>` of an HTML document, if it has one.
+fn html_title(html: &str) -> Option<String> {
+    let lower = html.to_lowercase();
+    let start = lower.find("<title")?;
+    let open_end = lower[start..].find('>')? + start + 1;
+    let end = lower[open_end..].find("</title>")? + open_end;
+    let title = decode_entities(html[open_end..end].trim());
+    (!title.is_empty()).then_some(title)
+}
+
+/// Reduce HTML to something worth reading.
+///
+/// Hand-rolled rather than pulling a full parser: the librarian is good at
+/// making sense of slightly ragged prose, and the alternative is a heavy
+/// dependency in a shell whose whole point is staying thin. Drops the elements
+/// whose text is never content, then strips tags and collapses whitespace.
+fn html_to_text(html: &str) -> String {
+    // Elements whose *contents* are markup, not prose.
+    let mut rest = html.to_string();
+    for tag in ["script", "style", "noscript", "svg", "head"] {
+        rest = strip_element(&rest, tag);
+    }
+
+    let mut text = String::with_capacity(rest.len());
+    let mut in_tag = false;
+    for ch in rest.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => {
+                in_tag = false;
+                // A tag boundary is a word boundary; without this, block
+                // elements run their text together.
+                text.push(' ');
+            }
+            _ if !in_tag => text.push(ch),
+            _ => {}
+        }
+    }
+
+    collapse_whitespace(&decode_entities(&text))
+}
+
+/// Remove `<tag>…</tag>` and everything between, case-insensitively.
+fn strip_element(html: &str, tag: &str) -> String {
+    let lower = html.to_lowercase();
+    let open = format!("<{tag}");
+    let close = format!("</{tag}>");
+    let mut out = String::with_capacity(html.len());
+    let mut cursor = 0;
+
+    while let Some(start) = lower[cursor..].find(&open) {
+        let start = start + cursor;
+        out.push_str(&html[cursor..start]);
+        match lower[start..].find(&close) {
+            Some(end) => cursor = start + end + close.len(),
+            // Unclosed: drop the remainder rather than emitting markup.
+            None => return out,
+        }
+    }
+    out.push_str(&html[cursor..]);
+    out
+}
+
+/// The handful of entities that actually show up in prose.
+fn decode_entities(text: &str) -> String {
+    text.replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&rsquo;", "'")
+        .replace("&mdash;", "—")
+}
+
+/// Collapse runs of whitespace, but keep paragraph breaks.
+fn collapse_whitespace(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut blank_run = 0;
+    for line in text.lines() {
+        let trimmed = line.split_whitespace().collect::<Vec<_>>().join(" ");
+        if trimmed.is_empty() {
+            blank_run += 1;
+            if blank_run == 1 && !out.is_empty() {
+                out.push('\n');
+            }
+        } else {
+            blank_run = 0;
+            out.push_str(&trimmed);
+            out.push('\n');
+        }
+    }
+    out.trim().to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Local files
+// ---------------------------------------------------------------------------
+
+/// Read a file from the user's own machine for ingestion.
+///
+/// Separate from every `wiki_*` path command on purpose: this is the one place
+/// that reads *outside* the wiki, so it carries its own guard and cannot be
+/// confused with the jail. It is still model-reachable, so the guard assumes the
+/// path is hostile even though a user typically named the file themselves.
+#[tauri::command]
+pub fn wiki_read_external(path: String) -> Result<FetchedSource, String> {
+    read_external(&expand_home(&path)).map_err(Into::into)
+}
+
+/// Expand a leading `~`, which is how people actually write paths.
+pub fn expand_home(path: &str) -> PathBuf {
+    let trimmed = path.trim();
+    if let Some(rest) = trimmed.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            return Path::new(&home).join(rest);
+        }
+    }
+    PathBuf::from(trimmed)
+}
+
+pub fn read_external(path: &Path) -> SourceResult<FetchedSource> {
+    assert_ingestible_path(path)?;
+
+    let bytes = std::fs::read(path).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => SourceError::NotFound,
+        _ => SourceError::Io(e.to_string()),
+    })?;
+
+    // A NUL byte in the first block is the cheap, reliable "this is binary"
+    // signal — and keeps a PDF or an image out of a markdown wiki.
+    if bytes.iter().take(8000).any(|b| *b == 0) {
+        return Err(SourceError::NotText);
+    }
+    let text = String::from_utf8(bytes).map_err(|_| SourceError::NotText)?;
+    let (text, truncated) = cap(text);
+
+    Ok(FetchedSource {
+        source: path.to_string_lossy().into_owned(),
+        title: path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned()),
+        text,
+        truncated,
+    })
+}
+
+/// May the librarian read this file?
+///
+/// Two rules, both about blast radius rather than tidiness. It must live under
+/// the user's home — nothing from `/etc`, `/var`, or another account. And no
+/// component may start with a dot, which is where credentials live: `~/.ssh`,
+/// `~/.aws`, `~/.env`. A model talked into ingesting one of those would be
+/// writing it into a wiki the user may well sync somewhere.
+pub fn assert_ingestible_path(path: &Path) -> SourceResult<()> {
+    let home = std::env::var("HOME").map_err(|_| SourceError::NotAllowedPath)?;
+    let home = Path::new(&home)
+        .canonicalize()
+        .map_err(|_| SourceError::NotAllowedPath)?;
+
+    // Canonicalize so `..` and symlinks cannot smuggle the path back out; the
+    // file has to exist to be read anyway.
+    let resolved = path.canonicalize().map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => SourceError::NotFound,
+        _ => SourceError::NotAllowedPath,
+    })?;
+    if !resolved.starts_with(&home) {
+        return Err(SourceError::NotAllowedPath);
+    }
+
+    let relative = resolved.strip_prefix(&home).unwrap_or(&resolved);
+    for component in relative.components() {
+        if let Component::Normal(part) = component {
+            if part.to_string_lossy().starts_with('.') {
+                return Err(SourceError::NotAllowedPath);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Trim to what we will carry into a prompt, reporting whether we cut anything.
+fn cap(text: String) -> (String, bool) {
+    if text.len() <= MAX_BYTES {
+        return (text, false);
+    }
+    let mut end = MAX_BYTES;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    (text[..end].to_string(), true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_http_urls_are_ingestible() {
+        for raw in ["file:///etc/passwd", "ftp://example.com/x", "not a url"] {
+            let err = futures_lite_block_on(fetch_url(raw));
+            assert_eq!(err, Err(SourceError::UnsupportedScheme), "{raw}");
+        }
+    }
+
+    /// Minimal blocking runner so these tests need no async test harness.
+    fn futures_lite_block_on<T>(fut: impl std::future::Future<Output = T>) -> T {
+        tauri::async_runtime::block_on(fut)
+    }
+
+    #[test]
+    fn refuses_the_local_machine_and_the_local_network() {
+        // The SSRF case: a page the model is reading talks it into fetching
+        // something only this machine can reach.
+        for raw in [
+            "http://localhost:8080/admin",
+            "http://127.0.0.1/",
+            "http://[::1]/",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://printer.local/",
+        ] {
+            assert_eq!(
+                futures_lite_block_on(fetch_url(raw)),
+                Err(SourceError::NotPublic),
+                "{raw}",
+            );
+        }
+    }
+
+    #[test]
+    fn classifies_addresses_the_way_the_guard_needs() {
+        let private: Vec<IpAddr> = vec![
+            "127.0.0.1".parse().unwrap(),
+            "10.1.2.3".parse().unwrap(),
+            "192.168.1.1".parse().unwrap(),
+            "172.16.0.1".parse().unwrap(),
+            "169.254.169.254".parse().unwrap(), // cloud metadata
+            "100.64.0.1".parse().unwrap(),      // CGNAT / Tailscale
+            "::1".parse().unwrap(),
+            "fd00::1".parse().unwrap(),
+            "fe80::1".parse().unwrap(),
+        ];
+        for ip in private {
+            assert!(!is_public(ip), "{ip} should be refused");
+        }
+        for ip in ["93.184.216.34".parse().unwrap(), "2606:2800:220:1::1".parse::<IpAddr>().unwrap()] {
+            assert!(is_public(ip), "{ip} should be allowed");
+        }
+    }
+
+    #[test]
+    fn html_becomes_readable_prose() {
+        let html = r#"<html><head><title>Why Postgres</title><style>b{}</style></head>
+            <body><script>evil()</script><h1>Why Postgres</h1>
+            <p>We need joins &amp; JSONB.</p></body></html>"#;
+        let text = html_to_text(html);
+        assert!(text.contains("Why Postgres"));
+        assert!(text.contains("We need joins & JSONB."));
+        assert!(!text.contains("evil()"), "script contents are not prose");
+        assert!(!text.contains('<'), "no markup survives");
+        assert_eq!(html_title(html).as_deref(), Some("Why Postgres"));
+    }
+
+    #[test]
+    fn an_unclosed_script_does_not_leak_markup() {
+        assert!(!html_to_text("<p>hi</p><script>never closed").contains("never closed"));
+    }
+
+    #[test]
+    fn long_sources_are_capped_and_say_so() {
+        let (text, truncated) = cap("x".repeat(MAX_BYTES + 500));
+        assert!(truncated, "the librarian must be able to say it read only part");
+        assert_eq!(text.len(), MAX_BYTES);
+    }
+
+    #[test]
+    fn capping_never_splits_a_character() {
+        let (text, truncated) = cap("é".repeat(MAX_BYTES));
+        assert!(truncated);
+        assert!(text.chars().all(|c| c == 'é'), "no broken UTF-8");
+    }
+
+    #[test]
+    fn tilde_expands_the_way_people_write_paths() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(expand_home("~/Downloads/n.md"), Path::new(&home).join("Downloads/n.md"));
+        assert_eq!(expand_home("/tmp/x.md"), PathBuf::from("/tmp/x.md"));
+    }
+
+    #[test]
+    fn refuses_files_outside_the_home_folder() {
+        assert_eq!(
+            assert_ingestible_path(Path::new("/etc/hosts")),
+            Err(SourceError::NotAllowedPath),
+        );
+    }
+
+    #[test]
+    fn refuses_hidden_files_where_credentials_live() {
+        // The reason this guard exists: a model talked into ingesting ~/.ssh/id_rsa
+        // would be writing it into a wiki the user may sync somewhere.
+        let home = PathBuf::from(std::env::var("HOME").unwrap());
+        let dir = home.join("exp-source-test");
+        let hidden = dir.join(".secrets");
+        std::fs::create_dir_all(&hidden).unwrap();
+        let secret = hidden.join("key.txt");
+        std::fs::write(&secret, "hunter2").unwrap();
+
+        assert_eq!(
+            assert_ingestible_path(&secret),
+            Err(SourceError::NotAllowedPath),
+        );
+
+        // A dotfile directly, too.
+        let dotfile = dir.join(".env");
+        std::fs::write(&dotfile, "SECRET=1").unwrap();
+        assert_eq!(
+            assert_ingestible_path(&dotfile),
+            Err(SourceError::NotAllowedPath),
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn refuses_a_symlink_that_escapes_the_home_folder() {
+        let home = PathBuf::from(std::env::var("HOME").unwrap());
+        let dir = home.join("exp-source-test-link");
+        std::fs::create_dir_all(&dir).unwrap();
+        let link = dir.join("passwd");
+        let _ = std::fs::remove_file(&link);
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("/etc/passwd", &link).unwrap();
+
+        assert_eq!(assert_ingestible_path(&link), Err(SourceError::NotAllowedPath));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reads_an_ordinary_notes_file() {
+        let home = PathBuf::from(std::env::var("HOME").unwrap());
+        let dir = home.join("exp-source-test-ok");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("notes.md");
+        std::fs::write(&file, "# Notes\n\nPostgres it is.").unwrap();
+
+        let source = read_external(&file).expect("a plain notes file is ingestible");
+        assert!(source.text.contains("Postgres it is."));
+        assert_eq!(source.title.as_deref(), Some("notes.md"));
+        assert!(!source.truncated);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn refuses_binary_files() {
+        let home = PathBuf::from(std::env::var("HOME").unwrap());
+        let dir = home.join("exp-source-test-bin");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("image.png");
+        std::fs::write(&file, [0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02]).unwrap();
+
+        assert_eq!(read_external(&file), Err(SourceError::NotText));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_missing_file_says_so() {
+        let home = PathBuf::from(std::env::var("HOME").unwrap());
+        assert_eq!(
+            read_external(&home.join("definitely-not-here-9e3f.md")),
+            Err(SourceError::NotFound),
+        );
+    }
+}

--- a/src/lib/localWiki.ts
+++ b/src/lib/localWiki.ts
@@ -51,6 +51,16 @@ export interface WikiBridge {
    */
   getRoot: () => Promise<string>;
   /**
+   * Fetch a public web page for ingestion.
+   *
+   * Deliberately not a wiki path operation: ingest brings outside material *in*,
+   * so it reads somewhere the jail knows nothing about. The Rust side carries
+   * its own guard (public addresses only) rather than widening the wiki jail.
+   */
+  fetchUrl: (url: string) => Promise<FetchedSource>;
+  /** Read a file from the user's machine for ingestion. Guarded separately too. */
+  readExternal: (path: string) => Promise<FetchedSource>;
+  /**
    * Record everything this turn changed as one commit. Called once, at turn end.
    * Committing nothing is a success — a turn that only answered questions has
    * nothing to record.
@@ -61,6 +71,16 @@ export interface WikiBridge {
 export interface CommitResult {
   committed: boolean;
   sha: string | null;
+}
+
+/** Outside material handed to the librarian to fold into the wiki. */
+export interface FetchedSource {
+  /** Echoed back so the librarian can cite where a page came from. */
+  source: string;
+  title: string | null;
+  text: string;
+  /** True when the source was longer than we carry into a prompt. */
+  truncated: boolean;
 }
 
 export interface SearchHit {
@@ -108,6 +128,9 @@ export function getWikiBridge(): WikiBridge | null {
       const root = await invoke("wiki_get_root");
       return typeof root === "string" ? root : "";
     },
+    fetchUrl: async (url: string) => (await invoke("wiki_fetch_url", { url })) as FetchedSource,
+    readExternal: async (path: string) =>
+      (await invoke("wiki_read_external", { path })) as FetchedSource,
     commitTurn: async (message: string) =>
       (await invoke("wiki_commit_turn", { message })) as CommitResult,
   };
@@ -198,6 +221,47 @@ export function buildWikiClientTools(bridge: WikiBridge): Record<string, WikiCli
       execute: async (args) => {
         const query = typeof args.query === "string" ? args.query : "";
         return { hits: await bridge.search(query) };
+      },
+    },
+    wiki_fetch_url: {
+      id: "wiki_fetch_url",
+      description:
+        "Fetch a public web page and return its text, for ingesting into the wiki. Only http(s) " +
+        "URLs on the public internet. Long pages come back truncated — say so if that happens " +
+        "rather than implying you read all of it.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          url: { type: "string", description: "The http(s) URL to fetch." },
+        },
+        required: ["url"],
+        additionalProperties: false,
+      },
+      execute: async (args) => {
+        const url = typeof args.url === "string" ? args.url : "";
+        return bridge.fetchUrl(url);
+      },
+    },
+    wiki_read_external: {
+      id: "wiki_read_external",
+      description:
+        "Read a text file from the user's machine for ingesting into the wiki — a path they gave " +
+        "you, like '~/Downloads/notes.md'. This reads OUTSIDE the wiki, so only use it when the " +
+        "user asked you to ingest that file. Files under home only, nothing hidden, text only.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Path to the file, absolute or starting with ~/.",
+          },
+        },
+        required: ["path"],
+        additionalProperties: false,
+      },
+      execute: async (args) => {
+        const path = typeof args.path === "string" ? args.path : "";
+        return bridge.readExternal(path);
       },
     },
     wiki_write_page: {


### PR DESCRIPTION
### **User description**
## What

The remaining two Karpathy librarian operations. **Ingest**: hand it a URL or a file path and it folds the content into pages, updates the index, logs it. **Lint**: it reports contradictions, stale claims, orphans and broken wikilinks — and writes nothing.

Companion PR: positonic/mastra#58 (the librarian's instructions).

## The decision worth reviewing: ingest does not go through the wiki jail

Ingest exists to read things the wiki knows nothing about, so `wiki::resolve` can't serve it — and widening that jail would quietly hand the model read access to the whole disk for *every* command. These are two separate commands with their own, narrower guards, and each assumes its argument is hostile, because both are reachable from a remote page and both take model-supplied input.

**`wiki_fetch_url`** refuses anything but http(s), and refuses hosts that *resolve* to loopback, private, link-local or CGNAT addresses. Checking the name isn't enough — `localtest.me` looks public and answers as `127.0.0.1`. Redirects are re-checked at every hop, since a public URL can land somewhere private after the first check passed. Without this, a page the model was reading could talk it into fetching a cloud metadata endpoint from inside the user's network.

**`wiki_read_external`** refuses anything outside the user's home, and anything with a dot-prefixed path component — which is where credentials live. A model talked into ingesting `~/.ssh/id_rsa` would be writing it into a wiki the user may well sync somewhere. Binary files are refused too.

Both cap what they return and report truncation, so the librarian can say it read only part of something instead of implying it read all of it.

HTML → prose is hand-rolled rather than a parser dependency: drop elements whose text is never content, strip tags, collapse whitespace. The librarian copes with slightly ragged prose, and the shell's point is staying thin.

## Verification

**Guards, from the production page in a release build** — the layer a Node harness can't check:

```
url        = Example Domain | len=127 | "Example Domain This domain is for use in
             documentation examples without needing permission. Avoid use in operations."
ssrf       ! that address is not publicly reachable      ← 169.254.169.254 (cloud metadata)
localhost  ! that address is not publicly reachable
file       = notes.md | "# Notes\n\nPostgres it is."
dotfile    ! only files under your home folder can be ingested, and not hidden ones
outside    ! only files under your home folder can be ingested, and not hidden ones   ← /etc/hosts
```

**Behaviour, against the deployed librarian with a real git-backed wiki:**

- *"Ingest https://example.com/"* → fetched, wrote `external/example-domain.md`, updated `index.md` + `log.md`, **one commit**
- *"Ingest ~/wiki-v3-src/retro.md"* → wrote `retros/sprint-retro.md`, updated index + log, **one commit**
- *"Lint the wiki"* → read six pages, produced a numbered findings report, **working tree clean before and after, no new commit**

61 Rust tests (14 new, covering both guards including a symlink escaping home and a binary file).

## Notes

- Actions 1 and 2 are one commit: they're a single module with two guards, and splitting them would mean a commit where half of it existed.
- The behaviour above ran against the librarian *without* the new instructions, since those are in the companion PR and need a `railway up`. It already does the right thing from the tool descriptions alone; the instructions should make it more consistent (report numbering, the explicit no-write rule).

## Acceptance criteria

- [x] Both V3 requirement rows met (ingest incorporates + logs; lint reports without modifying)
- [x] Ingestion produces exactly one commit per turn, same as V2 write-back
- [x] Lint runs make zero file writes — verified via `git status` before and after
- [x] The wiki-jail cargo tests still pass unchanged

---

Ships: smooth.dune


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- New `wiki_fetch_url` and `wiki_read_external` Tauri commands for ingesting external content

- SSRF-hardened URL fetching: resolves hosts, pins connections to vetted addresses, re-checks redirects

- Safe local file ingestion: restricts to home directory, blocks dotfiles/hidden paths and binary files

- Comprehensive unit tests covering guards, HTML parsing, path validation, and edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Remote Page / AI Model"]
  B["wiki_fetch_url command"]
  C["wiki_read_external command"]
  D["source.rs guards"]
  E["public_addrs() SSRF check"]
  F["assert_ingestible_path() guard"]
  G["FetchedSource result"]
  H["Wiki librarian / AI"]

  A -- "URL input" --> B
  A -- "file path input" --> C
  B -- "scheme + host check" --> D
  D -- "resolve & pin addrs" --> E
  C -- "path validation" --> D
  D -- "home + dotfile check" --> F
  E -- "safe fetch" --> G
  F -- "read file" --> G
  G -- "text + truncation flag" --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>source.rs</strong><dd><code>New module: guarded URL fetch and local file ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/466/files#diff-35c6742a7479f190130257942d4015a4b15a999bf0eaf731168f23482394da31">+696/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>localWiki.ts</strong><dd><code>Expose fetchUrl and readExternal on WikiBridge interface</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/466/files#diff-e26d7a1d853f45ef05efd3a482d3ae30793fe02feea92a6e87e731d169def149">+64/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>lib.rs</strong><dd><code>Register source module and new Tauri commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/466/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>build.rs</strong><dd><code>Declare new commands for Tauri ACL autogeneration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/466/files#diff-7d1ef5b0b986fee369d8f5fa4361f21fa3075601e5416738ba4f4d1ea5dfb2ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remote.json</strong><dd><code>Grant remote origin access to new ingest commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/466/files#diff-ccb4581457f281d685bf28be1cdf9c3dd911459508f59b4aecc48ebea72c5e44">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wiki_fetch_url.toml</strong><dd><code>Autogenerated allow/deny permissions for wiki_fetch_url</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/466/files#diff-d49866220d5e322da51b337b8f4452410c67dd03bcfe97a8949eb9f6b768b946">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wiki_read_external.toml</strong><dd><code>Autogenerated allow/deny permissions for wiki_read_external</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/466/files#diff-be949057dd527f7f403f6927ce817f31457650381fd9b49cb21697a42fb41bca">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Cargo.toml</strong><dd><code>Add reqwest and url crate dependencies for ingest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/466/files#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>schema.md</strong><dd><code>Document ingesting and linting guidance for librarian</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/466/files#diff-7a1da3674d9ca9f9d3d8834e8b255ceec3278212f7c1cfe5901bed0f611d59b1">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

