### PR TITLE
fix: keep the window controls off the sidebar in the desktop shells

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,9 +204,17 @@ fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<()> {
 
     // Match the Electron shell's `hiddenInset` chrome: the traffic lights float
     // over the page instead of sitting in a separate title bar.
+    //
+    // `hidden_title` is part of that match, not a nicety: `Overlay` alone keeps
+    // drawing the window title, which lands on top of the page's own top-left
+    // chrome (the sidebar's workspace switcher). Electron's `hiddenInset` hides
+    // the title for us; Tauri needs to be told. The page still needs to keep its
+    // content clear of the traffic lights themselves — see `--titlebar-inset` in
+    // `src/app/_components/layout/sidebar.css`.
     #[cfg(target_os = "macos")]
     let builder = builder
         .title_bar_style(tauri::TitleBarStyle::Overlay)
+        .hidden_title(true)
         .traffic_light_position(tauri::LogicalPosition::new(16.0, 16.0));
 
     builder.build()?;

--- a/src/app/(sidemenu)/layout.tsx
+++ b/src/app/(sidemenu)/layout.tsx
@@ -25,6 +25,7 @@ import { ZoeDrawer, ZoeFab } from '~/app/_components/layout/ZoeDrawer';
 import { CommandPalette } from '~/app/_components/layout/CommandPalette';
 import { ColorSchemeScript } from '@mantine/core';
 import { ThemeInitScript } from '~/app/_components/layout/ThemeInitScript';
+import { DesktopChromeScript } from '~/app/_components/layout/DesktopChromeScript';
 import { MantineRootProvider } from '~/app/_components/layout/MantineRootProvider';
 import { SessionProvider } from "next-auth/react";
 import { WorkspaceProvider } from '~/providers/WorkspaceProvider';
@@ -59,6 +60,8 @@ export default async function RootLayout({
             the (possibly just-migrated) mantine-color-scheme-value key. */}
         <ThemeInitScript />
         <ColorSchemeScript defaultColorScheme="dark" />
+        {/* Reserves the top-left corner for the desktop shells' window controls. */}
+        <DesktopChromeScript />
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1" />
         <link rel="manifest" href="/manifest.webmanifest" />
         <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/app/_components/layout/DesktopChromeScript.tsx
+++ b/src/app/_components/layout/DesktopChromeScript.tsx
@@ -1,0 +1,32 @@
+// Marks the document with the desktop shell hosting it, before first paint.
+//
+// Both shells use the macOS overlay title bar (Electron `hiddenInset`, Tauri
+// `TitleBarStyle::Overlay`), so the traffic lights float over the page's
+// top-left corner — which is the sidebar's workspace switcher. CSS reserves
+// room for them off `data-titlebar="overlay"`; doing it here rather than in a
+// client component keeps the sidebar from painting once in the wrong place and
+// then jumping.
+//
+// Detection mirrors `~/lib/platform.ts` and is duplicated as a string on
+// purpose: this runs in <head>, ahead of any bundle. Both globals are injected
+// before page scripts (Electron's preload, Tauri's init script), and a miss
+// just means no inset — never a broken layout.
+export function DesktopChromeScript() {
+  const script = `
+    try {
+      var shell = window.__TAURI_INTERNALS__ ? 'tauri'
+        : (window.electron ? 'electron' : null);
+      if (shell) {
+        var root = document.documentElement;
+        root.setAttribute('data-shell', shell);
+        // The overlay title bar is a macOS arrangement; other platforms keep
+        // their native chrome and need no inset.
+        if (/Mac/i.test(navigator.userAgent)) {
+          root.setAttribute('data-titlebar', 'overlay');
+        }
+      }
+    } catch (e) {}
+  `;
+
+  return <script dangerouslySetInnerHTML={{ __html: script }} />;
+}

--- a/src/app/_components/layout/Sidebar.tsx
+++ b/src/app/_components/layout/Sidebar.tsx
@@ -41,7 +41,7 @@ export default function Sidebar({ session, domain = 'forceflow.com' }: { session
       <button
         onClick={() => setIsMenuOpen(!isMenuOpen)}
         className={`
-          fixed top-[calc(0.5rem+env(safe-area-inset-top))] left-3 z-[100] p-1.5 rounded-md
+          sb-toggle fixed left-3 z-[100] p-1.5 rounded-md
           hover:bg-surface-hover transition-all duration-200
           ${isMenuOpen ? 'opacity-0 pointer-events-none' : 'opacity-100'}
         `}

--- a/src/app/_components/layout/sidebar.css
+++ b/src/app/_components/layout/sidebar.css
@@ -3,7 +3,28 @@
    .app-sidebar; this file uses only var().
    ============================================================ */
 
+/* ============================================================
+   Desktop-shell title bar inset
+
+   The Electron and Tauri shells both use the macOS overlay title
+   bar, so the traffic lights float over the page's top-left
+   corner — right where the sidebar header sits. DesktopChromeScript
+   stamps data-titlebar="overlay" on <html> before first paint;
+   everything anchored to the top-left leaves room for the controls
+   when it is set, and is untouched in the browser.
+   ============================================================ */
+:root {
+  --titlebar-inset: 0px;
+}
+
+html[data-titlebar="overlay"] {
+  /* Traffic lights sit at (16, 16) and are ~14px tall — clear them
+     plus a little breathing room. */
+  --titlebar-inset: 38px;
+}
+
 .app-sidebar {
+  padding-top: var(--titlebar-inset);
   background: var(--sb-bg);
   border-right: 1px solid var(--sb-hair);
   font-family: var(--sb-font);
@@ -13,6 +34,12 @@
 
 .app-sidebar .sb-workspace-divider {
   border-bottom: 1px solid var(--sb-hair);
+}
+
+/* Re-open button, shown in the same corner once the sidebar is closed —
+   so it has to clear the window controls too. */
+.sb-toggle {
+  top: calc(0.5rem + env(safe-area-inset-top) + var(--titlebar-inset));
 }
 
 /* ============================================================

--- a/src/app/_components/layout/sidebar.css
+++ b/src/app/_components/layout/sidebar.css
@@ -55,6 +55,16 @@ html[data-titlebar="overlay"] {
   }
 }
 
+/* Collapsed, the main column inherits the top-left corner from the sidebar —
+   window controls and all — so the inset has to move with it. Margin rather
+   than padding: it stacks on whatever responsive padding <main> has at this
+   breakpoint instead of replacing it, and rides the same 300ms transition as
+   the collapse, so the content slides down with the sidebar rather than
+   snapping. */
+html[data-titlebar="overlay"][data-sidebar="closed"] .sidebar-offset {
+  margin-top: var(--titlebar-inset);
+}
+
 /* ============================================================
    Create Action - soft tinted CTA
    ============================================================ */


### PR DESCRIPTION
### **User description**
## What

The macOS traffic lights and the native window title were both landing on the page's top-left corner — which is the sidebar's workspace switcher. Visible in the first screenshot from real use of the Tauri shell: window title, app logo and traffic lights all stacked in one corner.

Two causes, and fixing only one leaves the corner still wrong:

- **`TitleBarStyle::Overlay` keeps drawing the window title.** Electron's `hiddenInset` hides it for you; Tauri has to be told. `hidden_title(true)` completes the match — part of the arrangement, not a nicety.
- **The traffic lights are the page's problem.** They float at (16, 16) whatever the shell does. A single `--titlebar-inset` custom property (`0px` in a browser, `38px` in a shell) is applied to the sidebar and to the re-open button that takes the same corner once the sidebar is collapsed. One knob, so a wrong value is wrong in exactly one place.

The marker is stamped from `<head>` by `DesktopChromeScript` rather than a client component, so the sidebar never paints in the wrong place and then jumps. Detection duplicates `platform.ts` as an inline string deliberately — it runs ahead of any bundle, and a miss means no inset, never a broken layout.

**Electron benefits too.** It had the same overlap and nobody had noticed.

## Provenance

Found and fixed in a side session; pulled into the main flow so it gets a ticket, a branch and a PR like everything else. It was sitting **uncommitted on `main`** in the primary checkout, which is how work goes missing.

Two other uncommitted changes were in that working tree and are deliberately **not** here: a `CONTEXT.md` glossary edit (Action/Ticket definitions — belongs to a different, still-running session) and a `.claude/launch.json` alt-port dev-server entry (a workaround artifact from a wedged local server).

## Verification

`cargo test` 64 passing, typecheck and lint clean.

The visual measurement came from the originating session: on an authenticated `/today` at 1400×900, the sidebar header moves from `y=0` in the browser to `y=38` with the shell marker set, clear of the lights which end at `y≈30`.

Note that release builds load `https://exponential.im`, so the CSS half only reaches the packaged app once this is deployed. A debug build against localhost picks it up immediately.

## Acceptance criteria

- [x] No window title drawn over the page in the Tauri shell
- [x] Sidebar header and the collapsed-sidebar re-open button both clear the traffic lights
- [x] Browser and non-macOS unaffected — inset resolves to `0px`
- [x] No layout jump on load

---

Ships: sharp.yak


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix window controls overlapping sidebar's top-left corner in desktop shells

- Add `DesktopChromeScript` to stamp `data-titlebar="overlay"` before first paint

- Introduce `--titlebar-inset` CSS variable to reserve space for traffic lights

- Add `hidden_title(true)` to Tauri config to suppress native window title overlay


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DesktopChromeScript\n(injected in <head>)"]
  B["data-titlebar='overlay'\non <html>"]
  C["--titlebar-inset: 38px\n(CSS variable)"]
  D[".app-sidebar\npadding-top"]
  E[".sb-toggle\ntop offset"]
  F["sidebar-offset\nmargin-top (collapsed)"]
  G["Tauri hidden_title(true)\n(hides native window title)"]

  A -- "detects shell + macOS" --> B
  B -- "activates" --> C
  C -- "applied to" --> D
  C -- "applied to" --> E
  C -- "applied to" --> F
  G -- "completes Overlay match" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Inject DesktopChromeScript into page head</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/layout.tsx

<ul><li>Imports and renders <code>DesktopChromeScript</code> inside <code><head></code> before first paint<br> <li> Adds a comment explaining its purpose (reserving top-left corner for <br>window controls)</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/476/files#diff-3ef9e8f31a7c161af580053addacb71c9b6d07c4b67a82c41fb31764cd80ea11">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DesktopChromeScript.tsx</strong><dd><code>New script component to detect desktop shell before first paint</code></dd></summary>
<hr>

src/app/_components/layout/DesktopChromeScript.tsx

<ul><li>New component that injects an inline script into <code><head></code> before any bundle <br>loads<br> <li> Detects Tauri or Electron shell via <code>window.__TAURI_INTERNALS__</code> / <br><code>window.electron</code><br> <li> Sets <code>data-shell</code> and, on macOS, <code>data-titlebar="overlay"</code> on <code><html></code><br> <li> Silently no-ops on failure so a miss never breaks layout</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/476/files#diff-d84d9fac2757835aed5ff59d1d527112cfb1f639c43859d89a46de6e029b0f2a">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Sidebar.tsx</strong><dd><code>Move sidebar toggle top offset to CSS class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/layout/Sidebar.tsx

<ul><li>Removes hardcoded <code>top-[calc(0.5rem+env(safe-area-inset-top))]</code> from <br>toggle button<br> <li> Adds <code>sb-toggle</code> class so CSS can manage the top offset including <br>titlebar inset</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/476/files#diff-bf54b61d058d58b72a794df8066a0e435dbec01152a2de910a1587b33e382afa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sidebar.css</strong><dd><code>Add titlebar inset CSS variable and apply to sidebar and toggle</code></dd></summary>
<hr>

src/app/_components/layout/sidebar.css

<ul><li>Defines <code>--titlebar-inset</code> CSS variable (<code>0px</code> default, <code>38px</code> when <br><code>data-titlebar="overlay"</code>)<br> <li> Applies <code>padding-top: var(--titlebar-inset)</code> to <code>.app-sidebar</code><br> <li> Adds <code>.sb-toggle</code> rule incorporating the inset into the top calculation<br> <li> Adds <code>margin-top: var(--titlebar-inset)</code> to <code>.sidebar-offset</code> when sidebar <br>is collapsed and overlay is active</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/476/files#diff-4cfb15b78919917b546cf1fa120557eb91a368e4f54dd898a87569104f7917e2">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Add hidden_title to Tauri macOS window to suppress native title </code><br><code>overlay</code></dd></summary>
<hr>

src-tauri/src/lib.rs

<ul><li>Adds <code>.hidden_title(true)</code> to the macOS window builder alongside <br><code>TitleBarStyle::Overlay</code><br> <li> Adds comments explaining why <code>hidden_title</code> is required (Overlay alone <br>still draws the native title)</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/476/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

