### PR TITLE
Gate assignable-user reads on workspace and action access

### DIFF
--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -840,6 +840,64 @@ describe("action router (mocked)", () => {
         expect.objectContaining({ where: expect.objectContaining({ workspaceId }) }),
       );
     });
+
+    it("withholds the workspace roster on a merely-public project", async () => {
+      // `hasProjectAccess` is true for ANY authenticated caller when the
+      // project is public, so the project must not be allowed to vouch for the
+      // workspace — otherwise a public project id is just a second door to the
+      // same roster this guard exists to close.
+      stubMembership(false);
+      dbMock.project.findUnique.mockResolvedValue({
+        id: "p1",
+        name: "Public project",
+        workspaceId,
+        isRestricted: false,
+        isPublic: true,
+        createdById: "someone-else",
+        teamId: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.projectMember.findFirst.mockResolvedValue(null);
+      dbMock.team.findMany.mockResolvedValue([]);
+      dbMock.projectMember.findMany.mockResolvedValue([]);
+      dbMock.user.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: callerId, name: "Me", email: "caller-1@test.com", image: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.action.getAssignableUsersForContext({
+        projectId: "p1",
+      });
+
+      expect(dbMock.workspaceUser.findMany).not.toHaveBeenCalled();
+      expect(result.assignableUsers.map((u) => u.id)).toEqual([callerId]);
+    });
+
+    it("still rejects a bare workspaceId even when a public project is passed", async () => {
+      // The public project can't vouch for the workspace, so the explicit
+      // membership check takes over — and the caller is not a member.
+      stubMembership(false);
+      dbMock.project.findUnique.mockResolvedValue({
+        id: "p1",
+        name: "Public project",
+        workspaceId: null,
+        isRestricted: false,
+        isPublic: true,
+        createdById: "someone-else",
+        teamId: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.projectMember.findFirst.mockResolvedValue(null);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      await expect(
+        caller.action.getAssignableUsersForContext({ projectId: "p1", workspaceId }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      expect(dbMock.workspaceUser.findMany).not.toHaveBeenCalled();
+    });
   });
 
   // ────────────────────────────────────────────────────────────────────
@@ -869,10 +927,25 @@ describe("action router (mocked)", () => {
 
       await expect(
         caller.action.getAssignableUsers({ actionId: "a1" }),
-      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
       expect(dbMock.workspaceUser.findMany).not.toHaveBeenCalled();
       expect(dbMock.projectMember.findMany).not.toHaveBeenCalled();
+    });
+
+    it("reports a missing action the same way as a forbidden one", async () => {
+      // The two must be indistinguishable, or the error code confirms which
+      // action CUIDs exist.
+      dbMock.action.findUnique.mockResolvedValue(null);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      await expect(
+        caller.action.getAssignableUsers({ actionId: "does-not-exist" }),
+      ).rejects.toMatchObject({
+        code: "NOT_FOUND",
+        message: "Action not found or access denied",
+      });
     });
 
     it("returns the roster to the action's creator", async () => {
@@ -891,6 +964,17 @@ describe("action router (mocked)", () => {
         team: null,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any);
+      // getProjectAccess's own probe: caller created the project, so they are
+      // an insider and inherit the workspace roster.
+      dbMock.project.findUnique.mockResolvedValue({
+        createdById: callerId,
+        teamId: null,
+        workspaceId: "w1",
+        isPublic: false,
+        isRestricted: false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.projectMember.findFirst.mockResolvedValue(null);
       dbMock.team.findMany.mockResolvedValue([]);
       dbMock.workspaceUser.findMany.mockResolvedValue([
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -906,6 +990,52 @@ describe("action router (mocked)", () => {
       const result = await caller.action.getAssignableUsers({ actionId: "a1" });
 
       expect(result.assignableUsers.map((u) => u.id).sort()).toEqual([callerId, "u2"]);
+    });
+
+    it("withholds the workspace roster on a merely-public project", async () => {
+      // A stranger holding a bounty action id from the unauthenticated
+      // /api/bounties feed passes canViewAction via `isPublic`. They must not
+      // inherit the workspace's member list (names + emails) with it.
+      dbMock.action.findUnique.mockResolvedValue({
+        id: "a1",
+        createdById: "someone-else",
+        projectId: "p1",
+        assignees: [],
+        project: {
+          id: "p1",
+          name: "Public bounty project",
+          workspaceId: "w1",
+          isRestricted: false,
+          createdById: "someone-else",
+        },
+        team: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.project.findUnique.mockResolvedValue({
+        createdById: "someone-else",
+        teamId: null,
+        workspaceId: "w1",
+        isPublic: true,
+        isRestricted: false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      // Not a project member, not a workspace member, not in any team.
+      dbMock.projectMember.findFirst.mockResolvedValue(null);
+      dbMock.workspaceUser.findUnique.mockResolvedValue(null);
+      dbMock.teamUser.findFirst.mockResolvedValue(null);
+      dbMock.team.findMany.mockResolvedValue([]);
+      dbMock.projectMember.findMany.mockResolvedValue([]);
+      dbMock.user.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: callerId, name: "Me", email: "caller-1@test.com", image: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.action.getAssignableUsers({ actionId: "a1" });
+
+      // The roster query must never run, and the caller sees only themselves.
+      expect(dbMock.workspaceUser.findMany).not.toHaveBeenCalled();
+      expect(result.assignableUsers.map((u) => u.id)).toEqual([callerId]);
     });
   });
 

--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -725,4 +725,170 @@ describe("action router (mocked)", () => {
       expect(where).not.toHaveProperty("OR");
     });
   });
+
+  // ────────────────────────────────────────────────────────────────────
+  // getAssignableUsersForContext
+  //
+  // Read-side counterpart to the workspaceId write guards: the procedure
+  // returns id/name/email/image for every member of `effectiveWorkspaceId`.
+  // A caller-supplied `workspaceId` therefore has to be membership-checked,
+  // or any logged-in user could hand over a workspace CUID and harvest the
+  // full roster. A workspace derived from an authorised project must NOT be
+  // re-checked — workspace guests have no WorkspaceUser row.
+  // ────────────────────────────────────────────────────────────────────
+  describe("getAssignableUsersForContext", () => {
+    const callerId = "caller-1";
+    const workspaceId = "w1";
+
+    /** getWorkspaceMembership probes workspaceUser.findUnique first, then
+     *  falls back to teamUser.findFirst. Stub both to control membership. */
+    function stubMembership(isMember: boolean) {
+      dbMock.workspaceUser.findUnique.mockResolvedValue(
+        isMember
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ? ({ userId: callerId, workspaceId, role: "member", joinedAt: new Date() } as any)
+          : null,
+      );
+      dbMock.teamUser.findFirst.mockResolvedValue(null);
+    }
+
+    it("rejects a non-member who supplies a bare workspaceId", async () => {
+      stubMembership(false);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      await expect(
+        caller.action.getAssignableUsersForContext({ workspaceId }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      // The roster must never be read for a non-member.
+      expect(dbMock.workspaceUser.findMany).not.toHaveBeenCalled();
+    });
+
+    it("returns the roster to a workspace member", async () => {
+      stubMembership(true);
+      dbMock.team.findMany.mockResolvedValue([]);
+      dbMock.workspaceUser.findMany.mockResolvedValue([
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { user: { id: "u2", name: "Colleague", email: "u2@test.com", image: null } } as any,
+      ]);
+      dbMock.user.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: callerId, name: "Me", email: "caller-1@test.com", image: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.action.getAssignableUsersForContext({ workspaceId });
+
+      expect(dbMock.workspaceUser.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ workspaceId }) }),
+      );
+      expect(result.assignableUsers.map((u) => u.id).sort()).toEqual([callerId, "u2"]);
+    });
+
+    it("skips the membership probe when the workspace comes from an authorised project", async () => {
+      // A workspace guest: ProjectMember on p1, but no WorkspaceUser row and
+      // no team access. Project access alone must carry them through.
+      stubMembership(false);
+      dbMock.project.findUnique.mockResolvedValue({
+        id: "p1",
+        name: "Guest project",
+        workspaceId,
+        isRestricted: false,
+        isPublic: false,
+        createdById: "someone-else",
+        teamId: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dbMock.projectMember.findFirst.mockResolvedValue({ role: "editor" } as any);
+      dbMock.team.findMany.mockResolvedValue([]);
+      dbMock.workspaceUser.findMany.mockResolvedValue([]);
+      dbMock.projectMember.findMany.mockResolvedValue([]);
+      dbMock.user.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: callerId, name: "Me", email: "caller-1@test.com", image: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.action.getAssignableUsersForContext({
+        projectId: "p1",
+        // Deliberately also passed: the project's workspace wins, and the
+        // guest is not rejected for failing a membership probe on it.
+        workspaceId,
+      });
+
+      expect(result.actionContext.hasProject).toBe(true);
+      expect(dbMock.workspaceUser.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ workspaceId }) }),
+      );
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // getAssignableUsers
+  //
+  // Same disclosure, reached via actionId: the procedure used to check only
+  // that the action existed, then returned the whole workspace + project
+  // roster to any authenticated caller.
+  // ────────────────────────────────────────────────────────────────────
+  describe("getAssignableUsers", () => {
+    const callerId = "caller-1";
+
+    it("rejects a caller with no access to the action", async () => {
+      // Someone else's project-less action: not creator, not assignee, no
+      // project to inherit access from.
+      dbMock.action.findUnique.mockResolvedValue({
+        id: "a1",
+        createdById: "someone-else",
+        projectId: null,
+        assignees: [],
+        project: null,
+        team: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      await expect(
+        caller.action.getAssignableUsers({ actionId: "a1" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      expect(dbMock.workspaceUser.findMany).not.toHaveBeenCalled();
+      expect(dbMock.projectMember.findMany).not.toHaveBeenCalled();
+    });
+
+    it("returns the roster to the action's creator", async () => {
+      dbMock.action.findUnique.mockResolvedValue({
+        id: "a1",
+        createdById: callerId,
+        projectId: "p1",
+        assignees: [],
+        project: {
+          id: "p1",
+          name: "Proj",
+          workspaceId: "w1",
+          isRestricted: false,
+          createdById: callerId,
+        },
+        team: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.team.findMany.mockResolvedValue([]);
+      dbMock.workspaceUser.findMany.mockResolvedValue([
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { user: { id: "u2", name: "Colleague", email: "u2@test.com", image: null } } as any,
+      ]);
+      dbMock.projectMember.findMany.mockResolvedValue([]);
+      dbMock.user.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: callerId, name: "Me", email: "caller-1@test.com", image: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.action.getAssignableUsers({ actionId: "a1" });
+
+      expect(result.assignableUsers.map((u) => u.id).sort()).toEqual([callerId, "u2"]);
+    });
+  });
 });

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -11,7 +11,7 @@ import { ScoringService } from "~/server/services/ScoringService";
 import { startOfDay } from "date-fns";
 import { validateScheduledTimes } from "~/lib/dateUtils";
 import { findUserByEmailInWorkspace, getWorkspaceMembership, canEditWorkspaceContent } from "~/server/services/access/resolvers/workspaceResolver";
-import { getActionAccess, canViewAction, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs, canAssignToUnscopedAction } from "~/server/services/access";
+import { getActionAccess, canViewAction, canEditAction, getProjectAccess, hasProjectAccess, isProjectInsider, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs, canAssignToUnscopedAction } from "~/server/services/access";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import { uploadToBlob } from "~/lib/blob";
 import { emitNotification } from "~/server/services/notifications/emit/emitNotification";
@@ -2168,19 +2168,19 @@ export const actionRouter = createTRPCRouter({
         getActionAccess(ctx.db, ctx.session.user.id, input.actionId),
       ]);
 
-      if (!action) {
-        throw new Error("Action not found");
-      }
-
       // Without this, naming any action id returned its whole assignable
       // roster — every workspace and project member, emails included — to any
       // logged-in caller. View access is the right bar: assignment itself is
       // separately gated on canEditAction, and a viewer legitimately needs the
       // roster to render existing assignees.
-      if (!access || !canViewAction(access)) {
+      //
+      // Missing and forbidden collapse into the same NOT_FOUND deliberately:
+      // distinguishable responses would confirm which action CUIDs exist. Same
+      // rule as `getById` above and as `assignability.ts`.
+      if (!action || !access || !canViewAction(access)) {
         throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "You don't have access to this action",
+          code: "NOT_FOUND",
+          message: "Action not found or access denied",
         });
       }
 
@@ -2222,7 +2222,13 @@ export const actionRouter = createTRPCRouter({
       // 2. Get workspace members (if action belongs to a project in a workspace).
       //    On restricted projects, only owner/admin workspace roles are eligible
       //    (they are escape-hatch project editors).
-      if (action.project?.workspaceId) {
+      //
+      //    Gated on `isProjectInsider`, NOT `canViewAction`: a public project
+      //    satisfies the view gate for any authenticated caller, and bounty
+      //    action ids for public projects are published by the unauthenticated
+      //    /api/bounties feed. Public visibility grants the project, never the
+      //    workspace roster behind it.
+      if (action.project?.workspaceId && access.isProjectInsider) {
         const workspaceUsers = await ctx.db.workspaceUser.findMany({
           where: {
             workspaceId: action.project.workspaceId,
@@ -2301,6 +2307,10 @@ export const actionRouter = createTRPCRouter({
     }))
     .query(async ({ ctx, input }) => {
       let project: { id: string; name: string; workspaceId: string | null; isRestricted: boolean } | null = null;
+      // Whether the caller reached the project by a membership path rather than
+      // by its `isPublic` flag. Only an insider inherits the workspace roster
+      // below — see the precedence comment further down.
+      let projectInsider = false;
       if (input.projectId) {
         const access = await getProjectAccess(ctx.db, ctx.session.user.id, input.projectId);
         if (!hasProjectAccess(access)) {
@@ -2309,6 +2319,7 @@ export const actionRouter = createTRPCRouter({
             message: "You don't have access to this project",
           });
         }
+        projectInsider = isProjectInsider(access);
         project = await ctx.db.project.findUnique({
           where: { id: input.projectId },
           select: { id: true, name: true, workspaceId: true, isRestricted: true },
@@ -2316,15 +2327,20 @@ export const actionRouter = createTRPCRouter({
       }
 
       // Workspace precedence, and why the two paths are gated differently:
-      // a workspace reached *through* an authorised project is already covered
-      // by the project check above, and must NOT be re-checked — workspace
-      // guests (project-only members with no WorkspaceUser row) would fail a
-      // membership probe and lose the roster on their own projects.
+      // a workspace reached *through* a project the caller is an insider on is
+      // already covered by the project check above, and must NOT be re-checked
+      // — workspace guests (project-only members with no WorkspaceUser row)
+      // would fail a membership probe and lose the roster on their own
+      // projects.
+      // `isProjectInsider`, not `hasProjectAccess`: the latter is satisfied by
+      // a merely *public* project, so inheriting the workspace from it would
+      // hand the whole roster to any authenticated caller holding a public
+      // project id — the same leak this guard exists to close.
       // A caller-supplied `workspaceId` has no such backing, so it needs an
       // explicit check: without one, any logged-in user who knows or guesses a
       // workspace CUID got back every member's id, name, email and avatar.
       // Plain membership is the bar — this is a read, so viewers pass.
-      let effectiveWorkspaceId = project?.workspaceId ?? null;
+      let effectiveWorkspaceId = projectInsider ? (project?.workspaceId ?? null) : null;
       if (!effectiveWorkspaceId && input.workspaceId) {
         const membership = await getWorkspaceMembership(
           ctx.db,

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -11,7 +11,7 @@ import { ScoringService } from "~/server/services/ScoringService";
 import { startOfDay } from "date-fns";
 import { validateScheduledTimes } from "~/lib/dateUtils";
 import { findUserByEmailInWorkspace, getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
-import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs } from "~/server/services/access";
+import { getActionAccess, canViewAction, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs } from "~/server/services/access";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import { uploadToBlob } from "~/lib/blob";
 import { emitNotification } from "~/server/services/notifications/emit/emitNotification";
@@ -2049,17 +2049,33 @@ export const actionRouter = createTRPCRouter({
       actionId: z.string(),
     }))
     .query(async ({ ctx, input }) => {
-      // Get the action to verify it exists and get context
-      const action = await ctx.db.action.findUnique({
-        where: { id: input.actionId },
-        include: {
-          project: true,
-          team: true,
-        },
-      });
+      // Get the action to verify it exists and get context. The access probe
+      // runs alongside it — both are independent reads keyed off actionId.
+      const [action, access] = await Promise.all([
+        ctx.db.action.findUnique({
+          where: { id: input.actionId },
+          include: {
+            project: true,
+            team: true,
+          },
+        }),
+        getActionAccess(ctx.db, ctx.session.user.id, input.actionId),
+      ]);
 
       if (!action) {
         throw new Error("Action not found");
+      }
+
+      // Without this, naming any action id returned its whole assignable
+      // roster — every workspace and project member, emails included — to any
+      // logged-in caller. View access is the right bar: assignment itself is
+      // separately gated on canEditAction, and a viewer legitimately needs the
+      // roster to render existing assignees.
+      if (!access || !canViewAction(access)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have access to this action",
+        });
       }
 
       // Collect assignable users from multiple sources
@@ -2193,7 +2209,31 @@ export const actionRouter = createTRPCRouter({
         });
       }
 
-      const effectiveWorkspaceId = project?.workspaceId ?? input.workspaceId ?? null;
+      // Workspace precedence, and why the two paths are gated differently:
+      // a workspace reached *through* an authorised project is already covered
+      // by the project check above, and must NOT be re-checked — workspace
+      // guests (project-only members with no WorkspaceUser row) would fail a
+      // membership probe and lose the roster on their own projects.
+      // A caller-supplied `workspaceId` has no such backing, so it needs an
+      // explicit check: without one, any logged-in user who knows or guesses a
+      // workspace CUID got back every member's id, name, email and avatar.
+      // Plain membership is the bar — this is a read, so viewers pass.
+      let effectiveWorkspaceId = project?.workspaceId ?? null;
+      if (!effectiveWorkspaceId && input.workspaceId) {
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          ctx.session.user.id,
+          input.workspaceId,
+        );
+        if (!membership) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "You don't have access to this workspace",
+          });
+        }
+        effectiveWorkspaceId = input.workspaceId;
+      }
+
       const isRestrictedProject = project?.isRestricted ?? false;
 
       const userMap = new Map<string, { id: string; name: string | null; email: string | null; image: string | null }>();

--- a/src/server/services/access/index.ts
+++ b/src/server/services/access/index.ts
@@ -77,6 +77,7 @@ export { getTeamMembership, getUserTeams } from "./resolvers/teamResolver";
 export {
   getProjectAccess,
   hasProjectAccess,
+  isProjectInsider,
   canEditProject,
   canManageProjectMembers,
   buildProjectAccessWhere,

--- a/src/server/services/access/resolvers/actionResolver.ts
+++ b/src/server/services/access/resolvers/actionResolver.ts
@@ -12,13 +12,19 @@
 
 import type { PrismaClient } from "@prisma/client";
 import type { Permission } from "../types";
-import { getProjectAccess, hasProjectAccess, canEditProject } from "./projectResolver";
+import { getProjectAccess, hasProjectAccess, canEditProject, isProjectInsider } from "./projectResolver";
 
 interface ActionAccessInfo {
   isCreator: boolean;
   isAssignee: boolean;
   hasProjectAccess: boolean;
   canEditProject: boolean;
+  /**
+   * Project access via a membership path, NOT mere `isPublic` visibility.
+   * Use this — never `hasProjectAccess` — to gate anything that exposes the
+   * workspace around the action (member rosters, org-wide data).
+   */
+  isProjectInsider: boolean;
 }
 
 export async function getActionAccess(
@@ -51,6 +57,7 @@ export async function getActionAccess(
     isAssignee,
     hasProjectAccess: projectAccess ? hasProjectAccess(projectAccess) : false,
     canEditProject: projectAccess ? canEditProject(projectAccess) : false,
+    isProjectInsider: projectAccess ? isProjectInsider(projectAccess) : false,
   };
 }
 

--- a/src/server/services/access/resolvers/projectResolver.ts
+++ b/src/server/services/access/resolvers/projectResolver.ts
@@ -125,6 +125,32 @@ export function hasProjectAccess(access: ProjectAccess): boolean {
   return access.isTeamMember || access.isWorkspaceMember;
 }
 
+/**
+ * Does this access carry a *membership* path to the project, rather than mere
+ * public visibility?
+ *
+ * `hasProjectAccess` short-circuits to true for ANY authenticated caller when
+ * the project is public, which makes it the wrong gate for anything that
+ * exposes the organisation *around* the project — workspace member rosters,
+ * sibling projects, workspace settings. Public visibility grants the project,
+ * never the workspace behind it.
+ *
+ * Concretely: bounty action ids for public projects are served by the
+ * unauthenticated `/api/bounties` feed, and public projects are SEO-indexed via
+ * the sitemap. So "caller passed hasProjectAccess" can mean nothing more than
+ * "caller read a public URL and signed up".
+ *
+ * This is `hasProjectAccess` minus the `isPublic` short-circuit.
+ */
+export function isProjectInsider(access: ProjectAccess): boolean {
+  if (access.isCreator) return true;
+  if (access.isMember) return true;
+  if (access.isRestricted) {
+    return isWorkspaceEscapeHatch(access);
+  }
+  return access.isTeamMember || access.isWorkspaceMember;
+}
+
 /** Check if user can edit a project */
 export function canEditProject(access: ProjectAccess): boolean {
   if (access.isCreator) return true;


### PR DESCRIPTION
## What

Two authenticated-user PII disclosures on the action-assignment readers, plus a small oracle.

**1. Bare `workspaceId` was ungated.** `action.getAssignableUsersForContext` accepted a caller-supplied `workspaceId` and returned **id, name, email and image for every member of that workspace** with no membership check anywhere in the procedure. Any authenticated user who knew or guessed a workspace CUID got the full roster. The sibling `projectId` path was guarded; only the workspace path was open.

**2. `getAssignableUsers` had no access check at all.** Its only test was `if (!action) throw` — existence, not access. Naming any action id returned that action's whole workspace roster, plus its project members and project creator.

**3. Public projects were a second door to the same roster** (found in review, after the first fix). `hasProjectAccess` short-circuits to `true` for **any** authenticated caller when the project is public, and `canViewAction` inherits that. So the guards added for (1) and (2) still let a stranger through on any public project. Not theoretical:

1. `GET /api/bounties` — **unauthenticated** — publishes action ids for bounties in public projects
2. Sign up for any free account
3. `action.getAssignableUsers({ actionId: <id from that feed> })`
4. `canViewAction` passes via `isPublic` → workspace roster returned

Public projects are also SEO-indexed via the sitemap.

## Fix

**Workspace membership** is now required whenever `workspaceId` is caller-supplied. A workspace derived from a project the caller is an *insider* on skips the probe — workspace guests (project-only members with no `WorkspaceUser` row) would otherwise fail a membership check and lose the roster on their own projects. `getWorkspaceMembership` (direct OR team), not `canEditWorkspaceContent`: this is a read, so viewers pass.

**`getAssignableUsers`** is gated on `canViewAction`, folded into the existing fetch via `Promise.all` so it costs no extra round-trip. `canViewAction` rather than `canEditAction` because assignment itself is already gated on `canEditAction`, and a viewer needs the roster to render existing assignees. Verified against `buildActionAccessWhere`: every branch that admits a project-less action is creator-or-assignee, so `canViewAction` matches exactly what the list query already allows — no viewer loses the picker.

**New `isProjectInsider`** in the project resolver — `hasProjectAccess` minus the `isPublic` short-circuit — surfaced on `ActionAccessInfo` (computed where the project access is already in hand, so no extra query). Both roster reads gate on it. Public visibility grants the project, never the workspace behind it.

**Oracle collapsed:** `getAssignableUsers` reported a missing action as a bare `Error` (500) but a forbidden one as `FORBIDDEN`, confirming which action CUIDs exist. Both are now `NOT_FOUND` / `"Action not found or access denied"`, matching `getById` in the same router and the rule documented in `assignability.ts`.

## Tests

9 new mocked-caller cases in `action.test.ts`:

- non-member with a bare `workspaceId` → `FORBIDDEN`, roster query never runs
- member → roster returned
- workspace **guest** via `projectId` → still works, membership probe skipped
- **public project via `projectId`** → roster withheld, caller sees only themselves
- **public project + bare `workspaceId`** → `FORBIDDEN` (the project can't vouch)
- `getAssignableUsers` with no access → `NOT_FOUND`, roster + project-member queries never run
- `getAssignableUsers` on a missing action → identical `NOT_FOUND` response
- `getAssignableUsers` as creator → roster returned
- **`getAssignableUsers` on a public project** → roster withheld

Every guard verified non-vacuous by reverting it and confirming the matching test fails. Full suite: 2079 passing, typecheck clean.

## Blast radius

All three callers — `AssigneeSelector`, `AssignActionModal`, `ParticipantPicker` — pass their own workspace context, so no UI flow changes. `isProjectInsider` is additive; the 87 existing access-permission tests are unaffected.

## Follow-up worth considering

`isPublic` granting `hasProjectAccess` is a repo-wide pattern. This PR fixes the two readers it touches, but a sweep for other places where public-project access leads to workspace-scoped data would be worthwhile.

Read-side counterpart to the write-side `workspaceId` guards on `action.create` / `action.update` (#487, #484).