### PR TITLE
Pages open in a reading column, with a full-width toggle

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { Skeleton, Text, TextInput } from '@mantine/core';
+import { ActionIcon, Skeleton, Text, TextInput, Tooltip } from '@mantine/core';
+import { useLocalStorage } from '@mantine/hooks';
+import { IconViewportNarrow, IconViewportWide } from '@tabler/icons-react';
 import type { JSONContent } from '@tiptap/core';
 import { api } from '~/trpc/react';
 import { PageDocument } from '~/app/_components/pages/PageDocument';
@@ -80,6 +82,12 @@ function PageTitle({
   );
 }
 
+/** Reading-column width preference. Pages default to the same centred column
+ * the published (/p/...) render uses; "Full width" is the opt-in. Stored per
+ * browser (not on the page) so it stays a reader-side view preference rather
+ * than something one editor imposes on everyone. */
+const FULL_WIDTH_STORAGE_KEY = 'pages:full-width';
+
 function PageEditorContent({
   pageId,
   workspaceSlug,
@@ -88,6 +96,11 @@ function PageEditorContent({
   workspaceSlug: string;
 }) {
   const { data: page, isLoading, error } = api.page.get.useQuery({ id: pageId });
+  const [fullWidth, setFullWidth] = useLocalStorage({
+    key: FULL_WIDTH_STORAGE_KEY,
+    defaultValue: false,
+  });
+  const widthClass = fullWidth ? 'w-full' : 'mx-auto w-full max-w-3xl';
   const utils = api.useUtils();
   const editorHandleRef = useRef<RichDocEditorHandle | null>(null);
 
@@ -120,7 +133,7 @@ function PageEditorContent({
 
   if (isLoading) {
     return (
-      <div className="w-full px-6 py-8">
+      <div className={`${widthClass} px-6 py-8`}>
         <Skeleton height={36} width={320} mb="xl" />
         <Skeleton height={400} />
       </div>
@@ -129,7 +142,7 @@ function PageEditorContent({
 
   if (error || !page) {
     return (
-      <div className="w-full px-6 py-8">
+      <div className={`${widthClass} px-6 py-8`}>
         <Text className="text-text-secondary">
           {error?.data?.code === 'FORBIDDEN'
             ? "You don't have access to this page."
@@ -140,12 +153,31 @@ function PageEditorContent({
   }
 
   return (
-    <div className="w-full px-6 py-8">
+    <div className={`${widthClass} px-6 py-8`}>
       <div className="mb-4 flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
           <PageTitle pageId={page.id} initialTitle={page.title} editable={page.canEdit} />
         </div>
         <div className="flex items-center gap-2">
+          <Tooltip label={fullWidth ? 'Use narrow width' : 'Use full width'}>
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              aria-label={fullWidth ? 'Use narrow width' : 'Use full width'}
+              aria-pressed={fullWidth}
+              // Value form, not the updater form: Mantine's setter writes to
+              // localStorage *inside* the state updater, and React replays
+              // updaters, which would persist the toggle a second time and
+              // land back on the old value.
+              onClick={() => setFullWidth(!fullWidth)}
+            >
+              {fullWidth ? (
+                <IconViewportNarrow size={18} />
+              ) : (
+                <IconViewportWide size={18} />
+              )}
+            </ActionIcon>
+          </Tooltip>
           <FavoriteButton
             entityType="page"
             entityId={`pages/${page.id}`}


### PR DESCRIPTION
### **User description**
## What

Knowledge Pages (`/w/[workspace]/pages/[id]`) rendered edge-to-edge, so long prose ran the full width of the window. They now default to the same centred `max-w-3xl` column the published `/p/...` render already uses, and a toggle in the page header restores full width for wide content (tables, boards).

- Toggle sits left of the favourite star: **Use full width** ⇄ **Use narrow width** (`IconViewportWide` / `IconViewportNarrow`), with `aria-pressed` reflecting state.
- The choice persists in `localStorage` under `pages:full-width` and applies to every page in that browser — a reader-side view preference, not a page property, so one editor can't impose a layout on everyone else. (Happy to promote it to a per-page column on the `KnowledgePage` model if we'd rather it travel with the doc — that needs a migration.)
- Loading and error states use the same column so the width doesn't jump on load.

## Gotcha worth knowing

The toggle uses the **value** form of Mantine's `useLocalStorage` setter, not the updater form. `createStorage` performs its `localStorage.setItem` *inside* the state updater, and React replays updaters — so `setFullWidth(prev => !prev)` wrote `true`, then the replay wrote `false`, and the layout never changed. Found while verifying in the browser; there's a comment at the call site so it doesn't get "tidied" back.

## Verification

Against the running dev server with the `dev-fixture` workspace:

- new page renders in the centred column by default (DOM: `mx-auto w-full max-w-3xl px-6 py-8`)
- toggle → `w-full`, full-width layout, icon and tooltip flip
- toggle back → centred column again
- preference persists to `localStorage` and survives a reload

`npx tsc --noEmit` and `eslint` clean for the changed file.

No schema changes, no migration.


___

### **PR Type**
Enhancement


___

### **Description**
- Pages now default to a centred `max-w-3xl` reading column

- Full-width toggle added to page header with icon and tooltip

- Width preference persisted in `localStorage` as reader-side setting

- Loading and error states also respect the width preference


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["localStorage\n'pages:full-width'"] -- "useLocalStorage hook" --> B["fullWidth state"]
  B -- "false (default)" --> C["mx-auto w-full max-w-3xl\n(reading column)"]
  B -- "true" --> D["w-full\n(full width)"]
  E["ActionIcon toggle\n(IconViewportWide / IconViewportNarrow)"] -- "onClick setFullWidth(!fullWidth)" --> B
  C -- "applied to" --> F["loading / error / content divs"]
  D -- "applied to" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add centred reading column and full-width toggle to page editor</code></dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx

<ul><li>Added <code>useLocalStorage</code> hook to persist full-width preference under <br><code>pages:full-width</code> key<br> <li> Computed <code>widthClass</code> toggling between <code>mx-auto w-full max-w-3xl</code> and <br><code>w-full</code><br> <li> Applied <code>widthClass</code> to loading, error, and main content container divs<br> <li> Added <code>ActionIcon</code> toggle with <code>Tooltip</code>, <code>aria-pressed</code>, and <br><code>IconViewportWide</code>/<code>IconViewportNarrow</code> icons in the page header<br> <li> Added explanatory comment about using value form (not updater form) of <br>the Mantine setter to avoid React replay double-write bug</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/486/files#diff-6b79b72a995acbd10cc157f1131181cd7ed46fc478f1fd996884e2c162db08b2">+36/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

