### PR TITLE
feat(desktop): native macOS window tabs in the Tauri shell (ADR-0053)

### DIFF
--- a/docs/adr/0053-desktop-tabs-are-native-macos-window-tabs.md
+++ b/docs/adr/0053-desktop-tabs-are-native-macos-window-tabs.md
@@ -1,0 +1,105 @@
+# Desktop tabs are native macOS window tabs, under Safari-style chrome
+
+## Status
+
+Accepted — 2026-08-04
+
+> Note on numbering: the desktop-tabs PRD and tickets `cool.lark` / `lazy.lake`
+> cite this record as "ADR-0052". That number was taken by
+> [0052-overdue-cohorts-and-amnesty.md](0052-overdue-cohorts-and-amnesty.md)
+> before this file was written; this is the record they mean.
+
+## Context
+
+The Tauri shell (the desktop foray's daily driver) opens exactly one useful
+window. Following a link replaces what you were looking at, and anything
+stateful — a Zoe canvas mid-answer, a half-typed form — dies on navigation,
+because the app is a single route tree in a single webview. The V2 scope of the
+desktop feature is tabs.
+
+Constraints: no Tauri `unstable` feature (rules out multi-webview-in-one-window
+via `Window::add_child`), the Electron shell is not modified, and the web app
+must expose no tab affordance so tabs are unreachable from a browser by
+construction.
+
+## Decision
+
+**A tab is a real macOS window tab.** Every tab is its own `WebviewWindow`; all
+windows share one `tabbing_identifier`, and AppKit provides the tab bar,
+reordering, drag-out, the tab overview, and ⌘W. Each tab is a full live app
+instance, which is what makes backgrounded state survive without feature code.
+
+The `cool.lark` spike (built and inspected on release builds, 2026-08-04)
+forced three refinements the original design did not anticipate:
+
+1. **Merging must be explicit.** A shared `tabbing_identifier` only makes
+   windows *tabbable*; AppKit auto-merges only when the user's global
+   `AppleWindowTabbingMode` is `always`, and Apple's default is "In Full Screen
+   Only". The shell therefore calls `-[NSWindow addTabbedWindow:ordered:]`
+   (via `ns_window()` + `objc2`; neither tao nor tauri wraps it).
+
+2. **The chrome is Safari's, not Electron's.** The shell previously matched
+   Electron's `hiddenInset` overlay (`TitleBarStyle::Overlay`,
+   `hidden_title`, custom traffic-light position). On a real build the overlay
+   lost to the tab bar at every layer: tao implements
+   `traffic_light_position` by shrinking the titlebar container the tab bar
+   lives in (re-applied every `drawRect:`), so the bar was squashed and the
+   lights vanished; the full-size content view put the page under the chrome,
+   so scrolled content and the scrollbar showed through the titlebar row,
+   fixed-position modals opened underneath the tab bar, and the transparent
+   titlebar hit-tested through to the page, leaving the window undraggable
+   (tauri#9503). Each symptom had a workaround; the workarounds were a
+   machinery. A standard visible titlebar dissolves all of it: AppKit lays the
+   web view out *below* the chrome, and drag, zoom, scrollbars, and modals are
+   simply correct. `hidden_title(true)` keeps the empty titlebar row from
+   drawing a window title; tab labels are unaffected (they read
+   `NSWindow.tab.title`). The page-side consequence: the shell no longer
+   stamps `data-titlebar="overlay"`, so the 38px sidebar inset stays off and
+   the web app needs no inset at all.
+
+3. **Tab keys cannot be menu equivalents, and the menu must be extended, not
+   replaced.** AppKit matches non-⌘ key equivalents only after the responder
+   chain declines the key, and WKWebView consumes Tab — so ⌃Tab/⌃⇧Tab are
+   caught by a local `NSEvent` monitor (before webview dispatch), the way
+   Safari does it; the dispatched actions are AppKit's own
+   (`selectNextTab:` etc.). The menu is built by extending `Menu::default`:
+   a from-scratch menu has no submenu tagged `WINDOW_SUBMENU_ID`, so Tauri
+   never registers `NSApp.windowsMenu` and macOS silently loses the window
+   list. The tab-bar `+` button is AppKit's own, summoned by implementing
+   `newWindowForTab:` on the window class at runtime.
+
+The capability in `capabilities/remote.json` scopes to `["main", "tab-*"]`;
+tab windows are labelled `tab-<n>` from a counter, and the glob is the only
+place a label shape may be relied on. The `desktop_shell_info` bridge was
+verified working from inside a created tab on a release build.
+
+## Consequences
+
+- Backgrounded tabs keep running for free; session is shared (same WKWebView
+  data store), so no re-authentication per tab.
+- The Tauri shell's chrome now visibly diverges from the Electron shell's.
+  Accepted: Electron is expected to be retired, not kept in parity.
+- Tab labels all read "Exponential Beta" until URL-derived labels
+  (`tab_title`, the V2 ticket's action 2) land.
+- macOS-only by design. If a Windows/Linux shell ever happens, native tabbing
+  does not exist there and a different mechanism is required.
+
+## Rejected alternatives
+
+- **In-page tabs in the web app** (React or iframe, gated on `isTauri()`): a
+  `data-shell` check is a rule every future PR must respect; iframes also cost
+  a full app instance each plus duplicated chrome. The native mechanism makes
+  "no tabs in a browser" structural.
+- **A custom tab strip over multiple webviews in one window**: needs
+  `unstable`, plus reimplementing reorder/close/keyboard that AppKit provides.
+- **One shared sidebar with tabs swapping only the content pane**
+  (Notion-style): not expressible with native window tabs — a macOS tab *is* a
+  window — and every in-page route to it was rejected above. Raised and
+  declined during the spike.
+- **Keeping the overlay chrome and patching around the tab bar**: tried on
+  real builds during the spike (measured-inset push, body padding, modal CSS,
+  JS drag shim); every patch was another moving part and scroll-under-chrome
+  remained. This is the fallback the spike existed to evaluate, and the
+  evaluation said no.
+- **Reading `document.title` for tab labels**: effectively constant across
+  the authenticated app; every tab would read identically.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1003,6 +1003,7 @@ name = "exponential-beta"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "block2",
  "getrandom 0.3.4",
  "objc2",
  "objc2-app-kit",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1054,7 +1054,6 @@ dependencies = [
  "block2",
  "getrandom 0.3.4",
  "objc2",
- "objc2-app-kit",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2336,17 +2335,10 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "libc",
  "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-text",
- "objc2-core-video",
  "objc2-foundation",
- "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2366,7 +2358,6 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2425,19 +2416,6 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
-]
-
-[[package]]
-name = "objc2-core-video"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
-dependencies = [
- "bitflags 2.13.1",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-io-surface",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1004,6 +1004,8 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.3.4",
+ "objc2",
+ "objc2-app-kit",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2203,9 +2205,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2225,6 +2235,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2283,6 +2294,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +507,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]
@@ -837,12 +873,18 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever",
  "precomputed-hash",
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -979,6 +1021,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1061,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-deep-link",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
@@ -1025,6 +1074,12 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1052,6 +1107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1127,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1303,6 +1370,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1567,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +1588,15 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1780,6 +1877,20 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2101,6 +2212,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2271,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "num-conv"
@@ -2449,6 +2579,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,6 +2647,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -2719,6 +2870,18 @@ checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3759,6 +3922,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "tauri-plugin-deep-link"
 version = "2.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3994,6 +4172,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4328,6 +4520,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4593,6 +4796,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4712,6 +4985,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5199,6 +5478,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.19",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5268,6 +5565,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "yoke"
@@ -5354,6 +5668,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5418,6 +5752,21 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,15 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 url = "2"
 tauri-plugin-store = "2.4.4"
 
+# SPIKE (cool.lark) — throwaway. Sharing a tabbing identifier only makes windows
+# *tabbable*; AppKit merges them automatically only when the user's global
+# AppleWindowTabbingMode is "always", and Apple's default is "In Full Screen
+# Only". Neither tao nor tauri exposes -[NSWindow addTabbedWindow:ordered:], so
+# the spike reaches for it through ns_window(). Already a transitive dep.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-app-kit = "0.3"
+
 [profile.dev]
 # The shell is a thin wrapper around a remote page; incremental debug builds are
 # what we actually iterate on, so keep them cheap.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,8 @@ tauri-plugin-store = "2.4.4"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-app-kit = "0.3"
+# NSEvent local monitor blocks (⌃Tab has to be caught before WKWebView eats it).
+block2 = "0.6"
 
 [profile.dev]
 # The shell is a thin wrapper around a remote page; incremental debug builds are

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,7 +42,6 @@ tauri-plugin-clipboard-manager = "2"
 # the spike reaches for it through ns_window(). Already a transitive dep.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-app-kit = "0.3"
 # NSEvent local monitor blocks (⌃Tab has to be caught before WKWebView eats it).
 block2 = "0.6"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,9 @@ sha2 = "0.10"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "charset"] }
 url = "2"
 tauri-plugin-store = "2.4.4"
+# Cmd/Ctrl+L copies the frontmost tab's URL. Written from Rust, so it needs no
+# ACL grant and works on every platform the shell ever targets.
+tauri-plugin-clipboard-manager = "2"
 
 # SPIKE (cool.lark) — throwaway. Sharing a tabbing identifier only makes windows
 # *tabbable*; AppKit merges them automatically only when the user's global

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,11 +35,11 @@ tauri-plugin-store = "2.4.4"
 # ACL grant and works on every platform the shell ever targets.
 tauri-plugin-clipboard-manager = "2"
 
-# SPIKE (cool.lark) — throwaway. Sharing a tabbing identifier only makes windows
+# Native window tabs (ADR-0053). Sharing a tabbing identifier only makes windows
 # *tabbable*; AppKit merges them automatically only when the user's global
 # AppleWindowTabbingMode is "always", and Apple's default is "In Full Screen
 # Only". Neither tao nor tauri exposes -[NSWindow addTabbedWindow:ordered:], so
-# the spike reaches for it through ns_window(). Already a transitive dep.
+# the shell reaches for it through ns_window(). Already a transitive dep.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 # NSEvent local monitor blocks (⌃Tab has to be caught before WKWebView eats it).

