### PR TITLE
feat: grant agents access to multiple workspaces at once

### DIFF
--- a/src/app/(sidemenu)/settings/agents/page.tsx
+++ b/src/app/(sidemenu)/settings/agents/page.tsx
@@ -9,8 +9,8 @@ import {
   CopyButton,
   Group,
   Modal,
+  MultiSelect,
   Paper,
-  Select,
   Stack,
   Table,
   Text,
@@ -48,9 +48,14 @@ export default function ExternalAgentsPage() {
   const [keyModalAgentId, setKeyModalAgentId] = useState<string | null>(null);
   const [generatedSecret, setGeneratedSecret] = useState<string | null>(null);
   const [grantAgentId, setGrantAgentId] = useState<string | null>(null);
-  const [grantWorkspaceId, setGrantWorkspaceId] = useState<string | null>(null);
+  const [grantWorkspaceIds, setGrantWorkspaceIds] = useState<string[]>([]);
 
   const invalidate = () => utils.externalAgent.list.invalidate();
+
+  const closeGrantModal = () => {
+    setGrantAgentId(null);
+    setGrantWorkspaceIds([]);
+  };
 
   const createAgent = api.externalAgent.create.useMutation({
     onSuccess: async () => {
@@ -84,14 +89,13 @@ export default function ExternalAgentsPage() {
       notifications.show({ title: 'Could not revoke key', message: error.message, color: 'red' }),
   });
 
-  const grantWorkspace = api.externalAgent.grantWorkspace.useMutation({
+  const grantWorkspaces = api.externalAgent.grantWorkspaces.useMutation({
     onSuccess: async () => {
-      setGrantAgentId(null);
-      setGrantWorkspaceId(null);
+      closeGrantModal();
       await invalidate();
     },
     onError: (error) =>
-      notifications.show({ title: 'Could not add to workspace', message: error.message, color: 'red' }),
+      notifications.show({ title: 'Could not add to workspaces', message: error.message, color: 'red' }),
   });
 
   const revokeWorkspace = api.externalAgent.revokeWorkspace.useMutation({
@@ -113,6 +117,12 @@ export default function ExternalAgentsPage() {
       name: (value) => (value.trim().length === 0 ? 'Key label is required' : null),
     },
   });
+
+  // Only offer workspaces the agent isn't already in — re-granting is a no-op
+  // server-side, but listing them reads as if the agent lacked access.
+  const grantAgent = agents.find((agent) => agent.id === grantAgentId);
+  const grantedWorkspaceIds = new Set(grantAgent?.workspaces.map((ws) => ws.id) ?? []);
+  const grantableWorkspaces = workspaces.filter((ws) => !grantedWorkspaceIds.has(ws.id));
 
   const closeKeyModal = () => {
     setKeyModalAgentId(null);
@@ -353,47 +363,50 @@ export default function ExternalAgentsPage() {
         )}
       </Modal>
 
-      {/* Grant workspace */}
+      {/* Grant workspaces */}
       <Modal
         opened={grantAgentId !== null}
-        onClose={() => {
-          setGrantAgentId(null);
-          setGrantWorkspaceId(null);
-        }}
-        title="Add agent to workspace"
+        onClose={closeGrantModal}
+        title="Add agent to workspaces"
       >
         <Stack>
           <Text size="sm" c="dimmed">
             The agent joins as a member. You can only add it to workspaces where you have
             at least member access, and it loses access if you do.
           </Text>
-          <Select
-            label="Workspace"
-            placeholder="Pick a workspace"
-            data={workspaces.map((ws) => ({ value: ws.id, label: ws.name }))}
-            value={grantWorkspaceId}
-            onChange={setGrantWorkspaceId}
-          />
+          {grantableWorkspaces.length === 0 ? (
+            <Text size="sm" c="dimmed">
+              This agent is already in every workspace you can add it to.
+            </Text>
+          ) : (
+            <MultiSelect
+              label="Workspaces"
+              placeholder={grantWorkspaceIds.length > 0 ? undefined : 'Pick one or more workspaces'}
+              data={grantableWorkspaces.map((ws) => ({ value: ws.id, label: ws.name }))}
+              value={grantWorkspaceIds}
+              onChange={setGrantWorkspaceIds}
+              searchable
+              clearable
+              hidePickedOptions
+            />
+          )}
           <Group justify="flex-end">
-            <Button
-              variant="default"
-              onClick={() => {
-                setGrantAgentId(null);
-                setGrantWorkspaceId(null);
-              }}
-            >
+            <Button variant="default" onClick={closeGrantModal}>
               Cancel
             </Button>
             <Button
-              disabled={!grantWorkspaceId}
-              loading={grantWorkspace.isPending}
+              disabled={grantWorkspaceIds.length === 0}
+              loading={grantWorkspaces.isPending}
               onClick={() => {
-                if (grantAgentId && grantWorkspaceId) {
-                  grantWorkspace.mutate({ agentId: grantAgentId, workspaceId: grantWorkspaceId });
+                if (grantAgentId && grantWorkspaceIds.length > 0) {
+                  grantWorkspaces.mutate({
+                    agentId: grantAgentId,
+                    workspaceIds: grantWorkspaceIds,
+                  });
                 }
               }}
             >
-              Add
+              {grantWorkspaceIds.length > 1 ? `Add to ${grantWorkspaceIds.length}` : 'Add'}
             </Button>
           </Group>
         </Stack>

--- a/src/server/api/routers/__tests__/externalAgentGrant.test.ts
+++ b/src/server/api/routers/__tests__/externalAgentGrant.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for the grant-time half of the ADR-0049 delegation invariant:
+ * `externalAgent.grantWorkspaces`.
+ *
+ * The revoke-time half (cascades on owner removal/demotion) is covered by
+ * `src/server/services/__tests__/externalAgentAccess.test.ts`. This file covers
+ * the other direction — an owner can never delegate access they don't hold, and
+ * an agent never lands above `member`.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const OWNER_ID = "owner-1";
+const AGENT_ID = "agent-1";
+const SHADOW_ID = "shadow-1";
+
+function caller(db: DeepMockProxy<PrismaClient>) {
+  return createMockCaller({ userId: OWNER_ID, db: db as unknown as PrismaClient });
+}
+
+/** The owner is a human (humanOnlyProcedure) and owns the agent. */
+function arrangeOwner(db: DeepMockProxy<PrismaClient>) {
+  db.user.findUnique.mockResolvedValue({ isAgent: false } as never);
+  db.externalAgent.findFirst.mockResolvedValue({
+    id: AGENT_ID,
+    ownerId: OWNER_ID,
+    shadowUserId: SHADOW_ID,
+  } as never);
+  db.$transaction.mockResolvedValue([] as never);
+}
+
+/** Owner memberships as `workspaceUser.findMany` would return them. */
+function memberships(rows: Array<{ workspaceId: string; role: string }>) {
+  return rows.map((r) => ({ userId: OWNER_ID, ...r })) as never;
+}
+
+describe("externalAgent.grantWorkspaces", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+    arrangeOwner(db);
+  });
+
+  it("grants every workspace the owner can delegate, always at role member", async () => {
+    db.workspaceUser.findMany.mockResolvedValue(
+      memberships([
+        { workspaceId: "ws-1", role: "owner" },
+        { workspaceId: "ws-2", role: "admin" },
+        { workspaceId: "ws-3", role: "member" },
+      ]),
+    );
+
+    const result = await caller(db).externalAgent.grantWorkspaces({
+      agentId: AGENT_ID,
+      workspaceIds: ["ws-1", "ws-2", "ws-3"],
+    });
+
+    expect(result).toEqual({ granted: 3 });
+    expect(db.workspaceUser.upsert).toHaveBeenCalledTimes(3);
+    // ADR-0049 §3: agents hold `member` and nothing else — never the owner's
+    // own admin/owner role in the workspace they were granted from.
+    for (const workspaceId of ["ws-1", "ws-2", "ws-3"]) {
+      expect(db.workspaceUser.upsert).toHaveBeenCalledWith({
+        where: { userId_workspaceId: { userId: SHADOW_ID, workspaceId } },
+        create: { userId: SHADOW_ID, workspaceId, role: "member" },
+        update: { role: "member" },
+      });
+    }
+    expect(db.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects the whole batch when the owner is only a viewer in one workspace", async () => {
+    db.workspaceUser.findMany.mockResolvedValue(
+      memberships([
+        { workspaceId: "ws-1", role: "member" },
+        { workspaceId: "ws-2", role: "viewer" },
+      ]),
+    );
+    db.workspace.findMany.mockResolvedValue([{ name: "Coaching" }] as never);
+
+    await expect(
+      caller(db).externalAgent.grantWorkspaces({
+        agentId: AGENT_ID,
+        workspaceIds: ["ws-1", "ws-2"],
+      }),
+    ).rejects.toThrow(/Coaching/);
+
+    // All-or-nothing: the delegable workspace in the batch is not written either.
+    expect(db.workspaceUser.upsert).not.toHaveBeenCalled();
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects workspaces the owner reaches without a membership row (team / guest access)", async () => {
+    // `workspace.list` surfaces team-based and project-guest workspaces, so the
+    // picker can offer one the owner holds no `WorkspaceUser` row in at all.
+    db.workspaceUser.findMany.mockResolvedValue(
+      memberships([{ workspaceId: "ws-1", role: "member" }]),
+    );
+    db.workspace.findMany.mockResolvedValue([{ name: "Threshold" }] as never);
+
+    await expect(
+      caller(db).externalAgent.grantWorkspaces({
+        agentId: AGENT_ID,
+        workspaceIds: ["ws-1", "ws-team-only"],
+      }),
+    ).rejects.toThrow(/Threshold/);
+
+    expect(db.workspaceUser.upsert).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates repeated ids instead of tripping the all-or-nothing check", async () => {
+    db.workspaceUser.findMany.mockResolvedValue(
+      memberships([{ workspaceId: "ws-1", role: "member" }]),
+    );
+
+    const result = await caller(db).externalAgent.grantWorkspaces({
+      agentId: AGENT_ID,
+      workspaceIds: ["ws-1", "ws-1", "ws-1"],
+    });
+
+    expect(result).toEqual({ granted: 1 });
+    expect(db.workspaceUser.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-granting a workspace the agent already holds is an idempotent upsert", async () => {
+    db.workspaceUser.findMany.mockResolvedValue(
+      memberships([{ workspaceId: "ws-1", role: "admin" }]),
+    );
+
+    await expect(
+      caller(db).externalAgent.grantWorkspaces({
+        agentId: AGENT_ID,
+        workspaceIds: ["ws-1"],
+      }),
+    ).resolves.toEqual({ granted: 1 });
+
+    expect(db.workspaceUser.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ update: { role: "member" } }),
+    );
+  });
+
+  it("refuses an agent the caller does not own, before touching memberships", async () => {
+    db.externalAgent.findFirst.mockResolvedValue(null);
+
+    await expect(
+      caller(db).externalAgent.grantWorkspaces({
+        agentId: "someone-elses-agent",
+        workspaceIds: ["ws-1"],
+      }),
+    ).rejects.toThrow(/Agent not found/);
+
+    expect(db.workspaceUser.findMany).not.toHaveBeenCalled();
+    expect(db.workspaceUser.upsert).not.toHaveBeenCalled();
+  });
+
+  it("bounds the batch size", async () => {
+    await expect(
+      caller(db).externalAgent.grantWorkspaces({
+        agentId: AGENT_ID,
+        workspaceIds: Array.from({ length: 101 }, (_, i) => `ws-${i}`),
+      }),
+    ).rejects.toThrow();
+
+    expect(db.workspaceUser.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/api/routers/externalAgent.ts
+++ b/src/server/api/routers/externalAgent.ts
@@ -181,44 +181,44 @@ export const externalAgentRouter = createTRPCRouter({
       return { success: true };
     }),
 
-  grantWorkspace: humanOnlyProcedure
-    .input(z.object({ agentId: z.string(), workspaceId: z.string() }))
+  grantWorkspaces: humanOnlyProcedure
+    .input(z.object({ agentId: z.string(), workspaceIds: z.array(z.string()).min(1) }))
     .mutation(async ({ ctx, input }) => {
       const agent = await requireOwnedAgent(ctx.db, input.agentId, ctx.session.user.id);
+      const workspaceIds = [...new Set(input.workspaceIds)];
 
       // Delegation invariant, grant-time half: the owner must hold at least
-      // `member` in the target workspace themselves. A viewer cannot delegate
-      // member-level access (ADR-0049).
-      const ownerMembership = await ctx.db.workspaceUser.findUnique({
-        where: {
-          userId_workspaceId: {
-            userId: ctx.session.user.id,
-            workspaceId: input.workspaceId,
-          },
-        },
+      // `member` in every target workspace themselves. A viewer cannot delegate
+      // member-level access (ADR-0049). All-or-nothing — a partial grant would
+      // read as a full one in the UI.
+      const ownerMemberships = await ctx.db.workspaceUser.findMany({
+        where: { userId: ctx.session.user.id, workspaceId: { in: workspaceIds } },
       });
-      if (!ownerMembership || ownerMembership.role === "viewer") {
+      const delegable = new Set(
+        ownerMemberships.filter((m) => m.role !== "viewer").map((m) => m.workspaceId),
+      );
+      if (delegable.size !== workspaceIds.length) {
         throw new TRPCError({
           code: "FORBIDDEN",
-          message: "You need at least member access in a workspace to add your agent to it",
+          message:
+            "You need at least member access in every workspace you add your agent to — nothing was granted",
         });
       }
 
-      return ctx.db.workspaceUser.upsert({
-        where: {
-          userId_workspaceId: {
-            userId: agent.shadowUserId,
-            workspaceId: input.workspaceId,
-          },
-        },
-        // Agents only ever hold `member` (ADR-0049).
-        create: {
-          userId: agent.shadowUserId,
-          workspaceId: input.workspaceId,
-          role: "member",
-        },
-        update: { role: "member" },
-      });
+      await ctx.db.$transaction(
+        workspaceIds.map((workspaceId) =>
+          ctx.db.workspaceUser.upsert({
+            where: {
+              userId_workspaceId: { userId: agent.shadowUserId, workspaceId },
+            },
+            // Agents only ever hold `member` (ADR-0049).
+            create: { userId: agent.shadowUserId, workspaceId, role: "member" },
+            update: { role: "member" },
+          }),
+        ),
+      );
+
+      return { granted: workspaceIds.length };
     }),
 
   revokeWorkspace: humanOnlyProcedure

--- a/src/server/api/routers/externalAgent.ts
+++ b/src/server/api/routers/externalAgent.ts
@@ -182,7 +182,9 @@ export const externalAgentRouter = createTRPCRouter({
     }),
 
   grantWorkspaces: humanOnlyProcedure
-    .input(z.object({ agentId: z.string(), workspaceIds: z.array(z.string()).min(1) }))
+    // `.max` is a sanity bound, not a product limit — it caps the `IN` clause and
+    // the `$transaction` batch, both sized directly by this input.
+    .input(z.object({ agentId: z.string(), workspaceIds: z.array(z.string()).min(1).max(100) }))
     .mutation(async ({ ctx, input }) => {
       const agent = await requireOwnedAgent(ctx.db, input.agentId, ctx.session.user.id);
       const workspaceIds = [...new Set(input.workspaceIds)];
@@ -198,10 +200,20 @@ export const externalAgentRouter = createTRPCRouter({
         ownerMemberships.filter((m) => m.role !== "viewer").map((m) => m.workspaceId),
       );
       if (delegable.size !== workspaceIds.length) {
+        // Name the offenders — the picker is fed by `workspace.list`, which also
+        // surfaces team-based and project-guest workspaces where the owner holds
+        // no `WorkspaceUser` row at all. Without names, recovering from a
+        // rejected batch means bisecting the selection by hand.
+        const rejected = await ctx.db.workspace.findMany({
+          where: { id: { in: workspaceIds.filter((id) => !delegable.has(id)) } },
+          select: { name: true },
+        });
+        const names = rejected.map((w) => w.name).join(", ");
         throw new TRPCError({
           code: "FORBIDDEN",
-          message:
-            "You need at least member access in every workspace you add your agent to — nothing was granted",
+          message: names
+            ? `You need at least member access to add your agent to ${names} — nothing was granted`
+            : "You need at least member access in every workspace you add your agent to — nothing was granted",
         });
       }
 


### PR DESCRIPTION
### **User description**
## What

- `Select` → `MultiSelect` in the **Add agent to workspace** modal on `/settings/agents` — pick several workspaces in one pass, searchable and clearable.
- Workspaces the agent already belongs to are filtered out of the picker (re-granting was a server-side no-op, but listing them read as "no access"). If nothing is left to add, the modal says so instead of showing an empty picker.
- Submit button reads "Add to N" for multi-selections, so it's clear it's one action rather than N.
- `externalAgent.grantWorkspace` → `grantWorkspaces`, taking `workspaceIds: string[]`. The ADR-0049 delegation check runs for every target in a single query, then all grants land in one `$transaction`.

## Why

Granting an agent access to several workspaces meant reopening the modal once per workspace. Reported directly from the UI.

The bulk grant is **all-or-nothing**: if the owner is only a `viewer` in one of the picked workspaces, nothing is granted and the error says so. A partial grant would be indistinguishable from a full one in the badge list.

## Testing

- `tsc --noEmit` clean (pre-existing `@playwright/test` module-resolution errors are unrelated and untouched).
- `next lint` clean on both changed files.
- Unit suite green via pre-commit hook.
- Not exercised in a running browser — the change is a Mantine component swap plus a router input change, both type-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replace single workspace `Select` with `MultiSelect` for bulk agent grants

- Backend `grantWorkspace` → `grantWorkspaces` with batch transaction and all-or-nothing semantics

- Filter already-granted workspaces from picker; name rejected workspaces in error messages

- Add unit tests covering ADR-0049 delegation invariant for `grantWorkspaces`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["Settings/Agents Page"]
  Select["Select (single)"]
  MultiSelect["MultiSelect (multi, searchable)"]
  OldAPI["grantWorkspace\n(workspaceId: string)"]
  NewAPI["grantWorkspaces\n(workspaceIds: string[])"]
  Filter["Filter already-granted\nworkspaces"]
  Check["ADR-0049 delegation check\n(batch, all-or-nothing)"]
  Txn["$transaction\n(bulk upsert at member)"]
  Tests["Unit tests\nexternalAgentGrant.test.ts"]

  UI -- "was" --> Select
  UI -- "now" --> MultiSelect
  MultiSelect -- "calls" --> NewAPI
  Filter -- "feeds" --> MultiSelect
  NewAPI -- "validates" --> Check
  Check -- "on success" --> Txn
  OldAPI -- "replaced by" --> NewAPI
  Tests -- "covers" --> NewAPI
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Multi-workspace selection UI for agent grant modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/settings/agents/page.tsx

<ul><li>Replace <code>Select</code> with <code>MultiSelect</code> (searchable, clearable, <br><code>hidePickedOptions</code>) for workspace selection<br> <li> State changes from <code>grantWorkspaceId: string | null</code> to <br><code>grantWorkspaceIds: string[]</code><br> <li> Filter already-granted workspaces from the picker; show informational <br>message when none remain<br> <li> Submit button label shows count ("Add to N") for multi-selections; <br>calls <code>grantWorkspaces</code> mutation<br> <li> Extract <code>closeGrantModal</code> helper to reset both <code>grantAgentId</code> and <br><code>grantWorkspaceIds</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/497/files#diff-3286ab3f3a73e58efed3c720f43a6bf9554c520e2637bb0aeab65e9709ba92e4">+44/-31</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>externalAgent.ts</strong><dd><code>Bulk workspace grant with all-or-nothing transaction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/externalAgent.ts

<ul><li>Rename <code>grantWorkspace</code> to <code>grantWorkspaces</code>, accepting <code>workspaceIds: </code><br><code>string[]</code> (min 1, max 100)<br> <li> Deduplicate input IDs before processing<br> <li> Batch delegation check via <code>workspaceUser.findMany</code>; name rejected <br>workspaces in error message<br> <li> Wrap all upserts in a single <code>$transaction</code> for all-or-nothing semantics<br> <li> Return <code>{ granted: number }</code> instead of the upserted row</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/497/files#diff-67eb49ec4dfa3a0ac06a49f9b975f4c8b8618a9db9d3249ea4731e804c167e81">+40/-28</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>externalAgentGrant.test.ts</strong><dd><code>Unit tests for bulk agent workspace grant invariants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/__tests__/externalAgentGrant.test.ts

<ul><li>New test file covering <code>externalAgent.grantWorkspaces</code> ADR-0049 <br>delegation invariant<br> <li> Tests: successful batch grant (always at <code>member</code>), viewer rejection, <br>missing membership row rejection, deduplication, idempotent re-grant, <br>ownership check, batch size bound<br> <li> Uses <code>vitest-mock-extended</code> deep mock of <code>PrismaClient</code> — no real DB<br> <li> Mocks all external dependencies (next-auth, openai, env vars)</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/497/files#diff-5376e1b6dcc26eed1f436c4695963cd94311c0b6f29474c91312ecf8858ffbed">+231/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

