### PR TITLE
feat: agent visual testing - sessions without OAuth, seeded fixture, Playwright

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "exponential-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,8 @@ db-backups/
 .claude/skills/impeccable/
 .claude/skills/verify/
 .env*
+
+# Playwright (agent visual testing)
+/e2e/.auth/
+/e2e/.results/
+/playwright-report/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ Uses **Vitest** with a multi-project config (unit + integration). Tests run auto
 - `npm run test:integration` — Run integration tests (~75s, requires Docker/OrbStack)
 - `npm run test:all` — Run both unit and integration tests
 - `npm run check` — Lint + typecheck (always run before committing)
+- `npm run test:e2e` — Playwright visual/E2E suite: boots `next dev` on :3100, seeds the disposable `dev-fixture` workspace, mints a session (no OAuth), runs `e2e/*.spec.ts`. For ad-hoc authenticated browsing use `npm run dev:seed-fixture` + `npm run dev:session`. **See `/dev-docs/AGENT_VISUAL_TESTING.md`** — this is how to visually verify UI changes without a login wall.
 
 **Unit tests** (`*.test.ts`) — pure function tests, no DB needed:
 - Access control permissions (`src/server/services/access/__tests__/`)

--- a/dev-docs/AGENT_VISUAL_TESTING.md
+++ b/dev-docs/AGENT_VISUAL_TESTING.md
@@ -1,0 +1,85 @@
+# Agent visual testing
+
+How an agent (or a developer) verifies UI changes in a real, authenticated,
+data-bearing app — without an OAuth round-trip and without touching shared
+databases.
+
+## TL;DR
+
+```bash
+npm run test:e2e          # boots next dev on :3100, seeds, mints a session, runs e2e/*.spec.ts
+```
+
+For ad-hoc browsing instead of specs:
+
+```bash
+npm run dev:seed-fixture  # idempotent: workspace dev-fixture → product → feature → tickets
+npm run dev:session       # prints an authjs.session-token cookie for the fixture user
+```
+
+Set the printed cookie in any browser context, then open the URL the seed
+script prints. `npm run dev:session -- --json` for machine-readable output;
+`--email you@example.com` mints for any *existing* user (it never creates one).
+
+## How it works
+
+- The app uses NextAuth v5 with `session: { strategy: "jwt" }`
+  (`src/server/auth/config.ts`), so a session is a self-contained JWE derived
+  from `AUTH_SECRET` + the cookie name as salt. `scripts/dev-fixture/session.ts`
+  calls the same `encode()` the framework uses — no auth-bypass code path
+  exists in the app itself; nothing here ships to the client bundle.
+- `scripts/dev-fixture/seed.ts` seeds a disposable `dev-fixture` workspace:
+  one product (`fixture`), one feature, six tickets across statuses — including
+  one ticket that is deliberately scope-only (attached to a `FeatureScope`,
+  not the feature) because the feature Tickets accordion excludes those by
+  design; the fixture makes the exclusion observable.
+- `e2e/global-setup.ts` runs seed + mint and writes
+  `e2e/.auth/storageState.json` (cookies) and `e2e/.auth/fixture.json`
+  (seeded ids/urls). Both are gitignored. Every spec starts authenticated.
+- `playwright.config.ts` boots `next dev --turbo` on port **3100**
+  (`reuseExistingServer` outside CI), so the suite is one command with no
+  manual startup. Specs are `e2e/*.spec.ts`; vitest owns `*.test.ts`, so the
+  two suites never collide.
+
+## Safety rails
+
+`scripts/dev-fixture/env.ts` guards every entry point (both CLIs and the
+Playwright global-setup):
+
+- refuses `NODE_ENV=production`;
+- hard-blocks managed-service DB hosts (same pattern list as
+  `src/test/test-db.ts`, which exists because a test run once wiped
+  production);
+- requires a localhost-ish `DATABASE_URL` (or one that is explicitly a test
+  DB);
+- loads `.env.local` + `.env` the way `next dev` does — `AUTH_SECRET` lives in
+  `.env.local`, which Prisma's own env loader does **not** read.
+
+A minted cookie only works against a server sharing the local `AUTH_SECRET`;
+it is inert against production.
+
+## Writing specs
+
+- Prefer functional assertions (roles, links, badge text) over pixel diffs —
+  screenshots are attached to every test (`test.info().attach`) for human
+  review instead of being gated on.
+- First navigation to a route on `next dev` pays compile + fetch cost: anchor
+  each test with one generous `toBeVisible({ timeout: FIRST_PAINT_TIMEOUT })`
+  on real content, then assert normally (see `e2e/feature-tickets.spec.ts`).
+- Get seeded ids/urls from `loadFixture()` (`e2e/fixture-data.ts`) rather than
+  hardcoding CUIDs.
+
+## Cleanup
+
+Everything hangs off the fixture workspace; to remove it, delete the
+`dev-fixture` workspace (cascades to product/feature/tickets) and the
+`dev-fixture@exponential.test` user.
+
+## Not built (yet)
+
+- **CI wiring**: needs a Postgres service/testcontainer + `next build` +
+  `playwright install` in the workflow. The suite is CI-shaped already
+  (`forbidOnly`, retries, github reporter) — this is deliberate scope for a
+  follow-up PR.
+- **Pixel-diff gating** (`toHaveScreenshot`): add selectively once the suite
+  has been stable for a while, if at all.

