### PR TITLE
Report the failures we handle, instead of only the ones we don't

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,13 @@ SENTRY_WEBHOOK_SECRET=""
 SENTRY_WEBHOOK_TOKEN=""
 # Product that Sentry-filed bugs land in (defaults to the Exponential product).
 SENTRY_BUG_PRODUCT_ID=""
+# Set to file Bug Tickets for failures the app handled gracefully (a chat turn
+# that failed and offered Retry, a desktop bridge call that errored). Sentry
+# only ever sees what nobody caught, and only initialises on Vercel
+# prod/preview, so without this those failures are invisible — including every
+# one you hit running the desktop shell against localhost. Same destination and
+# dedup as Sentry-filed bugs; labelled "client-error" rather than "Sentry".
+CLIENT_ERROR_BUGS=""
 # Identity for the Errol system user that authors Sentry bugs (find-or-created lazily).
 SENTRY_BOT_EMAIL="errol@bots.exponential.im"
 SENTRY_BOT_NAME="Errol"

--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
-import * as Sentry from '@sentry/nextjs';
 import { api } from "~/trpc/react";
 import DOMPurify from 'dompurify';
 import ReactMarkdown from 'react-markdown';
@@ -31,6 +30,7 @@ import { useAgentModal, type ChatMessage, type PageContext } from '~/providers/A
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { trimByTokenBudget } from '~/lib/trim-conversation';
 import { classifyStreamError, describeStreamError } from '~/lib/chat/streamProtocol';
+import { reportHandledError } from '~/lib/reportHandledError';
 import { cardFromToolCalls } from '~/lib/chat/cardFromToolCalls';
 import { streamChatResponse, type ChatStreamUpdate } from '~/lib/chat/streamChatResponse';
 import { createLocalWikiStreamer, streamLocalWikiChat } from '~/lib/chat/streamLocalWikiChat';
@@ -713,7 +713,7 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
         status = await getWikiBridge()?.status();
       } catch (error) {
         console.error('[ManyChat] wiki_status failed — cannot tell if a wiki exists', error);
-        Sentry.captureException(error, { tags: { area: 'local-wiki-status' } });
+        reportHandledError(error, { area: 'local-wiki-status' });
       }
       if (!cancelled) setWikiStatus(status);
     })();
@@ -1490,15 +1490,22 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
       //    it as a normal answer with a subtle "ended early" + Retry footer.
       //  • !hadContent → nothing usable arrived. Convert the empty placeholder
       //    into a calm, single-line error with a Retry button.
-      // Nothing else reports this. The catch above swallows the error, so
-      // Sentry's automatic capture (unhandled errors only) never sees it — which
-      // is how a turn failing on "your credit balance is too low" produced no
-      // trace anywhere: not in Sentry, and so not in the Bug tickets the Sentry
-      // webhook files. Sentry only initialises on Vercel prod/preview, so this
-      // is a no-op in local dev.
-      Sentry.captureException(error, {
-        tags: { area: 'chat-stream', failureKind: kind, agentId: targetAgentId ?? 'unknown' },
-        extra: { hadContent, projectId, conversationId, attempt },
+      // Nothing else reports this. The catch above handles the error — rightly,
+      // the user gets a calm message and a Retry — but handling it is exactly
+      // why Sentry's automatic capture never saw it, and so why a turn failing
+      // on "your credit balance is too low" left no trace anywhere. Reported
+      // explicitly instead: to Sentry, and to a Bug Ticket, which unlike Sentry
+      // also works when the app is running against a local server.
+      reportHandledError(error, {
+        area: 'chat-stream',
+        kind,
+        context: {
+          agentId: targetAgentId ?? 'unknown',
+          hadContent: String(hadContent),
+          attempt: String(attempt),
+          ...(projectId ? { projectId } : {}),
+          conversationId,
+        },
       });
 
       const severity: 'error' | 'incomplete' = hadContent ? 'incomplete' : 'error';

--- a/src/app/_components/home/zoe-canvas/ZoeCanvas.module.css
+++ b/src/app/_components/home/zoe-canvas/ZoeCanvas.module.css
@@ -105,3 +105,13 @@
   font-size: 12px;
   margin-top: 6px;
 }
+
+/* The underlying error message, under the calm copy: present enough to act on,
+   quiet enough not to read as the answer. */
+.failureDetail {
+  color: var(--color-text-muted);
+  font-size: 12px;
+  margin-top: 4px;
+  opacity: 0.7;
+  overflow-wrap: break-word;
+}

--- a/src/app/_components/home/zoe-canvas/ZoeCanvas.tsx
+++ b/src/app/_components/home/zoe-canvas/ZoeCanvas.tsx
@@ -116,6 +116,11 @@ export function ZoeCanvas({ messages, isStreaming, onDismiss, onRetry }: ZoeCanv
                   )}
                 </div>
               )}
