### PR TITLE
fix: gate assignee writes on workspace membership

### DIFF
--- a/src/plugins/product/server/routers/__tests__/ticket.test.ts
+++ b/src/plugins/product/server/routers/__tests__/ticket.test.ts
@@ -107,6 +107,32 @@ function stubMembership(dbMock: DeepMockProxy<PrismaClient>, isMember: boolean) 
   );
 }
 
+/**
+ * Stub workspace membership *per user*: only `memberIds` belong to
+ * `workspaceId`.
+ *
+ * The plain `stubMembership` above answers the same way for everybody, which
+ * is fine while the caller is the only user being resolved. The assignee guard
+ * resolves a second user through the very same `workspaceUser.findUnique`, so
+ * these tests need a stub that can say "the caller is a member, the assignee
+ * is not" — otherwise the interesting case is unreachable.
+ */
+function stubMembershipByUser(
+  dbMock: DeepMockProxy<PrismaClient>,
+  memberIds: string[],
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dbMock.workspaceUser.findUnique.mockImplementation((args: any) => {
+    const userId = args?.where?.userId_workspaceId?.userId as string | undefined;
+    return Promise.resolve(
+      userId && memberIds.includes(userId)
+        ? { role: "member", workspaceId }
+        : null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) as any;
+  });
+}
+
 /** Stub the product lookup that `loadProductWithAccess` runs. */
 function stubProductLookup(dbMock: DeepMockProxy<PrismaClient>) {
   dbMock.product.findUnique.mockResolvedValue(
@@ -246,5 +272,157 @@ describe("ticket router — cross-workspace link guard (mocked)", () => {
       where: { id: "epic-1" },
       select: { workspaceId: true },
     });
+  });
+});
+
+/**
+ * `assigneeId` is the same class of hole as the epic/feature/cycle/scope links
+ * above, but it resolves to a `User` rather than to a workspace — and
+ * `ticket.getById` returns that user's `name` and `email`. Left unguarded, any
+ * authenticated user could assign an arbitrary CUID to a ticket in their own
+ * product and read a stranger's email straight back out.
+ */
+describe("ticket router — assignee containment guard (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+  const outsiderId = "user-outsider";
+
+  /** Stub the pre-update ticket load in `loadTicketWithAccess`. */
+  function stubTicketLoad(id = "ticket-1") {
+    dbMock.ticket.findUnique.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id, productId, status: "BACKLOG", product: { workspaceId } } as any,
+    );
+  }
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    stubProductLookup(dbMock);
+    // The caller belongs to the workspace; the outsider does not.
+    stubMembershipByUser(dbMock, [callerId]);
+  });
+
+  it("refuses to create a ticket assigned to a non-member", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.ticket.create({
+        productId,
+        title: "Harvest an email",
+        assigneeId: outsiderId,
+      }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Assignee not found in this workspace",
+    });
+
+    expect(dbMock.ticket.create).not.toHaveBeenCalled();
+  });
+
+  it("allows an assignee who belongs to the product's workspace", async () => {
+    stubMembershipByUser(dbMock, [callerId, "user-colleague"]);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    // As with the epic case, the create path continues into
+    // createTicketWithNumber (counter + transaction), which this mock DB does
+    // not model — reaching past the guard is the assertion.
+    await caller.product.ticket
+      .create({ productId, title: "Own colleague", assigneeId: "user-colleague" })
+      .catch((err: unknown) => {
+        expect(err).not.toMatchObject({
+          message: "Assignee not found in this workspace",
+        });
+      });
+  });
+
+  it("admits a team-based member, matching who can read the ticket", async () => {
+    // Not a direct WorkspaceUser, but reachable via a team linked to the
+    // workspace — the second path in getWorkspaceMembership, and the same one
+    // that lets this user read the ticket at all.
+    dbMock.teamUser.findFirst.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { role: "member", team: { workspaceId } } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.product.ticket
+      .create({ productId, title: "Team member", assigneeId: "user-team" })
+      .catch((err: unknown) => {
+        expect(err).not.toMatchObject({
+          message: "Assignee not found in this workspace",
+        });
+      });
+  });
+
+  it("refuses to update a ticket onto a non-member assignee", async () => {
+    stubTicketLoad();
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.ticket.update({ id: "ticket-1", assigneeId: outsiderId }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Assignee not found in this workspace",
+    });
+
+    expect(dbMock.ticket.update).not.toHaveBeenCalled();
+  });
+
+  it("still allows clearing the assignee (null is not a lookup)", async () => {
+    stubTicketLoad();
+    dbMock.ticket.update.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "ticket-1", assigneeId: null } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.product.ticket.update({ id: "ticket-1", assigneeId: null });
+
+    expect(dbMock.ticket.update).toHaveBeenCalled();
+  });
+
+  it("refuses a bulkUpdate that assigns a non-member", async () => {
+    dbMock.ticket.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "ticket-1", status: "BACKLOG", product: { workspaceId } } as any,
+    ]);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.ticket.bulkUpdate({
+        ids: ["ticket-1"],
+        assigneeId: outsiderId,
+      }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Assignee not found in this workspace",
+    });
+
+    expect(dbMock.ticket.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("refuses a bulkUpdate linking an epic from another workspace", async () => {
+    // bulkUpdate writes epicId/cycleId too, and was never covered by the
+    // cross-workspace link guard the create/update paths got.
+    dbMock.ticket.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "ticket-1", status: "BACKLOG", product: { workspaceId } } as any,
+    ]);
+    dbMock.epic.findUnique.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { workspaceId: "ws-other" } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.ticket.bulkUpdate({
+        ids: ["ticket-1"],
+        epicId: "epic-foreign",
+      }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Epic not found in this workspace",
+    });
+
+    expect(dbMock.ticket.updateMany).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -2,7 +2,10 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { loadProductWithAccess, assertWorkspaceMember } from "./product";
-import { assertWorkspaceScopedRefs } from "~/server/services/access";
+import {
+  assertWorkspaceScopedRefs,
+  assertAssignableUser,
+} from "~/server/services/access";
 import type { PrismaClient } from "@prisma/client";
 import { recordActivity } from "~/server/services/activity/recordActivity";
 import { createTicketWithNumber } from "../services/createTicket";