--- a/e2e/feature-tickets.spec.ts
+++ b/e2e/feature-tickets.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Visual verification of the feature Tickets accordion (PR 464) on both
+ * surfaces: the feature detail page and the peek drawer. Runs authenticated
+ * via the storageState minted in global-setup, against the seeded dev-fixture
+ * data (5 feature tickets + 1 scope-only ticket that must stay hidden).
+ *
+ * Assertions are functional (rows, badges, exclusions); a full-page screenshot
+ * is attached to every test for human review rather than pixel-diffed - see
+ * dev-docs/AGENT_VISUAL_TESTING.md for the reasoning.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { loadFixture } from "./fixture-data";
+
+const fixture = loadFixture();
+
+async function attachScreenshot(page: Page, name: string) {
+  await test.info().attach(name, {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+}
+
+/**
+ * First hit on a `next dev` route pays the compile + client fetch cost, which
+ * routinely exceeds the default 5s expect timeout. Anchor each test on content
+ * with one generous wait, then assert normally.
+ */
+const FIRST_PAINT_TIMEOUT = 60_000;
+
+test("feature detail page renders the Tickets accordion with the seeded tickets", async ({ page }) => {
+  await page.goto(fixture.featureUrl);
+  await expect(page.getByText("Tickets accordion fixture").first()).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  await expect(page.getByRole("button", { name: `Tickets ${fixture.featureTicketCount}` })).toBeVisible();
+
+  // Every feature-linked ticket renders as a row linking to its ticket page,
+  // carrying its ID and status badge inside the row.
+  for (const [id, title, status] of [
+    ["FP-1", "Render ticket rows in the accordion", "Done"],
+    ["FP-2", "Wire blocked indicator through ticket.list", "In progress"],
+    ["FP-3", "Empty state copy for ticketless features", "Backlog"],
+    ["FP-4", "Peek drawer keyboard navigation", "QA"],
+    ["FP-5", "Ticket row hover affordances", "Backlog"],
+  ] as const) {
+    const row = page.locator(`a[href*="/products/${fixture.productSlug}/tickets/"]`, { hasText: title });
+    await expect(row, `"${title}" should render as a ticket link`).toBeVisible();
+    await expect(row.getByText(id), `row should show display ID ${id}`).toBeVisible();
+    await expect(row.getByText(status, { exact: true }), `${id} should show status "${status}"`).toBeVisible();
+  }
+
+  // The scope-only ticket is excluded by design (accordion scopes by
+  // featureId, matching feature._count.tickets). Assert "no ticket LINK with
+  // that title" - plain getByText would also match the scope's description,
+  // which mentions it.
+  await expect(page.locator("a", { hasText: "Scope-only ticket" })).toHaveCount(0);
+
+  await attachScreenshot(page, "feature-detail-tickets-accordion");
+});
+
+test("feature peek drawer renders the same Tickets accordion", async ({ page }) => {
+  await page.goto(fixture.peekUrl);
+  await expect(page.getByText("Tickets accordion fixture").first()).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  await expect(page.getByRole("button", { name: `Tickets ${fixture.featureTicketCount}` })).toBeVisible();
+  await expect(
+    page.locator("a", { hasText: "Wire blocked indicator through ticket.list" }),
+  ).toBeVisible();
+  await expect(page.locator("a", { hasText: "Scope-only ticket" })).toHaveCount(0);
+
+  await attachScreenshot(page, "feature-peek-tickets-accordion");
+});

--- a/e2e/fixture-data.ts
+++ b/e2e/fixture-data.ts
@@ -1,0 +1,13 @@
+/**
+ * Reads the seeded-fixture manifest written by global-setup, giving specs the
+ * URLs/ids of the seeded data without hardcoding CUIDs.
+ */
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import type { SeededFixture } from "../scripts/dev-fixture/seed";
+
+export function loadFixture(): SeededFixture {
+  const file = path.join(path.dirname(fileURLToPath(import.meta.url)), ".auth", "fixture.json");
+  return JSON.parse(fs.readFileSync(file, "utf8")) as SeededFixture;
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,53 @@
+/**
+ * Playwright global setup: seed the dev-fixture workspace, mint a session
+ * cookie for the fixture user, and write both into e2e/.auth/ so every spec
+ * starts authenticated with known data - no OAuth round-trip anywhere.
+ *
+ * Runs the same production/managed-DB guards as the fixture scripts, so this
+ * suite physically cannot run against a non-local database.
+ */
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { loadDevEnvOrThrow } from "../scripts/dev-fixture/env";
+
+const AUTH_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), ".auth");
+
+export default async function globalSetup() {
+  loadDevEnvOrThrow();
+
+  // Imported after env loading so PrismaClient sees the right DATABASE_URL.
+  const { PrismaClient } = await import("@prisma/client");
+  const { seedDevFixture, FIXTURE } = await import("../scripts/dev-fixture/seed");
+  const { mintSessionCookie } = await import("../scripts/dev-fixture/session");
+
+  const db = new PrismaClient();
+  try {
+    const fixture = await seedDevFixture(db);
+    const session = await mintSessionCookie(db, { email: FIXTURE.userEmail });
+
+    fs.mkdirSync(AUTH_DIR, { recursive: true });
+    fs.writeFileSync(
+      path.join(AUTH_DIR, "storageState.json"),
+      JSON.stringify({
+        cookies: [
+          {
+            name: session.cookieName,
+            value: session.cookieValue,
+            domain: "localhost",
+            path: "/",
+            expires: Math.floor(session.expiresAt.getTime() / 1000),
+            httpOnly: true,
+            secure: false,
+            sameSite: "Lax" as const,
+          },
+        ],
+        origins: [],
+      }),
+    );
+    // Seeded ids/urls for specs (imported via fixture-data helper).
+    fs.writeFileSync(path.join(AUTH_DIR, "fixture.json"), JSON.stringify(fixture, null, 2));
+  } finally {
+    await db.$disconnect();
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,7 @@
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "^18.0.1",
+        "@playwright/test": "^1.62.1",
         "@tauri-apps/cli": "^2.11.4",
         "@testcontainers/postgresql": "^11.12.0",
         "@testing-library/dom": "^10.4.1",
@@ -6041,6 +6042,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@popperjs/core": {
@@ -20009,6 +20026,53 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
     "okr": "npx tsx scripts/okr-cli.ts",
     "okr:list": "npx tsx scripts/okr-cli.ts list",
     "okr:stats": "npx tsx scripts/okr-cli.ts stats",
-    "okr:workspaces": "npx tsx scripts/okr-cli.ts workspaces"
+    "okr:workspaces": "npx tsx scripts/okr-cli.ts workspaces",
+    "test:e2e": "playwright test",
+    "dev:session": "tsx scripts/dev-session.ts",
+    "dev:seed-fixture": "tsx scripts/seed-dev-fixture.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.104.2",
@@ -146,6 +149,7 @@
   },
   "devDependencies": {
     "@happy-dom/global-registrator": "^18.0.1",
+    "@playwright/test": "^1.62.1",
     "@tauri-apps/cli": "^2.11.4",
     "@testcontainers/postgresql": "^11.12.0",
     "@testing-library/dom": "^10.4.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * E2E / visual verification suite (dev-docs/AGENT_VISUAL_TESTING.md).
+ *
+ * `npx playwright test` is self-contained: the webServer block boots `next dev`
+ * on :3100, and global-setup seeds the dev-fixture workspace and mints a
+ * session cookie into e2e/.auth/ - no OAuth, no manual startup. Specs live in
+ * e2e/*.spec.ts (vitest owns *.test.ts, so the suites never collide).
+ *
+ * Dev-only by construction: global-setup runs the same guards as the fixture
+ * scripts (refuses NODE_ENV=production and non-local databases).
+ */
+const PORT = 3100;
+
+export default defineConfig({
+  testDir: "./e2e",
+  globalSetup: "./e2e/global-setup",
+  outputDir: "./e2e/.results",
+  // First hit on a `next dev` route pays compile + data-fetch cost; give each
+  // test room for one cold route rather than tuning per-assertion timeouts.
+  timeout: 120_000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : [["list"]],
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    storageState: "e2e/.auth/storageState.json",
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: `npx next dev --turbo -p ${PORT}`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/scripts/dev-fixture/env.ts
+++ b/scripts/dev-fixture/env.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared environment loading + safety guards for the dev-fixture tooling
+ * (scripts/dev-session.ts, scripts/seed-dev-fixture.ts, e2e/global-setup.ts).
+ *
+ * These scripts exist so an agent (or a developer) can get an authenticated,
+ * seeded local app without an OAuth round-trip. They must be impossible to
+ * point at production by accident, so the guards mirror the hard-blocks in
+ * src/test/test-db.ts (which exist because a test run once wiped production):
+ * managed-service DB hosts are refused unconditionally, and NODE_ENV=production
+ * refuses to run at all.
+ */
+import path from "path";
+import { fileURLToPath } from "url";
+// CJS default import - `@next/env` exposes no ESM named exports under tsx.
+import nextEnv from "@next/env";
+
+const { loadEnvConfig } = nextEnv;
+// ESM-safe __dirname (tsx runs these as ESM; Playwright's loader as CJS may
+// polyfill import.meta, so fall back either way).
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+
+// Same list as src/test/test-db.ts MANAGED_DB_HOST_PATTERNS. Kept as a copy on
+// purpose: importing from src/test would couple dev tooling to the test
+// harness's module graph (integration-setup mocks, vitest globals).
+const MANAGED_DB_HOST_PATTERNS: RegExp[] = [
+  /\.rlwy\.net/i,
+  /\.railway\.app/i,
+  /\.supabase\./i,
+  /\.neon\.tech/i,
+  /\.amazonaws\.com/i,
+  /\.azure\.com/i,
+  /\.gcp\.cloud/i,
+  /\.fly\.dev/i,
+  /digitalocean/i,
+  /\.aiven\.io/i,
+];
+
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "host.docker.internal"]);
+
+function redact(url: string): string {
+  return url.replace(/\/\/[^@/]*@/, "//***@");
+}
+
+/**
+ * Load .env.local + .env exactly the way `next dev` does (AUTH_SECRET lives in
+ * .env.local, which Prisma's own loader does NOT read), then verify this
+ * environment is a safe target. Throws with a clear message otherwise.
+ */
+export function loadDevEnvOrThrow(): void {
+  if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "[dev-fixture] Refusing to run with NODE_ENV=production. " +
+        "This tooling mints sessions and writes fixture rows - dev only.",
+    );
+  }
+
+  loadEnvConfig(path.resolve(scriptDir, "../.."), true, { info: () => undefined, error: console.error });
+
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    throw new Error("[dev-fixture] DATABASE_URL is not set after loading .env/.env.local");
+  }
+
+  for (const pattern of MANAGED_DB_HOST_PATTERNS) {
+    if (pattern.test(dbUrl)) {
+      throw new Error(
+        `[dev-fixture] Refusing managed-service DB host (matched ${pattern}): ${redact(dbUrl)}\n` +
+          "This tooling writes fixture rows and mints sessions - local databases only.",
+      );
+    }
+  }
+
+  let host: string;
+  try {
+    host = new URL(dbUrl).hostname;
+  } catch {
+    throw new Error(`[dev-fixture] DATABASE_URL is not a parseable URL: ${redact(dbUrl)}`);
+  }
+  if (!LOCAL_HOSTS.has(host) && !/[-_.]test/i.test(dbUrl)) {
+    throw new Error(
+      `[dev-fixture] DATABASE_URL host "${host}" is not local and does not look like a test DB: ${redact(dbUrl)}\n` +
+        "Point DATABASE_URL at a localhost Postgres to use the dev-fixture tooling.",
+    );
+  }
+
+  if (!process.env.AUTH_SECRET) {
+    throw new Error(
+      "[dev-fixture] AUTH_SECRET is not set after loading .env/.env.local - " +
+        "it is required to mint a session cookie the app will accept.",
+    );
+  }
+}

