### PR TITLE
feat: accept GlitchTip generic webhooks on the Sentry bug endpoints

### DIFF
--- a/dev-docs/OBSERVABILITY.md
+++ b/dev-docs/OBSERVABILITY.md
@@ -57,6 +57,28 @@ announcements to **Zulip** (`sentryZulip.ts`) and **Matrix**
 `.env.example`); the room must be unencrypted and the bot joined. Recurring
 errors that dedup onto an existing ticket do not re-notify.
 
+### GlitchTip senders
+
+The same endpoints accept GlitchTip's **generic (Slack-compatible) webhook**,
+which other services in this org use. Two differences from Sentry, both
+handled automatically:
+
+- **No `Sentry-Hook-Resource` header.** Its absence is what selects the
+  GlitchTip parser (`normalizeGlitchtipPayload`), which reads the flat
+  `{alias, issue_id, project, attachments[0].title/title_link}` shape instead
+  of Sentry's nested `data.issue`. Only `issue.new` / `issue.regression` file
+  a ticket; resolutions are ignored. If `issue_id` is missing the id is
+  recovered from the issue URL.
+- **No HMAC.** GlitchTip cannot sign the body, and its Alert Rule UI accepts
+  only a URL — no custom headers — so the shared secret may travel as a
+  `?token=` query param. On the per-workspace route the token is the
+  integration's own secret. Prefer the `X-Webhook-Token` header where the
+  sender supports it: query strings are more likely to be captured in proxy
+  and access logs.
+
+Security boundary: presenting a `Sentry-Hook-Signature` commits the sender to
+HMAC. An invalid signature is always a 401 — a valid token never rescues it.
+
 Tickets are labelled `Sentry` + `bug`, and additionally `ai-fixable` when the
 issue's Sentry project is listed in `SENTRY_AI_FIXABLE_PROJECTS` — the
 allowlist exists because the webhook is org-wide and a bug from another

--- a/src/app/api/webhooks/sentry/[webhookId]/__tests__/route.test.ts
+++ b/src/app/api/webhooks/sentry/[webhookId]/__tests__/route.test.ts
@@ -39,14 +39,18 @@ function fakeRequest(opts: {
   body: string;
   resource?: string;
   signature?: string;
+  tokenQuery?: string;
 }): NextRequest {
   const headers = new Map<string, string>();
   if (opts.signature !== undefined)
     headers.set("sentry-hook-signature", opts.signature);
   if (opts.resource !== undefined)
     headers.set("sentry-hook-resource", opts.resource);
+  const searchParams = new URLSearchParams();
+  if (opts.tokenQuery !== undefined) searchParams.set("token", opts.tokenQuery);
   return {
     headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+    nextUrl: { searchParams },
     text: () => Promise.resolve(opts.body),
   } as unknown as NextRequest;
 }
