### PR TITLE
fix: gate epic reads on workspace membership

### DIFF
--- a/src/plugins/product/server/routers/__tests__/ticket.test.ts
+++ b/src/plugins/product/server/routers/__tests__/ticket.test.ts
@@ -192,3 +192,59 @@ describe("ticket router — list Area filter (mocked)", () => {
     expect(findManyWhere(dbMock)).toMatchObject({ tags: { some: { tagId: areaTagId } } });
   });
 });
+
+describe("ticket router — cross-workspace link guard (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    stubProductLookup(dbMock);
+    stubMembership(dbMock, true);
+  });
+
+  it("refuses to create a ticket linked to an epic in another workspace", async () => {
+    dbMock.epic.findUnique.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { workspaceId: "ws-other" } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.ticket.create({
+        productId,
+        title: "Borrowed epic",
+        epicId: "epic-foreign",
+      }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Epic not found in this workspace",
+    });
+
+    expect(dbMock.ticket.create).not.toHaveBeenCalled();
+  });
+
+  it("allows an epic from the product's own workspace", async () => {
+    dbMock.epic.findUnique.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { workspaceId } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    // The create path continues into createTicketWithNumber (counter +
+    // transaction), which this mock DB does not model — reaching past the
+    // guard is the assertion, so any later failure is not a guard rejection.
+    await caller.product.ticket
+      .create({ productId, title: "Own epic", epicId: "epic-1" })
+      .catch((err: unknown) => {
+        expect(err).not.toMatchObject({
+          message: "Epic not found in this workspace",
+        });
+      });
+
+    expect(dbMock.epic.findUnique).toHaveBeenCalledWith({
+      where: { id: "epic-1" },
+      select: { workspaceId: true },
+    });
+  });
+});

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { loadProductWithAccess, assertWorkspaceMember } from "./product";
+import { assertWorkspaceScopedRefs } from "~/server/services/access";
 import type { PrismaClient } from "@prisma/client";
 import { recordActivity } from "~/server/services/activity/recordActivity";
 import { createTicketWithNumber } from "../services/createTicket";
