### PR TITLE
fix(okr): show linked features under the KR accordion

### DIFF
--- a/e2e/okr-kr-linked-work.spec.ts
+++ b/e2e/okr-kr-linked-work.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Visual verification of the KR "executing work" accordion on the OKRs tab.
+ * The seeded fixture KR carries BOTH a linked Project and a linked Feature
+ * (ADR-0050), so this spec pins the regression it was written for: features
+ * were saved by the Edit Key Result modal but never rendered under the KR.
+ *
+ * A full-page screenshot is attached for human review — see
+ * dev-docs/AGENT_VISUAL_TESTING.md.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { loadFixture } from "./fixture-data";
+import { FIXTURE } from "../scripts/dev-fixture/seed";
+
+const fixture = loadFixture();
+
+const FIRST_PAINT_TIMEOUT = 60_000;
+
+async function attachScreenshot(page: Page, name: string) {
+  await test.info().attach(name, {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+}
+
+test("KR accordion lists linked projects and linked features with type pills", async ({
+  page,
+}) => {
+  await page.goto(fixture.okrUrl);
+
+  const kr = page.getByText(FIXTURE.keyResultTitle).first();
+  await expect(kr).toBeVisible({ timeout: FIRST_PAINT_TIMEOUT });
+
+  // The objective card auto-expands; expand the KR row to reveal its work.
+  await kr.click();
+
+  const projectRow = page.getByRole("link", {
+    name: new RegExp(FIXTURE.projectName),
+  });
+  const featureRow = page.getByRole("link", {
+    name: new RegExp(FIXTURE.featureName),
+  });
+
+  await expect(projectRow).toBeVisible();
+  await expect(featureRow).toBeVisible();
+
+  // Each row is tagged with its kind, so the two edges stay distinguishable.
+  await expect(projectRow).toContainText("Project");
+  await expect(featureRow).toContainText("Feature");
+
+  // The feature row deep-links into the products area and carries its
+  // ticket-delivery signal (5 feature-linked tickets, 1 DONE).
+  await expect(featureRow).toHaveAttribute(
+    "href",
+    `/w/${fixture.workspaceSlug}/products/${fixture.productSlug}/features/${fixture.featureId}`,
+  );
+  await expect(featureRow).toContainText(`/${fixture.featureTicketCount} tickets`);
+
+  await attachScreenshot(page, "kr-linked-work.png");
+});

--- a/scripts/dev-fixture/seed.ts
+++ b/scripts/dev-fixture/seed.ts
@@ -181,9 +181,16 @@ export async function seedDevFixture(db: PrismaClient): Promise<SeededFixture> {
   // OKR execution links (ADR-0050): one objective → one KR carrying BOTH a
   // linked Project and a linked Feature, so the KR accordion on the OKRs tab
   // renders one row of each kind (Project pill / Feature pill).
+  // Project.workspace, Goal.workspace and KeyResult.workspace are all optional
+  // relations with no explicit onDelete, so Prisma defaults them to SetNull:
+  // dropping the `dev-fixture` workspace orphans these rows with a null
+  // workspaceId rather than cascading them away. Every path below therefore
+  // re-attaches `workspaceId`, so a seed → delete-workspace → seed cycle
+  // converges instead of resurrecting a workspace-less fixture the OKR
+  // dashboard (which queries by workspaceId) can't see.
   const project = await db.project.upsert({
     where: { slug: FIXTURE.projectSlug },
-    update: {},
+    update: { workspaceId: workspace.id },
     create: {
       name: FIXTURE.projectName,
       slug: FIXTURE.projectSlug,
@@ -193,36 +200,48 @@ export async function seedDevFixture(db: PrismaClient): Promise<SeededFixture> {
     },
   });
 
-  let objective = await db.goal.findFirst({
-    where: { workspaceId: workspace.id, title: FIXTURE.objectiveTitle },
+  // Matched on title alone (not workspaceId) so an orphaned goal is found and
+  // re-homed rather than duplicated.
+  const existingObjective = await db.goal.findFirst({
+    where: { title: FIXTURE.objectiveTitle, userId: user.id },
   });
-  objective ??= await db.goal.create({
-    data: {
-      title: FIXTURE.objectiveTitle,
-      period: FIXTURE.okrPeriod,
-      userId: user.id,
-      driUserId: user.id,
-      workspaceId: workspace.id,
-    },
-  });
+  const objective = existingObjective
+    ? await db.goal.update({
+        where: { id: existingObjective.id },
+        data: { workspaceId: workspace.id, period: FIXTURE.okrPeriod },
+      })
+    : await db.goal.create({
+        data: {
+          title: FIXTURE.objectiveTitle,
+          period: FIXTURE.okrPeriod,
+          userId: user.id,
+          driUserId: user.id,
+          workspaceId: workspace.id,
+        },
+      });
 
-  let keyResult = await db.keyResult.findFirst({
+  const existingKeyResult = await db.keyResult.findFirst({
     where: { goalId: objective.id, title: FIXTURE.keyResultTitle },
   });
-  keyResult ??= await db.keyResult.create({
-    data: {
-      title: FIXTURE.keyResultTitle,
-      targetValue: 100,
-      currentValue: 40,
-      startValue: 0,
-      unit: "percent",
-      period: FIXTURE.okrPeriod,
-      goalId: objective.id,
-      userId: user.id,
-      driUserId: user.id,
-      workspaceId: workspace.id,
-    },
-  });
+  const keyResult = existingKeyResult
+    ? await db.keyResult.update({
+        where: { id: existingKeyResult.id },
+        data: { workspaceId: workspace.id, period: FIXTURE.okrPeriod },
+      })
+    : await db.keyResult.create({
+        data: {
+          title: FIXTURE.keyResultTitle,
+          targetValue: 100,
+          currentValue: 40,
+          startValue: 0,
+          unit: "percent",
+          period: FIXTURE.okrPeriod,
+          goalId: objective.id,
+          userId: user.id,
+          driUserId: user.id,
+          workspaceId: workspace.id,
+        },
+      });
 
   await db.keyResultProject.upsert({
     where: {

--- a/scripts/dev-fixture/seed.ts
+++ b/scripts/dev-fixture/seed.ts
@@ -24,6 +24,11 @@ export const FIXTURE = {
   productSlug: "fixture",
   productName: "Fixture Product",
   featureName: "Tickets accordion fixture",
+  objectiveTitle: "Fixture objective for OKR execution links",
+  keyResultTitle: "Linked work renders under the KR accordion",
+  okrPeriod: "Annual-2026",
+  projectName: "Fixture Linked Project",
+  projectSlug: "fixture-linked-project",
 } as const;
 
 export interface SeededFixture {
@@ -39,6 +44,8 @@ export interface SeededFixture {
   featureTicketCount: number;
   /** Total tickets seeded, including the scope-only one the accordion hides. */
   totalTicketCount: number;
+  /** App-relative URL of the OKR dashboard holding the seeded objective. */
+  okrUrl: string;
 }
 
 interface TicketSpec {
@@ -171,6 +178,68 @@ export async function seedDevFixture(db: PrismaClient): Promise<SeededFixture> {
     },
   });
 
+  // OKR execution links (ADR-0050): one objective → one KR carrying BOTH a
+  // linked Project and a linked Feature, so the KR accordion on the OKRs tab
+  // renders one row of each kind (Project pill / Feature pill).
+  const project = await db.project.upsert({
+    where: { slug: FIXTURE.projectSlug },
+    update: {},
+    create: {
+      name: FIXTURE.projectName,
+      slug: FIXTURE.projectSlug,
+      status: "ACTIVE",
+      createdById: user.id,
+      workspaceId: workspace.id,
+    },
+  });
+
+  let objective = await db.goal.findFirst({
+    where: { workspaceId: workspace.id, title: FIXTURE.objectiveTitle },
+  });
+  objective ??= await db.goal.create({
+    data: {
+      title: FIXTURE.objectiveTitle,
+      period: FIXTURE.okrPeriod,
+      userId: user.id,
+      driUserId: user.id,
+      workspaceId: workspace.id,
+    },
+  });
+
+  let keyResult = await db.keyResult.findFirst({
+    where: { goalId: objective.id, title: FIXTURE.keyResultTitle },
+  });
+  keyResult ??= await db.keyResult.create({
+    data: {
+      title: FIXTURE.keyResultTitle,
+      targetValue: 100,
+      currentValue: 40,
+      startValue: 0,
+      unit: "percent",
+      period: FIXTURE.okrPeriod,
+      goalId: objective.id,
+      userId: user.id,
+      driUserId: user.id,
+      workspaceId: workspace.id,
+    },
+  });
+
+  await db.keyResultProject.upsert({
+    where: {
+      keyResultId_projectId: { keyResultId: keyResult.id, projectId: project.id },
+    },
+    update: {},
+    create: { keyResultId: keyResult.id, projectId: project.id },
+  });
+
+  await db.keyResultFeature.upsert({
+    where: {
+      keyResultId_featureId: { keyResultId: keyResult.id, featureId: feature.id },
+    },
+    update: {},
+    create: { keyResultId: keyResult.id, featureId: feature.id },
+  });
+
   const base = `/w/${FIXTURE.workspaceSlug}/products/${FIXTURE.productSlug}`;
   return {
     userId: user.id,
@@ -181,5 +250,6 @@ export async function seedDevFixture(db: PrismaClient): Promise<SeededFixture> {
     peekUrl: `${base}/features?peek=${feature.id}`,
     featureTicketCount: TICKETS.filter((t) => !t.scopeOnly).length,
     totalTicketCount: TICKETS.length,
+    okrUrl: `/w/${FIXTURE.workspaceSlug}/goals?tab=okrs&year=${FIXTURE.okrPeriod.split("-")[1]}&period=Annual`,
   };
 }

--- a/scripts/seed-dev-fixture.ts
+++ b/scripts/seed-dev-fixture.ts
@@ -23,6 +23,7 @@ async function main() {
     console.log(`  feature tickets: ${fixture.featureTicketCount} (of ${fixture.totalTicketCount} seeded - one is scope-only and excluded by design)`);
     console.log(`  feature page:    ${fixture.featureUrl}`);
     console.log(`  peek view:       ${fixture.peekUrl}`);
+    console.log(`  okr dashboard:   ${fixture.okrUrl}`);
     console.log(`\nMint a session for the fixture user with:\n  npx tsx scripts/dev-session.ts`);
   } finally {
     await db.$disconnect();

--- a/src/plugins/okr/client/components/ObjectiveCardV2.tsx
+++ b/src/plugins/okr/client/components/ObjectiveCardV2.tsx
@@ -10,6 +10,7 @@ import {
   IconTrash,
   IconMessageCircle,
   IconBriefcase,
+  IconBulb,
 } from "@tabler/icons-react";
 import { CreateGoalModal } from "~/app/_components/CreateGoalModal";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
@@ -52,6 +53,33 @@ interface LinkedProject {
   };
 }
 
+/** The second typed execution edge on a KR (ADR-0050). */
+interface LinkedFeature {
+  feature: {
+    id: string;
+    name: string;
+    status: string;
+    product: {
+      id: string;
+      name: string;
+      slug: string;
+    };
+    // V2 delivery signal (ADR-0050): null for ticketless features — no chip,
+    // never "0/0".
+    ticketProgress?: { done: number; total: number } | null;
+  };
+}
+
+/** One row in a KR's "executing work" list — a Project or a Feature. */
+interface LinkedWorkRow {
+  key: string;
+  kind: "project" | "feature";
+  name: string;
+  status: string;
+  href: string | null;
+  ticketProgress: { done: number; total: number } | null;
+}
+
 export interface ObjectiveCardKeyResult {
   id: string;
   title: string;
@@ -69,6 +97,7 @@ export interface ObjectiveCardKeyResult {
   user?: KrUser | null;
   driUser?: KrUser | null;
   projects?: LinkedProject[];
+  features?: LinkedFeature[];
 }
 
 interface LifeDomain {
@@ -283,8 +312,35 @@ function KrLine({
   const updated = relativeTimeLabel(latestCheckIn?.createdAt);
   const owner = kr.driUser ?? kr.user;
   const projects = kr.projects ?? [];
-  const hasProjects = projects.length > 0;
+  const features = kr.features ?? [];
   const projectCount = projects.length;
+  const featureCount = features.length;
+
+  // One merged "executing work" list: linked Projects and linked Features,
+  // each row tagged with its type (ADR-0050) — mirrors the detail drawer.
+  const linkedWork: LinkedWorkRow[] = [
+    ...projects.map(({ project }) => ({
+      key: `project-${project.id}`,
+      kind: "project" as const,
+      name: project.name,
+      status: project.status,
+      href: workspaceSlug
+        ? `/w/${workspaceSlug}/projects/${project.slug}-${project.id}`
+        : `/projects/${project.slug}-${project.id}`,
+      ticketProgress: null,
+    })),
+    ...features.map(({ feature }) => ({
+      key: `feature-${feature.id}`,
+      kind: "feature" as const,
+      name: feature.name,
+      status: feature.status,
+      href: workspaceSlug
+        ? `/w/${workspaceSlug}/products/${feature.product.slug}/features/${feature.id}`
+        : null,
+      ticketProgress: feature.ticketProgress ?? null,
+    })),
+  ];
+  const hasLinkedWork = linkedWork.length > 0;
 
   return (
     <div className="border-t border-border-primary first:border-t-0">
@@ -336,7 +392,7 @@ function KrLine({
         {/* Value + bar */}
         <div className="flex w-[180px] flex-col items-end gap-1.5">
           <div className="flex items-center gap-2">
-            {hasProjects && (
+            {projectCount > 0 && (
               <Tooltip
                 label={`${projectCount} linked ${
                   projectCount === 1 ? "project" : "projects"
@@ -345,6 +401,18 @@ function KrLine({
                 <span className="inline-flex items-center gap-1 rounded-sm bg-surface-tertiary px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-text-secondary">
                   <IconBriefcase size={10} />
                   {projectCount}
+                </span>
+              </Tooltip>
+            )}
+            {featureCount > 0 && (
+              <Tooltip
+                label={`${featureCount} linked ${
+                  featureCount === 1 ? "feature" : "features"
+                }`}
+              >
+                <span className="inline-flex items-center gap-1 rounded-sm bg-surface-tertiary px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-text-secondary">
+                  <IconBulb size={10} />
+                  {featureCount}
                 </span>
               </Tooltip>
             )}
@@ -447,36 +515,55 @@ function KrLine({
         </div>
       </div>
 
-      {/* Linked projects panel */}
+      {/* Executing work panel: linked projects + linked features */}
       <Collapse in={isExpanded}>
         <div className="space-y-1 pb-3 pl-7 pr-7 pt-1">
-          {hasProjects ? (
-            projects.map(({ project }) => (
-              <Link
-                key={project.id}
-                href={
-                  workspaceSlug
-                    ? `/w/${workspaceSlug}/projects/${project.slug}-${project.id}`
-                    : `/projects/${project.slug}-${project.id}`
-                }
-                className="group/project flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-surface-hover"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <span className="h-px w-3 flex-shrink-0 bg-border-secondary" />
-                <IconBriefcase size={12} className="flex-shrink-0 text-text-muted" />
-                <span className="truncate text-xs text-text-secondary transition-colors group-hover/project:text-brand-primary">
-                  {project.name}
-                </span>
-                <Badge size="xs" variant="light" color="gray">
-                  {project.status}
-                </Badge>
-              </Link>
-            ))
+          {hasLinkedWork ? (
+            linkedWork.map((row) => {
+              const RowIcon = row.kind === "feature" ? IconBulb : IconBriefcase;
+              const rowClass =
+                "group/link flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-surface-hover";
+              const content = (
+                <>
+                  <span className="h-px w-3 flex-shrink-0 bg-border-secondary" />
+                  <RowIcon size={12} className="flex-shrink-0 text-text-muted" />
+                  <span className="truncate text-xs text-text-secondary transition-colors group-hover/link:text-brand-primary">
+                    {row.name}
+                  </span>
+                  <Badge size="xs" variant="light" color="gray">
+                    {row.status}
+                  </Badge>
+                  {row.ticketProgress && (
+                    <span className="flex-shrink-0 rounded border border-border-secondary px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-text-muted">
+                      {row.ticketProgress.done}/{row.ticketProgress.total}{" "}
+                      tickets
+                    </span>
+                  )}
+                  <span className="ml-auto flex-shrink-0 rounded border border-border-secondary px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-secondary">
+                    {row.kind === "feature" ? "Feature" : "Project"}
+                  </span>
+                </>
+              );
+              return row.href ? (
+                <Link
+                  key={row.key}
+                  href={row.href}
+                  className={rowClass}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {content}
+                </Link>
+              ) : (
+                <div key={row.key} className={rowClass}>
+                  {content}
+                </div>
+              );
+            })
           ) : (
             <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-text-muted">
               <span className="h-px w-3 flex-shrink-0 bg-border-secondary" />
               <IconBriefcase size={12} className="flex-shrink-0" />
-              <span>No linked projects</span>
+              <span>No linked projects or features</span>
             </div>
           )}
         </div>

--- a/src/plugins/okr/client/components/OkrDashboard.tsx
+++ b/src/plugins/okr/client/components/OkrDashboard.tsx
@@ -257,6 +257,7 @@ export function OkrDashboard({
             user: kr.user,
             driUser: kr.driUser,
             projects: kr.projects,
+            features: kr.features,
           }),
         ),
       }));


### PR DESCRIPTION
### **User description**
## Problem

Linking a Feature to a Key Result from the **Edit Key Result** modal (ADR-0050) saved fine, but the feature never appeared under the KR on the OKRs tab — only linked Projects showed up.

Two gaps, both client-side:

- `OkrDashboard` reshapes each KR into `ObjectiveCardKeyResult` field-by-field and silently dropped `features` (the router already returns them, ticket progress and all).
- `ObjectiveCardV2`'s expanded KR panel only knew about projects.

## Change

- Pass `features` through the dashboard's KR reshape.
- Render one merged **executing work** list under the KR — projects and features together — mirroring the detail drawer's treatment:
  - each row carries a `PROJECT` / `FEATURE` pill,
  - feature rows deep-link to `/w/<ws>/products/<product>/features/<id>`,
  - feature rows show the ticket-delivery chip (`n/m tickets`, omitted for ticketless features — never "0/0").
- KR header gains a features count chip (bulb) beside the existing projects chip (briefcase).
- Empty state is now "No linked projects or features".

## Verification

- `scripts/dev-fixture/seed.ts` gains an objective + KR carrying **both** a linked project and the seeded feature, so the surface is reachable via `npm run dev:seed-fixture` (the script now prints the OKR dashboard URL).
- New `e2e/okr-kr-linked-work.spec.ts` asserts both rows render, are tagged with the right pill, and that the feature row deep-links and shows its ticket chip.
- `npx tsc --noEmit` clean, eslint clean on changed files, 1970 unit tests pass.

Screenshot of the fixture KR expanded: both rows present, `PROJECT` / `FEATURE` pills on the right, `1/5 tickets` on the feature.

### Note

The OKRs tab logs a pre-existing hydration warning (`<button>` inside `<button>` — the objective header button wraps ActionIcons in `ObjectiveCardV2`). Untouched by this PR; happy to file it separately.


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Fix: linked Features now render under KR accordion on OKRs tab

- Add merged "executing work" list with PROJECT/FEATURE type pills per row

- KR header gains a features count chip alongside existing projects chip

- Dev fixture and e2e spec added to pin the regression


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OkrDashboard\n(KR reshape)"] -- "pass features field" --> B["ObjectiveCardKeyResult\n(type definition)"]
  B -- "merged linkedWork list" --> C["KrLine component"]
  C -- "Project row" --> D["PROJECT pill + briefcase icon"]
  C -- "Feature row" --> E["FEATURE pill + bulb icon + ticket chip"]
  F["seed.ts fixture"] -- "seeds objective + KR\nwith project & feature" --> G["e2e spec\nokr-kr-linked-work.spec.ts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OkrDashboard.tsx</strong><dd><code>Pass features through KR reshape in OkrDashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/okr/client/components/OkrDashboard.tsx

<ul><li>Pass <code>features</code> field through when reshaping KR objects for <br><code>ObjectiveCardKeyResult</code><br> <li> Previously <code>features</code> was silently dropped, causing linked features to <br>never appear</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/474/files#diff-889bca4ccc882e62c348d484ae792375ad5527a219cadd0ddbcf25d6b4346d0b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ObjectiveCardV2.tsx</strong><dd><code>Render linked features in KR accordion with type pills</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/okr/client/components/ObjectiveCardV2.tsx

<ul><li>Add <code>LinkedFeature</code> and <code>LinkedWorkRow</code> interfaces for typed feature <br>execution edges<br> <li> Add <code>features</code> field to <code>ObjectiveCardKeyResult</code> interface<br> <li> Build merged <code>linkedWork</code> list combining projects and features with kind <br>tagging<br> <li> Render each row with PROJECT/FEATURE pill, feature rows include <br>ticket-delivery chip and deep-link<br> <li> Add <code>IconBulb</code> features count chip in KR header beside existing <br><code>IconBriefcase</code> projects chip<br> <li> Update empty state text to "No linked projects or features"</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/474/files#diff-a7e1704ae146d9d80148666652bd1d7ea8429e64650deff0109cc0d0cfa7c21e">+113/-26</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>seed.ts</strong><dd><code>Add idempotent OKR fixture with linked project and feature</code></dd></summary>
<hr>

scripts/dev-fixture/seed.ts

<ul><li>Add <code>objectiveTitle</code>, <code>keyResultTitle</code>, <code>okrPeriod</code>, <code>projectName</code>, <br><code>projectSlug</code> to <code>FIXTURE</code> constants<br> <li> Seed a Project, Goal (Objective), and KeyResult with both a linked <br>project and linked feature<br> <li> Re-attach <code>workspaceId</code> on all three paths to fix idempotency after <br>workspace delete<br> <li> Match goal on title rather than workspaceId to avoid duplication on <br>re-seed<br> <li> Return <code>okrUrl</code> in the seeded fixture result</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/474/files#diff-8018aeac7e376bda1b432246950f7b08afcb9fc18c457f7bcbecb56db13ad204">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>okr-kr-linked-work.spec.ts</strong><dd><code>Add e2e regression spec for KR linked work accordion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/okr-kr-linked-work.spec.ts

<ul><li>New e2e spec that navigates to the seeded OKR dashboard and expands <br>the fixture KR<br> <li> Asserts both project and feature rows are visible with correct type <br>pills<br> <li> Verifies feature row deep-links to the correct products URL<br> <li> Verifies feature row shows ticket-delivery chip with correct count<br> <li> Attaches a full-page screenshot for human review</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/474/files#diff-5761bfdd8cb0250aad2de3c52976a5d000792a4d5e304be249e1c859a5b4d472">+59/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>seed-dev-fixture.ts</strong><dd><code>Print OKR dashboard URL after fixture seed</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/seed-dev-fixture.ts

<ul><li>Print the OKR dashboard URL (<code>okrUrl</code>) after seeding for quick manual <br>verification</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/474/files#diff-767d700608177967056879162c643304519251c738479ec2fab6dad017900301">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

