### PR TITLE
feat: create the local wiki from a button, not a side effect

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -18,6 +18,7 @@ fn main() {
                 "wiki_commit_turn",
                 "wiki_search",
                 "wiki_get_root",
+                "wiki_status",
                 "wiki_fetch_url",
                 "wiki_read_external",
             ]),

--- a/src-tauri/capabilities/remote.json
+++ b/src-tauri/capabilities/remote.json
@@ -25,6 +25,7 @@
     "allow-wiki-commit-turn",
     "allow-wiki-search",
     "allow-wiki-get-root",
+    "allow-wiki-status",
     "allow-wiki-fetch-url",
     "allow-wiki-read-external"
   ]

--- a/src-tauri/permissions/autogenerated/wiki_status.toml
+++ b/src-tauri/permissions/autogenerated/wiki_status.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-wiki-status"
+description = "Enables the wiki_status command without any pre-configured scope."
+commands.allow = ["wiki_status"]
+
+[[permission]]
+identifier = "deny-wiki-status"
+description = "Denies the wiki_status command without any pre-configured scope."
+commands.deny = ["wiki_status"]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,6 +112,7 @@ pub fn run() {
             wiki::wiki_commit_turn,
             wiki::wiki_search,
             wiki::wiki_get_root,
+            wiki::wiki_status,
             source::wiki_fetch_url,
             source::wiki_read_external,
         ])

--- a/src-tauri/src/wiki.rs
+++ b/src-tauri/src/wiki.rs
@@ -199,6 +199,44 @@ pub struct WikiPage {
     pub bytes: u64,
 }
 
+/// What the app needs to decide between "offer to create a wiki" and "chat".
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WikiStatus {
+    /// Where it would live, whether or not it does — the first-run panel names
+    /// this so the user knows what is about to appear on their disk.
+    pub root: String,
+    pub exists: bool,
+    /// Whether the folder is a git repo. False for a folder restored from a
+    /// backup that lost `.git`, which still counts as existing.
+    pub git: bool,
+    pub page_count: usize,
+}
+
+/// Report on the wiki **without creating it**.
+///
+/// The distinction from `wiki_init` is the whole point: creating a folder in
+/// someone's Documents should be something they chose, not a side effect of
+/// asking a question. This is what the first-run panel asks before offering the
+/// button, so it must stay free of side effects.
+#[tauri::command]
+pub fn wiki_status(state: tauri::State<WikiRoot>) -> WikiStatus {
+    let root = current_root(&state);
+    status_at(&root)
+}
+
+pub fn status_at(root: &Path) -> WikiStatus {
+    let exists = root.is_dir();
+    WikiStatus {
+        root: root.to_string_lossy().into_owned(),
+        exists,
+        git: exists && root.join(".git").exists(),
+        // `list_pages` on a missing folder is an empty list, not an error, so
+        // this is safe to call either way.
+        page_count: list_pages(root).map(|p| p.len()).unwrap_or(0),
+    }
+}
+
 /// Create the wiki if it isn't there yet, and report where it is.
 ///
 /// Idempotent, and that matters: this runs at the start of a chat turn, so it
@@ -598,6 +636,49 @@ mod tests {
         // Writing a new page must work; only *escaping* is refused.
         let wiki = TempWiki::new("new-page");
         assert!(resolve(&wiki.root, "brand/new/page.md").is_ok());
+    }
+
+    #[test]
+    fn status_does_not_create_the_wiki() {
+        // The load-bearing property: the first-run panel calls this to decide
+        // whether to offer the button, so if it created anything the button
+        // would be asking permission for something already done.
+        let root = std::env::temp_dir().join("exp-wiki-status-none");
+        let _ = std::fs::remove_dir_all(&root);
+
+        let status = status_at(&root);
+        assert!(!status.exists);
+        assert!(!status.git);
+        assert_eq!(status.page_count, 0);
+        assert!(!root.exists(), "asking must not create");
+        // It still reports where the wiki *would* go, because the panel names
+        // the path before the user agrees to it.
+        assert_eq!(status.root, root.to_string_lossy());
+    }
+
+    #[test]
+    fn status_sees_a_wiki_that_exists() {
+        let wiki = TempWiki::new("status-exists");
+        init_at(&wiki.root).expect("init");
+        write_page(&wiki.root, "people/ada.md", "# Ada").unwrap();
+
+        let status = status_at(&wiki.root);
+        assert!(status.exists);
+        assert!(status.git);
+        assert_eq!(status.page_count, 4, "three seeds plus the page");
+    }
+
+    #[test]
+    fn a_wiki_without_git_still_counts_as_existing() {
+        // A folder restored from a backup that lost .git is still the user's
+        // wiki; offering to "create" it again would be wrong.
+        let wiki = TempWiki::new("status-nogit");
+        init_at(&wiki.root).expect("init");
+        std::fs::remove_dir_all(wiki.root.join(".git")).unwrap();
+
+        let status = status_at(&wiki.root);
+        assert!(status.exists);
+        assert!(!status.git);
     }
 
     #[test]

