### PR TITLE
chore(pr-agent): teach the reviewer this repo's house rules

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -19,6 +19,46 @@ num_max_findings = 4
 # Don't re-post the whole review on every push; update the existing comment.
 persistent_comment = true
 final_update_message = false
+# Repo-specific rules the reviewer can't infer from the diff. Mirrors CLAUDE.md —
+# keep the two in sync when a rule changes.
+extra_instructions = """
+Flag violations of this repo's house rules, with the rule named:
+
+Styling — no hardcoded colors anywhere (hex literals, rgb()/rgba(), Tailwind
+arbitrary-value color classes, or inline style color values). Colors come from
+design tokens: semantic Tailwind classes (bg-background-primary, text-text-primary,
+border-border-primary) or CSS variables declared in src/styles/globals.css. A
+pre-commit hook rejects these, so catching them in review saves a round-trip.
+
+TypeScript / ESLint (these fail the build) — prefer `??` over `||` for defaulting;
+no `any`; every promise awaited or explicitly handled; no `await` on non-promises;
+type-only imports use `import type`; no unused variables or imports.
+
+Access control — permission logic belongs in the centralized service at
+src/server/services/access/. Flag any new inline permission check in a router or
+component that duplicates what requireActionAccess / requireWorkspaceMembership /
+buildActionAccessWhere already do. Flag list/bulk queries that filter by
+createdById alone where an access-scoped where-clause is required. Note that
+workspace membership does not imply edit rights — viewers and guests pass
+membership checks, so mutations that must exclude them need an explicit role check.
+
+Database — `prisma db push` is forbidden in any form (it has caused data loss here);
+schema changes require a migration file under prisma/migrations. Flag edits to
+schema.prisma that arrive without one. Do not suggest removing the safety guards,
+marker-table check, or row-count threshold in src/test/test-db.ts.
+
+Content — authored prose renders through MarkdownRenderer and is accepted through
+MarkdownInput / CommentInput. Flag direct react-markdown imports,
+dangerouslySetInnerHTML, a bare Textarea used for prose, or a new Tiptap editor.
+
+Workspace scoping — data is workspace-scoped. Flag new queries or mutations over
+Project / Goal / Outcome / Action that ignore workspaceId and could leak rows
+across workspaces.
+
+Tests — integration tests (*.integration.test.ts, real DB via testcontainers) are
+deliberately rare. Prefer mocked Prisma with createMockCaller. Flag a new
+integration test that doesn't genuinely need real DB behaviour.
+"""
 
 [pr_description]
 # Auto-generate a structured description + walkthrough.
@@ -30,3 +70,13 @@ generate_ai_title = false
 # Improvement suggestions ("/improve"). Keep the volume sane.
 num_code_suggestions = 4
 commitable_code_suggestions = false
+# Suggestions must themselves be committable here — a suggestion containing a hex
+# color or `||` defaulting would be rejected by the pre-commit hook or the build.
+extra_instructions = """
+Never suggest code that would fail this repo's own gates: no hardcoded colors (use
+semantic Tailwind classes or CSS variables), no `||` where `??` is meant, no `any`,
+no unhandled promises, no `import` of types without `import type`.
+Prefer Next.js `Link` over `useRouter().push()` for navigation, and Server
+Components over Client Components unless interactivity requires otherwise.
+Skip cosmetic suggestions — Prettier already formats this repo.
+"""


### PR DESCRIPTION
PR-Agent reviews every PR here, but it had no knowledge of the conventions that `CLAUDE.md` and the pre-commit hooks enforce — so it could neither flag violations nor avoid suggesting code that would fail them.

## What

**`[pr_reviewer].extra_instructions`** — flag violations, naming the rule:

- **Styling** — hardcoded colors in any form (hex literals, `rgb()`/`rgba()`, Tailwind arbitrary-value color classes, inline style colors). Points at the semantic tokens and `src/styles/globals.css`.
- **TypeScript / ESLint** — the six build-failing rules: `??` over `||`, no `any`, promises awaited or handled, no `await` on non-promises, `import type`, no unused.
- **Access control** — inline permission checks that duplicate `src/server/services/access/`; list queries filtering on `createdById` alone. Includes the trap from PR 484: workspace membership passes for viewers and guests, so mutations that must exclude them need an explicit role check.
- **Database** — `prisma db push` forbidden; `schema.prisma` edits arriving without a migration; no suggestions that weaken the guards in `src/test/test-db.ts`.
- **Content** — direct `react-markdown` imports, `dangerouslySetInnerHTML`, bare `Textarea` for prose, new Tiptap editors (ADR-0017).
- **Workspace scoping** — queries over Project / Goal / Outcome / Action that ignore `workspaceId`.
- **Tests** — new `*.integration.test.ts` that does not genuinely need real DB behaviour.

**`[pr_code_suggestions].extra_instructions`** — keeps the suggestions themselves committable under those gates, prefers `Link` over `useRouter().push()`, and skips cosmetics since Prettier owns formatting.

## Why

CodeRabbit is configured nowhere in this repo and has posted zero comments across recent PRs, so PR-Agent is the only automated reviewer actually running. Repo-rule awareness is the main thing it was missing relative to a tool with path-based instructions.

## Notes

- Config-only change. No behavioural code touched.
- `num_max_findings` and `commitable_code_suggestions` deliberately left as they were.
- Verified the file parses with a real TOML parser; keys land in the right sections and `config.model` is unchanged.
- This PR is its own test case — PR-Agent should review it with the new instructions active.