### PR TITLE
fix: gate action create/update writes on workspace membership

### DIFF
--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -1052,6 +1052,34 @@ describe("action router (mocked)", () => {
         expect(dbMock.action.update).not.toHaveBeenCalled();
       });
 
+      it("refuses moving an action into a project the caller can't edit (epic guard unreached)", async () => {
+        // Regression guard for ordering: the project check must fire before
+        // anything downstream consumes the re-targeted workspace.
+        stubOwnedAction();
+        dbMock.project.findUnique.mockResolvedValue({
+          createdById: "someone-else",
+          teamId: null,
+          workspaceId: "w-foreign",
+          isPublic: false,
+          isRestricted: false,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        dbMock.projectMember.findFirst.mockResolvedValue(null);
+        stubNoMembership();
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+        await expect(
+          caller.action.update({
+            id: "a1",
+            projectId: "p-foreign",
+            epicId: "e-foreign",
+          }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        expect(dbMock.action.update).not.toHaveBeenCalled();
+      });
+
       it("allows clearing the workspace without a membership probe", async () => {
         // Detaching an action the caller can already edit grants no access.
         stubOwnedAction();
@@ -1063,6 +1091,52 @@ describe("action router (mocked)", () => {
 
         expect(dbMock.action.update).toHaveBeenCalled();
         expect(dbMock.workspaceUser.findUnique).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("ensureDailyPlanPromptAction", () => {
+      it("refuses a workspaceId the caller has no membership in", async () => {
+        // Called on every app load, and writes a row into whatever workspace
+        // it is handed — same hole as `create`, same guard.
+        stubNoMembership();
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+        await expect(
+          caller.action.ensureDailyPlanPromptAction({ workspaceId: "w-foreign" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        expect(dbMock.action.create).not.toHaveBeenCalled();
+        // Refused before even probing for an existing prompt action.
+        expect(dbMock.action.findFirst).not.toHaveBeenCalled();
+      });
+
+      it("lets a workspace member through", async () => {
+        stubWorkspaceRole("w1", "member");
+        dbMock.action.findFirst.mockResolvedValue(null);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        dbMock.action.create.mockResolvedValue({ id: "a1" } as any);
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+        const result = await caller.action.ensureDailyPlanPromptAction({
+          workspaceId: "w1",
+        });
+
+        expect(result).toMatchObject({ created: true, actionId: "a1" });
+        const data = dbMock.action.create.mock.calls[0]![0]!.data;
+        expect(data).toMatchObject({ workspaceId: "w1" });
+      });
+
+      it("needs no membership probe when no workspaceId is given", async () => {
+        dbMock.action.findFirst.mockResolvedValue(null);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        dbMock.action.create.mockResolvedValue({ id: "a1" } as any);
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+        await caller.action.ensureDailyPlanPromptAction({});
+
+        expect(dbMock.workspaceUser.findUnique).not.toHaveBeenCalled();
+        expect(dbMock.action.create).toHaveBeenCalled();
       });
     });
   });

--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -634,6 +634,16 @@ describe("action router (mocked)", () => {
         { userId: callerId, workspaceId: wsId, role: "member" } as any,
       );
 
+      // `create` authorises a caller-supplied workspaceId before writing, so
+      // the caller needs a writing role to reach the instrumentation at all.
+      dbMock.workspaceUser.findUnique.mockResolvedValue({
+        userId: callerId,
+        workspaceId: wsId,
+        role: "member",
+        joinedAt: new Date(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
       const caller = createMockCaller({ userId: callerId, db: dbMock });
 
       await expect(
@@ -884,6 +894,176 @@ describe("action router (mocked)", () => {
       await caller.action.assign({ actionId, userIds: [callerId] });
 
       expect(dbMock.actionAssignee.createMany).toHaveBeenCalled();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // create / update — workspace write authorisation
+  //
+  // `workspaceId` is free-form input on both mutations. Before this suite
+  // existed, `create` only checked access inside `if (input.projectId)`, so
+  // a caller supplying `workspaceId` alone wrote straight through to
+  // `db.action.create` with no membership check at all.
+  // ────────────────────────────────────────────────────────────────────
+  describe("workspace write authorisation", () => {
+    const callerId = "caller-1";
+
+    /** Caller reaches the workspace by no path at all. */
+    function stubNoMembership() {
+      dbMock.workspaceUser.findUnique.mockResolvedValue(null);
+      dbMock.teamUser.findFirst.mockResolvedValue(null);
+    }
+
+    /** Caller holds `role` via a direct WorkspaceUser row. */
+    function stubWorkspaceRole(workspaceId: string, role: string) {
+      dbMock.workspaceUser.findUnique.mockResolvedValue({
+        userId: callerId,
+        workspaceId,
+        role,
+        joinedAt: new Date(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.teamUser.findFirst.mockResolvedValue(null);
+    }
+
+    describe("create", () => {
+      it("refuses a workspaceId the caller has no membership in", async () => {
+        stubNoMembership();
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+        await expect(
+          caller.action.create({ name: "Injected", workspaceId: "w-foreign" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        // The whole point: no row lands in the foreign workspace.
+        expect(dbMock.action.create).not.toHaveBeenCalled();
+      });
+
+      it("refuses a workspace the caller is only a viewer of", async () => {
+        // Membership alone is not authority to write — `viewer` is read-only.
+        stubWorkspaceRole("w1", "viewer");
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+        await expect(
+          caller.action.create({ name: "Read-only", workspaceId: "w1" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        expect(dbMock.action.create).not.toHaveBeenCalled();
+      });
+
+      it("lets a workspace member create, persisting the workspaceId", async () => {
+        stubWorkspaceRole("w1", "member");
+        dbMock.action.create.mockResolvedValue({
+          id: "a1",
+          name: "Mine",
+          workspaceId: "w1",
+          project: null,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+        await caller.action.create({ name: "Mine", workspaceId: "w1" });
+
+        const data = dbMock.action.create.mock.calls[0]![0]!.data;
+        expect(data).toMatchObject({ workspaceId: "w1", createdById: callerId });
+      });
+
+      it("takes the workspace from the project, ignoring a foreign workspaceId", async () => {
+        // Caller genuinely owns the project (isCreator ⇒ canEditProject), but
+        // names someone else's workspace. The project must win, or project
+        // edit rights become a laundering route into any workspace.
+        dbMock.project.findUnique.mockResolvedValue({
+          createdById: callerId,
+          teamId: null,
+          workspaceId: "w-legit",
+          isPublic: false,
+          isRestricted: false,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        dbMock.projectMember.findFirst.mockResolvedValue(null);
+        dbMock.action.findFirst.mockResolvedValue(null);
+        stubNoMembership();
+        dbMock.action.create.mockResolvedValue({
+          id: "a1",
+          name: "Scoped",
+          workspaceId: "w-legit",
+          project: null,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+        await caller.action.create({
+          name: "Scoped",
+          projectId: "p1",
+          workspaceId: "w-foreign",
+        });
+
+        const data = dbMock.action.create.mock.calls[0]![0]!.data;
+        expect(data).toMatchObject({ workspaceId: "w-legit" });
+      });
+    });
+
+    describe("update", () => {
+      /** Caller is the action's creator, so `canEditAction` passes. */
+      function stubOwnedAction() {
+        dbMock.action.findUnique.mockResolvedValue({
+          createdById: callerId,
+          projectId: null,
+          assignees: [],
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+      }
+
+      it("refuses moving an action into a workspace the caller isn't in", async () => {
+        // Editing the action where it lives ≠ permission to relocate it.
+        stubOwnedAction();
+        stubNoMembership();
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+        await expect(
+          caller.action.update({ id: "a1", workspaceId: "w-foreign" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        expect(dbMock.action.update).not.toHaveBeenCalled();
+      });
+
+      it("refuses moving an action into a project the caller can't edit", async () => {
+        stubOwnedAction();
+        dbMock.project.findUnique.mockResolvedValue({
+          createdById: "someone-else",
+          teamId: null,
+          workspaceId: "w-foreign",
+          isPublic: false,
+          isRestricted: false,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        dbMock.projectMember.findFirst.mockResolvedValue(null);
+        stubNoMembership();
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+        await expect(
+          caller.action.update({ id: "a1", projectId: "p-foreign" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        expect(dbMock.action.update).not.toHaveBeenCalled();
+      });
+
+      it("allows clearing the workspace without a membership probe", async () => {
+        // Detaching an action the caller can already edit grants no access.
+        stubOwnedAction();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        dbMock.action.update.mockResolvedValue({ id: "a1", workspaceId: null } as any);
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+        await caller.action.update({ id: "a1", workspaceId: null });
+
+        expect(dbMock.action.update).toHaveBeenCalled();
+        expect(dbMock.workspaceUser.findUnique).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -493,7 +493,7 @@ export const actionRouter = createTRPCRouter({
       }
 
       // A linked epic must live in the action's own workspace, or its name and
-      // status leak back through the `epic` include below (#481). Resolved
+      // status leak back through the `epic` include below (PR 481). Resolved
       // against `targetWorkspaceId` — the workspace the action will actually
       // land in — rather than a caller-supplied id that may not be it.
       if (input.epicId) {
@@ -585,6 +585,14 @@ export const actionRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
+
+      // Same free-form `workspaceId` as `create`, and it lands in the same
+      // place — `db.action.create` below — so it needs the same guard. Without
+      // it, any authenticated user can drop a prompt action into an arbitrary
+      // workspace's task list by guessing its CUID.
+      if (input?.workspaceId) {
+        await assertCanWriteToWorkspace(ctx.db, userId, input.workspaceId);
+      }
 
       const today = startOfDay(new Date());
       const tomorrow = new Date(today);

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { Prisma } from "@prisma/client";
+import type { Prisma, PrismaClient } from "@prisma/client";
 import {
   createTRPCRouter,
   protectedProcedure,
@@ -10,7 +10,7 @@ import { parseActionInput } from "~/server/services/parsing";
 import { ScoringService } from "~/server/services/ScoringService";
 import { startOfDay } from "date-fns";
 import { validateScheduledTimes } from "~/lib/dateUtils";
-import { findUserByEmailInWorkspace, getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
+import { findUserByEmailInWorkspace, getWorkspaceMembership, canEditWorkspaceContent } from "~/server/services/access/resolvers/workspaceResolver";
 import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs, canAssignToUnscopedAction } from "~/server/services/access";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import { uploadToBlob } from "~/lib/blob";
@@ -27,6 +27,33 @@ import { recordActivity } from "~/server/services/activity/recordActivity";
 import { partitionActions } from "~/lib/actions/partition";
 import { groupOverdueCohorts, daysOverdue } from "~/lib/actions/triage";
 
+/**
+ * Guard a caller-supplied `workspaceId` on a write.
+ *
+ * `workspaceId` arrives as free-form input on `create`/`update`, so membership
+ * is never implied by having reached the mutation: without this check any
+ * authenticated user could inject rows into an arbitrary workspace's task list
+ * by guessing its CUID.
+ *
+ * Membership alone isn't sufficient either — `viewer` is a read-only role — so
+ * this asserts `canEditWorkspaceContent` (member and above). Project-only
+ * members ("guests") have no WorkspaceUser row and are refused here by design;
+ * their writes are authorised through the project path instead, which is why
+ * callers must skip this check for a workspace derived from the project.
+ */
+async function assertCanWriteToWorkspace(
+  db: PrismaClient,
+  userId: string,
+  workspaceId: string,
+) {
+  const membership = await getWorkspaceMembership(db, userId, workspaceId);
+  if (!canEditWorkspaceContent(membership?.role ?? null)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You don't have permission to add actions to this workspace",
+    });
+  }
+}
 
 export const actionRouter = createTRPCRouter({
   getAll: protectedProcedure
@@ -441,29 +468,39 @@ export const actionRouter = createTRPCRouter({
       // unchecked value plants the action — and the `created` activity event
       // fired for it further down — inside a workspace the caller has no
       // relationship to, where that workspace's members then see it in their
-      // feed. The project branch above only gates the *project*; when no
-      // projectId is supplied nothing else looks at this field at all.
-      if (input.workspaceId) {
-        const membership = await getWorkspaceMembership(
+      // feed. The project branch above only gates the *project*.
+      //
+      // A project dictates its own workspace, so it takes precedence over any
+      // caller-supplied `workspaceId`. The old precedence ran the other way,
+      // which let a caller attach a project they can genuinely edit while
+      // naming a foreign workspace, laundering the row into that workspace.
+      // `input.workspaceId` therefore only applies when there is no project, or
+      // when the project is personal (no workspace of its own).
+      const targetWorkspaceId = projectWorkspaceId ?? input.workspaceId ?? null;
+
+      // Authorise the destination workspace whenever it came from the caller
+      // rather than from the project. Skipping the project-derived case keeps
+      // project-only members ("guests") working — `canEditProject` above is
+      // their authorisation, and a bare `input.workspaceId` check would refuse
+      // them, since a guest has no WorkspaceUser row but every client sends
+      // workspaceId alongside projectId.
+      if (targetWorkspaceId && targetWorkspaceId !== projectWorkspaceId) {
+        await assertCanWriteToWorkspace(
           ctx.db,
           ctx.session.user.id,
-          input.workspaceId,
+          targetWorkspaceId,
         );
-        if (!membership) {
-          throw new TRPCError({
-            code: "FORBIDDEN",
-            message: "You don't have access to this workspace",
-          });
-        }
       }
 
       // A linked epic must live in the action's own workspace, or its name and
-      // status leak back through the `epic` include below.
+      // status leak back through the `epic` include below (#481). Resolved
+      // against `targetWorkspaceId` — the workspace the action will actually
+      // land in — rather than a caller-supplied id that may not be it.
       if (input.epicId) {
         await assertWorkspaceScopedRefs(
           ctx.db,
           ctx.session.user.id,
-          input.workspaceId ?? projectWorkspaceId,
+          targetWorkspaceId,
           { epicId: input.epicId },
         );
       }
@@ -471,16 +508,15 @@ export const actionRouter = createTRPCRouter({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const actionData: any = {
         ...input,
+        // Overrides the `workspaceId` spread from `...input`, which is exactly
+        // the field that was previously written through unchecked.
+        workspaceId: targetWorkspaceId ?? undefined,
         createdById: ctx.session.user.id,
         ...(input.isBounty ? { bountyStatus: "OPEN" } : {}),
         // External-agent principals stamp their surface (ADR-0049); the *who*
         // is createdById (the agent's shadow user), the *how* is source.
         ...(ctx.tokenType === "agent-key" ? { source: "agent" } : {}),
       };
-
-      if (input.projectId && !input.workspaceId && projectWorkspaceId) {
-        actionData.workspaceId = projectWorkspaceId;
-      }
 
       if (input.projectId) {
         actionData.kanbanStatus = "TODO";
@@ -672,15 +708,47 @@ export const actionRouter = createTRPCRouter({
         validateScheduledTimes(resolvedStart, resolvedEnd);
       }
 
-      // Sync workspaceId when projectId changes
+      // Re-targeting the action. `projectId` and `workspaceId` are both
+      // free-form input, and `canEditAction` above only proves the caller may
+      // edit the action where it currently lives — not that they may move it
+      // somewhere else. Each destination needs its own authorisation.
       if (updateData.projectId) {
-        const newProject = await ctx.db.project.findUnique({
-          where: { id: updateData.projectId },
-          select: { workspaceId: true },
-        });
+        const [targetProjectAccess, newProject] = await Promise.all([
+          getProjectAccess(ctx.db, ctx.session.user.id, updateData.projectId),
+          ctx.db.project.findUnique({
+            where: { id: updateData.projectId },
+            select: { workspaceId: true },
+          }),
+        ]);
+
+        if (!canEditProject(targetProjectAccess)) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "You don't have permission to move this action to that project",
+          });
+        }
+
+        // Sync workspaceId from the project, which wins over any caller-supplied
+        // value (same precedence as `create`). Only a personal project — one
+        // with no workspace — leaves `input.workspaceId` in play.
         if (newProject?.workspaceId) {
           updateData.workspaceId = newProject.workspaceId;
+        } else if (updateData.workspaceId) {
+          await assertCanWriteToWorkspace(
+            ctx.db,
+            ctx.session.user.id,
+            updateData.workspaceId,
+          );
         }
+      } else if (updateData.workspaceId) {
+        // Moving the action into a workspace by id alone. `null` falls through
+        // unchecked on purpose: detaching an action the caller can already edit
+        // grants no access to anything.
+        await assertCanWriteToWorkspace(
+          ctx.db,
+          ctx.session.user.id,
+          updateData.workspaceId,
+        );
       }
 
       // Same-workspace guard as create, resolved against the workspace the


### PR DESCRIPTION
### **User description**
## What

`action.create` was a bare `protectedProcedure` whose only access check lived inside `if (input.projectId)`. A caller supplying `workspaceId` **alone** never entered that branch, so the free-form id was spread straight into `db.action.create` — any authenticated user could inject rows into an arbitrary workspace's task list by guessing its CUID.

This is the **write-side** counterpart to the read leaks fixed in #481.

- Adds `assertCanWriteToWorkspace` (`getWorkspaceMembership` + `canEditWorkspaceContent`), applied wherever the destination workspace came from the caller rather than from an authorised project.
- Inverts the project/workspace precedence in `create`. It previously ran `input.projectId && !input.workspaceId`, letting a caller attach a project they can genuinely edit while naming a foreign workspace.
- Fixes the same hole in `action.update`, plus a second one found while auditing it: `updateData.projectId` was applied with **no check on the destination project**, so any action you could edit could be moved into an arbitrary project.
- 6 new unit tests using the mocked-caller pattern.

## Decisions worth a reviewer's eye

**Viewers are refused.** `canEditWorkspaceContent` is member-and-above. Membership alone isn't the bar — `viewer` is read-only, and that helper's docstring says to use it wherever a write happens.

**Guests keep working, and that's why the precedence had to flip.** All three UI callers (`CreateActionModal`, `GlobalAddTaskButton`, `NextActionCapture`) pass `projectId` *and* `workspaceId` together. A workspace guest has no `WorkspaceUser` row, so `getWorkspaceMembership` returns `null` for them — a naive "check whenever `workspaceId` is present" would have broken every guest creating a task in a project shared with them. Letting the project dictate the workspace closes the laundering route *and* keeps the guest path authorised through `canEditProject`.

**`workspaceId: null` on update is deliberately unchecked.** Detaching an action you can already edit grants no access to anything.

## Interaction with #481

Rebased onto #481, which added an `epicId` workspace-scope guard to the same two procedures. That guard resolved its workspace as `input.workspaceId ?? projectWorkspaceId` — the old, vulnerable ordering. It now resolves against `targetWorkspaceId`, i.e. the workspace the action will actually land in, so the epic check and the row itself can't disagree.

`bulkAssignProject` and `updateActionsProject` were audited and already guarded correctly — `create`/`update` were the outliers.

## Verification

- `tsc --noEmit` clean
- 2020 unit tests pass (208 files)
- ESLint clean on `action.ts`

## Follow-up (not in this PR)

`getAssignableUsersForContext` takes the same free-form `workspaceId`, guards only the `projectId` path, and returns id/name/**email** for every member of whatever workspace you name. Read-side counterpart, being handled separately.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Gate `action.create`/`update` writes on workspace membership via `assertCanWriteToWorkspace`

- Fix workspace/project precedence: project-derived workspace now wins over caller-supplied `workspaceId`

- Guard `ensureDailyPlanPromptAction` against unauthorized workspace injection

- Add 9 new unit tests covering workspace write authorization, viewer rejection, and project precedence


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["action.create (no workspace auth)"] -- "add assertCanWriteToWorkspace" --> B["action.create (workspace-gated)"]
  C["action.update (no destination auth)"] -- "add assertCanWriteToWorkspace + canEditProject" --> D["action.update (destination-gated)"]
  E["ensureDailyPlanPromptAction (no auth)"] -- "add assertCanWriteToWorkspace" --> F["ensureDailyPlanPromptAction (workspace-gated)"]
  G["project workspace"] -- "takes precedence over" --> H["caller-supplied workspaceId"]
  I["assertCanWriteToWorkspace"] -- "uses" --> J["getWorkspaceMembership + canEditWorkspaceContent"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.ts</strong><dd><code>Gate action write mutations on workspace membership</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/action.ts

<ul><li>Adds <code>assertCanWriteToWorkspace</code> helper using <code>getWorkspaceMembership</code> + <br><code>canEditWorkspaceContent</code><br> <li> Inverts project/workspace precedence so project-derived workspace wins <br>over caller-supplied <code>workspaceId</code><br> <li> Applies workspace write guard to <code>create</code>, <code>update</code>, and <br><code>ensureDailyPlanPromptAction</code><br> <li> Guards <code>update</code> against moving actions to unauthorized projects via <br><code>canEditProject</code> check</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/487/files#diff-5b198a3cc9e3495e32e4dcdf28771f225d15998a0c3ab9de63ef7f12941d1dbb">+100/-24</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.test.ts</strong><dd><code>Add unit tests for workspace write authorization on actions</code></dd></summary>
<hr>

src/server/api/routers/__tests__/action.test.ts

<ul><li>Adds <code>workspace write authorisation</code> describe block with 9 new unit <br>tests<br> <li> Tests cover: non-member rejection, viewer rejection, member success, <br>project precedence, update destination checks, <br><code>ensureDailyPlanPromptAction</code> guard<br> <li> Adds regression test ensuring project check fires before epic guard <br>downstream<br> <li> Fixes existing instrumentation test to include required <code>joinedAt</code> field <br>in mock</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/487/files#diff-1f49e232606ea60cceb17f43536f374c6e1ad7e88b96115c502088f6e4556999">+254/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

