### PR TITLE
feat: label Sentry bugs ai-fixable for allowlisted projects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,12 @@ SENTRY_BOT_NAME="Errol"
 # falls back to the workspace Zulip integration's default; the topic to "Sentry bugs".
 SENTRY_ZULIP_STREAM=""
 SENTRY_ZULIP_TOPIC=""
+# Comma-separated Sentry project slugs whose bugs get the `ai-fixable` label
+# (candidates for the AI bug fixer). The webhook is org-wide, so this keeps
+# other services' errors — which live in other repos — out of the queue.
+# Unset ⇒ no ticket is labelled. Note the fixer's real gate is status
+# READY_TO_PLAN, so a labelled ticket still waits for human triage.
+SENTRY_AI_FIXABLE_PROJECTS=""
 # Optional: Matrix announcement for new Sentry bugs. All three must be set to
 # enable; otherwise a silent no-op. The room must be UNENCRYPTED and the bot
 # must be joined to it. Room id is the internal id (!abc:server), not an alias.

--- a/dev-docs/OBSERVABILITY.md
+++ b/dev-docs/OBSERVABILITY.md
@@ -57,6 +57,17 @@ announcements to **Zulip** (`sentryZulip.ts`) and **Matrix**
 `.env.example`); the room must be unencrypted and the bot joined. Recurring
 errors that dedup onto an existing ticket do not re-notify.
 
+Tickets are labelled `Sentry` + `bug`, and additionally `ai-fixable` when the
+issue's Sentry project is listed in `SENTRY_AI_FIXABLE_PROJECTS` — the
+allowlist exists because the webhook is org-wide and a bug from another
+service's project lives in another repo, where the AI bug fixer (which checks
+out *this* repo) could not fix it.
+
+**The label alone does not start an AI run.** `.github/workflows/ai-bug-fixer.yml`
+selects on `--status READY_TO_PLAN --label ai-fixable`, and Sentry files
+tickets as `BACKLOG`. A human moving the ticket to `READY_TO_PLAN` is what
+arms it — deliberate, since a raw stack trace is rarely a sufficient spec.
+
 ## Other signals
 
 - **Vercel function logs** — tRPC internal errors are also `console.error`ed

--- a/src/server/services/sentry/SentryBugService.ts
+++ b/src/server/services/sentry/SentryBugService.ts
@@ -47,6 +47,35 @@ const TICKET_LABELS = [
   { name: "bug", slug: "bug", color: "avatar-red" },
 ] as const;
 
