### PR TITLE
Point the command palette at search.global

### DIFF
--- a/src/app/_components/layout/CommandPalette.tsx
+++ b/src/app/_components/layout/CommandPalette.tsx
@@ -109,6 +109,13 @@ const MODE_TYPES: Record<Exclude<Mode, 'ai'>, SearchType[] | null> = {
   goals: ['goal', 'keyResult', 'outcome'],
 };
 
+// Each search fans out to one `contains` query per entity type, and none of
+// those columns are trigram-indexed, so a query that matches nothing scans
+// every table. One character matches almost everything and tells you almost
+// nothing, so it isn't worth the round trip — navigation still filters from
+// the first keystroke.
+const MIN_SEARCH_LENGTH = 2;
+
 const SUGGESTED = [
   { icon: IconFlag, label: 'Run weekly plan', sub: 'Keystone ritual · 45 min' },
   { icon: IconTarget, label: 'Review Q2 OKR progress', sub: 'Summary from Zoe' },
@@ -163,7 +170,7 @@ export function CommandPalette() {
   const { data: searchData, isFetching: searchFetching } = api.search.global.useQuery(
     { query: debouncedQuery, workspaceId: workspaceId ?? undefined, limit: 5 },
     {
-      enabled: isOpen && mode !== 'ai' && debouncedQuery.length > 0,
+      enabled: isOpen && mode !== 'ai' && debouncedQuery.length >= MIN_SEARCH_LENGTH,
       // Keep the previous matches on screen while the next query is in flight,
       // instead of blanking the list on every keystroke.
       placeholderData: (previous) => previous,
@@ -307,7 +314,13 @@ export function CommandPalette() {
           row({
             key: `${section.type}-${item.id}`,
             label: item.title,
-            sub: item.subtitle ?? section.label,
+            // On routes with no workspace context (/calendar, a recording)
+            // the search spans workspaces, so name the one each result lives
+            // in — otherwise two same-named meetings are indistinguishable.
+            sub:
+              item.workspace && item.workspace.id !== workspaceId
+                ? item.workspace.name
+                : item.subtitle ?? section.label,
             icon: section.icon,
             href: item.url ?? '',
             accent: false,
@@ -336,7 +349,7 @@ export function CommandPalette() {
     }
 
     return sections;
-  }, [filteredPages, currentWorkspaceNav, otherWorkspaceNav, resultsByType, workspaceSlug]);
+  }, [filteredPages, currentWorkspaceNav, otherWorkspaceNav, resultsByType, workspaceSlug, workspaceId]);
 
   const allResults = useMemo(
     () => resultSections.flatMap((section) => section.rows),
@@ -348,7 +361,8 @@ export function CommandPalette() {
   const isSearching = q.length > 0 && (debouncedQuery !== trimmedQuery || searchFetching);
 
   const showSkeleton = isSearching && allResults.length === 0;
-  const showNoResults = q.length > 0 && !isSearching && allResults.length === 0;
+  const showNoResults =
+    q.length >= MIN_SEARCH_LENGTH && !isSearching && allResults.length === 0;
 
   const navigate = useCallback(
     (path: string) => {
@@ -386,9 +400,11 @@ export function CommandPalette() {
     [highlightedIndex, allResults, q, close, navigate, handleAskZoe],
   );
 
+  // Switching filter chips rebuilds the list, so a held index would point at
+  // an unrelated row.
   useEffect(() => {
     setHighlightedIndex(null);
-  }, [query]);
+  }, [query, mode]);
 
   const renderRow = (row: PaletteRow) => {
     const Icon = row.icon;

--- a/src/app/_components/layout/CommandPalette.tsx
+++ b/src/app/_components/layout/CommandPalette.tsx
@@ -141,6 +141,7 @@ export function CommandPalette() {
   const [mode, setMode] = useState<Mode>('all');
   const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const { workspaceId, workspaceSlug } = useWorkspace();
   const { openModal } = useAgentModal();
@@ -406,12 +407,23 @@ export function CommandPalette() {
     setHighlightedIndex(null);
   }, [query, mode]);
 
+  // The results area scrolls, and twelve sections overflow it easily — without
+  // this, arrowing past the fold moves the selection somewhere you can't see
+  // and Enter navigates to a row you never read.
+  useEffect(() => {
+    if (highlightedIndex === null) return;
+    listRef.current
+      ?.querySelector(`[data-palette-index="${highlightedIndex}"]`)
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex]);
+
   const renderRow = (row: PaletteRow) => {
     const Icon = row.icon;
     return (
       <UnstyledButton
         key={row.key}
         className={styles.resultRow}
+        data-palette-index={row.index}
         data-highlighted={highlightedIndex === row.index ? 'true' : 'false'}
         onClick={() => navigate(row.href)}
       >
@@ -522,7 +534,7 @@ export function CommandPalette() {
         })}
       </Group>
 
-      <div style={{ marginTop: 20, maxHeight: '52vh', overflowY: 'auto' }}>
+      <div ref={listRef} style={{ marginTop: 20, maxHeight: '52vh', overflowY: 'auto' }}>
         {showSkeleton ? (
           Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} height={36} mb={4} radius="sm" />
@@ -601,12 +613,28 @@ export function CommandPalette() {
             })}
           </>
         ) : (
-          resultSections.map((section, i) => (
-            <div key={section.key} style={{ marginTop: i === 0 ? 0 : 14 }}>
-              <div className={styles.colHeading}>{section.heading}</div>
-              {section.rows.map(renderRow)}
-            </div>
-          ))
+          <>
+            {resultSections.map((section, i) => (
+              <div key={section.key} style={{ marginTop: i === 0 ? 0 : 14 }}>
+                <div className={styles.colHeading}>{section.heading}</div>
+                {section.rows.map(renderRow)}
+              </div>
+            ))}
+            {/* Below the minimum the search hasn't run, so say so rather than
+                leaving an empty panel that reads as "nothing found". */}
+            {q.length < MIN_SEARCH_LENGTH && (
+              <Text
+                size="xs"
+                style={{
+                  color: 'var(--color-text-muted)',
+                  padding: resultSections.length > 0 ? '14px 0 0' : '24px 0',
+                  textAlign: resultSections.length > 0 ? 'left' : 'center',
+                }}
+              >
+                Keep typing to search…
+              </Text>
+            )}
+          </>
         )}
       </div>
     </Modal>

--- a/src/app/_components/layout/CommandPalette.tsx
+++ b/src/app/_components/layout/CommandPalette.tsx
@@ -357,9 +357,11 @@ export function CommandPalette() {
     [resultSections],
   );
 
-  // True from the first keystroke until results for that exact query land, so
-  // a slow search never flashes "No matches".
-  const isSearching = q.length > 0 && (debouncedQuery !== trimmedQuery || searchFetching);
+  // True from the first searchable keystroke until results for that exact
+  // query land, so a slow search never flashes "No matches" — and a query too
+  // short to search never flashes a skeleton for a request that won't be made.
+  const isSearching =
+    q.length >= MIN_SEARCH_LENGTH && (debouncedQuery !== trimmedQuery || searchFetching);
 
   const showSkeleton = isSearching && allResults.length === 0;
   const showNoResults =

--- a/src/app/_components/layout/CommandPalette.tsx
+++ b/src/app/_components/layout/CommandPalette.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import { useHotkeys } from '@mantine/hooks';
+import { useHotkeys, useDebouncedValue } from '@mantine/hooks';
 import {
   Modal,
   TextInput,
@@ -30,14 +30,22 @@ import {
   IconBook2,
   IconCalendarEvent,
   IconUsers,
+  IconTicket,
+  IconBulb,
+  IconTrophy,
+  IconUser,
+  IconBuilding,
 } from '@tabler/icons-react';
 import { api } from '~/trpc/react';
-import { stripHtml } from '~/lib/utils';
+import type { RouterOutputs } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { useAgentModal } from '~/providers/AgentModalProvider';
 import styles from '../home/WorkspaceHomeConceptD.module.css';
 
 type Mode = 'all' | 'projects' | 'tasks' | 'goals' | 'ai';
+
+type SearchResult = RouterOutputs['search']['global']['results'][number];
+type SearchType = SearchResult['type'];
 
 const MODES: { id: Mode; label: string; icon: React.ElementType }[] = [
   { id: 'all', label: 'All', icon: IconSparkles },
@@ -53,6 +61,8 @@ const PAGES = [
   { label: 'Tasks', path: 'projects-tasks', icon: IconSquareRoundedCheck },
   { label: 'Goals', path: 'goals', icon: IconTarget },
 ];
+
+const PAGE_LABELS = new Set(PAGES.map((p) => p.label.toLowerCase()));
 
 // Workspace-scoped sections surfaced when searching by workspace name.
 const WORKSPACE_SECTIONS: {
@@ -72,12 +82,51 @@ const WORKSPACE_SECTIONS: {
   { label: 'Calendar', icon: IconCalendar, href: () => `/calendar` },
 ];
 
+// How each entity type from search.global is presented, in the order the
+// sections appear. Two of the router's types are deliberately absent:
+// `workspace`, because a matching workspace already surfaces below with all of
+// its sub-pages, and `epic`, which has no detail route to navigate to.
+const RESULT_SECTIONS: { type: SearchType; label: string; icon: React.ElementType }[] = [
+  { type: 'project', label: 'Projects', icon: IconStack2 },
+  { type: 'action', label: 'Tasks', icon: IconSquareRoundedCheck },
+  { type: 'ticket', label: 'Tickets', icon: IconTicket },
+  { type: 'goal', label: 'Goals', icon: IconTarget },
+  { type: 'keyResult', label: 'Key results', icon: IconTrophy },
+  { type: 'outcome', label: 'Outcomes', icon: IconFlag },
+  { type: 'feature', label: 'Features', icon: IconBulb },
+  { type: 'product', label: 'Products', icon: IconLayoutGrid },
+  { type: 'page', label: 'Pages', icon: IconBook2 },
+  { type: 'meeting', label: 'Meetings', icon: IconCalendarEvent },
+  { type: 'contact', label: 'Contacts', icon: IconUser },
+  { type: 'organization', label: 'Organizations', icon: IconBuilding },
+];
+
+// Which entity types each filter chip keeps. `all` keeps everything.
+const MODE_TYPES: Record<Exclude<Mode, 'ai'>, SearchType[] | null> = {
+  all: null,
+  tasks: ['action', 'ticket'],
+  projects: ['project', 'product'],
+  goals: ['goal', 'keyResult', 'outcome'],
+};
+
 const SUGGESTED = [
   { icon: IconFlag, label: 'Run weekly plan', sub: 'Keystone ritual · 45 min' },
   { icon: IconTarget, label: 'Review Q2 OKR progress', sub: 'Summary from Zoe' },
   { icon: IconPlus, label: 'Create project', sub: 'Start from template' },
   { icon: IconCalendar, label: 'Plan my day', sub: 'Ask Zoe' },
 ] as const;
+
+type PaletteRow = {
+  key: string;
+  label: string;
+  sub: string;
+  icon: React.ElementType;
+  href: string;
+  /** Navigation rows are tinted; entity results stay muted. */
+  accent: boolean;
+  /** Position in the flat result list, for keyboard highlighting. */
+  index: number;
+};
 
 export function CommandPalette() {
   const [isOpen, setIsOpen] = useState(false);
@@ -104,26 +153,23 @@ export function CommandPalette() {
     }
   }, [isOpen]);
 
-  const showProjects = mode === 'all' || mode === 'projects';
-  const showTasks = mode === 'all' || mode === 'tasks';
-  const showGoals = mode === 'all' || mode === 'goals';
+  const trimmedQuery = query.trim();
+  const q = trimmedQuery.toLowerCase();
+  const [debouncedQuery] = useDebouncedValue(trimmedQuery, 180);
 
-  const { data: projectsData, isLoading: projectsLoading } = api.project.getAll.useQuery(
-    { workspaceId: workspaceId ?? undefined },
-    { enabled: !!workspaceId && isOpen && showProjects },
+  // One server-side search covering every entity type the app knows about,
+  // scoped to the workspace you are in, each block carrying the same access
+  // rules as that entity's own list endpoint.
+  const { data: searchData, isFetching: searchFetching } = api.search.global.useQuery(
+    { query: debouncedQuery, workspaceId: workspaceId ?? undefined, limit: 5 },
+    {
+      enabled: isOpen && mode !== 'ai' && debouncedQuery.length > 0,
+      // Keep the previous matches on screen while the next query is in flight,
+      // instead of blanking the list on every keystroke.
+      placeholderData: (previous) => previous,
+      staleTime: 30_000,
+    },
   );
-
-  const { data: actionsData, isLoading: actionsLoading } = api.action.getAll.useQuery(
-    { workspaceId: workspaceId ?? undefined },
-    { enabled: !!workspaceId && isOpen && showTasks },
-  );
-
-  const { data: goalsData, isLoading: goalsLoading } = api.goal.getAllMyGoals.useQuery(
-    { workspaceId: workspaceId ?? undefined },
-    { enabled: !!workspaceId && isOpen && showGoals },
-  );
-
-  const q = query.toLowerCase();
 
   // All workspaces the user can navigate to (for workspace-name search).
   const { data: workspacesData } = api.workspace.list.useQuery(undefined, {
@@ -150,103 +196,159 @@ export function CommandPalette() {
     return map;
   }, [workspacesData, pluginResults]);
 
-  const filteredWorkspaceNav = useMemo(() => {
-    if (!q) return [];
-    const results: { label: string; href: string; icon: React.ElementType }[] = [];
+  // Workspace sections split by where they belong in the list: the workspace
+  // you are in sits with the other navigation at the top, every other
+  // workspace goes below the results as somewhere to switch to.
+  const { currentWorkspaceNav, otherWorkspaceNav } = useMemo(() => {
+    const current: { label: string; href: string; icon: React.ElementType }[] = [];
+    const other: { label: string; href: string; icon: React.ElementType }[] = [];
+    if (!q) return { currentWorkspaceNav: current, otherWorkspaceNav: other };
+
     for (const w of workspacesData ?? []) {
       const productEnabled = productEnabledByWorkspaceId.get(w.id) ?? false;
+      const workspaceMatches = w.name.toLowerCase().includes(q);
+      const isCurrent = w.id === workspaceId;
       for (const section of WORKSPACE_SECTIONS) {
         if (section.requiresProduct && !productEnabled) continue;
-        const label = `${w.name} - ${section.label}`;
-        if (!label.toLowerCase().includes(q)) continue;
-        results.push({ label, href: section.href(w.slug), icon: section.icon });
+        if (isCurrent) {
+          // Inside your own workspace you navigate by section name. Matching
+          // its name too would list all nine sections above the results you
+          // actually searched for — and you are already in it.
+          if (PAGE_LABELS.has(section.label.toLowerCase())) continue;
+          if (!section.label.toLowerCase().includes(q)) continue;
+          current.push({ label: section.label, href: section.href(w.slug), icon: section.icon });
+        } else {
+          // Other workspaces are reached by name: "syntrofi" lists that
+          // workspace's sections. Matching on section name here turned a
+          // search for "projects" into one row per workspace you belong to.
+          if (!workspaceMatches) continue;
+          other.push({
+            label: `${w.name} - ${section.label}`,
+            href: section.href(w.slug),
+            icon: section.icon,
+          });
+        }
       }
     }
-    return results.slice(0, 12);
-  }, [q, workspacesData, productEnabledByWorkspaceId]);
-
-  const filteredProjects = useMemo(
-    () =>
-      showProjects
-        ? (projectsData ?? []).filter((p) => !q || p.name.toLowerCase().includes(q)).slice(0, 4)
-        : [],
-    [showProjects, projectsData, q],
-  );
-
-  const filteredActions = useMemo(
-    () =>
-      showTasks
-        ? (actionsData ?? [])
-            .filter((a) => q && stripHtml(a.name).toLowerCase().includes(q))
-            .slice(0, 4)
-        : [],
-    [showTasks, actionsData, q],
-  );
-
-  const filteredGoals = useMemo(
-    () =>
-      showGoals
-        ? (goalsData ?? []).filter((g) => q && g.title.toLowerCase().includes(q)).slice(0, 3)
-        : [],
-    [showGoals, goalsData, q],
-  );
+    return { currentWorkspaceNav: current, otherWorkspaceNav: other.slice(0, 10) };
+  }, [q, workspacesData, productEnabledByWorkspaceId, workspaceId]);
 
   const filteredPages = useMemo(
     () => (workspaceSlug ? PAGES.filter((p) => !q || p.label.toLowerCase().includes(q)) : []),
     [workspaceSlug, q],
   );
 
+  // Results carry the query they were fetched for. While the next search is in
+  // flight we keep the previous ones only if the typed query extends them —
+  // narrowing "fix" to "fixt" holds its results, starting a new word drops
+  // them rather than showing matches for something you are no longer typing.
+  const shownResults = useMemo(() => {
+    if (!searchData) return [];
+    return trimmedQuery.toLowerCase().startsWith(searchData.query.toLowerCase())
+      ? searchData.results
+      : [];
+  }, [searchData, trimmedQuery]);
+
+  const resultsByType = useMemo(() => {
+    const allowed = mode === 'ai' ? null : MODE_TYPES[mode];
+    const byType = new Map<SearchType, SearchResult[]>();
+    for (const result of shownResults) {
+      // Every row in the palette navigates somewhere; entities without a
+      // detail route are dropped rather than rendered as dead ends.
+      if (!result.url) continue;
+      if (allowed && !allowed.includes(result.type)) continue;
+      const bucket = byType.get(result.type);
+      if (bucket) bucket.push(result);
+      else byType.set(result.type, [result]);
+    }
+    return byType;
+  }, [shownResults, mode]);
+
+  // Sections in render order, each row carrying its position in the flat list
+  // so keyboard highlighting and rendering cannot drift apart.
+  const resultSections = useMemo(() => {
+    const sections: { key: string; heading: string; rows: PaletteRow[] }[] = [];
+    let index = 0;
+    const row = (r: Omit<PaletteRow, 'index'>): PaletteRow => ({ ...r, index: index++ });
+
+    const navRows: PaletteRow[] = [
+      ...filteredPages.map((p) =>
+        row({
+          key: `page-${p.path}`,
+          label: p.label,
+          sub: 'Navigate',
+          icon: p.icon,
+          href: `/w/${workspaceSlug}/${p.path}`,
+          accent: true,
+        }),
+      ),
+      ...currentWorkspaceNav.map((w, i) =>
+        row({
+          key: `workspace-nav-${i}`,
+          label: w.label,
+          sub: 'Navigate',
+          icon: w.icon,
+          href: w.href,
+          accent: true,
+        }),
+      ),
+    ];
+    if (navRows.length > 0) {
+      sections.push({ key: 'navigate', heading: 'Navigate', rows: navRows });
+    }
+
+    for (const section of RESULT_SECTIONS) {
+      const items = resultsByType.get(section.type) ?? [];
+      if (items.length === 0) continue;
+      sections.push({
+        key: section.type,
+        heading: section.label,
+        rows: items.map((item) =>
+          row({
+            key: `${section.type}-${item.id}`,
+            label: item.title,
+            sub: item.subtitle ?? section.label,
+            icon: section.icon,
+            href: item.url ?? '',
+            accent: false,
+          }),
+        ),
+      });
+    }
+
+    // Other workspaces go last: matching one by name lists all of its
+    // sections, which would otherwise bury the results you searched for.
+    if (otherWorkspaceNav.length > 0) {
+      sections.push({
+        key: 'other-workspaces',
+        heading: 'Other workspaces',
+        rows: otherWorkspaceNav.map((w, i) =>
+          row({
+            key: `other-workspace-${i}`,
+            label: w.label,
+            sub: 'Workspace',
+            icon: w.icon,
+            href: w.href,
+            accent: true,
+          }),
+        ),
+      });
+    }
+
+    return sections;
+  }, [filteredPages, currentWorkspaceNav, otherWorkspaceNav, resultsByType, workspaceSlug]);
+
   const allResults = useMemo(
-    () => [
-      ...filteredPages.map((p) => ({
-        type: 'page' as const,
-        label: p.label,
-        sub: 'Navigate',
-        icon: p.icon,
-        href: `/w/${workspaceSlug}/${p.path}`,
-      })),
-      ...filteredWorkspaceNav.map((w) => ({
-        type: 'workspace-nav' as const,
-        label: w.label,
-        sub: 'Workspace',
-        icon: w.icon,
-        href: w.href,
-      })),
-      ...filteredProjects.map((p) => ({
-        type: 'project' as const,
-        label: p.name,
-        sub: p.progress > 0 ? `${Math.round(p.progress)}% done` : 'Project',
-        icon: IconStack2,
-        href: `/w/${workspaceSlug}/projects/${p.slug}`,
-      })),
-      ...filteredActions.map((a) => ({
-        type: 'task' as const,
-        label: stripHtml(a.name),
-        sub: 'Task',
-        icon: IconSquareRoundedCheck,
-        href: `/w/${workspaceSlug}/projects-tasks`,
-      })),
-      ...filteredGoals.map((g) => ({
-        type: 'goal' as const,
-        label: g.title,
-        sub: 'Goal',
-        icon: IconTarget,
-        href: `/w/${workspaceSlug}/goals/${g.id}`,
-      })),
-    ],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filteredPages, filteredWorkspaceNav, filteredProjects, filteredActions, filteredGoals, workspaceSlug],
+    () => resultSections.flatMap((section) => section.rows),
+    [resultSections],
   );
 
-  const showNoResults =
-    q.length > 0 &&
-    filteredProjects.length === 0 &&
-    filteredActions.length === 0 &&
-    filteredGoals.length === 0 &&
-    filteredWorkspaceNav.length === 0 &&
-    filteredPages.length === 0;
+  // True from the first keystroke until results for that exact query land, so
+  // a slow search never flashes "No matches".
+  const isSearching = q.length > 0 && (debouncedQuery !== trimmedQuery || searchFetching);
 
-  const isLoading = (showProjects && projectsLoading) || (showTasks && actionsLoading) || (showGoals && goalsLoading);
+  const showSkeleton = isSearching && allResults.length === 0;
+  const showNoResults = q.length > 0 && !isSearching && allResults.length === 0;
 
   const navigate = useCallback(
     (path: string) => {
@@ -287,6 +389,42 @@ export function CommandPalette() {
   useEffect(() => {
     setHighlightedIndex(null);
   }, [query]);
+
+  const renderRow = (row: PaletteRow) => {
+    const Icon = row.icon;
+    return (
+      <UnstyledButton
+        key={row.key}
+        className={styles.resultRow}
+        data-highlighted={highlightedIndex === row.index ? 'true' : 'false'}
+        onClick={() => navigate(row.href)}
+      >
+        <Icon
+          size={14}
+          stroke={1.75}
+          style={{
+            color: row.accent ? 'var(--brand-400)' : 'var(--color-text-muted)',
+            flexShrink: 0,
+          }}
+        />
+        <Text
+          size="sm"
+          style={{
+            flex: 1,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            color: 'var(--color-text-primary)',
+          }}
+        >
+          {row.label}
+        </Text>
+        <Text size="xs" style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}>
+          {row.sub}
+        </Text>
+      </UnstyledButton>
+    );
+  };
 
   return (
     <Modal
@@ -368,8 +506,8 @@ export function CommandPalette() {
         })}
       </Group>
 
-      <div style={{ marginTop: 20 }}>
-        {isLoading ? (
+      <div style={{ marginTop: 20, maxHeight: '52vh', overflowY: 'auto' }}>
+        {showSkeleton ? (
           Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} height={36} mb={4} radius="sm" />
           ))
@@ -447,44 +585,12 @@ export function CommandPalette() {
             })}
           </>
         ) : (
-          allResults.map((result, i) => {
-            const Icon = result.icon;
-            return (
-              <UnstyledButton
-                key={`${result.type}-${i}`}
-                className={styles.resultRow}
-                data-highlighted={highlightedIndex === i ? 'true' : 'false'}
-                onClick={() => navigate(result.href)}
-              >
-                <Icon
-                  size={14}
-                  stroke={1.75}
-                  style={{
-                    color:
-                      result.type === 'page' || result.type === 'workspace-nav'
-                        ? 'var(--brand-400)'
-                        : 'var(--color-text-muted)',
-                    flexShrink: 0,
-                  }}
-                />
-                <Text
-                  size="sm"
-                  style={{
-                    flex: 1,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    color: 'var(--color-text-primary)',
-                  }}
-                >
-                  {result.label}
-                </Text>
-                <Text size="xs" style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}>
-                  {result.sub}
-                </Text>
-              </UnstyledButton>
-            );
-          })
+          resultSections.map((section, i) => (
+            <div key={section.key} style={{ marginTop: i === 0 ? 0 : 14 }}>
+              <div className={styles.colHeading}>{section.heading}</div>
+              {section.rows.map(renderRow)}
+            </div>
+          ))
         )}
       </div>
     </Modal>


### PR DESCRIPTION
### **User description**
## What

- ⌘K now runs one server-side `search.global` query instead of filtering three client-side lists. Coverage goes from projects/actions/goals to twelve entity types: projects, tasks, tickets, goals, key results, outcomes, features, products, pages, meetings, contacts, organizations. Each block keeps the access scoping of its own list endpoint. `epic` and `workspace` results are skipped — epics have no detail route, and workspaces already surface as navigation rows.
- Results are grouped under type headings, capped at 5 per type, and scoped to the workspace you are in.
- Workspace navigation no longer matches `"<Workspace> - <Section>"` as a single string. Your own workspace matches by section name (only the sections the top-level Navigate list doesn't already cover); other workspaces match by workspace name and moved to an "Other workspaces" section below the results.
- 180ms debounce; the previous query's results stay on screen only while you extend that query, so starting a new word shows the skeleton rather than matches for something you're no longer typing.
- Filter chips extended rather than changed: Tasks now covers tickets, Goals covers key results and outcomes.
- Keyboard highlight indices are assigned while building the rendered sections, so arrows and Enter can't drift out of sync with what's on screen.

## Why

`search.global` shipped in #478 for the CLI, SDK and MCP server, but ⌘K itself was never pointed at it — the API had broader coverage than the app UI. Searching "projects" also returned one navigation row per workspace, which is what prompted this.

## Verification

Manual, against the seeded `dev-fixture` workspace on a local dev server:

- `ticket` → 5 tickets + 1 feature (nothing ⌘K could find before)
- `fixture` → project, goal, feature, product, with "Other workspaces" last
- `projects` → one row (was 4, three of them per-workspace duplicates)
- ↓↓↓ + Enter → feature detail page; clicking a ticket row → ticket detail page
- Tasks chip + `ticket` → tickets only, feature excluded

`npm run typecheck`, `npm run test` (2,120 unit tests), and `npm run lint` all pass.


___

### **PR Type**
Enhancement


___

### **Description**
- Command palette now queries server-side `search.global`

- Coverage expands to twelve entity types, grouped sections

- Workspace nav split: current sections vs other workspaces

- Debounce, 2-char minimum, skeleton/no-match and scroll-into-view fixes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  input["⌘K query (debounced 180ms, min 2 chars)"]
  old["client-side filtering of project.getAll / action.getAll / goal.getAllMyGoals"]
  new["api.search.global (workspaceId, limit 5)"]
  modes["MODE_TYPES chips filter"]
  sections["RESULT_SECTIONS grouped rows + nav rows"]
  nav["currentWorkspaceNav / otherWorkspaceNav"]
  kb["indexed rows: arrow keys, Enter, scrollIntoView"]
  input -- "replaces" --> old
  input --> new
  new --> modes
  modes --> sections
  nav --> sections
  sections --> kb
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.tsx</strong><dd><code>Server-side global search powers the ⌘K palette</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/layout/CommandPalette.tsx

<ul><li>Replaces three client-side <code>getAll</code> queries and their local filtering <br>with a single <code>api.search.global</code> query, scoped to the current workspace <br>with <code>limit: 5</code>, debounced 180ms and gated behind a 2-character minimum.<br> <li> Adds <code>RESULT_SECTIONS</code> (12 entity types, excluding <code>workspace</code> and <code>epic</code>) <br>and <code>MODE_TYPES</code> so filter chips now map Tasks→actions/tickets, <br>Projects→projects/products, Goals→goals/key results/outcomes; results <br>without a <code>url</code> are dropped.<br> <li> Rebuilds row construction into <code>PaletteRow</code> objects with an explicit <br>flat <code>index</code>, keeping keyboard highlighting in sync with rendered <br>sections; adds <code>scrollIntoView</code> for the highlighted row, resets <br>highlight on mode change, and extracts a shared <code>renderRow</code> renderer.<br> <li> Reworks workspace navigation: current workspace matches by section <br>name (excluding labels already in <code>PAGES</code>), other workspaces match by <br>workspace name and render last under "Other workspaces"; results from <br>other workspaces show the workspace name as subtitle.<br> <li> Adjusts loading/empty states: skeleton only while an actual search is <br>in flight, "No matches" held until results land, and a "Keep typing to <br>search…" hint below the minimum length; results list becomes a scroll <br>container (<code>maxHeight: 52vh</code>).</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/503/files#diff-0013838800caad36867dc467a14704c56996820c63a945eca5fdc33a7d4dfb45">+294/-142</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

