### PR TITLE
V1: Features execute Key results

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -238,7 +238,7 @@ A strategic outcome — what Exponential schemas call `Goal`. Use the word "Obje
 _Avoid_: OKR (overloaded — see below), goal (only in code/schema references).
 
 **Key result**:
-The measurable arm of an Objective, stored as `KeyResult`. Has `currentValue`, `targetValue`, `status` (`on-track | at-risk | off-track | achieved`), and a `confidence` score. Lives under exactly one Objective via `keyResult.goalId`.
+The measurable arm of an Objective, stored as `KeyResult`. Has `currentValue`, `targetValue`, `status` (`on-track | at-risk | off-track | achieved`), and a `confidence` score. Lives under exactly one Objective via `keyResult.goalId`. Its execution links — the work moving its number — are typed joins to both **Projects** (`KeyResultProject`) and **Features** (`KeyResultFeature`), rendered as one "Executing work" list; `currentValue` is never derived from linked work — check-ins remain the only write path ([ADR-0050](docs/adr/0050-key-results-accept-feature-execution-links.md)).
 
 **OKR**:
 Shorthand for the *pair* (Objective + its Key results). Never use "OKR" to mean a single Objective or a single Key result on its own — be specific.

--- a/docs/adr/0050-key-results-accept-feature-execution-links.md
+++ b/docs/adr/0050-key-results-accept-feature-execution-links.md
@@ -1,0 +1,33 @@
+# Key results accept Features as execution links via a typed join table
+
+## Status
+
+Accepted — 2026-08-03
+
+## Context
+
+Exponential deliberately runs two parallel work registers ([CONTEXT.md](../../CONTEXT.md) "Product"): **Feature→Ticket** (product-management work, the permanent capability registry) and **Project→Action** (delivery/GTD endeavors). OKR alignment spans them asymmetrically: a Feature aligns to an **Objective** (`Feature.goalId`, powering the Product Roadmap swimlanes), but a **Key result**'s execution edge (`KeyResultProject`) accepts only Projects.
+
+Since most product-shaped execution happens as Features/Tickets, teams fabricate **shadow projects** to satisfy the KR link. Live evidence in the `clear` workspace: projects like "Decision Speed & Time-to-Aid Optimization" and "Org Onboarding & 90-Day Retention" exist solely to mirror the KRs they're linked to, while the KRs the product work actually executes ("MVP deployed to NRC field users", "Ship ≥2 situational analysis modules") have zero linked work — the Clear product's 32 Features / 344 Tickets can't be linked at all. This is the concrete source of the "Features and Projects feel duplicative" dissonance: the KR edge forces a Project into existence when the executing work is a Feature.
+
+## Decision
+
+1. **Add `KeyResultFeature`**, a typed join table mirroring `KeyResultProject` exactly: `{ keyResultId, featureId, assignedAt }`, `@@unique([keyResultId, featureId])`, cascade on both FKs. A Key result's execution set is the union of its linked Projects and linked Features.
+2. **Router symmetry**: `okr.linkFeature` / `okr.unlinkFeature` / `okr.updateLinkedFeatures` beside the existing project procedures, same workspace-membership guard; `okr.getById` / `okr.getByObjective` include linked Features alongside linked Projects.
+3. **One UI list**: the OKR detail drawer renders both link types as a single "Executing work" list with a per-row type indicator. The picker offers the workspace's Projects and its Products' Features.
+4. **Objective-alignment glue**: linking a Feature whose `goalId` is null sets it to the Key result's Objective; a Feature already aligned to a different Objective keeps its `goalId` (no silent overwrite).
+5. **KR progress stays outcome-driven**: `KeyResult.currentValue` is never derived from linked work; check-ins remain the only write path. Linked work is traceability and (later) delivery *context*, not a progress formula.
+
+## Considered alternatives
+
+- **Merge Feature and Project into one entity.** Rejected: they serve different lives (permanent product-capability registry vs time-bound workspace endeavors — ~100 real GTD/client Projects exist with no Product). The split is the deliberate answer to Linear's most-complained-about gap (no persistent feature catalogue beyond a delivery window); merging recreates it, and the migration would touch scopes, requirements, tickets, roadmap views, and the whole GTD ritual layer.
+- **Polymorphic `KeyResultContribution { entityType, entityId }`.** Rejected: loses FK integrity and cascade semantics on an execution edge. Repo precedent keeps ownership/execution edges typed ([ADR-0003](0003-product-owns-projects.md); EAV rejected in [ADR-0008](0008-pipeline-triage-model.md)); polymorphism-by-convention is reserved for low-stakes pins (`Favorite`, `CollectionMember` [ADR-0030](0030-generic-collection-list-primitive.md)).
+- **Objective-level alignment only (pure OKR doctrine: KRs measure, never own work).** Would drop `KeyResultProject` instead of widening it. Rejected: KR→work traceability is demonstrably used at review time, and `Feature.goalId` is too coarse to answer "what is moving *this* number".
+- **Auto-derive KR progress from linked-ticket completion.** Rejected: outputs are not outcomes; deriving `currentValue` from tickets is the classic OKR failure mode. (Delivery signal may be *displayed* beside a KR, never written into it.)
+
+## Consequences
+
+- Each future linkable work type means another typed join table — accepted; the only anticipated one is scope-level pinning, which lands as a nullable `scopeId` **on `KeyResultFeature`**, not a third table.
+- `Feature.goalId` and KR links can disagree when a Feature executes a KR under a different Objective than it aligns to; the fill-on-null rule plus no-overwrite keeps this an explicit, visible state rather than a silent mutation.
+- Data cleanup follows in `clear`: relink shadow projects' KRs to the real Features, then archive the shadow projects (keep genuinely real ones like "Webinar").
+- `CONTEXT.md`'s **Key result** entry gains the execution-links sentence in the implementation PR.