+// Marks the ticket as a candidate for the AI bug fixer. The workflow's real
+// gate is status READY_TO_PLAN (see .github/workflows/ai-bug-fixer.yml) — this
+// label alone does not start a run, so a human still triages the ticket out of
+// BACKLOG before any agent touches it.
+const AI_FIXABLE_LABEL = {
+  name: "ai-fixable",
+  slug: "ai-fixable",
+  color: "avatar-blue",
+} as const;
+
+/**
+ * Whether a Sentry issue's project maps to *this* codebase. The webhook is
+ * org-wide, so mastra-agents errors arrive here too — labelling those
+ * `ai-fixable` would point the fixer (which checks out this repo) at a bug
+ * that doesn't live here.
+ *
+ * `SENTRY_AI_FIXABLE_PROJECTS` is a comma-separated allowlist of Sentry
+ * project slugs. Unset ⇒ no ticket is labelled, so enabling the behaviour is
+ * an explicit, per-environment opt-in.
+ */
+function isAiFixableProject(projectSlug: string | null): boolean {
+  const allowlist = (process.env.SENTRY_AI_FIXABLE_PROJECTS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (allowlist.length === 0 || !projectSlug) return false;
+  return allowlist.includes(projectSlug);
+}
+
 /**
  * Find-or-create each workspace label and attach it to the ticket. Idempotent
  * (both upserts) and best-effort — a tagging failure is logged but never breaks
@@ -58,8 +87,9 @@ async function labelTicket(
   ticketId: string,
   workspaceId: string,
   authorId: string,
+  extraLabels: readonly { name: string; slug: string; color: string }[] = [],
 ): Promise<void> {
-  for (const label of TICKET_LABELS) {
+  for (const label of [...TICKET_LABELS, ...extraLabels]) {
     try {
       const tag = await db.tag.upsert({
         where: { slug_workspaceId: { slug: label.slug, workspaceId } },
@@ -149,7 +179,13 @@ export async function ingestSentryBug(
   });
 
   // Tag it with the workspace's "Sentry" and "bug" labels so these are filterable.
-  await labelTicket(db, ticket.id, product.workspaceId, errol.id);
+  await labelTicket(
+    db,
+    ticket.id,
+    product.workspaceId,
+    errol.id,
+    isAiFixableProject(bug.projectSlug) ? [AI_FIXABLE_LABEL] : [],
+  );
 
   // Announce the new bug in Zulip (best-effort) with a deep link to the ticket.
   // Only on creation — recurring errors that dedup above do not re-notify.

--- a/src/server/services/sentry/__tests__/SentryBugService.test.ts
+++ b/src/server/services/sentry/__tests__/SentryBugService.test.ts
@@ -39,6 +39,7 @@ const bug: SentryBug = {
   culprit: "app/page.tsx",
   url: "https://sentry.io/issues/42",
   shortId: "EXPONENTIAL-1AB",
+  projectSlug: "exponential-frontend",
 };
 
 beforeEach(() => {
@@ -48,6 +49,7 @@ beforeEach(() => {
   delete process.env.SENTRY_BOT_EMAIL;
   delete process.env.SENTRY_BOT_NAME;
   delete process.env.NEXT_PUBLIC_APP_URL;
+  delete process.env.SENTRY_AI_FIXABLE_PROJECTS;
   dbMock.product.findUnique.mockResolvedValue(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     {
@@ -114,6 +116,47 @@ describe("ingestSentryBug", () => {
     await ingestSentryBug(dbMock, bug);
     const arg = vi.mocked(createTicketWithNumber).mock.calls[0]![1];
     expect(arg.priority).toBeUndefined();
+  });
+
+  describe("ai-fixable label", () => {
+    it("is not applied when the allowlist is unset (opt-in only)", async () => {
+      await ingestSentryBug(dbMock, bug);
+
+      const slugs = dbMock.tag.upsert.mock.calls.map(
+        (c) => c[0].where.slug_workspaceId?.slug,
+      );
+      expect(slugs).not.toContain("ai-fixable");
+    });
+
+    it("is applied when the issue's Sentry project is allowlisted", async () => {
+      process.env.SENTRY_AI_FIXABLE_PROJECTS = "exponential-frontend";
+
+      await ingestSentryBug(dbMock, bug);
+
+      expect(dbMock.tag.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            slug_workspaceId: { slug: "ai-fixable", workspaceId: "ws-1" },
+          },
+          create: expect.objectContaining({
+            name: "ai-fixable",
+            slug: "ai-fixable",
+            category: "label",
+          }),
+        }),
+      );
+    });
+
+    it("is withheld for a project outside the allowlist (e.g. the backend service)", async () => {
+      process.env.SENTRY_AI_FIXABLE_PROJECTS = "exponential-frontend";
+
+      await ingestSentryBug(dbMock, { ...bug, projectSlug: "mastra-agents" });
+
+      const slugs = dbMock.tag.upsert.mock.calls.map(
+        (c) => c[0].where.slug_workspaceId?.slug,
+      );
+      expect(slugs).not.toContain("ai-fixable");
+    });
   });
 
   it("find-or-creates the 'Sentry' and 'bug' workspace labels and attaches them", async () => {

--- a/src/server/services/sentry/__tests__/sentryPayload.test.ts
+++ b/src/server/services/sentry/__tests__/sentryPayload.test.ts
@@ -81,6 +81,7 @@ describe("normalizeSentryPayload", () => {
           culprit: "app/page.tsx",
           permalink: "https://sentry.io/issues/42",
           shortId: "EXPONENTIAL-1AB",
+          project: { slug: "exponential-frontend" },
         },
       },
     });
@@ -91,7 +92,16 @@ describe("normalizeSentryPayload", () => {
       culprit: "app/page.tsx",
       url: "https://sentry.io/issues/42",
       shortId: "EXPONENTIAL-1AB",
+      projectSlug: "exponential-frontend",
     });
+  });
+
+  it("leaves projectSlug null when the payload omits the project", () => {
+    const bug = normalizeSentryPayload("issue", {
+      action: "created",
+      data: { issue: { id: 7, title: "No project in payload" } },
+    });
+    expect(bug?.projectSlug).toBeNull();
   });
 
   it("returns null for issue/created without an id (malformed)", () => {
@@ -123,6 +133,7 @@ describe("normalizeSentryPayload", () => {
           level: "fatal",
           culprit: "lib/parse.ts",
           web_url: "https://sentry.io/issues/99/events/abc",
+          project_slug: "exponential-frontend",
         },
       },
     });
@@ -133,6 +144,7 @@ describe("normalizeSentryPayload", () => {
       culprit: "lib/parse.ts",
       url: "https://sentry.io/issues/99/events/abc",
       shortId: null,
+      projectSlug: "exponential-frontend",
     });
   });
 

--- a/src/server/services/sentry/sentryPayload.ts
+++ b/src/server/services/sentry/sentryPayload.ts
@@ -18,6 +18,12 @@ export interface SentryBug {
   url: string | null;
   /** Short, friendly id like "EXPONENTIAL-1AB" (only present on the `issue` resource). */
   shortId: string | null;
+  /**
+   * Sentry project slug the issue belongs to (e.g. "exponential-frontend").
+   * The webhook is org-wide, so this is how we tell this app's errors from
+   * other services' (mastra-agents). Null when the payload omits it.
+   */
+  projectSlug: string | null;
 }
 
 /** Minimal view of the Sentry webhook body — only the fields we read. */
