### PR TITLE
Say what went wrong, and stop remembering a throwaway wiki root

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -140,6 +140,10 @@ pub fn run() {
 /// written back to the store so the choice survives a restart — including a
 /// first run, where it pins the default rather than leaving it implicit and
 /// liable to move if the default ever changes.
+///
+/// An `EXPONENTIAL_WIKI_ROOT` override is the exception: it applies to the launch
+/// that set it and is never written back, so a throwaway test root cannot become
+/// the permanent setting. See `wiki::resolve_root_for_launch`.
 fn resolve_wiki_root(app: &tauri::AppHandle) {
     use tauri_plugin_store::StoreExt;
 
@@ -149,14 +153,16 @@ fn resolve_wiki_root(app: &tauri::AppHandle) {
         .and_then(|store| store.get(wiki::STORE_KEY))
         .and_then(|value| value.as_str().map(str::to_owned));
 
-    let root = wiki::resolve_root(stored);
+    let wiki::RootChoice { root, persist } = wiki::resolve_root_for_launch(stored);
 
-    if let Ok(store) = app.store(wiki::STORE_FILE) {
-        store.set(wiki::STORE_KEY, root.to_string_lossy().to_string());
-        // Best-effort: a wiki that works but forgets its location next launch
-        // beats refusing to start.
-        if let Err(e) = store.save() {
-            eprintln!("[wiki] could not persist the wiki root: {e}");
+    if persist {
+        if let Ok(store) = app.store(wiki::STORE_FILE) {
+            store.set(wiki::STORE_KEY, root.to_string_lossy().to_string());
+            // Best-effort: a wiki that works but forgets its location next launch
+            // beats refusing to start.
+            if let Err(e) = store.save() {
+                eprintln!("[wiki] could not persist the wiki root: {e}");
+            }
         }
     }
 

--- a/src-tauri/src/wiki.rs
+++ b/src-tauri/src/wiki.rs
@@ -40,7 +40,8 @@ pub struct WikiRoot(pub Mutex<Option<PathBuf>>);
 pub const STORE_FILE: &str = "wiki.json";
 /// Key within that store.
 pub const STORE_KEY: &str = "root";
-/// Dev override, read at startup and then persisted like any other choice.
+/// Dev override, read at startup. Applies to that launch only — see
+/// `resolve_root_for_launch` for why it is deliberately never persisted.
 pub const ROOT_ENV: &str = "EXPONENTIAL_WIKI_ROOT";
 
 /// Default location — visible in Finder on purpose. The wiki is the user's, and
@@ -60,13 +61,34 @@ pub fn default_root() -> PathBuf {
 /// on that origin. Configuring the root is therefore an out-of-band act (the env
 /// var, or a future native settings UI), never an in-page one.
 pub fn resolve_root(stored: Option<String>) -> PathBuf {
+    resolve_root_for_launch(stored).root
+}
+
+/// The root for this launch, and whether it is ours to remember.
+pub struct RootChoice {
+    pub root: PathBuf,
+    /// False for an env override: that path is this launch's business only.
+    pub persist: bool,
+}
+
+/// Same decision as `resolve_root`, plus whether the answer should be written
+/// back to the store.
+///
+/// The env override is deliberately **not** persisted. It used to be, and that
+/// turned a one-off `EXPONENTIAL_WIKI_ROOT=/tmp/scratch` test run into the
+/// permanent setting: every later launch read that path back out of the store,
+/// so the app believed a wiki existed, the first-run panel never appeared, and
+/// the librarian read and wrote a throwaway folder the user had forgotten about.
+/// A variable set for one command should not outlive it.
+pub fn resolve_root_for_launch(stored: Option<String>) -> RootChoice {
     if let Some(from_env) = std::env::var(ROOT_ENV).ok().filter(|v| !v.trim().is_empty()) {
-        return PathBuf::from(from_env);
+        return RootChoice { root: PathBuf::from(from_env), persist: false };
     }
-    match stored.filter(|v| !v.trim().is_empty()) {
+    let root = match stored.filter(|v| !v.trim().is_empty()) {
         Some(path) => PathBuf::from(path),
         None => default_root(),
-    }
+    };
+    RootChoice { root, persist: true }
 }
 
 fn current_root(state: &WikiRoot) -> PathBuf {
@@ -895,6 +917,28 @@ mod tests {
             PathBuf::from("/tmp/override-wiki"),
         );
         std::env::remove_var(ROOT_ENV);
+    }
+
+    #[test]
+    fn the_env_override_is_not_remembered() {
+        // Regression: it used to be written back to the store, so a single
+        // `EXPONENTIAL_WIKI_ROOT=/tmp/scratch` run silently repointed the wiki
+        // for good — the app then believed a wiki existed and never offered to
+        // create the real one.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var(ROOT_ENV, "/tmp/override-wiki");
+        let choice = resolve_root_for_launch(Some("/tmp/stored-wiki".into()));
+        assert_eq!(choice.root, PathBuf::from("/tmp/override-wiki"));
+        assert!(!choice.persist, "an env override must not outlive its launch");
+        std::env::remove_var(ROOT_ENV);
+    }
+
+    #[test]
+    fn a_root_the_user_chose_is_remembered() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var(ROOT_ENV);
+        assert!(resolve_root_for_launch(None).persist);
+        assert!(resolve_root_for_launch(Some("/tmp/my-wiki".into())).persist);
     }
 
     #[test]

--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
+import * as Sentry from '@sentry/nextjs';
 import { api } from "~/trpc/react";
 import DOMPurify from 'dompurify';
 import ReactMarkdown from 'react-markdown';
@@ -29,7 +30,7 @@ import { DraftFeaturesReviewCard } from './DraftFeaturesReviewCard';
 import { useAgentModal, type ChatMessage, type PageContext } from '~/providers/AgentModalProvider';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { trimByTokenBudget } from '~/lib/trim-conversation';
-import { classifyStreamError } from '~/lib/chat/streamProtocol';
+import { classifyStreamError, describeStreamError } from '~/lib/chat/streamProtocol';
 import { cardFromToolCalls } from '~/lib/chat/cardFromToolCalls';
 import { streamChatResponse, type ChatStreamUpdate } from '~/lib/chat/streamChatResponse';
 import { createLocalWikiStreamer, streamLocalWikiChat } from '~/lib/chat/streamLocalWikiChat';
@@ -370,23 +371,32 @@ const MessageList = memo(function MessageList({ messages, conversationId, isStre
                     </div>
                   )}
                   {message.failure && (
-                    <div className="mt-1.5 flex items-center gap-2 text-text-muted text-xs">
-                      {/* Show the failure note when the main block above isn't
-                          already showing it: always for 'incomplete' (the block
-                          shows the partial answer), and for a contentless error. */}
-                      {(message.failure.severity === 'incomplete' || message.content === '') && (
-                        <span>{failureCopy(message.failure.kind, message.failure.severity)}</span>
-                      )}
-                      {message.failure.canRetry && message.failure.retryText && (
-                        <Button
-                          size="compact-xs"
-                          variant="subtle"
-                          color="gray"
-                          leftSection={<IconRefresh size={13} />}
-                          onClick={() => onRetry(message.failure!.retryText!)}
-                        >
-                          Try again
-                        </Button>
+                    <div className="mt-1.5 text-text-muted text-xs">
+                      <div className="flex items-center gap-2">
+                        {/* Show the failure note when the main block above isn't
+                            already showing it: always for 'incomplete' (the block
+                            shows the partial answer), and for a contentless error. */}
+                        {(message.failure.severity === 'incomplete' || message.content === '') && (
+                          <span>{failureCopy(message.failure.kind, message.failure.severity)}</span>
+                        )}
+                        {message.failure.canRetry && message.failure.retryText && (
+                          <Button
+                            size="compact-xs"
+                            variant="subtle"
+                            color="gray"
+                            leftSection={<IconRefresh size={13} />}
+                            onClick={() => onRetry(message.failure!.retryText!)}
+                          >
+                            Try again
+                          </Button>
+                        )}
+                      </div>
+                      {/* The thrown error's own words. Small and secondary, but
+                          present: without it a specific, fixable cause (an expired
+                          key, an empty credit balance) is indistinguishable from a
+                          passing network blip. */}
+                      {message.failure.detail && (
+                        <div className="mt-1 break-words opacity-70">{message.failure.detail}</div>
                       )}
                     </div>
                   )}
@@ -694,7 +704,17 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
     }
     let cancelled = false;
     void (async () => {
-      const status = await getWikiBridge()?.status();
+      // A rejected `wiki_status` used to leave this undefined for good, which
+      // renders as "the wiki exists" — the first-run panel is gated on a
+      // *known* absent wiki. The user then talks to a librarian with nothing to
+      // read. Say so instead of failing invisibly.
+      let status: WikiStatus | undefined;
+      try {
+        status = await getWikiBridge()?.status();
+      } catch (error) {
+        console.error('[ManyChat] wiki_status failed — cannot tell if a wiki exists', error);
+        Sentry.captureException(error, { tags: { area: 'local-wiki-status' } });
+      }
       if (!cancelled) setWikiStatus(status);
     })();
     return () => {
@@ -1470,12 +1490,24 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
       //    it as a normal answer with a subtle "ended early" + Retry footer.
       //  • !hadContent → nothing usable arrived. Convert the empty placeholder
       //    into a calm, single-line error with a Retry button.
+      // Nothing else reports this. The catch above swallows the error, so
+      // Sentry's automatic capture (unhandled errors only) never sees it — which
+      // is how a turn failing on "your credit balance is too low" produced no
+      // trace anywhere: not in Sentry, and so not in the Bug tickets the Sentry
+      // webhook files. Sentry only initialises on Vercel prod/preview, so this
+      // is a no-op in local dev.
+      Sentry.captureException(error, {
+        tags: { area: 'chat-stream', failureKind: kind, agentId: targetAgentId ?? 'unknown' },
+        extra: { hadContent, projectId, conversationId, attempt },
+      });
+
       const severity: 'error' | 'incomplete' = hadContent ? 'incomplete' : 'error';
       const failure: NonNullable<Message['failure']> = {
         severity,
         kind,
         canRetry: kind !== 'auth',
         retryText: text,
+        detail: describeStreamError(error),
       };
 
       setMessages((prev) => {

--- a/src/lib/chat/__tests__/streamProtocol.test.ts
+++ b/src/lib/chat/__tests__/streamProtocol.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   parseChatStreamBuffer,
   classifyStreamError,
+  describeStreamError,
 } from '../streamProtocol';
 
 const toolFrame = (payload: Record<string, unknown>) =>
@@ -195,5 +196,52 @@ describe('classifyStreamError', () => {
 
   it('classifies non-Error throwables as unknown', () => {
     expect(classifyStreamError('nope')).toEqual({ kind: 'unknown', retryable: false });
+  });
+
+  it('classifies provider billing and quota refusals as model errors', () => {
+    // The exact sentence the Anthropic API returns, which used to fall through
+    // to `unknown` and render as "Something went wrong handling that request."
+    expect(
+      classifyStreamError(
+        new Error(
+          'Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.',
+        ),
+      ),
+    ).toEqual({ kind: 'model', retryable: false });
+    expect(classifyStreamError(new Error('You exceeded your current quota'))).toEqual({
+      kind: 'model',
+      retryable: false,
+    });
+  });
+});
+
+describe('describeStreamError', () => {
+  it('returns the error message so the cause reaches the user', () => {
+    expect(describeStreamError(new Error('Your credit balance is too low'))).toBe(
+      'Your credit balance is too low',
+    );
+  });
+
+  it('keeps only the first line, dropping any stack the provider appended', () => {
+    expect(describeStreamError(new Error('Boom\n    at postToApi (index.mjs:1)'))).toBe('Boom');
+  });
+
+  it('caps a runaway message rather than filling the bubble', () => {
+    // Short words, so the masker doesn't take it for one long credential.
+    const detail = describeStreamError(new Error('very bad thing '.repeat(40)));
+    expect(detail).toHaveLength(241);
+    expect(detail?.endsWith('…')).toBe(true);
+  });
+
+  it('masks a credential the provider echoed back', () => {
+    const secret = 'ff_live_' + 'a'.repeat(40);
+    const detail = describeStreamError(new Error(`Invalid API key ${secret}`));
+    expect(detail).not.toContain(secret);
+    expect(detail).toContain('Invalid API key');
+  });
+
+  it('has nothing to add for an empty or non-Error throwable', () => {
+    expect(describeStreamError(new Error('   '))).toBeUndefined();
+    expect(describeStreamError(undefined)).toBeUndefined();
   });
 });

--- a/src/lib/chat/streamProtocol.ts
+++ b/src/lib/chat/streamProtocol.ts
@@ -15,6 +15,10 @@
  * consumes the chat stream (the Zoe drawer via ManyChat, the Zoe canvas).
  */
 
+// Pure regex helper, no server dependencies — imported rather than reimplemented
+// so client-shown error text is masked by exactly the rule the server logs use.
+import { maskTokenLike } from '~/server/utils/redactToolArgs';
+
 // One agent tool invocation, accumulated from __exp_tool__ frames.
 export interface ToolCall {
   id: string;
@@ -150,8 +154,47 @@ export function classifyStreamError(error: unknown): { kind: StreamFailureKind; 
   ) {
     return { kind: 'transport', retryable: true };
   }
+  // Provider-level refusals (billing, quota, rate limits). These arrive as a
+  // plain sentence from the model vendor — "Your credit balance is too low to
+  // access the Anthropic API" — with none of the words matched above, so they
+  // used to land in `unknown` and render as "Something went wrong", hiding the
+  // one fact that would have fixed it.
+  if (
+    text.includes('credit balance') ||
+    text.includes('quota') ||
+    text.includes('billing') ||
+    text.includes('insufficient_quota') ||
+    text.includes('rate limit')
+  ) {
+    return { kind: 'model', retryable: false };
+  }
   if (text.includes('mastra') || text.includes('agent')) {
     return { kind: 'model', retryable: false };
   }
   return { kind: 'unknown', retryable: false };
+}
+
+/**
+ * The thrown error's own words, for display beneath the calm copy.
+ *
+ * Returns undefined when there's nothing worth showing. Capped because some
+ * provider errors carry a whole stack trace, and a chat bubble is not a log
+ * viewer.
+ *
+ * Masked with the same rule the server applies before an error message reaches
+ * a log (`maskTokenLike`), because free-form provider text can echo a
+ * credential back — "Invalid API key ff_live_…". The server-mediated path goes
+ * further and shows the user nothing but a generic line
+ * (`formatUserFacingStreamError`); that stays as it is. This is for errors
+ * thrown at *this* end, where the alternative is not a safer message but no
+ * message at all.
+ */
+export function describeStreamError(error: unknown): string | undefined {
+  const raw =
+    error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  // Providers often append a stack after the sentence; the first line is the
+  // part a human reads.
+  const message = maskTokenLike(raw.split('\n')[0]?.trim() ?? '');
+  if (!message) return undefined;
+  return message.length > 240 ? `${message.slice(0, 240)}…` : message;
 }

--- a/src/providers/AgentModalProvider.tsx
+++ b/src/providers/AgentModalProvider.tsx
@@ -59,6 +59,17 @@ export interface ChatMessage {
     kind: 'transport' | 'idle-timeout' | 'auth' | 'model' | 'unknown';
     canRetry: boolean;
     retryText?: string;
+    /**
+     * What actually went wrong, in the words of whatever threw — shown beneath
+     * the calm copy above.
+     *
+     * Added because the copy alone is a dead end when the cause is real and
+     * specific: a provider that says "your credit balance is too low" rendered
+     * as "Something went wrong handling that request" leaves the user (and
+     * anyone they report it to) with nothing to act on. Undefined when there is
+     * nothing to add beyond the copy.
+     */
+    detail?: string;
   };
 }
 


### PR DESCRIPTION
## What

Two fixes that came out of a local-wiki turn failing with nothing to go on.

**The wiki root stopped being remembered from an env override.** `EXPONENTIAL_WIKI_ROOT` was written back into the store, so a single `EXPONENTIAL_WIKI_ROOT=/tmp/pw` test run became the permanent setting. Every launch since read `/tmp/pw` back out, the app concluded a wiki existed, the first-run panel never appeared, and the librarian was pointed at a scratch folder the user had forgotten about. `resolve_root_for_launch` now reports whether the answer is ours to remember; an override applies to its own launch and no further.

**A failed turn now says what failed.** The turn that prompted this died on `Your credit balance is too low to access the Anthropic API` — a plain sentence from the provider with none of the words `classifyStreamError` looks for, so it bucketed as `unknown` and rendered as "Something went wrong handling that request." Billing/quota refusals now classify as model errors, and the thrown message renders under the calm copy.

**And it reaches Sentry.** The catch block swallowed the error, and Sentry captures only what nobody handled — so the failure existed in no log, no Sentry issue, and therefore none of the Bug tickets the Sentry webhook files. Terminal chat failures are now captured with the agent id and failure kind.

## Decisions worth a look

**Showing the raw message runs against the server path's policy, deliberately.** `/api/chat/stream` maps agent errors to a generic line on purpose (`formatUserFacingStreamError`) because provider text can echo a credential. That stays. This only covers errors thrown at the *client* end — the local-wiki transport, a failed token mint — where the alternative isn't a safer message, it's no message. The text is masked with the same `maskTokenLike` rule the server applies before logging, first line only, capped at 240 chars.

**A rejected `wiki_status` used to read as "the wiki exists".** The status probe had no catch, so a rejection left the state undefined — which the first-run gate treats as "don't offer to create anything", since it only offers on a *known* absent wiki. Now it logs, reports, and the failure is visible.

## Verification

`streamProtocol.test.ts` covers the new classification, the masking, the first-line-only rule and the cap (26 tests, 5 new). Rust: 69 tests, 2 new asserting the override is used but not persisted, and that a stored or default root still is.

Not verified in a browser: the detail line's rendering (a guarded three-line addition). Playwright is declared but not installed in this checkout.

## Acceptance criteria

- [x] An env-var wiki root is used for that launch and never written to the store
- [x] A stored or defaulted root is still persisted, so the choice survives a restart
- [x] A provider billing/quota refusal renders as a model error, not "unknown"
- [x] The thrown message is shown under the copy, masked and capped
- [x] Terminal chat failures reach Sentry with agent id and failure kind
- [x] A rejected `wiki_status` is logged and reported rather than silently suppressing the first-run panel