--- a/src/app/_components/LocalWikiFirstRun.tsx
+++ b/src/app/_components/LocalWikiFirstRun.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+
+import type { WikiStatus } from "~/lib/localWiki";
+
+/**
+ * What you see when you pick the Local wiki librarian and don't have a wiki yet.
+ *
+ * It exists because the wiki used to appear as a side effect of asking a
+ * question — `wiki_init` ran at the start of every turn, so a folder and a git
+ * repo materialised in your Documents because you typed something. Creating
+ * files on someone's machine should be a decision they made, so this names the
+ * path and waits.
+ *
+ * It is also the only thing that tells you what the librarian *is* before you
+ * talk to it.
+ */
+export function LocalWikiFirstRun({
+  status,
+  onCreate,
+}: {
+  status: WikiStatus;
+  onCreate: () => Promise<void>;
+}) {
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const create = async () => {
+    setCreating(true);
+    setError(null);
+    try {
+      await onCreate();
+    } catch (e) {
+      // Most likely an unwritable folder. Show what actually went wrong rather
+      // than a spinner that never resolves.
+      setError(e instanceof Error ? e.message : String(e));
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center p-8">
+      <div className="max-w-md text-center">
+        <h2 className="text-lg font-medium text-text-primary">Create your local wiki</h2>
+
+        <p className="mt-3 text-sm leading-relaxed text-text-secondary">
+          A folder of markdown files, versioned with git, that the librarian reads and
+          writes on this machine. Ask it things and it answers from what it has filed;
+          tell it something worth keeping and it writes it down.
+        </p>
+
+        <p className="mt-3 text-sm leading-relaxed text-text-secondary">
+          Nothing in it is sent to Exponential&apos;s servers — only your messages and
+          whatever the librarian quotes back reach the model.
+        </p>
+
+        <p className="mt-4 break-all font-mono text-xs text-text-muted">{status.root}</p>
+
+        <button
+          type="button"
+          onClick={() => void create()}
+          disabled={creating}
+          className="mt-6 rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+        >
+          {creating ? "Creating…" : "Create wiki"}
+        </button>
+
+        {error && (
+          <p className="mt-4 text-sm text-red-500" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -38,10 +38,12 @@ import {
   LOCAL_WIKI_AGENT_NAME,
   buildWikiClientTools,
   getWikiBridge,
+  type WikiStatus,
 } from '~/lib/localWiki';
 import { preprocessAgentMarkdown, linkifyBareUrls } from '~/lib/chat/agentMarkdown';
 import { failureCopy } from '~/lib/chat/failureCopy';
 import { applyToolRefreshInvalidations } from './agent/toolRefreshInvalidation';
+import { LocalWikiFirstRun } from './LocalWikiFirstRun';
 
 // Module-level constants to avoid re-creation on every render
 const VIDEO_PATTERN = /\[Video ([a-zA-Z0-9_-]+)\]/g;
@@ -675,6 +677,30 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
   // The one call to our own backend a local-wiki turn makes. Everything after it
   // goes browser → Mastra directly, so wiki content never reaches Vercel.
   const mintAgentToken = api.mastra.mintAgentToken.useMutation();
+
+  // Whether this machine has a wiki yet. `undefined` means we haven't looked —
+  // which is the state on every surface that isn't the Tauri shell, since there
+  // is nothing to look at.
+  const [wikiStatus, setWikiStatus] = useState<WikiStatus | undefined>(undefined);
+  const localWikiSelected = defaultAgentId === LOCAL_WIKI_AGENT_ID;
+
+  // Ask (without creating) whenever the librarian is selected. Re-checked on
+  // selection rather than cached for the session, so deleting the wiki folder by
+  // hand brings the panel back instead of leaving the chat pointing at nothing.
+  useEffect(() => {
+    if (!localWikiSelected) {
+      setWikiStatus(undefined);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const status = await getWikiBridge()?.status();
+      if (!cancelled) setWikiStatus(status);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [localWikiSelected]);
   // Server-side /api/chat/stream now logs interactions (with full token/cache
   // data) and surfaces the row id back via the meta frame. The previous
   // client-side logInteraction.mutateAsync was removed to fix double-logging.
@@ -1298,10 +1324,11 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
 
       const streamResult = wikiBridge
         ? await (async () => {
-            // Idempotent, and cheap enough to do every turn — it guarantees the
-            // folder, its git repo and the seeded conventions exist before the
-            // librarian is asked to read them.
-            await wikiBridge.init();
+            // Deliberately no init() here. The wiki comes into being when the
+            // user presses the button in the first-run panel, and nowhere else —
+            // creating a folder in someone's Documents as a side effect of
+            // sending a message is not a decision they made. The panel replaces
+            // the composer until it exists, so a turn can only start once it does.
             const { token, mastraUrl } = await mintAgentToken.mutateAsync();
             return streamLocalWikiChat(
               createLocalWikiStreamer(mastraUrl, token),
@@ -1497,6 +1524,17 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
         </div>
       )}
 
+      {/* First run: the wiki does not exist until the user asks for it. */}
+      {localWikiSelected && wikiStatus && !wikiStatus.exists ? (
+        <LocalWikiFirstRun
+          status={wikiStatus}
+          onCreate={async () => {
+            await getWikiBridge()?.init();
+            setWikiStatus(await getWikiBridge()?.status());
+          }}
+        />
+      ) : (
+        <>
       {/* Messages Area */}
       <MessageList messages={messages} conversationId={conversationId} isStreaming={isStreaming} onRetry={retryTurn} />
       
@@ -1664,6 +1702,8 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
           </div>
         )}
       </div>
+        </>
+      )}
 
     </div>
   );

--- a/src/lib/localWiki.ts
+++ b/src/lib/localWiki.ts
@@ -27,6 +27,15 @@ export interface WikiInfo {
   git: boolean;
 }
 
+/** Whether there is a wiki yet, and where it would go if not. */
+export interface WikiStatus {
+  /** Where it lives, or would live — the first-run panel names this. */
+  root: string;
+  exists: boolean;
+  git: boolean;
+  pageCount: number;
+}
+
 export interface WikiPage {
   /** Path relative to the wiki root — the handle every other call takes. */
   path: string;
@@ -38,7 +47,15 @@ export interface WikiPage {
  * ask (a browser, or the Electron shell).
  */
 export interface WikiBridge {
-  /** Create the wiki if absent. Idempotent; safe to call every turn. */
+  /**
+   * Report on the wiki **without creating it**.
+   *
+   * The distinction from `init` is the point: creating a folder in someone's
+   * Documents should be something they chose. This is what the first-run panel
+   * asks before offering to create anything.
+   */
+  status: () => Promise<WikiStatus>;
+  /** Create the wiki. Idempotent, so pressing the button twice is harmless. */
   init: () => Promise<WikiInfo>;
   listPages: () => Promise<WikiPage[]>;
   readPage: (path: string) => Promise<string>;
@@ -113,6 +130,7 @@ export function getWikiBridge(): WikiBridge | null {
   if (!invoke) return null;
 
   return {
+    status: async () => (await invoke("wiki_status")) as WikiStatus,
     init: async () => (await invoke("wiki_init")) as WikiInfo,
     listPages: async () => ((await invoke("wiki_list_pages")) ?? []) as WikiPage[],
     readPage: async (path: string) => {


### PR DESCRIPTION
### **User description**
## What

Selecting the Local wiki librarian with no wiki yet now shows this instead of an empty composer:

> **Create your local wiki**
> A folder of markdown files, versioned with git, that the librarian reads and writes on this machine. Ask it things and it answers from what it has filed; tell it something worth keeping and it writes it down.
>
> Nothing in it is sent to Exponential's servers — only your messages and whatever the librarian quotes back reach the model.
>
> `/Users/you/Documents/exponential-wiki`
>
> **[ Create wiki ]**

## Why

James hit this on first real use: the only way to bring the wiki into existence was to select the librarian and type something like *"what's in my wiki?"*. Nothing told you that.

The discoverability problem is the visible half. The other half is that `wiki_init` ran at the start of **every** turn, so the folder and its git repo materialised in your Documents because you sent a message. Creating files on someone's machine should be a decision they made.

## Decisions worth a look

**The per-turn `init` is gone, not kept as a safety net.** Keeping it would mean the wiki could still appear without the button in edge cases — exactly the property we were trying to remove. The panel replaces the composer until the wiki exists, so a turn can only start once it does.

**New read-only `wiki_status`.** `wiki_init` reports `created`, but only after the fact, which is no use to something deciding whether to *offer* creation. `wiki_status` is side-effect free and tested for it, since that's the whole point.

**Re-checked on selection, not cached.** Delete the folder by hand and the panel comes back, rather than the chat pointing at nothing. Agreed with James as the intended behaviour.

**A folder that lost its `.git` still counts as existing.** Someone restoring from a backup shouldn't be offered a fresh wiki over the top of their pages.

## Verification

67 Rust tests (3 new): status doesn't create anything, sees an existing wiki with the right page count, and treats a git-less folder as existing.

Panel checked in a browser at the real breakpoint rather than from the markup — layout, the path in monospace, and the button disabling to "Creating…" while it runs.

## Acceptance criteria

- [x] Selecting Local wiki with no wiki shows the panel naming the folder path
- [x] No wiki folder is created until the button is pressed
- [x] After creation the panel does not reappear
- [x] Never appears outside the Tauri shell — same bridge gating as the picker entry
- [x] Init stays idempotent, so pressing twice or creating over a restored backup is harmless

---

Ships: shiny.melon


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace implicit wiki creation side-effect with explicit first-run UI panel

- Add new read-only `wiki_status` Tauri command to check wiki existence without creating it

- Remove per-turn `wiki_init` call; wiki only created when user clicks "Create wiki" button

- Add 3 new Rust tests verifying `status_at` is side-effect free and handles edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User selects Local Wiki librarian"]
  B["wiki_status called (read-only)"]
  C{"Wiki exists?"}
  D["LocalWikiFirstRun panel shown"]
  E["User clicks 'Create wiki'"]
  F["wiki_init called (creates folder + git)"]
  G["Normal chat composer shown"]

  A -- "on selection" --> B
  B --> C
  C -- "no" --> D
  D -- "button click" --> E
  E --> F
  F -- "status refreshed" --> G
  C -- "yes" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>LocalWikiFirstRun.tsx</strong><dd><code>New first-run panel component for wiki creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/475/files#diff-980800c8e04e7d012bb7646fdbff3a0487154ceb0c57f872e482b23a18b0c63a">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ManyChat.tsx</strong><dd><code>Wire wiki status check and first-run panel into chat UI</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/475/files#diff-6f0e68ce865b0629e85c68dbd985a102db9f321cea87620c205f1863eece6ed4">+44/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>localWiki.ts</strong><dd><code>Add WikiStatus interface and status bridge method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/475/files#diff-e26d7a1d853f45ef05efd3a482d3ae30793fe02feea92a6e87e731d169def149">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wiki.rs</strong><dd><code>Add side-effect-free wiki_status command and tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/475/files#diff-c76367aec524f64c600801f6cccf9d93a2e5200c880815f90f56cf232b8fc8d7">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>build.rs</strong><dd><code>Register wiki_status command in Tauri build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/475/files#diff-7d1ef5b0b986fee369d8f5fa4361f21fa3075601e5416738ba4f4d1ea5dfb2ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Register wiki_status handler in Tauri app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/475/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remote.json</strong><dd><code>Grant allow-wiki-status capability to remote</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/475/files#diff-ccb4581457f281d685bf28be1cdf9c3dd911459508f59b4aecc48ebea72c5e44">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wiki_status.toml</strong><dd><code>Auto-generated permissions file for wiki_status command</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/475/files#diff-dbfbdf6942db36ef7d1d4275e03b318aa19ade68ed8f30c11dc89b3c19c32b61">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