@@ -355,6 +358,15 @@ export const ticketRouter = createTRPCRouter({
         scopeId: input.scopeId,
       });
 
+      // Same reasoning for the assignee, whose name and email come back through
+      // `getById`'s include: only someone who could already read this ticket
+      // may be assigned it.
+      await assertAssignableUser(
+        ctx.db,
+        product.workspaceId,
+        input.assigneeId,
+      );
+
       // If templateId provided, load its body as the starting body (unless body already given)
       let body = input.body;
       if (!body && input.templateId) {
@@ -443,6 +455,12 @@ export const ticketRouter = createTRPCRouter({
           cycleId: input.cycleId,
           scopeId: input.scopeId,
         },
+      );
+
+      await assertAssignableUser(
+        ctx.db,
+        previousTicket.product.workspaceId,
+        input.assigneeId,
       );
 
       const { id, ...rest } = input;
@@ -575,6 +593,18 @@ export const ticketRouter = createTRPCRouter({
       );
       for (const workspaceId of workspaceIds) {
         await assertWorkspaceMember(ctx.db, ctx.session.user.id, workspaceId);
+
+        // The same link and assignee guards as `create`/`update` — this path
+        // writes the identical foreign keys and its tickets are read back
+        // through the identical includes. The patch applies uniformly, so a
+        // reference must be valid in *every* workspace the selection spans.
+        await assertWorkspaceScopedRefs(
+          ctx.db,
+          ctx.session.user.id,
+          workspaceId,
+          { epicId: input.epicId, cycleId: input.cycleId },
+        );
+        await assertAssignableUser(ctx.db, workspaceId, input.assigneeId);
       }
 
       const data: Record<string, unknown> = Object.fromEntries(fields);

--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -626,6 +626,13 @@ describe("action router (mocked)", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
       dbMock.action.create.mockResolvedValue(created);
+      // `create` now verifies membership before writing into an explicit
+      // workspace, so this fixture has to make the caller a member — the
+      // subject under test here is the instrumentation catch, not access.
+      dbMock.workspaceUser.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { userId: callerId, workspaceId: wsId, role: "member" } as any,
+      );
 
       const caller = createMockCaller({ userId: callerId, db: dbMock });
 
@@ -723,6 +730,160 @@ describe("action router (mocked)", () => {
       const where = dbMock.action.findMany.mock.calls[0]![0]!.where!;
       expect(where).toMatchObject({ createdById: callerId });
       expect(where).not.toHaveProperty("OR");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // create — workspace containment
+  // ────────────────────────────────────────────────────────────────────
+  describe("create workspace containment", () => {
+    const callerId = "caller-1";
+    const workspaceId = "w1";
+
+    /** Only `memberIds` belong to `workspaceId`. */
+    function stubMembers(memberIds: string[]) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dbMock.workspaceUser.findUnique.mockImplementation((args: any) => {
+        const userId = args?.where?.userId_workspaceId?.userId as
+          | string
+          | undefined;
+        return Promise.resolve(
+          userId && memberIds.includes(userId)
+            ? { userId, workspaceId, role: "member", joinedAt: new Date() }
+            : null,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ) as any;
+      });
+      dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+    }
+
+    it("refuses to plant an action in a workspace the caller is not in", async () => {
+      // No projectId, so nothing else in `create` ever looks at workspaceId —
+      // it was spread straight into the row, and the `created` activity event
+      // fired into that workspace's feed.
+      stubMembers([]);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await expect(
+        caller.action.create({ name: "Trespass", workspaceId }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      expect(dbMock.action.create).not.toHaveBeenCalled();
+    });
+
+    it("allows a member to create an action in their own workspace", async () => {
+      stubMembers([callerId]);
+      dbMock.action.create.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: "a1", name: "Mine", workspaceId, project: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.create({ name: "Mine", workspaceId });
+
+      expect(dbMock.action.create).toHaveBeenCalled();
+    });
+
+    it("needs no membership probe when no workspaceId is supplied", async () => {
+      dbMock.action.create.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: "a1", name: "Personal", workspaceId: null, project: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.create({ name: "Personal" });
+
+      expect(dbMock.workspaceUser.findUnique).not.toHaveBeenCalled();
+      expect(dbMock.action.create).toHaveBeenCalled();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // assign — assignee containment on project-less, team-less actions
+  // ────────────────────────────────────────────────────────────────────
+  describe("assign assignee containment", () => {
+    const callerId = "caller-1";
+    const workspaceId = "w1";
+    const outsiderId = "user-outsider";
+    const actionId = "a1";
+
+    /** An action with neither project nor team — the branch that used to
+     *  allow assigning literally any user id. */
+    function stubUnscopedAction(opts?: { workspaceId?: string | null }) {
+      dbMock.action.findUnique.mockResolvedValue({
+        id: actionId,
+        name: "Loose end",
+        projectId: null,
+        project: null,
+        teamId: null,
+        team: null,
+        workspaceId: opts?.workspaceId ?? null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      // Caller passes buildActionAccessWhere (they created it).
+      dbMock.action.findFirst.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: actionId } as any,
+      );
+    }
+
+    it("refuses an arbitrary user id, which used to leak their email back", async () => {
+      stubUnscopedAction();
+      dbMock.workspaceUser.findUnique.mockResolvedValue(null as never);
+      dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+      dbMock.team.findFirst.mockResolvedValue(null as never);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await expect(
+        caller.action.assign({ actionId, userIds: [outsiderId] }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+      expect(dbMock.actionAssignee.createMany).not.toHaveBeenCalled();
+    });
+
+    it("does not name the rejected user in the error", async () => {
+      stubUnscopedAction();
+      dbMock.workspaceUser.findUnique.mockResolvedValue(null as never);
+      dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+      dbMock.team.findFirst.mockResolvedValue(null as never);
+      // If the router still looked the user up to build the message, this
+      // identity would end up in the error string.
+      dbMock.user.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { name: "Ada Lovelace", email: "ada@example.com" } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const err = await caller.action
+        .assign({ actionId, userIds: [outsiderId] })
+        .catch((e: unknown) => e);
+
+      expect(String((err as Error).message)).not.toContain("ada@example.com");
+      expect(String((err as Error).message)).not.toContain("Ada Lovelace");
+    });
+
+    it("still allows a member of the action's workspace", async () => {
+      stubUnscopedAction({ workspaceId });
+      dbMock.workspaceUser.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { role: "member", workspaceId } as any,
+      );
+      dbMock.actionAssignee.findMany.mockResolvedValue([]);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.assign({ actionId, userIds: ["user-colleague"] });
+
+      expect(dbMock.actionAssignee.createMany).toHaveBeenCalled();
+    });
+
+    it("still allows self-assignment on a context-less action", async () => {
+      stubUnscopedAction();
+      dbMock.actionAssignee.findMany.mockResolvedValue([]);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.assign({ actionId, userIds: [callerId] });
+
+      expect(dbMock.actionAssignee.createMany).toHaveBeenCalled();
     });
   });
 });

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -11,7 +11,7 @@ import { ScoringService } from "~/server/services/ScoringService";
 import { startOfDay } from "date-fns";
 import { validateScheduledTimes } from "~/lib/dateUtils";
 import { findUserByEmailInWorkspace, getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
-import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs } from "~/server/services/access";
+import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs, canAssignToUnscopedAction } from "~/server/services/access";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import { uploadToBlob } from "~/lib/blob";
 import { emitNotification } from "~/server/services/notifications/emit/emitNotification";
@@ -434,6 +434,26 @@ export const actionRouter = createTRPCRouter({
           nextKanbanOrder = maxOrderAcrossBoard.kanbanOrder + 1;
         } else {
           nextKanbanOrder = 1;
+        }
+      }
+
+      // `input.workspaceId` is spread straight into the create below, so an
+      // unchecked value plants the action — and the `created` activity event
+      // fired for it further down — inside a workspace the caller has no
+      // relationship to, where that workspace's members then see it in their
+      // feed. The project branch above only gates the *project*; when no
+      // projectId is supplied nothing else looks at this field at all.
+      if (input.workspaceId) {
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          ctx.session.user.id,
+          input.workspaceId,
+        );
+        if (!membership) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "You don't have access to this workspace",
+          });
         }
       }
 
@@ -1799,21 +1819,28 @@ export const actionRouter = createTRPCRouter({
             (member: { userId: string }) => member.userId === userId,
           );
         }
-        // No project or team - allow assignment to any user
+        // No project and no team: this used to allow assigning ANY user id,
+        // and the include below returns `user.email` — the same PII leak the
+        // ticket assignee guard closes. Fall back to the action's workspace
+        // and the caller's teams, which is exactly what the picker offers.
         else {
-          canAssign = true;
+          canAssign = await canAssignToUnscopedAction(
+            ctx.db,
+            ctx.session.user.id,
+            action.workspaceId,
+            userId,
+          );
         }
 
         if (!canAssign) {
-          const user = await ctx.db.user.findUnique({
-            where: { id: userId },
-            select: { name: true, email: true },
+          // Deliberately does NOT name the rejected user. The old message
+          // looked them up and echoed `name ?? email` back, which handed the
+          // caller a stranger's identity on exactly the path where they had
+          // just been told they have no relationship to them.
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: `Assignee not found in this ${action.projectId ? "project" : action.teamId ? "team" : "workspace"}`,
           });
-          const userName = user?.name ?? user?.email ?? userId;
-
-          throw new Error(
-            `User ${userName} cannot be assigned to this action. They must be a member of the ${action.projectId ? "project" : "team"}.`,
-          );
         }
       }
 
@@ -2007,21 +2034,24 @@ export const actionRouter = createTRPCRouter({
               (member: { userId: string }) => member.userId === userId,
             );
           }
-          // No project or team - allow assignment to any user
+          // Same fallback as `assign`: no project and no team means the
+          // action's workspace and the caller's teams decide, not "anyone".
           else {
-            canAssign = true;
+            canAssign = await canAssignToUnscopedAction(
+              ctx.db,
+              ctx.session.user.id,
+              action.workspaceId,
+              userId,
+            );
           }
 
           if (!canAssign) {
-            const user = await ctx.db.user.findUnique({
-              where: { id: userId },
-              select: { name: true, email: true },
+            // Names the action (the caller owns it) but never the rejected
+            // user — see the matching guard in `assign`.
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: `Assignee not found in this ${action.projectId ? "project" : action.teamId ? "team" : "workspace"} (action "${action.name}")`,
             });
-            const userName = user?.name ?? user?.email ?? userId;
-
-            throw new Error(
-              `User ${userName} cannot be assigned to action "${action.name}". They must be a member of the ${action.projectId ? "project" : "team"}.`,
-            );
           }
         }
       }