@@ -31,6 +37,7 @@ interface SentryWebhookBody {
       culprit?: string;
       permalink?: string;
       shortId?: string;
+      project?: { slug?: string };
     };
     event?: {
       issue_id?: string | number;
@@ -38,6 +45,7 @@ interface SentryWebhookBody {
       level?: string;
       culprit?: string;
       web_url?: string;
+      project_slug?: string;
     };
   };
 }
@@ -120,6 +128,7 @@ export function normalizeSentryPayload(
       culprit: issue.culprit ?? null,
       url: issue.permalink ?? null,
       shortId: issue.shortId ?? null,
+      projectSlug: issue.project?.slug ?? null,
     };
   }
 
@@ -134,6 +143,7 @@ export function normalizeSentryPayload(
       url: event.web_url ?? null,
       // `event_alert` payloads don't carry a short id.
       shortId: null,
+      projectSlug: event.project_slug ?? null,
     };
   }
 


### PR DESCRIPTION
### **User description**
## Why

Sentry-filed bug Tickets should be visible to the AI bug fixer.

## What

- Adds the `ai-fixable` label to Sentry-filed tickets, gated on `SENTRY_AI_FIXABLE_PROJECTS` (comma-separated Sentry project slugs).
- Threads the Sentry project slug through payload normalization (`data.issue.project.slug` / `data.event.project_slug`) so that decision is possible.
- 4 new unit tests; all 50 Sentry-area tests pass.

## Two design notes worth reviewing

**1. The label does not by itself start an AI run.** `.github/workflows/ai-bug-fixer.yml` selects on `--status READY_TO_PLAN --label ai-fixable`, and this service files tickets as `BACKLOG`. So a labelled ticket waits for a human to move it to `READY_TO_PLAN`. Kept deliberately: a raw stack trace is a thin spec, and auto-arming every production error lets one noisy error burn metered budget and open PRs unattended. Trivial to change if we want full automation.

**2. Why an allowlist rather than labelling everything.** The inbound webhook is org-wide, so `mastra-agents` errors also file tickets here. Labelling those `ai-fixable` would hand the fixer — which checks out *this* repo — a bug that lives in another one. Unset ⇒ nothing is labelled, so the behaviour is an explicit per-environment opt-in. Production will be set to `exponential-frontend`.

## Validation

ESLint clean; `vitest --project unit` Sentry suites 50/50 green; unit suite via pre-commit; Vercel build via pre-push.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add `ai-fixable` label to Sentry-filed tickets for allowlisted projects

- Gate labeling on `SENTRY_AI_FIXABLE_PROJECTS` env var (comma-separated slugs)

- Thread `projectSlug` through `SentryBug` interface and payload normalization

