### PR TITLE
fix(today): keep the Today title clear of the re-open button

### DIFF
--- a/src/app/_components/today-redesign/today-desktop.css
+++ b/src/app/_components/today-redesign/today-desktop.css
@@ -45,6 +45,19 @@
   border-bottom: 1px solid var(--td-hair);
   white-space: nowrap;
   flex-shrink: 0;
+  /* Matches the sidebar's own collapse animation, so the title slides aside
+     rather than jumping when the corner button appears. */
+  transition: padding-left 300ms ease-in-out;
+}
+
+/* Collapsed, the sidebar leaves a fixed re-open button in the window's
+   top-left corner (x 12–44). This page goes full-bleed, so its bar starts at
+   the very edge of the content column and is the one header the button lands
+   on — 20px puts the title straight under it. WorkspaceTopbar sidesteps this
+   with a flat 40px; here the extra space is only spent while the button is
+   actually there. */
+html[data-sidebar="closed"] .td-topbar {
+  padding-left: 52px;
 }
 
 .td-topbar__title {


### PR DESCRIPTION
### **User description**
## What

Collapsing the sidebar leaves a fixed re-open button in the window's top-left corner (x 12–44). `/today` renders full-bleed — it cancels `<main>`'s padding with `-m-4 -mt-16 sm:-mt-4 lg:-m-8` — so its bar starts at the very edge of the content column, and its `20px` padding put the title directly under that button. The ☰ was drawn on top of the "T" in "Today".

Every other page is already fine: `WorkspaceTopbar` carries a flat `padding: 0 40px`.

The space is spent only while the button is actually there (`html[data-sidebar="closed"]`), and transitions over the same 300ms as the collapse so the title slides aside rather than jumping.

## Why

Fallout spotted while fixing the macOS window-control overlap in #476 — the button moved down with the titlebar inset, but it was landing on this title in the browser too. Predates that PR; separate fix.

## Verification

Measured at 1400×900 on `/today`:

| state | title left | button right | overlap |
|---|---|---|---|
| collapsed (browser) | 20 → **52** | 44 | gone, 8px gap |
| collapsed + shell inset | **52**, top 51 | 44, top 46–78 | gone, both clear of lights (y≤30) |
| open | 240 (unchanged) | hidden | n/a |

Sidebar open is untouched — padding resolves back to `20px`.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix Today title overlapping sidebar re-open button when collapsed

- Add `padding-left: 52px` to `.td-topbar` only when sidebar is closed

- Add 300ms transition to match sidebar collapse animation timing

- Applies only to full-bleed `/today` page; other pages unaffected


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["html[data-sidebar='closed']"]
  B[".td-topbar\npadding-left: 52px"]
  C["Sidebar re-open button\n(x: 12–44px)"]
  D["Today title\n(clear of button, 8px gap)"]

  A -- "activates" --> B
  B -- "pushes title right of" --> C
  C -- "no longer overlaps" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>today-desktop.css</strong><dd><code>Reserve space in Today topbar when sidebar is collapsed</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/today-redesign/today-desktop.css

<ul><li>Adds <code>transition: padding-left 300ms ease-in-out</code> to <code>.td-topbar</code> to <br>animate smoothly with sidebar collapse<br> <li> Adds <code>html[data-sidebar="closed"] .td-topbar</code> rule setting <code>padding-left: </code><br><code>52px</code> to clear the fixed re-open button (x: 12–44px)<br> <li> Adds explanatory comments describing why the extra padding is needed <br>only on this full-bleed page</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/477/files#diff-45f4d56a944c3cacf41abd758375ac279636bccf7bd58d4d3d52ed7eabbf093d">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