--- a/src/server/services/access/__tests__/assignability.test.ts
+++ b/src/server/services/access/__tests__/assignability.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for the assignability guards.
+ *
+ * Sibling to workspaceRefs.test.ts. `assigneeId` opens the same kind of
+ * sideways read path as the epic/feature/cycle/scope links, except the row it
+ * points at is a `User` — and the includes on `ticket.getById` and
+ * `action.assign` return that user's `name` and `email`. The rule under test:
+ * you may only assign someone who could already read the thing.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import {
+  assertAssignableUser,
+  canAssignToUnscopedAction,
+} from "../assignability";
+
+const CALLER_ID = "user-caller";
+const MEMBER_ID = "user-member";
+const OUTSIDER_ID = "user-outsider";
+const WORKSPACE_ID = "ws-1";
+
+/** Only `memberIds` hold a direct WorkspaceUser row for WORKSPACE_ID. */
+function stubDirectMembers(
+  db: DeepMockProxy<PrismaClient>,
+  memberIds: string[],
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db.workspaceUser.findUnique.mockImplementation((args: any) => {
+    const userId = args?.where?.userId_workspaceId?.userId as string | undefined;
+    return Promise.resolve(
+      userId && memberIds.includes(userId)
+        ? { role: "member", workspaceId: WORKSPACE_ID }
+        : null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) as any;
+  });
+}
+
+describe("assertAssignableUser", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = mockDeep<PrismaClient>();
+    mockReset(db);
+  });
+
+  it("skips null/undefined so unassigning stays allowed", async () => {
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, null),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, undefined),
+    ).resolves.toBeUndefined();
+    expect(db.workspaceUser.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("accepts a direct workspace member", async () => {
+    stubDirectMembers(db, [MEMBER_ID]);
+
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, MEMBER_ID),
+    ).resolves.toBeUndefined();
+  });
+
+  it("accepts a team-based member — the same path that lets them read", async () => {
+    stubDirectMembers(db, []);
+    db.teamUser.findFirst.mockResolvedValue({
+      role: "member",
+      team: { workspaceId: WORKSPACE_ID },
+    } as never);
+
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, MEMBER_ID),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a user with no membership at all", async () => {
+    stubDirectMembers(db, []);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, OUTSIDER_ID),
+    ).rejects.toBeInstanceOf(TRPCError);
+  });
+
+  it("rejects as NOT_FOUND, so the error is not an existence oracle", async () => {
+    stubDirectMembers(db, []);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, OUTSIDER_ID),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Assignee not found in this workspace",
+    });
+  });
+
+  it("rejects a workspace guest: project-only access cannot read tickets", async () => {
+    // A guest has a ProjectMember row but no WorkspaceUser and no team, so
+    // getWorkspaceMembership returns null — deliberately, since the same
+    // resolver gates every ticket read.
+    stubDirectMembers(db, []);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+    db.projectMember.findFirst.mockResolvedValue({ id: "pm-1" } as never);
+
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, OUTSIDER_ID),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});
+
+describe("canAssignToUnscopedAction", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = mockDeep<PrismaClient>();
+    mockReset(db);
+  });
+
+  it("always allows self-assignment, even with no workspace", async () => {
+    await expect(
+      canAssignToUnscopedAction(db, CALLER_ID, null, CALLER_ID),
+    ).resolves.toBe(true);
+    expect(db.team.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("allows a member of the action's workspace", async () => {
+    stubDirectMembers(db, [MEMBER_ID]);
+
+    await expect(
+      canAssignToUnscopedAction(db, CALLER_ID, WORKSPACE_ID, MEMBER_ID),
+    ).resolves.toBe(true);
+  });
+
+  it("allows a user who shares a team with the caller", async () => {
+    stubDirectMembers(db, []);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+    db.team.findFirst.mockResolvedValue({ id: "team-1" } as never);
+
+    await expect(
+      canAssignToUnscopedAction(db, CALLER_ID, null, MEMBER_ID),
+    ).resolves.toBe(true);
+  });
+
+  it("refuses a stranger — no workspace, no shared team", async () => {
+    stubDirectMembers(db, []);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+    db.team.findFirst.mockResolvedValue(null as never);
+
+    await expect(
+      canAssignToUnscopedAction(db, CALLER_ID, null, OUTSIDER_ID),
+    ).resolves.toBe(false);
+  });
+
+  it("refuses a stranger even when the action has a workspace", async () => {
+    stubDirectMembers(db, [CALLER_ID]);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+    db.team.findFirst.mockResolvedValue(null as never);
+
+    await expect(
+      canAssignToUnscopedAction(db, CALLER_ID, WORKSPACE_ID, OUTSIDER_ID),
+    ).resolves.toBe(false);
+  });
+});

--- a/src/server/services/access/assignability.ts
+++ b/src/server/services/access/assignability.ts
@@ -1,0 +1,105 @@
+/**
+ * Assignability guards.
+ *
+ * Sibling to `workspaceRefs.ts`: same class of hole, different target. A write
+ * that accepts a foreign key opens a *read* path, because the pointed-at row's
+ * fields come back inside the pointing row's own `include`.
+ *
+ * For `assigneeId` the pointed-at row is a `User`, and the include returns
+ * `name` and `email`. So without this guard an authenticated user can create a
+ * ticket in their own product, set `assigneeId` to an arbitrary user CUID, read
+ * the ticket back through `ticket.getById`, and harvest that user's email — a
+ * user-enumeration / PII disclosure path that needs only a valid CUID.
+ *
+ * The rule, one line: **you may only assign someone who could already read the
+ * thing you are assigning them to.** Assignment is not a capability grant — it
+ * cannot reach further than the reader set, or it becomes a way to pull a
+ * stranger's identity into a workspace they have nothing to do with.
+ *
+ * Two consequences worth stating, because both were open questions:
+ *
+ *  - **Workspace guests are not assignable to tickets.** A guest (project-only
+ *    `ProjectMember`, no `WorkspaceUser` row) is refused by
+ *    `getWorkspaceMembership`, which is the same resolver behind
+ *    `assertWorkspaceMember` — the gate on every ticket read. A guest therefore
+ *    cannot open the ticket at all, so assigning one is both useless and a
+ *    leak. Excluding them keeps the assignable set a subset of the reader set.
+ *  - **External-agent shadow users need no exception.** ADR-0049 gives each
+ *    agent's shadow user ordinary `WorkspaceUser` rows, granted by the owner,
+ *    so they pass through `getWorkspaceMembership` unchanged.
+ *
+ * Rejections are NOT_FOUND rather than FORBIDDEN so the error cannot be used as
+ * an oracle confirming that a given CUID belongs to a real user somewhere.
+ */
+
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+import { getWorkspaceMembership } from "./resolvers/workspaceResolver";
+
+/**
+ * Throw unless `assigneeId` may be assigned work inside `workspaceId`.
+ *
+ * A `null` or `undefined` assignee means "not being set" (or "being cleared")
+ * and is skipped — unassigning is always allowed.
+ *
+ * Used by the ticket router, where the workspace is never ambiguous: a ticket's
+ * workspace comes from its product. Actions, whose scope can be a project, a
+ * team, or nothing at all, use `canAssignToUnscopedAction` below.
+ */
+export async function assertAssignableUser(
+  db: PrismaClient,
+  workspaceId: string,
+  assigneeId: string | null | undefined,
+): Promise<void> {
+  if (!assigneeId) return;
+
+  const membership = await getWorkspaceMembership(db, assigneeId, workspaceId);
+  if (!membership) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Assignee not found in this workspace",
+    });
+  }
+}
+
+/**
+ * May `candidateId` be assigned to an action that has neither a project nor a
+ * team?
+ *
+ * `action.assign` validates candidates against the action's project or team,
+ * but fell through to an unconditional `true` when the action had neither —
+ * and then returned `assignees.user.email`, reopening the same leak.
+ *
+ * The replacement mirrors exactly what `getAssignableUsers` offers the picker
+ * for such an action, so the server enforces what the UI already presents:
+ * yourself (1), members of the action's workspace (2), and users who share a
+ * team with you (3). Nothing wider.
+ */
+export async function canAssignToUnscopedAction(
+  db: PrismaClient,
+  callerId: string,
+  workspaceId: string | null,
+  candidateId: string,
+): Promise<boolean> {
+  // 1. Self-assignment is always legitimate and leaks nothing new.
+  if (candidateId === callerId) return true;
+
+  // 2. Members of the action's own workspace, when it has one.
+  if (workspaceId) {
+    const membership = await getWorkspaceMembership(db, candidateId, workspaceId);
+    if (membership) return true;
+  }
+
+  // 3. Users who share a team with the caller — the picker's fallback for an
+  //    action with no workspace context at all.
+  const sharedTeam = await db.team.findFirst({
+    where: {
+      AND: [
+        { members: { some: { userId: candidateId } } },
+        { members: { some: { userId: callerId } } },
+      ],
+    },
+    select: { id: true },
+  });
+  return sharedTeam !== null;
+}

