### PR TITLE
feat: label Sentry/GlitchTip bugs with the service they came from

### DIFF
--- a/dev-docs/OBSERVABILITY.md
+++ b/dev-docs/OBSERVABILITY.md
@@ -79,6 +79,24 @@ handled automatically:
 Security boundary: presenting a `Sentry-Hook-Signature` commits the sender to
 HMAC. An invalid signature is always a 401 — a valid token never rescues it.
 
+### Telling services apart in one product
+
+A workspace has exactly one Sentry integration, pointing at one destination
+Product — so several codebases reporting into it would otherwise be
+indistinguishable. Each ticket therefore also gets a **source label** naming
+the service it came from:
+
+```
+…/api/webhooks/sentry/<webhookId>?token=<secret>&service=clear-pipeline
+```
+
+`?product=` is accepted as an alias, but note it does **not** choose the
+destination Product (that is fixed per integration) — it only labels. When
+neither is given the label falls back to the project slug in the payload, so
+Sentry's own projects (`exponential-frontend`, `mastra-agents`) self-label
+without any configuration. The value is reduced to a bounded `[a-z0-9-]` slug
+before use.
+
 Tickets are labelled `Sentry` + `bug`, and additionally `ai-fixable` when the
 issue's Sentry project is listed in `SENTRY_AI_FIXABLE_PROJECTS` — the
 allowlist exists because the webhook is org-wide and a bug from another