+              {/* The thrown error's own words — same treatment as the drawer,
+                  so a specific cause isn't only visible on one surface. */}
+              {message.failure?.detail && (
+                <div className={classes.failureDetail}>{message.failure.detail}</div>
+              )}
               {message.card?.kind === 'draft-actions' && (
                 <DraftActionsReviewCard transcriptionId={message.card.transcriptionId} />
               )}

--- a/src/app/_components/home/zoe-canvas/useCanvasEngagement.ts
+++ b/src/app/_components/home/zoe-canvas/useCanvasEngagement.ts
@@ -4,7 +4,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '~/trpc/react';
 import { useAgentModal, type ChatMessage } from '~/providers/AgentModalProvider';
 import { streamChatResponse, type ChatStreamCoreMessage } from '~/lib/chat/streamChatResponse';
-import { classifyStreamError } from '~/lib/chat/streamProtocol';
+import { classifyStreamError, describeStreamError } from '~/lib/chat/streamProtocol';
+import { reportHandledError } from '~/lib/reportHandledError';
 import { cardFromToolCalls } from '~/lib/chat/cardFromToolCalls';
 import { trimByTokenBudget } from '~/lib/trim-conversation';
 import { applyToolRefreshInvalidations } from '~/app/_components/agent/toolRefreshInvalidation';