@@ -153,5 +157,63 @@ describe("POST /api/webhooks/sentry/[webhookId]", () => {
     );
     expect(res.status).toBe(200);
     expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  describe("unsigned GlitchTip requests", () => {
+    const glitchtipBody = JSON.stringify({
+      alias: "issue.new",
+      issue_id: 555,
+      project: "clear-pipeline",
+      attachments: [{ title: "OperationalError: connection reset" }],
+    });
+
+    it("accepts the integration's own secret as a query token", async () => {
+      const res = await POST(
+        fakeRequest({ body: glitchtipBody, tokenQuery: SECRET }),
+        ctx,
+      );
+
+      expect(res.status).toBe(200);
+      expect(ingestSentryBug).toHaveBeenCalledTimes(1);
+      const arg = ingestSentryBug.mock.calls[0]![1] as unknown as {
+        issueId: string;
+        projectSlug: string;
+      };
+      expect(arg.issueId).toBe("555");
+      expect(arg.projectSlug).toBe("clear-pipeline");
+      // Routed to this tenant's configured product, as for signed requests.
+      expect(ingestSentryBug.mock.calls[0]![2]).toEqual({
+        productId: "prod-1",
+      });
+    });
+
+    it("rejects a wrong query token with 401", async () => {
+      const res = await POST(
+        fakeRequest({ body: glitchtipBody, tokenQuery: "not-the-secret" }),
+        ctx,
+      );
+      expect(res.status).toBe(401);
+      expect(ingestSentryBug).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unsigned request carrying no token at all", async () => {
+      const res = await POST(fakeRequest({ body: glitchtipBody }), ctx);
+      expect(res.status).toBe(401);
+      expect(ingestSentryBug).not.toHaveBeenCalled();
+    });
+
+    it("never lets a valid token rescue a request whose signature is invalid", async () => {
+      // Security boundary: offering a signature commits the sender to HMAC.
+      const res = await POST(
+        fakeRequest({
+          body: glitchtipBody,
+          signature: "deadbeef",
+          tokenQuery: SECRET,
+        }),
+        ctx,
+      );
+      expect(res.status).toBe(401);
+      expect(ingestSentryBug).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/api/webhooks/sentry/[webhookId]/route.ts
+++ b/src/app/api/webhooks/sentry/[webhookId]/route.ts
@@ -2,8 +2,9 @@ import { type NextRequest, NextResponse } from "next/server";
 import { db } from "~/server/db";
 import { ingestSentryBug } from "~/server/services/sentry/SentryBugService";
 import {
-  normalizeSentryPayload,
+  normalizeIssueWebhook,
   verifySentrySignature,
+  verifyWebhookToken,
 } from "~/server/services/sentry/sentryPayload";
 import { getDecryptedKey } from "~/server/utils/credentialHelper";
 
@@ -17,9 +18,19 @@ import { getDecryptedKey } from "~/server/utils/credentialHelper";
  * integration's stored secret, and files the issue as a Bug Ticket in the
  * workspace's chosen destination Product (`providerConfig.productId`).
  *
- * Unlike the global route, there is no shared env secret and no unauthenticated
- * mode — a configured integration always has a secret, so every request must
- * carry a valid `Sentry-Hook-Signature`.
+ * Unlike the global route there is no shared env secret and no unauthenticated
+ * mode: a configured integration always has a secret, and every request must
+ * prove knowledge of it one of two ways.
+ *
+ *  - **Sentry** signs the raw body — `Sentry-Hook-Signature` must verify by
+ *    HMAC against the integration's secret. Whenever a signature is present it
+ *    must be valid; there is no falling back to the weaker gate.
+ *  - **GlitchTip's generic webhook** cannot sign and cannot set headers (its
+ *    Alert Rule UI takes only a URL), so it may instead present the same
+ *    secret verbatim as a `?token=` query param, compared constant-time. This
+ *    is strictly weaker — it proves the sender knows the secret but not that
+ *    the body is untampered, and query strings are more prone to landing in
+ *    proxy logs — so it is accepted only when no signature was offered.
  */
 export async function POST(
   request: NextRequest,
@@ -69,9 +80,29 @@ export async function POST(
       );
     }
 
-    if (!signature || !verifySentrySignature(rawBody, signature, secret)) {
-      console.error(`[sentry webhook ${webhookId}] invalid signature`);
-      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    if (signature) {
+      // A signature was offered: it must verify. No fallback to the token gate.
+      if (!verifySentrySignature(rawBody, signature, secret)) {
+        console.error(`[sentry webhook ${webhookId}] invalid signature`);
+        return NextResponse.json(
+          { error: "Invalid signature" },
+          { status: 401 },
+        );
+      }
+    } else {
+      // Unsigned (GlitchTip): the same secret must be presented verbatim.
+      const provided =
+        request.headers.get("x-webhook-token") ??
+        request.nextUrl.searchParams.get("token");
+      if (!provided || !verifyWebhookToken(provided, secret)) {
+        console.error(
+          `[sentry webhook ${webhookId}] unsigned request with invalid or missing token`,
+        );
+        return NextResponse.json(
+          { error: "Invalid signature" },
+          { status: 401 },
+        );
+      }
     }
 
     if (integration.status !== "ACTIVE") {
@@ -81,17 +112,13 @@ export async function POST(
       );
     }
 
-    if (!resource) {
-      return NextResponse.json(
-        { error: "Missing Sentry-Hook-Resource header" },
-        { status: 400 },
-      );
-    }
-
-    const bug = normalizeSentryPayload(resource, JSON.parse(rawBody) as unknown);
+    // No resource header ⇒ treat as GlitchTip's generic webhook.
+    const bug = normalizeIssueWebhook(resource, JSON.parse(rawBody) as unknown);
     if (!bug) {
       // Not an event we file as a bug (installation, comment, resolved, etc.).
-      return NextResponse.json({ message: `Ignored Sentry ${resource} event` });
+      return NextResponse.json({
+        message: `Ignored ${resource ?? "glitchtip"} event`,
+      });
     }
 
     const config = integration.providerConfig as { productId?: string } | null;

--- a/src/app/api/webhooks/sentry/__tests__/route.test.ts
+++ b/src/app/api/webhooks/sentry/__tests__/route.test.ts
@@ -36,14 +36,21 @@ function fakeRequest(opts: {
   body: string;
   resource?: string;
   signature?: string;
+  tokenHeader?: string;
+  tokenQuery?: string;
 }): NextRequest {
   const headers = new Map<string, string>();
   if (opts.signature !== undefined)
     headers.set("sentry-hook-signature", opts.signature);
   if (opts.resource !== undefined)
     headers.set("sentry-hook-resource", opts.resource);
+  if (opts.tokenHeader !== undefined)
+    headers.set("x-webhook-token", opts.tokenHeader);
+  const searchParams = new URLSearchParams();
+  if (opts.tokenQuery !== undefined) searchParams.set("token", opts.tokenQuery);
   return {
     headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+    nextUrl: { searchParams },
     text: () => Promise.resolve(opts.body),
   } as unknown as NextRequest;
 }
@@ -93,5 +100,109 @@ describe("POST /api/webhooks/sentry", () => {
     expect(ingestSentryBug).toHaveBeenCalledTimes(1);
     const arg = ingestSentryBug.mock.calls[0]![1] as unknown as { issueId: string };
     expect(arg.issueId).toBe("42");
+  });
+});
+
+/**
+ * GlitchTip's generic webhook: no `Sentry-Hook-Resource` header, a flat body,
+ * and a secret that can only travel in the URL. Token auth only — HMAC is not
+ * available to it — so these tests run with the secret gate off.
+ */
+describe("POST /api/webhooks/sentry (GlitchTip generic webhook)", () => {
+  const TOKEN = "glitchtip-shared-token";
+
+  const glitchtipBody = JSON.stringify({
+    alias: "issue.new",
+    text: "GlitchTip Alert",
+    issue_id: 777,
+    project: "clear-api",
+    attachments: [
+      {
+        title: "TypeError: cannot read property of undefined",
+        title_link: "https://glitchtip.example.com/org/clear-api/issues/777",
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    delete process.env.SENTRY_WEBHOOK_SECRET;
+    process.env.SENTRY_WEBHOOK_TOKEN = TOKEN;
+  });
+
+  it("accepts the shared secret as a query param and files the issue", async () => {
+    const res = await POST(
+      fakeRequest({ body: glitchtipBody, tokenQuery: TOKEN }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(ingestSentryBug).toHaveBeenCalledTimes(1);
+    const arg = ingestSentryBug.mock.calls[0]![1] as unknown as {
+      issueId: string;
+      title: string;
+      url: string;
+      projectSlug: string;
+    };
+    expect(arg.issueId).toBe("777");
+    // The attachment title is the real error; `text` is boilerplate.
+    expect(arg.title).toBe("TypeError: cannot read property of undefined");
+    expect(arg.projectSlug).toBe("clear-api");
+    expect(arg.url).toBe(
+      "https://glitchtip.example.com/org/clear-api/issues/777",
+    );
+  });
+
+  it("still accepts the token in the header (preferred over the query param)", async () => {
+    const res = await POST(
+      fakeRequest({ body: glitchtipBody, tokenHeader: TOKEN }),
+    );
+    expect(res.status).toBe(200);
+    expect(ingestSentryBug).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a wrong query token with 401 and does not ingest", async () => {
+    const res = await POST(
+      fakeRequest({ body: glitchtipBody, tokenQuery: "wrong-token" }),
+    );
+    expect(res.status).toBe(401);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("ignores a resolution event rather than filing a ticket for it", async () => {
+    const body = JSON.stringify({
+      alias: "issue.resolved",
+      issue_id: 777,
+      attachments: [{ title: "TypeError: already fixed" }],
+    });
+    const res = await POST(fakeRequest({ body, tokenQuery: TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("recovers the issue id from the issue URL when issue_id is absent", async () => {
+    const body = JSON.stringify({
+      alias: "issue.new",
+      attachments: [
+        {
+          title: "RangeError: out of range",
+          title_link: "https://glitchtip.example.com/org/clear-mvp/issues/12345",
+        },
+      ],
+    });
+    const res = await POST(fakeRequest({ body, tokenQuery: TOKEN }));
+
+    expect(res.status).toBe(200);
+    const arg = ingestSentryBug.mock.calls[0]![1] as unknown as {
+      issueId: string;
+    };
+    expect(arg.issueId).toBe("12345");
+  });
+
+  it("ignores a payload with no recoverable issue id", async () => {
+    const body = JSON.stringify({ alias: "issue.new", text: "no id anywhere" });
+    const res = await POST(fakeRequest({ body, tokenQuery: TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/webhooks/sentry/route.ts
+++ b/src/app/api/webhooks/sentry/route.ts
@@ -2,26 +2,35 @@ import { type NextRequest, NextResponse } from "next/server";
 import { db } from "~/server/db";
 import { ingestSentryBug } from "~/server/services/sentry/SentryBugService";
 import {
-  normalizeSentryPayload,
+  normalizeIssueWebhook,
   verifySentrySignature,
   verifyWebhookToken,
 } from "~/server/services/sentry/sentryPayload";
 
 /**
- * Sentry → Exponential bug webhook (ADR-0027).
+ * Sentry / GlitchTip → Exponential bug webhook (ADR-0027).
  *
- * Configure a Sentry internal integration to POST here on the `issue` (created)
- * resource. Each new Sentry issue becomes a Bug Ticket (`type: BUG`,
- * `status: BACKLOG`) in the configured product, authored by the Errol system
- * user. Recurring errors are collapsed onto one ticket in a later slice (dedup).
+ * Each new issue becomes a Bug Ticket (`type: BUG`, `status: BACKLOG`) in the
+ * configured product, authored by the Errol system user. Recurring errors are
+ * collapsed onto one ticket (dedup on the issue id).
+ *
+ * Two senders, distinguished by the `Sentry-Hook-Resource` header:
+ *  - **Sentry** sends the header plus a nested `{action, data.issue}` body.
+ *  - **GlitchTip's generic webhook** sends no header and a flat, Slack-styled
+ *    body. Its Alert Rule UI accepts only a URL — no custom headers — so the
+ *    shared secret may also travel as a `?token=` query param.
  *
  * Auth: two independent gates, each active only when its env var is set.
- *  - `SENTRY_WEBHOOK_TOKEN`: a shared secret the sender echoes in the
- *    `X-Webhook-Token` header. For senders that can set headers but can't sign
- *    the body (e.g. Glitchtip, which has no HMAC signing yet).
+ *  - `SENTRY_WEBHOOK_TOKEN`: a shared secret echoed in the `X-Webhook-Token`
+ *    header, or (for GlitchTip) the `token` query param. The header is
+ *    preferred: query strings are far more likely to be captured in proxy and
+ *    access logs, so the param exists only because GlitchTip allows nothing
+ *    else.
  *  - `SENTRY_WEBHOOK_SECRET`: real Sentry signs the raw body with HMAC-SHA256
  *    using the integration's Client Secret and sends it in
  *    `Sentry-Hook-Signature`. Verification is one-way, like the GitHub webhook.
+ *    GlitchTip cannot sign, so a GlitchTip-only deployment should configure
+ *    the token and leave the secret unset.
  * If both are set, both must pass; if neither is set, the endpoint is open
  * (logged). Configure at least one in any internet-facing deployment.
  */
@@ -33,7 +42,9 @@ export async function POST(request: NextRequest) {
 
     const token = process.env.SENTRY_WEBHOOK_TOKEN;
     if (token) {
-      const provided = request.headers.get("x-webhook-token");
+      const provided =
+        request.headers.get("x-webhook-token") ??
+        request.nextUrl.searchParams.get("token");
       if (!provided || !verifyWebhookToken(provided, token)) {
         console.error("[sentry webhook] invalid or missing webhook token");
         return NextResponse.json({ error: "Invalid token" }, { status: 401 });
@@ -57,17 +68,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!resource) {
-      return NextResponse.json(
-        { error: "Missing Sentry-Hook-Resource header" },
-        { status: 400 },
-      );
-    }
-
-    const bug = normalizeSentryPayload(resource, JSON.parse(rawBody) as unknown);
+    // No resource header ⇒ treat as GlitchTip's generic webhook.
+    const bug = normalizeIssueWebhook(resource, JSON.parse(rawBody) as unknown);
     if (!bug) {
       // Not an event we file as a bug (installation, comment, resolved, etc.).
-      return NextResponse.json({ message: `Ignored Sentry ${resource} event` });
+      return NextResponse.json({
+        message: `Ignored ${resource ?? "glitchtip"} event`,
+      });
     }
 
     const result = await ingestSentryBug(db, bug);

--- a/src/server/services/sentry/sentryPayload.ts
+++ b/src/server/services/sentry/sentryPayload.ts
@@ -51,6 +51,110 @@ interface SentryWebhookBody {
 }
 
 /**
+ * Minimal view of a GlitchTip *generic* (Slack-compatible) webhook body.
+ *
+ * GlitchTip has two outbound webhook modes. Its Sentry-compatible mode sends
+ * the nested `{action, data.issue}` shape handled above; its generic mode —
+ * the one its Alert Rule UI offers by default — sends this flat, Slack-styled
+ * shape instead, with no `Sentry-Hook-Resource` header.
+ */
+interface GlitchtipWebhookBody {
+  /** Event type slug, e.g. "issue.new" / "issue.resolved". Sometimes a bot name. */
+  alias?: string;
+  /** Human-readable summary; often boilerplate like "GlitchTip Alert". */
+  text?: string;
+  /** GlitchTip sends the issue id at the top level. */
+  issue_id?: string | number;
+  /** Project slug as a bare string (Sentry nests it under `project.slug`). */
+  project?: string | { slug?: string };
+  culprit?: string;
+  level?: string;
+  /** Slack-style content — the real error title/link live here. */
+  attachments?: {
+    title?: string;
+    title_link?: string;
+    text?: string;
+  }[];
+}
+
+/**
+ * Aliases we file a bug for. Anything else dotted (`issue.resolved`,
+ * `issue.archived`, …) is ignored. Dedup makes a mistake here cheap — a second
+ * event for a known issue id collapses onto the existing ticket — but not
+ * filing on resolutions keeps the backlog honest.
+ */
+const GLITCHTIP_NEW_ISSUE_ALIASES = ["issue.new", "issue.regression"];
+
+/** Trailing issue id in a GlitchTip issue URL: `…/issues/12345`. */
+const GLITCHTIP_ISSUE_URL = /\/issues\/(\d+)/;
+
+/**
+ * Turn a GlitchTip generic-webhook body into a normalized {@link SentryBug}, or
+ * `null` if it isn't a new-issue event we file.
+ */
+export function normalizeGlitchtipPayload(body: unknown): SentryBug | null {
+  const payload = (body ?? {}) as GlitchtipWebhookBody;
+
+  // `alias` is the event type when dotted. Some GlitchTip versions put a bot
+  // name there instead, so only *dotted* values are treated as a filter —
+  // otherwise we'd ignore every event on a deployment that sends "GlitchTip".
+  const alias = payload.alias;
+  if (
+    typeof alias === "string" &&
+    alias.includes(".") &&
+    !GLITCHTIP_NEW_ISSUE_ALIASES.includes(alias)
+  ) {
+    return null;
+  }
+
+  const attachment = payload.attachments?.[0];
+  const url = attachment?.title_link ?? null;
+
+  // Prefer the explicit id; fall back to parsing the issue URL so this still
+  // works on versions that omit `issue_id`. Without either we have no dedup
+  // key, so the event is not fileable.
+  const issueId =
+    payload.issue_id !== undefined && payload.issue_id !== null
+      ? String(payload.issue_id)
+      : (GLITCHTIP_ISSUE_URL.exec(url ?? "")?.[1] ?? null);
+  if (!issueId) return null;
+
+  // The attachment title carries the actual error; `text` is often boilerplate.
+  const title = attachment?.title ?? payload.text ?? "Untitled GlitchTip issue";
+
+  const projectSlug =
+    typeof payload.project === "string"
+      ? payload.project
+      : (payload.project?.slug ?? null);
+
+  return {
+    issueId,
+    title,
+    level: payload.level ?? null,
+    culprit: payload.culprit ?? null,
+    url,
+    // GlitchTip's generic payload has no Sentry-style short id.
+    shortId: null,
+    projectSlug,
+  };
+}
+
+/**
+ * Normalize an inbound issue webhook from either sender.
+ *
+ * Sentry always sends a `Sentry-Hook-Resource` header; GlitchTip's generic
+ * webhook sends none, so its absence is the discriminator.
+ */
+export function normalizeIssueWebhook(
+  resource: string | null,
+  body: unknown,
+): SentryBug | null {
+  return resource
+    ? normalizeSentryPayload(resource, body)
+    : normalizeGlitchtipPayload(body);
+}
+
+/**
  * Verify a Sentry integration-platform webhook signature.
  *
  * Sentry signs the raw request body with HMAC-SHA256 using the integration's


### PR DESCRIPTION
### **User description**
## Why

Sibling services (clear-api, clear-mvp, clear-pipeline, clear-context-pipeline) report to GlitchTip, and we want their errors to file Exponential bug Tickets + announce in Matrix through the same pipeline.

GlitchTip has two outbound webhook modes. Its **generic (Slack-compatible)** mode — what its Alert Rule UI offers, and what clear-api's own receiver is built against (`src/routes/webhooks.ts:10-14,54`) — sends a flat `{alias, text, issue_id, project, attachments}` body with **no `Sentry-Hook-Resource` header**. Both of our endpoints required that header (400 before parsing) and understood only Sentry's nested `data.issue` shape, so those alerts could never file anything.

## What

- `normalizeGlitchtipPayload` parses the flat shape; `normalizeIssueWebhook` dispatches on whether the resource header is present. Files on `issue.new`/`issue.regression` only (resolutions ignored); recovers the issue id from the issue URL when `issue_id` is absent; reads the real error title from `attachments[0].title` (GlitchTip's `text` is usually boilerplate).
- Accepts the shared secret as a `?token=` query param alongside `X-Webhook-Token`, because GlitchTip can set neither custom headers nor a signature. On the per-workspace route the token is that integration's own stored secret, so per-tenant product routing works for GlitchTip senders too.
- `.env.example` / `dev-docs/OBSERVABILITY.md` updated.

## Security

Presenting a `Sentry-Hook-Signature` commits the sender to HMAC: an invalid signature is always 401 and a valid token **cannot** rescue it (explicit regression test). The token path is reachable only when no signature was offered. The docs note why the query param is the weaker option and to prefer the header where a sender supports it. Signed Sentry traffic is behaviourally unchanged.

## Validation

10 new tests; 60 green across the Sentry suites. ESLint clean; unit suite via pre-commit; Vercel build via pre-push.

## Caveat for the reviewer

The GlitchTip payload shape is taken from clear-api's documented receiver — I had no live GlitchTip instance to verify against. The parser is deliberately defensive (multiple field fallbacks, URL-derived issue id), and a first live alert will confirm or correct it.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add GlitchTip generic webhook support to Sentry bug endpoints

- Introduce `normalizeGlitchtipPayload` and `normalizeIssueWebhook` dispatcher for flat vs nested body shapes

- Accept shared secret via `?token=` query param for GlitchTip (which cannot set headers or sign bodies)

- Add 10 new tests covering GlitchTip auth, parsing, and security boundary; update docs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Incoming Webhook Request"] -- "has Sentry-Hook-Signature" --> B["verifySentrySignature (HMAC)"]
  A -- "no signature, has X-Webhook-Token or ?token=" --> C["verifyWebhookToken (constant-time)"]
  B -- "valid" --> D["normalizeIssueWebhook"]
  C -- "valid" --> D
  D -- "Sentry-Hook-Resource present" --> E["normalizeSentryPayload (nested data.issue)"]
  D -- "no resource header" --> F["normalizeGlitchtipPayload (flat alias/attachments)"]
  E -- "issue.new / issue.regression" --> G["ingestSentryBug"]
  F -- "issue.new / issue.regression" --> G
  E -- "other events" --> H["Ignored 200"]
  F -- "other events / no id" --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sentryPayload.ts</strong><dd><code>Add GlitchTip payload normalization and dispatcher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/sentry/sentryPayload.ts

<ul><li>Add <code>GlitchtipWebhookBody</code> interface describing the flat <br>Slack-compatible payload shape<br> <li> Add <code>normalizeGlitchtipPayload</code> function that parses alias, issue id <br>(with URL fallback), title from attachments, and project slug<br> <li> Add <code>normalizeIssueWebhook</code> dispatcher that routes to <br><code>normalizeSentryPayload</code> or <code>normalizeGlitchtipPayload</code> based on presence <br>of the resource header<br> <li> Define <code>GLITCHTIP_NEW_ISSUE_ALIASES</code> and <code>GLITCHTIP_ISSUE_URL</code> constants</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/472/files#diff-9fb183a5f05420e895fb352bdada266a8673a9bbb23b30673fd7cbe24ed3cedb">+104/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Support GlitchTip on global Sentry webhook route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/webhooks/sentry/route.ts

<ul><li>Replace <code>normalizeSentryPayload</code> call with <code>normalizeIssueWebhook</code> to <br>support both senders<br> <li> Extend token lookup to also check <code>?token=</code> query param (for GlitchTip)<br> <li> Remove hard 400 on missing <code>Sentry-Hook-Resource</code> header; absence now <br>selects GlitchTip path<br> <li> Update JSDoc to document both senders and the dual auth gates</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/472/files#diff-546031f2a49c647572b89c88c0f6710a2601b261f41c538c408759e83d3c5911">+26/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Support GlitchTip on per-workspace Sentry webhook route</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/webhooks/sentry/[webhookId]/route.ts

<ul><li>Replace <code>normalizeSentryPayload</code> with <code>normalizeIssueWebhook</code>; remove <br>mandatory resource header check<br> <li> Add unsigned (GlitchTip) auth branch: checks <code>X-Webhook-Token</code> header <br>then <code>?token=</code> query param against integration's stored secret<br> <li> Signature presence commits sender to HMAC with no token fallback<br> <li> Update JSDoc to explain both auth modes and their security trade-offs</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/472/files#diff-83be8ca30c49e84204f569f47f565e51c47589b5cc5735455ffa592497762967">+43/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.test.ts</strong><dd><code>Add GlitchTip webhook tests for global route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/webhooks/sentry/__tests__/route.test.ts

<ul><li>Add <code>tokenHeader</code> and <code>tokenQuery</code> options to <code>fakeRequest</code> helper; add <br><code>nextUrl.searchParams</code> mock<br> <li> Add new <code>describe</code> block with 6 GlitchTip tests: query param auth, <br>header auth, wrong token, resolution ignored, id from URL, no <br>recoverable id</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/472/files#diff-abe5deece2f81b9af4f33700bc50cf55a2245a1b9fe221489967a2ce023103ac">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.test.ts</strong><dd><code>Add GlitchTip webhook tests for per-workspace route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/webhooks/sentry/[webhookId]/__tests__/route.test.ts

<ul><li>Add <code>tokenQuery</code> option to <code>fakeRequest</code> helper; add <code>nextUrl.searchParams</code> <br>mock<br> <li> Add <code>describe</code> block with 4 GlitchTip tests: correct token accepted, <br>wrong token rejected, no token rejected, valid token cannot rescue <br>invalid signature</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/472/files#diff-1312a845a0e138d23bd62cc13e9130a16c85028f3e0f4418533eefc801327448">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OBSERVABILITY.md</strong><dd><code>Document GlitchTip webhook integration and security notes</code></dd></summary>
<hr>

dev-docs/OBSERVABILITY.md

<ul><li>Add "GlitchTip senders" section explaining the flat payload format, <br>alias filtering, id recovery, and <code>?token=</code> query param<br> <li> Document security boundary: a presented signature must verify; a valid <br>token cannot rescue an invalid signature</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/472/files#diff-e608379e40bafc9cc6a526c79545546dac14663e40ebdbc6733813229078f1a6">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