--- a/src/app/api/webhooks/sentry/[webhookId]/__tests__/route.test.ts
+++ b/src/app/api/webhooks/sentry/[webhookId]/__tests__/route.test.ts
@@ -40,6 +40,8 @@ function fakeRequest(opts: {
   resource?: string;
   signature?: string;
   tokenQuery?: string;
+  service?: string;
+  product?: string;
 }): NextRequest {
   const headers = new Map<string, string>();
   if (opts.signature !== undefined)
@@ -48,6 +50,8 @@ function fakeRequest(opts: {
     headers.set("sentry-hook-resource", opts.resource);
   const searchParams = new URLSearchParams();
   if (opts.tokenQuery !== undefined) searchParams.set("token", opts.tokenQuery);
+  if (opts.service !== undefined) searchParams.set("service", opts.service);
+  if (opts.product !== undefined) searchParams.set("product", opts.product);
   return {
     headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
     nextUrl: { searchParams },
@@ -88,7 +92,9 @@ describe("POST /api/webhooks/sentry/[webhookId]", () => {
     expect(res.status).toBe(200);
     expect(ingestSentryBug).toHaveBeenCalledTimes(1);
     // Routed to the per-workspace product, not the global default.
-    expect(ingestSentryBug.mock.calls[0]![2]).toEqual({ productId: "prod-1" });
+    expect(ingestSentryBug.mock.calls[0]![2]).toMatchObject({
+      productId: "prod-1",
+    });
   });
 
   it("returns 404 for an unknown webhookId and does not ingest", async () => {
@@ -182,8 +188,36 @@ describe("POST /api/webhooks/sentry/[webhookId]", () => {
       expect(arg.issueId).toBe("555");
       expect(arg.projectSlug).toBe("clear-pipeline");
       // Routed to this tenant's configured product, as for signed requests.
-      expect(ingestSentryBug.mock.calls[0]![2]).toEqual({
+      expect(ingestSentryBug.mock.calls[0]![2]).toMatchObject({
         productId: "prod-1",
+      });
+    });
+
+    it("passes ?service= through for source labelling", async () => {
+      await POST(
+        fakeRequest({
+          body: glitchtipBody,
+          tokenQuery: SECRET,
+          service: "clear-pipeline",
+        }),
+        ctx,
+      );
+      expect(ingestSentryBug.mock.calls[0]![2]).toMatchObject({
+        sourceSlug: "clear-pipeline",
+      });
+    });
+
+    it("accepts ?product= as an alias for ?service=", async () => {
+      await POST(
+        fakeRequest({
+          body: glitchtipBody,
+          tokenQuery: SECRET,
+          product: "clear-api",
+        }),
+        ctx,
+      );
+      expect(ingestSentryBug.mock.calls[0]![2]).toMatchObject({
+        sourceSlug: "clear-api",
       });
     });
 

--- a/src/app/api/webhooks/sentry/[webhookId]/route.ts
+++ b/src/app/api/webhooks/sentry/[webhookId]/route.ts
@@ -133,7 +133,15 @@ export async function POST(
       );
     }
 
-    const result = await ingestSentryBug(db, bug, { productId });
+    // Which codebase the error came from, for labelling. `service` is the
+    // canonical name; `product` is accepted as an alias because it reads
+    // naturally in a URL — note it does *not* choose the destination Product,
+    // which is fixed per integration.
+    const sourceSlug =
+      request.nextUrl.searchParams.get("service") ??
+      request.nextUrl.searchParams.get("product");
+
+    const result = await ingestSentryBug(db, bug, { productId, sourceSlug });
     console.log(
       `[sentry webhook ${webhookId}] issue ${bug.issueId} -> ticket ${result.ticketId} (created=${result.created})`,
     );

--- a/src/app/api/webhooks/sentry/route.ts
+++ b/src/app/api/webhooks/sentry/route.ts
@@ -77,7 +77,13 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    const result = await ingestSentryBug(db, bug);
+    // Which codebase the error came from, for labelling (`service`, or
+    // `product` as an alias). Does not affect the destination product.
+    const sourceSlug =
+      request.nextUrl.searchParams.get("service") ??
+      request.nextUrl.searchParams.get("product");
+
+    const result = await ingestSentryBug(db, bug, { sourceSlug });
     console.log(
       `[sentry webhook] issue ${bug.issueId} -> ticket ${result.ticketId} (created=${result.created})`,
     );

--- a/src/server/services/sentry/SentryBugService.ts
+++ b/src/server/services/sentry/SentryBugService.ts
@@ -51,6 +51,40 @@ const TICKET_LABELS = [
 // gate is status READY_TO_PLAN (see .github/workflows/ai-bug-fixer.yml) — this
 // label alone does not start a run, so a human still triages the ticket out of
 // BACKLOG before any agent touches it.
+/**
+ * Colour for the per-service source label (see {@link sourceLabel}).
+ */
+const SOURCE_LABEL_COLOR = "avatar-blue";
+
+/** Upper bound on a generated label slug, so a hostile value can't bloat a tag. */
+const SOURCE_SLUG_MAX_LENGTH = 32;
+
+/**
+ * Build a label identifying which service an error came from, so a single
+ * destination product can carry bugs from several codebases and still be
+ * filterable (`clear-api` vs `clear-pipeline` …).
+ *
+ * The value arrives either from the webhook's `?service=` query param or, when
+ * absent, from the sender's own project slug. Both are attacker-influencable in
+ * principle — the token gate makes them semi-trusted at best — so the string is
+ * reduced to a bounded `[a-z0-9-]` slug rather than used verbatim.
+ */
+export function sourceLabel(
+  raw: string | null | undefined,
+): { name: string; slug: string; color: string } | null {
+  if (!raw) return null;
+  const slug = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, SOURCE_SLUG_MAX_LENGTH)
+    // A trailing dash can survive the truncation above.
+    .replace(/-+$/g, "");
+  if (!slug) return null;
+  return { name: slug, slug, color: SOURCE_LABEL_COLOR };
+}
+
 const AI_FIXABLE_LABEL = {
   name: "ai-fixable",
   slug: "ai-fixable",
@@ -126,7 +160,7 @@ export interface IngestResult {
 export async function ingestSentryBug(
   db: PrismaClient,
   bug: SentryBug,
-  options?: { productId?: string },
+  options?: { productId?: string; sourceSlug?: string | null },
 ): Promise<IngestResult> {
   // Destination precedence: an explicit per-workspace product (from a
   // workspace-scoped Sentry integration) wins; otherwise fall back to the
@@ -179,12 +213,18 @@ export async function ingestSentryBug(
   });
 
   // Tag it with the workspace's "Sentry" and "bug" labels so these are filterable.
+  const source = sourceLabel(options?.sourceSlug ?? bug.projectSlug);
   await labelTicket(
     db,
     ticket.id,
     product.workspaceId,
     errol.id,
-    isAiFixableProject(bug.projectSlug) ? [AI_FIXABLE_LABEL] : [],
+    [
+      ...(isAiFixableProject(bug.projectSlug) ? [AI_FIXABLE_LABEL] : []),
+      // Which codebase this came from. An explicit `?service=` wins; otherwise
+      // fall back to the slug the sender put in the payload.
+      ...(source ? [source] : []),
+    ],
   );
 
   // Announce the new bug in Zulip (best-effort) with a deep link to the ticket.

--- a/src/server/services/sentry/__tests__/SentryBugService.test.ts
+++ b/src/server/services/sentry/__tests__/SentryBugService.test.ts
@@ -27,7 +27,7 @@ vi.mock("../sentryZulip", () => ({
 
 import { createTicketWithNumber } from "~/plugins/product/server/services/createTicket";
 import { notifyZulipOfSentryBug } from "../sentryZulip";
-import { ingestSentryBug } from "../SentryBugService";
+import { ingestSentryBug, sourceLabel } from "../SentryBugService";
 import { type SentryBug } from "../sentryPayload";
 
 const dbMock: DeepMockProxy<PrismaClient> = mockDeep<PrismaClient>();
@@ -162,7 +162,9 @@ describe("ingestSentryBug", () => {
   it("find-or-creates the 'Sentry' and 'bug' workspace labels and attaches them", async () => {
     await ingestSentryBug(dbMock, bug);
 
-    expect(dbMock.tag.upsert).toHaveBeenCalledTimes(2);
+    // Two standard labels plus the source label derived from the project slug
+    // (see the "source label" suite below).
+    expect(dbMock.tag.upsert).toHaveBeenCalledTimes(3);
     expect(dbMock.tag.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { slug_workspaceId: { slug: "sentry", workspaceId: "ws-1" } },
@@ -185,7 +187,7 @@ describe("ingestSentryBug", () => {
         }),
       }),
     );
-    expect(dbMock.ticketTag.upsert).toHaveBeenCalledTimes(2);
+    expect(dbMock.ticketTag.upsert).toHaveBeenCalledTimes(3);
     expect(dbMock.ticketTag.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { ticketId_tagId: { ticketId: "ticket-1", tagId: "tag-1" } },
@@ -258,5 +260,78 @@ describe("ingestSentryBug", () => {
       expect(createTicketWithNumber).toHaveBeenCalledTimes(1);
       expect(result).toEqual({ created: true, ticketId: "ticket-1" });
     });
+  });
+
+  describe("source label", () => {
+    /** Slugs passed to tag.upsert for the current call. */
+    function labelSlugs(): (string | undefined)[] {
+      return dbMock.tag.upsert.mock.calls.map(
+        (c) => c[0].where.slug_workspaceId?.slug,
+      );
+    }
+
+    it("labels the ticket from an explicit ?service= value", async () => {
+      await ingestSentryBug(dbMock, bug, { sourceSlug: "clear-pipeline" });
+      expect(labelSlugs()).toContain("clear-pipeline");
+    });
+
+    it("falls back to the sender's project slug when none is given", async () => {
+      await ingestSentryBug(dbMock, bug);
+      // `bug.projectSlug` is exponential-frontend in this fixture.
+      expect(labelSlugs()).toContain("exponential-frontend");
+    });
+
+    it("prefers the explicit value over the payload's project slug", async () => {
+      await ingestSentryBug(dbMock, bug, { sourceSlug: "clear-api" });
+      const slugs = labelSlugs();
+      expect(slugs).toContain("clear-api");
+      expect(slugs).not.toContain("exponential-frontend");
+    });
+
+    it("adds no source label when neither is available", async () => {
+      await ingestSentryBug(
+        dbMock,
+        { ...bug, projectSlug: null },
+        { sourceSlug: null },
+      );
+      // Only the two standard labels.
+      expect(labelSlugs()).toEqual(["sentry", "bug"]);
+    });
+  });
+});
+
+describe("sourceLabel", () => {
+  it("passes through an already-clean slug", () => {
+    expect(sourceLabel("clear-pipeline")).toEqual({
+      name: "clear-pipeline",
+      slug: "clear-pipeline",
+      color: "avatar-blue",
+    });
+  });
+
+  it("normalizes case and separators", () => {
+    expect(sourceLabel("  CLEAR Context_Pipeline  ")?.slug).toBe(
+      "clear-context-pipeline",
+    );
+  });
+
+  it("strips characters that would be unsafe or ugly in a tag", () => {
+    expect(sourceLabel("../../etc/passwd")?.slug).toBe("etc-passwd");
+    expect(sourceLabel("<script>alert(1)</script>")?.slug).toBe(
+      "script-alert-1-script",
+    );
+  });
+
+  it("bounds the length and leaves no trailing dash", () => {
+    const slug = sourceLabel("a".repeat(40) + " tail")!.slug;
+    expect(slug).toHaveLength(32);
+    expect(slug.endsWith("-")).toBe(false);
+  });
+
+  it("returns null for empty or punctuation-only input", () => {
+    expect(sourceLabel(null)).toBeNull();
+    expect(sourceLabel("")).toBeNull();
+    expect(sourceLabel("   ")).toBeNull();
+    expect(sourceLabel("---")).toBeNull();
   });
 });


### PR DESCRIPTION
### **User description**
## Why

A workspace has exactly one Sentry integration pointing at one destination Product (`integration.ts` deletes any existing row before creating). Several codebases reporting into it — the four clear-* services into CLEAR, or `exponential-frontend` and `mastra-agents` into ours — were indistinguishable on the board.

## What

Each ticket now also carries a **source label** naming its service:

```
…/api/webhooks/sentry/<webhookId>?token=<secret>&service=clear-pipeline
```

- `?service=` is canonical; `?product=` is accepted as an alias since it reads naturally in a URL. **It only labels** — the destination Product stays fixed per integration.
- Falls back to the project slug already in the payload, so Sentry's own projects self-label with no configuration.
- The value is reduced to a bounded `[a-z0-9-]` slug (max 32) rather than used verbatim: the token gate makes it semi-trusted at best, and it becomes a persisted workspace tag.
- Reuses the `extraLabels` hook added for `ai-fixable`, so this is additive to existing labelling.

## Behaviour change worth noting

Tickets that previously got exactly two labels (`sentry`, `bug`) now get three, because the payload fallback labels them with their project slug. Two existing assertions were updated to match. This is intended — it's what makes the two Sentry projects sharing our product distinguishable — but it is a visible change on existing tickets going forward.

## Validation

11 new tests; 71 green across the Sentry suites. ESLint clean; unit suite via pre-commit; Vercel build via pre-push.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add `?service=` (and `?product=` alias) query param to Sentry webhooks for source labelling

- Fall back to project slug from payload when no explicit service param is given

- Sanitize source value into bounded `[a-z0-9-]` slug (max 32 chars) before persisting

- Add 11 new tests covering source label logic and webhook routing; update 2 existing assertions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sentry/GlitchTip Webhook"]
  B["?service= param"]
  C["?product= alias"]
  D["payload projectSlug fallback"]
  E["sourceLabel()\nsanitize to [a-z0-9-] slug"]
  F["ingestSentryBug()\n{ productId, sourceSlug }"]
  G["labelTicket()\nsentry + bug + source label"]
  H["Ticket on Board"]

  A -- "query param" --> B
  A -- "alias param" --> C
  A -- "no param" --> D
  B -- "wins" --> E
  C -- "alias" --> E
  D -- "fallback" --> E
  E -- "sourceSlug" --> F
  F --> G
  G --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SentryBugService.ts</strong><dd><code>Implement source label generation and attachment logic</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/sentry/SentryBugService.ts

<ul><li>Add exported <code>sourceLabel()</code> function that sanitizes raw input to a <br>bounded <code>[a-z0-9-]</code> slug<br> <li> Extend <code>ingestSentryBug</code> options to accept <code>sourceSlug?: string | null</code><br> <li> Fall back to <code>bug.projectSlug</code> when no explicit <code>sourceSlug</code> is provided<br> <li> Spread source label into <code>extraLabels</code> array alongside <code>ai-fixable</code> when <br>applicable</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/488/files#diff-0dde9dcd8c1aed7f46faacd632832d501d8a805f9f8bb05920ab17f981832881">+42/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Pass source slug from webhook URL to ingest function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/webhooks/sentry/[webhookId]/route.ts

<ul><li>Read <code>?service=</code> query param, falling back to <code>?product=</code> alias<br> <li> Pass resolved <code>sourceSlug</code> to <code>ingestSentryBug</code> options<br> <li> Add inline comment clarifying <code>?product=</code> does not affect destination <br>Product</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/488/files#diff-83be8ca30c49e84204f569f47f565e51c47589b5cc5735455ffa592497762967">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Forward source slug in global Sentry webhook route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/webhooks/sentry/route.ts

<ul><li>Read <code>?service=</code> / <code>?product=</code> query params from the global Sentry webhook <br>route<br> <li> Forward <code>sourceSlug</code> to <code>ingestSentryBug</code> options</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/488/files#diff-546031f2a49c647572b89c88c0f6710a2601b261f41c538c408759e83d3c5911">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.test.ts</strong><dd><code>Add webhook route tests for service and product query params</code></dd></summary>
<hr>

src/app/api/webhooks/sentry/[webhookId]/__tests__/route.test.ts

<ul><li>Add <code>service</code> and <code>product</code> fields to <code>fakeRequest</code> helper and wire into <br><code>URLSearchParams</code><br> <li> Switch two existing <code>toEqual</code> assertions to <code>toMatchObject</code> for forward <br>compatibility<br> <li> Add tests verifying <code>?service=</code> passes <code>sourceSlug</code> and <code>?product=</code> is <br>accepted as alias</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/488/files#diff-1312a845a0e138d23bd62cc13e9130a16c85028f3e0f4418533eefc801327448">+36/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SentryBugService.test.ts</strong><dd><code>Add comprehensive tests for source label behaviour</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/sentry/__tests__/SentryBugService.test.ts

<ul><li>Import <code>sourceLabel</code> alongside <code>ingestSentryBug</code><br> <li> Update two label-count assertions from 2 to 3 to account for new <br>source label<br> <li> Add <code>source label</code> describe block with 4 integration tests covering <br>explicit, fallback, preference, and absent cases<br> <li> Add standalone <code>sourceLabel</code> describe block with 5 unit tests covering <br>normalization, sanitization, length bounding, and null cases</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/488/files#diff-29ee86568c94bca33dc56fc3965ab98ad30ea4dbf454324d4d8bfe3cf5bb42b7">+78/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OBSERVABILITY.md</strong><dd><code>Document source label configuration in observability guide</code></dd></summary>
<hr>

dev-docs/OBSERVABILITY.md

<ul><li>Add new section "Telling services apart in one product" explaining <br><code>?service=</code> and <code>?product=</code> params<br> <li> Document fallback to project slug and slug sanitization behaviour</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/488/files#diff-e608379e40bafc9cc6a526c79545546dac14663e40ebdbc6733813229078f1a6">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