@@ -258,6 +259,16 @@ export function useCanvasEngagement({
 
         setIsStreaming(false);
 
+        // A dismissal is the user's own doing, not a fault — reporting those
+        // would fill the tracker with people changing their minds.
+        if (!wasDismissed) {
+          reportHandledError(error, {
+            area: 'zoe-canvas-stream',
+            kind,
+            context: { hadContent: String(hadContent), attempt: String(attempt) },
+          });
+        }
+
         // One abort rule (ADR-0040): a dismissal mid-stream marks the turn
         // `incomplete` — the existing partial-answer + Retry treatment, visible
         // in the drawer where the thread lives on.
@@ -266,7 +277,7 @@ export function useCanvasEngagement({
         patchTrailingAi(last => ({
           agentName: severity === 'error' ? (last.agentName ?? 'Assistant') : last.agentName,
           content: severity === 'error' ? '' : last.content,
-          failure: { severity, kind, canRetry: kind !== 'auth', retryText: trimmedText },
+          failure: { severity, kind, canRetry: kind !== 'auth', retryText: trimmedText, detail: describeStreamError(error) },
         }));
       } finally {
         if (abortRef.current === abortController) abortRef.current = null;

--- a/src/app/api/client-errors/__tests__/route.test.ts
+++ b/src/app/api/client-errors/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the handled-client-error route. The route reads only
+ * `request.json()`, so a tiny fake request is enough. Auth, the DB and the
+ * ingest service are mocked so the route's own decisions — the env gate, the
+ * kind filter, the rate limit, and never failing loudly — are what's under test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.hoisted(() => {
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+vi.mock("~/server/db", () => ({ db: {} }));
+
+const { ingestSentryBug, auth } = vi.hoisted(() => ({
+  ingestSentryBug: vi.fn(),
+  auth: vi.fn(),
+}));
+vi.mock("~/server/services/sentry/SentryBugService", () => ({ ingestSentryBug }));
+vi.mock("~/server/auth", () => ({ auth }));
+
+import { POST } from "../route";
+
+function fakeRequest(body: unknown): NextRequest {
+  return { json: () => Promise.resolve(body) } as unknown as NextRequest;
+}
+
+const report = {
+  area: "chat-stream",
+  kind: "model",
+  message: "Your credit balance is too low",
+};
+
+/** Each test gets its own user so the module-level rate limiter can't bleed. */
+let userSeq = 0;
+function signedIn(): void {
+  userSeq += 1;
+  auth.mockResolvedValue({ user: { id: `user-${userSeq}` } });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.CLIENT_ERROR_BUGS = "1";
+  ingestSentryBug.mockResolvedValue({ created: true, ticketId: "ticket-1" });
+  signedIn();
+});
+
+afterEach(() => {
+  delete process.env.CLIENT_ERROR_BUGS;
+});
+
+describe("POST /api/client-errors", () => {
+  it("files a bug for a reportable failure", async () => {
+    const res = await POST(fakeRequest(report));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ filed: true, ticketId: "ticket-1" });
+    const [, bug, options] = ingestSentryBug.mock.calls[0]!;
+    expect(bug.title).toContain("Your credit balance is too low");
+    expect(options.body).toContain("never reached Sentry");
+    // Labelled as what it is, so the "Sentry" label keeps meaning Sentry.
+    expect(options.labels.map((l: { slug: string }) => l.slug)).toEqual([
+      "client-error",
+      "bug",
+    ]);
+  });
+
+  it("stays off unless the environment opts in", async () => {
+    delete process.env.CLIENT_ERROR_BUGS;
+
+    expect(await (await POST(fakeRequest(report))).json()).toEqual({
+      filed: false,
+      reason: "disabled",
+    });
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("refuses an unauthenticated report", async () => {
+    auth.mockResolvedValue(null);
+
+    const res = await POST(fakeRequest(report));
+
+    expect(res.status).toBe(401);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("does not file a dropped connection", async () => {
+    const res = await POST(fakeRequest({ ...report, kind: "transport" }));
+
+    expect(await res.json()).toEqual({ filed: false, reason: "not-reportable" });
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed report", async () => {
+    const res = await POST(fakeRequest({ area: "chat-stream" }));
+
+    expect(res.status).toBe(400);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("stops a runaway client after the per-user ceiling", async () => {
+    // 20 distinct errors are plausible; the 21st in an hour is a loop.
+    for (let i = 0; i < 20; i += 1) {
+      await POST(fakeRequest({ ...report, message: `failure number ${i}` }));
+    }
+    expect(ingestSentryBug).toHaveBeenCalledTimes(20);
+
+    const res = await POST(fakeRequest({ ...report, message: "one too many" }));
+
+    expect(await res.json()).toEqual({ filed: false, reason: "rate-limited" });
+    expect(ingestSentryBug).toHaveBeenCalledTimes(20);
+  });
+
+  it("never turns a reporting failure into a second failure", async () => {
+    ingestSentryBug.mockRejectedValue(new Error("product not found"));
+
+    const res = await POST(fakeRequest(report));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ filed: false, reason: "ingest-failed" });
+  });
+});

--- a/src/app/api/client-errors/route.ts
+++ b/src/app/api/client-errors/route.ts
@@ -1,0 +1,112 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { ingestSentryBug } from "~/server/services/sentry/SentryBugService";
+import {
+  buildClientErrorBody,
+  buildClientErrorBug,
+  shouldFileClientError,
+  type ClientErrorReport,
+} from "~/server/services/clientErrors/clientErrorBug";
+
+/**
+ * Files a failure the browser handled gracefully as a Bug Ticket.
+ *
+ * The counterpart to `/api/webhooks/sentry`: that route covers errors Sentry
+ * saw, and Sentry sees only what nobody caught. Everything the app handles well
+ * — a chat turn that renders "try again", a bridge call that logs and carries
+ * on — produced no issue and therefore no ticket. The catch stays; this is how
+ * it gets reported.
+ *
+ * Authenticated by the user's own session rather than an HMAC, which is the
+ * reason this is a separate route and not the webhook: the webhook's signing
+ * secret cannot be shipped to a browser.
+ *
+ * Off unless `CLIENT_ERROR_BUGS` is set. Filing tickets from client reports is
+ * a per-environment decision — the destination product is shared, and a
+ * misbehaving build could otherwise fill someone's tracker.
+ */
+
+const ReportSchema = z.object({
+  area: z.string().min(1).max(64),
+  kind: z.string().max(32).optional(),
+  message: z.string().min(1).max(2000),
+  context: z.record(z.string().max(64), z.string().max(500)).optional(),
+});
+
+/**
+ * Per-user ceiling on tickets *created* per window.
+ *
+ * Repeats of one fault already collapse — the ingest service dedups on the
+ * fingerprint — so this only bites when a single user produces many *distinct*
+ * errors, which is the runaway case worth stopping.
+ *
+ * In-memory, so it is per server instance and resets on deploy. That is weaker
+ * than it looks on serverless, and deliberately not a database round-trip on a
+ * path whose whole job is to be cheap and best-effort. Dedup is the real
+ * defence; this is the backstop.
+ */
+const MAX_REPORTS_PER_WINDOW = 20;
+const WINDOW_MS = 60 * 60 * 1000;
+const recentByUser = new Map<string, { count: number; resetAt: number }>();
+
+function overRateLimit(userId: string, now: number): boolean {
+  const entry = recentByUser.get(userId);
+  if (!entry || now >= entry.resetAt) {
+    recentByUser.set(userId, { count: 1, resetAt: now + WINDOW_MS });
+    return false;
+  }
+  entry.count += 1;
+  return entry.count > MAX_REPORTS_PER_WINDOW;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!process.env.CLIENT_ERROR_BUGS) {
+    // Not an error: the reporter is fire-and-forget and must not care.
+    return NextResponse.json({ filed: false, reason: "disabled" });
+  }
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let report: ClientErrorReport;
+  try {
+    report = ReportSchema.parse(await request.json());
+  } catch {
+    return NextResponse.json({ error: "Invalid report" }, { status: 400 });
+  }
+
+  if (!shouldFileClientError(report.kind)) {
+    return NextResponse.json({ filed: false, reason: "not-reportable" });
+  }
+
+  if (overRateLimit(session.user.id, Date.now())) {
+    console.warn(`[client-errors] rate limit hit for user ${session.user.id}`);
+    return NextResponse.json({ filed: false, reason: "rate-limited" });
+  }
+
+  try {
+    const result = await ingestSentryBug(db, buildClientErrorBug(report), {
+      body: buildClientErrorBody(report),
+      labels: CLIENT_ERROR_LABELS,
+    });
+    return NextResponse.json({ filed: result.created, ticketId: result.ticketId });
+  } catch (error) {
+    // Reporting a failure must never become a second failure the user sees.
+    console.error("[client-errors] could not file a bug:", error);
+    return NextResponse.json({ filed: false, reason: "ingest-failed" });
+  }
+}
+
+/**
+ * "bug" so it sits with the Sentry-filed ones; "client-error" instead of
+ * "Sentry" so the Sentry label keeps meaning the thing it says.
+ */
+const CLIENT_ERROR_LABELS = [
+  { name: "client-error", slug: "client-error", color: "avatar-orange" },
+  { name: "bug", slug: "bug", color: "avatar-red" },
+] as const;

--- a/src/lib/reportHandledError.ts
+++ b/src/lib/reportHandledError.ts
@@ -1,0 +1,87 @@
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Report a failure the app handled gracefully.
+ *
+ * The gap this fills: Sentry's automatic capture only sees errors *nobody*
+ * caught, so every `catch` that logs a line and renders a calm message was
+ * invisible — no Sentry issue, and therefore none of the Bug Tickets the Sentry
+ * webhook files (ADR-0027). The graceful handling is right; the silence was
+ * not.
+ *
+ * Two destinations, on purpose:
+ *  - **Sentry**, which does the grouping, release tracking and alerting, but
+ *    only initialises on Vercel prod/preview — so it is silent for anyone
+ *    running the desktop shell against a local server.
+ *  - **A Bug Ticket**, via `/api/client-errors`, which works wherever the app
+ *    runs and lands the failure in the tracker where it gets triaged.
+ *
+ * Best-effort by construction: reporting an error must never raise one. Every
+ * failure here is swallowed, because a reporter that throws would take out the
+ * error path it was meant to illuminate.
+ */
+/**
+ * Readable text for whatever was thrown.
+ *
+ * Not just `String(error)`: a rejected IPC call or a fetch wrapper can throw a
+ * plain object, and stringifying that gives "[object Object]" — a ticket titled
+ * with which is worse than no ticket, because it looks like signal.
+ */
+function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (typeof error === "number" || typeof error === "boolean") return String(error);
+  if (typeof error === "object" && error !== null) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+    try {
+      return JSON.stringify(error).slice(0, 500);
+    } catch {
+      // Circular, or a getter that throws.
+      return "";
+    }
+  }
+  return "";
+}
+
+export function reportHandledError(
+  error: unknown,
+  options: {
+    /** Where this happened — `chat-stream`, `local-wiki-status`, … Becomes the ticket's culprit and part of its dedup key. */
+    area: string;
+    /** The classification the caller already made, if any. Governs whether a ticket is filed at all. */
+    kind?: string;
+    /** Extra context rendered in the ticket body and attached to the Sentry event. Strings only, so nothing unserializable slips in. */
+    context?: Record<string, string>;
+  },
+): void {
+  const { area, kind, context } = options;
+
+  try {
+    Sentry.captureException(error, {
+      tags: { area, ...(kind ? { failureKind: kind } : {}) },
+      ...(context ? { extra: context } : {}),
+    });
+  } catch {
+    // A Sentry SDK that isn't initialised, or a transport that refuses.
+  }
+
+  const message = messageOf(error);
+  if (!message.trim()) return;
+
+  // Fire-and-forget. `keepalive` so a report survives the navigation that a
+  // fatal-looking error often triggers.
+  try {
+    void fetch("/api/client-errors", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ area, kind, message: message.slice(0, 2000), context }),
+      keepalive: true,
+    }).catch(() => {
+      // Offline, blocked, or the endpoint is off. Nothing to do — this path
+      // exists to make failures visible, not to add one.
+    });
+  } catch {
+    // `fetch` missing entirely (SSR, an exotic webview).
+  }
+}

