### PR TITLE
fix(topbar): link the section crumb to its own index

### DIFF
--- a/src/app/_components/layout/WorkspaceTopbar.tsx
+++ b/src/app/_components/layout/WorkspaceTopbar.tsx
@@ -23,17 +23,35 @@ const PAGE_LABELS: Record<string, string> = {
   inbox: 'Inbox',
 };
 
-function getCurrentPageLabel(pathname: string, workspaceSlug: string): string {
+/**
+ * The section crumb: the label for the area we're in, plus where it links.
+ *
+ * `href` is null when there is nowhere to go — either we're already on the
+ * section's own index (the crumb is the current page), or we're on a global
+ * route like `/recording/{id}`, where the leading segment isn't guaranteed to
+ * have an index page to land on. Every `/w/{slug}/{segment}` does have one.
+ */
+function getSectionCrumb(
+  pathname: string,
+  workspaceSlug: string,
+): { label: string; href: string | null } {
   const prefix = `/w/${workspaceSlug}/`;
-  let segment = '';
-  if (pathname.startsWith(prefix)) {
-    segment = pathname.slice(prefix.length).split('/')[0] ?? '';
-  } else {
-    // Global routes like /today, /inbox: take the first non-empty path segment.
-    segment = pathname.replace(/^\//, '').split('/')[0] ?? '';
-  }
-  if (!segment) return '';
-  return PAGE_LABELS[segment] ?? segment.charAt(0).toUpperCase() + segment.slice(1);
+  const underWorkspace = pathname.startsWith(prefix);
+  const rest = underWorkspace
+    ? pathname.slice(prefix.length)
+    : // Global routes like /today, /inbox: take the first non-empty segment.
+      pathname.replace(/^\//, '');
+
+  const parts = rest.split('/').filter(Boolean);
+  const segment = parts[0] ?? '';
+  if (!segment) return { label: '', href: null };
+
+  const label =
+    PAGE_LABELS[segment] ?? segment.charAt(0).toUpperCase() + segment.slice(1);
+  const href =
+    underWorkspace && parts.length > 1 ? `${prefix}${segment}` : null;
+
+  return { label, href };
 }
 
 /** Extract the page id when on a page-detail route (`/w/{slug}/pages/{id}`). */
@@ -60,7 +78,7 @@ export function WorkspaceTopbar() {
 
   if (!workspace || !workspaceSlug) return null;
 
-  const pageLabel = getCurrentPageLabel(pathname, workspaceSlug);
+  const section = getSectionCrumb(pathname, workspaceSlug);
 
   return (
     <div className={styles.topbar}>
@@ -69,15 +87,15 @@ export function WorkspaceTopbar() {
         <Link href={`/w/${workspaceSlug}`} className={styles.crumbRoot}>
           {workspace.name}
         </Link>
-        {pageLabel && (
+        {section.label && (
           <>
             <span className={styles.crumbSep}>/</span>
-            {pageDetailId ? (
-              <Link href={`/w/${workspaceSlug}/pages`} className={styles.crumbLink}>
-                {pageLabel}
+            {section.href ? (
+              <Link href={section.href} className={styles.crumbLink}>
+                {section.label}
               </Link>
             ) : (
-              <span>{pageLabel}</span>
+              <span>{section.label}</span>
             )}
           </>
         )}

--- a/src/app/_components/layout/WorkspaceTopbar.tsx
+++ b/src/app/_components/layout/WorkspaceTopbar.tsx
@@ -36,6 +36,10 @@ function getSectionCrumb(
   workspaceSlug: string,
 ): { label: string; href: string | null } {
   const prefix = `/w/${workspaceSlug}/`;
+  // The workspace root redirects onwards, so it has no section of its own —
+  // without this it would parse as the segment "w" and render a "W" crumb.
+  if (pathname === `/w/${workspaceSlug}`) return { label: '', href: null };
+
   const underWorkspace = pathname.startsWith(prefix);
   const rest = underWorkspace
     ? pathname.slice(prefix.length)

--- a/src/app/_components/layout/__tests__/WorkspaceTopbar.test.tsx
+++ b/src/app/_components/layout/__tests__/WorkspaceTopbar.test.tsx
@@ -52,6 +52,49 @@ describe('WorkspaceTopbar', () => {
     expect(screen.getByText('Products')).toBeInTheDocument();
   });
 
+  it('links the section crumb to its index when we are below it', () => {
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByRole('link', { name: 'Products' })).toHaveAttribute(
+      'href',
+      '/w/syntrofi/products',
+    );
+  });
+
+  it('leaves the section crumb as text on the section index itself', () => {
+    mockUsePathname.mockReturnValue('/w/syntrofi/products');
+
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByText('Products')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Products' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('still links a page-detail route back to the pages index', () => {
+    mockUsePathname.mockReturnValue('/w/syntrofi/pages/page-1');
+
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByRole('link', { name: 'Pages' })).toHaveAttribute(
+      'href',
+      '/w/syntrofi/pages',
+    );
+  });
+
+  it('leaves the section crumb as text on global routes', () => {
+    // Global segments like `/recording/{id}` have no index page to land on.
+    mockUsePathname.mockReturnValue('/recording/abc123');
+
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByText('Recording')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Recording' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('renders nothing without a workspace', () => {
     mockUseWorkspace.mockReturnValue({ workspace: null, workspaceSlug: null });
 

--- a/src/app/_components/layout/__tests__/WorkspaceTopbar.test.tsx
+++ b/src/app/_components/layout/__tests__/WorkspaceTopbar.test.tsx
@@ -83,6 +83,15 @@ describe('WorkspaceTopbar', () => {
     );
   });
 
+  it('shows no section crumb at the workspace root', () => {
+    mockUsePathname.mockReturnValue('/w/syntrofi');
+
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByRole('link', { name: 'Syntrofi' })).toBeInTheDocument();
+    expect(screen.queryByText('W')).not.toBeInTheDocument();
+  });
+
   it('leaves the section crumb as text on global routes', () => {
     // Global segments like `/recording/{id}` have no index page to land on.
     mockUsePathname.mockReturnValue('/recording/abc123');


### PR DESCRIPTION
## What

- The section crumb (`Products`, `Meetings`, `Settings`…) now links to `/w/{workspaceSlug}/{segment}` whenever the current route goes deeper than it.
- Generalises the hand-rolled special case that previously only linked the pages-detail route back to `/w/{slug}/pages` — that behaviour is unchanged, it just falls out of the general rule now.
- On the section index itself the crumb is the current page, so it stays plain text.
- Global routes stay plain text: every `/w/{slug}/{segment}` has an index page to land on, but global segments like `/recording/{id}` and `/video/{id}` don't.

## Why

Follow-up to #492. With the workspace name linked, `Products` was the remaining dead crumb on a route like `/w/syntrofi/products/exponential/features`.

## Verification

`npx tsc --noEmit`, `npx next lint` and `npm run test` (2086 tests) pass locally. Four new cases cover the link target, the section index, the page-detail route, and global routes. Not visually checked in a running dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)