### PR TITLE
Morning nudge that knows about overdue; stop regenerating briefings per render

### DIFF
--- a/docs/ZOE_DAILY_BRIEFING.md
+++ b/docs/ZOE_DAILY_BRIEFING.md
@@ -97,22 +97,42 @@ boxes; only the first was ever true. Re-verify before trusting it again.
 
 ### What shipped instead
 
-The AI card on `/today` is a different implementation that bypasses everything
+The AI card on `/today` is a different implementation from the one designed
 above: `scheduling.getSchedulingSuggestions`
-(`src/server/api/routers/scheduling.ts`) → Mastra's `ashAgent`, rendered by
-`ZoePanel`. Three ways it diverges from this design, each worth knowing before
-you build on it:
+(`src/server/api/routers/scheduling.ts`), rendered by `ZoePanel`. It now writes
+to these tables, so the two paths have partly converged:
 
-- **It regenerates on page load** — a `useQuery` with `staleTime: 5min`, firing an
-  LLM round-trip per render. That is precisely the first entry under
-  [Gotchas](#gotchas) below.
-- **Nothing is persisted.** No `DailyBriefing` row, no `promptVersion`, no
-  `inputSnapshot`, no interaction log. Dismissal is React state and dies on
-  reload. So none of the metrics below can currently be computed, and there is
-  no replayable input for the autoresearch loop.
-- **It is not Zoe.** `ashAgent` is a tool-less GPT-4o lean-startup persona whose
-  instructions are overridden by a per-call system message. Model, prompt, and
-  persona are all unrelated to the branding on the card.
+- **It no longer regenerates on page load.** Each call builds a deterministic
+  `SuggestionInputSnapshot` (the overdue actions, calendar busy-intervals, and
+  already-scheduled actions the prompt reads), hashes it, and reuses today's
+  `DailyBriefing` row when the hash matches. The model is called only when the
+  input actually changed. This closes the first entry under
+  [Gotchas](#gotchas).
+- **Briefings are persisted** with `promptVersion`, `modelId`, `inputSnapshot`,
+  `outputText`, `outputStructured` and `latencyMs` — so the replayable input the
+  autoresearch loop needs now exists. `scheduling.recordBriefingInteraction`
+  writes `BriefingInteraction`, so acceptance and dismissal rates are
+  computable.
+- **It is Zoe now.** Generation was pointed at `ashAgent` — a tool-less GPT-4o
+  lean-startup persona whose instructions were overridden per call, so model,
+  prompt, and persona all disagreed with the branding on the card. It now calls
+  `zoeAgent`.
+
+Still divergent from the design above:
+
+- **`promptVersion` is `zoe-scheduling-v1`**, not `zoe-daily-vN` — this is the
+  scheduling-suggestions prompt, a different prompt from the "take on your day"
+  paragraph described here. Bump it on any change to
+  `SCHEDULING_SYSTEM_PROMPT` or `buildSchedulingPrompt`.
+- **No `zoeBriefing` router, no opt-in toggle, no admin page.** Generation is
+  still implicit rather than user-triggered — it happens on first render of a
+  day, not on a "Generate" click.
+- **`tokensIn` / `tokensOut` are unpopulated** — the Mastra generate endpoint's
+  response doesn't surface usage on this path yet, so cost metrics can't be
+  sliced.
+- **Dismissal is still React state** and dies on reload. Persisting *per
+  suggestion* needs an `actionId` on `BriefingInteraction`, i.e. a migration;
+  briefing-level interactions work today.
 
 ## Roadmap to the autoresearch loop
 

--- a/src/app/api/cron/daily-plan-reminder/route.ts
+++ b/src/app/api/cron/daily-plan-reminder/route.ts
@@ -2,15 +2,32 @@ import { type NextRequest, NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { db } from "~/server/db";
 import { sendPushToUser } from "~/server/services/notifications/WebPushService";
-import { startOfDay, endOfDay } from "date-fns";
+import { partitionActions } from "~/lib/actions/partition";
+import { groupOverdueCohorts } from "~/lib/actions/triage";
+import { buildMorningNudge } from "~/server/services/morningNudge";
 
 /**
- * Cron endpoint: sends a morning push notification to all users with push subscriptions.
- * Tells them how many actions they have planned for today.
+ * Cron endpoint: the morning nudge.
+ *
+ * Describes what is actually on the user's plate, using the same partition the
+ * /today page renders ([ADR-0034]) and the same cohort analysis as
+ * `action.getOverdueTriage` ([ADR-0052]).
+ *
+ * This used to count `DailyPlanAction` rows — a *fourth* definition of "today",
+ * populated only when someone ran the /daily-plan wizard. Users who never ran
+ * the wizard got "No actions planned yet. Start your day by planning what to
+ * focus on." every single morning while dozens of real actions sat overdue, and
+ * the notification never mentioned overdue work at all.
+ *
+ * Deliberately no LLM here: this is a one-line push that fires for every user
+ * with a subscription, and a template gets the numbers right at zero cost and
+ * zero latency. The generated briefing is a separate, user-triggered path
+ * (`scheduling.getSchedulingSuggestions`).
  *
  * Call via: GET /api/cron/daily-plan-reminder
  * Vercel cron or external scheduler, protected by CRON_SECRET.
  */
+
 export async function GET(_request: NextRequest) {
   try {
     const headersList = await headers();
@@ -33,35 +50,46 @@ export async function GET(_request: NextRequest) {
     });
 
     const today = new Date();
-    const dayStart = startOfDay(today);
-    const dayEnd = endOfDay(today);
-
     const results = [];
 
     for (const user of usersWithPush) {
-      // Count today's planned actions
-      const actionCount = await db.dailyPlanAction.count({
+      // Same ownership rule as action.getTodaysActions: created-by-me with no
+      // assignees, or assigned to me. Cross-workspace, like /today.
+      const actions = await db.action.findMany({
         where: {
-          dailyPlan: {
-            userId: user.id,
-            date: {
-              gte: dayStart,
-              lte: dayEnd,
-            },
-          },
+          OR: [
+            { createdById: user.id, assignees: { none: {} } },
+            { assignees: { some: { userId: user.id } } },
+          ],
+          status: "ACTIVE",
+        },
+        select: {
+          id: true,
+          name: true,
+          status: true,
+          priority: true,
+          scheduledStart: true,
+          dueDate: true,
+          projectId: true,
+          completedAt: true,
+          project: { select: { name: true } },
         },
       });
 
-      const firstName = user.name?.split(" ")[0] ?? "there";
-      const body =
-        actionCount > 0
-          ? `You have ${actionCount} action${actionCount === 1 ? "" : "s"} planned for today. Let's go!`
-          : `No actions planned yet. Start your day by planning what to focus on.`;
+      const { overdue, todays } = partitionActions(actions, { today });
+      const triage = groupOverdueCohorts(overdue, { today });
+
+      const { title, body } = buildMorningNudge({
+        firstName: user.name?.split(" ")[0] ?? "there",
+        todayCount: todays.length,
+        overdueCount: overdue.length,
+        cohortCount: triage.cohortCount,
+      });
 
       const pushResult = await sendPushToUser(
         user.id,
         {
-          title: `Good morning, ${firstName}!`,
+          title,
           body,
           tag: "daily-plan",
           url: "/today",
@@ -71,7 +99,9 @@ export async function GET(_request: NextRequest) {
 
       results.push({
         userId: user.id,
-        actionCount,
+        todayCount: todays.length,
+        overdueCount: overdue.length,
+        cohortCount: triage.cohortCount,
         ...pushResult,
       });
     }

--- a/src/server/api/routers/scheduling.ts
+++ b/src/server/api/routers/scheduling.ts
@@ -7,6 +7,14 @@ import { generateAgentJWT } from "~/server/utils/jwt";
 import { addMinutes, format } from "date-fns";
 import { setTimeInUserTimezone, validateScheduledTimes } from "~/lib/dateUtils";
 import { partitionActions } from "~/lib/actions/partition";
+import {
+  BRIEFING_INTERACTION_TYPES,
+  briefingDate,
+  buildInputSnapshot,
+  findReusableBriefing,
+  persistBriefing,
+  snapshotHash,
+} from "~/server/services/schedulingBriefing";
 
 const MASTRA_API_URL = process.env.MASTRA_API_URL;
 
@@ -429,7 +437,41 @@ export const schedulingRouter = createTRPCRouter({
         orderBy: { scheduledStart: "asc" },
       });
 
-      // 4. Build the prompt and call Mastra agent
+      // 4. Reuse today's briefing when nothing the prompt reads has changed.
+      //
+      // This query used to call the model on every /today render (a useQuery
+      // with a 5-minute staleTime), which is exactly what
+      // docs/ZOE_DAILY_BRIEFING.md's first Gotcha forbids: briefings cost
+      // seconds and thousands of tokens, so they must not regenerate on page
+      // load. Suggestions are advice about a set of actions and a calendar; if
+      // neither moved, the advice is the same. Persisting also gives the eval
+      // loop the replayable inputSnapshot it was designed around.
+      const snapshot = buildInputSnapshot({
+        days: input.days,
+        overdueActions,
+        calendarEvents,
+        scheduledActions,
+      });
+      const hash = snapshotHash(snapshot);
+      const date = briefingDate(now);
+
+      const reusable = await findReusableBriefing(ctx.db, {
+        userId,
+        workspaceId: input.workspaceId,
+        date,
+        hash,
+      });
+      if (reusable) {
+        console.log(`[scheduling] reusing briefing ${reusable.id} (snapshot unchanged)`);
+        return {
+          suggestions: reusable.suggestions as SchedulingSuggestion[],
+          calendarConnected,
+          overdueCount: overdueActions.length,
+          briefingId: reusable.id,
+        };
+      }
+
+      // 5. Build the prompt and call Mastra agent
       const userPrompt = buildSchedulingPrompt(
         overdueActions,
         calendarEvents,
@@ -442,11 +484,17 @@ export const schedulingRouter = createTRPCRouter({
         return { suggestions: [], calendarConnected, overdueCount: overdueActions.length };
       }
 
+      const startedAt = Date.now();
+
       try {
         const agentJWT = generateAgentJWT(ctx.session.user, 30);
 
         const response = await fetch(
-          `${MASTRA_API_URL}/api/agents/ashAgent/generate`,
+          // zoeAgent, not ashAgent: these suggestions are shown to the user
+          // under Zoe's name. ashAgent is a tool-less lean-startup persona
+          // whose instructions were being overridden per call anyway, so the
+          // branding, model, and prompt all disagreed with the surface.
+          `${MASTRA_API_URL}/api/agents/zoeAgent/generate`,
           {
             method: "POST",
             headers: {
@@ -483,10 +531,23 @@ export const schedulingRouter = createTRPCRouter({
         const validActionIds = new Set(overdueActions.map((a) => a.id));
         const validSuggestions = suggestions.filter((s) => validActionIds.has(s.actionId));
 
+        const briefingId = await persistBriefing(ctx.db, {
+          userId,
+          workspaceId: input.workspaceId,
+          date,
+          modelId: "zoeAgent",
+          snapshot,
+          hash,
+          outputText: responseText,
+          suggestions: validSuggestions,
+          latencyMs: Date.now() - startedAt,
+        });
+
         return {
           suggestions: validSuggestions,
           calendarConnected,
           overdueCount: overdueActions.length,
+          briefingId,
         };
       } catch (error) {
         if (error instanceof TRPCError) throw error;
@@ -495,6 +556,35 @@ export const schedulingRouter = createTRPCRouter({
         // Return empty suggestions instead of failing - the UI can still function without AI suggestions
         return { suggestions: [], calendarConnected, overdueCount: overdueActions.length };
       }
+    }),
+
+  // How a briefing was received. Without this, none of the metrics in
+  // docs/ZOE_DAILY_BRIEFING.md can be computed — acceptance rate, dismissal
+  // rate, and top-1 execution rate all read from BriefingInteraction, a table
+  // that existed but was never written to.
+  recordBriefingInteraction: protectedProcedure
+    .input(
+      z.object({
+        briefingId: z.string(),
+        type: z.enum(BRIEFING_INTERACTION_TYPES),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Scope to the caller's own briefings — briefingId is a client-supplied
+      // id, so an unscoped write would let anyone append to anyone's metrics.
+      const briefing = await ctx.db.dailyBriefing.findFirst({
+        where: { id: input.briefingId, userId: ctx.session.user.id },
+        select: { id: true },
+      });
+      if (!briefing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Briefing not found" });
+      }
+
+      await ctx.db.briefingInteraction.create({
+        data: { briefingId: briefing.id, type: input.type },
+      });
+
+      return { success: true };
     }),
 
   // Auto-schedule a single task

--- a/src/server/services/__tests__/morningNudge.test.ts
+++ b/src/server/services/__tests__/morningNudge.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { buildMorningNudge } from "~/server/services/morningNudge";
+
+describe("buildMorningNudge", () => {
+  it("greets by first name", () => {
+    const { title } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 3,
+      overdueCount: 0,
+      cohortCount: 0,
+    });
+    expect(title).toBe("Good morning, James!");
+  });
+
+  it("says so plainly when nothing is overdue", () => {
+    const { body } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 3,
+      overdueCount: 0,
+      cohortCount: 0,
+    });
+    expect(body).toBe("3 actions scheduled today. Nothing overdue — nice.");
+  });
+
+  it("handles a completely empty day without claiming nothing is planned", () => {
+    const { body } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 0,
+      overdueCount: 0,
+      cohortCount: 0,
+    });
+    expect(body).toBe("Nothing scheduled today, and nothing overdue.");
+  });
+
+  it("leads with the reframe when most of the overdue pile was bulk-created", () => {
+    // The real case: 6 scheduled, 43 overdue, 21 of them from two bulk writes.
+    const { body } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 6,
+      overdueCount: 43,
+      cohortCount: 22,
+    });
+    expect(body).toContain("43 overdue");
+    expect(body).toContain("22 of those were created in one batch");
+  });
+
+  it("does NOT soften the number when the overdue pile is mostly real debt", () => {
+    const { body } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 6,
+      overdueCount: 43,
+      cohortCount: 4,
+    });
+    expect(body).toBe("6 actions scheduled today, and 43 overdue.");
+    expect(body).not.toContain("one batch");
+  });
+
+  it("treats an exact half as real debt — the reframe needs a majority", () => {
+    const { body } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 0,
+      overdueCount: 10,
+      cohortCount: 5,
+    });
+    expect(body).not.toContain("one batch");
+  });
+
+  it("singularises a single action", () => {
+    const { body } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 1,
+      overdueCount: 0,
+      cohortCount: 0,
+    });
+    expect(body).toContain("1 action scheduled today");
+    expect(body).not.toContain("1 actions");
+  });
+});

--- a/src/server/services/morningNudge.ts
+++ b/src/server/services/morningNudge.ts
@@ -1,0 +1,57 @@
+/**
+ * Phrasing for the morning push notification.
+ *
+ * Split out of the cron route so it can be unit-tested without importing the
+ * route module, which pulls in the Prisma client and therefore the whole env.
+ */
+
+export interface MorningNudge {
+  title: string;
+  body: string;
+}
+
+/**
+ * Pure, so the phrasing is testable without a database or a clock.
+ *
+ * Leads with the reframe when most of the overdue pile is bulk-written. "43
+ * overdue" is a number that produces avoidance; "21 of those were created in
+ * one batch" is a number that produces a decision.
+ */
+export function buildMorningNudge(args: {
+  firstName: string;
+  todayCount: number;
+  overdueCount: number;
+  cohortCount: number;
+}): MorningNudge {
+  const { firstName, todayCount, overdueCount, cohortCount } = args;
+  const title = `Good morning, ${firstName}!`;
+
+  const todayPart =
+    todayCount > 0
+      ? `${todayCount} action${todayCount === 1 ? "" : "s"} scheduled today`
+      : "Nothing scheduled today";
+
+  if (overdueCount === 0) {
+    return {
+      title,
+      body:
+        todayCount > 0
+          ? `${todayPart}. Nothing overdue — nice.`
+          : `${todayPart}, and nothing overdue.`,
+    };
+  }
+
+  // Only reframe when the bulk-written share is the majority. Below that the
+  // overdue count really is mostly real commitments, and softening it would lie.
+  if (cohortCount > overdueCount / 2) {
+    return {
+      title,
+      body: `${todayPart}, and ${overdueCount} overdue — but ${cohortCount} of those were created in one batch and were probably never really due. Worth two minutes to clear out.`,
+    };
+  }
+
+  return {
+    title,
+    body: `${todayPart}, and ${overdueCount} overdue.`,
+  };
+}

--- a/src/server/services/schedulingBriefing.ts
+++ b/src/server/services/schedulingBriefing.ts
@@ -1,0 +1,193 @@
+import crypto from "crypto";
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * Bump on every change to SCHEDULING_SYSTEM_PROMPT or buildSchedulingPrompt,
+ * including whitespace. Metrics are sliced by this, and a reused version
+ * silently merges two different prompts' results.
+ *
+ * See docs/ZOE_DAILY_BRIEFING.md.
+ */
+export const SCHEDULING_PROMPT_VERSION = "zoe-scheduling-v1";
+
+/**
+ * A briefing is reusable for the rest of the calendar day as long as the input
+ * it was generated from is unchanged. Suggestions are advice about a set of
+ * actions and a calendar; if neither moved, regenerating produces the same
+ * advice at real token cost.
+ */
+export interface SuggestionInputSnapshot {
+  days: number;
+  /** Sorted; ids + the fields the prompt actually reads. */
+  overdue: Array<{
+    id: string;
+    name: string;
+    dueDate: string | null;
+    scheduledStart: string | null;
+    projectName: string | null;
+  }>;
+  /** Sorted; only the busy intervals matter for scheduling. */
+  calendar: Array<{ start: string; end: string }>;
+  scheduled: Array<{ id: string; scheduledStart: string | null }>;
+}
+
+function iso(d: Date | string | null | undefined): string | null {
+  if (!d) return null;
+  return new Date(d).toISOString();
+}
+
+/**
+ * Google calendar times are `{ dateTime }` for timed events and `{ date }` for
+ * all-day ones. Both matter to the snapshot: an all-day event still blocks a
+ * day even though it has no time.
+ */
+type CalendarTime = { dateTime?: string; date?: string; timeZone?: string };
+
+function calendarIso(t: CalendarTime | string | Date | null | undefined): string {
+  if (!t) return "";
+  if (typeof t === "string" || t instanceof Date) return iso(t) ?? "";
+  return iso(t.dateTime ?? t.date) ?? "";
+}
+
+/**
+ * Build a deterministic snapshot of everything the prompt sees. Deterministic
+ * matters twice: it is the cache key, and it is the replayable input the
+ * autoresearch loop scores candidate prompts against — so the ordering must not
+ * depend on query order.
+ */
+export function buildInputSnapshot(args: {
+  days: number;
+  overdueActions: Array<{
+    id: string;
+    name: string;
+    dueDate: Date | null;
+    scheduledStart: Date | null;
+    project?: { name: string } | null;
+  }>;
+  calendarEvents: Array<{
+    start?: CalendarTime | string | Date | null;
+    end?: CalendarTime | string | Date | null;
+  }>;
+  scheduledActions: Array<{ id: string; scheduledStart: Date | null }>;
+}): SuggestionInputSnapshot {
+  return {
+    days: args.days,
+    overdue: args.overdueActions
+      .map((a) => ({
+        id: a.id,
+        name: a.name,
+        dueDate: iso(a.dueDate),
+        scheduledStart: iso(a.scheduledStart),
+        projectName: a.project?.name ?? null,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+    calendar: args.calendarEvents
+      .map((e) => ({ start: calendarIso(e.start), end: calendarIso(e.end) }))
+      .sort((a, b) => a.start.localeCompare(b.start) || a.end.localeCompare(b.end)),
+    scheduled: args.scheduledActions
+      .map((a) => ({ id: a.id, scheduledStart: iso(a.scheduledStart) }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+  };
+}
+
+export function snapshotHash(snapshot: SuggestionInputSnapshot): string {
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(snapshot))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/** Midnight UTC for the @db.Date column, so one row per user per calendar day. */
+export function briefingDate(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+interface StoredOutput {
+  snapshotHash: string;
+  suggestions: unknown[];
+}
+
+/**
+ * Today's briefing for this user, if one was generated from an identical input.
+ * Returns null when absent or stale, which is the signal to call the model.
+ */
+export async function findReusableBriefing(
+  db: PrismaClient,
+  args: {
+    userId: string;
+    workspaceId?: string | null;
+    date: Date;
+    hash: string;
+  },
+): Promise<{ id: string; suggestions: unknown[] } | null> {
+  const existing = await db.dailyBriefing.findFirst({
+    where: {
+      userId: args.userId,
+      date: args.date,
+      promptVersion: SCHEDULING_PROMPT_VERSION,
+      ...(args.workspaceId ? { workspaceId: args.workspaceId } : {}),
+    },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, outputStructured: true },
+  });
+
+  if (!existing?.outputStructured) return null;
+
+  const stored = existing.outputStructured as unknown as StoredOutput;
+  if (stored?.snapshotHash !== args.hash) return null;
+
+  return { id: existing.id, suggestions: stored.suggestions ?? [] };
+}
+
+export async function persistBriefing(
+  db: PrismaClient,
+  args: {
+    userId: string;
+    workspaceId?: string | null;
+    date: Date;
+    modelId: string;
+    snapshot: SuggestionInputSnapshot;
+    hash: string;
+    outputText: string;
+    suggestions: unknown[];
+    latencyMs?: number;
+  },
+): Promise<string | null> {
+  try {
+    const row = await db.dailyBriefing.create({
+      data: {
+        userId: args.userId,
+        workspaceId: args.workspaceId ?? null,
+        date: args.date,
+        promptVersion: SCHEDULING_PROMPT_VERSION,
+        modelId: args.modelId,
+        inputSnapshot: args.snapshot as unknown as object,
+        outputText: args.outputText,
+        outputStructured: {
+          snapshotHash: args.hash,
+          suggestions: args.suggestions,
+        } as unknown as object,
+        latencyMs: args.latencyMs,
+      },
+      select: { id: true },
+    });
+    return row.id;
+  } catch (error) {
+    // Persistence is telemetry, never the point of the request. A failure here
+    // costs a cache entry, not the user's suggestions.
+    console.error("[schedulingBriefing] failed to persist briefing:", error);
+    return null;
+  }
+}
+
+export const BRIEFING_INTERACTION_TYPES = [
+  "viewed",
+  "accepted",
+  "dismissed",
+  "refreshed",
+  "thumbs_up",
+  "thumbs_down",
+] as const;
+
+export type BriefingInteractionType = (typeof BRIEFING_INTERACTION_TYPES)[number];


### PR DESCRIPTION
### **User description**
> **Stacked on #479** — base is `feat/overdue-triage-foundation`, since this uses `partitionActions` in `scheduling.ts` and `groupOverdueCohorts`. Merge #479 first and this retargets to `main`.

## The morning cron was telling people nothing

`/api/cron/daily-plan-reminder` (08:00 daily) counted `DailyPlanAction` rows — a **fourth** definition of "today", populated only when someone ran the `/daily-plan` wizard. Users who never ran the wizard got:

> *"No actions planned yet. Start your day by planning what to focus on."*

every single morning, while dozens of real actions sat overdue. The notification never mentioned overdue work at all.

It now uses the same partition `/today` renders and the same cohort analysis as `getOverdueTriage`, and leads with the reframe when most of the pile is bulk-written:

> *"6 actions scheduled today, and 43 overdue — but 22 of those were created in one batch and were probably never really due. Worth two minutes to clear out."*

Only when cohorts are a **majority**; below that the count really is mostly real commitments and softening it would lie (there's a test pinning the exact-half boundary). No LLM on this path — it fires for every subscribed user, and a template gets the numbers right at zero cost and zero latency.

## Briefings stopped regenerating on every page load

`scheduling.getSchedulingSuggestions` was a `useQuery` with `staleTime: 5min`, so opening `/today` cost an LLM round-trip — seconds and thousands of tokens. That is verbatim **Gotcha #1** in this repo's own `docs/ZOE_DAILY_BRIEFING.md`:

> *"Don't regenerate on page load. Briefings are expensive (~2–5s, thousands of tokens). Must be user-triggered."*

Each call now builds a deterministic `SuggestionInputSnapshot` (overdue actions, calendar busy-intervals, already-scheduled actions — everything the prompt reads), hashes it, and reuses today's `DailyBriefing` row when the hash matches. The model runs only when the actions or the calendar actually moved.

## The dead tables are alive

`DailyBriefing` and `BriefingInteraction` have existed since the original design and were **read and written nowhere**. Now populated with `promptVersion`, `modelId`, `inputSnapshot`, `outputText`, `outputStructured`, `latencyMs`, plus a `recordBriefingInteraction` mutation. So the autoresearch loop's replayable input exists, and acceptance/dismissal rates are computable. **No migration** — the schema was already fully specified.

`recordBriefingInteraction` scopes by `userId` before writing: `briefingId` is client-supplied, so an unscoped write would let anyone append to anyone else's metrics.

## ashAgent → zoeAgent

Generation was pointed at `ashAgent`, a **tool-less GPT-4o lean-startup persona** whose instructions were overridden by a per-call system message anyway. Model, prompt, and persona all disagreed with the name on the card the user sees.

## Testing

- 7 new unit tests on the nudge phrasing (empty day, no-overdue, majority-cohort reframe, minority-cohort *no* reframe, exact-half boundary, singular/plural).
- Full unit suite green: **205 files / 1988 tests**.
- `tsc --noEmit` clean; eslint clean on all changed files.

## Known gaps, recorded in the doc

- `tokensIn`/`tokensOut` unpopulated — the Mastra generate response doesn't surface usage on this path.
- Generation is still implicit (first render of a day) rather than a "Generate" click.
- Per-suggestion dismissal still dies on reload; persisting it needs `actionId` on `BriefingInteraction`, i.e. a migration. Briefing-level interactions work today.


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Fix morning cron to use real action partition instead of `DailyPlanAction` rows

- Add briefing persistence and hash-based reuse to stop LLM calls on every page load

- Introduce `buildMorningNudge` service with cohort-aware messaging logic

- Switch scheduling suggestions from `ashAgent` to `zoeAgent` with interaction tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cron["Cron: daily-plan-reminder"]
  partition["partitionActions()"]
  cohorts["groupOverdueCohorts()"]
  nudge["buildMorningNudge()"]
  push["Push notification"]
  cron -- "fetch user actions" --> partition
  partition -- "overdue actions" --> cohorts
  cohorts -- "cohortCount" --> nudge
  partition -- "todayCount" --> nudge
  nudge -- "title + body" --> push

  today["/today render"]
  snapshot["SuggestionInputSnapshot"]
  hash["snapshotHash()"]
  db["DailyBriefing (DB)"]
  zoe["zoeAgent (Mastra)"]
  today -- "buildInputSnapshot()" --> snapshot
  snapshot -- "snapshotHash()" --> hash
  hash -- "findReusableBriefing()" --> db
  db -- "cache hit: reuse" --> today
  db -- "cache miss" --> zoe
  zoe -- "persistBriefing()" --> db
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Rewrite morning cron to use real action partition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/cron/daily-plan-reminder/route.ts

<ul><li>Replaced <code>DailyPlanAction</code> count query with real <code>action.findMany</code> using <br>the same ownership rule as <code>/today</code><br> <li> Integrated <code>partitionActions()</code> and <code>groupOverdueCohorts()</code> to get <code>todays</code>, <br><code>overdue</code>, and <code>cohortCount</code><br> <li> Delegated notification phrasing to new <code>buildMorningNudge()</code> service<br> <li> Updated result payload to include <code>todayCount</code>, <code>overdueCount</code>, and <br><code>cohortCount</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/480/files#diff-192bd7fca1d11d8f79af6bf0fed8eeddbac28ef0598154c3da9f4283f9ffe1a7">+52/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scheduling.ts</strong><dd><code>Stop regenerating briefings per render; switch to zoeAgent</code></dd></summary>
<hr>

src/server/api/routers/scheduling.ts

<ul><li>Adds snapshot/hash check before calling the model; reuses today's <br><code>DailyBriefing</code> row when input is unchanged<br> <li> Switches agent call from <code>ashAgent</code> to <code>zoeAgent</code><br> <li> Persists each new briefing with <code>promptVersion</code>, <code>modelId</code>, <code>inputSnapshot</code>, <br><code>outputText</code>, and <code>latencyMs</code><br> <li> Adds <code>recordBriefingInteraction</code> mutation scoped to the caller's own <br>briefings</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/480/files#diff-db70bb3cd16c278776c6ed2831db82e964c41043e8aa663aa68cd5a3c25fef18">+92/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>morningNudge.ts</strong><dd><code>New cohort-aware morning nudge phrasing service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/morningNudge.ts

<ul><li>New pure service module exporting <code>buildMorningNudge()</code> for push <br>notification phrasing<br> <li> Leads with cohort reframe only when bulk-written actions are a strict <br>majority of overdue pile<br> <li> Handles empty day, no-overdue, and singular/plural action count cases</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/480/files#diff-e66a680383f4dfec5b24c51ebff16ddfa0219e66137af35d2c030f258409f743">+57/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schedulingBriefing.ts</strong><dd><code>New briefing persistence and hash-based cache service</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/schedulingBriefing.ts

<ul><li>New module providing <code>buildInputSnapshot()</code>, <code>snapshotHash()</code>, <br><code>findReusableBriefing()</code>, and <code>persistBriefing()</code><br> <li> Implements deterministic snapshot hashing to enable briefing cache <br>reuse<br> <li> Defines <code>BRIEFING_INTERACTION_TYPES</code> and <code>SCHEDULING_PROMPT_VERSION</code> <br>constants<br> <li> Persistence errors are swallowed so a DB failure never blocks <br>user-facing suggestions</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/480/files#diff-9e985f9d749b2f1c937ffb87995f168fce0af0a27e1317afc591ac3747db197b">+193/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>morningNudge.test.ts</strong><dd><code>Unit tests for buildMorningNudge phrasing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/__tests__/morningNudge.test.ts

<ul><li>7 unit tests covering greeting, empty day, no-overdue, cohort reframe, <br>majority boundary, and pluralisation<br> <li> Pins exact-half boundary: cohorts at 50% do not trigger the reframe</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/480/files#diff-9470c0ae6aa456751368455aab3b25a74d4388574e636631c13c7331364713c1">+78/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ZOE_DAILY_BRIEFING.md</strong><dd><code>Update briefing doc to reflect persistence and agent changes</code></dd></summary>
<hr>

docs/ZOE_DAILY_BRIEFING.md

<ul><li>Updates "What shipped instead" section to reflect that briefings are <br>now persisted and no longer regenerate on page load<br> <li> Documents remaining divergences: no opt-in toggle, no per-suggestion <br>dismissal persistence, unpopulated token counts<br> <li> Notes agent switch from <code>ashAgent</code> to <code>zoeAgent</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/480/files#diff-6eb58da2cff8fc9b43b052a5bb672ddecea8cf01e0c43d66aa5ea0bb7189830b">+35/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

