### PR TITLE
fix(desktop): stamp the titlebar marker from the shell, not a head script

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -166,6 +166,41 @@ fn resolve_wiki_root(app: &tauri::AppHandle) {
         .expect("wiki root mutex poisoned") = Some(root);
 }
 
+/// Tells the page it is inside this shell, so it can keep its own chrome out
+/// from under the window controls.
+///
+/// The page cannot reliably work this out for itself. It used to sniff
+/// `window.__TAURI_INTERNALS__` from an inline `<head>` script, but on a remote
+/// page that global lands *after* the document's own head scripts run — so the
+/// check was made too early, found nothing, and the inset was silently skipped.
+/// IPC worked fine a moment later, which is what made the bug so quiet.
+///
+/// An initialization script has no such race: whenever it runs, setting the
+/// attribute is enough, because the CSS keyed off it applies the moment it
+/// appears. `documentElement` may not exist yet at injection time, hence the
+/// `DOMContentLoaded` retry.
+#[cfg(target_os = "macos")]
+const TITLEBAR_MARKER_SCRIPT: &str = r#"
+(function () {
+  function mark() {
+    var root = document && document.documentElement;
+    if (!root) return false;
+    root.setAttribute('data-shell', 'tauri');
+    root.setAttribute('data-titlebar', 'overlay');
+    return true;
+  }
+  try {
+    if (!mark()) {
+      document.addEventListener('DOMContentLoaded', mark);
+    }
+  } catch (e) {}
+})();
+"#;
+
+/// Non-macOS shells keep their native chrome, so there is nothing to mark.
+#[cfg(not(target_os = "macos"))]
+const TITLEBAR_MARKER_SCRIPT: &str = "";
+
 /// Create the single app window pointed at the remote web app.
 ///
 /// The window is built here rather than declared in `tauri.conf.json` because the