- Add 4 new unit tests; update docs and `.env.example`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sentry Webhook (org-wide)"] -- "normalizeSentryPayload" --> B["SentryBug\n+ projectSlug"]
  B -- "ingestSentryBug" --> C["isAiFixableProject()"]
  C -- "slug in SENTRY_AI_FIXABLE_PROJECTS?" --> D{"Allowlisted?"}
  D -- "yes" --> E["labelTicket with ai-fixable"]
  D -- "no" --> F["labelTicket without ai-fixable"]
  E --> G["Ticket (BACKLOG + ai-fixable)"]
  F --> H["Ticket (BACKLOG only)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sentryPayload.ts</strong><dd><code>Add projectSlug to SentryBug interface and payload normalization</code></dd></summary>
<hr>

src/server/services/sentry/sentryPayload.ts

<ul><li>Add <code>projectSlug: string | null</code> field to <code>SentryBug</code> interface with JSDoc<br> <li> Extend <code>SentryWebhookBody</code> to include <code>project.slug</code> (issue) and <br><code>project_slug</code> (event)<br> <li> Populate <code>projectSlug</code> in both <code>issue</code> and <code>event_alert</code> normalization <br>branches</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/469/files#diff-9fb183a5f05420e895fb352bdada266a8673a9bbb23b30673fd7cbe24ed3cedb">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SentryBugService.ts</strong><dd><code>Conditionally apply ai-fixable label based on project allowlist</code></dd></summary>
<hr>

src/server/services/sentry/SentryBugService.ts

<ul><li>Add <code>AI_FIXABLE_LABEL</code> constant for the <code>ai-fixable</code> label definition<br> <li> Add <code>isAiFixableProject()</code> function gated on <code>SENTRY_AI_FIXABLE_PROJECTS</code> <br>env var<br> <li> Extend <code>labelTicket()</code> to accept optional <code>extraLabels</code> parameter<br> <li> Pass <code>ai-fixable</code> label conditionally when ingesting a Sentry bug</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/469/files#diff-0dde9dcd8c1aed7f46faacd632832d501d8a805f9f8bb05920ab17f981832881">+38/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SentryBugService.test.ts</strong><dd><code>Add unit tests for ai-fixable label allowlist logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/sentry/__tests__/SentryBugService.test.ts

<ul><li>Add <code>projectSlug</code> to the shared <code>bug</code> fixture<br> <li> Clean up <code>SENTRY_AI_FIXABLE_PROJECTS</code> env var in <code>beforeEach</code><br> <li> Add 3 new tests covering allowlist unset, project allowlisted, and <br>project not allowlisted cases</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/469/files#diff-29ee86568c94bca33dc56fc3965ab98ad30ea4dbf454324d4d8bfe3cf5bb42b7">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sentryPayload.test.ts</strong><dd><code>Update payload tests to cover projectSlug normalization</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/sentry/__tests__/sentryPayload.test.ts

<ul><li>Add <code>project.slug</code> to issue payload fixture and assert <code>projectSlug</code> in <br>output<br> <li> Add <code>project_slug</code> to event_alert payload fixture and assert <code>projectSlug</code> <br>in output<br> <li> Add test for <code>projectSlug</code> being null when payload omits project field</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/469/files#diff-a2d3da285e5a808be94eca390bd7a24054ee55fabd37c150e553bc9b04d12e43">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.example</strong><dd><code>Document SENTRY_AI_FIXABLE_PROJECTS environment variable</code>&nbsp; </dd></summary>
<hr>

.env.example

<ul><li>Add <code>SENTRY_AI_FIXABLE_PROJECTS</code> env var with explanatory comment about <br>org-wide webhook and human triage gate</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/469/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OBSERVABILITY.md</strong><dd><code>Document ai-fixable labeling and allowlist in observability docs</code></dd></summary>
<hr>

dev-docs/OBSERVABILITY.md

<ul><li>Document <code>ai-fixable</code> label behavior and the <code>SENTRY_AI_FIXABLE_PROJECTS</code> <br>allowlist rationale<br> <li> Clarify that the label alone does not start an AI run; human triage <br>via <code>READY_TO_PLAN</code> is required</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/469/files#diff-e608379e40bafc9cc6a526c79545546dac14663e40ebdbc6733813229078f1a6">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

