### PR TITLE
feat(api): expose the workspace member roster so agents can @mention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -648,6 +648,10 @@ Per-repo configuration for Matt Pocock's engineering skills (`/triage`, `/to-iss
 
 Work items (features, PRDs, bugs, tickets) live in **Exponential** under workspace `syntrofi` / product `exponential`. Use the `exponential` CLI. Ephemeral in-session checklists can use `TodoWrite`; there is no separate mandatory tracker. (Legacy `bd`/beads is read-only and being wound down — see the **Task Tracking** section above.) See [`docs/agents/issue-tracker.md`](docs/agents/issue-tracker.md).
 
+### Commenting and @mentions
+
+Features, tickets, actions, pages, and goals all take comments from the CLI (`exponential <entity> comment add`). Mentions are the literal markup `@[Name](userId)` — plain `@andi` notifies nobody. Use `--mention andi` to expand it, and `exponential workspaces members` to look someone up. See [`docs/agents/commenting.md`](docs/agents/commenting.md).
+
 ### Triage labels
 
 Exponential uses **ticket statuses** as triage routing — no labels. Canonical role → status mapping (e.g. `ready-for-agent` → `READY_TO_PLAN`, `wontfix` → `ARCHIVED`) lives in [`docs/agents/triage-labels.md`](docs/agents/triage-labels.md).

--- a/docs/agents/commenting.md
+++ b/docs/agents/commenting.md
@@ -1,0 +1,64 @@
+# Commenting and @mentions from the CLI
+
+Every commentable entity in Exponential is reachable from the `exponential` CLI. Add `--json` (or pipe) for machine-readable output.
+
+| Entity | Command |
+| --- | --- |
+| Feature (PRD) | `exponential features comment {list,add,reply,update,rm,resolve,unresolve}` |
+| Ticket | `exponential tickets comment {list,add,update,delete}` |
+| Action | `exponential actions comment {list,add,update,delete}` |
+| Page | `exponential pages comment {list,add,update,rm}` |
+| Goal | `exponential goals comment {list,add,update,rm}` |
+
+Editing and deleting are **author-only** everywhere — the server rejects touching someone else's comment.
+
+## Mentioning someone
+
+A mention is the literal markup `@[Display Name](userId)` inside the comment body. That exact form is what the notification pipeline parses; plain `@andi` does nothing.
+
+You do not have to build it by hand. `--mention` takes a name, email, or user id and expands it:
+
+```bash
+exponential features comment add --feature cmsejeixc0001l204uzlrhg2l \
+  --mention andi \
+  -m "@andi — could you sanity-check the scope here before we commit?"
+```
+
+`@andi` is substituted in place, so the sentence still reads:
+
+> `@[Andi Stanner](cm…) — could you sanity-check the scope here before we commit?`
+
+If the body has no matching `@handle`, the mention is prepended instead, so `-m "ptal?"` works too. `--mention` is repeatable.
+
+Tokens resolve against the workspace roster: exact id, full name, or email wins outright; otherwise first names and email local-parts are matched case-insensitively. An **ambiguous token is an error**, not a guess — mentioning the wrong colleague is worse than failing.
+
+`--mention` needs a workspace to resolve against. It uses your default workspace; pass `--workspace <slug>` when the entity lives elsewhere.
+
+## Finding the user id
+
+```bash
+exponential workspaces members --search andi --json
+```
+
+Each row carries a `mentionSyntax` field — the ready-to-paste token — plus `source`, which is `workspace` for a direct member or `team` for someone who reaches the workspace through a linked team.
+
+That distinction matters if you ever write the markup by hand: the name-only form `@[Andi Stanner]` only resolves against **direct** members, so team-based members must be mentioned by id. `mentionSyntax` is always the id form and always works.
+
+Mentions naming a non-member (or an agent principal) are silently dropped by the server — comment content never leaks outside the workspace.
+
+## Finding the entity id
+
+- Features, tickets, pages, goals: `exponential search "<text>" --json` returns `type`, `id`, and `url` for each hit.
+- Goal ids are **integers**, not CUIDs — the other entities use CUIDs.
+- A feature URL like `…/features?peek=cmsejeixc0001l204uzlrhg2l` carries the feature id in the `peek` parameter.
+
+## Threads on features
+
+Feature comments can be anchored to a span of the PRD body. Those carry a `threadId` and can be resolved:
+
+```bash
+exponential features comment resolve --feature <id> --thread <threadId>
+exponential features comment unresolve --feature <id> --thread <threadId>
+```
+
+Doc-level comments have no `threadId` and cannot be resolved. Replies are one level deep — replying to a reply still hangs off the root comment.