--- a/src/server/services/access/index.ts
+++ b/src/server/services/access/index.ts
@@ -107,3 +107,9 @@ export type { KnowledgePageAccessInfo } from "./resolvers/knowledgePageResolver"
 // Cross-workspace link guards (epic/feature/cycle/scope foreign keys)
 export { assertWorkspaceScopedRefs } from "./workspaceRefs";
 export type { WorkspaceScopedRefs } from "./workspaceRefs";
+
+// Assignability guards (assigneeId / ActionAssignee foreign keys to User)
+export {
+  assertAssignableUser,
+  canAssignToUnscopedAction,
+} from "./assignability";


### PR DESCRIPTION
### **User description**
Follow-up to #481 (now merged), which deliberately left `assigneeId` out of scope. Rebased onto `main`.

## The leak

`ticket.create` / `update` / `bulkUpdate` accept any user CUID as `assigneeId` and write it through unchecked. `ticket.getById` then returns:

```ts
assignee: { select: { id: true, name: true, email: true, image: true } }
```

…and gates that read only on the **caller's** membership in the ticket's product workspace — never the assignee's. So any authenticated user can create a ticket in their own product, set `assigneeId` to an arbitrary CUID, read it back, and harvest a stranger's name and email. User enumeration needing nothing but a valid id.