@@ -345,6 +346,15 @@ export const ticketRouter = createTRPCRouter({
         input.productId,
       );
 
+      // A linked epic/feature/cycle/scope must live in the product's own
+      // workspace, or its fields leak back through this ticket's includes.
+      await assertWorkspaceScopedRefs(ctx.db, product.workspaceId, {
+        epicId: input.epicId,
+        featureId: input.featureId,
+        cycleId: input.cycleId,
+        scopeId: input.scopeId,
+      });
+
       // If templateId provided, load its body as the starting body (unless body already given)
       let body = input.body;
       if (!body && input.templateId) {
@@ -420,6 +430,15 @@ export const ticketRouter = createTRPCRouter({
         ctx.session.user.id,
         input.id,
       );
+
+      // Same-workspace guard as create — `rest` is spread straight into the
+      // update, so a foreign epic/feature/cycle/scope id would otherwise stick.
+      await assertWorkspaceScopedRefs(ctx.db, previousTicket.product.workspaceId, {
+        epicId: input.epicId,
+        featureId: input.featureId,
+        cycleId: input.cycleId,
+        scopeId: input.scopeId,
+      });
 
       const { id, ...rest } = input;
       const data: Record<string, unknown> = { ...rest };

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -348,7 +348,7 @@ export const ticketRouter = createTRPCRouter({
 
       // A linked epic/feature/cycle/scope must live in the product's own
       // workspace, or its fields leak back through this ticket's includes.
-      await assertWorkspaceScopedRefs(ctx.db, product.workspaceId, {
+      await assertWorkspaceScopedRefs(ctx.db, ctx.session.user.id, product.workspaceId, {
         epicId: input.epicId,
         featureId: input.featureId,
         cycleId: input.cycleId,
@@ -433,12 +433,17 @@ export const ticketRouter = createTRPCRouter({
 
       // Same-workspace guard as create — `rest` is spread straight into the
       // update, so a foreign epic/feature/cycle/scope id would otherwise stick.
-      await assertWorkspaceScopedRefs(ctx.db, previousTicket.product.workspaceId, {
-        epicId: input.epicId,
-        featureId: input.featureId,
-        cycleId: input.cycleId,
-        scopeId: input.scopeId,
-      });
+      await assertWorkspaceScopedRefs(
+        ctx.db,
+        ctx.session.user.id,
+        previousTicket.product.workspaceId,
+        {
+          epicId: input.epicId,
+          featureId: input.featureId,
+          cycleId: input.cycleId,
+          scopeId: input.scopeId,
+        },
+      );
 
       const { id, ...rest } = input;
       const data: Record<string, unknown> = { ...rest };

--- a/src/server/api/routers/__tests__/epic.test.ts
+++ b/src/server/api/routers/__tests__/epic.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for the `epic` router's access gating.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety"). Covers the 2026-08-04 audit fixes:
+ * `getById` must require workspace membership (it previously returned any epic
+ * to any authenticated user), and the gate must be the centralized
+ * `getWorkspaceMembership` resolver so team-based workspace members are
+ * admitted, matching the ticket/feature/product routers.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const WORKSPACE_ID = "ws-1";
+const USER_ID = "user-1";
+const EPIC = { id: "epic-1", name: "Payments", workspaceId: WORKSPACE_ID };
+
+type MembershipKind = "direct" | "team" | "none";
+
+// getWorkspaceMembership → direct WorkspaceUser lookup, then team fallback
+function mockMembership(dbMock: DeepMockProxy<PrismaClient>, kind: MembershipKind) {
+  dbMock.workspaceUser.findUnique.mockResolvedValue(
+    kind === "direct"
+      ? ({ role: "member", workspaceId: WORKSPACE_ID } as never)
+      : null,
+  );
+  dbMock.teamUser.findFirst.mockResolvedValue(
+    kind === "team"
+      ? ({ role: "member", team: { workspaceId: WORKSPACE_ID } } as never)
+      : null,
+  );
+}
+
+describe("epic router access gating (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  describe("getById", () => {
+    it("denies a non-member even when the epic exists (the audit gap)", async () => {
+      mockMembership(dbMock, "none");
+      dbMock.epic.findUnique.mockResolvedValue(EPIC as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(caller.epic.getById({ id: EPIC.id })).rejects.toMatchObject({
+        code: "FORBIDDEN",
+      });
+    });
+
+    it("admits a team-based workspace member", async () => {
+      mockMembership(dbMock, "team");
+      dbMock.epic.findUnique.mockResolvedValue(EPIC as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(caller.epic.getById({ id: EPIC.id })).resolves.toMatchObject({
+        id: EPIC.id,
+      });
+    });
+
+    it("still 404s on a missing epic before any membership check", async () => {
+      dbMock.epic.findUnique.mockResolvedValue(null as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(caller.epic.getById({ id: "nope" })).rejects.toMatchObject({
+        code: "NOT_FOUND",
+      });
+      expect(dbMock.workspaceUser.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("list", () => {
+    it("admits a team-based workspace member (previously direct-only)", async () => {
+      mockMembership(dbMock, "team");
+      dbMock.epic.findMany.mockResolvedValue([EPIC] as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.epic.list({ workspaceId: WORKSPACE_ID }),
+      ).resolves.toMatchObject([{ id: EPIC.id }]);
+    });
+
+    it("denies a non-member", async () => {
+      mockMembership(dbMock, "none");
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.epic.list({ workspaceId: WORKSPACE_ID }),
+      ).rejects.toBeInstanceOf(TRPCError);
+      expect(dbMock.epic.findMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/api/routers/__tests__/search.test.ts
+++ b/src/server/api/routers/__tests__/search.test.ts
@@ -91,7 +91,10 @@ vi.mock("~/lib/blob", () => ({
 
 // ── Imports of code under test (must come AFTER vi.mock calls) ───────
 import { createMockCaller } from "~/test/trpc-helpers";
-import { buildActionAccessWhere } from "~/server/services/access";
+import {
+  buildActionAccessWhere,
+  buildWorkspaceAccessWhere,
+} from "~/server/services/access";
 
 const callerId = "user-1";
 const workspaceId = "ws-1";
@@ -180,6 +183,16 @@ describe("search router — global (mocked)", () => {
     expect(where?.status).toEqual({ notIn: ["DELETED", "DRAFT"] });
     // Access scoping comes from buildActionAccessWhere, not a hand-rolled copy.
     expect(where?.OR).toEqual(buildActionAccessWhere(callerId).OR);
+  });
+
+  it("scopes epics to direct-or-team workspace membership, like the epic router", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.search.global({ query: "brew" });
+
+    const epicWhere = dbMock.epic.findMany.mock.calls[0]?.[0]?.where;
+    // Access scoping comes from buildWorkspaceAccessWhere (direct OR
+    // team-based membership), not a hand-rolled direct-members-only copy.
+    expect(epicWhere?.workspace).toEqual({ is: buildWorkspaceAccessWhere(callerId) });
   });
 
   it("workspace-scoped search filters projects/goals to the workspace for members", async () => {

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -11,7 +11,7 @@ import { ScoringService } from "~/server/services/ScoringService";
 import { startOfDay } from "date-fns";
 import { validateScheduledTimes } from "~/lib/dateUtils";
 import { findUserByEmailInWorkspace, getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
-import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere } from "~/server/services/access";
+import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs } from "~/server/services/access";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import { uploadToBlob } from "~/lib/blob";
 import { emitNotification } from "~/server/services/notifications/emit/emitNotification";
@@ -436,6 +436,16 @@ export const actionRouter = createTRPCRouter({
         }
       }
 
+      // A linked epic must live in the action's own workspace, or its name and
+      // status leak back through the `epic` include below.
+      if (input.epicId) {
+        await assertWorkspaceScopedRefs(
+          ctx.db,
+          input.workspaceId ?? projectWorkspaceId,
+          { epicId: input.epicId },
+        );
+      }
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const actionData: any = {
         ...input,
@@ -649,6 +659,19 @@ export const actionRouter = createTRPCRouter({
         if (newProject?.workspaceId) {
           updateData.workspaceId = newProject.workspaceId;
         }
+      }
+
+      // Same-workspace guard as create, resolved against the workspace the
+      // action will have *after* any projectId-driven move above.
+      if (updateData.epicId) {
+        await assertWorkspaceScopedRefs(
+          ctx.db,
+          updateData.workspaceId ??
+            currentAction?.workspaceId ??
+            currentAction?.project?.workspaceId ??
+            null,
+          { epicId: updateData.epicId },
+        );
       }
 
       // Set completedAt timestamp when completing, clear when uncompleting

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -441,6 +441,7 @@ export const actionRouter = createTRPCRouter({
       if (input.epicId) {
         await assertWorkspaceScopedRefs(
           ctx.db,
+          ctx.session.user.id,
           input.workspaceId ?? projectWorkspaceId,
           { epicId: input.epicId },
         );
@@ -666,6 +667,7 @@ export const actionRouter = createTRPCRouter({
       if (updateData.epicId) {
         await assertWorkspaceScopedRefs(
           ctx.db,
+          ctx.session.user.id,
           updateData.workspaceId ??
             currentAction?.workspaceId ??
             currentAction?.project?.workspaceId ??

--- a/src/server/api/routers/epic.ts
+++ b/src/server/api/routers/epic.ts
@@ -1,10 +1,31 @@
 import { z } from "zod";
+import type { PrismaClient } from "@prisma/client";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
+import { getWorkspaceMembership } from "~/server/services/access";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 
 const epicStatusSchema = z.enum(["OPEN", "IN_PROGRESS", "DONE", "CANCELLED"]);
 const epicPrioritySchema = z.enum(["HIGH", "MEDIUM", "LOW", "NONE"]);
+
+/**
+ * Ensure the caller is a member of the workspace (directly or via a team).
+ * Throws FORBIDDEN otherwise.
+ */
+async function assertWorkspaceMember(
+  db: PrismaClient,
+  userId: string,
+  workspaceId: string,
+) {
+  const membership = await getWorkspaceMembership(db, userId, workspaceId);
+  if (!membership) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You must be a member of this workspace",
+    });
+  }
+  return membership;
+}
 
 export const epicRouter = createTRPCRouter({
   // List all epics for a workspace
@@ -16,21 +37,7 @@ export const epicRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
-      const member = await ctx.db.workspaceUser.findUnique({
-        where: {
-          userId_workspaceId: {
-            userId: ctx.session.user.id,
-            workspaceId: input.workspaceId,
-          },
-        },
-      });
-
-      if (!member) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "You must be a member of this workspace",
-        });
-      }
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, input.workspaceId);
 
       return ctx.db.epic.findMany({
         where: {
@@ -85,6 +92,8 @@ export const epicRouter = createTRPCRouter({
         });
       }
 
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, epic.workspaceId);
+
       return epic;
     }),
 
@@ -101,21 +110,7 @@ export const epicRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const member = await ctx.db.workspaceUser.findUnique({
-        where: {
-          userId_workspaceId: {
-            userId: ctx.session.user.id,
-            workspaceId: input.workspaceId,
-          },
-        },
-      });
-
-      if (!member) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "You must be a member of this workspace to create epics",
-        });
-      }
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, input.workspaceId);
 
       return ctx.db.epic.create({
         data: {
@@ -157,21 +152,7 @@ export const epicRouter = createTRPCRouter({
         });
       }
 
-      const member = await ctx.db.workspaceUser.findUnique({
-        where: {
-          userId_workspaceId: {
-            userId: ctx.session.user.id,
-            workspaceId: epic.workspaceId,
-          },
-        },
-      });
-
-      if (!member) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "You must be a member of this workspace to update epics",
-        });
-      }
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, epic.workspaceId);
 
       return ctx.db.epic.update({
         where: { id },
@@ -194,21 +175,11 @@ export const epicRouter = createTRPCRouter({
         });
       }
 
-      const member = await ctx.db.workspaceUser.findUnique({
-        where: {
-          userId_workspaceId: {
-            userId: ctx.session.user.id,
-            workspaceId: epic.workspaceId,
-          },
-        },
-      });
-
-      if (!member) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "You must be a member of this workspace to delete epics",
-        });
-      }
+      const member = await assertWorkspaceMember(
+        ctx.db,
+        ctx.session.user.id,
+        epic.workspaceId,
+      );
 
       const canDelete =
         member.role === "owner" ||

--- a/src/server/api/routers/search.ts
+++ b/src/server/api/routers/search.ts
@@ -329,13 +329,13 @@ async function searchFeatures({ db, userId, q, workspaceId, limit }: SearchArgs)
   }));
 }
 
-// Mirrors the epic router's gate: DIRECT workspace membership only (team-based
-// members are denied there, so they are denied here too).
+// Mirrors the epic router's gate: direct or team-based workspace membership
+// (getWorkspaceMembership; guests denied).
 async function searchEpics({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
   const epics = await db.epic.findMany({
     where: {
       ...(workspaceId ? { workspaceId } : {}),
-      workspace: { members: { some: { userId } } },
+      workspace: { is: buildWorkspaceAccessWhere(userId) },
       name: insensitive(q),
     },
     select: {

--- a/src/server/services/access/__tests__/workspaceRefs.test.ts
+++ b/src/server/services/access/__tests__/workspaceRefs.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the cross-workspace link guard.
+ *
+ * Covers the sideways route to the 2026-08-04 epic audit finding: a ticket or
+ * action in workspace A must not be able to point at an epic (or feature,
+ * cycle, scope) in workspace B, because the pointed-at row's fields come back
+ * inside the pointing row's own include.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import { assertWorkspaceScopedRefs } from "../workspaceRefs";
+
+const WORKSPACE_ID = "ws-1";
+const OTHER_WORKSPACE_ID = "ws-2";
+
+describe("assertWorkspaceScopedRefs", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = mockDeep<PrismaClient>();
+    mockReset(db);
+  });
+
+  it("is a no-op when no references are supplied", async () => {
+    await expect(
+      assertWorkspaceScopedRefs(db, WORKSPACE_ID, {}),
+    ).resolves.toBeUndefined();
+    expect(db.epic.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("skips null/undefined references so unlinking stays allowed", async () => {
+    await expect(
+      assertWorkspaceScopedRefs(db, WORKSPACE_ID, {
+        epicId: null,
+        featureId: undefined,
+      }),
+    ).resolves.toBeUndefined();
+    expect(db.epic.findUnique).not.toHaveBeenCalled();
+    expect(db.feature.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("accepts an epic in the same workspace", async () => {
+    db.epic.findUnique.mockResolvedValue({ workspaceId: WORKSPACE_ID } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, WORKSPACE_ID, { epicId: "epic-1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects an epic from another workspace without confirming it exists", async () => {
+    db.epic.findUnique.mockResolvedValue({
+      workspaceId: OTHER_WORKSPACE_ID,
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, WORKSPACE_ID, { epicId: "epic-foreign" }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Epic not found in this workspace",
+    });
+  });
+
+  it("rejects an epic id that does not exist at all", async () => {
+    db.epic.findUnique.mockResolvedValue(null as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, WORKSPACE_ID, { epicId: "nope" }),
+    ).rejects.toBeInstanceOf(TRPCError);
+  });
+
+  it("rejects any workspace-scoped reference when the pointing row has no workspace", async () => {
+    db.epic.findUnique.mockResolvedValue({ workspaceId: WORKSPACE_ID } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, null, { epicId: "epic-1" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("resolves a feature through its product's workspace", async () => {
+    db.feature.findUnique.mockResolvedValue({
+      product: { workspaceId: OTHER_WORKSPACE_ID },
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, WORKSPACE_ID, { featureId: "feat-1" }),
+    ).rejects.toMatchObject({ message: "Feature not found in this workspace" });
+  });
+
+  it("resolves a cycle through its List row", async () => {
+    db.list.findUnique.mockResolvedValue({
+      workspaceId: OTHER_WORKSPACE_ID,
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, WORKSPACE_ID, { cycleId: "cycle-1" }),
+    ).rejects.toMatchObject({ message: "Cycle not found in this workspace" });
+  });
+
+  it("resolves a scope through feature → product → workspace", async () => {
+    db.featureScope.findUnique.mockResolvedValue({
+      feature: { product: { workspaceId: WORKSPACE_ID } },
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, WORKSPACE_ID, { scopeId: "scope-1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects when any one of several references is foreign", async () => {
+    db.epic.findUnique.mockResolvedValue({ workspaceId: WORKSPACE_ID } as never);
+    db.feature.findUnique.mockResolvedValue({
+      product: { workspaceId: WORKSPACE_ID },
+    } as never);
+    db.list.findUnique.mockResolvedValue({
+      workspaceId: OTHER_WORKSPACE_ID,
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, WORKSPACE_ID, {
+        epicId: "epic-1",
+        featureId: "feat-1",
+        cycleId: "cycle-foreign",
+      }),
+    ).rejects.toMatchObject({ message: "Cycle not found in this workspace" });
+  });
+});

--- a/src/server/services/access/__tests__/workspaceRefs.test.ts
+++ b/src/server/services/access/__tests__/workspaceRefs.test.ts
@@ -14,6 +14,7 @@ import type { PrismaClient } from "@prisma/client";
 
 import { assertWorkspaceScopedRefs } from "../workspaceRefs";
 
+const USER_ID = "user-1";
 const WORKSPACE_ID = "ws-1";
 const OTHER_WORKSPACE_ID = "ws-2";
 
@@ -27,14 +28,14 @@ describe("assertWorkspaceScopedRefs", () => {
 
   it("is a no-op when no references are supplied", async () => {
     await expect(
-      assertWorkspaceScopedRefs(db, WORKSPACE_ID, {}),
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, {}),
     ).resolves.toBeUndefined();
     expect(db.epic.findUnique).not.toHaveBeenCalled();
   });
 
   it("skips null/undefined references so unlinking stays allowed", async () => {
     await expect(
-      assertWorkspaceScopedRefs(db, WORKSPACE_ID, {
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, {
         epicId: null,
         featureId: undefined,
       }),
@@ -47,7 +48,7 @@ describe("assertWorkspaceScopedRefs", () => {
     db.epic.findUnique.mockResolvedValue({ workspaceId: WORKSPACE_ID } as never);
 
     await expect(
-      assertWorkspaceScopedRefs(db, WORKSPACE_ID, { epicId: "epic-1" }),
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { epicId: "epic-1" }),
     ).resolves.toBeUndefined();
   });
 
@@ -57,7 +58,7 @@ describe("assertWorkspaceScopedRefs", () => {
     } as never);
 
     await expect(
-      assertWorkspaceScopedRefs(db, WORKSPACE_ID, { epicId: "epic-foreign" }),
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { epicId: "epic-foreign" }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Epic not found in this workspace",
@@ -68,16 +69,61 @@ describe("assertWorkspaceScopedRefs", () => {
     db.epic.findUnique.mockResolvedValue(null as never);
 
     await expect(
-      assertWorkspaceScopedRefs(db, WORKSPACE_ID, { epicId: "nope" }),
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { epicId: "nope" }),
     ).rejects.toBeInstanceOf(TRPCError);
   });
 
-  it("rejects any workspace-scoped reference when the pointing row has no workspace", async () => {
+  // A workspace-less action (no workspaceId, no project) has no containment
+  // rule to apply, so membership in the reference's workspace is the check.
+  // EditActionModal offers the context workspace's epics for these actions.
+  it("accepts a reference for a workspace-less row when the caller is a member", async () => {
     db.epic.findUnique.mockResolvedValue({ workspaceId: WORKSPACE_ID } as never);
+    db.workspaceUser.findUnique.mockResolvedValue({
+      role: "member",
+      workspaceId: WORKSPACE_ID,
+    } as never);
 
     await expect(
-      assertWorkspaceScopedRefs(db, null, { epicId: "epic-1" }),
+      assertWorkspaceScopedRefs(db, USER_ID, null, { epicId: "epic-1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a reference for a workspace-less row when the caller is not a member", async () => {
+    db.epic.findUnique.mockResolvedValue({
+      workspaceId: OTHER_WORKSPACE_ID,
+    } as never);
+    db.workspaceUser.findUnique.mockResolvedValue(null as never);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, null, { epicId: "epic-foreign" }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("admits a team-based member on the workspace-less path", async () => {
+    db.epic.findUnique.mockResolvedValue({ workspaceId: WORKSPACE_ID } as never);
+    db.workspaceUser.findUnique.mockResolvedValue(null as never);
+    db.teamUser.findFirst.mockResolvedValue({
+      role: "member",
+      team: { workspaceId: WORKSPACE_ID },
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, null, { epicId: "epic-1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not consult membership when the pointing row has a workspace", async () => {
+    db.epic.findUnique.mockResolvedValue({
+      workspaceId: OTHER_WORKSPACE_ID,
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { epicId: "epic-1" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    // Containment is the whole rule here — being a member of the epic's
+    // workspace must not let you link it into a different workspace's ticket.
+    expect(db.workspaceUser.findUnique).not.toHaveBeenCalled();
   });
 
   it("resolves a feature through its product's workspace", async () => {
@@ -86,7 +132,7 @@ describe("assertWorkspaceScopedRefs", () => {
     } as never);
 
     await expect(
-      assertWorkspaceScopedRefs(db, WORKSPACE_ID, { featureId: "feat-1" }),
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { featureId: "feat-1" }),
     ).rejects.toMatchObject({ message: "Feature not found in this workspace" });
   });
 
@@ -96,7 +142,7 @@ describe("assertWorkspaceScopedRefs", () => {
     } as never);
 
     await expect(
-      assertWorkspaceScopedRefs(db, WORKSPACE_ID, { cycleId: "cycle-1" }),
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { cycleId: "cycle-1" }),
     ).rejects.toMatchObject({ message: "Cycle not found in this workspace" });
   });
 
@@ -106,7 +152,7 @@ describe("assertWorkspaceScopedRefs", () => {
     } as never);
 
     await expect(
-      assertWorkspaceScopedRefs(db, WORKSPACE_ID, { scopeId: "scope-1" }),
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { scopeId: "scope-1" }),
     ).resolves.toBeUndefined();
   });
 
@@ -120,7 +166,7 @@ describe("assertWorkspaceScopedRefs", () => {
     } as never);
 
     await expect(
-      assertWorkspaceScopedRefs(db, WORKSPACE_ID, {
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, {
         epicId: "epic-1",
         featureId: "feat-1",
         cycleId: "cycle-foreign",

--- a/src/server/services/access/index.ts
+++ b/src/server/services/access/index.ts
@@ -103,3 +103,7 @@ export {
   buildKnowledgePageAccessWhere,
 } from "./resolvers/knowledgePageResolver";
 export type { KnowledgePageAccessInfo } from "./resolvers/knowledgePageResolver";
+
+// Cross-workspace link guards (epic/feature/cycle/scope foreign keys)
+export { assertWorkspaceScopedRefs } from "./workspaceRefs";
+export type { WorkspaceScopedRefs } from "./workspaceRefs";

--- a/src/server/services/access/workspaceRefs.ts
+++ b/src/server/services/access/workspaceRefs.ts
@@ -1,0 +1,119 @@
+/**
+ * Cross-workspace link guards.
+ *
+ * Tickets and actions carry optional foreign keys to workspace-scoped rows
+ * (epic, feature, cycle, scope). The routers gate the *pointing* row — the
+ * ticket's product workspace, the action's project — but a foreign key is a
+ * second read path: the pointed-at row's fields come back inside the pointing
+ * row's own `include`.
+ *
+ * So without this guard, a member of workspace A can create a ticket in their
+ * own product, set `epicId` to an epic in workspace B, and read that epic's
+ * name and status back through `ticket.getById`. That is the 2026-08-04 epic
+ * audit finding (`epic.getById` had no membership check) reachable sideways.
+ *
+ * Every workspace-scoped reference must therefore live in the same workspace
+ * as the row pointing at it. Mismatches raise NOT_FOUND rather than FORBIDDEN
+ * so the error does not confirm that the id exists in some other workspace.
+ */
+
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * Workspace-scoped rows a ticket or action can reference. A `null` or
+ * `undefined` value means "not being set" and is skipped — unlinking is
+ * always allowed.
+ */
+export interface WorkspaceScopedRefs {
+  epicId?: string | null;
+  featureId?: string | null;
+  cycleId?: string | null;
+  scopeId?: string | null;
+}
+
+/**
+ * Throw unless every supplied reference resolves to `workspaceId`.
+ *
+ * `workspaceId` is the effective workspace of the pointing row. It may be
+ * null (an action with no workspace), in which case any workspace-scoped
+ * reference is incoherent and rejected.
+ */
+export async function assertWorkspaceScopedRefs(
+  db: PrismaClient,
+  workspaceId: string | null,
+  refs: WorkspaceScopedRefs,
+): Promise<void> {
+  const lookups: Array<Promise<{ label: string; refWorkspaceId: string | null }>> =
+    [];
+
+  if (refs.epicId) {
+    lookups.push(
+      db.epic
+        .findUnique({
+          where: { id: refs.epicId },
+          select: { workspaceId: true },
+        })
+        .then((row) => ({
+          label: "Epic",
+          refWorkspaceId: row?.workspaceId ?? null,
+        })),
+    );
+  }
+
+  if (refs.featureId) {
+    lookups.push(
+      db.feature
+        .findUnique({
+          where: { id: refs.featureId },
+          select: { product: { select: { workspaceId: true } } },
+        })
+        .then((row) => ({
+          label: "Feature",
+          refWorkspaceId: row?.product.workspaceId ?? null,
+        })),
+    );
+  }
+
+  // A "cycle" is a List row (Ticket.cycle → List, relation "TicketCycle").
+  if (refs.cycleId) {
+    lookups.push(
+      db.list
+        .findUnique({
+          where: { id: refs.cycleId },
+          select: { workspaceId: true },
+        })
+        .then((row) => ({
+          label: "Cycle",
+          refWorkspaceId: row?.workspaceId ?? null,
+        })),
+    );
+  }
+
+  if (refs.scopeId) {
+    lookups.push(
+      db.featureScope
+        .findUnique({
+          where: { id: refs.scopeId },
+          select: {
+            feature: { select: { product: { select: { workspaceId: true } } } },
+          },
+        })
+        .then((row) => ({
+          label: "Scope",
+          refWorkspaceId: row?.feature.product.workspaceId ?? null,
+        })),
+    );
+  }
+
+  if (lookups.length === 0) return;
+
+  for (const { label, refWorkspaceId } of await Promise.all(lookups)) {
+    if (!refWorkspaceId || refWorkspaceId !== workspaceId) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: `${label} not found in this workspace`,
+      });
+    }
+  }
+}

--- a/src/server/services/access/workspaceRefs.ts
+++ b/src/server/services/access/workspaceRefs.ts
@@ -19,6 +19,7 @@
 
 import { TRPCError } from "@trpc/server";
 import type { PrismaClient } from "@prisma/client";
+import { getWorkspaceMembership } from "./resolvers/workspaceResolver";
 
 /**
  * Workspace-scoped rows a ticket or action can reference. A `null` or
@@ -33,14 +34,22 @@ export interface WorkspaceScopedRefs {
 }
 
 /**
- * Throw unless every supplied reference resolves to `workspaceId`.
+ * Throw unless the caller may link every supplied reference.
  *
- * `workspaceId` is the effective workspace of the pointing row. It may be
- * null (an action with no workspace), in which case any workspace-scoped
- * reference is incoherent and rejected.
+ * `workspaceId` is the effective workspace of the pointing row:
+ *
+ *  - When set, the reference must live in that same workspace (containment).
+ *    Tickets always take this path — a ticket's workspace comes from its
+ *    product, so a reference from anywhere else is incoherent.
+ *  - When null — an action with no workspace and no project — containment is
+ *    undefined, so fall back to the security requirement itself: the caller
+ *    must be a member of the reference's own workspace. `EditActionModal`
+ *    offers the context workspace's epics for such actions, so rejecting
+ *    outright would break a supported flow.
  */
 export async function assertWorkspaceScopedRefs(
   db: PrismaClient,
+  userId: string,
   workspaceId: string | null,
   refs: WorkspaceScopedRefs,
 ): Promise<void> {
@@ -109,11 +118,25 @@ export async function assertWorkspaceScopedRefs(
   if (lookups.length === 0) return;
 
   for (const { label, refWorkspaceId } of await Promise.all(lookups)) {
-    if (!refWorkspaceId || refWorkspaceId !== workspaceId) {
+    if (!refWorkspaceId) {
       throw new TRPCError({
         code: "NOT_FOUND",
         message: `${label} not found in this workspace`,
       });
     }
+
+    if (refWorkspaceId === workspaceId) continue;
+
+    // Pointing row has no workspace of its own: membership in the
+    // reference's workspace is the check that matters.
+    if (workspaceId === null) {
+      const membership = await getWorkspaceMembership(db, userId, refWorkspaceId);
+      if (membership) continue;
+    }
+
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: `${label} not found in this workspace`,
+    });
   }
 }

--- a/src/server/services/tags/TagAssignmentService.ts
+++ b/src/server/services/tags/TagAssignmentService.ts
@@ -1,6 +1,10 @@
 import type { PrismaClient, Tag } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
-import { canEditAction, getActionAccess } from "~/server/services/access";
+import {
+  canEditAction,
+  getActionAccess,
+  getWorkspaceMembership,
+} from "~/server/services/access";
 
 export type TagEntityType = "action" | "ticket" | "feature" | "epic";
 
@@ -127,9 +131,9 @@ async function requireWorkspaceMember(
   userId: string,
   workspaceId: string,
 ): Promise<void> {
-  const membership = await db.workspaceUser.findUnique({
-    where: { userId_workspaceId: { userId, workspaceId } },
-  });
+  // Centralized resolver: direct OR team-based membership. A hand-rolled
+  // workspaceUser lookup here used to deny team-based members.
+  const membership = await getWorkspaceMembership(db, userId, workspaceId);
   if (!membership) {
     throw new TRPCError({
       code: "FORBIDDEN",


### PR DESCRIPTION
### **User description**
Closes the 2026-08-04 epic access audit findings, plus the same leak reached through a different door.

## The audit findings

**`epic.getById` had no access check at all.** Any authenticated user could read any epic by CUID — name, description, dates, owner, and the full action list with assignees. It now loads the epic, 404s if absent, then asserts workspace membership, matching `ticket.getById`'s ordering.

**`epic.list` (and create/update/delete) gated on a direct `db.workspaceUser.findUnique`,** which denied team-based workspace members that the ticket/feature/product routers admit. All five procedures now go through `getWorkspaceMembership` (direct OR team) via a local `assertWorkspaceMember` helper, the same shape `product.ts` uses. `delete`'s owner/admin check still works — team members resolve to role `member`, so they can still only delete their own epics.

`searchEpics` in `search.ts` mirrored the direct-only behaviour; it now uses `buildWorkspaceAccessWhere`, the where-clause twin of `getWorkspaceMembership`, exactly as the ticket and feature blocks do. `TagAssignmentService` had its own hand-rolled direct-only copy gating epic tagging — also swapped, so a team member who can now read an epic can also tag it.

## The sideways route (found while fixing the above)

Tickets and actions carry optional FKs to workspace-scoped rows, and the routers gate the *pointing* row while returning the *pointed-at* row's fields inside their own `include`. None of those FKs were validated:

- `ticket.create` / `ticket.update` accept `epicId`, `featureId`, `cycleId`, `scopeId` and write them straight through. `ticket.getById` returns `epic: { id, name, status }`.
- `action.create` / `action.update` accept `epicId` and return the same epic select.

So a member of workspace A could create a ticket in their own product, set `epicId` to an epic in workspace B, and read that epic's name and status back — the finding this PR closes, reopened through a link. Notably `templateId`, immediately above in the same mutation, *was* already validated this way, which is what makes the omission look accidental rather than deliberate.

New `assertWorkspaceScopedRefs` (in the access service) resolves each supplied reference to its workspace — epic direct, feature via product, cycle via its `List` row, scope via feature → product — and rejects mismatches with `NOT_FOUND` rather than `FORBIDDEN` so the error doesn't confirm the id exists somewhere else. Null/undefined are skipped, so unlinking still works.

One wrinkle the second commit handles: strict containment would have broken a legitimate flow. An action can have neither a `workspaceId` nor a project, and `EditActionModal` offers the *context* workspace's epics for exactly those, so linking one is expected. On that null-workspace path only, the guard falls back to the security requirement it was standing in for — the caller must be a member of the reference's workspace. Rows that do have a workspace keep strict containment, and membership is deliberately not consulted for them: belonging to the epic's workspace must not let you link it into a different workspace's ticket.

## Tests

- `epic.test.ts` (new) — `getById` denies a non-member when the epic exists, admits a team-based member, still 404s before any membership probe; `list` admits team members and denies non-members.
- `workspaceRefs.test.ts` (new) — same-workspace accept, foreign reject, nonexistent reject, null-workspace reject, each of the four resolution paths, and mixed refs where one is foreign.
- `ticket.test.ts` — create refuses a foreign epic and never reaches `ticket.create`; an own-workspace epic passes the guard.
- `search.test.ts` — asserts the epic where-clause equals `buildWorkspaceAccessWhere`, so scoping can't regress to a hand-rolled copy.

Typecheck and lint clean; 1992 unit tests pass.

## Not addressed here

`assigneeId` on tickets is unvalidated in the same way, and `ticket.getById` returns `assignee: { id, name, email, image }` — so an arbitrary user CUID leaks that user's **email**. That's a different check (user membership, not workspace containment) with product semantics I didn't want to invent — worth its own ticket. Thirteen other routers still use direct-only `workspaceUser.findUnique` (`workspace.ts` ×25, `view.ts` ×6, `list.ts` ×6, `tag.ts` ×5, …); those deny too much rather than too little, so they're a consistency sweep rather than a security queue.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix epic access control: `getById` lacked membership check, all procedures now use `getWorkspaceMembership` (direct + team)

- Block cross-workspace FK leaks: tickets/actions can no longer link epics, features, cycles, or scopes from foreign workspaces

- Fix `searchEpics` and `TagAssignmentService` to use centralized membership resolver (team members previously denied)

- Add comprehensive unit tests for all new access guards


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["epic.getById (no auth)"] -- "add assertWorkspaceMember" --> B["epic.getById (workspace-gated)"]
  C["epic list/create/update/delete (direct-only)"] -- "replace with getWorkspaceMembership" --> D["epic procedures (direct + team)"]
  E["ticket.create / ticket.update"] -- "add assertWorkspaceScopedRefs" --> F["cross-workspace FK blocked"]
  G["action.create / action.update"] -- "add assertWorkspaceScopedRefs" --> F
  H["searchEpics (direct-only)"] -- "use buildWorkspaceAccessWhere" --> I["searchEpics (direct + team)"]
  J["TagAssignmentService (direct-only)"] -- "use getWorkspaceMembership" --> K["TagAssignmentService (direct + team)"]
  L["workspaceRefs.ts"] -- "new service" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>epic.ts</strong><dd><code>Add workspace membership check to all epic procedures</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/481/files#diff-737ea566df8468c7d11217c4cc278a1c8954e62773ed3f28048bcfdd22492fd5">+31/-60</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workspaceRefs.ts</strong><dd><code>New cross-workspace FK guard service for tickets and actions</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/481/files#diff-1dde13ac84147ebc7b832c39ae20aa7b9970df02b0eeda8c926c1f28248c7ba1">+142/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ticket.ts</strong><dd><code>Guard ticket create/update against cross-workspace FK references</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/481/files#diff-2c667429b802690451b0f2771795cba4b39b00fb9a8b2cca853b1f95497032c5">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>action.ts</strong><dd><code>Guard action create/update against cross-workspace epic FK</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/481/files#diff-5b198a3cc9e3495e32e4dcdf28771f225d15998a0c3ab9de63ef7f12941d1dbb">+26/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>search.ts</strong><dd><code>Fix searchEpics to use team-aware workspace membership filter</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/481/files#diff-8e2eb893e53f741f2d3019aa28559a3d29775df802c1921a49c131a2ac642dc8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TagAssignmentService.ts</strong><dd><code>Replace direct-only membership check with centralized resolver</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/481/files#diff-86cc8925e1dc09502ba36ce8e11ad3534683570eb6a74af7e987f34fc33f3642">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>index.ts</strong><dd><code>Export new assertWorkspaceScopedRefs and WorkspaceScopedRefs</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/481/files#diff-74fa8db7237706b8a79d9f10fdaee87b9805928dd72cb942e4b2d489a2215dc3">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>epic.test.ts</strong><dd><code>New unit tests for epic router access gating</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/481/files#diff-c5cde11d8e655b5486e4a715f6e4d88ebc8117e7ca41855ccf21bc1850c99768">+156/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workspaceRefs.test.ts</strong><dd><code>New unit tests for cross-workspace FK guard service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/481/files#diff-55d126822bfc9904bc7c15dd55b8e04cbcca32320b6d694553eeb652031f0a82">+176/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ticket.test.ts</strong><dd><code>Add tests for cross-workspace epic link rejection in tickets</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/481/files#diff-66527097b6bcfccf7a0834b7eb1748adc3c1d1c4757849b6b03fcd4a6da75849">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>search.test.ts</strong><dd><code>Add test verifying searchEpics uses team-aware membership filter</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/481/files#diff-1418f51be20f3b84b307919114b069b418ca595159877c6cef4e2f916b24cb4e">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