--- a/docs/agents/commenting.md
+++ b/docs/agents/commenting.md
@@ -42,6 +42,8 @@ exponential workspaces members --search andi --json
 
 Each row carries a `mentionSyntax` field — the ready-to-paste token — plus `source`, which is `workspace` for a direct member or `team` for someone who reaches the workspace through a linked team.
 
+`role` is always the **workspace** role. Team-based members report `member` there no matter their team role; their team role is in `teamRole`. Don't gate on `role` expecting a team `owner` to appear as a workspace owner — they hold no workspace authority.
+
 That distinction matters if you ever write the markup by hand: the name-only form `@[Andi Stanner]` only resolves against **direct** members, so team-based members must be mentioned by id. `mentionSyntax` is always the id form and always works.
 
 Mentions naming a non-member (or an agent principal) are silently dropped by the server — comment content never leaks outside the workspace.

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -427,7 +427,10 @@ export const featureRouter = createTRPCRouter({
             },
           },
           tags: { include: { tag: true } },
-          _count: { select: { tickets: true } },
+          // `comments` is a count, not the list: the UI loads the thread lazily
+          // via `featureComment.list`, and API callers need to know a discussion
+          // exists before paying for it.
+          _count: { select: { tickets: true, comments: true } },
         },
       });
       if (!feature) {

--- a/src/server/api/routers/__tests__/workspaceMembers.test.ts
+++ b/src/server/api/routers/__tests__/workspaceMembers.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for `workspace.listMembers` — the roster API and CLI callers use
+ * to turn a name into a user id so they can write `@[Name](userId)` mentions.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const USER_ID = "user-1";
+const WORKSPACE_ID = "ws-1";
+
+function caller(db: DeepMockProxy<PrismaClient>) {
+  return createMockCaller({ userId: USER_ID, db: db as unknown as PrismaClient });
+}
+
+/** Make the caller a member so the access gate passes. */
+function grantAccess(db: DeepMockProxy<PrismaClient>) {
+  db.workspaceUser.findUnique.mockResolvedValue({
+    userId: USER_ID,
+    workspaceId: WORKSPACE_ID,
+    role: "owner",
+  } as never);
+}
+
+function directRow(id: string, name: string | null, role = "member") {
+  return { role, user: { id, name, email: `${id}@example.com`, image: null } };
+}
+
+function teamRow(id: string, name: string | null, role = "member") {
+  return {
+    role,
+    user: { id, name, email: `${id}@example.com`, image: null },
+    team: { id: "team-1", name: "Platform" },
+  };
+}
+
+describe("workspace.listMembers", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+  });
+
+  it("refuses callers who are not members", async () => {
+    db.workspaceUser.findUnique.mockResolvedValue(null);
+
+    await expect(
+      caller(db).workspace.listMembers({ workspaceId: WORKSPACE_ID }),
+    ).rejects.toThrow(/don't have access/i);
+  });
+
+  it("returns direct members with ready-to-paste mention syntax", async () => {
+    grantAccess(db);
+    db.workspaceUser.findMany.mockResolvedValue([
+      directRow("u1", "Andi Stanner", "admin"),
+    ] as never);
+    db.teamUser.findMany.mockResolvedValue([] as never);
+
+    const members = await caller(db).workspace.listMembers({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(members).toHaveLength(1);
+    expect(members[0]).toMatchObject({
+      id: "u1",
+      role: "admin",
+      source: "workspace",
+      mentionSyntax: "@[Andi Stanner](u1)",
+    });
+  });
+
+  it("includes team-based members, marked as such", async () => {
+    grantAccess(db);
+    db.workspaceUser.findMany.mockResolvedValue([] as never);
+    db.teamUser.findMany.mockResolvedValue([teamRow("u2", "Team Only")] as never);
+
+    const members = await caller(db).workspace.listMembers({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(members).toHaveLength(1);
+    expect(members[0]).toMatchObject({
+      id: "u2",
+      source: "team",
+      mentionSyntax: "@[Team Only](u2)",
+    });
+    expect(members[0]?.teams).toEqual([{ id: "team-1", name: "Platform" }]);
+  });
+
+  it("lists someone once when they are both a direct and a team member, keeping the direct role", async () => {
+    grantAccess(db);
+    db.workspaceUser.findMany.mockResolvedValue([
+      directRow("u1", "Andi Stanner", "owner"),
+    ] as never);
+    db.teamUser.findMany.mockResolvedValue([
+      teamRow("u1", "Andi Stanner", "member"),
+    ] as never);
+
+    const members = await caller(db).workspace.listMembers({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(members).toHaveLength(1);
+    expect(members[0]).toMatchObject({
+      id: "u1",
+      role: "owner",
+      source: "workspace",
+    });
+    // The team still shows up, so callers can see how the access is granted.
+    expect(members[0]?.teams).toEqual([{ id: "team-1", name: "Platform" }]);
+  });
+
+  it("falls back to the email when a member has no display name", async () => {
+    grantAccess(db);
+    db.workspaceUser.findMany.mockResolvedValue([directRow("u3", null)] as never);
+    db.teamUser.findMany.mockResolvedValue([] as never);
+
+    const members = await caller(db).workspace.listMembers({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(members[0]?.mentionSyntax).toBe("@[u3@example.com](u3)");
+  });
+
+  it("sorts by display name so output is stable", async () => {
+    grantAccess(db);
+    db.workspaceUser.findMany.mockResolvedValue([
+      directRow("u2", "Zoe"),
+      directRow("u1", "Andi Stanner"),
+    ] as never);
+    db.teamUser.findMany.mockResolvedValue([] as never);
+
+    const members = await caller(db).workspace.listMembers({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(members.map((m) => m.name)).toEqual(["Andi Stanner", "Zoe"]);
+  });
+});

--- a/src/server/api/routers/__tests__/workspaceMembers.test.ts
+++ b/src/server/api/routers/__tests__/workspaceMembers.test.ts
@@ -76,12 +76,19 @@ function caller(db: DeepMockProxy<PrismaClient>) {
   return createMockCaller({ userId: USER_ID, db: db as unknown as PrismaClient });
 }
 
-/** Make the caller a member so the access gate passes. */
+/**
+ * Satisfy `requireWorkspaceMembership("view")`, which resolves through
+ * AccessControlService rather than reading WorkspaceUser inline.
+ */
 function grantAccess(db: DeepMockProxy<PrismaClient>) {
   db.workspaceUser.findUnique.mockResolvedValue({
     userId: USER_ID,
     workspaceId: WORKSPACE_ID,
     role: "owner",
+  } as never);
+  db.workspace.findUnique.mockResolvedValue({
+    id: WORKSPACE_ID,
+    ownerId: USER_ID,
   } as never);
 }
 
@@ -107,10 +114,11 @@ describe("workspace.listMembers", () => {
 
   it("refuses callers who are not members", async () => {
     db.workspaceUser.findUnique.mockResolvedValue(null);
+    db.workspace.findUnique.mockResolvedValue(null);
 
     await expect(
       caller(db).workspace.listMembers({ workspaceId: WORKSPACE_ID }),
-    ).rejects.toThrow(/don't have access/i);
+    ).rejects.toThrow();
   });
 
   it("returns direct members with ready-to-paste mention syntax", async () => {
@@ -146,6 +154,10 @@ describe("workspace.listMembers", () => {
     expect(members[0]).toMatchObject({
       id: "u2",
       source: "team",
+      // The TEAM role is "member" here, but the point is that a team role
+      // never lands in `role` — it is reported separately.
+      role: "member",
+      teamRole: "member",
       mentionSyntax: "@[Team Only](u2)",
     });
     expect(members[0]?.teams).toEqual([{ id: "team-1", name: "Platform" }]);
@@ -168,10 +180,28 @@ describe("workspace.listMembers", () => {
     expect(members[0]).toMatchObject({
       id: "u1",
       role: "owner",
+      teamRole: null,
       source: "workspace",
     });
     // The team still shows up, so callers can see how the access is granted.
     expect(members[0]?.teams).toEqual([{ id: "team-1", name: "Platform" }]);
+  });
+
+  it("never reports a team role as the workspace role", async () => {
+    grantAccess(db);
+    db.workspaceUser.findMany.mockResolvedValue([] as never);
+    db.teamUser.findMany.mockResolvedValue([
+      teamRow("u9", "Team Owner", "owner"),
+    ] as never);
+
+    const members = await caller(db).workspace.listMembers({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    // A team owner has no workspace-level authority — callers reading `role`
+    // to gate on owner/admin must not be misled.
+    expect(members[0]?.role).toBe("member");
+    expect(members[0]?.teamRole).toBe("owner");
   });
 
   it("falls back to the email when a member has no display name", async () => {

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -1491,6 +1491,89 @@ export const workspaceRouter = createTRPCRouter({
       });
     }),
 
+  // Roster of everyone who belongs to a workspace: direct WorkspaceUser rows
+  // plus users who reach it through a linked team. Any member can read it —
+  // the same roster the app already ships inside `workspace.list`, exposed as
+  // a first-class query so API and CLI callers can resolve a name to a user id
+  // without fetching every workspace. This is what makes `@[Name](userId)`
+  // mentions writable from outside the app: `mentionSyntax` on each row is the
+  // exact token to paste into a comment body.
+  //
+  // `source` matters for mentions: name-only `@[Name]` markup resolves against
+  // direct members only, so team-based members must be mentioned by id.
+  listMembers: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const membership = await getWorkspaceMembership(
+        ctx.db,
+        ctx.session.user.id,
+        input.workspaceId,
+      );
+      if (!membership) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You don't have access to this workspace",
+        });
+      }
+
+      const userSelect = {
+        id: true,
+        name: true,
+        email: true,
+        image: true,
+      } as const;
+
+      const [direct, viaTeam] = await Promise.all([
+        ctx.db.workspaceUser.findMany({
+          where: { workspaceId: input.workspaceId },
+          select: { role: true, user: { select: userSelect } },
+        }),
+        ctx.db.teamUser.findMany({
+          where: { team: { workspaceId: input.workspaceId } },
+          select: {
+            role: true,
+            user: { select: userSelect },
+            team: { select: { id: true, name: true } },
+          },
+        }),
+      ]);
+
+      const members = direct.map((m) => ({
+        ...m.user,
+        role: m.role,
+        source: "workspace" as const,
+        teams: [] as { id: string; name: string }[],
+        // Both forms work; the id form is unambiguous when two members share
+        // a display name, and is the only form that reaches team-based members.
+        mentionSyntax: `@[${m.user.name ?? m.user.email ?? "Unknown"}](${m.user.id})`,
+      }));
+
+      const byId = new Map(members.map((m) => [m.id, m]));
+
+      for (const t of viaTeam) {
+        const existing = byId.get(t.user.id);
+        if (existing) {
+          // Already a direct member — record the team but keep the direct role,
+          // matching the role precedence `workspace.list` uses.
+          existing.teams.push(t.team);
+          continue;
+        }
+        const added = {
+          ...t.user,
+          role: t.role,
+          source: "team" as const,
+          teams: [t.team],
+          mentionSyntax: `@[${t.user.name ?? t.user.email ?? "Unknown"}](${t.user.id})`,
+        };
+        byId.set(t.user.id, added);
+        members.push(added);
+      }
+
+      return members.sort((a, b) =>
+        (a.name ?? a.email ?? "").localeCompare(b.name ?? b.email ?? ""),
+      );
+    }),
+
   // List project-only "guests" of a workspace: users with ProjectMember rows
   // in some project of the workspace but no WorkspaceUser row and no
   // team-based membership. Read-only for the Members tab; management happens

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -10,6 +10,7 @@ import {
   buildWorkspaceAccessWhere,
   buildWorkspaceVisibilityWhere,
 } from "~/server/services/access";
+import { requireWorkspaceMembership } from "~/server/services/access/middleware";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import {
   generateSecureToken,
@@ -1503,19 +1504,8 @@ export const workspaceRouter = createTRPCRouter({
   // direct members only, so team-based members must be mentioned by id.
   listMembers: protectedProcedure
     .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
     .query(async ({ ctx, input }) => {
-      const membership = await getWorkspaceMembership(
-        ctx.db,
-        ctx.session.user.id,
-        input.workspaceId,
-      );
-      if (!membership) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "You don't have access to this workspace",
-        });
-      }
-
       const userSelect = {
         id: true,
         name: true,
@@ -1546,7 +1536,15 @@ export const workspaceRouter = createTRPCRouter({
         name: string | null;
         email: string | null;
         image: string | null;
+        /**
+         * The member's WORKSPACE role. Team-based members get "member", the
+         * same synthesized role `workspace.list` gives them — a team `owner`
+         * is not a workspace owner, so their team role must never land here
+         * where a caller would read it as workspace authority.
+         */
         role: string;
+        /** The team role, when access is team-based. Null for direct members. */
+        teamRole: string | null;
         source: "workspace" | "team";
         teams: { id: string; name: string }[];
         mentionSyntax: string;
@@ -1560,6 +1558,7 @@ export const workspaceRouter = createTRPCRouter({
       const members: Member[] = direct.map((m) => ({
         ...m.user,
         role: m.role,
+        teamRole: null,
         source: "workspace",
         teams: [],
         mentionSyntax: mention(m.user),
@@ -1577,7 +1576,10 @@ export const workspaceRouter = createTRPCRouter({
         }
         const added: Member = {
           ...t.user,
-          role: t.role,
+          // Not `t.role` — that is the team role, and surfacing it as `role`
+          // would let a team admin read as a workspace admin.
+          role: "member",
+          teamRole: t.role,
           source: "team",
           teams: [t.team],
           mentionSyntax: mention(t.user),

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -1538,14 +1538,31 @@ export const workspaceRouter = createTRPCRouter({
         }),
       ]);
 
-      const members = direct.map((m) => ({
+      // Named so the array admits both sources — inferring it from the direct
+      // rows alone would narrow `source` to "workspace" and reject the team
+      // rows appended below.
+      interface Member {
+        id: string;
+        name: string | null;
+        email: string | null;
+        image: string | null;
+        role: string;
+        source: "workspace" | "team";
+        teams: { id: string; name: string }[];
+        mentionSyntax: string;
+      }
+
+      const mention = (user: { id: string; name: string | null; email: string | null }) =>
+        // Both forms work; the id form is unambiguous when two members share a
+        // display name, and is the only form that reaches team-based members.
+        `@[${user.name ?? user.email ?? "Unknown"}](${user.id})`;
+
+      const members: Member[] = direct.map((m) => ({
         ...m.user,
         role: m.role,
-        source: "workspace" as const,
-        teams: [] as { id: string; name: string }[],
-        // Both forms work; the id form is unambiguous when two members share
-        // a display name, and is the only form that reaches team-based members.
-        mentionSyntax: `@[${m.user.name ?? m.user.email ?? "Unknown"}](${m.user.id})`,
+        source: "workspace",
+        teams: [],
+        mentionSyntax: mention(m.user),
       }));
 
       const byId = new Map(members.map((m) => [m.id, m]));
@@ -1558,12 +1575,12 @@ export const workspaceRouter = createTRPCRouter({
           existing.teams.push(t.team);
           continue;
         }
-        const added = {
+        const added: Member = {
           ...t.user,
           role: t.role,
-          source: "team" as const,
+          source: "team",
           teams: [t.team],
-          mentionSyntax: `@[${t.user.name ?? t.user.email ?? "Unknown"}](${t.user.id})`,
+          mentionSyntax: mention(t.user),
         };
         byId.set(t.user.id, added);
         members.push(added);


### PR DESCRIPTION
### **User description**
## Why

An agent was asked to comment on a feature and tag a colleague. It couldn't — and the reason wasn't the CLI.

Mentions are stored as the literal markup `@[Display Name](userId)`. Resolving "andi" to a user id requires enumerating workspace members, and **no procedure did that**. `workspace.addMember`, `removeMember` and `updateMemberRole` all exist; there was no way to *list* them.

## What

**`workspace.listMembers`** — direct `WorkspaceUser` rows plus anyone reaching the workspace through a linked team, deduped with the direct role winning (matching the precedence `workspace.list` already uses). Any member can read it; it's the same roster the app already ships inside `workspace.list`, just exposed as a first-class query so callers don't fetch every workspace to find one person.

Two fields exist specifically for callers outside the app:
- `mentionSyntax` — the exact token to paste into a comment body.
- `source` (`workspace` | `team`) — this matters: name-only `@[Name]` markup resolves against **direct members only**, so team-based members must be mentioned by id. The team query mirrors `resolveMentionRecipients` exactly, so the roster and the notifier agree on who counts as a member.

**`feature.getById` returns a comments count.** Feature comments were the one discussion thread invisible to a caller holding the entity — `ticket.getById` and `insight` already include theirs. A count rather than the list keeps the page query cheap; the thread is one `featureComment.list` away.

**`docs/agents/commenting.md`** — the mention markup and per-entity comment commands were undocumented anywhere.

## Testing

6 unit tests (mocked Prisma, no DB) covering the access gate, both member sources, the dedup case, the no-display-name fallback, and sort stability. Full suite: 2151 passing. Typecheck and lint clean.

## Ships with

- exponential-sdk `feat/comments-and-members`
- exponential-cli `feat/comment-commands`

Backend-only and additive — no migration, no UI change.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add `workspace.listMembers` roster query with mention syntax

- Dedupe direct vs team members, separate `teamRole`

- Return comments count from `feature.getById`

- Add mention/commenting docs and unit tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI/API caller"] -- "workspaceId" --> B["workspace.listMembers"]
  B -- "requireWorkspaceMembership('view')" --> C["access gate"]
  B --> D["WorkspaceUser rows (source: workspace)"]
  B --> E["TeamUser rows (source: team)"]
  D -- "dedupe, direct role wins" --> F["Member[] with mentionSyntax"]
  E --> F
  G["feature.getById"] -- "_count" --> H["comments count"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.ts</strong><dd><code>New `workspace.listMembers` roster procedure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/workspace.ts

<ul><li>Adds <code>listMembers</code> protected procedure gated by <br><code>requireWorkspaceMembership("view")</code><br> <li> Queries direct <code>workspaceUser</code> rows and team-based <code>teamUser</code> rows in <br>parallel<br> <li> Merges/dedupes by user id, keeping the direct workspace role and <br>collecting <code>teams</code><br> <li> Emits <code>mentionSyntax</code>, <code>source</code>, and separate <code>teamRole</code> per member, sorted <br>by display name</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/501/files#diff-b94d59060e1c78a6a505a0a58d90bb366e921cdd053126776199f6abcee0f846">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>feature.ts</strong><dd><code>Return comments count from `feature.getById`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/routers/feature.ts

<ul><li>Adds <code>comments</code> to the <code>_count</code> select in <code>feature.getById</code><br> <li> Comment explains why a count is returned rather than the thread</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/501/files#diff-bff1a29f77efa7f846d655a0106c96302d007305d09f09ecb53ab204ef97d03d">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspaceMembers.test.ts</strong><dd><code>Unit tests for the member roster query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/__tests__/workspaceMembers.test.ts

<ul><li>New unit test suite for <code>workspace.listMembers</code> using <code>mockDeep<PrismaClient>()</code><br> <li> Mocks env vars, next-auth providers and <code>~/server/db</code> proxy<br> <li> Covers access denial, direct and team members, dedup precedence, team <br>role isolation, email fallback and sort stability</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/501/files#diff-3b35570cdba7ae36ac54e05d3322e7368528fef84ac227cc659a3b780683d24b">+233/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commenting.md</strong><dd><code>Document commenting and @mention workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/agents/commenting.md

<ul><li>New doc covering per-entity comment CLI commands<br> <li> Explains <code>@[Name](userId)</code> mention markup and <code>--mention</code> expansion<br> <li> Documents <code>workspaces members</code> output fields (<code>mentionSyntax</code>, <code>source</code>, <br><code>role</code> vs <code>teamRole</code>)<br> <li> Notes entity id lookup and feature comment threads/resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/501/files#diff-b841d453621b55c2c4b23a740cdc285a31387acc61eec97eadb7d3f63067d8e1">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Reference commenting docs in agent guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Adds a "Commenting and @mentions" section<br> <li> Links to <code>docs/agents/commenting.md</code> and notes mention markup <br>requirements</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/501/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