--- a/src-tauri/capabilities/remote.json
+++ b/src-tauri/capabilities/remote.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "remote-app",
   "description": "IPC surface granted to the Exponential web app loaded from its own origin. A remote page gets no usable Tauri bridge without this: `remote.urls` opts the origin in, and every command it may call must be granted below by name. Both apex and www are listed because exponential.im 301s to www — the webview's effective origin is the redirect target.",
-  "windows": ["main"],
+  "windows": ["main", "tab-*"],
   "remote": {
     "urls": [
       "https://exponential.im/*",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -282,6 +282,9 @@ const TITLEBAR_MARKER_SCRIPT: &str = r#"
     if (!root) return false;
     root.setAttribute('data-shell', 'tauri');
     root.setAttribute('data-titlebar', 'overlay');
+    // Only the tabbed shell stamps this; sidebar.css keys the main column's
+    // top clearance on it, so the live V1 shell is unaffected.
+    root.setAttribute('data-tabs', 'native');
     return true;
   }
   try {
@@ -354,8 +357,17 @@ fn push_titlebar_inset(window: &tauri::WebviewWindow) {
 
     // A hidden tab bar reports the plain titlebar height; both cases are just
     // "whatever AppKit says", which is the whole point.
+    //
+    // The body padding is SPIKE-ONLY: the packaged build loads production, whose
+    // stylesheet doesn't yet have the `html[data-tabs="native"] .sidebar-offset`
+    // rule that will do this properly, so the shell pads the page itself to make
+    // the fix visible on a real build. V2 pushes only the variable and lets the
+    // deployed CSS consume it — shipping both would double the inset.
     let _ = window.eval(&format!(
-        "document.documentElement.style.setProperty('--titlebar-inset','{inset:.0}px')"
+        "(function() {{\
+           document.documentElement.style.setProperty('--titlebar-inset','{inset:.0}px');\
+           if (document.body) document.body.style.paddingTop = '{inset:.0}px';\
+         }})()"
     ));
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -280,19 +280,19 @@ fn resolve_wiki_root(app: &tauri::AppHandle) {
         .expect("wiki root mutex poisoned") = Some(root);
 }
 
-/// Tells the page it is inside this shell, so it can keep its own chrome out
-/// from under the window controls.
+/// Tells the page it is inside this shell.
 ///
 /// The page cannot reliably work this out for itself. It used to sniff
 /// `window.__TAURI_INTERNALS__` from an inline `<head>` script, but on a remote
 /// page that global lands *after* the document's own head scripts run — so the
-/// check was made too early, found nothing, and the inset was silently skipped.
-/// IPC worked fine a moment later, which is what made the bug so quiet.
+/// check was made too early, found nothing, and the marking was silently
+/// skipped. IPC worked fine a moment later, which is what made the bug so
+/// quiet. An initialization script has no such race; `documentElement` may not
+/// exist yet at injection time, hence the `DOMContentLoaded` retry.
 ///
-/// An initialization script has no such race: whenever it runs, setting the
-/// attribute is enough, because the CSS keyed off it applies the moment it
-/// appears. `documentElement` may not exist yet at injection time, hence the
-/// `DOMContentLoaded` retry.
+/// With the Safari-style chrome this stamps only `data-shell` — the overlay-era
+/// `data-titlebar` marking (and the 38px sidebar inset it switched on) is
+/// deliberately gone, because the page no longer sits under any chrome.
 #[cfg(target_os = "macos")]
 const TITLEBAR_MARKER_SCRIPT: &str = r#"
 (function () {
@@ -300,32 +300,15 @@ const TITLEBAR_MARKER_SCRIPT: &str = r#"
     var root = document && document.documentElement;
     if (!root) return false;
     root.setAttribute('data-shell', 'tauri');
-    root.setAttribute('data-titlebar', 'overlay');
-    // Only the tabbed shell stamps this; sidebar.css keys the main column's
-    // top clearance on it, so the live V1 shell is unaffected.
-    root.setAttribute('data-tabs', 'native');
+    // Deliberately NOT stamping data-titlebar="overlay": with the Safari-style
+    // visible titlebar the page starts below the chrome, so the 38px inset that
+    // attribute switches on in sidebar.css would be pure dead space.
     return true;
   }
   try {
     if (!mark()) {
       document.addEventListener('DOMContentLoaded', mark);
     }
-    // Overlay titlebars hit-test through to the page (tauri#9503), so without
-    // this the window cannot be dragged at all: the traffic-light row delivers
-    // its mousedowns to the webview, which ignores them. Any press in the
-    // chrome strip hands off to a native window drag. The tab bar itself is an
-    // opaque native view whose events never reach the page, so this only fires
-    // where AppKit isn't already handling the gesture. Costs titlebar
-    // double-click-to-zoom, which was equally unreachable before.
-    document.addEventListener('mousedown', function (e) {
-      if (e.button !== 0) return;
-      var inset = parseFloat(
-        getComputedStyle(document.documentElement).getPropertyValue('--titlebar-inset')
-      ) || 0;
-      if (inset <= 0 || e.clientY >= inset) return;
-      var t = window.__TAURI_INTERNALS__;
-      if (t && t.invoke) t.invoke('plugin:window|start_dragging');
-    });
   } catch (e) {}
 })();
 "#;
@@ -361,58 +344,6 @@ fn spike_second_window(app: &tauri::AppHandle) -> tauri::Result<()> {
     #[cfg(not(target_os = "macos"))]
     let _ = app;
     Ok(())
-}
-
-/// SPIKE (cool.lark) — throwaway. Tell the page how much room the chrome is
-/// actually taking, instead of letting it guess.
-///
-/// `sidebar.css` hardcodes `--titlebar-inset: 38px`, a number tuned for the
-/// squashed 30pt titlebar the old traffic-light inset forced. With native tabs
-/// the row is titlebar + tab bar, so 38px is ~22pt short and the sidebar
-/// collides with the tabs. A bigger constant would be just as wrong the other
-/// way: macOS hides the tab bar at one tab, and then 60px is 30pt of dead space.
-///
-/// `contentLayoutRect` is AppKit's own answer — the part of the window not
-/// covered by titlebar, toolbar, or tab bar. Under `FullSizeContentView` the
-/// window frame and the content view are the same height, so the difference
-/// between them is exactly the inset the page needs to clear. An inline style
-/// on `documentElement` outranks the stylesheet's attribute selector, so this
-/// wins without the web app having to change.
-#[cfg(target_os = "macos")]
-fn push_titlebar_inset(window: &tauri::WebviewWindow) {
-    let Ok(ptr) = window.ns_window() else {
-        return;
-    };
-
-    // Safe: the pointer comes from a live window, and this only reads geometry.
-    let inset = unsafe {
-        let ns = &*(ptr as *const objc2_app_kit::NSWindow);
-        ns.frame().size.height - ns.contentLayoutRect().size.height
-    };
-
-    // A hidden tab bar reports the plain titlebar height; both cases are just
-    // "whatever AppKit says", which is the whole point.
-    //
-    // Everything past the variable push is SPIKE-ONLY: the packaged build loads
-    // production, whose stylesheet doesn't yet have the `data-tabs="native"`
-    // rules that will do this properly, so the shell applies their effect itself
-    // to make the fix visible on a real build — body padding for the page, and
-    // an injected copy of the modal rule, because modals portal to <body> with
-    // position: fixed and no amount of body padding reaches them. V2 pushes only
-    // the variable and lets the deployed CSS consume it — shipping both would
-    // double the inset.
-    let _ = window.eval(&format!(
-        "(function() {{\
-           document.documentElement.style.setProperty('--titlebar-inset','{inset:.0}px');\
-           if (document.body) document.body.style.paddingTop = '{inset:.0}px';\
-           if (document.head && !document.getElementById('__spike_tabs_css')) {{\
-             var s = document.createElement('style');\
-             s.id = '__spike_tabs_css';\
-             s.textContent = '.mantine-Modal-inner {{ padding-top: calc(var(--titlebar-inset) + 16px) !important; }}';\
-             document.head.appendChild(s);\
-           }}\
-         }})()"
-    ));
 }
 
 /// SPIKE (cool.lark) — throwaway. Tab commands, sent to whichever window is
@@ -642,60 +573,34 @@ fn build_window(app: &tauri::AppHandle, label: &str) -> tauri::Result<tauri::Web
             }
             open_externally(&new_window_opener, url.as_str());
             tauri::webview::NewWindowResponse::Deny
-        })
-        // SPIKE (cool.lark) — throwaway. `eval` runs against the *current*
-        // document, so an inset pushed before the page loads is thrown away with
-        // the empty document it landed in. Every load has to re-push.
-        .on_page_load(|window, _| {
-            #[cfg(target_os = "macos")]
-            push_titlebar_inset(&window);
-            let _ = &window;
         });
 
-    // Match the Electron shell's `hiddenInset` chrome: the traffic lights float
-    // over the page instead of sitting in a separate title bar.
+    // SPIKE (cool.lark) — the chrome decision this spike exists to test, and
+    // the overlay LOST. Safari-style chrome (a standard titlebar; the web view
+    // starts below it) instead of Electron-matching overlay chrome, because on
+    // a real build the overlay fought native tabs at every layer:
     //
-    // `hidden_title` is part of that match, not a nicety: `Overlay` alone keeps
-    // drawing the window title, which lands on top of the page's own top-left
-    // chrome (the sidebar's workspace switcher). Electron's `hiddenInset` hides
-    // the title for us; Tauri needs to be told. The page still needs to keep its
-    // content clear of the traffic lights themselves — see `--titlebar-inset` in
-    // `src/app/_components/layout/sidebar.css`.
+    //   - `traffic_light_position` shrinks the titlebar container the tab bar
+    //     lives in (tao's inset hack re-runs every drawRect:), squashing the
+    //     bar and hiding the lights;
+    //   - the full-size content view puts the page under the chrome, so
+    //     scrolled content and the scrollbar showed through the titlebar row,
+    //     fixed-position modals opened under the tab bar, and the transparent
+    //     titlebar hit-tested through to the page, leaving the window
+    //     undraggable (tauri#9503);
+    //   - each had a workaround, and each workaround was another moving part.
+    //
+    // A visible titlebar dissolves all of it: AppKit lays content below the
+    // chrome, dragging/zoom/scrollbars behave natively, and the page needs no
+    // inset at all. `hidden_title` keeps the empty titlebar row from drawing a
+    // window title over its middle; tab labels are unaffected (they read
+    // NSWindow.tab.title, not the titlebar drawing).
     #[cfg(target_os = "macos")]
     let builder = builder
