### PR TITLE
V2: Delivery signal on Executing work

### DIFF
--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -1994,6 +1994,7 @@ export function OkrDetailDrawer({
                         name: p.project.name,
                         status: p.project.status,
                         href: null as string | null,
+                        progress: null as { done: number; total: number } | null,
                       })),
                       ...view.features.map((f) => ({
                         key: `feature-${f.feature.id}`,
@@ -2003,6 +2004,9 @@ export function OkrDetailDrawer({
                         href: workspace?.slug
                           ? `/w/${workspace.slug}/products/${f.feature.product.slug}/features/${f.feature.id}`
                           : null,
+                        // V2 delivery signal (ADR-0050): null for ticketless
+                        // features — no chip, never "0/0".
+                        progress: f.feature.ticketProgress ?? null,
                       })),
                     ].map((row, idx) => {
                       const rowClass = `grid grid-cols-[32px_1fr_auto] items-center gap-3 px-4 py-3 ${
@@ -2024,8 +2028,15 @@ export function OkrDetailDrawer({
                               {row.status}
                             </div>
                           </div>
-                          <span className="rounded border border-border-secondary px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-secondary">
-                            {row.typeLabel}
+                          <span className="flex items-center gap-1.5">
+                            {row.progress && (
+                              <span className="rounded border border-border-secondary px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-text-muted">
+                                {row.progress.done}/{row.progress.total} tickets
+                              </span>
+                            )}
+                            <span className="rounded border border-border-secondary px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-secondary">
+                              {row.typeLabel}
+                            </span>
                           </span>
                         </>
                       );

--- a/src/plugins/okr/server/routers/__tests__/keyResultTicketProgress.test.ts
+++ b/src/plugins/okr/server/routers/__tests__/keyResultTicketProgress.test.ts
@@ -1,0 +1,254 @@
+/**
+ * V2 delivery signal (ADR-0050): done/total ticket counts on the linked
+ * features carried by okr.getById / okr.getByObjective.
+ *
+ * External behavior under test:
+ * - "Done" is the Delivery metrics page's completion definition (ADR-0047):
+ *   DONE or DEPLOYED — ARCHIVED counts toward total but never toward done.
+ * - Ticketless features carry ticketProgress: null (the chip is absent, never
+ *   "0/0").
+ * - No linked features → no ticket query at all.
+ * - Strictly display-only: the delivery signal never writes the key result
+ *   (currentValue stays check-in-only).
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const USER_ID = "user-1";
+const WORKSPACE_ID = "ws-1";
+const KR_ID = "kr-1";
+
+function featureLink(featureId: string) {
+  return {
+    id: `link-${featureId}`,
+    keyResultId: KR_ID,
+    featureId,
+    feature: {
+      id: featureId,
+      name: `Feature ${featureId}`,
+      status: "IN_DEVELOPMENT",
+      product: { id: "prod-1", name: "P", slug: "p", icon: null, color: null },
+    },
+  };
+}
+
+function groupRow(featureId: string, status: string, count: number) {
+  return { featureId, status, _count: { _all: count } };
+}
+
+type FeatureWithProgress = {
+  feature: { id: string; ticketProgress: { done: number; total: number } | null };
+};
+
+describe("okr.getById — delivery signal (ticketProgress)", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+    db.keyResult.findFirst.mockResolvedValue({
+      id: KR_ID,
+      userId: USER_ID,
+      goalId: 42,
+      projects: [],
+      features: [featureLink("feat-tickets"), featureLink("feat-none")],
+    } as never);
+  });
+
+  it("attaches done/total per the ADR-0047 definition; ticketless features get null", async () => {
+    // Tracer scenario: 5 tickets, 2 of them DONE/DEPLOYED -> "2/5".
+    db.ticket.groupBy.mockResolvedValue([
+      groupRow("feat-tickets", "IN_PROGRESS", 3),
+      groupRow("feat-tickets", "DONE", 1),
+      groupRow("feat-tickets", "DEPLOYED", 1),
+    ] as never);
+    const caller = createMockCaller({ userId: USER_ID, db });
+
+    const result = (await caller.okr.getById({ id: KR_ID })) as unknown as {
+      features: FeatureWithProgress[];
+    };
+
+    expect(result.features[0]!.feature.ticketProgress).toEqual({
+      done: 2,
+      total: 5,
+    });
+    // Absent chip contract: null, never { done: 0, total: 0 }.
+    expect(result.features[1]!.feature.ticketProgress).toBeNull();
+  });
+
+  it("counts ARCHIVED toward total but never toward done (narrower than COMPLETED_TICKET_STATUSES)", async () => {
+    db.ticket.groupBy.mockResolvedValue([
+      groupRow("feat-tickets", "ARCHIVED", 2),
+      groupRow("feat-tickets", "DONE", 1),
+    ] as never);
+    const caller = createMockCaller({ userId: USER_ID, db });
+
+    const result = (await caller.okr.getById({ id: KR_ID })) as unknown as {
+      features: FeatureWithProgress[];
+    };
+
+    expect(result.features[0]!.feature.ticketProgress).toEqual({
+      done: 1,
+      total: 3,
+    });
+  });
+
+  it("skips the ticket query entirely when no features are linked", async () => {
+    db.keyResult.findFirst.mockResolvedValue({
+      id: KR_ID,
+      userId: USER_ID,
+      goalId: 42,
+      projects: [],
+      features: [],
+    } as never);
+    const caller = createMockCaller({ userId: USER_ID, db });
+
+    await caller.okr.getById({ id: KR_ID });
+
+    expect(db.ticket.groupBy).not.toHaveBeenCalled();
+  });
+
+  it("never writes the key result — the signal is display-only", async () => {
+    db.ticket.groupBy.mockResolvedValue([
+      groupRow("feat-tickets", "DONE", 5),
+    ] as never);
+    const caller = createMockCaller({ userId: USER_ID, db });
+
+    await caller.okr.getById({ id: KR_ID });
+
+    expect(db.keyResult.update).not.toHaveBeenCalled();
+    expect(db.keyResult.updateMany).not.toHaveBeenCalled();
+    expect(db.keyResultCheckIn.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("okr.getByObjective — delivery signal (ticketProgress)", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+    db.workspaceUser.findUnique.mockResolvedValue({
+      role: "member",
+      workspaceId: WORKSPACE_ID,
+    } as never);
+    db.goal.findMany.mockResolvedValue([
+      {
+        id: 42,
+        progressOverride: null,
+        keyResults: [
+          {
+            id: KR_ID,
+            status: "on-track",
+            currentValue: 1,
+            targetValue: 10,
+            startValue: 0,
+            checkIns: [],
+            projects: [],
+            features: [featureLink("feat-tickets"), featureLink("feat-none")],
+          },
+        ],
+      },
+    ] as never);
+  });
+
+  it("attaches done/total to nested linked features; ticketless features get null", async () => {
+    db.ticket.groupBy.mockResolvedValue([
+      groupRow("feat-tickets", "QA", 1),
+      groupRow("feat-tickets", "DEPLOYED", 2),
+    ] as never);
+    const caller = createMockCaller({ userId: USER_ID, db });
+
+    const result = (await caller.okr.getByObjective({
+      workspaceId: WORKSPACE_ID,
+    })) as unknown as Array<{ keyResults: Array<{ features: FeatureWithProgress[] }> }>;
+
+    const features = result[0]!.keyResults[0]!.features;
+    expect(features[0]!.feature.ticketProgress).toEqual({ done: 2, total: 3 });
+    expect(features[1]!.feature.ticketProgress).toBeNull();
+
+    // One deduped query for the whole response.
+    expect(db.ticket.groupBy).toHaveBeenCalledTimes(1);
+    const arg = db.ticket.groupBy.mock.calls[0]![0] as unknown as {
+      where: { featureId: { in: string[] } };
+    };
+    expect([...arg.where.featureId.in].sort()).toEqual([
+      "feat-none",
+      "feat-tickets",
+    ]);
+  });
+
+  it("never writes the key result — the signal is display-only", async () => {
+    db.ticket.groupBy.mockResolvedValue([] as never);
+    const caller = createMockCaller({ userId: USER_ID, db });
+
+    await caller.okr.getByObjective({ workspaceId: WORKSPACE_ID });
+
+    expect(db.keyResult.update).not.toHaveBeenCalled();
+    expect(db.keyResult.updateMany).not.toHaveBeenCalled();
+    expect(db.keyResultCheckIn.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { PrismaClient } from "@prisma/client";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
@@ -12,6 +13,45 @@ import {
   mergeObjectiveActivity,
   type ObjectiveActivityItem,
 } from "../objectiveActivity";
+
+// "Done" for the delivery signal = the Delivery metrics page's completion
+// definition (ADR-0047, SprintAnalyticsService): DONE or DEPLOYED —
+// deliberately narrower than lib/ticket-statuses' COMPLETED_TICKET_STATUSES,
+// which also counts ARCHIVED.
+const DELIVERY_DONE_STATUSES: ReadonlySet<string> = new Set([
+  "DONE",
+  "DEPLOYED",
+]);
+
+/**
+ * Done/total ticket counts for the given features — the V2 delivery signal on
+ * a key result's "Executing work" list (ADR-0050). Computed read-side on
+ * request, never stored; strictly display context — nothing here ever writes
+ * KeyResult.currentValue. Ticketless features are absent from the map so the
+ * UI renders no chip (never "0/0").
+ */
+async function getTicketProgressByFeature(
+  db: PrismaClient,
+  featureIds: string[],
+): Promise<Map<string, { done: number; total: number }>> {
+  const progress = new Map<string, { done: number; total: number }>();
+  if (featureIds.length === 0) return progress;
+
+  const grouped = await db.ticket.groupBy({
+    by: ["featureId", "status"],
+    where: { featureId: { in: featureIds } },
+    _count: { _all: true },
+  });
+
+  for (const row of grouped) {
+    if (row.featureId == null) continue;
+    const entry = progress.get(row.featureId) ?? { done: 0, total: 0 };
+    entry.total += row._count._all;
+    if (DELIVERY_DONE_STATUSES.has(row.status)) entry.done += row._count._all;
+    progress.set(row.featureId, entry);
+  }
+  return progress;
+}
 
 // Input validation schemas
 const createKeyResultInput = z.object({
@@ -403,7 +443,24 @@ export const keyResultRouter = createTRPCRouter({
         });
       }
 
-      return keyResult;
+      // V2 delivery signal (ADR-0050): attach done/total ticket counts to
+      // each linked feature. Null for ticketless features — the drawer
+      // renders no chip rather than "0/0".
+      const progressByFeature = await getTicketProgressByFeature(
+        ctx.db,
+        keyResult.features.map((link) => link.feature.id),
+      );
+
+      return {
+        ...keyResult,
+        features: keyResult.features.map((link) => ({
+          ...link,
+          feature: {
+            ...link.feature,
+            ticketProgress: progressByFeature.get(link.feature.id) ?? null,
+          },
+        })),
+      };
     }),
 
   // Batch lookup of KR metadata by ids — used by Phase 3 of weekly review

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -35,11 +35,14 @@ async function getTicketProgressByFeature(
   featureIds: string[],
 ): Promise<Map<string, { done: number; total: number }>> {
   const progress = new Map<string, { done: number; total: number }>();
-  if (featureIds.length === 0) return progress;
+  // The same feature may execute several key results in one response
+  // (getByObjective) — dedupe before querying.
+  const uniqueIds = [...new Set(featureIds)];
+  if (uniqueIds.length === 0) return progress;
 
   const grouped = await db.ticket.groupBy({
     by: ["featureId", "status"],
-    where: { featureId: { in: featureIds } },
+    where: { featureId: { in: uniqueIds } },
     _count: { _all: true },
   });
 
@@ -350,6 +353,17 @@ export const keyResultRouter = createTRPCRouter({
         orderBy: { title: "asc" },
       });
 
+      // V2 delivery signal (ADR-0050): one groupBy across every linked
+      // feature in the response, attached as done/total per feature below.
+      const progressByFeature = await getTicketProgressByFeature(
+        ctx.db,
+        goals.flatMap((goal) =>
+          goal.keyResults.flatMap((kr) =>
+            kr.features.map((link) => link.feature.id),
+          ),
+        ),
+      );
+
       // Calculate progress for each objective. A manual progressOverride wins
       // over the KR-derived mean (see goalProgress.ts); falls back to 0 when a
       // goal has neither an override nor measurable key results.
@@ -368,6 +382,17 @@ export const keyResultRouter = createTRPCRouter({
 
         return {
           ...goal,
+          keyResults: keyResults.map((kr) => ({
+            ...kr,
+            features: kr.features.map((link) => ({
+              ...link,
+              feature: {
+                ...link.feature,
+                ticketProgress:
+                  progressByFeature.get(link.feature.id) ?? null,
+              },
+            })),
+          })),
           progress: resolved,
           statusCounts,
         };


### PR DESCRIPTION
### **User description**
Ticket: `epic.canyon` (cmsdiujj70005kv04aai1efqp), feature cmsdi8z2r000hjs04ahyt074w, scope V2. Decision record: ADR-0050. Builds on V1 (#470).

> **Stacked PR** — targets `feature/external-agents` (which now contains V1 via the #470 squash) and merges **after** it. The diff below is exactly this ticket's two commits.

Delivery-signal context on the "Executing work" list: each linked-feature row on a Key result now shows **done/total ticket progress** — read-side context beside the KR, never written into it.

## What's in here

- **Read-side counts**: `okr.getById` and `okr.getByObjective` attach `ticketProgress: { done, total } | null` to every linked feature — computed live per request via one deduped `ticket.groupBy` per response (no persistence, no extra query per feature).
- **Done definition**: `DONE` or `DEPLOYED` — the Delivery metrics page's completion definition (ADR-0047, `SprintAnalyticsService`), deliberately **narrower** than `lib/ticket-statuses`' `COMPLETED_TICKET_STATUSES`, which also counts `ARCHIVED`. ARCHIVED tickets count toward total, never toward done.
- **Drawer chip**: feature rows in "Executing work" render a "2/5 tickets" chip (semantic tokens only). The chip is **absent** for ticketless features — `ticketProgress` is `null`, never `0/0`. Project rows get no chip (Actions have their own semantics — out of scope).

## Constraints held

- Strictly display-only: no code path writes `KeyResult.currentValue` from ticket progress (pinned by tests).
- No per-scope breakdown; no progress on linked projects.
- `KeyResultProject` untouched; no hardcoded colors.

## Tests

6 new unit tests (mocked Prisma, no DB): the 2/5 tracer scenario, the ARCHIVED-excluded-from-done definition, null-for-ticketless (chip absence), query skipped when no features are linked, single deduped groupBy across a whole getByObjective response, and the never-writes-the-KR constraint on both reads.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add read-side ticket progress (`done/total`) to linked features in `getById` and `getByObjective`

- Introduce `getTicketProgressByFeature` helper using a single deduped `ticket.groupBy` per response

- Render a "done/total tickets" chip in the "Executing work" drawer for features with tickets

- Add 6 unit tests covering the delivery signal, done definition, null-for-ticketless, and display-only constraint


___

### Diagram Walkthrough


```mermaid
flowchart LR
  helper["getTicketProgressByFeature\n(one deduped groupBy)"]
  getById["okr.getById\nattaches ticketProgress"]
  getByObjective["okr.getByObjective\nattaches ticketProgress"]
  drawer["OkrDetailDrawer\n'done/total tickets' chip"]
  tests["keyResultTicketProgress.test.ts\n6 unit tests"]

  helper -- "Map featureId → {done,total}" --> getById
  helper -- "Map featureId → {done,total}" --> getByObjective
  getById -- "ticketProgress on features" --> drawer
  getByObjective -- "ticketProgress on features" --> drawer
  getById -- "tested by" --> tests
  getByObjective -- "tested by" --> tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>keyResult.ts</strong><dd><code>Attach read-side ticket progress to linked features in OKR queries</code></dd></summary>
<hr>

src/plugins/okr/server/routers/keyResult.ts

<ul><li>Add <code>DELIVERY_DONE_STATUSES</code> constant (<code>DONE</code>, <code>DEPLOYED</code>) matching ADR-0047 <br>definition<br> <li> Add <code>getTicketProgressByFeature</code> helper that runs one deduped <br><code>ticket.groupBy</code> and returns a <code>Map<featureId, {done, total}></code><br> <li> Extend <code>getById</code> to call the helper and attach <code>ticketProgress</code> (or <code>null</code>) <br>to each linked feature<br> <li> Extend <code>getByObjective</code> to call the helper across all features in the <br>response and spread <code>ticketProgress</code> into each nested feature link</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/471/files#diff-bc84848f5eb855384754b26268587f4d82ba0a0d871410753ab5c0435dcfab3d">+83/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OkrDetailDrawer.tsx</strong><dd><code>Render conditional ticket progress chip in Executing work drawer</code></dd></summary>
<hr>

src/plugins/okr/client/components/OkrDetailDrawer.tsx

<ul><li>Add <code>progress</code> field (<code>{done, total} | null</code>) to the unified row shape for <br>both projects and features<br> <li> Project rows always get <code>progress: null</code>; feature rows get <br><code>f.feature.ticketProgress ?? null</code><br> <li> Render a "done/total tickets" chip beside the type label only when <br><code>progress</code> is non-null (never "0/0")<br> <li> Wrap type-label span in a flex container to accommodate the optional <br>progress chip</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/471/files#diff-997f0c66c35e5d98639f2be6dcda60d6df6df9d5a6590a4197af8acdcbf8656c">+13/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>keyResultTicketProgress.test.ts</strong><dd><code>Unit tests for V2 delivery signal ticket progress on key results</code></dd></summary>
<hr>

src/plugins/okr/server/routers/__tests__/keyResultTicketProgress.test.ts

<ul><li>New test file with 6 unit tests using <code>mockDeep<PrismaClient>()</code> (no real DB)<br> <li> Tests cover: 2/5 tracer scenario, ARCHIVED-excluded-from-done, null <br>for ticketless features, query skipped when no features linked, single <br>deduped <code>groupBy</code> across <code>getByObjective</code>, and never-writes-the-KR <br>constraint<br> <li> Covers both <code>okr.getById</code> and <code>okr.getByObjective</code> delivery signal paths</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/471/files#diff-5f37fd37956f6fb72ae6ecc184024d8edd65d9ce0d6a2b160254dfdf0b3aec26">+254/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

