### PR TITLE
docs: public External Agents guide

### DIFF
--- a/content/docs/features/external-agents.md
+++ b/content/docs/features/external-agents.md
@@ -1,0 +1,74 @@
+---
+title: External Agents
+description: Connect third-party AI agents to Exponential as first-class team members with their own identity, scoped access, and revocable keys
+---
+
+## Overview
+
+External agents let you connect autonomous AI software — [Hermes Agent](https://hermes-agent.nousresearch.com/), MCP clients, custom scripts, anything that can send an HTTP request — to Exponential **as its own identity**, not as you.
+
+When your agent creates a task, the task says the *agent* created it. Your workspace's activity feed and members list show the agent with an **agent** badge, so everyone can see what the software did versus what you did.
+
+This is different from Zoe, Exponential's built-in assistant: Zoe works *with* you in a conversation and acts as you with your confirmation. An external agent works *for* you, on its own, under its own name.
+
+## How It Works
+
+1. **Create an agent** — give it a name ("Hermes", "Standup Bot").
+2. **Grant it workspaces** — the agent joins as a **member** of workspaces you choose. It can only join workspaces where you yourself have at least member access.
+3. **Create a key** — a secret starting with `exp_agent_`, shown exactly once. Put it in your agent software's configuration.
+4. **The agent works** — it authenticates with the key and sees only the workspaces you granted. Everything it does is attributed to it.
+
+## Setting Up
+
+### Create an Agent
+
+1. Go to **Settings → Agents**
+2. Click **New agent** and name it
+3. Click **Add** next to *Workspaces* and pick where it may work
+4. Click **New key**, label it (e.g. "laptop"), and **copy the key immediately** — it is never shown again
+
+### Point Your Software at Exponential
+
+Your agent authenticates by sending the key as a Bearer token:
+
+```
+Authorization: Bearer exp_agent_...
+```
+
+For agent software that runs shell commands (like Hermes), the simplest path is the [Exponential CLI](/docs/features/api-access) with the agent key as its token.
+
+## Access & Safety
+
+External agents are deliberately more limited than human members:
+
+- **Member role only.** An agent is always a workspace *member* — never an owner or admin. It cannot manage members, change workspace settings, or manage other agents.
+- **Your access is the ceiling.** An agent can never do more than you can. If you leave a workspace or are changed to viewer, your agents lose that workspace immediately and automatically.
+- **No credential minting.** Agents cannot create API tokens, connect integrations, or generate any other credentials.
+- **Revocation is instant.** Deleting a key blocks the agent on its very next request. Workspace admins can also remove an agent from the members list at any time, without touching your keys.
+
+## Keys
+
+- A key is shown **once**, at creation. Store it in your agent's config; if you lose it, revoke it and create a new one.
+- Each agent can hold up to 10 keys — create a second key and delete the first to rotate without downtime.
+- The Agents page shows each key's **last used** time, so you can spot stale or unexpected activity.
+
+## Attribution
+
+Everything an agent does is recorded under the agent's own name:
+
+- Tasks show the agent as creator, with source `agent`
+- The workspace **activity feed** shows the agent's actions with an agent badge
+- The **members list** shows the agent as a member with an agent badge
+
+Deleting an agent removes its keys and workspace access immediately; its past work stays attributed to it in your history.
+
+## FAQ
+
+**Can an agent be read-only?**
+Not yet. Agents always join as members. A read-only (viewer) tier is planned.
+
+**Can my whole team share one agent?**
+Agents are personal — each agent belongs to the user who created it, and its access is tied to that user's. Shared workspace-owned agents are under consideration.
+
+**Does this replace API tokens?**
+No — [API tokens](/docs/features/api-access) act *as you* and are right for webhooks and personal automation. Use an external agent when software should have its own identity and audit trail.

--- a/src/lib/docs/navigation.ts
+++ b/src/lib/docs/navigation.ts
@@ -24,6 +24,7 @@ import {
   IconBuildingSkyscraper,
   IconUsers,
   IconRobot,
+  IconRobotFace,
   IconKey,
   IconPlayerPlay,
   IconLayoutNavbar,
@@ -181,6 +182,11 @@ export const docsNavigation: DocNavSection[] = [
         title: "API Access",
         href: "/docs/features/api-access",
         icon: IconKey,
+      },
+      {
+        title: "External Agents",
+        href: "/docs/features/external-agents",
+        icon: IconRobotFace,
       },
       {
         title: "Settings",


### PR DESCRIPTION
### **User description**
## Summary

Public-facing documentation for the External Agents feature that shipped in #473 — the one piece that didn't make that PR.

- New `/docs/features/external-agents` page: what an external agent is (vs Zoe and vs API tokens), setup walkthrough, the access & safety model (member-only, owner-capped access, instant key revocation), key rotation, and attribution.
- Registered in the docs sidebar under Features (after API Access).

Docs-only — no code, no migration. Verified rendering locally (title, TOC, content).

Feature decision record: ADR-0049.


___

### **PR Type**
Documentation


___

### **Description**
- Add public-facing docs page for External Agents feature

- Register "External Agents" entry in docs sidebar navigation

- Document setup, access model, key management, and attribution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  navFile["navigation.ts\nsidebar config"]
  mdFile["external-agents.md\ndocs content"]
  sidebar["Docs Sidebar\nFeatures section"]
  docsPage["'/docs/features/external-agents'\npublic page"]

  navFile -- "registers entry" --> sidebar
  mdFile -- "renders as" --> docsPage
  sidebar -- "links to" --> docsPage
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>navigation.ts</strong><dd><code>Register External Agents entry in docs sidebar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/docs/navigation.ts

<ul><li>Import <code>IconRobotFace</code> icon for the new sidebar entry<br> <li> Add "External Agents" navigation item under Features, after "API <br>Access"</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/489/files#diff-567fa2f0c7ae8b48e513eb1dcf5db8a75e069a791f9720079ac7482d870b22e6">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>external-agents.md</strong><dd><code>Add full External Agents user-facing documentation page</code>&nbsp; &nbsp; </dd></summary>
<hr>

content/docs/features/external-agents.md

<ul><li>New 74-line markdown doc explaining what external agents are vs Zoe <br>and API tokens<br> <li> Covers setup walkthrough (create agent, grant workspaces, create key, <br>authenticate)<br> <li> Documents access & safety model (member-only, owner-capped, instant <br>revocation, no credential minting)<br> <li> Includes key rotation guidance, attribution behavior, and FAQ</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/489/files#diff-12f7e6daee00e9eb7e5d6f54a4a841c044468fa3078ad6965203a35f0c6b29b6">+74/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