`assigneeId` was left out of #481 because it resolves to a `User` rather than to a workspace, so the containment rule `assertWorkspaceScopedRefs` applies doesn't answer it.

## The rule, and why it wasn't mine to invent

The open question was "is this user allowed to be assigned here", with guests and agent shadow users flagged as needing a deliberate call. It turned out the codebase had **already decided**, in two places that both bypass these routers:

- `ticketSync/resolvers.ts:94` (`resolveAssigneeIdByEmail`) requires a `WorkspaceUser` row in the ticket's workspace before it will resolve an assignee.
- `workspaceResolver.ts:168` (`findUserByEmailInWorkspace`) does the same for the agent integration.
- The ticket assignee picker offers exactly `workspace.members`.

So `assertAssignableUser` doesn't introduce a policy — it makes the routers obey the one the rest of the codebase already applies:

> **You may only assign someone who could already read the thing you're assigning them to.**

Assignment is not a capability grant. It must not reach past the reader set, or it becomes a way to pull a stranger's identity into a workspace they have nothing to do with.

Both flagged sub-questions fall out of that rather than needing a separate ruling:

- **Workspace guests are not assignable.** `getWorkspaceMembership` is the same resolver behind `assertWorkspaceMember`, the gate on every ticket read — a project-only guest can't open the ticket at all, so assigning one is both useless and a leak.
- **Agent shadow users need no exception.** ADR-0049 (§48-49) gives them ordinary `WorkspaceUser` rows, so they pass through unchanged.

