### PR TITLE
fix(ui): let the workspace crumb clear the sidebar re-open button

### DIFF
--- a/e2e/topbar-crumb.spec.ts
+++ b/e2e/topbar-crumb.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+
+const FIRST_PAINT_TIMEOUT = 60_000;
+
+/**
+ * Collapsed, the sidebar's re-open button is fixed in the top-left corner and
+ * the workspace crumb starts in that same gutter. With the topbar's default
+ * 40px padding the two overlapped (the folder icon began 4px *inside* the
+ * button's box); the crumb has to give it room.
+ */
+test("collapsed sidebar: the crumb clears the re-open button", async ({ page }) => {
+  await page.goto("/w/dev-fixture/projects");
+  await expect(page.getByText("Dev Fixture").first()).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  await page.getByLabel("Collapse menu").click();
+  const toggle = page.getByLabel("Open sidebar");
+  await toggle.waitFor();
+  // The crumb slides across on the same 300ms transition as the collapse.
+  await page.waitForTimeout(600);
+
+  // The crumb's leading folder icon is the left-most thing in the topbar.
+  const toggleBox = await toggle.boundingBox();
+  const crumbBox = await page.locator("svg.tabler-icon-folder").first().boundingBox();
+  expect(toggleBox).not.toBeNull();
+  expect(crumbBox).not.toBeNull();
+  expect(crumbBox!.x).toBeGreaterThanOrEqual(toggleBox!.x + toggleBox!.width);
+
+  await test.info().attach("collapsed-topbar", {
+    body: await page.screenshot({ clip: { x: 0, y: 0, width: 640, height: 120 } }),
+    contentType: "image/png",
+  });
+});

--- a/src/app/_components/layout/WorkspaceTopbar.module.css
+++ b/src/app/_components/layout/WorkspaceTopbar.module.css
@@ -6,6 +6,20 @@
   border-bottom: 1px solid var(--color-border-primary);
   flex-shrink: 0;
   gap: 8px;
+  /* Matches the 300ms sidebar collapse, so the crumb slides across with it
+     instead of jumping when the gutter below appears/disappears. */
+  transition: padding-left 300ms ease-in-out;
+}
+
+/* Collapsed, the sidebar's re-open button parks in this row's left gutter
+   (fixed, 12px from the viewport edge, ~32px wide) and the 40px padding
+   leaves the crumb almost touching it. On sm+ the topbar is edge-to-edge,
+   so it owns that corner and has to give the button its own space; below
+   640px <main>'s own padding already keeps the two apart. */
+@media (min-width: 640px) {
+  :global(html[data-sidebar='closed']) .topbar {
+    padding-left: 60px;
+  }
 }
 
 .crumb {


### PR DESCRIPTION
### **User description**
## What

Collapsed, the sidebar's re-open button is `fixed` 12px from the viewport edge and ~32px wide (ending at x=44), while the topbar's `padding: 0 40px` started the crumb's folder icon at **x=40** — 4px *inside* the button's box. The row read as cramped, and the hamburger's hover target ran under the crumb.

Reported against a page-detail route (`/w/{slug}/pages/{id}`), but it affects every workspace route with the sidebar collapsed.

## Fix

`WorkspaceTopbar.module.css`: give the button its own gutter (60px) whenever `html[data-sidebar="closed"]`, on the same 300ms transition as the collapse so the crumb slides across rather than snapping.

Scoped to `min-width: 640px`, where `.wrapper`'s negative margins make the topbar edge-to-edge and it owns the corner. Below 640px, `<main>`'s own 16px padding already keeps the two apart.

## Verification

Measured in the browser against the seeded `dev-fixture` workspace:

| | folder icon x | gap from the button's box |
|---|---|---|
| before | 40 | **−4px (overlapping)** |
| after | 60 | +16px |

Sidebar-open geometry is unchanged (the toggle is hidden then, and the padding stays 40px).

Adds `e2e/topbar-crumb.spec.ts`, which collapses the sidebar and asserts the crumb starts past the button's right edge — so a future padding change can't silently reintroduce the overlap. It fails on the pre-fix CSS.

Lint, `tsc --noEmit`, and the unit suite all pass.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix crumb overlapping sidebar re-open button in collapsed state

- Add 60px left padding on `sm+` when sidebar is closed, with 300ms transition

- Add E2E test asserting crumb clears the toggle button's bounding box


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sidebar collapsed\n(data-sidebar='closed')"]
  B["Topbar padding-left: 40px\n(overlapping button)"]
  C["Topbar padding-left: 60px\n(300ms transition, sm+)"]
  D["Crumb clears re-open button\n(+16px gap)"]
  A -- "before fix" --> B
  A -- "after fix" --> C
  C -- "result" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WorkspaceTopbar.module.css</strong><dd><code>Increase topbar left padding when sidebar is collapsed</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/layout/WorkspaceTopbar.module.css

<ul><li>Add <code>transition: padding-left 300ms ease-in-out</code> to <code>.topbar</code> for smooth <br>crumb movement<br> <li> Add <code>@media (min-width: 640px)</code> block that sets <code>padding-left: 60px</code> when <br><code>html[data-sidebar='closed']</code><br> <li> Scoped to <code>sm+</code> breakpoint where topbar is edge-to-edge and owns the <br>top-left corner</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/485/files#diff-501873cc092689ba177f70a73db57f18484c8dcea8ac01b52fc14033a4517d66">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>topbar-crumb.spec.ts</strong><dd><code>E2E test verifying crumb clears collapsed sidebar button</code>&nbsp; </dd></summary>
<hr>

e2e/topbar-crumb.spec.ts

<ul><li>New Playwright E2E test that navigates to a workspace route and <br>collapses the sidebar<br> <li> Asserts the crumb's folder icon <code>x</code> position is at or past the toggle <br>button's right edge<br> <li> Attaches a screenshot of the collapsed topbar as a test artifact</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/485/files#diff-732eec2bb9843de871493c023ffbca2a8b946cd77a1e75acf166c1412f98b42f">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