--- a/scripts/dev-fixture/seed.ts
+++ b/scripts/dev-fixture/seed.ts
@@ -1,0 +1,185 @@
+/**
+ * Seed a small, self-contained fixture for visual verification of the product
+ * feature views: one workspace, one product, one feature carrying tickets in
+ * assorted statuses. Everything hangs off the `dev-fixture` workspace slug so
+ * it is obviously disposable and deletable in one cascade.
+ *
+ * Idempotent: stable slugs/numbers, upserts throughout - safe to re-run.
+ *
+ * The ticket spread is deliberate, not decorative:
+ *   - statuses span BACKLOG → DONE so status badges exercise their palette
+ *   - one IN_PROGRESS ticket depends on an open ticket → BlockedIndicator fires
+ *   - one ticket is attached to a scope ONLY (scopeId set, featureId null) -
+ *     the feature Tickets accordion excludes it by design (it scopes by
+ *     featureId, same as feature._count.tickets), so the fixture makes that
+ *     design decision observable: 6 tickets exist, the accordion shows 5.
+ */
+import type { PrismaClient } from "@prisma/client";
+
+export const FIXTURE = {
+  userEmail: "dev-fixture@exponential.test",
+  userName: "Dev Fixture",
+  workspaceSlug: "dev-fixture",
+  workspaceName: "Dev Fixture",
+  productSlug: "fixture",
+  productName: "Fixture Product",
+  featureName: "Tickets accordion fixture",
+} as const;
+
+export interface SeededFixture {
+  userId: string;
+  workspaceSlug: string;
+  productSlug: string;
+  featureId: string;
+  /** App-relative URL of the seeded feature's detail page. */
+  featureUrl: string;
+  /** App-relative URL of the features list with the seeded feature peeked. */
+  peekUrl: string;
+  /** Tickets linked to the feature (visible in the accordion). */
+  featureTicketCount: number;
+  /** Total tickets seeded, including the scope-only one the accordion hides. */
+  totalTicketCount: number;
+}
+
+interface TicketSpec {
+  number: number;
+  title: string;
+  status: "BACKLOG" | "IN_PROGRESS" | "BLOCKED" | "QA" | "DONE";
+  priority: number | null;
+  assign: boolean;
+  /** Attach to the scope INSTEAD of the feature (the excluded case). */
+  scopeOnly?: boolean;
+}
+
+const TICKETS: TicketSpec[] = [
+  { number: 1, title: "Render ticket rows in the accordion", status: "DONE", priority: 1, assign: true },
+  { number: 2, title: "Wire blocked indicator through ticket.list", status: "IN_PROGRESS", priority: 0, assign: true },
+  { number: 3, title: "Empty state copy for ticketless features", status: "BACKLOG", priority: 3, assign: false },
+  { number: 4, title: "Peek drawer keyboard navigation", status: "QA", priority: 2, assign: true },
+  { number: 5, title: "Ticket row hover affordances", status: "BACKLOG", priority: null, assign: false },
+  { number: 6, title: "Scope-only ticket (must NOT appear in the feature accordion)", status: "BACKLOG", priority: null, assign: false, scopeOnly: true },
+];
+
+export async function seedDevFixture(db: PrismaClient): Promise<SeededFixture> {
+  const user = await db.user.upsert({
+    where: { email: FIXTURE.userEmail },
+    update: {},
+    create: {
+      email: FIXTURE.userEmail,
+      name: FIXTURE.userName,
+      emailVerified: new Date(),
+    },
+  });
+
+  const workspace = await db.workspace.upsert({
+    where: { slug: FIXTURE.workspaceSlug },
+    update: {},
+    create: {
+      slug: FIXTURE.workspaceSlug,
+      name: FIXTURE.workspaceName,
+      type: "team",
+      ownerId: user.id,
+    },
+  });
+
+  await db.workspaceUser.upsert({
+    where: { userId_workspaceId: { userId: user.id, workspaceId: workspace.id } },
+    update: { role: "owner" },
+    create: { userId: user.id, workspaceId: workspace.id, role: "owner" },
+  });
+
+  const product = await db.product.upsert({
+    where: { workspaceId_slug: { workspaceId: workspace.id, slug: FIXTURE.productSlug } },
+    update: {},
+    create: {
+      workspaceId: workspace.id,
+      slug: FIXTURE.productSlug,
+      name: FIXTURE.productName,
+      createdById: user.id,
+      // Linear-style IDs (FP-1 ...) rather than fun shortIds: exercises the
+      // generateLinearId branch of the accordion's display-ID logic.
+      funTicketIds: false,
+      ticketCounter: TICKETS.length,
+    },
+  });
+
+  let feature = await db.feature.findFirst({
+    where: { productId: product.id, name: FIXTURE.featureName },
+  });
+  feature ??= await db.feature.create({
+    data: {
+      productId: product.id,
+      name: FIXTURE.featureName,
+      description:
+        "Seeded by scripts/seed-dev-fixture.ts for visual verification of the feature Tickets accordion.",
+      status: "IN_PROGRESS",
+      createdById: user.id,
+    },
+  });
+
+  let scope = await db.featureScope.findFirst({
+    where: { featureId: feature.id, version: "v1.0" },
+  });
+  scope ??= await db.featureScope.create({
+    data: {
+      featureId: feature.id,
+      version: "v1.0",
+      description: "First slice - carries the scope-only ticket.",
+      status: "IN_PROGRESS",
+    },
+  });
+
+  const byNumber = new Map<number, string>();
+  for (const spec of TICKETS) {
+    const ticket = await db.ticket.upsert({
+      where: { productId_number: { productId: product.id, number: spec.number } },
+      update: {
+        status: spec.status,
+        featureId: spec.scopeOnly ? null : feature.id,
+        scopeId: spec.scopeOnly ? scope.id : null,
+      },
+      create: {
+        productId: product.id,
+        number: spec.number,
+        title: spec.title,
+        type: "FEATURE",
+        status: spec.status,
+        priority: spec.priority,
+        featureId: spec.scopeOnly ? null : feature.id,
+        scopeId: spec.scopeOnly ? scope.id : null,
+        createdById: user.id,
+        assigneeId: spec.assign ? user.id : null,
+      },
+    });
+    byNumber.set(spec.number, ticket.id);
+  }
+
+  // Ticket 2 (IN_PROGRESS) depends on open ticket 3 → derived isBlocked=true,
+  // so the accordion's BlockedIndicator renders.
+  await db.ticketDependency.upsert({
+    where: {
+      ticketId_dependsOnId: {
+        ticketId: byNumber.get(2)!,
+        dependsOnId: byNumber.get(3)!,
+      },
+    },
+    update: {},
+    create: {
+      ticketId: byNumber.get(2)!,
+      dependsOnId: byNumber.get(3)!,
+      createdById: user.id,
+    },
+  });
+
+  const base = `/w/${FIXTURE.workspaceSlug}/products/${FIXTURE.productSlug}`;
+  return {
+    userId: user.id,
+    workspaceSlug: FIXTURE.workspaceSlug,
+    productSlug: FIXTURE.productSlug,
+    featureId: feature.id,
+    featureUrl: `${base}/features/${feature.id}`,
+    peekUrl: `${base}/features?peek=${feature.id}`,
+    featureTicketCount: TICKETS.filter((t) => !t.scopeOnly).length,
+    totalTicketCount: TICKETS.length,
+  };
+}