--- a/src/server/services/clientErrors/__tests__/clientErrorBug.test.ts
+++ b/src/server/services/clientErrors/__tests__/clientErrorBug.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildClientErrorBody,
+  buildClientErrorBug,
+  fingerprintClientError,
+  shouldFileClientError,
+} from "../clientErrorBug";
+
+const report = (over: Partial<Parameters<typeof buildClientErrorBug>[0]> = {}) => ({
+  area: "chat-stream",
+  kind: "model",
+  message: "Your credit balance is too low to access the Anthropic API.",
+  ...over,
+});
+
+describe("shouldFileClientError", () => {
+  it("files the kinds that mean something is broken", () => {
+    expect(shouldFileClientError("model")).toBe(true);
+    expect(shouldFileClientError("unknown")).toBe(true);
+    // No classification at all: nobody decided it was benign.
+    expect(shouldFileClientError(undefined)).toBe(true);
+  });
+
+  it("ignores the kinds that are the network or the user's session", () => {
+    expect(shouldFileClientError("transport")).toBe(false);
+    expect(shouldFileClientError("idle-timeout")).toBe(false);
+    expect(shouldFileClientError("auth")).toBe(false);
+  });
+});
+
+describe("fingerprintClientError", () => {
+  it("collapses repeats of the same fault onto one id", () => {
+    expect(fingerprintClientError(report())).toBe(fingerprintClientError(report()));
+  });
+
+  it("ignores the digits that differ between occurrences", () => {
+    // A request id or a byte count must not split one fault into many tickets.
+    expect(fingerprintClientError(report({ message: "Upload failed after 1423 bytes" }))).toBe(
+      fingerprintClientError(report({ message: "Upload failed after 87 bytes" })),
+    );
+  });
+
+  it("keeps genuinely different faults apart", () => {
+    const credit = fingerprintClientError(report());
+    const other = fingerprintClientError(report({ message: "Model overloaded" }));
+    const elsewhere = fingerprintClientError(report({ area: "zoe-canvas-stream" }));
+    expect(new Set([credit, other, elsewhere]).size).toBe(3);
+  });
+
+  it("names the origin in the id, so a client bug is recognisable as one", () => {
+    expect(fingerprintClientError(report())).toMatch(/^client:chat-stream:[0-9a-f]{12}$/);
+  });
+});
+
+describe("buildClientErrorBug", () => {
+  it("titles the ticket with where it broke and what it said", () => {
+    const bug = buildClientErrorBug(report());
+    expect(bug.title).toBe(
+      "chat-stream: Your credit balance is too low to access the Anthropic API.",
+    );
+    expect(bug.culprit).toBe("chat-stream");
+    expect(bug.level).toBe("error");
+  });
+
+  it("leaves projectSlug null so the AI fixer is not pointed at a stackless report", () => {
+    expect(buildClientErrorBug(report()).projectSlug).toBeNull();
+  });
+
+  it("masks a credential the error echoed back", () => {
+    const secret = "sk_live_" + "b".repeat(40);
+    const bug = buildClientErrorBug(report({ message: `Invalid key ${secret}` }));
+    expect(bug.title).not.toContain(secret);
+  });
+
+  it("caps a runaway message so the title stays a title", () => {
+    const bug = buildClientErrorBug(report({ message: "no ".repeat(200) }));
+    expect(bug.title.length).toBeLessThan(200);
+  });
+});
+
+describe("buildClientErrorBody", () => {
+  it("says where the report came from, rather than claiming Sentry saw it", () => {
+    const body = buildClientErrorBody(report());
+    expect(body).toContain("never reached Sentry");
+    expect(body).not.toContain("Reported automatically from Sentry");
+  });
+
+  it("renders the context a triager needs", () => {
+    const body = buildClientErrorBody(report({ context: { agentId: "localWikiAgent" } }));
+    expect(body).toContain("**Failure kind:** model");
+    expect(body).toContain("**agentId:** localWikiAgent");
+  });
+
+  it("masks credentials in context values too", () => {
+    const secret = "tok_" + "c".repeat(40);
+    const body = buildClientErrorBody(report({ context: { url: `https://x.test/${secret}` } }));
+    expect(body).not.toContain(secret);
+  });
+});

