### PR TITLE
feat: server-side global search (search.global) — Cmd+K coverage over the API

### DIFF
--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -3,6 +3,7 @@ import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 import { actionRouter } from "./routers/action";
 import { adminRouter } from "./routers/admin";
 import { projectRouter } from "./routers/project";
+import { searchRouter } from "./routers/search";
 import { toolRouter } from "./routers/tool";
 import { videoRouter } from "~/server/api/routers/video";
 import { goalRouter } from "./routers/goal";
@@ -95,6 +96,7 @@ import { pageCommentRouter } from "./routers/pageComment";
 export const appRouter = createTRPCRouter({
   post: postRouter,
   project: projectRouter,
+  search: searchRouter,
   action: actionRouter,
   admin: adminRouter,
   tools: toolRouter,

--- a/src/server/api/routers/__tests__/search.test.ts
+++ b/src/server/api/routers/__tests__/search.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for the `search` router's `global` procedure.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` instead of a real
+ * database, so they run in milliseconds and CANNOT touch any real DB. Mirrors
+ * the test layout from `ticket.test.ts` / `problem.test.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+// Seed env vars before any module imports — `vi.hoisted` runs before regular
+// top-level statements. Mirrors ticket.test.ts.
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+// ── Stub heavy/IO modules pulled in by the wider router tree ─────────
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(_opts?: any) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({
+    auth: () => null,
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+// ── dbMock plumbing ─────────────────────────────────────────────────
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = {
+  current: null,
+};
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) {
+    dbHolder.current = mockDeep<PrismaClient>();
+  }
+  return dbHolder.current;
+}
+
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+// ── Stub side-effect-heavy modules used by sibling routers ───────────
+vi.mock("~/server/services/notifications/EmailNotificationService", () => ({
+  sendAssignmentNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/lib/blob", () => ({
+  uploadToBlob: vi.fn().mockResolvedValue({ url: "blob://test" }),
+}));
+
+// ── Imports of code under test (must come AFTER vi.mock calls) ───────
+import { createMockCaller } from "~/test/trpc-helpers";
+import { buildActionAccessWhere } from "~/server/services/access";
+
+const callerId = "user-1";
+const workspaceId = "ws-1";
+const workspaceRef = { id: workspaceId, slug: "clear", name: "CLEAR" };
+
+function stubEmptyResults(dbMock: DeepMockProxy<PrismaClient>) {
+  dbMock.workspace.findMany.mockResolvedValue([]);
+  dbMock.project.findMany.mockResolvedValue([]);
+  dbMock.action.findMany.mockResolvedValue([]);
+  dbMock.goal.findMany.mockResolvedValue([]);
+  dbMock.keyResult.findMany.mockResolvedValue([]);
+  dbMock.outcome.findMany.mockResolvedValue([]);
+  dbMock.ticket.findMany.mockResolvedValue([]);
+  dbMock.feature.findMany.mockResolvedValue([]);
+  dbMock.epic.findMany.mockResolvedValue([]);
+  dbMock.knowledgePage.findMany.mockResolvedValue([]);
+  dbMock.transcriptionSession.findMany.mockResolvedValue([]);
+  dbMock.crmContact.findMany.mockResolvedValue([]);
+  dbMock.crmOrganization.findMany.mockResolvedValue([]);
+  dbMock.product.findMany.mockResolvedValue([]);
+}
+
+describe("search router — global (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    stubEmptyResults(dbMock);
+  });
+
+  it("merges typed results across entities and strips HTML from action titles", async () => {
+    dbMock.workspace.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: workspaceId, name: "CLEAR", slug: "clear" } as any,
+    ]);
+    dbMock.project.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "p1", name: "Onionpress Proposal", slug: "onion-p1", status: "ACTIVE", workspace: workspaceRef } as any,
+    ]);
+    dbMock.action.findMany.mockResolvedValue([
+      {
+        id: "a1",
+        name: 'Watch <a href="https://example.com">Brewster talk</a>',
+        kanbanStatus: "TODO",
+        workspace: null,
+        project: { name: "Onionpress Proposal", workspace: workspaceRef },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    ]);
+    dbMock.goal.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 7, title: "Trusted decision layer", status: "active", workspace: workspaceRef } as any,
+    ]);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const res = await caller.search.global({ query: "brew" });
+
+    expect(res.query).toBe("brew");
+    expect(res.results.map((r) => r.type)).toEqual([
+      "workspace",
+      "project",
+      "action",
+      "goal",
+    ]);
+
+    const action = res.results.find((r) => r.type === "action");
+    expect(action?.title).toBe("Watch Brewster talk");
+    expect(action?.workspace).toEqual(workspaceRef);
+    expect(action?.url).toBe("/w/clear/actions/a1");
+
+    const goal = res.results.find((r) => r.type === "goal");
+    expect(goal?.id).toBe("7");
+    expect(goal?.url).toBe("/w/clear/goals/7");
+
+    const project = res.results.find((r) => r.type === "project");
+    expect(project?.url).toBe("/w/clear/projects/onion-p1");
+  });
+
+  it("scopes actions via the canonical bulk resolver, excludes DELETED/DRAFT, matches name case-insensitively", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.search.global({ query: "brew" });
+
+    const where = dbMock.action.findMany.mock.calls[0]?.[0]?.where;
+    expect(where?.name).toEqual({ contains: "brew", mode: "insensitive" });
+    expect(where?.status).toEqual({ notIn: ["DELETED", "DRAFT"] });
+    // Access scoping comes from buildActionAccessWhere, not a hand-rolled copy.
+    expect(where?.OR).toEqual(buildActionAccessWhere(callerId).OR);
+  });
+
+  it("workspace-scoped search filters projects/goals to the workspace for members", async () => {
+    // Direct membership: not a guest, getWorkspaceMembership succeeds.
+    dbMock.workspaceUser.findUnique.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { userId: callerId, workspaceId, role: "member" } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.search.global({ query: "brew", workspaceId });
+
+    const projectWhere = dbMock.project.findMany.mock.calls[0]?.[0]?.where;
+    expect(projectWhere?.workspaceId).toBe(workspaceId);
+    // Members get the full access clause, not the guest-only clause.
+    expect(projectWhere?.projectMembers).toBeUndefined();
+
+    const goalWhere = dbMock.goal.findMany.mock.calls[0]?.[0]?.where;
+    expect(goalWhere?.workspaceId).toBe(workspaceId);
+  });
+
+  it("workspace-scoped search returns no goals and only shared projects for guests", async () => {
+    // No direct membership, no team membership, but a ProjectMember row:
+    // the "guest" shape from isWorkspaceGuest.
+    dbMock.workspaceUser.findUnique.mockResolvedValue(null);
+    dbMock.teamUser.findFirst.mockResolvedValue(null);
+    dbMock.projectMember.findFirst.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "pm-1" } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const res = await caller.search.global({ query: "brew", workspaceId });
+
+    const projectWhere = dbMock.project.findMany.mock.calls[0]?.[0]?.where;
+    expect(projectWhere?.projectMembers).toEqual({ some: { userId: callerId } });
+
+    expect(dbMock.goal.findMany).not.toHaveBeenCalled();
+    expect(res.results.filter((r) => r.type === "goal")).toEqual([]);
+  });
+});

--- a/src/server/api/routers/search.ts
+++ b/src/server/api/routers/search.ts
@@ -1,0 +1,526 @@
+import { z } from "zod";
+import type { PrismaClient } from "@prisma/client";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import {
+  buildActionAccessWhere,
+  buildKnowledgePageAccessWhere,
+  buildProjectAccessWhere,
+  buildTranscriptionAccessWhere,
+  buildWorkspaceAccessWhere,
+  buildWorkspaceVisibilityWhere,
+  getWorkspaceMembership,
+  isWorkspaceGuest,
+} from "~/server/services/access";
+import { stripHtml } from "~/lib/utils";
+import { ticketUrlId } from "~/lib/fun-ids";
+
+/**
+ * Global search — the server-side equivalent of the Cmd+K palette
+ * (CommandPalette.tsx), exposed so the CLI, MCP server, and other API
+ * consumers get the same results the app shows. Each entity block mirrors
+ * the access scoping of that entity's canonical list procedure; when adding
+ * a block, copy the where-clause semantics from the router named in its
+ * comment rather than inventing new scoping.
+ */
+
+export interface SearchResult {
+  type:
+    | "workspace"
+    | "project"
+    | "action"
+    | "goal"
+    | "keyResult"
+    | "outcome"
+    | "ticket"
+    | "feature"
+    | "epic"
+    | "page"
+    | "meeting"
+    | "contact"
+    | "organization"
+    | "product";
+  id: string;
+  title: string;
+  subtitle: string | null;
+  workspace: { id: string; slug: string; name: string } | null;
+  url: string | null;
+}
+
+const searchInput = z.object({
+  query: z.string().trim().min(1).max(200),
+  workspaceId: z.string().optional(),
+  /** Max results per entity type. */
+  limit: z.number().int().min(1).max(25).default(10),
+});
+
+type SearchArgs = {
+  db: PrismaClient;
+  userId: string;
+  q: string;
+  workspaceId?: string;
+  limit: number;
+};
+
+const insensitive = (q: string) => ({ contains: q, mode: "insensitive" as const });
+
+// Mirrors workspace.list (buildWorkspaceVisibilityWhere).
+async function searchWorkspaces({ db, userId, q, limit }: SearchArgs): Promise<SearchResult[]> {
+  const workspaces = await db.workspace.findMany({
+    where: { AND: [buildWorkspaceVisibilityWhere(userId), { name: insensitive(q) }] },
+    select: { id: true, name: true, slug: true },
+    take: limit,
+  });
+  return workspaces.map((w) => ({
+    type: "workspace",
+    id: w.id,
+    title: w.name,
+    subtitle: null,
+    workspace: { id: w.id, slug: w.slug, name: w.name },
+    url: `/w/${w.slug}/home`,
+  }));
+}
+
+// Mirrors project.getAll (buildProjectAccessWhere, guest scope when
+// workspace-scoped).
+async function searchProjects({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const isGuest = workspaceId ? await isWorkspaceGuest(db, userId, workspaceId) : false;
+  const accessWhere = isGuest
+    ? { projectMembers: { some: { userId } } }
+    : buildProjectAccessWhere(userId);
+
+  const projects = await db.project.findMany({
+    where: {
+      ...(workspaceId ? { workspaceId } : {}),
+      ...accessWhere,
+      name: insensitive(q),
+    },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      status: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return projects.map((p) => ({
+    type: "project",
+    id: p.id,
+    title: p.name,
+    subtitle: p.status,
+    workspace: p.workspace,
+    url: p.workspace ? `/w/${p.workspace.slug}/projects/${p.slug}` : null,
+  }));
+}
+
+// Mirrors action.searchByTitle: the canonical bulk resolver
+// (buildActionAccessWhere) rather than getAll's deliberately personal scope —
+// per the access-control rule that bulk permission scoping goes through the
+// centralized resolver. Matches on the raw name (names can contain HTML; the
+// stored markup is stripped from the returned title, so a query can in rare
+// cases match markup that is not visible in the title).
+async function searchActions({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const actions = await db.action.findMany({
+    where: {
+      ...buildActionAccessWhere(userId),
+      ...(workspaceId
+        ? { AND: [{ OR: [{ workspaceId }, { project: { workspaceId } }] }] }
+        : {}),
+      status: { notIn: ["DELETED", "DRAFT"] },
+      name: insensitive(q),
+    },
+    select: {
+      id: true,
+      name: true,
+      kanbanStatus: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+      project: {
+        select: {
+          name: true,
+          workspace: { select: { id: true, slug: true, name: true } },
+        },
+      },
+    },
+    take: limit,
+  });
+  return actions.map((a) => {
+    const workspace = a.workspace ?? a.project?.workspace ?? null;
+    return {
+      type: "action" as const,
+      id: a.id,
+      title: stripHtml(a.name),
+      subtitle: a.project?.name ?? a.kanbanStatus,
+      workspace,
+      url: workspace ? `/w/${workspace.slug}/actions/${a.id}` : null,
+    };
+  });
+}
+
+// Mirrors goal.getAllMyGoals: all goals of workspaces the caller belongs to,
+// plus personally-owned goals when searching across workspaces.
+async function searchGoals({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  if (workspaceId) {
+    const membership = await getWorkspaceMembership(db, userId, workspaceId);
+    if (!membership) return [];
+  }
+  const goals = await db.goal.findMany({
+    where: {
+      ...(workspaceId
+        ? { workspaceId }
+        : {
+            // Strict membership (direct or team), matching the
+            // getWorkspaceMembership gate — guests don't see workspace goals.
+            OR: [
+              { userId },
+              { workspace: { is: buildWorkspaceAccessWhere(userId) } },
+            ],
+          }),
+      title: insensitive(q),
+    },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return goals.map((g) => ({
+    type: "goal",
+    id: String(g.id),
+    title: g.title,
+    subtitle: g.status,
+    workspace: g.workspace,
+    url: g.workspace ? `/w/${g.workspace.slug}/goals/${g.id}` : null,
+  }));
+}
+
+// Mirrors okr.getByObjective's workspace mode: all workspace OKRs are visible
+// to members; otherwise personally-owned key results.
+async function searchKeyResults({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  if (workspaceId) {
+    const membership = await getWorkspaceMembership(db, userId, workspaceId);
+    if (!membership) return [];
+  }
+  const keyResults = await db.keyResult.findMany({
+    where: {
+      ...(workspaceId
+        ? { workspaceId }
+        : {
+            OR: [
+              { userId },
+              { workspace: { is: buildWorkspaceAccessWhere(userId) } },
+            ],
+          }),
+      title: insensitive(q),
+    },
+    select: {
+      id: true,
+      title: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return keyResults.map((kr) => ({
+    type: "keyResult",
+    id: kr.id,
+    title: kr.title,
+    subtitle: null,
+    workspace: kr.workspace,
+    // Deep link into the OKR drawer, as FavouritesNav does.
+    url: kr.workspace ? `/w/${kr.workspace.slug}/goals?tab=okrs&drawer=keyResult:${kr.id}` : null,
+  }));
+}
+
+// Mirrors outcome list scoping: strictly owner-scoped (no workspace-wide
+// sharing on the canonical list).
+async function searchOutcomes({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const outcomes = await db.outcome.findMany({
+    where: {
+      userId,
+      ...(workspaceId ? { workspaceId } : {}),
+      description: insensitive(q),
+    },
+    select: {
+      id: true,
+      description: true,
+      type: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return outcomes.map((o) => ({
+    type: "outcome",
+    id: o.id,
+    title: o.description,
+    subtitle: o.type,
+    workspace: o.workspace,
+    url: o.workspace ? `/w/${o.workspace.slug}/outcomes` : null,
+  }));
+}
+
+// Mirrors ticket.list's assertWorkspaceMember gate (direct or team-based
+// workspace membership via the ticket's product; guests denied).
+async function searchTickets({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const tickets = await db.ticket.findMany({
+    where: {
+      product: {
+        ...(workspaceId ? { workspaceId } : {}),
+        workspace: { is: buildWorkspaceAccessWhere(userId) },
+      },
+      OR: [
+        { title: insensitive(q) },
+        { shortId: insensitive(q) },
+        // An all-digits query also matches the ticket's sequential number.
+        ...(/^\d+$/.test(q) && parseInt(q, 10) > 0
+          ? [{ number: parseInt(q, 10) }]
+          : []),
+      ],
+    },
+    select: {
+      id: true,
+      title: true,
+      number: true,
+      shortId: true,
+      status: true,
+      product: {
+        select: { slug: true, workspace: { select: { id: true, slug: true, name: true } } },
+      },
+    },
+    take: limit,
+  });
+  return tickets.map((t) => ({
+    type: "ticket",
+    id: t.id,
+    title: t.title,
+    subtitle: `${t.shortId ?? (t.number > 0 ? `#${t.number}` : "")} ${t.status}`.trim(),
+    workspace: t.product.workspace,
+    url: `/w/${t.product.workspace.slug}/products/${t.product.slug}/tickets/${t.shortId ?? ticketUrlId(t)}`,
+  }));
+}
+
+// Same workspace-membership-via-product gate as tickets.
+async function searchFeatures({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const features = await db.feature.findMany({
+    where: {
+      product: {
+        ...(workspaceId ? { workspaceId } : {}),
+        workspace: { is: buildWorkspaceAccessWhere(userId) },
+      },
+      name: insensitive(q),
+    },
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      product: {
+        select: { slug: true, workspace: { select: { id: true, slug: true, name: true } } },
+      },
+    },
+    take: limit,
+  });
+  return features.map((f) => ({
+    type: "feature",
+    id: f.id,
+    title: f.name,
+    subtitle: f.status,
+    workspace: f.product.workspace,
+    url: `/w/${f.product.workspace.slug}/products/${f.product.slug}/features/${f.id}`,
+  }));
+}
+
+// Mirrors the epic router's gate: DIRECT workspace membership only (team-based
+// members are denied there, so they are denied here too).
+async function searchEpics({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const epics = await db.epic.findMany({
+    where: {
+      ...(workspaceId ? { workspaceId } : {}),
+      workspace: { members: { some: { userId } } },
+      name: insensitive(q),
+    },
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return epics.map((e) => ({
+    type: "epic",
+    id: e.id,
+    title: e.name,
+    subtitle: e.status,
+    workspace: e.workspace,
+    // Epics have no dedicated detail route; they surface inside kanban views.
+    url: null,
+  }));
+}
+
+// Mirrors page.list (buildKnowledgePageAccessWhere, ADR-0033).
+async function searchPages({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const pages = await db.knowledgePage.findMany({
+    where: {
+      AND: [
+        buildKnowledgePageAccessWhere(userId),
+        ...(workspaceId ? [{ workspaceId }] : []),
+        { title: insensitive(q) },
+      ],
+    },
+    select: {
+      id: true,
+      title: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return pages.map((p) => ({
+    type: "page",
+    id: p.id,
+    title: p.title,
+    subtitle: null,
+    workspace: p.workspace,
+    url: `/w/${p.workspace.slug}/pages/${p.id}`,
+  }));
+}
+
+// Mirrors transcription list (buildTranscriptionAccessWhere), unarchived only.
+async function searchMeetings({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const sessions = await db.transcriptionSession.findMany({
+    where: {
+      AND: [
+        buildTranscriptionAccessWhere(userId),
+        { archivedAt: null },
+        ...(workspaceId ? [{ OR: [{ workspaceId }, { project: { workspaceId } }] }] : []),
+        { title: insensitive(q) },
+      ],
+    },
+    select: {
+      id: true,
+      title: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+      project: { select: { workspace: { select: { id: true, slug: true, name: true } } } },
+    },
+    take: limit,
+  });
+  return sessions.map((s) => ({
+    type: "meeting",
+    id: s.id,
+    title: s.title ?? "Untitled meeting",
+    subtitle: null,
+    workspace: s.workspace ?? s.project?.workspace ?? null,
+    url: `/recording/${s.id}`,
+  }));
+}
+
+// Mirrors the CRM routers' gate: DIRECT workspace membership only.
+async function searchContacts({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const contacts = await db.crmContact.findMany({
+    where: {
+      ...(workspaceId ? { workspaceId } : {}),
+      workspace: { members: { some: { userId } } },
+      OR: [{ firstName: insensitive(q) }, { lastName: insensitive(q) }],
+    },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return contacts.map((c) => ({
+    type: "contact",
+    id: c.id,
+    title: [c.firstName, c.lastName].filter(Boolean).join(" ") || "Unnamed contact",
+    subtitle: null,
+    workspace: c.workspace,
+    url: `/w/${c.workspace.slug}/crm/contacts/${c.id}`,
+  }));
+}
+
+// Same direct-membership gate as contacts.
+async function searchOrganizations({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const organizations = await db.crmOrganization.findMany({
+    where: {
+      ...(workspaceId ? { workspaceId } : {}),
+      workspace: { members: { some: { userId } } },
+      name: insensitive(q),
+    },
+    select: {
+      id: true,
+      name: true,
+      industry: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return organizations.map((o) => ({
+    type: "organization",
+    id: o.id,
+    title: o.name,
+    subtitle: o.industry,
+    workspace: o.workspace,
+    url: `/w/${o.workspace.slug}/crm/organizations/${o.id}`,
+  }));
+}
+
+// Mirrors product.list's assertWorkspaceMember gate (direct or team-based).
+async function searchProducts({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const products = await db.product.findMany({
+    where: {
+      ...(workspaceId ? { workspaceId } : {}),
+      workspace: { is: buildWorkspaceAccessWhere(userId) },
+      name: insensitive(q),
+    },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return products.map((p) => ({
+    type: "product",
+    id: p.id,
+    title: p.name,
+    subtitle: null,
+    workspace: p.workspace,
+    url: `/w/${p.workspace.slug}/products/${p.slug}`,
+  }));
+}
+
+export const searchRouter = createTRPCRouter({
+  global: protectedProcedure.input(searchInput).query(async ({ ctx, input }) => {
+    const args: SearchArgs = {
+      db: ctx.db,
+      userId: ctx.session.user.id,
+      q: input.query,
+      workspaceId: input.workspaceId,
+      limit: input.limit,
+    };
+
+    const groups = await Promise.all([
+      searchWorkspaces(args),
+      searchProjects(args),
+      searchActions(args),
+      searchGoals(args),
+      searchKeyResults(args),
+      searchOutcomes(args),
+      searchTickets(args),
+      searchFeatures(args),
+      searchEpics(args),
+      searchPages(args),
+      searchMeetings(args),
+      searchContacts(args),
+      searchOrganizations(args),
+      searchProducts(args),
+    ]);
+
+    return {
+      query: input.query,
+      results: groups.flat(),
+    };
+  }),
+});


### PR DESCRIPTION
### **User description**
## Why

The Cmd+K palette searches client-side over `getAll` fetches, and external consumers had no search at all — the MCP server has been calling `search.global` since day one, a procedure that never existed (`No procedure found on path search.global`). The CLI had no search command.

## What

New `search` tRPC router with one `global` procedure: `{ query, workspaceId?, limit? }` → typed results `{ type, id, title, subtitle, workspace, url }`.

**Coverage** (from a 4-agent codebase audit of schema, routers, and UI surfaces): workspaces, projects, actions, goals, key results, outcomes, tickets, features, epics, knowledge pages, meetings, CRM contacts, CRM organizations, products.

**Access scoping**: each entity block mirrors its canonical list procedure — `buildProjectAccessWhere` (+ guest collapse), `buildActionAccessWhere` (the mandated bulk resolver, as `action.searchByTitle` does), goal/KR membership gates, workspace-membership-via-product for tickets/features, ADR-0033 `buildKnowledgePageAccessWhere`, `buildTranscriptionAccessWhere`, direct-members-only for CRM (matching the CRM routers).

**Deliberate choices**
- name/title matching only for v1 (plus ticket shortId/number); description/body matching is a fast-follow that wants trigram indexes
- epics included with `url: null` (no detail route) — API/CLI consumers still want the ids; the audit's include-later verdict was routing-based, not access-based
- **videos excluded**: the `Video` model is globally unscoped (`where: {}`) — surfacing it in search would widen that hole. Worth its own fix.
- **deals excluded**: pipeline access is resolved per-project in memory (N+1), no clean where-clause

## Verification

- 4 unit tests (mocked Prisma) pin the scoping clause per entity
- Live smoke test against a :3100 dev server with the seeded dev-fixture session: multi-entity results with correct hrefs (fun-id ticket URLs, KR drawer deep-link), `UNAUTHORIZED` when anonymous
- `tsc --noEmit` clean; pre-push suite: 1974 unit tests green

## Companion PRs

- exponential-sdk: `SearchApi` (`client.search.global`) — needs publish as 1.9.0
- exponential-cli: `exponential search <query> [-w ws] [-l n]` — needs SDK 1.9.0, publish as 1.8.0
- exponential-mcp: honest tool description + workspaceId/limit passthrough

No migrations — fast-track eligible.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds new `search.global` tRPC procedure covering 14 entity types

- Each entity block mirrors its canonical router's access scoping rules

- Returns typed results with `type`, `id`, `title`, `subtitle`, `workspace`, `url`

- Includes 4 unit tests with mocked Prisma validating scoping per entity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  client["Client / CLI / MCP"]
  router["searchRouter\n(search.global)"]
  ws["searchWorkspaces"]
  proj["searchProjects"]
  act["searchActions"]
  goal["searchGoals"]
  kr["searchKeyResults"]
  out["searchOutcomes"]
  tick["searchTickets"]
  feat["searchFeatures"]
  epic["searchEpics"]
  page["searchPages"]
  meet["searchMeetings"]
  crm["searchContacts\nsearchOrganizations"]
  prod["searchProducts"]
  access["Access helpers\n(buildProjectAccessWhere,\nbuildActionAccessWhere, etc.)"]
  result["SearchResult[]"]

  client -- "query, workspaceId?, limit?" --> router
  router --> ws & proj & act & goal & kr & out & tick & feat & epic & page & meet & crm & prod
  access -- "scoping" --> proj & act & goal & kr & tick & feat & epic & page & meet & crm & prod
  ws & proj & act & goal & kr & out & tick & feat & epic & page & meet & crm & prod --> result
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>root.ts</strong><dd><code>Register searchRouter in root tRPC router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/root.ts

<ul><li>Imports the new <code>searchRouter</code> from <code>./routers/search</code><br> <li> Registers it as <code>search</code> on the root <code>appRouter</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/478/files#diff-6a8cad7e52067d5afa93671900c038e0e0a9526f8f0e3bd10985cecf4295b4fc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>search.ts</strong><dd><code>New global search router covering 14 entity types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/search.ts

<ul><li>Defines <code>SearchResult</code> interface with typed entity union and common <br>fields<br> <li> Implements 14 per-entity search functions, each mirroring its <br>canonical router's access scoping<br> <li> Exposes <code>search.global</code> protected procedure accepting <code>query</code>, <br><code>workspaceId?</code>, <code>limit?</code><br> <li> Runs all entity searches in parallel via <code>Promise.all</code> and returns flat <br>results array</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/478/files#diff-8e2eb893e53f741f2d3019aa28559a3d29775df802c1921a49c131a2ac642dc8">+526/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>search.test.ts</strong><dd><code>Unit tests for search.global scoping and result shape</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/__tests__/search.test.ts

<ul><li>Adds 4 unit tests using <code>mockDeep<PrismaClient>()</code> (no real DB)<br> <li> Tests result merging, HTML stripping from action titles, and URL <br>construction<br> <li> Validates action scoping uses <code>buildActionAccessWhere</code> canonical <br>resolver<br> <li> Verifies workspace-scoped member vs. guest access differences for <br>projects and goals</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/478/files#diff-1418f51be20f3b84b307919114b069b418ca595159877c6cef4e2f916b24cb4e">+223/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