--- a/scripts/dev-fixture/session.ts
+++ b/scripts/dev-fixture/session.ts
@@ -1,0 +1,71 @@
+/**
+ * Mint a NextAuth session cookie for an EXISTING user - no OAuth round-trip.
+ *
+ * The app uses `session: { strategy: "jwt" }` (src/server/auth/config.ts), so a
+ * session is a self-contained JWE encrypted with a key derived from
+ * AUTH_SECRET + the cookie name as salt. `encode()` from next-auth/jwt is the
+ * exact function the framework itself uses; we only supply the payload the
+ * app's `jwt` callback would have produced after a real sign-in (sub, email,
+ * isAdmin).
+ *
+ * Deliberately refuses to create users: minting is for pointing a browser at
+ * data that already exists, and the seed script owns fixture creation.
+ */
+import type { PrismaClient } from "@prisma/client";
+import { encode } from "next-auth/jwt";
+
+/**
+ * Cookie name on plain-http localhost. NextAuth prefixes `__Secure-` when
+ * serving over https - if you run `next dev --experimental-https`, this (and
+ * the salt, which must equal the cookie name) both change.
+ */
+export const SESSION_COOKIE_NAME = "authjs.session-token";
+
+const DEFAULT_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
+
+export interface MintedSession {
+  cookieName: string;
+  cookieValue: string;
+  userId: string;
+  email: string;
+  expiresAt: Date;
+}
+
+export async function mintSessionCookie(
+  db: PrismaClient,
+  opts: { email: string; maxAgeSeconds?: number },
+): Promise<MintedSession> {
+  const user = await db.user.findUnique({
+    where: { email: opts.email },
+    select: { id: true, email: true, name: true, image: true, isAdmin: true },
+  });
+  if (!user?.email) {
+    throw new Error(
+      `[dev-session] No user with email "${opts.email}". ` +
+        "This script never creates users - run scripts/seed-dev-fixture.ts first, " +
+        "or pass the email of a user that already exists locally.",
+    );
+  }
+
+  const maxAge = opts.maxAgeSeconds ?? DEFAULT_MAX_AGE_SECONDS;
+  const cookieValue = await encode({
+    token: {
+      sub: user.id,
+      email: user.email,
+      name: user.name,
+      picture: user.image,
+      isAdmin: user.isAdmin,
+    },
+    secret: process.env.AUTH_SECRET!,
+    salt: SESSION_COOKIE_NAME,
+    maxAge,
+  });
+
+  return {
+    cookieName: SESSION_COOKIE_NAME,
+    cookieValue,
+    userId: user.id,
+    email: user.email,
+    expiresAt: new Date(Date.now() + maxAge * 1000),
+  };
+}

