### PR TITLE
Surface bulk-created cohorts on /today, with a one-click amnesty

### DIFF
--- a/src/app/_components/actions/hooks/useBulkActionMutations.ts
+++ b/src/app/_components/actions/hooks/useBulkActionMutations.ts
@@ -24,6 +24,14 @@ interface BulkDeleteInput {
   onError?: () => void;
 }
 
+interface BulkDeferInput {
+  actionIds: string[];
+  /** When true, fires `dailyPlan.markProcessedOverdue` after success. */
+  fromOverdue?: boolean;
+  onSuccess?: (data: { count: number }) => void;
+  onError?: () => void;
+}
+
 interface BulkAssignProjectInput {
   actionIds: string[];
   projectId: string;
@@ -34,6 +42,7 @@ interface BulkAssignProjectInput {
 interface UseBulkActionMutationsResult {
   bulkReschedule: (input: BulkRescheduleInput) => void;
   bulkDelete: (input: BulkDeleteInput) => void;
+  bulkDefer: (input: BulkDeferInput) => void;
   bulkAssignProject: (input: BulkAssignProjectInput) => void;
   isMutating: boolean;
 }
@@ -70,8 +79,15 @@ export function useBulkActionMutations(
     onSettled: invalidateAll,
   });
 
+  const defer = api.action.bulkDefer.useMutation({
+    onSettled: invalidateAll,
+  });
+
   const isMutating =
-    reschedule.isPending || remove.isPending || assignProject.isPending;
+    reschedule.isPending ||
+    remove.isPending ||
+    assignProject.isPending ||
+    defer.isPending;
 
   return {
     bulkReschedule: ({
@@ -101,6 +117,32 @@ export function useBulkActionMutations(
             notifications.show({
               title: "Reschedule failed",
               message: "Could not reschedule the selected actions.",
+              color: "red",
+            });
+            onError?.();
+          },
+        },
+      );
+    },
+
+    bulkDefer: ({ actionIds, fromOverdue, onSuccess, onError }) => {
+      if (actionIds.length === 0) return;
+      defer.mutate(
+        { actionIds },
+        {
+          onSuccess: (data) => {
+            notifications.show({
+              title: "Back in the backlog",
+              message: `${data.count} action${data.count === 1 ? "" : "s"} no longer counted as overdue. They're still in their projects, just undated.`,
+              color: "green",
+            });
+            if (fromOverdue) markProcessedOverdue.mutate({});
+            onSuccess?.(data);
+          },
+          onError: () => {
+            notifications.show({
+              title: "Could not defer",
+              message: "The selected actions were left unchanged.",
               color: "red",
             });
             onError?.();

--- a/src/app/_components/today-redesign/TodayDesktopShell.tsx
+++ b/src/app/_components/today-redesign/TodayDesktopShell.tsx
@@ -13,6 +13,7 @@ import { useDetailedActionsEnabled } from "~/hooks/useDetailedActionsEnabled";
 import { useDayRollover } from "~/hooks/useDayRollover";
 import { formatRelativeDueAge, hourFloat } from "~/lib/actions/dates";
 import { overdueAnchor } from "~/lib/actions/partition";
+import { groupOverdueCohorts } from "~/lib/actions/triage";
 import type { Action } from "~/lib/actions/types";
 import { CreateActionModal } from "../CreateActionModal";
 import { EditActionModal } from "../EditActionModal";
@@ -141,7 +142,12 @@ export function TodayDesktopShell({
 
   // ---- Mutations -----------------------------------------------------------
   const { updateAction } = useActionMutations({ viewName: "today" });
-  const { bulkReschedule, bulkDelete } = useBulkActionMutations({
+  const {
+    bulkReschedule,
+    bulkDelete,
+    bulkDefer,
+    isMutating: isBulkMutating,
+  } = useBulkActionMutations({
     viewName: "today",
   });
   const handleComplete = (id: string) => {
@@ -265,6 +271,23 @@ export function TodayDesktopShell({
       fromOverdue: true,
     });
   }, [bulkReschedule, partition.overdue]);
+
+  // Most large overdue piles are a few bulk writes, not a lot of missed
+  // commitments. Computed client-side from the same `partition.overdue` the
+  // rows below render, using the same pure function as `action.getOverdueTriage`
+  // and the agent tools — so the page, the endpoint, and Zoe cannot disagree,
+  // and it costs no extra fetch (ADR-0052).
+  const overdueTriage = useMemo(
+    () => groupOverdueCohorts(partition.overdue, { today }),
+    [partition.overdue, today],
+  );
+
+  const handleDeferCohort = useCallback(
+    (actionIds: string[]) => {
+      bulkDefer({ actionIds, fromOverdue: true });
+    },
+    [bulkDefer],
+  );
 
   // ---- Bulk selection -----------------------------------------------------
   const selection = useBulkSelection(
@@ -469,6 +492,48 @@ export function TodayDesktopShell({
                             Reschedule all → Today
                           </button>
                         )}
+                      </div>
+                    )}
+                    {overdueOpen && overdueTriage.cohorts.length > 0 && !bulkMode && (
+                      <div className="td-amnesty">
+                        <p className="td-amnesty__lede">
+                          {overdueTriage.cohortCount} of these{" "}
+                          {overdueTriage.totalOverdue} were created in one go —
+                          they were probably never really due on that date.
+                        </p>
+                        {overdueTriage.cohorts.map((cohort) => (
+                          <div
+                            key={cohort.stampedAt.toISOString()}
+                            className="td-amnesty__cohort"
+                          >
+                            <div className="td-amnesty__detail">
+                              <span className="td-amnesty__count">
+                                {cohort.count} actions
+                              </span>
+                              <span className="td-amnesty__meta">
+                                {cohort.daysOverdue === 1
+                                  ? "dated yesterday"
+                                  : `dated ${cohort.daysOverdue}d ago`}
+                                {cohort.projectNames.length > 0 &&
+                                  ` · ${cohort.projectNames.slice(0, 3).join(", ")}`}
+                                {cohort.projectNames.length > 3 &&
+                                  ` +${cohort.projectNames.length - 3} more`}
+                              </span>
+                            </div>
+                            <button
+                              type="button"
+                              className="td-amnesty__action"
+                              disabled={isBulkMutating}
+                              onClick={() => handleDeferCohort(cohort.actionIds)}
+                            >
+                              Back to backlog
+                            </button>
+                          </div>
+                        ))}
+                        <p className="td-amnesty__note">
+                          Nothing is deleted — they stay in their projects,
+                          just without a date.
+                        </p>
                       </div>
                     )}
                     {overdueOpen &&

--- a/src/app/_components/today-redesign/today-desktop.css
+++ b/src/app/_components/today-redesign/today-desktop.css
@@ -638,3 +638,79 @@ html[data-sidebar="closed"] .td-topbar {
    the redesign. (Used by the original top bar in DoPageContent
    when filter !== 'today'.)
    ============================================================ */
+
+/* ---- Overdue amnesty ----------------------------------------------------
+   Surfaces bulk-written cohorts inside the overdue section. A large overdue
+   count is usually a few batch writes, not a lot of missed commitments, and
+   "Reschedule all → Today" is the wrong move for those — it re-inflicts the
+   pile tomorrow. See ADR-0052. */
+.td-amnesty {
+  padding: 12px 24px 14px;
+  border-bottom: 1px solid var(--td-hair);
+  background: var(--td-prio-urgent-10);
+}
+
+.td-amnesty__lede {
+  margin: 0 0 10px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--td-text);
+}
+
+.td-amnesty__cohort {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 0;
+}
+
+.td-amnesty__detail {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.td-amnesty__count {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--td-text);
+  white-space: nowrap;
+}
+
+.td-amnesty__meta {
+  font-size: 11px;
+  color: var(--td-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.td .td-amnesty__action {
+  margin-left: auto;
+  flex-shrink: 0;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--td-prio-urgent-dim);
+  color: var(--td-prio-urgent);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+}
+
+.td .td-amnesty__action:hover:not(:disabled) {
+  background: var(--td-prio-urgent-10);
+}
+
+.td .td-amnesty__action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.td-amnesty__note {
+  margin: 8px 0 0;
+  font-size: 10.5px;
+  color: var(--td-muted);
+}


### PR DESCRIPTION
### **User description**
## Why

The overdue triage capability from #479 was reachable from the CLI, the SDK, the MCP server, and Zoe — but **not from the page you're looking at when you feel buried.**

`/today` offered exactly one bulk affordance, **"Reschedule all → Today"**, which is the wrong move for most large piles: it moves everything forward 24 hours and re-inflicts it tomorrow.

## What it looks like

The overdue section now leads with the reframe when cohorts exist:

> **9 of these 11 were created in one go** — they were probably never really due on that date.
>
> **6 actions** · dated 10d ago · Net Worth Baseline, Tax Reserve System — `Back to backlog`
> **3 actions** · dated 12d ago · Onionpress Proposal — `Back to backlog`
>
> *Nothing is deleted — they stay in their projects, just without a date.*

Each cohort gets its own button, so you can defer one bulk write without touching the rest. Only rendered when cohorts actually exist, and hidden in bulk-edit mode where the selection toolbar already owns that section.

## One source of truth

Cohorts are computed **client-side** from the same `partition.overdue` the rows below render, via the same `groupOverdueCohorts()` the tRPC endpoint and the agent tools call. So the page, `action.getOverdueTriage`, and Zoe cannot disagree — and it costs **no extra fetch**. That's the ADR-0034 pattern, extended in ADR-0052.

`bulkDefer` joins the bulk mutations hook alongside `bulkReschedule`, with a toast that says the work is still there rather than implying something was thrown away, and fires `markProcessedOverdue` like the other overdue-clearing paths so the daily score recalculates.

Styling reuses the existing `--td-*` tokens — no new colors.

## Testing

Verified in a real authenticated browser against a seeded `dev-fixture` workspace (localhost DB) per `dev-docs/AGENT_VISUAL_TESTING.md`, with two synthetic cohorts (6 + 3) and 2 individually-dated loose actions:

- Panel renders with the correct counts, dates, and project names; loose actions correctly excluded from both cohorts.
- Clicked "Back to backlog" on the 6-action cohort → **overdue 11 → 5**, that cohort disappeared, the lede recalculated to *"3 of these 5 were created in one go"*, and the remaining cohort and both loose items were untouched.
- Confirmed in the database afterwards: all 6 rows still `ACTIVE`, still attached to their projects, with only `dueDate`/`scheduledStart` cleared. Nothing deleted.
- Full unit suite green: **205 files / 1985 tests**. `tsc --noEmit` and eslint clean.

## Not covered

Mobile (`ActionsList.tsx` / `TodayLayout.tsx`) still shows only "Reschedule all → Today". Worth a follow-up — the hook and the pure function are both already shared, so it's markup plus the existing `bulkDefer`.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add bulk-write cohort detection UI to `/today` overdue section

- New `bulkDefer` mutation clears dates, returning actions to project backlogs

- Cohorts computed client-side from shared `partition.overdue` — no extra fetch

- CSS styles added for new amnesty panel using existing `--td-*` tokens


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["partition.overdue"] -- "groupOverdueCohorts()" --> B["Cohorts (bulk writes)"]
  A -- "groupOverdueCohorts()" --> C["Loose actions"]
  B -- "rendered in" --> D["td-amnesty panel"]
  D -- "Back to backlog button" --> E["handleDeferCohort()"]
  E -- "bulkDefer()" --> F["useBulkActionMutations"]
  F -- "api.action.bulkDefer" --> G["Actions cleared of dates"]
  F -- "markProcessedOverdue" --> H["Daily score recalculates"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useBulkActionMutations.ts</strong><dd><code>Add bulkDefer mutation to bulk action mutations hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/actions/hooks/useBulkActionMutations.ts

<ul><li>Add <code>BulkDeferInput</code> interface with <code>actionIds</code>, <code>fromOverdue</code>, and <br>callbacks<br> <li> Add <code>bulkDefer</code> to <code>UseBulkActionMutationsResult</code> interface<br> <li> Wire <code>api.action.bulkDefer</code> mutation with <code>invalidateAll</code> on settled<br> <li> Implement <code>bulkDefer</code> handler with success/error toasts and <br><code>markProcessedOverdue</code> call<br> <li> Include <code>defer.isPending</code> in <code>isMutating</code> flag</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/483/files#diff-acd7c4db9f6159e98b50b08d4c55281038927aa7ddb76739c5dc4a25109e1ef1">+43/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TodayDesktopShell.tsx</strong><dd><code>Render overdue cohort amnesty panel in today view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/today-redesign/TodayDesktopShell.tsx

<ul><li>Import <code>groupOverdueCohorts</code> from triage lib<br> <li> Destructure <code>bulkDefer</code> and <code>isBulkMutating</code> from <code>useBulkActionMutations</code><br> <li> Compute <code>overdueTriage</code> via <code>useMemo</code> from <code>partition.overdue</code><br> <li> Add <code>handleDeferCohort</code> callback wiring cohort action IDs to <code>bulkDefer</code><br> <li> Render <code>td-amnesty</code> panel with cohort list and "Back to backlog" buttons <br>when cohorts exist and not in bulk-edit mode</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/483/files#diff-00486f261f8e0fa50280355f8c7d48001ae5e904fdd67d21ce7ba20060bec597">+66/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>today-desktop.css</strong><dd><code>Add CSS styles for overdue amnesty cohort panel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/today-redesign/today-desktop.css

<ul><li>Add <code>.td-amnesty</code> container styles with background using <br><code>--td-prio-urgent-10</code> token<br> <li> Add <code>.td-amnesty__lede</code>, <code>.td-amnesty__cohort</code>, <code>.td-amnesty__detail</code> layout <br>styles<br> <li> Add <code>.td-amnesty__count</code>, <code>.td-amnesty__meta</code>, <code>.td-amnesty__note</code> <br>typography styles<br> <li> Add <code>.td-amnesty__action</code> button styles with hover and disabled states</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/483/files#diff-45f4d56a944c3cacf41abd758375ac279636bccf7bd58d4d3d52ed7eabbf093d">+76/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