-        .title_bar_style(tauri::TitleBarStyle::Overlay)
         .hidden_title(true)
-        // SPIKE (cool.lark) — throwaway. `.traffic_light_position(16, 16)` is
-        // deliberately *not* here. tao implements it by shrinking the entire
-        // titlebar container view to `button height + y` and pinning it to the
-        // window top (view.rs `inset_traffic_lights`), re-running on every
-        // drawRect:. The native tab bar lives in that same container, so the
-        // inset squashes it and the traffic lights vanish behind it — which is
-        // what the previous spike build showed. Left off here to see whether
-        // AppKit's default placement lays the tab bar out after the lights, the
-        // way Safari and Finder do.
         .tabbing_identifier("im.exponential.beta.tabs");
 
     let window = builder.build()?;
-
-    // SPIKE (cool.lark) — throwaway. Closing a tab down to one makes macOS hide
-    // the tab bar, which changes the inset without reloading anything, so
-    // `on_page_load` alone would leave the page reserving a row that is no
-    // longer there. Focus is the cheap catch-all: it fires on tab switch and
-    // after a close, which is every moment the answer can have changed.
-    #[cfg(target_os = "macos")]
-    {
-        let watched = window.clone();
-        window.on_window_event(move |event| {
-            if matches!(
-                event,
-                tauri::WindowEvent::Resized(_) | tauri::WindowEvent::Focused(true)
-            ) {
-                push_titlebar_inset(&watched);
-            }
-        });
-    }
-
     Ok(window)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,6 +85,76 @@ fn desktop_shell_info() -> ShellInfo {
     }
 }
 