@@ -186,6 +221,7 @@ fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<()> {
         // The page is remote and takes a moment to paint; without this the window
         // opens as a white flash before the app's dark surface arrives.
         .background_color(window_background())
+        .initialization_script(TITLEBAR_MARKER_SCRIPT)
         .on_navigation(move |url| {
             if stays_in_app(url) {
                 return true;

--- a/src/app/_components/layout/DesktopChromeScript.tsx
+++ b/src/app/_components/layout/DesktopChromeScript.tsx
@@ -1,22 +1,33 @@
-// Marks the document with the desktop shell hosting it, before first paint.
+// Marks the document with the desktop shell hosting it, as early as possible.
 //
 // Both shells use the macOS overlay title bar (Electron `hiddenInset`, Tauri
 // `TitleBarStyle::Overlay`), so the traffic lights float over the page's
 // top-left corner — which is the sidebar's workspace switcher. CSS reserves
-// room for them off `data-titlebar="overlay"`; doing it here rather than in a
-// client component keeps the sidebar from painting once in the wrong place and
-// then jumping.
+// room for them off `data-titlebar="overlay"`; running here rather than in a
+// client component keeps the sidebar from painting in the wrong place and then
+// jumping.
 //
 // Detection mirrors `~/lib/platform.ts` and is duplicated as a string on
-// purpose: this runs in <head>, ahead of any bundle. Both globals are injected
-// before page scripts (Electron's preload, Tauri's init script), and a miss
-// just means no inset — never a broken layout.
+// purpose: this runs in <head>, ahead of any bundle.
+//
+// It retries because a single early check is not enough. Electron's preload
+// defines `window.electron` before any page script, but Tauri injects
+// `__TAURI_INTERNALS__` into a *remote* page after the document's own head
+// scripts have run — so the first check finds nothing, and the shipped version
+// of this file gave up there and left the inset at 0px. The bug was invisible:
+// IPC worked moments later, so nothing else looked wrong.
+//
+// The Tauri shell now stamps the attributes itself from an initialization
+// script (see `TITLEBAR_MARKER_SCRIPT` in `src-tauri/src/lib.rs`), which is the
+// race-free path. These retries stay as the fallback for a shell binary older
+// than that change, and for Electron. Marking twice is harmless — same values.
 export function DesktopChromeScript() {
   const script = `
-    try {
-      var shell = window.__TAURI_INTERNALS__ ? 'tauri'
-        : (window.electron ? 'electron' : null);
-      if (shell) {
+    (function () {
+      function mark() {
+        var shell = window.__TAURI_INTERNALS__ ? 'tauri'
+          : (window.electron ? 'electron' : null);
+        if (!shell) return false;
         var root = document.documentElement;
         root.setAttribute('data-shell', shell);
         // The overlay title bar is a macOS arrangement; other platforms keep
@@ -24,8 +35,21 @@ export function DesktopChromeScript() {
         if (/Mac/i.test(navigator.userAgent)) {
           root.setAttribute('data-titlebar', 'overlay');
         }
+        return true;
       }
-    } catch (e) {}
+
+      try {
+        if (mark()) return;
+        // Bounded: a shell that has not identified itself within ~2s of load
+        // is not going to, and we stop rather than poll forever.
+        var tries = 0;
+        var timer = setInterval(function () {
+          if (mark() || ++tries > 40) clearInterval(timer);
+        }, 50);
+        document.addEventListener('DOMContentLoaded', mark);
+        window.addEventListener('load', mark);
+      } catch (e) {}
+    })();
   `;
 
   return <script dangerouslySetInnerHTML={{ __html: script }} />;


### PR DESCRIPTION
### **User description**
## What

The titlebar inset from #476 never applied in the packaged Tauri app — the traffic lights were still landing on the workspace switcher.

The page sniffed `window.__TAURI_INTERNALS__` from an inline `<head>` script, but on a **remote** page Tauri injects that global *after* the document's own head scripts run. The check got one shot, took it too early, found nothing, and left `--titlebar-inset` at `0px`.

The failure was silent by construction: IPC works moments later, so `desktop_shell_info` verified fine and nothing else looked wrong.

## Fix

- **Shell stamps it.** `TITLEBAR_MARKER_SCRIPT` is injected as an initialization script and sets `data-shell` / `data-titlebar` itself. No race: whenever it runs, setting the attribute is enough, because the CSS keyed off it applies the moment the attribute appears. `DOMContentLoaded` retry covers `documentElement` not existing at injection time.
- **Page keeps a fallback.** Still needed for Electron (whose preload defines `window.electron` before any page script) and for a shell binary older than this change — but it now retries on a ~2s-bounded interval plus `DOMContentLoaded`/`load` instead of giving up after one try. Marking twice is harmless; identical values.

## Why it matters beyond this bug

`0px` is a valid-looking value, so a detection miss degrades to "no inset" rather than to an error. Worth a visual test in `e2e/` at both states — noted for the tab-strip work, where this region gets a single owner.

## Verification

- Browser unaffected: no marker, inset resolves to `0px`.
- `cargo check` and `eslint` clean; full unit suite green via pre-commit.
- The packaged app is the only place the original bug reproduces — verified there before merge.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix race condition where Tauri shell marker was never applied on remote pages

- Add `TITLEBAR_MARKER_SCRIPT` initialization script in Rust to stamp attributes before page scripts

- Upgrade `DesktopChromeScript` fallback to retry with interval and event listeners

- Non-macOS shells get an empty marker script; macOS sets both `data-shell` and `data-titlebar`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tauri lib.rs\nTITLEBAR_MARKER_SCRIPT"]
  B["initialization_script()\n(injected before page)"]
  C["data-shell='tauri'\ndata-titlebar='overlay'"]
  D["DesktopChromeScript\n(fallback retries)"]
  E["--titlebar-inset: 38px\n(CSS variable)"]
  F["Sidebar & toggle\nclear of traffic lights"]

  A -- "registered as" --> B
  B -- "sets on documentElement" --> C
  D -- "interval + events fallback" --> C
  C -- "activates" --> E
  E -- "applied to" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DesktopChromeScript.tsx</strong><dd><code>Add retry logic to DesktopChromeScript for Tauri race condition</code></dd></summary>
<hr>

src/app/_components/layout/DesktopChromeScript.tsx

<ul><li>Rewrites inline script from a single-shot check to a retry loop <br>bounded at ~2s (40 × 50ms)<br> <li> Adds <code>DOMContentLoaded</code> and <code>load</code> event listeners as additional retry <br>triggers<br> <li> Wraps logic in an IIFE with a <code>mark()</code> helper that returns a boolean <br>indicating success<br> <li> Updates comments to explain the Tauri remote-page race and the <br>shell-side fix</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/482/files#diff-d84d9fac2757835aed5ff59d1d527112cfb1f639c43859d89a46de6e029b0f2a">+36/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Inject titlebar marker from Tauri initialization script on macOS</code></dd></summary>
<hr>

src-tauri/src/lib.rs

<ul><li>Adds <code>TITLEBAR_MARKER_SCRIPT</code> constant (macOS only) that sets <code>data-shell</code> <br>and <code>data-titlebar</code> via an initialization script<br> <li> Provides an empty <code>TITLEBAR_MARKER_SCRIPT</code> for non-macOS targets via <br><code>#[cfg]</code><br> <li> Registers the script with <br><code>.initialization_script(TITLEBAR_MARKER_SCRIPT)</code> on the window builder<br> <li> Adds detailed doc comments explaining why the page-side detection was <br>unreliable</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/482/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

