### PR TITLE
test(wiki): cover the first run, where the wiki does not exist yet

### DIFF
--- a/e2e/local-wiki.spec.ts
+++ b/e2e/local-wiki.spec.ts
@@ -322,7 +322,15 @@ async function installUncreatedWikiStub(page: Page, { initFails = false } = {}) 
         calls.push(cmd);
         switch (cmd) {
           case "wiki_status":
-            return Promise.resolve({ root, exists, git: exists, pageCount: 0 });
+            // pageCount derived, not hardcoded: the real command counts the
+            // folder, and a stub that reports 0 pages while wiki_list_pages
+            // returns three is a lie the next reader would have to discover.
+            return Promise.resolve({
+              root,
+              exists,
+              git: exists,
+              pageCount: Object.keys(store).length,
+            });
           case "wiki_init": {
             if (failing) {
               return Promise.reject(new Error("Permission denied (os error 13)"));
@@ -377,8 +385,11 @@ test("with no wiki yet, arriving at /wiki offers to create one — and creates n
   // what the reader cares about, and waiting on it means the call log below
   // is read after the handler has run rather than racing it.
   await expect(page.getByRole("heading", { name: "Local wiki" })).toBeVisible();
-  for (const seed of ["index.md", "schema.md", "log.md"]) {
-    await expect(page.getByText(seed, { exact: true })).toBeVisible();
+  // Asserted on the row's link target rather than its text: it pins that the
+  // seed is listed *and* points at the right page, and it can't be made
+  // ambiguous later by a breadcrumb or header repeating the filename.
+  for (const seed of ["index", "schema", "log"]) {
+    await expect(page.locator(`a[href="/wiki/${seed}"]`)).toBeVisible();
   }
   expect(await commandsCalled(page)).toContain("wiki_init");
 });

--- a/e2e/local-wiki.spec.ts
+++ b/e2e/local-wiki.spec.ts
@@ -373,12 +373,14 @@ test("with no wiki yet, arriving at /wiki offers to create one — and creates n
 
   await page.getByRole("button", { name: "Create wiki" }).click();
 
-  // Created, seeded, and listed.
-  expect(await commandsCalled(page)).toContain("wiki_init");
+  // Created, seeded, and listed. The visible result is asserted first: it's
+  // what the reader cares about, and waiting on it means the call log below
+  // is read after the handler has run rather than racing it.
   await expect(page.getByRole("heading", { name: "Local wiki" })).toBeVisible();
   for (const seed of ["index.md", "schema.md", "log.md"]) {
     await expect(page.getByText(seed, { exact: true })).toBeVisible();
   }
+  expect(await commandsCalled(page)).toContain("wiki_init");
 });
 
 test("a wiki that cannot be created says why", async ({ page }) => {

--- a/e2e/local-wiki.spec.ts
+++ b/e2e/local-wiki.spec.ts
@@ -297,3 +297,102 @@ test("in a browser, the wiki says where it actually lives", async ({ page }) => 
     timeout: FIRST_PAINT_TIMEOUT,
   });
 });
+
+/**
+ * A desktop shell whose wiki folder does not exist yet — what a first-time
+ * user actually meets. `initFails` makes `wiki_init` reject, standing in for
+ * the realistic failure: a folder the app may not write to.
+ */
+async function installUncreatedWikiStub(page: Page, { initFails = false } = {}) {
+  await page.addInitScript((failing: boolean) => {
+    const store: Record<string, string> = {};
+    let exists = false;
+    const calls: string[] = [];
+    (window as unknown as { __WIKI_CALLS__: string[] }).__WIKI_CALLS__ = calls;
+    const root = "/Users/dev/Documents/exponential-wiki";
+
+    (
+      window as unknown as {
+        __TAURI_INTERNALS__: {
+          invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+        };
+      }
+    ).__TAURI_INTERNALS__ = {
+      invoke: (cmd: string, args?: Record<string, unknown>) => {
+        calls.push(cmd);
+        switch (cmd) {
+          case "wiki_status":
+            return Promise.resolve({ root, exists, git: exists, pageCount: 0 });
+          case "wiki_init": {
+            if (failing) {
+              return Promise.reject(new Error("Permission denied (os error 13)"));
+            }
+            exists = true;
+            // The three fixed files `init_at` seeds.
+            store["index.md"] = "# Index\n";
+            store["schema.md"] = "# How this wiki works\n";
+            store["log.md"] = "# Log\n";
+            return Promise.resolve({ root, created: true, git: true });
+          }
+          case "wiki_list_pages":
+            return Promise.resolve(
+              Object.keys(store)
+                .sort()
+                .map((path) => ({ path, bytes: (store[path] ?? "").length })),
+            );
+          case "wiki_read_page":
+            return Promise.resolve(store[String(args?.path)] ?? "");
+          case "wiki_get_root":
+            return Promise.resolve(root);
+          default:
+            return Promise.reject(new Error(`unexpected command ${cmd}`));
+        }
+      },
+    };
+  }, initFails);
+}
+
+const commandsCalled = (page: Page) =>
+  page.evaluate(() => (window as unknown as { __WIKI_CALLS__: string[] }).__WIKI_CALLS__);
+
+test("with no wiki yet, arriving at /wiki offers to create one — and creates nothing on its own", async ({
+  page,
+}) => {
+  await installUncreatedWikiStub(page);
+  await page.goto("/wiki");
+
+  await expect(page.getByText("Create your local wiki")).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+  // It names the folder it would create before creating it.
+  await expect(page.getByText("/Users/dev/Documents/exponential-wiki")).toBeVisible();
+
+  // The guarantee worth protecting: a folder and a git repo appear in someone's
+  // Documents because they chose it, never as a side effect of navigation.
+  expect(await commandsCalled(page)).not.toContain("wiki_init");
+
+  await page.getByRole("button", { name: "Create wiki" }).click();
+
+  // Created, seeded, and listed.
+  expect(await commandsCalled(page)).toContain("wiki_init");
+  await expect(page.getByRole("heading", { name: "Local wiki" })).toBeVisible();
+  for (const seed of ["index.md", "schema.md", "log.md"]) {
+    await expect(page.getByText(seed, { exact: true })).toBeVisible();
+  }
+});
+
+test("a wiki that cannot be created says why", async ({ page }) => {
+  await installUncreatedWikiStub(page, { initFails: true });
+  await page.goto("/wiki");
+
+  await expect(page.getByText("Create your local wiki")).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+  await page.getByRole("button", { name: "Create wiki" }).click();
+
+  // The reason, not a spinner that never resolves. Scoped to <main>, since
+  // Next's route announcer is also a role="alert" living outside it.
+  await expect(page.getByRole("main").getByRole("alert")).toContainText("Permission denied");
+  // And the button comes back, so a fixed permission can be retried.
+  await expect(page.getByRole("button", { name: "Create wiki" })).toBeEnabled();
+});


### PR DESCRIPTION
### **User description**
## What

Two e2e cases for the local wiki's first run — the state a brand-new user meets, where the wiki folder doesn't exist yet.

- `/wiki` with no wiki: the panel names the folder it would create, and **no `wiki_init` fires until the button is pressed**. Then it seeds `index.md` / `schema.md` / `log.md` and lists them.
- A wiki that can't be created (unwritable folder): the reason is shown and the button stays retryable, rather than a spinner that never resolves.

## Why

The stub in `e2e/local-wiki.spec.ts` always reported an existing wiki, so the first-run branch was never exercised by anything. That's the branch carrying the guarantee with actual consequences: **visiting a page must not create a folder and a git repo in someone's Documents.** Only choosing to must.

That guarantee is the entire reason `LocalWikiFirstRun` exists — the wiki used to appear as a side effect of asking the librarian a question — and nothing checked it. A refactor that moved `init()` back into the load path would have gone unnoticed.

Tests only; no product code changes.


___

### **PR Type**
Tests


___

### **Description**
- Add e2e coverage for wiki first-run flow

- New stub simulating a not-yet-created wiki

- Assert `wiki_init` fires only on button click

- Cover init failure: reason shown, button retryable


___

### Diagram Walkthrough


```mermaid
flowchart LR
  stub["installUncreatedWikiStub()"] -- "exists=false" --> visit["visit /wiki"]
  visit --> panel["'Create your local wiki' + folder path"]
  panel -- "no wiki_init called" --> guarantee["nothing created on navigation"]
  panel -- "click 'Create wiki'" --> ok["seeds index/schema/log, links listed"]
  stub -- "initFails=true" --> fail["alert shows 'Permission denied', button retryable"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>local-wiki.spec.ts</strong><dd><code>Add first-run and init-failure e2e tests for local wiki</code>&nbsp; &nbsp; </dd></summary>
<hr>

e2e/local-wiki.spec.ts

<ul><li>Added <code>installUncreatedWikiStub</code> helper stubbing <br><code>__TAURI_INTERNALS__.invoke</code> for a wiki that does not exist yet, with an <br><code>initFails</code> option and a recorded <code>__WIKI_CALLS__</code> log.<br> <li> Stub derives <code>pageCount</code> from the seeded store so <code>wiki_status</code> and <br><code>wiki_list_pages</code> stay consistent; <code>wiki_init</code> seeds <code>index.md</code>, <code>schema.md</code>, <br><code>log.md</code>.<br> <li> New test verifies the first-run panel names the target folder, that <br><code>wiki_init</code> is not invoked on navigation, and that clicking "Create <br>wiki" seeds and lists the pages (asserted via link <code>href</code>).<br> <li> New test verifies a failing <code>wiki_init</code> surfaces the error in the <br><code>main</code>-scoped alert and leaves the "Create wiki" button enabled for <br>retry.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/502/files#diff-fca70be4c7a0830f89c949759544952cbc9c265eed1a442b1b009cfeb1d4d893">+112/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

