### PR TITLE
fix(topbar): link the workspace crumb back to the workspace root

### DIFF
--- a/src/app/_components/layout/WorkspaceTopbar.module.css
+++ b/src/app/_components/layout/WorkspaceTopbar.module.css
@@ -30,9 +30,21 @@
   color: var(--color-text-secondary);
 }
 
-.crumbCurrent {
+/* The workspace name links back to the workspace root. It keeps the emphasised
+   look of the leading crumb, so hover has to be an underline rather than the
+   colour shift the dimmer .crumbLink crumbs use. */
+.crumbRoot {
   color: var(--color-text-primary);
   font-weight: 500;
+  text-decoration: none;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.crumbRoot:hover {
+  text-decoration: underline;
 }
 
 .crumbSep {

--- a/src/app/_components/layout/WorkspaceTopbar.tsx
+++ b/src/app/_components/layout/WorkspaceTopbar.tsx
@@ -66,7 +66,9 @@ export function WorkspaceTopbar() {
     <div className={styles.topbar}>
       <div className={styles.crumb}>
         <IconFolder size={14} stroke={1.75} style={{ color: 'var(--color-text-muted)' }} />
-        <span className={styles.crumbCurrent}>{workspace.name}</span>
+        <Link href={`/w/${workspaceSlug}`} className={styles.crumbRoot}>
+          {workspace.name}
+        </Link>
         {pageLabel && (
           <>
             <span className={styles.crumbSep}>/</span>

--- a/src/app/_components/layout/__tests__/WorkspaceTopbar.test.tsx
+++ b/src/app/_components/layout/__tests__/WorkspaceTopbar.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '~/test/test-utils';
+import '@testing-library/jest-dom/vitest';
+import { WorkspaceTopbar } from '../WorkspaceTopbar';
+
+const { mockUseWorkspace, mockUsePathname } = vi.hoisted(() => ({
+  mockUseWorkspace: vi.fn(),
+  mockUsePathname: vi.fn(() => '/w/syntrofi/products/exponential/features'),
+}));
+
+vi.mock('~/providers/WorkspaceProvider', () => ({
+  useWorkspace: () => mockUseWorkspace(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    page: { parentCrumb: { useQuery: () => ({ data: undefined }) } },
+  },
+}));
+
+describe('WorkspaceTopbar', () => {
+  beforeEach(() => {
+    mockUseWorkspace.mockReset();
+    mockUseWorkspace.mockReturnValue({
+      workspace: { name: 'Syntrofi' },
+      workspaceSlug: 'syntrofi',
+    });
+    mockUsePathname.mockReturnValue('/w/syntrofi/products/exponential/features');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('links the workspace name back to the workspace root', () => {
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByRole('link', { name: 'Syntrofi' })).toHaveAttribute(
+      'href',
+      '/w/syntrofi',
+    );
+  });
+
+  it('keeps the workspace link on deep routes, alongside the section crumb', () => {
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByRole('link', { name: 'Syntrofi' })).toBeInTheDocument();
+    expect(screen.getByText('Products')).toBeInTheDocument();
+  });
+
+  it('renders nothing without a workspace', () => {
+    mockUseWorkspace.mockReturnValue({ workspace: null, workspaceSlug: null });
+
+    render(<WorkspaceTopbar />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

- The leading crumb in the workspace topbar (the workspace name next to the folder icon) is now a link to `/w/{workspaceSlug}` instead of plain text.
- It keeps the emphasised styling of the leading crumb, so hover feedback is an underline rather than the colour shift the dimmer trailing crumbs use.
- Adds `WorkspaceTopbar.test.tsx` covering the link target, the deep-route case, and the no-workspace case.

## Why

On a deep route like `/w/syntrofi/products/exponential/features` the breadcrumb was the obvious way back to the workspace, but the workspace name wasn't clickable.

## Verification

`npx tsc --noEmit`, `npx next lint` and `npm run test` (2082 tests) all pass locally. Not visually checked in a running dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)