### PR TITLE
chore(pr-agent): move the reviewer to Claude Opus 5

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -24,10 +24,12 @@ jobs:
           ANTHROPIC.KEY: ${{ secrets.ANTHROPIC_KEY }}
           # Repo-level behaviour is version-controlled in .pr_agent.toml.
           # Model selection is kept here so the secret/model live together.
-          config.model: "anthropic/claude-sonnet-4-6"
+          config.model: "anthropic/claude-opus-5"
           # Point the fallback at another Anthropic model so PR-Agent never
           # falls back to OpenAI (which would require an OPENAI_API_KEY).
           config.fallback_models: '["anthropic/claude-sonnet-4-6"]'
+          # Needed if the image's litellm has no registry entry for the model.
+          config.custom_model_max_tokens: "200000"
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "true"
           github_action_config.auto_improve: "true"

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -5,8 +5,13 @@
 [config]
 # Keep both the primary and fallback on Anthropic so PR-Agent never tries to
 # initialise an OpenAI client (which would require OPENAI_API_KEY).
-model = "anthropic/claude-sonnet-4-6"
+model = "anthropic/claude-opus-5"
 fallback_models = ["anthropic/claude-sonnet-4-6"]
+# Declared so PR-Agent can budget the diff even when the bundled litellm build
+# predates this model and has no registry entry for it (without this, an
+# unregistered model errors during token counting). This is only the ceiling —
+# the effective diff budget is PR-Agent's own max_model_tokens, 32k by default.
+custom_model_max_tokens = 200000
 # Markdown rendering of the model's suggestions.
 publish_output = true
 
@@ -15,7 +20,9 @@ publish_output = true
 require_score_review = false
 require_tests_review = true
 require_security_review = true
-num_max_findings = 4
+# Raised from 4: Opus 5 follows caps and severity filters literally, so a tight
+# limit discards findings it would otherwise surface.
+num_max_findings = 8
 # Don't re-post the whole review on every push; update the existing comment.
 persistent_comment = true
 final_update_message = false


### PR DESCRIPTION
### **User description**
Switches the automated reviewer from `claude-sonnet-4-6` to `claude-opus-5`.

## Why

Opus 5 is materially stronger at code review specifically — high precision *and* high recall, with the extra findings mostly real rather than false positives.

The cost case is easy. Measured from this repo's own PR-Agent logs: **3,389 and 4,746 prompt tokens per model call**, three calls per PR (describe / review / improve) — so roughly 12k input and 3k output tokens per PR.

| Model | $/M in-out | ~Cost per PR |
|---|---|---|
| Sonnet 4.6 (before) | $3 / $15 | ~$0.08 |
| Opus 5 (after) | $5 / $25 | ~$0.14 |

About six cents more per PR.

## Also changed

- **`num_max_findings` 4 → 8.** Opus 5 follows caps and severity filters literally, so a tight limit throws away the recall this upgrade is buying.
- **`custom_model_max_tokens = 200000`.** Declared so token counting still works if the action image's bundled litellm has no registry entry for a model this new. It is only a ceiling — the effective diff budget stays PR-Agent's own `max_model_tokens` (32k default), which the logs confirm is what actually bounds the diff today.
- **Fallback stays on `claude-sonnet-4-6`**, so an Opus-side problem degrades to a working reviewer rather than to nothing.

## Note on behaviour

Opus 5 thinks by default (a change from 4.6, where it was opt-in). PR-Agent sets no `thinking` parameter, so this just happens; the output-token estimate above accounts for it.

## Verifying

The first run on this PR is the test. Look for `Generating prediction with anthropic/claude-opus-5` in the PR Agent job log, and a real "PR Reviewer Guide" comment rather than "Failed to generate".


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Switch PR-Agent reviewer model to `claude-opus-5`

- Keep `claude-sonnet-4-6` as fallback model

- Declare `custom_model_max_tokens = 200000` for token counting

- Raise `num_max_findings` from 4 to 8


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR event"] --> B["PR-Agent config"]
  B -- "primary model" --> C["anthropic/claude-opus-5"]
  B -- "fallback" --> D["anthropic/claude-sonnet-4-6"]
  B -- "custom_model_max_tokens=200000" --> E["token counting"]
  B -- "num_max_findings=8" --> F["more review findings"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_agent.yml</strong><dd><code>Point workflow model env at Claude Opus 5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr_agent.yml

<ul><li>Changed <code>config.model</code> from <code>anthropic/claude-sonnet-4-6</code> to <br><code>anthropic/claude-opus-5</code><br> <li> Added <code>config.custom_model_max_tokens: "200000"</code> for images whose <br>litellm lacks a registry entry<br> <li> Fallback model list left on <code>anthropic/claude-sonnet-4-6</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/498/files#diff-fc2b2ed01cad745cb09e9c20e7c91db7f4f1eb9796abb84bbdce7dd0f77dace8">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.pr_agent.toml</strong><dd><code>Update repo PR-Agent config for Opus 5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pr_agent.toml

<ul><li>Updated <code>model</code> to <code>anthropic/claude-opus-5</code>, keeping Sonnet 4.6 fallback<br> <li> Added <code>custom_model_max_tokens = 200000</code> with explanatory comment<br> <li> Raised <code>num_max_findings</code> from 4 to 8 with rationale comment</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/498/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