The guard accepts direct-OR-team membership, slightly wider than the picker's direct-only list — deliberately, since team members *can* read tickets.

## Three adjacent holes found in the same pass

1. **`ticket.bulkUpdate` never got #481's link guard.** It writes `epicId`/`cycleId` too, leaving the original epic leak reachable through the bulk path. Now guarded.
2. **`action.create` plants actions in arbitrary workspaces.** `input.workspaceId` is spread straight into the row, and when no `projectId` is supplied *nothing* checks it — including the `created` activity event, which lands in that workspace's feed for its members to see. (Confirms the suspicion raised alongside the report.)
3. **`action.assign` / `bulkAssign` fell through to `canAssign = true`** for an action with neither project nor team, and return `assignees.user.email` — the same leak by another route. Worse: the rejection path looked the *refused* user up and echoed `name ?? email` into the error string, handing over an identity precisely when telling the caller they have no relationship to it. Both now defer to the action's workspace and the caller's shared teams, mirroring what `getAssignableUsers` already offers the picker; the message no longer names anyone.

Rejections are `NOT_FOUND`, matching #481's reasoning: the error must not confirm a CUID belongs to a real user somewhere.

## Tests

19 new unit tests — `assignability.test.ts` for the guard, plus router-level blocks in `ticket.test.ts` (following #481's `cross-workspace link guard` block) and `action.test.ts`.

Each refusal test was **negative-controlled**: with the guard stubbed out, exactly the 3 ticket-assignee tests and the bulkUpdate-epic test fail, while the permissive ones ("allows a member", "team member", "clearing the assignee", "self-assignment") keep passing. So they pin the guard rather than passing incidentally.

One test asserts the error does *not* contain a planted `Ada Lovelace` / `ada@example.com`, covering the echo regression directly.

Full suite: **2031 unit tests across 208 files pass**; `tsc --noEmit` clean; eslint clean.

One pre-existing fixture needed updating — `does not break action.create when recordActivity rejects` created an action in a workspace without ever establishing membership, which is exactly the hole closed here. It now stubs membership; the subject under test (the instrumentation `.catch`) is unchanged.

## Note

No ADR: the module docstring in `assignability.ts` carries the reasoning, matching the precedent `workspaceRefs.ts` set in #481, and per CLAUDE.md's "sparingly" bar the trade-off was already resolved in the codebase rather than newly decided here. Happy to add one if you'd rather have the guest exclusion recorded more visibly.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Gate `assigneeId` writes on workspace membership to prevent email/PII harvesting via ticket/action includes

- Fix `action.assign`/`bulkAssign` to replace unconditional `canAssign = true` with `canAssignToUnscopedAction` check

- Guard `action.create` workspace field: planting actions in foreign workspaces now blocked

- Add `assertAssignableUser` and `canAssignToUnscopedAction` services with comprehensive unit tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ticket.create / update / bulkUpdate"]
  B["action.create"]
  C["action.assign / bulkAssign"]
  D["assertAssignableUser"]
  E["canAssignToUnscopedAction"]
  F["getWorkspaceMembership"]
  G["PII leak blocked"]

  A -- "assigneeId guard" --> D
  B -- "workspaceId membership check" --> F
  C -- "no-project/team fallback" --> E
  D -- "uses" --> F
  E -- "uses" --> F
  D --> G
  E --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>assignability.ts</strong><dd><code>New assignability guard service for tickets and actions</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/484/files#diff-bdbb80f0cf7e89b02f6ebbd79c1a83be82c9f3c287b36b0bd06f631f868f0c06">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ticket.ts</strong><dd><code>Add assignee containment guard to create, update, bulkUpdate</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/484/files#diff-2c667429b802690451b0f2771795cba4b39b00fb9a8b2cca853b1f95497032c5">+31/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>action.ts</strong><dd><code>Guard workspace write and fix unconditional assignee allow</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/484/files#diff-5b198a3cc9e3495e32e4dcdf28771f225d15998a0c3ab9de63ef7f12941d1dbb">+51/-21</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>index.ts</strong><dd><code>Export new assignability guard functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/484/files#diff-74fa8db7237706b8a79d9f10fdaee87b9805928dd72cb942e4b2d489a2215dc3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>assignability.test.ts</strong><dd><code>New unit tests for assignability guard functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/484/files#diff-fd77abbdd831cdaba905d58c6337714078a27ada3c19c689fff0a5815beb4751">+168/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ticket.test.ts</strong><dd><code>Add assignee containment and bulkUpdate guard tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/484/files#diff-66527097b6bcfccf7a0834b7eb1748adc3c1d1c4757849b6b03fcd4a6da75849">+178/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>action.test.ts</strong><dd><code>Add workspace containment and assignee guard tests for actions</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/484/files#diff-1f49e232606ea60cceb17f43536f374c6e1ad7e88b96115c502088f6e4556999">+161/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