--- a/src/server/services/clientErrors/clientErrorBug.ts
+++ b/src/server/services/clientErrors/clientErrorBug.ts
@@ -1,0 +1,122 @@
+import crypto from "crypto";
+
+import { maskTokenLike } from "~/server/utils/redactToolArgs";
+import type { SentryBug } from "~/server/services/sentry/sentryPayload";
+
+/**
+ * Turning a *handled* client-side failure into a Bug Ticket.
+ *
+ * The Sentry webhook (ADR-0027) only ever sees errors Sentry itself saw, and
+ * Sentry only sees what nobody caught. Every failure the app handles gracefully
+ * — a chat turn that renders a calm "try again", a bridge call that logs and
+ * carries on — was therefore invisible: no Sentry issue, so no Bug Ticket, so
+ * nothing to triage. That is the gap this closes.
+ *
+ * Deliberately *not* done by having the browser call the Sentry webhook route:
+ * that route authenticates by HMAC over the raw body using the integration's
+ * client secret, which cannot live in a webview, and it would mean fabricating
+ * Sentry issue ids and permalinks that lead nowhere. This files the same shape
+ * through the same ingest service, honestly labelled as what it is.
+ */
+
+/** A failure the client handled, reported for triage. */
+export interface ClientErrorReport {
+  /** Where in the app it happened — `chat-stream`, `local-wiki-status`, … */
+  area: string;
+  /** The classification the UI already made, when it made one. */
+  kind?: string;
+  /** The thrown error's message. Masked and capped before it lands anywhere. */
+  message: string;
+  /** Optional context: the agent, the route, the surface. Values are capped. */
+  context?: Record<string, string>;
+}
+
+/** Longest error text carried into a ticket title. */
+const MAX_TITLE_CHARS = 160;
+/** Longest single context value rendered in the body. */
+const MAX_CONTEXT_CHARS = 200;
+
+/**
+ * Failure kinds worth a ticket.
+ *
+ * A dropped connection on a train is not a defect, and filing it would bury the
+ * ones that are — the tracker is for things a person can fix. `auth` is
+ * excluded for the same reason: an expired session is the app working as
+ * designed. What's left is the model/provider refusing, and the genuinely
+ * unclassified, which is exactly the bucket today's "Something went wrong"
+ * belonged to.
+ */
+const REPORTABLE_KINDS = new Set(["model", "unknown"]);
+
+export function shouldFileClientError(kind: string | undefined): boolean {
+  // No classification at all means nobody decided this was benign.
+  return kind === undefined || REPORTABLE_KINDS.has(kind);
+}
+
+/**
+ * Stable id for "this error, again".
+ *
+ * The ingest service dedups on it, so the fingerprint decides whether a
+ * recurring failure collapses onto one ticket or files a hundred. Built from
+ * the area, the kind and the *message*, so two different faults in the same
+ * component stay separate — at the cost of a message carrying a request id
+ * splitting into many. Numbers are stripped for exactly that reason.
+ */
+export function fingerprintClientError(report: ClientErrorReport): string {
+  const normalized = maskTokenLike(report.message)
+    .toLowerCase()
+    // Ids, timestamps, byte counts — the parts that differ between two
+    // occurrences of the same fault.
+    .replace(/\d+/g, "#")
+    .trim();
+  const digest = crypto
+    .createHash("sha1")
+    .update(`${report.area}|${report.kind ?? ""}|${normalized}`)
+    .digest("hex")
+    .slice(0, 12);
+  return `client:${report.area}:${digest}`;
+}
+
+/** Trim a string for display, marking the cut so nobody reads it as complete. */
+function cap(text: string, max: number): string {
+  const clean = text.replace(/\s+/g, " ").trim();
+  return clean.length > max ? `${clean.slice(0, max)}…` : clean;
+}
+
+/**
+ * Normalize a report into the shape the bug ingest already understands.
+ *
+ * `projectSlug` is deliberately null: it is what gates the `ai-fixable` label,
+ * and a handled client error has no stack and no Sentry issue to work from, so
+ * pointing the fixer at one would waste a run. A human triages these.
+ */
+export function buildClientErrorBug(report: ClientErrorReport): SentryBug {
+  const message = cap(maskTokenLike(report.message), MAX_TITLE_CHARS);
+  return {
+    issueId: fingerprintClientError(report),
+    title: `${report.area}: ${message || "handled error with no message"}`,
+    level: "error",
+    culprit: report.area,
+    url: null,
+    shortId: null,
+    projectSlug: null,
+  };
+}
+
+/**
+ * The ticket body. Separate from `buildBugBody` because that one opens with
+ * "Reported automatically from Sentry", which would be untrue here.
+ */
+export function buildClientErrorBody(report: ClientErrorReport): string {
+  const lines: string[] = [
+    "Reported automatically from the app — a failure the UI handled gracefully, so it never reached Sentry.",
+    "",
+    `- **Area:** ${report.area}`,
+  ];
+  if (report.kind) lines.push(`- **Failure kind:** ${report.kind}`);
+  for (const [key, value] of Object.entries(report.context ?? {})) {
+    lines.push(`- **${key}:** ${cap(maskTokenLike(value), MAX_CONTEXT_CHARS)}`);
+  }
+  lines.push("", "```", cap(maskTokenLike(report.message), 1000), "```");
+  return lines.join("\n");
+}

