### PR TITLE
Overdue triage: cohort detection, amnesty verb, agent schedule writes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -146,6 +146,14 @@ _Avoid_: Today's plan (reserved — that's the narrower voice **Daily brief**), 
 The short, **speakable** morning summary built by `generateBriefingData` and surfaced by voice's `get_todays_plan` **coarse tool** and the web morning briefing. **Narrower than Today's actions on purpose**: it counts only **due-today** (`dueDate` in `[startOfDay, endOfDay]`) and **overdue-by-`dueDate`** actions plus low-progress projects — it does **not** include scheduled-today or inbox actions. So the **Daily brief** and **Today's actions** can legitimately disagree on what "today" contains (the brief omits a scheduled-but-not-due "Pay Malte"). This divergence is **known and accepted for now**; converging voice onto the **Today's actions** definition is deferred, not done. See [ADR-0034](docs/adr/0034-todays-actions-shared-partition.md).
 _Avoid_: Treating the brief as the source of truth for `/today`; "today's plan" for the `/today` list.
 
+**Overdue cohort**:
+A set of overdue **Actions** sharing one *exact* anchor instant (`scheduledStart`, else `dueDate`, to the millisecond) — the fingerprint of a single bulk write: a generated project plan, a template, an import. Hand-entered dates carry the millisecond the user hit save and effectively never collide, so ≥3 actions on one instant means one writer created them all. Surfaced by `action.getOverdueTriage`, which splits an overdue pile into **cohorts** and **loose** debt. The distinction matters because it changes the disposition: cohort members were never individually due and deserve **amnesty**; loose actions are real missed commitments. Typically most of a large overdue count is cohorts — 21 of 40 in the case that motivated this.
+_Avoid_: Batch, cluster, group (all used for unrelated concepts); "duplicate" (cohort members are distinct actions).
+
+**Amnesty**:
+Clearing an **Action**'s dates (`scheduledStart`, `scheduledEnd`, `dueDate`) so it returns to its **Project** backlog untimed, via `action.bulkDefer`. The counterpart to rescheduling, and the right move for an **Overdue cohort**: rescheduling says "still due, later" and re-inflicts the pile tomorrow, amnesty says "this was never really due — stop counting it against me". Deliberately a distinct verb from `action.bulkReschedule({ dueDate: null })` even though the row effect is identical, because intent is what callers and agent tool-discovery need to express. Kanban status is untouched — an Action can be untimed and still in progress.
+_Avoid_: Snooze (implies it comes back), dismiss/archive/delete (the Action stays ACTIVE and live), defer *as a user-facing word* (that's the procedure name, not the concept).
+
 ### Weekly planning
 
 **Weekly plan**:

--- a/docs/ZOE_DAILY_BRIEFING.md
+++ b/docs/ZOE_DAILY_BRIEFING.md
@@ -1,7 +1,9 @@
 # Zoe Daily Briefing — Internal Reference
 
 > **Audience:** future-you + collaborators. Not user-facing. Not linked from any public docs site.
-> **Status:** v1 (logging infrastructure). Eval loop not yet built.
+> **Status:** **Design only — not implemented.** Everything below is the intended
+> design. Only the schema exists; see [Current state](#current-state) for what is
+> actually built, and what shipped instead.
 
 ## What this is
 
@@ -78,14 +80,39 @@ Computed by the admin page at `/admin/daily-briefing` (when built).
 
 **Pick one primary metric.** Default: top-1 execution rate. Acceptance rate is the fastest signal but easiest to goodhart.
 
-## Current state (v1)
+## Current state
 
-- [x] Schema: `DailyBriefing`, `BriefingInteraction`, `NavigationPreference.showDailyBriefing`
-- [x] Opt-in toggle in `/settings`
-- [x] tRPC router `zoeBriefing` (generate, getCurrent, refresh, recordInteraction)
-- [x] `DailyBriefingCard` on `/today` (renders when filter=today AND preference enabled)
-- [x] Admin page at `/admin/daily-briefing` for metrics
-- [ ] **Not built yet:** eval harness, fixture set, prompt variant scoring
+Verified 2026-08-04. An earlier revision of this file checked five of these
+boxes; only the first was ever true. Re-verify before trusting it again.
+
+- [x] Schema: `DailyBriefing` (`prisma/schema.prisma:1897`), `BriefingInteraction`
+      (`:1920`), `NavigationPreference.showDailyBriefing` (`:1888`) — **all three
+      exist and none is read or written anywhere in `src/`.** Dead tables.
+- [ ] Opt-in toggle in `/settings` — `showDailyBriefing` appears zero times in `src/`.
+- [ ] tRPC router `zoeBriefing` — does not exist. (`src/server/api/routers/briefing.ts`
+      is the unrelated data-aggregation router; there is no `zoeBriefing.ts`.)
+- [ ] `DailyBriefingCard` on `/today` — no such component.
+- [ ] Admin page at `/admin/daily-briefing` — no such route.
+- [ ] Eval harness, fixture set, prompt variant scoring.
+
+### What shipped instead
+
+The AI card on `/today` is a different implementation that bypasses everything
+above: `scheduling.getSchedulingSuggestions`
+(`src/server/api/routers/scheduling.ts`) → Mastra's `ashAgent`, rendered by
+`ZoePanel`. Three ways it diverges from this design, each worth knowing before
+you build on it:
+
+- **It regenerates on page load** — a `useQuery` with `staleTime: 5min`, firing an
+  LLM round-trip per render. That is precisely the first entry under
+  [Gotchas](#gotchas) below.
+- **Nothing is persisted.** No `DailyBriefing` row, no `promptVersion`, no
+  `inputSnapshot`, no interaction log. Dismissal is React state and dies on
+  reload. So none of the metrics below can currently be computed, and there is
+  no replayable input for the autoresearch loop.
+- **It is not Zoe.** `ashAgent` is a tool-less GPT-4o lean-startup persona whose
+  instructions are overridden by a per-call system message. Model, prompt, and
+  persona are all unrelated to the branding on the card.
 
 ## Roadmap to the autoresearch loop
 

--- a/docs/adr/0052-overdue-cohorts-and-amnesty.md
+++ b/docs/adr/0052-overdue-cohorts-and-amnesty.md
@@ -1,0 +1,107 @@
+# Overdue triage: bulk-write cohorts detected by exact instant, amnesty as its own verb
+
+## Status
+
+Accepted — 2026-08-04
+
+## Context
+
+A user opened `/today` to 40 overdue actions and reported being overwhelmed. The
+pile was not 40 missed commitments: **21 of the 40 were two bulk writes** — 17
+actions stamped `2026-07-25T08:29:55.483Z` across six projects, and 4 stamped
+`2026-07-23T07:00:00.000Z` — generated project plans that received one blanket
+date at creation. Only 19 were individually-dated debt.
+
+The only bulk affordance on the page is **"Reschedule all → Today"**
+(`action.bulkReschedule`), which sets `scheduledStart` to now for every selected
+action. Applied to this pile it moves 40 items forward 24 hours and re-inflicts
+them tomorrow — it treats a data-provenance artifact as a scheduling problem.
+Nothing in the product distinguishes "you missed this" from "nobody ever
+intended this to be due that day", so neither the user nor an agent can propose
+a disposition better than "move it all".
+
+This blocks the morning-agent work: an agent handed 40 undifferentiated overdue
+rows can only summarize them. The useful sentence — *"17 of these were written
+in one batch and were never individually due; want them back in their project
+backlogs?"* — requires a distinction the data model does not currently express.
+
+## Decision
+
+Add a **read** that classifies the pile and a **write** that expresses amnesty.
+
+- **Cohorts are detected by exact anchor instant.** `groupOverdueCohorts()` in
+  `~/lib/actions/triage.ts` groups overdue actions by their `overdueAnchor`
+  (`scheduledStart`, else `dueDate`) at **millisecond** equality; ≥3 members is
+  a cohort, everything else is `loose`. The heuristic is deliberately crude and
+  deliberately exact: a human dating actions one at a time carries the
+  millisecond they hit save, so collisions are effectively impossible, while a
+  single `createMany` writes one identical value to every row. No timestamp
+  metadata, no `source` sniffing, no model call — the fingerprint is already in
+  the data.
+
+- **`action.getOverdueTriage`** returns `{ totalOverdue, cohortCount, cohorts,
+  loose }`, each cohort carrying `stampedAt`, `count`, `daysOverdue`,
+  `projectNames`, and `actionIds` — enough for a caller to *explain* the cohort
+  before acting on it. It reuses `partitionActions()` for the overdue set, so it
+  and `/today` always describe the same pile ([ADR-0034](0034-todays-actions-shared-partition.md)).
+
+- **`action.bulkDefer` is a separate procedure from `bulkReschedule`**, despite
+  clearing the same columns that `bulkReschedule({ dueDate: null })` clears. The
+  row effect is identical; the *intent* is not, and intent is the thing callers
+  need to express — most of all agents, whose tool discovery is BM25 over tool
+  descriptions. A verb named "defer" with a description about untimed backlogs
+  is findable for "these were never due"; an overload of "reschedule" with a
+  null argument is not. It also gives the two operations independent activity
+  provenance.
+
+- **Amnesty touches dates only.** `kanbanStatus` is left alone: an action can be
+  untimed and still in progress on a board.
+
+- The suggestion generator (`scheduling.getSchedulingSuggestions`) is moved onto
+  `partitionActions()` in the same change. It selected overdue by `dueDate <
+  today` while the panel that renders it is *gated* on the client partition, so
+  the banner could appear over a pile it had nothing to say about, and it
+  ignored every scheduled-but-never-due action.
+
+## Considered alternatives
+
+- **Fuzzy clustering (same minute / same hour / same day).** Rejected — it
+  merges genuinely distinct decisions. Three actions dated across one working
+  day are three choices; three sharing a millisecond are one. Widening the
+  window trades a heuristic with essentially no false positives for one with
+  many, to catch bulk writes that are rare in practice (a `createMany` shares an
+  instant; only a slow scripted loop would not).
+- **Persist the provenance instead — a `batchId` written at creation.** The
+  honest fix, and not exclusive with this one, but it is schema + migration +
+  backfill and it cannot classify a single existing row. The anchor fingerprint
+  works on data already in the database, today. Revisit if cohort quality proves
+  insufficient.
+- **Use `Action.source` or `createdAt` proximity.** Rejected — `source` records
+  the channel (`app`, `notion`, `api`), not the write, and is identical across
+  hand-created and bulk-created actions from the same surface. `createdAt`
+  proximity has the fuzzy-window problem plus false positives from any busy
+  minute of manual entry.
+- **Let the LLM classify the pile.** Rejected as the primary mechanism — it is a
+  deterministic grouping over a timestamp, it must be right the same way every
+  time, and it should not cost a model call. The agent's job is to *propose the
+  disposition* from the grouping, which is genuinely judgement.
+- **Only add `getOverdueTriage`, reuse `bulkReschedule(null)` for the write.**
+  Rejected on discovery grounds above.
+
+## Consequences
+
+- New `~/lib/actions/triage.ts` (`groupOverdueCohorts`, `daysOverdue`,
+  `COHORT_MIN_SIZE`) with unit tests; pure and clock-injected like
+  `partitionActions`.
+- New `action.getOverdueTriage` and `action.bulkDefer`; `mastra.updateAction`
+  gains `scheduledStart` / `scheduledEnd` / `duration` — until now no agent
+  could write a "do date" at all, so no agent could move anything out of the
+  overdue bucket.
+- `scheduling.getSchedulingSuggestions` now fetches ACTIVE actions and
+  partitions in memory rather than filtering by `dueDate` in SQL, matching the
+  existing `getTodaysActions` pattern.
+- CONTEXT.md gains **Overdue cohort** and **Amnesty**. These become the shared
+  vocabulary for the CLI, SDK, MCP server, and Mastra tools that wrap this
+  contract.
+- The cohort threshold (3) and exact-instant rule are heuristics, recorded here
+  so a future reader knows they were chosen, not inherited.

--- a/src/lib/actions/__tests__/triage.test.ts
+++ b/src/lib/actions/__tests__/triage.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { partitionActions } from "../partition";
+import {
+  COHORT_MIN_SIZE,
+  daysOverdue,
+  groupOverdueCohorts,
+  type TriageableAction,
+} from "../triage";
+
+// A fixed "today" so the suite is deterministic regardless of the wall clock.
+const TODAY = new Date("2026-08-04T09:00:00.000Z");
+
+function action(overrides: Partial<TriageableAction> = {}): TriageableAction {
+  return {
+    id: Math.random().toString(36).slice(2),
+    name: "an action",
+    status: "ACTIVE",
+    priority: "Quick",
+    scheduledStart: null,
+    dueDate: null,
+    projectId: null,
+    completedAt: null,
+    project: null,
+    ...overrides,
+  };
+}
+
+/** N actions sharing one exact instant — the signature of a bulk write. */
+function bulk(
+  n: number,
+  stamp: string,
+  overrides: Partial<TriageableAction> = {},
+): TriageableAction[] {
+  return Array.from({ length: n }, (_, i) =>
+    action({ id: `bulk-${stamp}-${i}`, dueDate: new Date(stamp), ...overrides }),
+  );
+}
+
+describe("groupOverdueCohorts", () => {
+  it("groups actions sharing an exact instant into one cohort", () => {
+    const stamp = "2026-07-25T08:29:55.483Z";
+    const { cohorts, loose } = groupOverdueCohorts(bulk(17, stamp), {
+      today: TODAY,
+    });
+
+    expect(cohorts).toHaveLength(1);
+    expect(cohorts[0]!.count).toBe(17);
+    expect(cohorts[0]!.stampedAt.toISOString()).toBe(stamp);
+    expect(cohorts[0]!.daysOverdue).toBe(10);
+    expect(loose).toHaveLength(0);
+  });
+
+  it("leaves individually-dated actions loose even when they share a calendar day", () => {
+    // Same day, different instants — a human dating things one at a time.
+    const sameDay = [
+      action({ id: "a", dueDate: new Date("2026-07-25T08:29:55.483Z") }),
+      action({ id: "b", dueDate: new Date("2026-07-25T11:02:13.001Z") }),
+      action({ id: "c", dueDate: new Date("2026-07-25T16:44:09.777Z") }),
+    ];
+
+    const { cohorts, loose } = groupOverdueCohorts(sameDay, { today: TODAY });
+
+    expect(cohorts).toHaveLength(0);
+    expect(loose.map((a) => a.id).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it(`needs ${COHORT_MIN_SIZE} members before a shared instant counts as a cohort`, () => {
+    const pair = bulk(COHORT_MIN_SIZE - 1, "2026-07-25T08:29:55.483Z");
+    expect(groupOverdueCohorts(pair, { today: TODAY }).cohorts).toHaveLength(0);
+
+    const trio = bulk(COHORT_MIN_SIZE, "2026-07-25T08:29:55.483Z");
+    expect(groupOverdueCohorts(trio, { today: TODAY }).cohorts).toHaveLength(1);
+  });
+
+  it("separates multiple bulk writes and orders them biggest first", () => {
+    const overdue = [
+      ...bulk(4, "2026-07-23T07:00:00.000Z"),
+      ...bulk(17, "2026-07-25T08:29:55.483Z"),
+      action({ id: "solo", dueDate: new Date("2026-07-30T22:00:00.000Z") }),
+    ];
+
+    const triage = groupOverdueCohorts(overdue, { today: TODAY });
+
+    expect(triage.totalOverdue).toBe(22);
+    expect(triage.cohorts.map((c) => c.count)).toEqual([17, 4]);
+    expect(triage.cohortCount).toBe(21);
+    expect(triage.loose.map((a) => a.id)).toEqual(["solo"]);
+  });
+
+  it("reports the distinct projects a cohort spans, so it can be explained", () => {
+    const overdue = [
+      ...bulk(2, "2026-07-25T08:29:55.483Z", {
+        project: { name: "Net Worth Baseline" },
+      }),
+      ...bulk(2, "2026-07-25T08:29:55.483Z", {
+        project: { name: "Tax Reserve System" },
+      }),
+    ];
+    // Both helpers stamp ids by index, so de-dupe ids before grouping.
+    const unique = overdue.map((a, i) => ({ ...a, id: `a${i}` }));
+
+    const { cohorts } = groupOverdueCohorts(unique, { today: TODAY });
+
+    expect(cohorts).toHaveLength(1);
+    expect(cohorts[0]!.projectNames.sort()).toEqual([
+      "Net Worth Baseline",
+      "Tax Reserve System",
+    ]);
+  });
+
+  it("keys the cohort on scheduledStart when present (schedule wins, as in partitionActions)", () => {
+    // Identical scheduledStart, differing dueDates: still one bulk write.
+    const overdue = Array.from({ length: 3 }, (_, i) =>
+      action({
+        id: `s${i}`,
+        scheduledStart: new Date("2026-07-25T08:29:55.483Z"),
+        dueDate: new Date(`2026-07-2${i + 1}T12:00:00.000Z`),
+      }),
+    );
+
+    const { cohorts } = groupOverdueCohorts(overdue, { today: TODAY });
+
+    expect(cohorts).toHaveLength(1);
+    expect(cohorts[0]!.count).toBe(3);
+  });
+
+  it("orders loose debt oldest first", () => {
+    const overdue = [
+      action({ id: "recent", dueDate: new Date("2026-08-02T12:00:00.000Z") }),
+      action({ id: "ancient", dueDate: new Date("2026-06-01T12:00:00.000Z") }),
+      action({ id: "middling", dueDate: new Date("2026-07-15T12:00:00.000Z") }),
+    ];
+
+    const { loose } = groupOverdueCohorts(overdue, { today: TODAY });
+
+    expect(loose.map((a) => a.id)).toEqual(["ancient", "middling", "recent"]);
+  });
+
+  it("consumes partitionActions output directly (the real call path)", () => {
+    // A mixed pile: a bulk-dated plan, one real overdue item, one due today,
+    // one completed. Only the overdue ones should reach triage.
+    const all = [
+      ...bulk(3, "2026-07-25T08:29:55.483Z"),
+      action({ id: "real", dueDate: new Date("2026-07-30T09:00:00.000Z") }),
+      action({ id: "today", dueDate: new Date("2026-08-04T09:00:00.000Z") }),
+      action({
+        id: "done",
+        status: "COMPLETED",
+        dueDate: new Date("2026-07-01T09:00:00.000Z"),
+      }),
+    ];
+
+    const { overdue } = partitionActions(all, { today: TODAY });
+    const triage = groupOverdueCohorts(overdue, { today: TODAY });
+
+    expect(triage.totalOverdue).toBe(4);
+    expect(triage.cohorts).toHaveLength(1);
+    expect(triage.cohorts[0]!.count).toBe(3);
+    expect(triage.loose.map((a) => a.id)).toEqual(["real"]);
+  });
+});
+
+describe("daysOverdue", () => {
+  it("counts whole days from the anchor to today", () => {
+    expect(
+      daysOverdue({ scheduledStart: null, dueDate: new Date("2026-07-25T08:29:55.483Z") }, TODAY),
+    ).toBe(10);
+  });
+
+  it("prefers scheduledStart over dueDate, matching overdueAnchor", () => {
+    expect(
+      daysOverdue(
+        {
+          scheduledStart: new Date("2026-08-01T08:00:00.000Z"),
+          dueDate: new Date("2026-06-01T08:00:00.000Z"),
+        },
+        TODAY,
+      ),
+    ).toBe(3);
+  });
+
+  it("returns 0 when there is no anchor at all", () => {
+    expect(daysOverdue({ scheduledStart: null, dueDate: null }, TODAY)).toBe(0);
+  });
+});

--- a/src/lib/actions/triage.ts
+++ b/src/lib/actions/triage.ts
@@ -1,0 +1,137 @@
+import { overdueAnchor, type PartitionableAction } from "~/lib/actions/partition";
+
+/**
+ * Minimum members before a shared anchor instant counts as a bulk write rather
+ * than coincidence. Two actions can plausibly land on the same instant (a
+ * two-item paste); three is already implausible by hand.
+ */
+export const COHORT_MIN_SIZE = 3;
+
+export interface TriageableAction extends PartitionableAction {
+  name: string;
+  project?: { name: string | null } | null;
+}
+
+export interface OverdueCohort<T> {
+  /** The exact instant every member is stamped with. */
+  stampedAt: Date;
+  daysOverdue: number;
+  count: number;
+  /** Distinct project names represented, for explaining the cohort to a human. */
+  projectNames: string[];
+  actionIds: string[];
+  actions: T[];
+}
+
+export interface OverdueTriage<T> {
+  totalOverdue: number;
+  /** How many of `totalOverdue` sit inside a cohort. */
+  cohortCount: number;
+  cohorts: OverdueCohort<T>[];
+  /** Individually-dated overdue actions — real debt, worth reading one by one. */
+  loose: T[];
+}
+
+function startOfDay(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+/**
+ * Whole days between an action's overdue anchor and today. 0 when it has no
+ * anchor (which `partitionActions` never produces for the overdue bucket).
+ */
+export function daysOverdue(
+  a: Pick<PartitionableAction, "scheduledStart" | "dueDate">,
+  today: Date,
+): number {
+  const anchor = overdueAnchor(a);
+  if (!anchor) return 0;
+  return Math.round(
+    (startOfDay(today).getTime() - anchor.getTime()) / (24 * 60 * 60 * 1000),
+  );
+}
+
+/**
+ * Split an overdue pile into bulk-written **cohorts** and individually-dated
+ * **loose** debt.
+ *
+ * A large overdue count is usually not a large number of missed commitments.
+ * It is a handful of bulk writes — a generated project plan, a template, an
+ * import — each stamping every row it created with one identical timestamp.
+ * Those actions were never individually due, so rescheduling them forward just
+ * re-inflicts the pile tomorrow; the honest disposition is to un-date them
+ * (`action.bulkDefer`).
+ *
+ * Exact-instant equality is the fingerprint. Hand-entered dates carry the
+ * millisecond the user hit save and effectively never collide, so a shared
+ * instant across {@link COHORT_MIN_SIZE}+ actions means one writer wrote them
+ * all at once.
+ *
+ * Pure: callers pass `today` so results are deterministic and testable.
+ */
+export function groupOverdueCohorts<T extends TriageableAction>(
+  overdue: T[],
+  options: { today: Date },
+): OverdueTriage<T> {
+  const { today } = options;
+
+  const byAnchor = new Map<number, T[]>();
+  const undated: T[] = [];
+  for (const a of overdue) {
+    const raw = a.scheduledStart ?? a.dueDate;
+    if (!raw) {
+      undated.push(a);
+      continue;
+    }
+    const key = new Date(raw).getTime();
+    const bucket = byAnchor.get(key);
+    if (bucket) bucket.push(a);
+    else byAnchor.set(key, [a]);
+  }
+
+  const cohorts: OverdueCohort<T>[] = [];
+  const loose: T[] = [...undated];
+
+  for (const [key, members] of byAnchor) {
+    if (members.length < COHORT_MIN_SIZE) {
+      loose.push(...members);
+      continue;
+    }
+    const projectNames = [
+      ...new Set(
+        members
+          .map((m) => m.project?.name)
+          .filter((n): n is string => Boolean(n)),
+      ),
+    ];
+    cohorts.push({
+      stampedAt: new Date(key),
+      daysOverdue: daysOverdue(members[0]!, today),
+      count: members.length,
+      projectNames,
+      actionIds: members.map((m) => m.id),
+      actions: members,
+    });
+  }
+
+  // Biggest cohort first — that is the one worth offering amnesty on.
+  cohorts.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.stampedAt.getTime() - b.stampedAt.getTime();
+  });
+  // Oldest real debt first.
+  loose.sort((a, b) => {
+    const diff = daysOverdue(b, today) - daysOverdue(a, today);
+    if (diff !== 0) return diff;
+    return a.id.localeCompare(b.id);
+  });
+
+  return {
+    totalOverdue: overdue.length,
+    cohortCount: cohorts.reduce((n, c) => n + c.count, 0),
+    cohorts,
+    loose,
+  };
+}

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -25,6 +25,7 @@ import {
 } from "~/server/services/projectActivity";
 import { recordActivity } from "~/server/services/activity/recordActivity";
 import { partitionActions } from "~/lib/actions/partition";
+import { groupOverdueCohorts, daysOverdue } from "~/lib/actions/triage";
 
 
 export const actionRouter = createTRPCRouter({
@@ -1059,6 +1060,94 @@ export const actionRouter = createTRPCRouter({
       };
     }),
 
+  // Why is the overdue pile the size it is? `getTodaysActions` answers "what is
+  // overdue"; this answers "what kind of overdue", which is what anyone (human
+  // or agent) needs before proposing a disposition.
+  //
+  // The signal is the anchor timestamp. A human dating actions one at a time
+  // produces distinct times; a bulk write — a generated project plan, an
+  // import, a template — stamps every row with a single millisecond-identical
+  // value. So actions sharing an exact anchor are a **cohort**: almost
+  // certainly never individually due, and the right disposition is amnesty
+  // (`bulkDefer`), not another reschedule. Everything else is `loose` — real,
+  // individually-dated debt worth actually looking at.
+  getOverdueTriage: protectedProcedure
+    .input(
+      z
+        .object({
+          workspaceId: z.string().optional(),
+        })
+        .optional(),
+    )
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      // Same ownership and scoping rules as getTodaysActions, so the triage
+      // view and the /today page always describe the same pile.
+      const actions = await ctx.db.action.findMany({
+        where: {
+          AND: [
+            {
+              OR: [
+                { createdById: userId, assignees: { none: {} } },
+                { assignees: { some: { userId } } },
+              ],
+            },
+            ...(input?.workspaceId
+              ? [
+                  {
+                    OR: [
+                      { workspaceId: input.workspaceId },
+                      { project: { workspaceId: input.workspaceId } },
+                    ],
+                  },
+                ]
+              : []),
+          ],
+          status: "ACTIVE",
+        },
+        select: {
+          id: true,
+          name: true,
+          status: true,
+          priority: true,
+          scheduledStart: true,
+          dueDate: true,
+          projectId: true,
+          completedAt: true,
+          project: { select: { name: true } },
+        },
+      });
+
+      const today = new Date();
+      const { overdue } = partitionActions(actions, { today });
+      const triage = groupOverdueCohorts(overdue, { today });
+
+      const toRow = (a: (typeof overdue)[number]) => ({
+        id: a.id,
+        name: a.name,
+        priority: a.priority,
+        scheduledStart: a.scheduledStart,
+        dueDate: a.dueDate,
+        projectName: a.project?.name ?? null,
+        daysOverdue: daysOverdue(a, today),
+      });
+
+      return {
+        totalOverdue: triage.totalOverdue,
+        cohortCount: triage.cohortCount,
+        cohorts: triage.cohorts.map((c) => ({
+          stampedAt: c.stampedAt,
+          daysOverdue: c.daysOverdue,
+          count: c.count,
+          projectNames: c.projectNames,
+          actionIds: c.actionIds,
+          actions: c.actions.map(toRow),
+        })),
+        loose: triage.loose.map(toRow),
+      };
+    }),
+
   getByDateRange: protectedProcedure
     .input(
       z.object({
@@ -1483,6 +1572,69 @@ export const actionRouter = createTRPCRouter({
       return {
         count: input.actionIds.length,
         actionIds: input.actionIds,
+      };
+    }),
+
+  // Amnesty: un-date actions back to their project backlog.
+  //
+  // Deliberately distinct from `bulkReschedule({ dueDate: null })`, which has
+  // the same effect on the rows. The difference is intent, and intent is what
+  // callers (and agents doing tool discovery) need to express: rescheduling
+  // says "this is still due, later"; deferring says "this was never really due
+  // — stop counting it against me". Most large overdue piles are the second
+  // case (a project plan bulk-stamped with one date), and rescheduling them
+  // just re-inflicts the pile tomorrow.
+  //
+  // Only the dates are touched. Kanban status is left alone on purpose: an
+  // action can be untimed and still be IN_PROGRESS on a board.
+  bulkDefer: protectedProcedure
+    .input(z.object({
+      actionIds: z.array(z.string()).min(1).max(200),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      // Snapshot before clearing so the activity rows record what was lost.
+      const toDefer = await ctx.db.action.findMany({
+        where: {
+          id: { in: input.actionIds },
+          ...buildActionAccessWhere(ctx.session.user.id),
+        },
+        select: { id: true, projectId: true, dueDate: true, scheduledStart: true },
+      });
+
+      const result = await ctx.db.action.updateMany({
+        where: {
+          id: { in: toDefer.map((a) => a.id) },
+          ...buildActionAccessWhere(ctx.session.user.id),
+        },
+        data: {
+          scheduledStart: null,
+          scheduledEnd: null,
+          dueDate: null,
+        },
+      });
+
+      const projectScoped = toDefer.filter((a) => a.projectId !== null);
+      if (projectScoped.length > 0) {
+        void Promise.all(
+          projectScoped.map((a) =>
+            logProjectActivity(ctx.db, {
+              projectId: a.projectId!,
+              actionId: a.id,
+              type: PROJECT_ACTIVITY_TYPES.DUE_DATE_CHANGED,
+              fromValue: (a.dueDate ?? a.scheduledStart)?.toISOString() ?? null,
+              toValue: null,
+              changedById: ctx.session.user.id,
+            }),
+          ),
+        ).catch((err: unknown) => {
+          console.error("[projectActivity] bulkDefer:", err);
+        });
+      }
+
+      return {
+        count: result.count,
+        actionIds: toDefer.map((a) => a.id),
+        message: `Deferred ${result.count} action${result.count === 1 ? '' : 's'} back to the backlog`,
       };
     }),
 

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -4325,6 +4325,13 @@ export const mastraRouter = createTRPCRouter({
       priority: z.enum(PRIORITY_VALUES).optional(),
       status: z.enum(['ACTIVE', 'COMPLETED', 'CANCELLED']).optional(),
       dueDate: z.string().nullable().optional(), // ISO string
+      // The "do date" and its block. Without these an agent can propose a time
+      // but never move the action to it — the /today partition keys off
+      // scheduledStart (schedule wins over dueDate), so rescheduling anything
+      // out of the overdue bucket requires writing this field.
+      scheduledStart: z.string().nullable().optional(), // ISO string
+      scheduledEnd: z.string().nullable().optional(), // ISO string
+      duration: z.number().int().positive().nullable().optional(), // minutes
     }))
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
@@ -4366,6 +4373,19 @@ export const mastraRouter = createTRPCRouter({
       if (fields.priority !== undefined) updateData.priority = fields.priority;
       if (fields.dueDate !== undefined) {
         updateData.dueDate = fields.dueDate ? new Date(fields.dueDate) : null;
+      }
+      if (fields.scheduledStart !== undefined) {
+        updateData.scheduledStart = fields.scheduledStart
+          ? new Date(fields.scheduledStart)
+          : null;
+      }
+      if (fields.scheduledEnd !== undefined) {
+        updateData.scheduledEnd = fields.scheduledEnd
+          ? new Date(fields.scheduledEnd)
+          : null;
+      }
+      if (fields.duration !== undefined) {
+        updateData.duration = fields.duration;
       }
 
       // Handle status change
@@ -4415,6 +4435,9 @@ export const mastraRouter = createTRPCRouter({
           status: action.status,
           priority: action.priority,
           dueDate: action.dueDate?.toISOString(),
+          scheduledStart: action.scheduledStart?.toISOString(),
+          scheduledEnd: action.scheduledEnd?.toISOString(),
+          duration: action.duration,
           projectId: action.projectId,
           project: action.project,
         },

--- a/src/server/api/routers/scheduling.ts
+++ b/src/server/api/routers/scheduling.ts
@@ -6,6 +6,7 @@ import { AutoSchedulingService } from "~/server/services/AutoSchedulingService";
 import { generateAgentJWT } from "~/server/utils/jwt";
 import { addMinutes, format } from "date-fns";
 import { setTimeInUserTimezone, validateScheduledTimes } from "~/lib/dateUtils";
+import { partitionActions } from "~/lib/actions/partition";
 
 const MASTRA_API_URL = process.env.MASTRA_API_URL;
 
@@ -349,15 +350,21 @@ export const schedulingRouter = createTRPCRouter({
       const endDate = new Date(today);
       endDate.setDate(endDate.getDate() + input.days);
 
-      // 1. Fetch overdue actions with projects and outcomes
-      const overdueActions = await ctx.db.action.findMany({
+      // 1. Fetch overdue actions with projects and outcomes.
+      //
+      // Overdue is resolved through the shared `partitionActions()` rule
+      // (ADR-0034) rather than a local `dueDate < today` filter. The panel that
+      // renders these suggestions is *gated* on the client partition, so a
+      // narrower rule here meant the banner could appear on a pile it then had
+      // nothing to say about — and it silently ignored every scheduled-but-
+      // never-due action, which is the most common overdue shape.
+      const candidates = await ctx.db.action.findMany({
         where: {
           OR: [
             { createdById: userId, assignees: { none: {} } },
             { assignees: { some: { userId: userId } } },
           ],
           status: "ACTIVE",
-          dueDate: { lt: today },
           ...(input.actionIds ? { id: { in: input.actionIds } } : {}),
           ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
         },
@@ -372,11 +379,11 @@ export const schedulingRouter = createTRPCRouter({
             },
           },
         },
-        orderBy: [
-          { dueDate: "asc" }, // Oldest overdue first
-        ],
-        take: 20, // Limit to 20 overdue actions to avoid huge prompts
       });
+
+      // Partition sorts overdue by priority, then oldest debt first.
+      const overdueActions = partitionActions(candidates, { today: now }).overdue
+        .slice(0, 20); // Cap to avoid huge prompts
 
       if (overdueActions.length === 0) {
         return { suggestions: [], calendarConnected: true };


### PR DESCRIPTION
### **User description**
## Why

A user opened `/today` to **40 overdue actions** and reported being overwhelmed. Running the new detector against their real data:

```
total overdue      : 40
in bulk cohorts    : 21
real (loose) debt  : 19

  cohort of 17  stamped 2026-07-25T08:29:55.483Z  (10d)
     projects: Entity Money Map, Net Worth Baseline, Tax Reserve System,
               Exponential, Spending Intelligence, Obligations Register
  cohort of 4   stamped 2026-07-23T07:00:00.000Z  (12d)
     projects: Onionpress Proposal
```

Over half the pile was two bulk writes — generated project plans that got one blanket date. The only bulk affordance on the page, **"Reschedule all → Today"**, moves all 40 forward 24 hours and re-inflicts them tomorrow: it treats a data-provenance artifact as a scheduling problem.

This also blocks the morning-agent work. An agent handed 40 undifferentiated rows can only summarize them; the useful sentence — *"17 of these were written in one batch and were never individually due, want them back in their backlogs?"* — needs a distinction the model didn't express.

## What

- **`groupOverdueCohorts()`** (`src/lib/actions/triage.ts`) groups overdue actions by **exact anchor instant** (millisecond equality, ≥3 members). Hand-dated actions carry the millisecond the user hit save and effectively never collide; a `createMany` writes one identical value to every row. Pure and clock-injected, like `partitionActions`.
- **`action.getOverdueTriage`** → `{ totalOverdue, cohortCount, cohorts, loose }`, each cohort carrying `stampedAt` / `count` / `daysOverdue` / `projectNames` / `actionIds` — enough to *explain* a cohort before acting on it. Reuses `partitionActions()`, so it and `/today` always describe the same pile ([ADR-0034](docs/adr/0034-todays-actions-shared-partition.md)).
- **`action.bulkDefer`** clears the dates so actions fall back to their project backlog untimed. Kept separate from `bulkReschedule({ dueDate: null })` despite the identical row effect — intent is what callers need to express, and agent tool discovery is BM25 over descriptions. Kanban status untouched.
- **`mastra.updateAction` gains `scheduledStart` / `scheduledEnd` / `duration`.** No agent could write a do-date until now, so **no agent could move anything out of the overdue bucket at all** — Zoe could propose "move this to 9am" and not do it.
- **`scheduling.getSchedulingSuggestions` now resolves overdue through `partitionActions`** instead of a local `dueDate < today` filter. The panel it feeds is *gated* on the client partition, so the two could disagree: the banner appeared over piles it had nothing to say about, and it ignored every scheduled-but-never-due action.

## Docs

`docs/ZOE_DAILY_BRIEFING.md` claimed `[x]` for five things that were never built — no `zoeBriefing` router, no `DailyBriefingCard`, no settings toggle, no admin page; `DailyBriefing` / `BriefingInteraction` are dead tables read and written nowhere. Corrected, with a note on what shipped instead (`ZoePanel` → `ashAgent`) and how it diverges — notably that it regenerates on page load, which is the first entry under that doc's own Gotchas.

New [ADR-0052](docs/adr/0052-overdue-cohorts-and-amnesty.md). CONTEXT.md gains **Overdue cohort** and **Amnesty** — shared vocabulary for the CLI/SDK/MCP/Mastra wrappers that follow.

## Testing

- 11 new unit tests covering cohort grouping, the `COHORT_MIN_SIZE` boundary, same-day-different-instant (stays loose), schedule-wins keying, ordering, and the real `partitionActions` → `groupOverdueCohorts` call path.
- Full unit suite green: **204 files / 1981 tests**.
- `tsc --noEmit` clean; eslint clean on all changed files.
- Cohort detector validated against real production-shaped data (output above).

## Follow-ups (not in this PR)

Client surfaces still expose none of this — `exponential actions today` returns 6 items and silently hides all 40 overdue; MCP `get_actions` has no date filter at all. Those wrappers, plus suggestion persistence and the morning cron rewrite, are separate PRs.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add `groupOverdueCohorts()` to detect bulk-write cohorts by exact timestamp

- Add `action.getOverdueTriage` and `action.bulkDefer` triage/amnesty endpoints

- Fix `scheduling.getSchedulingSuggestions` to use shared `partitionActions()` rule

- Extend `mastra.updateAction` with `scheduledStart`, `scheduledEnd`, `duration` fields


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Overdue actions pile"] -- "groupOverdueCohorts()" --> B["Cohorts (bulk writes)"]
  A -- "groupOverdueCohorts()" --> C["Loose (real debt)"]
  B -- "action.bulkDefer" --> D["Untimed backlog (amnesty)"]
  C -- "mastra.updateAction\n(scheduledStart/End/duration)" --> E["Rescheduled actions"]
  F["scheduling.getSchedulingSuggestions"] -- "partitionActions()" --> A
  G["action.getOverdueTriage"] -- "returns" --> B
  G -- "returns" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>triage.ts</strong><dd><code>New cohort detection and overdue triage logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/479/files#diff-c0552adcc7c16473d790eb0d43d0c603f8ebe83fbb294e806e00547e1d7f26cf">+137/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>action.ts</strong><dd><code>Add getOverdueTriage query and bulkDefer mutation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/479/files#diff-5b198a3cc9e3495e32e4dcdf28771f225d15998a0c3ab9de63ef7f12941d1dbb">+152/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mastra.ts</strong><dd><code>Extend updateAction with scheduling date/duration fields</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/479/files#diff-afd76ed5d04839b106766464d541d99c9b1d0e8b28477ea826c7dcf52db960bb">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>triage.test.ts</strong><dd><code>Unit tests for groupOverdueCohorts and daysOverdue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/479/files#diff-d00bfa85fd9868acc8a00687c3d989217ccdc40658c4127dccda2fb90d32534c">+185/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>scheduling.ts</strong><dd><code>Replace local dueDate filter with shared partitionActions rule</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/479/files#diff-db70bb3cd16c278776c6ed2831db82e964c41043e8aa663aa68cd5a3c25fef18">+14/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>0052-overdue-cohorts-and-amnesty.md</strong><dd><code>ADR documenting cohort detection and amnesty design decisions</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/479/files#diff-99c2b5edee01890464ba7ef18e47abd5a3f5a3614a883cb6a35b616876000f5b">+107/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CONTEXT.md</strong><dd><code>Add Overdue cohort and Amnesty to shared vocabulary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/479/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ZOE_DAILY_BRIEFING.md</strong><dd><code>Correct inaccurate implementation status checkboxes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/479/files#diff-6eb58da2cff8fc9b43b052a5bb672ddecea8cf01e0c43d66aa5ea0bb7189830b">+36/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