--- a/prisma/migrations/20260803194611_add_key_result_feature/migration.sql
+++ b/prisma/migrations/20260803194611_add_key_result_feature/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "KeyResultFeature" (
+    "id" TEXT NOT NULL,
+    "keyResultId" TEXT NOT NULL,
+    "featureId" TEXT NOT NULL,
+    "assignedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "KeyResultFeature_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "KeyResultFeature_keyResultId_idx" ON "KeyResultFeature"("keyResultId");
+
+-- CreateIndex
+CREATE INDEX "KeyResultFeature_featureId_idx" ON "KeyResultFeature"("featureId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "KeyResultFeature_keyResultId_featureId_key" ON "KeyResultFeature"("keyResultId", "featureId");
+
+-- AddForeignKey
+ALTER TABLE "KeyResultFeature" ADD CONSTRAINT "KeyResultFeature_keyResultId_fkey" FOREIGN KEY ("keyResultId") REFERENCES "KeyResult"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "KeyResultFeature" ADD CONSTRAINT "KeyResultFeature_featureId_fkey" FOREIGN KEY ("featureId") REFERENCES "Feature"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3099,6 +3099,7 @@ model KeyResult {
   checkIns  KeyResultCheckIn[]
   comments  KeyResultComment[] // Discussion comments on this key result
   projects  KeyResultProject[] // Projects linked to this key result
+  features  KeyResultFeature[] // Features linked to this key result (ADR-0050)
 
   @@index([goalId])
   @@index([userId])
@@ -3136,6 +3137,23 @@ model KeyResultProject {
   @@unique([keyResultId, projectId])
   @@index([keyResultId])
   @@index([projectId])
+}
+
+// Typed execution edge from a Key result to a Feature, mirroring
+// KeyResultProject. A KR's execution set is the union of its linked Projects
+// and linked Features (ADR-0050).
+model KeyResultFeature {
+  id          String   @id @default(cuid())
+  keyResultId String
+  featureId   String
+  assignedAt  DateTime @default(now())
+
+  keyResult KeyResult @relation(fields: [keyResultId], references: [id], onDelete: Cascade)
+  feature   Feature   @relation(fields: [featureId], references: [id], onDelete: Cascade)
+
+  @@unique([keyResultId, featureId])
+  @@index([keyResultId])
+  @@index([featureId])
 }
 
 // ============================================
@@ -4141,6 +4159,7 @@ model Feature {
   tags                FeatureTag[]
   comments            FeatureComment[]
   pages               FeaturePage[]
+  keyResultLinks      KeyResultFeature[] // Key results this feature executes (ADR-0050)
 
   @@index([productId])
   @@index([goalId])

--- a/src/plugins/okr/client/components/EditKeyResultModal.tsx
+++ b/src/plugins/okr/client/components/EditKeyResultModal.tsx
@@ -108,6 +108,7 @@ export function EditKeyResultModal({
   const [status, setStatus] = useState<StatusType>("on-track");
   const [confidence, setConfidence] = useState<number | null>(null);
   const [selectedProjectIds, setSelectedProjectIds] = useState<string[]>([]);
+  const [selectedFeatureIds, setSelectedFeatureIds] = useState<string[]>([]);
   const [driUserId, setDriUserId] = useState<string | null>(null);
   const [objectiveId, setObjectiveId] = useState<string | null>(null);
 
@@ -120,6 +121,14 @@ export function EditKeyResultModal({
     { workspaceId: workspace?.id ?? createWorkspaceId },
     { enabled: opened && !!(workspace?.id ?? createWorkspaceId) }
   );
+
+  // Fetch the workspace's Products' Features for the second execution edge
+  // (ADR-0050). Reuses the Product Roadmap's lean query — no new procedure.
+  const { data: availableFeatures = [] } =
+    api.product.feature.listForWorkspace.useQuery(
+      { workspaceId: workspace?.id ?? createWorkspaceId ?? "" },
+      { enabled: opened && !!(workspace?.id ?? createWorkspaceId) }
+    );
 
   // Fetch objectives (goals) the user owns in this workspace, for reassignment
   const { data: availableObjectives = [] } = api.okr.getAvailableGoals.useQuery(
@@ -148,6 +157,7 @@ export function EditKeyResultModal({
     setStatus("on-track");
     setConfidence(null);
     setSelectedProjectIds(initialProjectIds ?? []);
+    setSelectedFeatureIds([]);
     setDriUserId(defaultDriUserId ?? currentUser?.id ?? null);
   };
 
@@ -184,6 +194,12 @@ export function EditKeyResultModal({
         (freshKeyResult as { projects?: Array<{ project: { id: string } }> })
           ?.projects?.map((p) => p.project.id) ?? [];
       setSelectedProjectIds(linkedProjectIds);
+
+      // Populate selected features from freshKeyResult if available
+      const linkedFeatureIds =
+        (freshKeyResult as { features?: Array<{ feature: { id: string } }> })
+          ?.features?.map((f) => f.feature.id) ?? [];
+      setSelectedFeatureIds(linkedFeatureIds);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentKeyResult, currentUser?.id, freshKeyResult, isCreate, opened]);
@@ -248,6 +264,14 @@ export function EditKeyResultModal({
     },
   });
 
+  // Update linked features mutation (ADR-0050)
+  const updateLinkedFeatures = api.okr.updateLinkedFeatures.useMutation({
+    onSuccess: async () => {
+      await utils.okr.getByObjective.invalidate();
+      await utils.okr.getById.invalidate();
+    },
+  });
+
   // Delete mutation
   const deleteKeyResult = api.okr.delete.useMutation({
     onSuccess: async () => {
@@ -286,6 +310,13 @@ export function EditKeyResultModal({
           });
         }
 
+        if (selectedFeatureIds.length > 0) {
+          await updateLinkedFeatures.mutateAsync({
+            keyResultId: created.id,
+            featureIds: selectedFeatureIds,
+          });
+        }
+
         onSuccess?.();
         onClose();
         return;
@@ -315,6 +346,12 @@ export function EditKeyResultModal({
       updateLinkedProjects.mutate({
         keyResultId: currentKeyResult.id,
         projectIds: selectedProjectIds,
+      });
+
+      // Save linked features
+      updateLinkedFeatures.mutate({
+        keyResultId: currentKeyResult.id,
+        featureIds: selectedFeatureIds,
       });
 
       onSuccess?.();
@@ -540,7 +577,7 @@ export function EditKeyResultModal({
             </>
           )}
 
-          <Divider label="Linked Projects" labelPosition="center" />
+          <Divider label="Executing Work" labelPosition="center" />
 
           {/* Project Selection */}
           <MultiSelect
@@ -553,6 +590,22 @@ export function EditKeyResultModal({
             }))}
             value={selectedProjectIds}
             onChange={setSelectedProjectIds}
+            searchable
+            clearable
+            styles={selectStyles}
+          />
+
+          {/* Feature Selection (ADR-0050) */}
+          <MultiSelect
+            label="Linked features"
+            description="Select features that execute this key result"
+            placeholder="Choose features..."
+            data={availableFeatures.map((f) => ({
+              value: f.id,
+              label: `${f.name} (${f.product.name})`,
+            }))}
+            value={selectedFeatureIds}
+            onChange={setSelectedFeatureIds}
             searchable
             clearable
             styles={selectStyles}
@@ -582,7 +635,8 @@ export function EditKeyResultModal({
                 loading={
                   updateKeyResult.isPending ||
                   createKeyResult.isPending ||
-                  updateLinkedProjects.isPending
+                  updateLinkedProjects.isPending ||
+                  updateLinkedFeatures.isPending
                 }
                 disabled={!title}
               >

--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { Drawer, Tooltip, ActionIcon, Skeleton, Textarea, Menu } from "@mantine/core";
 import {
   IconTarget,
@@ -23,6 +24,7 @@ import {
 } from "@tabler/icons-react";
 import { formatDistanceToNow, format } from "date-fns";
 import { api, type RouterOutputs } from "~/trpc/react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { useFavorite } from "~/app/_components/shared/useFavorite";
 import {
   clamp01,
@@ -1387,6 +1389,8 @@ export function OkrDetailDrawer({
   const utils = api.useUtils();
   const [tab, setTab] = useState<string>("overview");
   const [size, setSize] = useState<TopBarSize>("m");
+  // Workspace slug for feature deep-links in the "Executing work" list.
+  const { workspace } = useWorkspace();
 
   // The "krs" / "projects" tabs are entity-specific, so a tab that's valid for
   // one entity renders a blank body for another. Reset to "overview" whenever
@@ -1744,7 +1748,7 @@ export function OkrDetailDrawer({
       { id: "overview", label: "Overview" },
       {
         id: "projects",
-        label: "Projects",
+        label: "Executing work",
         count: view.projects.length + view.features.length,
       },
       {
@@ -1961,71 +1965,84 @@ export function OkrDetailDrawer({
             {tab === "projects" && view.kind === "keyResult" && (
               <>
                 <SectionHeader
-                  title="Linked projects"
+                  title="Executing work"
                   count={view.projects.length + view.features.length}
                   action={
                     <button
                       type="button"
                       className="inline-flex items-center gap-1 rounded px-2 py-1 text-[11px] text-text-secondary hover:bg-surface-hover hover:text-text-primary"
                     >
-                      <IconLink size={11} /> Link project
+                      <IconLink size={11} /> Link work
                     </button>
                   }
                 />
                 {view.projects.length + view.features.length === 0 ? (
                   <div className="rounded-xl border border-dashed border-border-primary p-8 text-center text-sm text-text-muted">
-                    No projects linked to this key result yet.
+                    No work linked to this key result yet.
                   </div>
                 ) : (
                   <div className="overflow-hidden rounded-xl border border-border-secondary">
-                    {view.projects.map((p, idx) => (
-                      <div
-                        key={p.project.id}
-                        className={`grid grid-cols-[32px_1fr_auto] items-center gap-3 px-4 py-3 ${
-                          idx > 0 ? "border-t border-border-secondary" : ""
-                        }`}
-                      >
-                        <div
-                          className="grid h-8 w-8 place-items-center rounded-md text-xs font-semibold text-text-inverse"
-                          style={{ background: "var(--color-brand-primary)" }}
+                    {[
+                      // One merged "Executing work" list: linked Projects and
+                      // linked Features, each row tagged with its type
+                      // (ADR-0050). Feature rows deep-link into the products
+                      // area; project rows keep their current (non-link)
+                      // rendering.
+                      ...view.projects.map((p) => ({
+                        key: `project-${p.project.id}`,
+                        typeLabel: "Project" as const,
+                        name: p.project.name,
+                        status: p.project.status,
+                        href: null as string | null,
+                      })),
+                      ...view.features.map((f) => ({
+                        key: `feature-${f.feature.id}`,
+                        typeLabel: "Feature" as const,
+                        name: f.feature.name,
+                        status: f.feature.status,
+                        href: workspace?.slug
+                          ? `/w/${workspace.slug}/products/${f.feature.product.slug}/features/${f.feature.id}`
+                          : null,
+                      })),
+                    ].map((row, idx) => {
+                      const rowClass = `grid grid-cols-[32px_1fr_auto] items-center gap-3 px-4 py-3 ${
+                        idx > 0 ? "border-t border-border-secondary" : ""
+                      }`;
+                      const content = (
+                        <>
+                          <div
+                            className="grid h-8 w-8 place-items-center rounded-md text-xs font-semibold text-text-inverse"
+                            style={{ background: "var(--color-brand-primary)" }}
+                          >
+                            {(row.name ?? "·").slice(0, 2).toUpperCase()}
+                          </div>
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium text-text-primary">
+                              {row.name}
+                            </div>
+                            <div className="text-[11px] text-text-muted">
+                              {row.status}
+                            </div>
+                          </div>
+                          <span className="rounded border border-border-secondary px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-secondary">
+                            {row.typeLabel}
+                          </span>
+                        </>
+                      );
+                      return row.href ? (
+                        <Link
+                          key={row.key}
+                          href={row.href}
+                          className={`${rowClass} hover:bg-surface-hover`}
                         >
-                          {(p.project.name ?? "·").slice(0, 2).toUpperCase()}
+                          {content}
+                        </Link>
+                      ) : (
+                        <div key={row.key} className={rowClass}>
+                          {content}
                         </div>
-                        <div className="min-w-0">
-                          <div className="truncate text-sm font-medium text-text-primary">
-                            {p.project.name}
-                          </div>
-                          <div className="text-[11px] text-text-muted">
-                            {p.project.status}
-                          </div>
-                        </div>
-                      </div>
-                    ))}
-                    {view.features.map((f, idx) => (
-                      <div
-                        key={f.feature.id}
-                        className={`grid grid-cols-[32px_1fr_auto] items-center gap-3 px-4 py-3 ${
-                          view.projects.length + idx > 0
-                            ? "border-t border-border-secondary"
-                            : ""
-                        }`}
-                      >
-                        <div
-                          className="grid h-8 w-8 place-items-center rounded-md text-xs font-semibold text-text-inverse"
-                          style={{ background: "var(--color-brand-primary)" }}
-                        >
-                          {(f.feature.name ?? "·").slice(0, 2).toUpperCase()}
-                        </div>
-                        <div className="min-w-0">
-                          <div className="truncate text-sm font-medium text-text-primary">
-                            {f.feature.name}
-                          </div>
-                          <div className="text-[11px] text-text-muted">
-                            {f.feature.status}
-                          </div>
-                        </div>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               </>

--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -1694,6 +1694,7 @@ export function OkrDetailDrawer({
       trend,
       checkIns: kr.checkIns ?? [],
       projects: kr.projects ?? [],
+      features: kr.features ?? [],
       latestUpdate,
     };
   }, [
@@ -1741,7 +1742,11 @@ export function OkrDetailDrawer({
     }
     return [
       { id: "overview", label: "Overview" },
-      { id: "projects", label: "Projects", count: view.projects.length },
+      {
+        id: "projects",
+        label: "Projects",
+        count: view.projects.length + view.features.length,
+      },
       {
         id: "activity",
         label: "Activity",
@@ -1957,7 +1962,7 @@ export function OkrDetailDrawer({
               <>
                 <SectionHeader
                   title="Linked projects"
-                  count={view.projects.length}
+                  count={view.projects.length + view.features.length}
                   action={
                     <button
                       type="button"
@@ -1967,7 +1972,7 @@ export function OkrDetailDrawer({
                     </button>
                   }
                 />
-                {view.projects.length === 0 ? (
+                {view.projects.length + view.features.length === 0 ? (
                   <div className="rounded-xl border border-dashed border-border-primary p-8 text-center text-sm text-text-muted">
                     No projects linked to this key result yet.
                   </div>
@@ -1992,6 +1997,31 @@ export function OkrDetailDrawer({
                           </div>
                           <div className="text-[11px] text-text-muted">
                             {p.project.status}
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                    {view.features.map((f, idx) => (
+                      <div
+                        key={f.feature.id}
+                        className={`grid grid-cols-[32px_1fr_auto] items-center gap-3 px-4 py-3 ${
+                          view.projects.length + idx > 0
+                            ? "border-t border-border-secondary"
+                            : ""
+                        }`}
+                      >
+                        <div
+                          className="grid h-8 w-8 place-items-center rounded-md text-xs font-semibold text-text-inverse"
+                          style={{ background: "var(--color-brand-primary)" }}
+                        >
+                          {(f.feature.name ?? "·").slice(0, 2).toUpperCase()}
+                        </div>
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium text-text-primary">
+                            {f.feature.name}
+                          </div>
+                          <div className="text-[11px] text-text-muted">
+                            {f.feature.status}
                           </div>
                         </div>
                       </div>

--- a/src/plugins/okr/server/routers/__tests__/keyResultFeatureLinks.test.ts
+++ b/src/plugins/okr/server/routers/__tests__/keyResultFeatureLinks.test.ts
@@ -1,0 +1,295 @@
+/**
+ * okr.linkFeature / okr.unlinkFeature — the Feature execution edge of a key
+ * result (ADR-0050).
+ *
+ * External behavior under test:
+ * - linkFeature creates the (keyResult, feature) pair exactly once (upsert
+ *   semantics — idempotent on relink).
+ * - Cross-workspace features are rejected; the link row is never written.
+ * - KR-side authz mirrors linkProject: KR owner OR workspace member via the
+ *   centralized resolver; strangers get NOT_FOUND. The feature-side guard
+ *   mirrors feature.update: membership in the feature's workspace is required
+ *   even for the KR owner.
+ * - unlinkFeature deletes only the link row — never either entity.
+ * - okr.getById carries linked features with the lean select shape.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const OWNER_ID = "user-owner";
+const MEMBER_ID = "user-member";
+const STRANGER_ID = "user-stranger";
+const WORKSPACE_ID = "ws-1";
+const OTHER_WORKSPACE_ID = "ws-2";
+const KR_ID = "kr-1";
+const FEATURE_ID = "feat-1";
+
+const KR_ROW = {
+  id: KR_ID,
+  userId: OWNER_ID,
+  workspaceId: WORKSPACE_ID,
+  goalId: 42,
+};
+
+const FEATURE_ROW = {
+  id: FEATURE_ID,
+  goalId: null,
+  product: { workspaceId: WORKSPACE_ID },
+};
+
+describe("okr.linkFeature / okr.unlinkFeature", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+    db.keyResult.findFirst.mockResolvedValue(KR_ROW as never);
+    db.feature.findUnique.mockResolvedValue(FEATURE_ROW as never);
+    // No team-derived access in these tests; direct membership is set per test.
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+  });
+
+  function grantMembership() {
+    db.workspaceUser.findUnique.mockResolvedValue({
+      role: "member",
+      workspaceId: WORKSPACE_ID,
+    } as never);
+  }
+
+  function denyMembership() {
+    db.workspaceUser.findUnique.mockResolvedValue(null as never);
+  }
+
+  describe("linkFeature", () => {
+    it("creates the (keyResult, feature) pair exactly once via upsert", async () => {
+      grantMembership();
+      const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+      const result = await caller.okr.linkFeature({
+        keyResultId: KR_ID,
+        featureId: FEATURE_ID,
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(db.keyResultFeature.upsert).toHaveBeenCalledTimes(1);
+      const arg = db.keyResultFeature.upsert.mock.calls[0]![0];
+      expect(arg.where).toEqual({
+        keyResultId_featureId: { keyResultId: KR_ID, featureId: FEATURE_ID },
+      });
+      expect(arg.create).toEqual({ keyResultId: KR_ID, featureId: FEATURE_ID });
+      // Relink is a no-op, not a second row or an error.
+      expect(arg.update).toEqual({});
+      expect(db.keyResultFeature.create).not.toHaveBeenCalled();
+      expect(db.keyResultFeature.createMany).not.toHaveBeenCalled();
+    });
+
+    it("allows the KR owner when they are a workspace member", async () => {
+      grantMembership();
+      const caller = createMockCaller({ userId: OWNER_ID, db });
+
+      await expect(
+        caller.okr.linkFeature({ keyResultId: KR_ID, featureId: FEATURE_ID }),
+      ).resolves.toEqual({ success: true });
+    });
+
+    it("rejects a stranger (not owner, no membership) with NOT_FOUND", async () => {
+      denyMembership();
+      const caller = createMockCaller({ userId: STRANGER_ID, db });
+
+      await expect(
+        caller.okr.linkFeature({ keyResultId: KR_ID, featureId: FEATURE_ID }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+      expect(db.keyResultFeature.upsert).not.toHaveBeenCalled();
+    });
+
+    it("rejects the KR owner when they are not a member of the feature's workspace (feature.update parity)", async () => {
+      denyMembership();
+      const caller = createMockCaller({ userId: OWNER_ID, db });
+
+      await expect(
+        caller.okr.linkFeature({ keyResultId: KR_ID, featureId: FEATURE_ID }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      expect(db.keyResultFeature.upsert).not.toHaveBeenCalled();
+    });
+
+    it("rejects a feature whose product belongs to a different workspace", async () => {
+      grantMembership();
+      db.feature.findUnique.mockResolvedValue({
+        ...FEATURE_ROW,
+        product: { workspaceId: OTHER_WORKSPACE_ID },
+      } as never);
+      const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+      await expect(
+        caller.okr.linkFeature({ keyResultId: KR_ID, featureId: FEATURE_ID }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      expect(db.keyResultFeature.upsert).not.toHaveBeenCalled();
+    });
+
+    it("rejects linking to a key result with no workspace", async () => {
+      grantMembership();
+      db.keyResult.findFirst.mockResolvedValue({
+        ...KR_ROW,
+        workspaceId: null,
+      } as never);
+      const caller = createMockCaller({ userId: OWNER_ID, db });
+
+      await expect(
+        caller.okr.linkFeature({ keyResultId: KR_ID, featureId: FEATURE_ID }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      expect(db.keyResultFeature.upsert).not.toHaveBeenCalled();
+    });
+
+    it("rejects a missing feature with NOT_FOUND", async () => {
+      grantMembership();
+      db.feature.findUnique.mockResolvedValue(null as never);
+      const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+      await expect(
+        caller.okr.linkFeature({ keyResultId: KR_ID, featureId: "feat-missing" }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+      expect(db.keyResultFeature.upsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("unlinkFeature", () => {
+    it("deletes only the link row — never the feature or the key result", async () => {
+      grantMembership();
+      const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+      const result = await caller.okr.unlinkFeature({
+        keyResultId: KR_ID,
+        featureId: FEATURE_ID,
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(db.keyResultFeature.deleteMany).toHaveBeenCalledTimes(1);
+      expect(db.keyResultFeature.deleteMany).toHaveBeenCalledWith({
+        where: { keyResultId: KR_ID, featureId: FEATURE_ID },
+      });
+      expect(db.feature.delete).not.toHaveBeenCalled();
+      expect(db.feature.deleteMany).not.toHaveBeenCalled();
+      expect(db.keyResult.delete).not.toHaveBeenCalled();
+      expect(db.keyResult.deleteMany).not.toHaveBeenCalled();
+      // Unlink never touches the feature's Objective alignment.
+      expect(db.feature.update).not.toHaveBeenCalled();
+      expect(db.feature.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("rejects a stranger with NOT_FOUND without deleting anything", async () => {
+      denyMembership();
+      const caller = createMockCaller({ userId: STRANGER_ID, db });
+
+      await expect(
+        caller.okr.unlinkFeature({ keyResultId: KR_ID, featureId: FEATURE_ID }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+      expect(db.keyResultFeature.deleteMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getById", () => {
+    it("includes linked features with the lean select shape beside projects", async () => {
+      db.keyResult.findFirst.mockResolvedValue({
+        ...KR_ROW,
+        projects: [],
+        features: [],
+      } as never);
+      const caller = createMockCaller({ userId: OWNER_ID, db });
+
+      await caller.okr.getById({ id: KR_ID });
+
+      expect(db.keyResult.findFirst).toHaveBeenCalledTimes(1);
+      const arg = db.keyResult.findFirst.mock.calls[0]![0]!;
+      const include = arg.include as {
+        projects?: unknown;
+        features?: {
+          include?: { feature?: { select?: Record<string, unknown> } };
+        };
+      };
+
+      // Projects stay untouched; features ride alongside.
+      expect(include.projects).toBeDefined();
+      const featureSelect = include.features?.include?.feature?.select;
+      expect(featureSelect).toBeDefined();
+      expect(Object.keys(featureSelect!).sort()).toEqual([
+        "id",
+        "name",
+        "product",
+        "status",
+      ]);
+      const productSelect = (
+        featureSelect!.product as { select: Record<string, unknown> }
+      ).select;
+      expect(Object.keys(productSelect).sort()).toEqual([
+        "color",
+        "icon",
+        "id",
+        "name",
+        "slug",
+      ]);
+    });
+  });
+});

--- a/src/plugins/okr/server/routers/__tests__/keyResultFeatureLinks.test.ts
+++ b/src/plugins/okr/server/routers/__tests__/keyResultFeatureLinks.test.ts
@@ -110,6 +110,12 @@ describe("okr.linkFeature / okr.unlinkFeature", () => {
     db.feature.findUnique.mockResolvedValue(FEATURE_ROW as never);
     // No team-derived access in these tests; direct membership is set per test.
     db.teamUser.findFirst.mockResolvedValue(null as never);
+    // Interactive-transaction passthrough: run the callback against the same
+    // mock so per-model assertions observe writes made inside $transaction.
+    db.$transaction.mockImplementation((async (arg: unknown) =>
+      typeof arg === "function"
+        ? (arg as (tx: PrismaClient) => unknown)(db)
+        : Promise.all(arg as Promise<unknown>[])) as never);
   });
 
   function grantMembership() {
@@ -212,6 +218,51 @@ describe("okr.linkFeature / okr.unlinkFeature", () => {
         caller.okr.linkFeature({ keyResultId: KR_ID, featureId: "feat-missing" }),
       ).rejects.toMatchObject({ code: "NOT_FOUND" });
       expect(db.keyResultFeature.upsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("linkFeature — goalId fill-on-null (ADR-0050)", () => {
+    it("sets a null goalId to the key result's Objective when linking", async () => {
+      grantMembership();
+      // FEATURE_ROW has goalId: null.
+      const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+      await caller.okr.linkFeature({ keyResultId: KR_ID, featureId: FEATURE_ID });
+
+      expect(db.feature.update).toHaveBeenCalledTimes(1);
+      expect(db.feature.update).toHaveBeenCalledWith({
+        where: { id: FEATURE_ID },
+        data: { goalId: KR_ROW.goalId },
+      });
+    });
+
+    it("leaves a feature already aligned to the same Objective unchanged", async () => {
+      grantMembership();
+      db.feature.findUnique.mockResolvedValue({
+        ...FEATURE_ROW,
+        goalId: KR_ROW.goalId,
+      } as never);
+      const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+      await caller.okr.linkFeature({ keyResultId: KR_ID, featureId: FEATURE_ID });
+
+      expect(db.keyResultFeature.upsert).toHaveBeenCalledTimes(1);
+      expect(db.feature.update).not.toHaveBeenCalled();
+    });
+
+    it("never overwrites alignment to a different Objective", async () => {
+      grantMembership();
+      db.feature.findUnique.mockResolvedValue({
+        ...FEATURE_ROW,
+        goalId: 999, // aligned elsewhere
+      } as never);
+      const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+      await caller.okr.linkFeature({ keyResultId: KR_ID, featureId: FEATURE_ID });
+
+      expect(db.keyResultFeature.upsert).toHaveBeenCalledTimes(1);
+      expect(db.feature.update).not.toHaveBeenCalled();
+      expect(db.feature.updateMany).not.toHaveBeenCalled();
     });
   });
 

--- a/src/plugins/okr/server/routers/__tests__/updateLinkedFeatures.test.ts
+++ b/src/plugins/okr/server/routers/__tests__/updateLinkedFeatures.test.ts
@@ -1,0 +1,315 @@
+/**
+ * okr.updateLinkedFeatures — transactional replace of a key result's Feature
+ * execution set (ADR-0050), plus the `features` include on okr.getByObjective.
+ *
+ * External behavior under test:
+ * - The set is replaced atomically: delete-all-then-recreate inside one
+ *   transaction, mirroring updateLinkedProjects' shape.
+ * - Authz is linkFeature's workspace-member guard, NOT updateLinkedProjects'
+ *   owner-only check: a non-owner workspace member may save the set.
+ * - Fill-on-null applies to newly created links; aligned features are never
+ *   overwritten.
+ * - Cross-workspace features reject the whole batch before anything is
+ *   written.
+ * - getByObjective carries linked features with the lean select shape.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const OWNER_ID = "user-owner";
+const MEMBER_ID = "user-member";
+const WORKSPACE_ID = "ws-1";
+const OTHER_WORKSPACE_ID = "ws-2";
+const KR_ID = "kr-1";
+
+const KR_ROW = {
+  id: KR_ID,
+  userId: OWNER_ID,
+  workspaceId: WORKSPACE_ID,
+  goalId: 42,
+};
+
+function featureRow(id: string, goalId: number | null, workspaceId = WORKSPACE_ID) {
+  return { id, goalId, product: { workspaceId } };
+}
+
+describe("okr.updateLinkedFeatures", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+    db.keyResult.findFirst.mockResolvedValue(KR_ROW as never);
+    db.keyResult.findUnique.mockResolvedValue({
+      ...KR_ROW,
+      projects: [],
+      features: [],
+    } as never);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+    db.workspaceUser.findUnique.mockResolvedValue({
+      role: "member",
+      workspaceId: WORKSPACE_ID,
+    } as never);
+    // Interactive-transaction passthrough: run the callback against the same
+    // mock so per-model assertions observe writes made inside $transaction.
+    db.$transaction.mockImplementation((async (arg: unknown) =>
+      typeof arg === "function"
+        ? (arg as (tx: PrismaClient) => unknown)(db)
+        : Promise.all(arg as Promise<unknown>[])) as never);
+  });
+
+  it("replaces the set atomically: delete-all-then-recreate in one transaction", async () => {
+    db.feature.findMany.mockResolvedValue([
+      featureRow("feat-1", 7),
+      featureRow("feat-2", 7),
+    ] as never);
+    const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+    await caller.okr.updateLinkedFeatures({
+      keyResultId: KR_ID,
+      featureIds: ["feat-1", "feat-2"],
+    });
+
+    expect(db.$transaction).toHaveBeenCalledTimes(1);
+    expect(db.keyResultFeature.deleteMany).toHaveBeenCalledWith({
+      where: { keyResultId: KR_ID },
+    });
+    expect(db.keyResultFeature.createMany).toHaveBeenCalledWith({
+      data: [
+        { keyResultId: KR_ID, featureId: "feat-1" },
+        { keyResultId: KR_ID, featureId: "feat-2" },
+      ],
+    });
+  });
+
+  it("is allowed for a non-owner workspace member (linkFeature authz, not owner-only)", async () => {
+    db.feature.findMany.mockResolvedValue([featureRow("feat-1", 7)] as never);
+    const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+    const result = await caller.okr.updateLinkedFeatures({
+      keyResultId: KR_ID,
+      featureIds: ["feat-1"],
+    });
+
+    expect(result).toMatchObject({ id: KR_ID });
+    expect(db.keyResultFeature.createMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a stranger with NOT_FOUND before writing", async () => {
+    db.workspaceUser.findUnique.mockResolvedValue(null as never);
+    const caller = createMockCaller({ userId: "user-stranger", db });
+
+    await expect(
+      caller.okr.updateLinkedFeatures({
+        keyResultId: KR_ID,
+        featureIds: ["feat-1"],
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(db.keyResultFeature.deleteMany).not.toHaveBeenCalled();
+    expect(db.keyResultFeature.createMany).not.toHaveBeenCalled();
+  });
+
+  it("applies fill-on-null to newly created links only — aligned features stay untouched", async () => {
+    db.feature.findMany.mockResolvedValue([
+      featureRow("feat-null", null),
+      featureRow("feat-aligned", 999),
+    ] as never);
+    const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+    await caller.okr.updateLinkedFeatures({
+      keyResultId: KR_ID,
+      featureIds: ["feat-null", "feat-aligned"],
+    });
+
+    expect(db.feature.updateMany).toHaveBeenCalledTimes(1);
+    expect(db.feature.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["feat-null"] } },
+      data: { goalId: KR_ROW.goalId },
+    });
+  });
+
+  it("rejects the whole batch when any feature is cross-workspace, writing nothing", async () => {
+    db.feature.findMany.mockResolvedValue([
+      featureRow("feat-1", null),
+      featureRow("feat-other", null, OTHER_WORKSPACE_ID),
+    ] as never);
+    const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+    await expect(
+      caller.okr.updateLinkedFeatures({
+        keyResultId: KR_ID,
+        featureIds: ["feat-1", "feat-other"],
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(db.$transaction).not.toHaveBeenCalled();
+    expect(db.keyResultFeature.deleteMany).not.toHaveBeenCalled();
+    expect(db.keyResultFeature.createMany).not.toHaveBeenCalled();
+    expect(db.feature.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown feature ids with NOT_FOUND, writing nothing", async () => {
+    db.feature.findMany.mockResolvedValue([featureRow("feat-1", null)] as never);
+    const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+    await expect(
+      caller.okr.updateLinkedFeatures({
+        keyResultId: KR_ID,
+        featureIds: ["feat-1", "feat-missing"],
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(db.keyResultFeature.createMany).not.toHaveBeenCalled();
+  });
+
+  it("clears the set with an empty list — link rows only, goalId never cleared", async () => {
+    const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+    await caller.okr.updateLinkedFeatures({
+      keyResultId: KR_ID,
+      featureIds: [],
+    });
+
+    expect(db.keyResultFeature.deleteMany).toHaveBeenCalledWith({
+      where: { keyResultId: KR_ID },
+    });
+    expect(db.keyResultFeature.createMany).not.toHaveBeenCalled();
+    expect(db.feature.update).not.toHaveBeenCalled();
+    expect(db.feature.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("returns the key result with both execution edges in the lean shape", async () => {
+    db.feature.findMany.mockResolvedValue([featureRow("feat-1", 7)] as never);
+    const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+    await caller.okr.updateLinkedFeatures({
+      keyResultId: KR_ID,
+      featureIds: ["feat-1"],
+    });
+
+    const arg = db.keyResult.findUnique.mock.calls[0]![0]!;
+    const include = arg.include as {
+      projects?: unknown;
+      features?: { include?: { feature?: { select?: Record<string, unknown> } } };
+    };
+    expect(include.projects).toBeDefined();
+    expect(
+      Object.keys(include.features?.include?.feature?.select ?? {}).sort(),
+    ).toEqual(["id", "name", "product", "status"]);
+  });
+});
+
+describe("okr.getByObjective — features include", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+    db.workspaceUser.findUnique.mockResolvedValue({
+      role: "member",
+      workspaceId: WORKSPACE_ID,
+    } as never);
+    db.goal.findMany.mockResolvedValue([]);
+  });
+
+  it("carries linked features beside linked projects with the lean select shape", async () => {
+    const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+    await caller.okr.getByObjective({ workspaceId: WORKSPACE_ID });
+
+    const arg = db.goal.findMany.mock.calls[0]![0]!;
+    const krInclude = (
+      arg.include as {
+        keyResults: {
+          include: {
+            projects?: unknown;
+            features?: {
+              include?: { feature?: { select?: Record<string, unknown> } };
+            };
+          };
+        };
+      }
+    ).keyResults.include;
+
+    expect(krInclude.projects).toBeDefined();
+    const featureSelect = krInclude.features?.include?.feature?.select;
+    expect(featureSelect).toBeDefined();
+    expect(Object.keys(featureSelect!).sort()).toEqual([
+      "id",
+      "name",
+      "product",
+      "status",
+    ]);
+    const productSelect = (
+      featureSelect!.product as { select: Record<string, unknown> }
+    ).select;
+    expect(Object.keys(productSelect).sort()).toEqual([
+      "color",
+      "icon",
+      "id",
+      "name",
+      "slug",
+    ]);
+  });
+});

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -282,6 +282,27 @@ export const keyResultRouter = createTRPCRouter({
                   },
                 },
               },
+              // Linked Features — the second typed execution edge (ADR-0050).
+              features: {
+                include: {
+                  feature: {
+                    select: {
+                      id: true,
+                      name: true,
+                      status: true,
+                      product: {
+                        select: {
+                          id: true,
+                          name: true,
+                          slug: true,
+                          icon: true,
+                          color: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
             },
             orderBy: { createdAt: "asc" },
           },
@@ -751,6 +772,146 @@ export const keyResultRouter = createTRPCRouter({
   // check updateLinkedProjects uses). Feature-side guard matches
   // feature.update: the feature must live in the same workspace as the KR and
   // the caller must be a member of that workspace.
+
+  // Update linked features (batch operation for modal save). Transactional
+  // delete-all-then-recreate mirroring updateLinkedProjects' shape, but with
+  // linkFeature's workspace-member authz (deliberately NOT the owner-only
+  // check updateLinkedProjects retains).
+  updateLinkedFeatures: protectedProcedure
+    .input(
+      z.object({
+        keyResultId: z.string(),
+        featureIds: z.array(z.string()),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const keyResult = await ctx.db.keyResult.findFirst({
+        where: { id: input.keyResultId },
+        select: { id: true, userId: true, workspaceId: true, goalId: true },
+      });
+
+      const membership =
+        keyResult?.workspaceId != null
+          ? await getWorkspaceMembership(ctx.db, userId, keyResult.workspaceId)
+          : null;
+
+      if (!keyResult || (keyResult.userId !== userId && !membership)) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Key result not found",
+        });
+      }
+
+      const featureIds = [...new Set(input.featureIds)];
+
+      if (featureIds.length > 0) {
+        const features = await ctx.db.feature.findMany({
+          where: { id: { in: featureIds } },
+          select: {
+            id: true,
+            goalId: true,
+            product: { select: { workspaceId: true } },
+          },
+        });
+
+        if (features.length !== featureIds.length) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "One or more features not found",
+          });
+        }
+
+        if (
+          !keyResult.workspaceId ||
+          features.some(
+            (f) => f.product.workspaceId !== keyResult.workspaceId
+          )
+        ) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message:
+              "Feature belongs to a different workspace than this key result",
+          });
+        }
+
+        if (!membership) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "You don't have access to this workspace",
+          });
+        }
+
+        // Fill-on-null applies to every link the replace creates (ADR-0050):
+        // features with no Objective alignment inherit the KR's Objective;
+        // aligned ones are never overwritten.
+        const unalignedIds = features
+          .filter((f) => f.goalId == null)
+          .map((f) => f.id);
+
+        await ctx.db.$transaction(async (tx) => {
+          await tx.keyResultFeature.deleteMany({
+            where: { keyResultId: input.keyResultId },
+          });
+          await tx.keyResultFeature.createMany({
+            data: featureIds.map((featureId) => ({
+              keyResultId: input.keyResultId,
+              featureId,
+            })),
+          });
+          if (unalignedIds.length > 0) {
+            await tx.feature.updateMany({
+              where: { id: { in: unalignedIds } },
+              data: { goalId: keyResult.goalId },
+            });
+          }
+        });
+      } else {
+        // Clearing the set removes link rows only — no feature-side guard
+        // needed, and no goalId is ever cleared on unlink.
+        await ctx.db.keyResultFeature.deleteMany({
+          where: { keyResultId: input.keyResultId },
+        });
+      }
+
+      // Return the key result with both execution edges, lean select only.
+      return ctx.db.keyResult.findUnique({
+        where: { id: input.keyResultId },
+        include: {
+          projects: {
+            include: {
+              project: {
+                select: {
+                  id: true,
+                  name: true,
+                  status: true,
+                },
+              },
+            },
+          },
+          features: {
+            include: {
+              feature: {
+                select: {
+                  id: true,
+                  name: true,
+                  status: true,
+                  product: {
+                    select: {
+                      id: true,
+                      name: true,
+                      slug: true,
+                      icon: true,
+                      color: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+    }),
 
   // Link a single feature to a key result
   linkFeature: protectedProcedure

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -347,6 +347,28 @@ export const keyResultRouter = createTRPCRouter({
               },
             },
           },
+          // Linked Features — the second typed execution edge (ADR-0050).
+          // Lean select only: these payloads transit agent tool calls.
+          features: {
+            include: {
+              feature: {
+                select: {
+                  id: true,
+                  name: true,
+                  status: true,
+                  product: {
+                    select: {
+                      id: true,
+                      name: true,
+                      slug: true,
+                      icon: true,
+                      color: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
           driUser: {
             select: { id: true, name: true, email: true, image: true },
           },
@@ -717,6 +739,100 @@ export const keyResultRouter = createTRPCRouter({
           keyResultId: input.keyResultId,
           projectId: input.projectId,
         },
+      });
+
+      return { success: true };
+    }),
+
+  // ── Feature execution links (ADR-0050) ────────────────────────────────
+  // Features are the second typed execution edge of a key result, mirroring
+  // the project procedures above. KR-side authz matches linkProject (owner OR
+  // workspace membership via the centralized resolver — NOT the owner-only
+  // check updateLinkedProjects uses). Feature-side guard matches
+  // feature.update: the feature must live in the same workspace as the KR and
+  // the caller must be a member of that workspace.
+
+  // Link a single feature to a key result
+  linkFeature: protectedProcedure
+    .input(
+      z.object({
+        keyResultId: z.string(),
+        featureId: z.string(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const keyResult = await ctx.db.keyResult.findFirst({
+        where: { id: input.keyResultId },
+        select: { id: true, userId: true, workspaceId: true, goalId: true },
+      });
+
+      // Resolve workspace membership once — it serves both the KR-side authz
+      // (owner OR member, mirroring linkProject) and the feature-side guard.
+      const membership =
+        keyResult?.workspaceId != null
+          ? await getWorkspaceMembership(ctx.db, userId, keyResult.workspaceId)
+          : null;
+
+      if (!keyResult || (keyResult.userId !== userId && !membership)) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Key result not found",
+        });
+      }
+
+      const feature = await ctx.db.feature.findUnique({
+        where: { id: input.featureId },
+        select: {
+          id: true,
+          goalId: true,
+          product: { select: { workspaceId: true } },
+        },
+      });
+
+      if (!feature) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Feature not found",
+        });
+      }
+
+      // Cross-workspace links are rejected: the feature's product must belong
+      // to the key result's workspace.
+      if (
+        !keyResult.workspaceId ||
+        feature.product.workspaceId !== keyResult.workspaceId
+      ) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Feature belongs to a different workspace than this key result",
+        });
+      }
+
+      // Parity with feature.update's assertWorkspaceMember guard: the caller
+      // must be a member of the feature's workspace (a KR owner who isn't a
+      // member of the workspace may not link its features).
+      if (!membership) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have access to this workspace",
+        });
+      }
+
+      // Idempotent: the unique (keyResultId, featureId) pair is created once.
+      await ctx.db.keyResultFeature.upsert({
+        where: {
+          keyResultId_featureId: {
+            keyResultId: input.keyResultId,
+            featureId: input.featureId,
+          },
+        },
+        create: {
+          keyResultId: input.keyResultId,
+          featureId: input.featureId,
+        },
+        update: {}, // No-op if already exists
       });
 
       return { success: true };

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -820,19 +820,32 @@ export const keyResultRouter = createTRPCRouter({
         });
       }
 
-      // Idempotent: the unique (keyResultId, featureId) pair is created once.
-      await ctx.db.keyResultFeature.upsert({
-        where: {
-          keyResultId_featureId: {
+      // Create the link and apply the Objective-alignment glue in one
+      // transaction (ADR-0050): a feature with no alignment inherits the KR's
+      // Objective; a feature already aligned — same or different Objective —
+      // is never overwritten.
+      await ctx.db.$transaction(async (tx) => {
+        // Idempotent: the unique (keyResultId, featureId) pair is created once.
+        await tx.keyResultFeature.upsert({
+          where: {
+            keyResultId_featureId: {
+              keyResultId: input.keyResultId,
+              featureId: input.featureId,
+            },
+          },
+          create: {
             keyResultId: input.keyResultId,
             featureId: input.featureId,
           },
-        },
-        create: {
-          keyResultId: input.keyResultId,
-          featureId: input.featureId,
-        },
-        update: {}, // No-op if already exists
+          update: {}, // No-op if already exists
+        });
+
+        if (feature.goalId == null) {
+          await tx.feature.update({
+            where: { id: feature.id },
+            data: { goalId: keyResult.goalId },
+          });
+        }
       });
 
       return { success: true };

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -838,6 +838,79 @@ export const keyResultRouter = createTRPCRouter({
       return { success: true };
     }),
 
+  // Unlink a single feature from a key result. Deletes only the link row —
+  // never the feature or the key result on the other side.
+  unlinkFeature: protectedProcedure
+    .input(
+      z.object({
+        keyResultId: z.string(),
+        featureId: z.string(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const keyResult = await ctx.db.keyResult.findFirst({
+        where: { id: input.keyResultId },
+        select: { id: true, userId: true, workspaceId: true },
+      });
+
+      const membership =
+        keyResult?.workspaceId != null
+          ? await getWorkspaceMembership(ctx.db, userId, keyResult.workspaceId)
+          : null;
+
+      if (!keyResult || (keyResult.userId !== userId && !membership)) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Key result not found",
+        });
+      }
+
+      const feature = await ctx.db.feature.findUnique({
+        where: { id: input.featureId },
+        select: {
+          id: true,
+          product: { select: { workspaceId: true } },
+        },
+      });
+
+      if (!feature) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Feature not found",
+        });
+      }
+
+      if (
+        !keyResult.workspaceId ||
+        feature.product.workspaceId !== keyResult.workspaceId
+      ) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Feature belongs to a different workspace than this key result",
+        });
+      }
+
+      if (!membership) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have access to this workspace",
+        });
+      }
+
+      // Delete only the link row. The feature's goalId is deliberately left
+      // untouched — unlink never clears Objective alignment (ADR-0050).
+      await ctx.db.keyResultFeature.deleteMany({
+        where: {
+          keyResultId: input.keyResultId,
+          featureId: input.featureId,
+        },
+      });
+
+      return { success: true };
+    }),
+
   // Get available periods (quarters)
   getPeriods: protectedProcedure.query(() => {
     const currentYear = new Date().getFullYear();


### PR DESCRIPTION
### **User description**
Ticket: `zesty.prism` (cmsdiu3ix0001kv04o3sl1ngk), feature cmsdi8z2r000hjs04ahyt074w. Decision record: ADR-0050.

> **Stacked PR** — targets `feature/external-agents` (the open migration branch; shared-dev-DB stacking rule) and merges **after** it. The diff below is exactly this ticket's six commits.

Key results gain a second typed execution edge: **`KeyResultFeature`**, mirroring the frozen `KeyResultProject`. This kills the shadow-project workaround — Features can now be linked directly to the KRs they execute.

## What's in here

- **Schema**: `KeyResultFeature { keyResultId, featureId, assignedAt }` with `@@unique([keyResultId, featureId])`, cascade on both FKs; back-relations `KeyResult.features` / `Feature.keyResultLinks`. Migration `add_key_result_feature`.
- **Router symmetry** in the OKR plugin: `okr.linkFeature` / `okr.unlinkFeature` / `okr.updateLinkedFeatures` (transactional replace). KR-side authz mirrors `linkProject` (owner OR workspace member via the centralized resolver — deliberately NOT `updateLinkedProjects`' owner-only check). Feature-side guard mirrors `feature.update`: same-workspace only, workspace membership required. `okr.getById` / `okr.getByObjective` include `features` beside `projects`, lean select only.
- **`goalId` fill-on-null** (ADR-0050 §4): linking a Feature with no Objective alignment sets its `goalId` to the KR's Objective, in the same transaction as link creation. Existing alignment is never overwritten; unlink never clears it.
- **Drawer**: the KR view's "Projects" tab is now **"Executing work"** — one merged list of linked Projects and Features with a per-row type chip; feature rows deep-link into the products area; empty state "No work linked to this key result yet."
- **Modal**: `EditKeyResultModal` gains a "Linked features" MultiSelect (fed by the existing `product.feature.listForWorkspace` — no new query), saved via `updateLinkedFeatures` in both create and edit flows.

## Constraints held

- `KeyResultProject` rows, procedures, and its owner-only `updateLinkedProjects` quirk are untouched (all diff hunks are additive).
- `KeyResult.currentValue` is never written from linked work — check-ins remain the only write path.
- Weekly-plan surfaces (`LinkKeyResultPopover`, `KeyResultsSection`, `FocusRecapCard`) unchanged; no CLI/SDK/Zoe support in V1.
- No hardcoded colors — semantic tokens only.

## Tests

22 new unit tests (mocked Prisma, no DB): link idempotency, three authz paths, cross-workspace rejection, fill-on-null / no-overwrite, link-only deletes, atomic replace, lean read shapes in `getById` / `getByObjective`.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `KeyResultFeature` typed join table as second execution edge for key results

- Implement `linkFeature`, `unlinkFeature`, `updateLinkedFeatures` tRPC procedures with workspace-member authz

- Merge Projects and Features into unified "Executing work" UI in drawer and modal

- Add comprehensive unit tests and ADR-0050 documentation for the feature execution edge


___

### Diagram Walkthrough


```mermaid
flowchart LR
  schema["KeyResultFeature\n(schema + migration)"]
  router["keyResult.ts router\nlinkFeature / unlinkFeature\nupdateLinkedFeatures"]
  drawer["OkrDetailDrawer\n'Executing work' tab\n(Projects + Features merged)"]
  modal["EditKeyResultModal\nLinked features MultiSelect"]
  tests["Unit tests\nkeyResultFeatureLinks\nupdateLinkedFeatures"]
  adr["ADR-0050\ndocs + CONTEXT.md"]

  schema -- "back-relations" --> router
  router -- "getById / getByObjective\nfeatures include" --> drawer
  router -- "updateLinkedFeatures mutation" --> modal
  router -- "tested by" --> tests
  schema -- "documented in" --> adr
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>schema.prisma</strong><dd><code>Add KeyResultFeature model and back-relations on KeyResult and Feature</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/470/files#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565c">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>keyResult.ts</strong><dd><code>Add linkFeature, unlinkFeature, updateLinkedFeatures procedures with </code><br><code>authz</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/470/files#diff-bc84848f5eb855384754b26268587f4d82ba0a0d871410753ab5c0435dcfab3d">+363/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>OkrDetailDrawer.tsx</strong><dd><code>Merge Projects and Features into unified Executing work tab in drawer</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/470/files#diff-997f0c66c35e5d98639f2be6dcda60d6df6df9d5a6590a4197af8acdcbf8656c">+73/-26</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>EditKeyResultModal.tsx</strong><dd><code>Add Linked features MultiSelect and updateLinkedFeatures mutation to </code><br><code>modal</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/470/files#diff-e327fdef9c7c4fd6a744c749a1a0f181b6c0928074cdd3bc90752e3359cb2b61">+56/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>migration.sql</strong><dd><code>Migration SQL creating KeyResultFeature table with indexes and FKs</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/470/files#diff-bfcefed87ca093d3df103a3de997aa897f2b4d9167a6d16e9141b8fff37ef0c7">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>keyResultFeatureLinks.test.ts</strong><dd><code>Unit tests for linkFeature, unlinkFeature, goalId fill-on-null, and </code><br><code>getById</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/470/files#diff-634640d0e7c21dcf3db28e82317e06eff475c45e484e7d8744a31e144c3e5be2">+346/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>updateLinkedFeatures.test.ts</strong><dd><code>Unit tests for updateLinkedFeatures batch replace and getByObjective </code><br><code>features</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/470/files#diff-f87720e233eacc975d8a02452c22670b5fed4f1ed56400cfd8ed909212b51cb0">+315/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>0050-key-results-accept-feature-execution-links.md</strong><dd><code>ADR-0050 documenting KeyResultFeature decision and consequences</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/470/files#diff-6ffa1224857b9e56fb3a4906ae96446ebe3931d4c97f922292e1955d227a7b75">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CONTEXT.md</strong><dd><code>Update Key result entry with execution-links sentence referencing </code><br><code>ADR-0050</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/470/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

