### PR TITLE
chore(pr-agent): add a second reviewer running GLM via OpenRouter

### DIFF
--- a/.github/workflows/pr_agent_glm.yml
+++ b/.github/workflows/pr_agent_glm.yml
@@ -1,0 +1,47 @@
+name: PR Agent (GLM)
+# Second automated reviewer: the same qodo-ai/pr-agent action as pr_agent.yml,
+# pointed at GLM via OpenRouter instead of Anthropic. Two independent readers
+# applying the same house rules from .pr_agent.toml.
+#
+# No `issue_comment` trigger here (unlike pr_agent.yml) — manual `/review`
+# commands should reach one reviewer, not both.
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+jobs:
+  pr_agent_glm_job:
+    # Skip bot-triggered events so the two reviewers can't set each other off.
+    if: ${{ github.event.sender.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+    name: PR Agent review (GLM)
+    steps:
+      - name: PR Agent action step
+        id: pragent_glm
+        uses: qodo-ai/pr-agent@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # These env vars override the repo-root .pr_agent.toml, which is read
+          # by BOTH workflows. Anything that must differ per reviewer belongs
+          # here, not in that file.
+          config.model: "openrouter/z-ai/glm-5.2"
+          config.fallback_models: '["openrouter/z-ai/glm-4.7"]'
+          # GLM is not in litellm's registry under this name; without an
+          # explicit ceiling, token counting fails before the first call.
+          config.custom_model_max_tokens: "200000"
+          github_action_config.auto_review: "true"
+          github_action_config.auto_improve: "true"
+          # Off deliberately: pr_agent.yml already rewrites the PR body, and two
+          # agents writing the same description means last-writer-wins.
+          github_action_config.auto_describe: "false"
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'
+          # Off deliberately: PR-Agent finds its persistent comment by matching
+          # the body prefix, with no per-instance marker and no lock. Left on,
+          # this reviewer would update the Anthropic reviewer's comment in place
+          # instead of posting its own.
+          pr_reviewer.persistent_comment: "false"
+          pr_code_suggestions.persistent_comment: "false"

--- a/.github/workflows/pr_agent_glm.yml
+++ b/.github/workflows/pr_agent_glm.yml
@@ -24,7 +24,9 @@ jobs:
         uses: qodo-ai/pr-agent@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENROUTER__KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Dotted, matching ANTHROPIC.KEY in pr_agent.yml — the action maps
+          # env vars to settings by literal dot, not by dunder.
+          OPENROUTER.KEY: ${{ secrets.OPENROUTER_API_KEY }}
           # These env vars override the repo-root .pr_agent.toml, which is read
           # by BOTH workflows. Anything that must differ per reviewer belongs
           # here, not in that file.


### PR DESCRIPTION
### **User description**
Adds a second automated reviewer: the same `qodo-ai/pr-agent` action, pointed at **GLM 5.2 through OpenRouter** instead of Anthropic. Two independent readers applying the same house rules from `.pr_agent.toml`.

## No fork required

PR-Agent takes an unregistered model through config alone — `config.model` plus `config.custom_model_max_tokens`, per its [changing-a-model docs](https://github.com/qodo-ai/pr-agent/blob/main/docs/docs/usage-guide/changing_a_model.md). This PR is one workflow file.

Cost is ~2¢ per PR (GLM 5.2 is $0.76/$2.42 per M; this repo averages ~12k in / ~3k out per PR).

## The real work: keeping the two instances apart

Both instances post as `github-actions`, so they collide by default. From `github_provider.py`, PR-Agent locates its persistent comment by matching the **body prefix** (`comments[i].body.startswith(prefix)`) — no per-instance marker, no lock.

| Setting | Value here | Why |
|---|---|---|
| `pr_reviewer.persistent_comment` | `false` | Left on, this reviewer would find and overwrite the Anthropic reviewer's "PR Reviewer Guide" comment instead of posting its own |
| `pr_code_suggestions.persistent_comment` | `false` | Same collision on the suggestions comment |
| `github_action_config.auto_describe` | `false` | `pr_agent.yml` already rewrites the PR body; two agents writing it means last-writer-wins |
| `issue_comment` trigger | omitted | Manual `/review` commands should reach one reviewer, not both |

Per-instance settings live in the **workflow env**, not `.pr_agent.toml` — that file sits at the repo root and is read by both workflows. Shared settings (the house-rule `extra_instructions`) stay there on purpose, so both reviewers apply the same standards.

## Before this can run

The `OPENROUTER_API_KEY` repo secret does not exist yet and needs adding. Until then this workflow runs and fails on auth; it has no effect on the existing reviewer or on CI.

## Verifying

On the first run with the secret in place, check the PR Agent (GLM) job log for `Generating prediction with openrouter/z-ai/glm-5.2`. If it says `anthropic/...` instead, the repo-root `.pr_agent.toml` is winning over the workflow env and this reviewer is silently billing the Anthropic key — the one thing worth eyeballing on the first run.


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Add second automated PR reviewer using GLM 5.2 via OpenRouter

- Configure GLM reviewer to avoid conflicts with existing Anthropic reviewer
  - Disable persistent comments to prevent overwriting Anthropic's comments
  - Disable auto-describe to prevent last-writer-wins PR body conflicts
  - Omit `issue_comment` trigger so manual `/review` commands reach one reviewer

- Fix OpenRouter API key env var to use dotted name (`OPENROUTER.KEY`)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  trigger["PR Event (opened/reopened/\nready_for_review/synchronize)"]
  glm_workflow["pr_agent_glm.yml\n(GLM Reviewer)"]
  anthropic_workflow["pr_agent.yml\n(Anthropic Reviewer)"]
  openrouter["OpenRouter API\n(GLM 5.2 / GLM 4.7 fallback)"]
  pr_comments["PR Comments\n(non-persistent)"]
  pr_body["PR Body\n(auto_describe off)"]
  toml[".pr_agent.toml\n(shared house rules)"]

  trigger -- "triggers" --> glm_workflow
  trigger -- "triggers" --> anthropic_workflow
  glm_workflow -- "reads" --> toml
  anthropic_workflow -- "reads" --> toml
  glm_workflow -- "calls" --> openrouter
  glm_workflow -- "posts" --> pr_comments
  anthropic_workflow -- "writes" --> pr_body
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_agent_glm.yml</strong><dd><code>Add GLM-based second PR reviewer workflow via OpenRouter</code>&nbsp; </dd></summary>
<hr>

.github/workflows/pr_agent_glm.yml

<ul><li>New workflow file adding a second automated PR reviewer using GLM 5.2 <br>via OpenRouter<br> <li> Configures model, fallback, and max tokens for GLM (not in litellm <br>registry by default)<br> <li> Disables <code>auto_describe</code> and persistent comments to avoid conflicts with <br>the Anthropic reviewer<br> <li> Uses dotted env var <code>OPENROUTER.KEY</code> to correctly pass API credentials <br>to the action</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/499/files#diff-bb0b232f5e7f558ea33c510e85e574a370c3844e624c3a259f3123928710c06b">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