+/// SPIKE (cool.lark) — throwaway. The shell has run Tauri's default menu until
+/// now, and the tab shortcuts do not survive that.
+///
+/// AppKit is supposed to inject Show Next/Previous Tab into whatever submenu is
+/// registered as `NSApp.windowsMenu`, and the preconditions all hold — tao
+/// leaves `allowsAutomaticWindowTabbing` on, and Tauri does call
+/// `set_as_windows_menu_for_nsapp` for the submenu tagged `WINDOW_SUBMENU_ID`.
+/// The items still never reached the keyboard, so they are declared explicitly
+/// here. The actions are AppKit's own, so the behaviour is Safari's — cycling
+/// wraps, the overview is the real overview — rather than a reimplementation.
+///
+/// Built by *extending* `Menu::default`, never by constructing a menu from
+/// scratch. A fresh menu has no submenu carrying `WINDOW_SUBMENU_ID`, so
+/// `set_as_windows_menu_for_nsapp` never fires and macOS silently loses the
+/// window list and its tab handling. Adding a tab shortcut that way would remove
+/// the others.
+#[cfg(target_os = "macos")]
+fn build_menu(app: &tauri::AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
+    use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
+
+    let menu = Menu::default(app)?;
+
+    let new_tab = MenuItem::with_id(app, "new-tab", "New Tab", true, Some("CmdOrCtrl+T"))?;
+    let next_tab = MenuItem::with_id(app, "next-tab", "Show Next Tab", true, Some("Ctrl+Tab"))?;
+    let prev_tab = MenuItem::with_id(
+        app,
+        "prev-tab",
+        "Show Previous Tab",
+        true,
+        Some("Ctrl+Shift+Tab"),
+    )?;
+    let overview = MenuItem::with_id(
+        app,
+        "tab-overview",
+        "Show All Tabs",
+        true,
+        Some("CmdOrCtrl+Shift+Backslash"),
+    )?;
+
+    // New Tab sits above Close Window in File, where Safari puts it.
+    if let Some(file) = submenu_named(&menu, "File") {
+        file.insert(&new_tab, 0)?;
+    }
+
+    if let Some(window) = menu
+        .get(tauri::menu::WINDOW_SUBMENU_ID)
+        .and_then(|item| item.as_submenu().cloned())
+    {
+        window.append(&PredefinedMenuItem::separator(app)?)?;
+        window.append(&next_tab)?;
+        window.append(&prev_tab)?;
+        window.append(&overview)?;
+    }
+
+    Ok(menu)
+}
+
+/// The default menu gives its submenus no ids except Window and Help, so File
+/// has to be found by the label the user reads.
+#[cfg(target_os = "macos")]
+fn submenu_named(
+    menu: &tauri::menu::Menu<tauri::Wry>,
+    name: &str,
+) -> Option<tauri::menu::Submenu<tauri::Wry>> {
+    menu.items().ok()?.into_iter().find_map(|item| {
+        let submenu = item.as_submenu()?;
+        (submenu.text().ok()? == name).then(|| submenu.clone())
+    })
+}
+
 pub fn run() {
     tauri::Builder::default()
         // Single-instance must be registered first (plugin's own requirement).
@@ -99,6 +169,22 @@ pub fn run() {
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::default().build())
+        .menu(|app| {
+            #[cfg(target_os = "macos")]
+            return build_menu(app);
+            #[cfg(not(target_os = "macos"))]
+            return tauri::menu::Menu::default(app);
+        })
+        .on_menu_event(|_app, _event| {
+            #[cfg(target_os = "macos")]
+            match _event.id().as_ref() {
+                "new-tab" => tabs::open(_app),
+                "next-tab" => tabs::select_next(_app),
+                "prev-tab" => tabs::select_previous(_app),
+                "tab-overview" => tabs::toggle_overview(_app),
+                _ => {}
+            }
+        })
         .manage(auth::LoginState::default())
         .manage(wiki::WikiRoot::default())
         .invoke_handler(tauri::generate_handler![
@@ -292,6 +378,92 @@ fn push_titlebar_inset(window: &tauri::WebviewWindow) {
     let _ = window.eval(&format!(
         "document.documentElement.style.setProperty('--titlebar-inset','{inset:.0}px')"
     ));
+}
+
+/// SPIKE (cool.lark) — throwaway. Tab commands, sent to whichever window is
+/// frontmost.
+///
+/// `selectNextTab:`, `selectPreviousTab:` and `toggleTabOverview:` are AppKit's
+/// own actions, so the behaviour is Safari's by construction — cycling wraps,
+/// the overview is the real overview — rather than something reimplemented and
+/// approximately right.
+#[cfg(target_os = "macos")]
+mod tabs {
+    use objc2::runtime::AnyObject;
+    use tauri::Manager;
+
+    /// Labels are `tab-<n>` to match the capability glob. Nothing reads them.
+    static NEXT_LABEL: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(1);
+
+    pub fn next_label() -> String {
+        let n = NEXT_LABEL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        format!("tab-{n}")
+    }
+
+    pub fn frontmost(app: &tauri::AppHandle) -> Option<tauri::WebviewWindow> {
+        let windows = app.webview_windows();
+        windows
+            .values()
+            .find(|w| w.is_focused().unwrap_or(false))
+            .or_else(|| windows.values().next())
+            .cloned()
+    }
+
+    fn ns_window(window: &tauri::WebviewWindow) -> Option<*mut AnyObject> {
+        window.ns_window().ok().map(|ptr| ptr as *mut AnyObject)
+    }
+
+    pub fn select_next(app: &tauri::AppHandle) {
+        if let Some(ns) = frontmost(app).as_ref().and_then(ns_window) {
+            unsafe {
+                let _: () = objc2::msg_send![ns, selectNextTab: std::ptr::null::<AnyObject>()];
+            }
+        }
+    }
+
+    pub fn select_previous(app: &tauri::AppHandle) {
+        if let Some(ns) = frontmost(app).as_ref().and_then(ns_window) {
+            unsafe {
+                let _: () = objc2::msg_send![ns, selectPreviousTab: std::ptr::null::<AnyObject>()];
+            }
+        }
+    }
+
+    pub fn toggle_overview(app: &tauri::AppHandle) {
+        if let Some(ns) = frontmost(app).as_ref().and_then(ns_window) {
+            unsafe {
+                let _: () = objc2::msg_send![ns, toggleTabOverview: std::ptr::null::<AnyObject>()];
+            }
+        }
+    }
+
+    /// Open a tab in the frontmost window's tab group.
+    ///
+    /// `addTabbedWindow:` rather than trusting the shared identifier: AppKit only
+    /// auto-merges when the user's global `AppleWindowTabbingMode` is `always`,
+    /// and Apple's default is "In Full Screen Only" — so without this an ordinary
+    /// user gets a detached window and no tab at all.
+    pub fn open(app: &tauri::AppHandle) {
+        let host = frontmost(app);
+        let Ok(()) = super::build_window(app, &next_label()) else {
+            return;
+        };
+        let Some(host_ns) = host.as_ref().and_then(ns_window) else {
+            return;
+        };
+        // The window just built is the newest one; find it by the label we used.
+        let Some(added) = app
+            .webview_windows()
+            .values()
+            .max_by_key(|w| w.label().to_owned())
+            .and_then(|w| ns_window(w))
+        else {
+            return;
+        };
+        unsafe {
+            let _: () = objc2::msg_send![host_ns, addTabbedWindow: added, ordered: 1isize];
+        }
+    }
 }
 
 fn build_window(app: &tauri::AppHandle, label: &str) -> tauri::Result<()> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,7 +204,12 @@ pub fn run() {
         ])
         .setup(|app| {
             resolve_wiki_root(app.handle());
-            build_main_window(app.handle())?;
+            let _main = build_main_window(app.handle())?;
+            #[cfg(target_os = "macos")]
+            {
+                install_tab_key_monitor(app.handle());
+                install_plus_button(app.handle(), &_main);
+            }
             // SPIKE (cool.lark) — throwaway. Second window sharing the tabbing
             // identifier, so a release build opens with a native tab bar and the
             // two questions can be looked at. Delete with the rest of the spike.
@@ -296,53 +301,27 @@ const TITLEBAR_MARKER_SCRIPT: &str = "";
 /// The window is built here rather than declared in `tauri.conf.json` because the
 /// URL is build-dependent (dev server vs production) and a `WebviewUrl::External`
 /// in static config cannot express that.
-fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<()> {
+fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<tauri::WebviewWindow> {
     build_window(app, "main")
 }
 
-/// SPIKE (cool.lark) — throwaway. A second window with the same tabbing
-/// identifier, labelled `tab-2` so the capability glob (`"windows": ["main",
-/// "tab-*"]`, also spike-only) gets exercised at the same time: if the bridge
-/// reaches this window, `desktop_shell_info` answers from inside the tab.
+/// SPIKE (cool.lark) — throwaway. A second tab at startup, so the build opens
+/// with a tab bar to inspect and the capability glob (`"windows": ["main",
+/// "tab-*"]`, also spike-only) gets exercised: if the bridge reaches the second
+/// window, `desktop_shell_info` answers from inside a tab.
 ///
-/// The identifier alone is not enough to produce a tab. It makes the windows
-/// *tabbable*; AppKit only merges them on its own when the user's global
+/// The shared tabbing identifier alone is not enough to produce a tab. It makes
+/// windows *tabbable*; AppKit only merges them on its own when the user's global
 /// `AppleWindowTabbingMode` is `always`, and Apple ships that preference
 /// defaulting to "In Full Screen Only". Left there, the second window opens as a
-/// plain window behind the first and there is no tab bar to inspect at all —
-/// which is exactly what the first spike build showed.
-///
-/// `-[NSWindow addTabbedWindow:ordered:]` merges regardless of the preference,
-/// and is the only way to get a tab deterministically. Neither tao nor tauri
-/// wraps it, so this goes through `ns_window()`.
+/// plain window behind the first and there is no tab bar at all — which is
+/// exactly what the first spike build showed. `tabs::open` goes through
+/// `-[NSWindow addTabbedWindow:ordered:]`, which merges deterministically.
 fn spike_second_window(app: &tauri::AppHandle) -> tauri::Result<()> {
-    build_window(app, "tab-2")?;
-
     #[cfg(target_os = "macos")]
-    {
-        use objc2::runtime::AnyObject;
-
-        // NSWindowOrderingMode::Above.
-        const NS_WINDOW_ABOVE: isize = 1;
-
-        let (Some(first), Some(second)) = (
-            app.get_webview_window("main"),
-            app.get_webview_window("tab-2"),
-        ) else {
-            eprintln!("[spike] a window went missing before tabs could be merged");
-            return Ok(());
-        };
-
-        let first = first.ns_window()? as *mut AnyObject;
-        let second = second.ns_window()? as *mut AnyObject;
-
-        // Safe: both pointers come from live windows, and `setup` runs on the
-        // main thread, which is where AppKit requires this call.
-        unsafe {
-            let _: () = objc2::msg_send![first, addTabbedWindow: second, ordered: NS_WINDOW_ABOVE];
-        }
-    }
-
+    tabs::open(app);
+    #[cfg(not(target_os = "macos"))]
+    let _ = app;
     Ok(())
 }
 
@@ -445,28 +424,116 @@ mod tabs {
     /// user gets a detached window and no tab at all.
     pub fn open(app: &tauri::AppHandle) {
         let host = frontmost(app);
-        let Ok(()) = super::build_window(app, &next_label()) else {
+        let Ok(created) = super::build_window(app, &next_label()) else {
             return;
         };
-        let Some(host_ns) = host.as_ref().and_then(ns_window) else {
-            return;
-        };
-        // The window just built is the newest one; find it by the label we used.
-        let Some(added) = app
-            .webview_windows()
-            .values()
-            .max_by_key(|w| w.label().to_owned())
-            .and_then(|w| ns_window(w))
+        let (Some(host_ns), Some(created_ns)) =
+            (host.as_ref().and_then(ns_window), ns_window(&created))
         else {
             return;
         };
+        // NSWindowOrderingMode::Above — new tab lands after the current one.
         unsafe {
-            let _: () = objc2::msg_send![host_ns, addTabbedWindow: added, ordered: 1isize];
+            let _: () = objc2::msg_send![host_ns, addTabbedWindow: created_ns, ordered: 1isize];
         }
+        let _ = created.set_focus();
     }
 }
 
-fn build_window(app: &tauri::AppHandle, label: &str) -> tauri::Result<()> {
+/// SPIKE (cool.lark) — throwaway. ⌃Tab / ⌃⇧Tab, caught the way Safari catches
+/// them: before the web view sees the key.
+///
+/// These cannot be menu key equivalents. AppKit matches a non-⌘ equivalent only
+/// after the responder chain declines the key, and WKWebView consumes Tab —
+/// which is why the menu items alone (previous build) never fired. A local
+/// NSEvent monitor runs before dispatch, so it wins regardless of what the
+/// webview would do with the key. The menu items stay for discoverability; the
+/// monitor swallowing the event just means they are never reached by keyboard.
+#[cfg(target_os = "macos")]
+fn install_tab_key_monitor(app: &tauri::AppHandle) {
+    use objc2::runtime::AnyObject;
+
+    const KEY_DOWN_MASK: u64 = 1 << 10; // NSEventMaskKeyDown
+    const SHIFT: u64 = 1 << 17; // NSEventModifierFlagShift
+    const CONTROL: u64 = 1 << 18; // NSEventModifierFlagControl
+    const OPTION: u64 = 1 << 19; // NSEventModifierFlagOption
+    const COMMAND: u64 = 1 << 20; // NSEventModifierFlagCommand
+    const TAB_KEY_CODE: u16 = 48;
+
+    let handle = app.clone();
+    let block = block2::RcBlock::new(move |event: *mut AnyObject| -> *mut AnyObject {
+        let (key_code, flags): (u16, u64) = unsafe {
+            (
+                objc2::msg_send![event, keyCode],
+                objc2::msg_send![event, modifierFlags],
+            )
+        };
+        if key_code == TAB_KEY_CODE && flags & CONTROL != 0 && flags & (COMMAND | OPTION) == 0 {
+            if flags & SHIFT != 0 {
+                tabs::select_previous(&handle);
+            } else {
+                tabs::select_next(&handle);
+            }
+            return std::ptr::null_mut(); // swallowed — the webview never tabs focus
+        }
+        event
+    });
+
+    // The monitor and its block live for the life of the app; there is no
+    // teardown moment, so leaking both is the correct lifetime.
+    unsafe {
+        let _monitor: *mut AnyObject = objc2::msg_send![
+            objc2::class!(NSEvent),
+            addLocalMonitorForEventsMatchingMask: KEY_DOWN_MASK,
+            handler: &*block
+        ];
+    }
+    std::mem::forget(block);
+}
+
+/// SPIKE (cool.lark) — throwaway. The `+` at the right end of the tab bar.
+///
+/// AppKit draws Safari's plus button by itself the moment any responder in the
+/// window's chain implements `newWindowForTab:` — the button *is* that check.
+/// Neither tao nor tauri implements it, so it is added to the window's own class
+/// at runtime, once; the class is tao's window subclass, so every tab gets the
+/// button from the same patch.
+#[cfg(target_os = "macos")]
+static TAB_APP_HANDLE: OnceLock<tauri::AppHandle> = OnceLock::new();
+
+#[cfg(target_os = "macos")]
+fn install_plus_button(app: &tauri::AppHandle, window: &tauri::WebviewWindow) {
+    use objc2::runtime::AnyObject;
+
+    let _ = TAB_APP_HANDLE.set(app.clone());
+
+    extern "C-unwind" fn new_window_for_tab(
+        _this: *mut AnyObject,
+        _sel: objc2::runtime::Sel,
+        _sender: *mut AnyObject,
+    ) {
+        // Runs on the main thread — AppKit action dispatch, same as a menu item.
+        if let Some(app) = TAB_APP_HANDLE.get() {
+            tabs::open(app);
+        }
+    }
+
+    let Ok(ptr) = window.ns_window() else {
+        return;
+    };
+    unsafe {
+        let ns = ptr as *mut AnyObject;
+        let class: *mut objc2::runtime::AnyClass = objc2::msg_send![ns, class];
+        let imp = std::mem::transmute::<
+            extern "C-unwind" fn(*mut AnyObject, objc2::runtime::Sel, *mut AnyObject),
+            objc2::runtime::Imp,
+        >(new_window_for_tab);
+        // "v@:@" — returns void, takes self, _cmd, sender.
+        objc2::ffi::class_addMethod(class, objc2::sel!(newWindowForTab:), imp, c"v@:@".as_ptr());
+    }
+}
+
+fn build_window(app: &tauri::AppHandle, label: &str) -> tauri::Result<tauri::WebviewWindow> {
     let url = app_base_url()
         .parse()
         .unwrap_or_else(|e| panic!("{BASE_URL_ENV} is not a valid URL: {e}"));
@@ -553,7 +620,7 @@ fn build_window(app: &tauri::AppHandle, label: &str) -> tauri::Result<()> {
         });
     }
 
-    Ok(())
+    Ok(window)
 }
 
 /// Hand a URL to the user's default browser.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -218,8 +218,80 @@ fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<()> {
 /// identifier, labelled `tab-2` so the capability glob (`"windows": ["main",
 /// "tab-*"]`, also spike-only) gets exercised at the same time: if the bridge
 /// reaches this window, `desktop_shell_info` answers from inside the tab.
+///
+/// The identifier alone is not enough to produce a tab. It makes the windows
+/// *tabbable*; AppKit only merges them on its own when the user's global
+/// `AppleWindowTabbingMode` is `always`, and Apple ships that preference
+/// defaulting to "In Full Screen Only". Left there, the second window opens as a
+/// plain window behind the first and there is no tab bar to inspect at all —
+/// which is exactly what the first spike build showed.
+///
+/// `-[NSWindow addTabbedWindow:ordered:]` merges regardless of the preference,
+/// and is the only way to get a tab deterministically. Neither tao nor tauri
+/// wraps it, so this goes through `ns_window()`.
 fn spike_second_window(app: &tauri::AppHandle) -> tauri::Result<()> {
-    build_window(app, "tab-2")
+    build_window(app, "tab-2")?;
+
+    #[cfg(target_os = "macos")]
+    {
+        use objc2::runtime::AnyObject;
+
+        // NSWindowOrderingMode::Above.
+        const NS_WINDOW_ABOVE: isize = 1;
+
+        let (Some(first), Some(second)) = (
+            app.get_webview_window("main"),
+            app.get_webview_window("tab-2"),
+        ) else {
+            eprintln!("[spike] a window went missing before tabs could be merged");
+            return Ok(());
+        };
+
+        let first = first.ns_window()? as *mut AnyObject;
+        let second = second.ns_window()? as *mut AnyObject;
+
+        // Safe: both pointers come from live windows, and `setup` runs on the
+        // main thread, which is where AppKit requires this call.
+        unsafe {
+            let _: () = objc2::msg_send![first, addTabbedWindow: second, ordered: NS_WINDOW_ABOVE];
+        }
+    }
+
+    Ok(())
+}
+
+/// SPIKE (cool.lark) — throwaway. Tell the page how much room the chrome is
+/// actually taking, instead of letting it guess.
+///
+/// `sidebar.css` hardcodes `--titlebar-inset: 38px`, a number tuned for the
+/// squashed 30pt titlebar the old traffic-light inset forced. With native tabs
+/// the row is titlebar + tab bar, so 38px is ~22pt short and the sidebar
+/// collides with the tabs. A bigger constant would be just as wrong the other
+/// way: macOS hides the tab bar at one tab, and then 60px is 30pt of dead space.
+///
+/// `contentLayoutRect` is AppKit's own answer — the part of the window not
+/// covered by titlebar, toolbar, or tab bar. Under `FullSizeContentView` the
+/// window frame and the content view are the same height, so the difference
+/// between them is exactly the inset the page needs to clear. An inline style
+/// on `documentElement` outranks the stylesheet's attribute selector, so this
+/// wins without the web app having to change.
+#[cfg(target_os = "macos")]
+fn push_titlebar_inset(window: &tauri::WebviewWindow) {
+    let Ok(ptr) = window.ns_window() else {
+        return;
+    };
+
+    // Safe: the pointer comes from a live window, and this only reads geometry.
+    let inset = unsafe {
+        let ns = &*(ptr as *const objc2_app_kit::NSWindow);
+        ns.frame().size.height - ns.contentLayoutRect().size.height
+    };
+
+    // A hidden tab bar reports the plain titlebar height; both cases are just
+    // "whatever AppKit says", which is the whole point.
+    let _ = window.eval(&format!(
+        "document.documentElement.style.setProperty('--titlebar-inset','{inset:.0}px')"
+    ));
 }
 
 fn build_window(app: &tauri::AppHandle, label: &str) -> tauri::Result<()> {
@@ -255,6 +327,14 @@ fn build_window(app: &tauri::AppHandle, label: &str) -> tauri::Result<()> {
             }
             open_externally(&new_window_opener, url.as_str());
             tauri::webview::NewWindowResponse::Deny
+        })
+        // SPIKE (cool.lark) — throwaway. `eval` runs against the *current*
+        // document, so an inset pushed before the page loads is thrown away with
+        // the empty document it landed in. Every load has to re-push.
+        .on_page_load(|window, _| {
+            #[cfg(target_os = "macos")]
+            push_titlebar_inset(&window);
+            let _ = &window;
         });
 
     // Match the Electron shell's `hiddenInset` chrome: the traffic lights float
@@ -270,12 +350,37 @@ fn build_window(app: &tauri::AppHandle, label: &str) -> tauri::Result<()> {
     let builder = builder
         .title_bar_style(tauri::TitleBarStyle::Overlay)
         .hidden_title(true)
-        .traffic_light_position(tauri::LogicalPosition::new(16.0, 16.0))
-        // SPIKE (cool.lark) — throwaway. Shared identifier is the whole native
-        // tabbing mechanism; AppKit draws the tab bar from it.
+        // SPIKE (cool.lark) — throwaway. `.traffic_light_position(16, 16)` is
+        // deliberately *not* here. tao implements it by shrinking the entire
+        // titlebar container view to `button height + y` and pinning it to the
+        // window top (view.rs `inset_traffic_lights`), re-running on every
+        // drawRect:. The native tab bar lives in that same container, so the
+        // inset squashes it and the traffic lights vanish behind it — which is
+        // what the previous spike build showed. Left off here to see whether
+        // AppKit's default placement lays the tab bar out after the lights, the
+        // way Safari and Finder do.
         .tabbing_identifier("im.exponential.beta.tabs");
 
-    builder.build()?;
+    let window = builder.build()?;
+
+    // SPIKE (cool.lark) — throwaway. Closing a tab down to one makes macOS hide
+    // the tab bar, which changes the inset without reloading anything, so
+    // `on_page_load` alone would leave the page reserving a row that is no
+    // longer there. Focus is the cheap catch-all: it fires on tab switch and
+    // after a close, which is every moment the answer can have changed.
+    #[cfg(target_os = "macos")]
+    {
+        let watched = window.clone();
+        window.on_window_event(move |event| {
+            if matches!(
+                event,
+                tauri::WindowEvent::Resized(_) | tauri::WindowEvent::Focused(true)
+            ) {
+                push_titlebar_inset(&watched);
+            }
+        });
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,42 +101,64 @@ fn desktop_shell_info() -> ShellInfo {
 /// `set_as_windows_menu_for_nsapp` never fires and macOS silently loses the
 /// window list and its tab handling. Adding a tab shortcut that way would remove
 /// the others.
-#[cfg(target_os = "macos")]
+///
+/// Cross-platform on purpose, even though tabs are macOS-only: Copy Page URL is
+/// wanted everywhere the shell might run, and `CmdOrCtrl` resolves per platform.
+/// (Linux's default menu has no File submenu, so the item is macOS/Windows —
+/// acceptable for a shell that only targets macOS today.)
 fn build_menu(app: &tauri::AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
-    use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
+    use tauri::menu::{Menu, MenuItem};
 
     let menu = Menu::default(app)?;
 
-    let new_tab = MenuItem::with_id(app, "new-tab", "New Tab", true, Some("CmdOrCtrl+T"))?;
-    let next_tab = MenuItem::with_id(app, "next-tab", "Show Next Tab", true, Some("Ctrl+Tab"))?;
-    let prev_tab = MenuItem::with_id(
+    // ⌘L. Safari focuses the address bar; with no address bar, copying the URL
+    // is the useful half of the gesture.
+    let copy_url = MenuItem::with_id(
         app,
-        "prev-tab",
-        "Show Previous Tab",
+        "copy-url",
+        "Copy Page URL",
         true,
-        Some("Ctrl+Shift+Tab"),
+        Some("CmdOrCtrl+L"),
     )?;
-    let overview = MenuItem::with_id(
-        app,
-        "tab-overview",
-        "Show All Tabs",
-        true,
-        Some("CmdOrCtrl+Shift+Backslash"),
-    )?;
-
-    // New Tab sits above Close Window in File, where Safari puts it.
     if let Some(file) = submenu_named(&menu, "File") {
-        file.insert(&new_tab, 0)?;
+        file.insert(&copy_url, 0)?;
     }
 
-    if let Some(window) = menu
-        .get(tauri::menu::WINDOW_SUBMENU_ID)
-        .and_then(|item| item.as_submenu().cloned())
+    #[cfg(target_os = "macos")]
     {
-        window.append(&PredefinedMenuItem::separator(app)?)?;
-        window.append(&next_tab)?;
-        window.append(&prev_tab)?;
-        window.append(&overview)?;
+        use tauri::menu::PredefinedMenuItem;
+
+        let new_tab = MenuItem::with_id(app, "new-tab", "New Tab", true, Some("CmdOrCtrl+T"))?;
+        let next_tab = MenuItem::with_id(app, "next-tab", "Show Next Tab", true, Some("Ctrl+Tab"))?;
+        let prev_tab = MenuItem::with_id(
+            app,
+            "prev-tab",
+            "Show Previous Tab",
+            true,
+            Some("Ctrl+Shift+Tab"),
+        )?;
+        let overview = MenuItem::with_id(
+            app,
+            "tab-overview",
+            "Show All Tabs",
+            true,
+            Some("CmdOrCtrl+Shift+Backslash"),
+        )?;
+
+        // New Tab sits above Close Window in File, where Safari puts it.
+        if let Some(file) = submenu_named(&menu, "File") {
+            file.insert(&new_tab, 0)?;
+        }
+
+        if let Some(window) = menu
+            .get(tauri::menu::WINDOW_SUBMENU_ID)
+            .and_then(|item| item.as_submenu().cloned())
+        {
+            window.append(&PredefinedMenuItem::separator(app)?)?;
+            window.append(&next_tab)?;
+            window.append(&prev_tab)?;
+            window.append(&overview)?;
+        }
     }
 
     Ok(menu)
@@ -144,7 +166,6 @@ fn build_menu(app: &tauri::AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::
 
 /// The default menu gives its submenus no ids except Window and Help, so File
 /// has to be found by the label the user reads.
-#[cfg(target_os = "macos")]
 fn submenu_named(
     menu: &tauri::menu::Menu<tauri::Wry>,
     name: &str,
@@ -169,21 +190,19 @@ pub fn run() {
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::default().build())
-        .menu(|app| {
+        .plugin(tauri_plugin_clipboard_manager::init())
+        .menu(build_menu)
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            "copy-url" => copy_current_url(app),
             #[cfg(target_os = "macos")]
-            return build_menu(app);
-            #[cfg(not(target_os = "macos"))]
-            return tauri::menu::Menu::default(app);
-        })
-        .on_menu_event(|_app, _event| {
+            "new-tab" => tabs::open(app),
             #[cfg(target_os = "macos")]
-            match _event.id().as_ref() {
-                "new-tab" => tabs::open(_app),
-                "next-tab" => tabs::select_next(_app),
-                "prev-tab" => tabs::select_previous(_app),
-                "tab-overview" => tabs::toggle_overview(_app),
-                _ => {}
-            }
+            "next-tab" => tabs::select_next(app),
+            #[cfg(target_os = "macos")]
+            "prev-tab" => tabs::select_previous(app),
+            #[cfg(target_os = "macos")]
+            "tab-overview" => tabs::toggle_overview(app),
+            _ => {}
         })
         .manage(auth::LoginState::default())
         .manage(wiki::WikiRoot::default())
@@ -291,6 +310,22 @@ const TITLEBAR_MARKER_SCRIPT: &str = r#"
     if (!mark()) {
       document.addEventListener('DOMContentLoaded', mark);
     }
+    // Overlay titlebars hit-test through to the page (tauri#9503), so without
+    // this the window cannot be dragged at all: the traffic-light row delivers
+    // its mousedowns to the webview, which ignores them. Any press in the
+    // chrome strip hands off to a native window drag. The tab bar itself is an
+    // opaque native view whose events never reach the page, so this only fires
+    // where AppKit isn't already handling the gesture. Costs titlebar
+    // double-click-to-zoom, which was equally unreachable before.
+    document.addEventListener('mousedown', function (e) {
+      if (e.button !== 0) return;
+      var inset = parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue('--titlebar-inset')
+      ) || 0;
+      if (inset <= 0 || e.clientY >= inset) return;
+      var t = window.__TAURI_INTERNALS__;
+      if (t && t.invoke) t.invoke('plugin:window|start_dragging');
+    });
   } catch (e) {}
 })();
 "#;
@@ -358,15 +393,24 @@ fn push_titlebar_inset(window: &tauri::WebviewWindow) {
     // A hidden tab bar reports the plain titlebar height; both cases are just
     // "whatever AppKit says", which is the whole point.
     //
-    // The body padding is SPIKE-ONLY: the packaged build loads production, whose
-    // stylesheet doesn't yet have the `html[data-tabs="native"] .sidebar-offset`
-    // rule that will do this properly, so the shell pads the page itself to make
-    // the fix visible on a real build. V2 pushes only the variable and lets the
-    // deployed CSS consume it — shipping both would double the inset.
+    // Everything past the variable push is SPIKE-ONLY: the packaged build loads
+    // production, whose stylesheet doesn't yet have the `data-tabs="native"`
+    // rules that will do this properly, so the shell applies their effect itself
+    // to make the fix visible on a real build — body padding for the page, and
+    // an injected copy of the modal rule, because modals portal to <body> with
+    // position: fixed and no amount of body padding reaches them. V2 pushes only
+    // the variable and lets the deployed CSS consume it — shipping both would
+    // double the inset.
     let _ = window.eval(&format!(
         "(function() {{\
            document.documentElement.style.setProperty('--titlebar-inset','{inset:.0}px');\
            if (document.body) document.body.style.paddingTop = '{inset:.0}px';\
+           if (document.head && !document.getElementById('__spike_tabs_css')) {{\
+             var s = document.createElement('style');\
+             s.id = '__spike_tabs_css';\
+             s.textContent = '.mantine-Modal-inner {{ padding-top: calc(var(--titlebar-inset) + 16px) !important; }}';\
+             document.head.appendChild(s);\
+           }}\
          }})()"
     ));
 }
@@ -381,7 +425,6 @@ fn push_titlebar_inset(window: &tauri::WebviewWindow) {
 #[cfg(target_os = "macos")]
 mod tabs {
     use objc2::runtime::AnyObject;
-    use tauri::Manager;
 
     /// Labels are `tab-<n>` to match the capability glob. Nothing reads them.
     static NEXT_LABEL: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(1);
@@ -391,21 +434,12 @@ mod tabs {
         format!("tab-{n}")
     }
 
-    pub fn frontmost(app: &tauri::AppHandle) -> Option<tauri::WebviewWindow> {
-        let windows = app.webview_windows();
-        windows
-            .values()
-            .find(|w| w.is_focused().unwrap_or(false))
-            .or_else(|| windows.values().next())
-            .cloned()
-    }
-
     fn ns_window(window: &tauri::WebviewWindow) -> Option<*mut AnyObject> {
         window.ns_window().ok().map(|ptr| ptr as *mut AnyObject)
     }
 
     pub fn select_next(app: &tauri::AppHandle) {
-        if let Some(ns) = frontmost(app).as_ref().and_then(ns_window) {
+        if let Some(ns) = super::frontmost_window(app).as_ref().and_then(ns_window) {
             unsafe {
                 let _: () = objc2::msg_send![ns, selectNextTab: std::ptr::null::<AnyObject>()];
             }
@@ -413,7 +447,7 @@ mod tabs {
     }
 
     pub fn select_previous(app: &tauri::AppHandle) {
-        if let Some(ns) = frontmost(app).as_ref().and_then(ns_window) {
+        if let Some(ns) = super::frontmost_window(app).as_ref().and_then(ns_window) {
             unsafe {
                 let _: () = objc2::msg_send![ns, selectPreviousTab: std::ptr::null::<AnyObject>()];
             }
@@ -421,7 +455,7 @@ mod tabs {
     }
 
     pub fn toggle_overview(app: &tauri::AppHandle) {
-        if let Some(ns) = frontmost(app).as_ref().and_then(ns_window) {
+        if let Some(ns) = super::frontmost_window(app).as_ref().and_then(ns_window) {
             unsafe {
                 let _: () = objc2::msg_send![ns, toggleTabOverview: std::ptr::null::<AnyObject>()];
             }
@@ -435,7 +469,7 @@ mod tabs {
     /// and Apple's default is "In Full Screen Only" — so without this an ordinary
     /// user gets a detached window and no tab at all.
     pub fn open(app: &tauri::AppHandle) {
-        let host = frontmost(app);
+        let host = super::frontmost_window(app);
         let Ok(created) = super::build_window(app, &next_label()) else {
             return;
         };
@@ -449,6 +483,36 @@ mod tabs {
             let _: () = objc2::msg_send![host_ns, addTabbedWindow: created_ns, ordered: 1isize];
         }
         let _ = created.set_focus();
+    }
+}
+
+/// The window the user is looking at, or any window as a fallback.
+///
+/// The fallback matters at startup and in menu handlers that can fire while no
+/// window reports focus; "some window" beats a silently dead menu item.
+fn frontmost_window(app: &tauri::AppHandle) -> Option<tauri::WebviewWindow> {
+    let windows = app.webview_windows();
+    windows
+        .values()
+        .find(|w| w.is_focused().unwrap_or(false))
+        .or_else(|| windows.values().next())
+        .cloned()
+}
+
+/// Cmd/Ctrl+L. In a browser that focuses the address bar; the shell has no
+/// address bar, so it copies the frontmost tab's URL instead — the half of ⌘L
+/// people actually want here (grabbing a link to the page they're on).
+fn copy_current_url(app: &tauri::AppHandle) {
+    use tauri_plugin_clipboard_manager::ClipboardExt;
+
+    let Some(window) = frontmost_window(app) else {
+        return;
+    };
+    let Ok(url) = window.url() else {
+        return;
+    };
+    if let Err(e) = app.clipboard().write_text(url.to_string()) {
+        eprintln!("[shell] could not copy the current URL: {e}");
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,15 +85,15 @@ fn desktop_shell_info() -> ShellInfo {
     }
 }
 
-/// SPIKE (cool.lark) — throwaway. The shell has run Tauri's default menu until
-/// now, and the tab shortcuts do not survive that.
+/// The app menu: Tauri's default, extended with tab items (ADR-0053).
 ///
-/// AppKit is supposed to inject Show Next/Previous Tab into whatever submenu is
-/// registered as `NSApp.windowsMenu`, and the preconditions all hold — tao
-/// leaves `allowsAutomaticWindowTabbing` on, and Tauri does call
-/// `set_as_windows_menu_for_nsapp` for the submenu tagged `WINDOW_SUBMENU_ID`.
-/// The items still never reached the keyboard, so they are declared explicitly
-/// here. The actions are AppKit's own, so the behaviour is Safari's — cycling
+/// The tab shortcuts have to be declared explicitly. AppKit is supposed to
+/// inject Show Next/Previous Tab into whatever submenu is registered as
+/// `NSApp.windowsMenu`, and the preconditions all hold — tao leaves
+/// `allowsAutomaticWindowTabbing` on, and Tauri does call
+/// `set_as_windows_menu_for_nsapp` for the submenu tagged `WINDOW_SUBMENU_ID` —
+/// but on a real build the injected items never reached the keyboard. The
+/// actions dispatched are AppKit's own, so the behaviour is Safari's — cycling
 /// wraps, the overview is the real overview — rather than a reimplementation.
 ///
 /// Built by *extending* `Menu::default`, never by constructing a menu from
@@ -229,10 +229,6 @@ pub fn run() {
                 install_tab_key_monitor(app.handle());
                 install_plus_button(app.handle(), &_main);
             }
-            // SPIKE (cool.lark) — throwaway. Second window sharing the tabbing
-            // identifier, so a release build opens with a native tab bar and the
-            // two questions can be looked at. Delete with the rest of the spike.
-            spike_second_window(app.handle())?;
 
             let handle = app.handle().clone();
             app.deep_link().on_open_url(move |event| {
@@ -326,28 +322,8 @@ fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<tauri::WebviewWind
     build_window(app, "main")
 }
 
-/// SPIKE (cool.lark) — throwaway. A second tab at startup, so the build opens
-/// with a tab bar to inspect and the capability glob (`"windows": ["main",
-/// "tab-*"]`, also spike-only) gets exercised: if the bridge reaches the second
-/// window, `desktop_shell_info` answers from inside a tab.
-///
-/// The shared tabbing identifier alone is not enough to produce a tab. It makes
-/// windows *tabbable*; AppKit only merges them on its own when the user's global
-/// `AppleWindowTabbingMode` is `always`, and Apple ships that preference
-/// defaulting to "In Full Screen Only". Left there, the second window opens as a
-/// plain window behind the first and there is no tab bar at all — which is
-/// exactly what the first spike build showed. `tabs::open` goes through
-/// `-[NSWindow addTabbedWindow:ordered:]`, which merges deterministically.
-fn spike_second_window(app: &tauri::AppHandle) -> tauri::Result<()> {
-    #[cfg(target_os = "macos")]
-    tabs::open(app);
-    #[cfg(not(target_os = "macos"))]
-    let _ = app;
-    Ok(())
-}
-
-/// SPIKE (cool.lark) — throwaway. Tab commands, sent to whichever window is
-/// frontmost.
+/// Native macOS window tabs (ADR-0053). Tab commands are sent to whichever
+/// window is frontmost.
 ///
 /// `selectNextTab:`, `selectPreviousTab:` and `toggleTabOverview:` are AppKit's
 /// own actions, so the behaviour is Safari's by construction — cycling wraps,
@@ -447,8 +423,8 @@ fn copy_current_url(app: &tauri::AppHandle) {
     }
 }
 
-/// SPIKE (cool.lark) — throwaway. ⌃Tab / ⌃⇧Tab, caught the way Safari catches
-/// them: before the web view sees the key.
+/// ⌃Tab / ⌃⇧Tab, caught the way Safari catches them: before the web view sees
+/// the key.
 ///
 /// These cannot be menu key equivalents. AppKit matches a non-⌘ equivalent only
 /// after the responder chain declines the key, and WKWebView consumes Tab —
@@ -498,7 +474,7 @@ fn install_tab_key_monitor(app: &tauri::AppHandle) {
     std::mem::forget(block);
 }
 
-/// SPIKE (cool.lark) — throwaway. The `+` at the right end of the tab bar.
+/// The `+` at the right end of the tab bar.
 ///
 /// AppKit draws Safari's plus button by itself the moment any responder in the
 /// window's chain implements `newWindowForTab:` — the button *is* that check.
@@ -549,9 +525,10 @@ fn build_window(app: &tauri::AppHandle, label: &str) -> tauri::Result<tauri::Web
     let new_window_opener = app.clone();
 
     let builder = tauri::WebviewWindowBuilder::new(app, label, tauri::WebviewUrl::External(url))
-        // SPIKE (cool.lark) — throwaway. Distinct per window, so the tab bar
-        // shows whether AppKit reads the (hidden) window title for its label.
-        .title(format!("Exponential Beta — {label}"))
+        // Also each tab's label, via NSWindow.tab.title. URL-derived per-tab
+        // titles are the V2 ticket's next action; until then every tab reads
+        // the same, which is the known gap, not a bug.
+        .title("Exponential Beta")
         .inner_size(1400.0, 900.0)
         .min_inner_size(800.0, 600.0)
         // The page is remote and takes a moment to paint; without this the window
@@ -575,10 +552,10 @@ fn build_window(app: &tauri::AppHandle, label: &str) -> tauri::Result<tauri::Web
             tauri::webview::NewWindowResponse::Deny
         });
 
-    // SPIKE (cool.lark) — the chrome decision this spike exists to test, and
-    // the overlay LOST. Safari-style chrome (a standard titlebar; the web view
-    // starts below it) instead of Electron-matching overlay chrome, because on
-    // a real build the overlay fought native tabs at every layer:
+    // Safari-style chrome: a standard titlebar, with the web view laid out
+    // below it — NOT the Electron-matching overlay chrome this shell used
+    // before tabs. The cool.lark spike tried overlay + native tabs on a real
+    // build, and the overlay lost at every layer (ADR-0053):
     //
     //   - `traffic_light_position` shrinks the titlebar container the tab bar
     //     lives in (tao's inset hack re-runs every drawRect:), squashing the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -119,6 +119,10 @@ pub fn run() {
         .setup(|app| {
             resolve_wiki_root(app.handle());
             build_main_window(app.handle())?;
+            // SPIKE (cool.lark) — throwaway. Second window sharing the tabbing
+            // identifier, so a release build opens with a native tab bar and the
+            // two questions can be looked at. Delete with the rest of the spike.
+            spike_second_window(app.handle())?;
 
             let handle = app.handle().clone();
             app.deep_link().on_open_url(move |event| {
@@ -207,6 +211,18 @@ const TITLEBAR_MARKER_SCRIPT: &str = "";
 /// URL is build-dependent (dev server vs production) and a `WebviewUrl::External`
 /// in static config cannot express that.
 fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<()> {
+    build_window(app, "main")
+}
+
+/// SPIKE (cool.lark) — throwaway. A second window with the same tabbing
+/// identifier, labelled `tab-2` so the capability glob (`"windows": ["main",
+/// "tab-*"]`, also spike-only) gets exercised at the same time: if the bridge
+/// reaches this window, `desktop_shell_info` answers from inside the tab.
+fn spike_second_window(app: &tauri::AppHandle) -> tauri::Result<()> {
+    build_window(app, "tab-2")
+}
+
+fn build_window(app: &tauri::AppHandle, label: &str) -> tauri::Result<()> {
     let url = app_base_url()
         .parse()
         .unwrap_or_else(|e| panic!("{BASE_URL_ENV} is not a valid URL: {e}"));
@@ -214,8 +230,10 @@ fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<()> {
     let opener = app.clone();
     let new_window_opener = app.clone();
 
-    let builder = tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::External(url))
-        .title("Exponential Beta")
+    let builder = tauri::WebviewWindowBuilder::new(app, label, tauri::WebviewUrl::External(url))
+        // SPIKE (cool.lark) — throwaway. Distinct per window, so the tab bar
+        // shows whether AppKit reads the (hidden) window title for its label.
+        .title(format!("Exponential Beta — {label}"))
         .inner_size(1400.0, 900.0)
         .min_inner_size(800.0, 600.0)
         // The page is remote and takes a moment to paint; without this the window
@@ -252,7 +270,10 @@ fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<()> {
     let builder = builder
         .title_bar_style(tauri::TitleBarStyle::Overlay)
         .hidden_title(true)
-        .traffic_light_position(tauri::LogicalPosition::new(16.0, 16.0));
+        .traffic_light_position(tauri::LogicalPosition::new(16.0, 16.0))
+        // SPIKE (cool.lark) — throwaway. Shared identifier is the whole native
+        // tabbing mechanism; AppKit draws the tab bar from it.
+        .tabbing_identifier("im.exponential.beta.tabs");
 
     builder.build()?;
     Ok(())

--- a/src/app/_components/layout/DesktopChromeScript.tsx
+++ b/src/app/_components/layout/DesktopChromeScript.tsx
@@ -1,26 +1,26 @@
 // Marks the document with the desktop shell hosting it, as early as possible.
 //
-// Both shells use the macOS overlay title bar (Electron `hiddenInset`, Tauri
-// `TitleBarStyle::Overlay`), so the traffic lights float over the page's
-// top-left corner — which is the sidebar's workspace switcher. CSS reserves
-// room for them off `data-titlebar="overlay"`; running here rather than in a
-// client component keeps the sidebar from painting in the wrong place and then
-// jumping.
+// The Electron shell uses the macOS overlay title bar (`hiddenInset`), so the
+// traffic lights float over the page's top-left corner — which is the
+// sidebar's workspace switcher. CSS reserves room for them off
+// `data-titlebar="overlay"`; running here rather than in a client component
+// keeps the sidebar from painting in the wrong place and then jumping.
+//
+// The overlay stamp is Electron-ONLY. The tabbed Tauri shell (ADR-0053) uses
+// Safari-style chrome — a visible titlebar with the webview laid out below it —
+// and needs no inset at all; it stamps `data-shell` itself from an
+// initialization script (`TITLEBAR_MARKER_SCRIPT` in `src-tauri/src/lib.rs`)
+// and deliberately does not stamp `data-titlebar`. Stamping overlay here on
+// detecting Tauri would resurrect a 38px dead inset in that shell, so don't.
+// (Pre-tab Tauri binaries older than PR 482 relied on this fallback for their
+// overlay inset; they lose it, and the answer is to update the app.)
 //
 // Detection mirrors `~/lib/platform.ts` and is duplicated as a string on
 // purpose: this runs in <head>, ahead of any bundle.
 //
-// It retries because a single early check is not enough. Electron's preload
-// defines `window.electron` before any page script, but Tauri injects
-// `__TAURI_INTERNALS__` into a *remote* page after the document's own head
-// scripts have run — so the first check finds nothing, and the shipped version
-// of this file gave up there and left the inset at 0px. The bug was invisible:
-// IPC worked moments later, so nothing else looked wrong.
-//
-// The Tauri shell now stamps the attributes itself from an initialization
-// script (see `TITLEBAR_MARKER_SCRIPT` in `src-tauri/src/lib.rs`), which is the
-// race-free path. These retries stay as the fallback for a shell binary older
-// than that change, and for Electron. Marking twice is harmless — same values.
+// It retries because a single early check is not enough: Electron's preload
+// defines `window.electron` before any page script, but on a slow bridge the
+// first check can still miss. Marking twice is harmless — same values.
 export function DesktopChromeScript() {
   const script = `
     (function () {
@@ -30,9 +30,9 @@ export function DesktopChromeScript() {
         if (!shell) return false;
         var root = document.documentElement;
         root.setAttribute('data-shell', shell);
-        // The overlay title bar is a macOS arrangement; other platforms keep
-        // their native chrome and need no inset.
-        if (/Mac/i.test(navigator.userAgent)) {
+        // Overlay inset is Electron-only (macOS arrangement); the tabbed Tauri
+        // shell sits below a real titlebar and must NOT get the inset.
+        if (shell === 'electron' && /Mac/i.test(navigator.userAgent)) {
           root.setAttribute('data-titlebar', 'overlay');
         }
         return true;

--- a/src/app/_components/layout/sidebar.css
+++ b/src/app/_components/layout/sidebar.css
@@ -55,15 +55,11 @@ html[data-titlebar="overlay"] {
   }
 }
 
-/* Collapsed, the main column inherits the top-left corner from the sidebar —
-   window controls and all — so the inset has to move with it. Margin rather
-   than padding: it stacks on whatever responsive padding <main> has at this
-   breakpoint instead of replacing it, and rides the same 300ms transition as
-   the collapse, so the content slides down with the sidebar rather than
-   snapping. */
-html[data-titlebar="overlay"][data-sidebar="closed"] .sidebar-offset {
-  margin-top: var(--titlebar-inset);
-}
+/* Collapsing the sidebar used to drop the whole main column by the inset, on the
+   grounds that it inherited the top-left corner and the traffic lights with it.
+   Removed: the re-open button below carries its own inset, so it still clears
+   the controls, and dropping the entire column was a visible lurch to buy
+   clearance for one button. */
 
 /* ============================================================
    Create Action - soft tinted CTA

--- a/src/app/_components/layout/sidebar.css
+++ b/src/app/_components/layout/sidebar.css
@@ -73,6 +73,15 @@ html[data-tabs="native"] .sidebar-offset {
   padding-top: var(--titlebar-inset);
 }
 
+/* Modals portal to <body> with position: fixed, so neither the column padding
+   above nor anything else in page flow keeps them clear of the tab bar.
+   !important is load-bearing: CreateActionModal (and friends) set the inner
+   padding as an inline style, which would beat a plain rule. One selector
+   covers every Mantine modal rather than chasing them per-component. */
+html[data-tabs="native"] .mantine-Modal-inner {
+  padding-top: calc(var(--titlebar-inset) + 16px) !important;
+}
+
 /* ============================================================
    Create Action - soft tinted CTA
    ============================================================ */

--- a/src/app/_components/layout/sidebar.css
+++ b/src/app/_components/layout/sidebar.css
@@ -61,26 +61,10 @@ html[data-titlebar="overlay"] {
    the controls, and dropping the entire column was a visible lurch to buy
    clearance for one button. */
 
-/* Native tab bar (Tauri V2 shell). Unlike the overlay titlebar — transparent
-   chrome with two floating buttons in the sidebar's corner — a tab bar is an
-   opaque strip across the whole window, so the main column has to clear it too,
-   not just the sidebar. Keyed on data-tabs, which only the tabbed shell stamps:
-   the live V1 shell stamps data-titlebar="overlay" alone, and keying on that
-   would drop the main column 38px in a shell that has no tab bar. The shell
-   measures the real chrome height (titlebar + tab bar, or just titlebar when a
-   lone tab hides the bar) and keeps --titlebar-inset current. */
-html[data-tabs="native"] .sidebar-offset {
-  padding-top: var(--titlebar-inset);
-}
-
-/* Modals portal to <body> with position: fixed, so neither the column padding
-   above nor anything else in page flow keeps them clear of the tab bar.
-   !important is load-bearing: CreateActionModal (and friends) set the inner
-   padding as an inline style, which would beat a plain rule. One selector
-   covers every Mantine modal rather than chasing them per-component. */
-html[data-tabs="native"] .mantine-Modal-inner {
-  padding-top: calc(var(--titlebar-inset) + 16px) !important;
-}
+/* The tabbed Tauri shell (V2) uses a visible native titlebar — Safari-style —
+   so the page starts below the chrome and needs no inset at all. It stamps
+   data-shell="tauri" but deliberately NOT data-titlebar="overlay"; only the
+   Electron shell and the pre-tabs Tauri shell take the 38px above. */
 
 /* ============================================================
    Create Action - soft tinted CTA

--- a/src/app/_components/layout/sidebar.css
+++ b/src/app/_components/layout/sidebar.css
@@ -61,6 +61,18 @@ html[data-titlebar="overlay"] {
    the controls, and dropping the entire column was a visible lurch to buy
    clearance for one button. */
 
+/* Native tab bar (Tauri V2 shell). Unlike the overlay titlebar — transparent
+   chrome with two floating buttons in the sidebar's corner — a tab bar is an
+   opaque strip across the whole window, so the main column has to clear it too,
+   not just the sidebar. Keyed on data-tabs, which only the tabbed shell stamps:
+   the live V1 shell stamps data-titlebar="overlay" alone, and keying on that
+   would drop the main column 38px in a shell that has no tab bar. The shell
+   measures the real chrome height (titlebar + tab bar, or just titlebar when a
+   lone tab hides the bar) and keeps --titlebar-inset current. */
+html[data-tabs="native"] .sidebar-offset {
+  padding-top: var(--titlebar-inset);
+}
+
 /* ============================================================
    Create Action - soft tinted CTA
    ============================================================ */


### PR DESCRIPTION
### **User description**
## What

Native macOS window tabs for the Tauri shell, grown out of the `cool.lark` spike and hardened on real release builds through several rounds of hands-on review:

- Every window shares a `tabbing_identifier`; merging is explicit via `addTabbedWindow:` (AppKit only auto-merges under `AppleWindowTabbingMode=always`, which is not Apple's default). Labels are `tab-<n>`; the ACL capability covers created tabs via the `["main", "tab-*"]` glob, verified by invoking `desktop_shell_info` from inside a created tab on a release build.
- **Safari-style chrome**: standard visible titlebar with the webview laid out below the chrome, replacing the Electron-matching overlay. On a real build the overlay fought native tabs at every layer — tao's traffic-light inset squashes the titlebar container the tab bar lives in, scrolled content and the scrollbar showed through the chrome, modals opened under the tab bar, and the window was undraggable (tauri-apps/tauri#9503). ADR-0053 records the decision and the rejected patch-around route.
- ⌘T New Tab (File menu), ⌃Tab / ⌃⇧Tab cycling via an NSEvent local monitor (WKWebView consumes Tab before menu key-equivalents can match), ⌘⇧\ tab overview, and AppKit's own tab-bar `+` button via a runtime `newWindowForTab:` implementation. The menu extends `Menu::default` rather than replacing it, preserving the `NSApp.windowsMenu` registration.
- ⌘/⌃L copies the current page URL (clipboard plugin, Rust-side, no ACL grant needed).
- Web side: the tabbed shell stops stamping `data-titlebar="overlay"` so no sidebar inset is reserved; the collapsed-sidebar content drop in `sidebar.css` is removed as no longer necessary.

Known gap, deliberate: all tab labels read "Exponential Beta" until URL-derived titles land (action 2 of the V2 ticket, `lazy.lake`).

## Why

The shell opens exactly one useful window: following a link destroys your place, and any in-page state dies on navigation. Native window tabs make backgrounded state survive for free — each tab is a live app instance — without adding any tab UI to the web app.

Spike ticket: `cool.lark` (#450). V2 ticket: `lazy.lake` (#451), whose remaining actions (URL-derived labels, ⌘-click interceptor, `target=_blank` handling, sign-in de-`main`-ing) build on this.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Implement native macOS window tabs using Safari-style chrome (ADR-0053)

- Add tab keyboard shortcuts, `+` button, and `⌘L` URL copy

- Replace overlay titlebar with standard visible titlebar for tab compatibility

- Document architecture decision and rejected alternatives in ADR-0053


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["build_window(label)"] -- "shared tabbing_identifier" --> B["WebviewWindow"]
  B -- "addTabbedWindow:ordered:" --> C["Tab Group (AppKit)"]
  D["Menu (extended default)"] -- "new-tab / next-tab / prev-tab / overview" --> E["tabs::open/select_next/select_previous/toggle_overview"]
  F["NSEvent local monitor"] -- "⌃Tab / ⌃⇧Tab (before WKWebView)" --> E
  G["newWindowForTab: (runtime patch)"] -- "+ button" --> E
  H["copy-url menu event"] -- "⌘L" --> I["clipboard_manager::write_text"]
  B -- "data-shell=tauri (no overlay stamp)" --> J["Web page (no 38px inset)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Implement native macOS window tabs and Safari-style chrome</code></dd></summary>
<hr>

src-tauri/src/lib.rs

<ul><li>Added <code>tabs</code> module with <code>open</code>, <code>select_next</code>, <code>select_previous</code>, <br><code>toggle_overview</code> using <code>objc2</code> AppKit calls<br> <li> Added <code>build_menu</code> extending <code>Menu::default</code> with tab and Copy Page URL <br>items; wired <code>on_menu_event</code> handler<br> <li> Added <code>install_tab_key_monitor</code> (NSEvent local monitor for ⌃Tab) and <br><code>install_plus_button</code> (runtime <code>newWindowForTab:</code> patch)<br> <li> Replaced <code>TitleBarStyle::Overlay</code> + traffic-light inset with <br><code>hidden_title</code> + <code>tabbing_identifier</code> (Safari-style chrome)<br> <li> Refactored <code>build_main_window</code> into parameterized <code>build_window(label)</code> <br>returning <code>WebviewWindow</code>; added <code>frontmost_window</code> and <code>copy_current_url</code> <br>helpers</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/490/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+347/-24</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sidebar.css</strong><dd><code>Remove collapsed-sidebar inset drop, add tab chrome comments</code></dd></summary>
<hr>

src/app/_components/layout/sidebar.css

<ul><li>Removed <code>html[data-titlebar="overlay"][data-sidebar="closed"] </code><br><code>.sidebar-offset</code> rule that dropped the main column by the titlebar <br>inset on sidebar collapse<br> <li> Added explanatory comments about the tabbed Tauri shell using a <br>visible native titlebar with no inset</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/490/files#diff-4cfb15b78919917b546cf1fa120557eb91a368e4f54dd898a87569104f7917e2">+10/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add clipboard, objc2, and block2 dependencies for tabs</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/Cargo.toml

<ul><li>Added <code>tauri-plugin-clipboard-manager = "2"</code> for <code>⌘L</code> URL copy<br> <li> Added macOS-only dependencies <code>objc2 = "0.6"</code> and <code>block2 = "0.6"</code> for <br>AppKit/NSEvent interop</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/490/files#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote.json</strong><dd><code>Extend IPC capability to tab windows via glob</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/capabilities/remote.json

<ul><li>Extended <code>windows</code> ACL from <code>["main"]</code> to <code>["main", "tab-*"]</code> to grant IPC <br>to created tab windows</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/490/files#diff-ccb4581457f281d685bf28be1cdf9c3dd911459508f59b4aecc48ebea72c5e44">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DesktopChromeScript.tsx</strong><dd><code>Restrict overlay titlebar stamp to Electron shell only</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/layout/DesktopChromeScript.tsx

<ul><li>Restricted <code>data-titlebar="overlay"</code> stamping to Electron shell only <br>(was applied to all macOS shells)<br> <li> Updated comments to clarify Tauri tabbed shell uses Safari-style <br>chrome with no overlay inset<br> <li> Simplified retry rationale; removed Tauri-specific retry logic now <br>handled by <code>TITLEBAR_MARKER_SCRIPT</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/490/files#diff-d84d9fac2757835aed5ff59d1d527112cfb1f639c43859d89a46de6e029b0f2a">+20/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>0053-desktop-tabs-are-native-macos-window-tabs.md</strong><dd><code>Add ADR-0053 for native macOS window tabs decision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/adr/0053-desktop-tabs-are-native-macos-window-tabs.md

<ul><li>New ADR documenting the decision to use native macOS window tabs under <br>Safari-style chrome<br> <li> Records three spike-discovered refinements: explicit merge, chrome <br>switch, and NSEvent monitor approach<br> <li> Documents rejected alternatives including in-page tabs, custom tab <br>strip, overlay chrome patches</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/490/files#diff-a7f8b855bf063e544b80e21422088658942e29dbebf3964f91b54a70a4f92494">+105/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