--- a/scripts/dev-session.ts
+++ b/scripts/dev-session.ts
@@ -1,0 +1,46 @@
+/**
+ * Mint a NextAuth session cookie for an existing local user - no OAuth.
+ *
+ *   npx tsx scripts/dev-session.ts                       # fixture user
+ *   npx tsx scripts/dev-session.ts --email you@x.com     # any existing user
+ *   npx tsx scripts/dev-session.ts --json                # machine-readable
+ *
+ * Dev-only: refuses NODE_ENV=production and non-local databases (see
+ * scripts/dev-fixture/env.ts). The cookie only works against a server sharing
+ * this environment's AUTH_SECRET.
+ */
+import { loadDevEnvOrThrow } from "./dev-fixture/env";
+
+async function main() {
+  loadDevEnvOrThrow();
+
+  // Imported after env loading so PrismaClient sees the right DATABASE_URL.
+  const { PrismaClient } = await import("@prisma/client");
+  const { mintSessionCookie } = await import("./dev-fixture/session");
+  const { FIXTURE } = await import("./dev-fixture/seed");
+
+  const args = process.argv.slice(2);
+  const emailFlag = args.indexOf("--email");
+  const email = emailFlag >= 0 ? args[emailFlag + 1] : FIXTURE.userEmail;
+  if (!email) throw new Error("--email requires a value");
+
+  const db = new PrismaClient();
+  try {
+    const session = await mintSessionCookie(db, { email });
+    if (args.includes("--json")) {
+      console.log(JSON.stringify(session, null, 2));
+    } else {
+      console.log(`User:    ${session.email} (${session.userId})`);
+      console.log(`Expires: ${session.expiresAt.toISOString()}`);
+      console.log(`Cookie:  ${session.cookieName}=${session.cookieValue}`);
+      console.log(`\ncurl example:\n  curl -H "Cookie: ${session.cookieName}=${session.cookieValue}" http://localhost:3000/`);
+    }
+  } finally {
+    await db.$disconnect();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/seed-dev-fixture.ts
+++ b/scripts/seed-dev-fixture.ts
@@ -1,0 +1,35 @@
+/**
+ * Seed the disposable `dev-fixture` workspace for visual verification.
+ *
+ *   npx tsx scripts/seed-dev-fixture.ts
+ *
+ * Idempotent - safe to re-run. Dev-only: refuses NODE_ENV=production and
+ * non-local databases (see scripts/dev-fixture/env.ts). To remove everything,
+ * delete the `dev-fixture` workspace (cascades) and the fixture user.
+ */
+import { loadDevEnvOrThrow } from "./dev-fixture/env";
+
+async function main() {
+  loadDevEnvOrThrow();
+
+  const { PrismaClient } = await import("@prisma/client");
+  const { seedDevFixture, FIXTURE } = await import("./dev-fixture/seed");
+
+  const db = new PrismaClient();
+  try {
+    const fixture = await seedDevFixture(db);
+    console.log(`Seeded fixture workspace "${FIXTURE.workspaceSlug}"`);
+    console.log(`  user:            ${FIXTURE.userEmail}`);
+    console.log(`  feature tickets: ${fixture.featureTicketCount} (of ${fixture.totalTicketCount} seeded - one is scope-only and excluded by design)`);
+    console.log(`  feature page:    ${fixture.featureUrl}`);
+    console.log(`  peek view:       ${fixture.peekUrl}`);
+    console.log(`\nMint a session for the fixture user with:\n  npx tsx scripts/dev-session.ts`);
+  } finally {
+    await db.$disconnect();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
### **User description**
## Problem

PR 464 shipped without anyone seeing the UI render. The dev server ran, but every authenticated route redirected to sign-in, and an agent cannot complete an OAuth flow — so compile/lint/unit tests were the only verification. This closes that gap permanently.

## What this adds

**One-command visual verification:**

```bash
npm run test:e2e   # boots next dev on :3100, seeds, mints a session, runs e2e/*.spec.ts
```

**For ad-hoc authenticated browsing:**

```bash
npm run dev:seed-fixture   # idempotent dev-fixture workspace → product → feature → tickets
npm run dev:session        # prints an authjs.session-token cookie (never creates users)
```

### How

- **Session without OAuth** — the app uses NextAuth v5 `strategy: "jwt"`, so a session is a self-contained JWE derived from `AUTH_SECRET` + cookie-name salt. `scripts/dev-fixture/session.ts` calls the same `encode()` the framework uses. **No auth-bypass path is added to the app** — nothing here ships in the bundle, and a minted cookie is inert against any server with a different `AUTH_SECRET`.
- **Seed data worth looking at** — `scripts/dev-fixture/seed.ts` creates a disposable `dev-fixture` workspace: six tickets across statuses, one blocked by an open dependency (exercises `BlockedIndicator`), and one deliberately scope-only — the case the feature Tickets accordion excludes by design, made observable (6 exist, accordion shows 5).
- **Playwright** — `webServer` boots the app itself; `global-setup` seeds + mints into gitignored `e2e/.auth/`. `e2e/feature-tickets.spec.ts` retroactively covers PR 464 on both surfaces (detail page + peek): row links, display IDs, status badges, scope-only exclusion. Screenshots attached per test for human review; no pixel-diff gating. Specs are `*.spec.ts`, vitest owns `*.test.ts` — no collision.
- **Safety rails** (`scripts/dev-fixture/env.ts`, every entry point): refuses `NODE_ENV=production`, hard-blocks managed-service DB hosts (same list as `src/test/test-db.ts`), requires a local `DATABASE_URL`, loads `.env.local` + `.env` the way `next dev` does.
- `.claude/launch.json` encodes app startup; `dev-docs/AGENT_VISUAL_TESTING.md` documents the workflow; CLAUDE.md points at it.

## Verification

- Full loop proven end-to-end: seed → mint → `/api/auth/session` returns the fixture session → authenticated feature page rendered in a real browser (accordion, FP-* IDs, blocked indicator, exclusion all confirmed visually).
- `npx playwright test`: **2 passed** (~22s including server boot).
- `tsc --noEmit` and ESLint clean; full unit suite green via pre-commit hook.

## Out of scope (deliberate)

- **CI wiring** — needs Postgres service + `next build` + `playwright install` in the workflow; config is already CI-shaped (`forbidOnly`, retries, github reporter). Follow-up PR.
- **Pixel-diff gating** — add `toHaveScreenshot()` selectively once the suite has soak time, if at all.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add Playwright E2E suite for authenticated visual verification without OAuth

- Add dev-fixture seed script creating workspace, product, feature, and 6 tickets

- Add session minting script using NextAuth `encode()` to generate valid JWE cookies

- Add safety guards blocking production/managed-DB usage across all fixture tooling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["npm run test:e2e"]
  B["playwright.config.ts\n(webServer: next dev :3100)"]
  C["e2e/global-setup.ts"]
  D["scripts/dev-fixture/env.ts\n(safety guards)"]
  E["scripts/dev-fixture/seed.ts\n(upsert workspace/product/feature/tickets)"]
  F["scripts/dev-fixture/session.ts\n(encode() → JWE cookie)"]
  G["e2e/.auth/storageState.json\n+ fixture.json"]
  H["e2e/feature-tickets.spec.ts\n(functional assertions + screenshots)"]

  A -- "boots" --> B
  A -- "runs" --> C
  C -- "loads env via" --> D
  C -- "calls" --> E
  C -- "calls" --> F
  E -- "writes" --> G
  F -- "writes" --> G
  G -- "storageState" --> H
  B -- "serves app to" --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>feature-tickets.spec.ts</strong><dd><code>Playwright specs for feature Tickets accordion on detail and peek</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-60d35647d3f277e98719a671835fd9b835067fff771e0b1909d712dd2d46264a">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fixture-data.ts</strong><dd><code>Helper to load seeded fixture manifest for specs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-a4187bd1485a8e901d08fdaaac767b9224fe53efd9580e6661969d198b497daf">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>global-setup.ts</strong><dd><code>Playwright global setup: seed fixture and mint session cookie</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-74fc75d071389f4aeb53655c72791fc553969e3e69c4db5b8d9c7d5b55a9c6bc">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>playwright.config.ts</strong><dd><code>Playwright configuration with webServer and auth storageState</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>launch.json</strong><dd><code>Claude launch config for app dev server startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-f02a361fa828af1bddd7c60baccb9ec7036882b427c5e6f2d734cf6414f3b36c">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>env.ts</strong><dd><code>Safety guards: block production and managed-DB usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-82064b12e479bd80bedeb32cea462921b230845c61a83de082b25670eef1f187">+92/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>seed.ts</strong><dd><code>Idempotent seed script for dev-fixture workspace and tickets</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-8018aeac7e376bda1b432246950f7b08afcb9fc18c457f7bcbecb56db13ad204">+185/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>session.ts</strong><dd><code>Mint NextAuth JWT session cookie without OAuth round-trip</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-44af5c90e32b49575bee2629161f7d2e3a884599d1d6db689dab43dd77b06983">+71/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dev-session.ts</strong><dd><code>CLI entry point to mint and print session cookie</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-aa4a979e64a9eb3dd58640b3990aea3f71b4779a83d15bb894d28a05c97bf19e">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>seed-dev-fixture.ts</strong><dd><code>CLI entry point to seed dev-fixture workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-767d700608177967056879162c643304519251c738479ec2fab6dad017900301">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CLAUDE.md</strong><dd><code>Document test:e2e command and visual testing workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENT_VISUAL_TESTING.md</strong><dd><code>New guide for agent visual testing without OAuth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-29890adbb485d57adef87462331a74e11dc38b8c54830a373459383b39b3f6a2">+85/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Add Playwright dependency and test:e2e, dev:session, dev:seed-fixture </code><br><code>scripts</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/468/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