--- a/src/server/services/sentry/SentryBugService.ts
+++ b/src/server/services/sentry/SentryBugService.ts
@@ -121,9 +121,9 @@ async function labelTicket(
   ticketId: string,
   workspaceId: string,
   authorId: string,
-  extraLabels: readonly { name: string; slug: string; color: string }[] = [],
+  labels: readonly { name: string; slug: string; color: string }[],
 ): Promise<void> {
-  for (const label of [...TICKET_LABELS, ...extraLabels]) {
+  for (const label of labels) {
     try {
       const tag = await db.tag.upsert({
         where: { slug_workspaceId: { slug: label.slug, workspaceId } },
@@ -160,7 +160,22 @@ export interface IngestResult {
 export async function ingestSentryBug(
   db: PrismaClient,
   bug: SentryBug,
-  options?: { productId?: string; sourceSlug?: string | null },
+  options?: {
+    productId?: string;
+    sourceSlug?: string | null;
+    /**
+     * Ticket body, when the caller isn't Sentry. Defaults to `buildBugBody`,
+     * which opens with "Reported automatically from Sentry" — true for the
+     * webhook, a lie for anything else (see `clientErrorBug`).
+     */
+    body?: string;
+    /**
+     * Labels in place of the default "Sentry" + "bug" pair. A handled client
+     * error is a bug, but it did not come from Sentry, and filtering on that
+     * label should keep meaning what it says.
+     */
+    labels?: readonly { name: string; slug: string; color: string }[];
+  },
 ): Promise<IngestResult> {
   // Destination precedence: an explicit per-workspace product (from a
   // workspace-scoped Sentry integration) wins; otherwise fall back to the
@@ -205,27 +220,27 @@ export async function ingestSentryBug(
     workspaceId: product.workspaceId,
     createdById: errol.id,
     title: bug.title,
-    body: buildBugBody(bug),
+    body: options?.body ?? buildBugBody(bug),
     type: "BUG",
     status: "BACKLOG",
     // Priority is left unset — a human assigns it during triage.
+    // `sentryIssueId` stays the key for non-Sentry origins too: it is the dedup
+    // path queried above, and a second path would mean a second lookup for no
+    // gain. The value's `client:` prefix says where it came from.
     links: { sentryIssueId: bug.issueId, sentryUrl: bug.url },
   });
 
-  // Tag it with the workspace's "Sentry" and "bug" labels so these are filterable.
+  // Tag it so these are filterable. `labelTicket` now takes the complete set
+  // rather than prepending its own, so the origin's labels are named here.
   const source = sourceLabel(options?.sourceSlug ?? bug.projectSlug);
-  await labelTicket(
-    db,
-    ticket.id,
-    product.workspaceId,
-    errol.id,
-    [
-      ...(isAiFixableProject(bug.projectSlug) ? [AI_FIXABLE_LABEL] : []),
-      // Which codebase this came from. An explicit `?service=` wins; otherwise
-      // fall back to the slug the sender put in the payload.
-      ...(source ? [source] : []),
-    ],
-  );
+  await labelTicket(db, ticket.id, product.workspaceId, errol.id, [
+    // "Sentry" + "bug" unless the caller is not Sentry and says otherwise.
+    ...(options?.labels ?? TICKET_LABELS),
+    ...(isAiFixableProject(bug.projectSlug) ? [AI_FIXABLE_LABEL] : []),
+    // Which codebase this came from. An explicit `?service=` wins; otherwise
+    // fall back to the slug the sender put in the payload.
+    ...(source ? [source] : []),
+  ]);
 
   // Announce the new bug in Zulip (best-effort) with a deep link to the ticket.
   // Only on creation — recurring errors that dedup above do not re-notify.


### PR DESCRIPTION
## What

Sentry's automatic capture only sees errors *nobody* caught. Every `catch` that logs a line and renders a calm message was therefore invisible: no Sentry issue, and so none of the Bug Tickets the Sentry webhook files (ADR-0027). A chat turn dying on `Your credit balance is too low to access the Anthropic API` left no trace anywhere — which is how it went unnoticed until someone hit it by hand.

The graceful handling stays exactly as it is. What changes is that the failure gets reported.

`reportHandledError(error, { area, kind, context })` sends to two places:

- **Sentry** — the same Issue an uncaught error would produce: same grouping, same alert rules, same webhook.
- **`/api/client-errors`** — files a Bug Ticket through `ingestSentryBug`, the same service the webhook calls. This is the path that works when Sentry isn't running at all: both Sentry configs gate on `VERCEL_ENV`, so every failure hit while running the desktop shell against a local server was unreportable by construction.

Wired at the chat stream failure path, the local-wiki status probe, and the Zoe canvas stream, which had the same blind spot. The canvas also picks up the failure detail line the drawer got in #494, so the two chat surfaces behave the same.

## Decisions worth a look

**Not by having the browser call the Sentry webhook.** That was the first instinct and it doesn't work: the route authenticates by HMAC over the raw body using the integration's client secret, which cannot ship to a webview, and it would mean fabricating Sentry issue ids and permalinks that lead nowhere. One layer in — the ingest service — gives the same ticket, the same dedup and the same destination, honestly labelled.

**Guards, because a tracker that fills with noise stops being read.** Dedup on a digit-insensitive fingerprint, so a recurring fault is one ticket and a request id in the message doesn't split it into a hundred — today's outage would have filed exactly one. Transport drops, idle timeouts and expired sessions are never filed: a train tunnel is not a defect. A per-user hourly ceiling as a backstop. Messages and context masked with the same `maskTokenLike` rule the server logs use. And off entirely unless `CLIENT_ERROR_BUGS` is set, since the destination product is shared and a misbehaving build shouldn't be able to fill someone's tracker.

**`projectSlug` is left null**, so these never get the `ai-fixable` label. A handled client error has no stack for the fixer to work from; a human triages.

**`labelTicket` now takes the complete label set** rather than prepending its own defaults, so an origin can say it isn't Sentry. Note this merged with the `sourceSlug` work that landed in main while this was in flight — the call site now composes default-or-override, ai-fixable, and source labels in one place.

## Verification

465 unit tests pass, 20 new: the fingerprint's stability and its insensitivity to digits, masking of credentials in both title and context, the kind filter, and the route's env gate, auth, rate limit, and its refusal to turn a reporting failure into a second user-visible one. The existing Sentry webhook tests cover the label path this touched.

Not exercised end-to-end against a real database — the route test mocks `ingestSentryBug` — so the first real ticket is worth eyeballing after `CLIENT_ERROR_BUGS` is set.

## Acceptance criteria

- [x] A gracefully-handled failure reaches Sentry with its area and failure kind
- [x] It also files a Bug Ticket, without a Sentry issue existing
- [x] Recurring instances of one fault collapse onto a single ticket
- [x] Network drops and expired sessions are not filed
- [x] Nothing is filed unless the environment opts in
- [x] Credentials echoed in an error message never reach a ticket
- [x] A failure in the reporting path is invisible to the user