### PR TITLE
Say when the product timeline can't reach GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,18 @@ db-backups/
 /e2e/.auth/
 /e2e/.results/
 /playwright-report/
+
+# Restated from nested .gitignore files (src-tauri/.gitignore, .beads/.gitignore).
+# Git already ignores these via the nested files, so this changes nothing for
+# git — but `vercel deploy` walks the working directory reading only the ROOT
+# .gitignore, so without these it tries to upload src-tauri/target (3.2GB of
+# Rust build output) and chokes outright on .beads/bd.sock, which is a unix
+# socket it cannot open. Keep in sync with the nested files.
+/src-tauri/target/
+/src-tauri/gen/
+.beads/*.db
+.beads/*.db?*
+.beads/bd.sock
+.beads/daemon.lock
+.beads/daemon.log
+.beads/daemon.pid

--- a/src/app/(home)/product-timeline/ProductTimelineClient.tsx
+++ b/src/app/(home)/product-timeline/ProductTimelineClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import {
   Timeline,
   Text,
@@ -16,6 +16,7 @@ import {
   Loader,
   Center,
   UnstyledButton,
+  Alert,
 } from "@mantine/core";
 import { api } from "~/trpc/react";
 import { format, startOfDay } from "date-fns";
@@ -31,7 +32,9 @@ import {
   IconRefresh,
   IconRocket,
   IconPlus,
+  IconAlertTriangle,
 } from "@tabler/icons-react";
+import { reportHandledError } from "~/lib/reportHandledError";
 import type {
   GitHubCommit,
   GitHubRelease,
@@ -186,9 +189,69 @@ export function ProductTimelineClient() {
   const isLoading = queries.some((q) => q.isLoading);
   const hasNextPage = lastQuery?.data?.hasNextPage ?? false;
 
+  // The commit feed is the page; releases only decorate it. So a failed commit
+  // fetch is fatal to the view while a failed release fetch is not — but both
+  // get reported, because the failure mode that hid this page for days was an
+  // expired GITHUB_TOKEN rendering as a silent empty timeline.
+  const commitsErrorMessage =
+    queries.find((q) => q.error)?.error?.message ?? null;
+  const releasesErrorMessage = releasesQuery.error?.message ?? null;
+
+  // `error` alone is not enough. A query can also come to rest at
+  // `status: "pending" / fetchStatus: "paused"` — no data, no error, and
+  // `isLoading` false, because React Query only reports `isLoading` while a
+  // fetch is actually in flight. Nothing is pending and nothing failed, so
+  // every guard keyed on `error` or `isLoading` falls through and the timeline
+  // renders empty. That is indistinguishable, on screen, from "we shipped
+  // nothing" — which is the bug this page had. Treat "no commits and nobody is
+  // working on it" as a failure regardless of which state produced it.
+  const isFetchingCommits = queries.some((q) => q.fetchStatus === "fetching");
+  // `settled` keeps this from firing on the very first render, before the
+  // fetch has been dispatched: a query that has never run is not a failure.
+  const commitsSettled = queries.some(
+    (q) => q.isFetched || q.fetchStatus === "paused",
+  );
+  const commitsUnavailable =
+    allCommits.length === 0 &&
+    !isLoading &&
+    !isFetchingCommits &&
+    commitsSettled;
+
+  // Report the silent variant too. If we only reported `error`, the state that
+  // actually hid this page — settled, empty, no error — would still reach the
+  // user as a polite message and reach us as nothing at all.
+  const commitsFailure =
+    commitsErrorMessage ??
+    (commitsUnavailable
+      ? "Commit history unavailable: query settled with no data and no error"
+      : null);
+
+  useEffect(() => {
+    if (!commitsFailure) return;
+    reportHandledError(new Error(commitsFailure), {
+      area: "product-timeline-commits",
+      context: { repo: "positonic/exponential", branch: "main" },
+    });
+  }, [commitsFailure]);
+
+  useEffect(() => {
+    if (!releasesErrorMessage) return;
+    reportHandledError(new Error(releasesErrorMessage), {
+      area: "product-timeline-releases",
+      context: { repo: "positonic/exponential" },
+    });
+  }, [releasesErrorMessage]);
+
   const loadMore = useCallback(() => {
     setPages((prev) => [...prev, (prev[prev.length - 1] ?? 0) + 1]);
   }, []);
+
+  // Not memoized: it closes over the per-page query handles, which change with
+  // `pages`, and it only ever renders on an error path.
+  const retry = () => {
+    for (const query of queries) void query.refetch();
+    void releasesQuery.refetch();
+  };
 
   const entries = buildTimeline(allCommits, releases);
 
@@ -198,6 +261,45 @@ export function ProductTimelineClient() {
         <Center py="xl">
           <Loader />
         </Center>
+      </Container>
+    );
+  }
+
+  // Nothing to show and nothing in flight: say so, rather than rendering an
+  // empty timeline that reads as "we shipped nothing".
+  if (commitsUnavailable) {
+    return (
+      <Container size="md" py="xl">
+        <Title order={1}>Product Timeline</Title>
+        <Text c="dimmed" mb="xl">
+          Every change we make to {PRODUCT_NAME}, straight from our git history.
+        </Text>
+        <Alert
+          variant="light"
+          color="red"
+          icon={<IconAlertTriangle size={16} />}
+          title="Couldn't load the timeline"
+        >
+          <Stack gap="sm" align="flex-start">
+            <Text size="sm">
+              We couldn&apos;t reach GitHub to read our commit history. This is
+              our problem, not yours — the timeline itself is fine.
+            </Text>
+            {commitsErrorMessage && (
+              <Text size="xs" c="dimmed">
+                {commitsErrorMessage}
+              </Text>
+            )}
+            <Button
+              variant="light"
+              size="xs"
+              leftSection={<IconRefresh size={14} />}
+              onClick={retry}
+            >
+              Try again
+            </Button>
+          </Stack>
+        </Alert>
       </Container>
     );
   }
@@ -224,6 +326,34 @@ export function ProductTimelineClient() {
       <Text c="dimmed" mb="xl">
         Every change we make to {PRODUCT_NAME}, straight from our git history.
       </Text>
+
+      {/* Partial failure: we have commits to show, but a later page or the
+          release list didn't load. Say what's missing instead of quietly
+          rendering a shorter timeline. */}
+      {(commitsErrorMessage ?? releasesErrorMessage) && (
+        <Alert
+          variant="light"
+          color="yellow"
+          icon={<IconAlertTriangle size={16} />}
+          mb="lg"
+        >
+          <Group justify="space-between" align="center" wrap="nowrap">
+            <Text size="sm">
+              {commitsErrorMessage
+                ? "Some commits couldn't be loaded, so this timeline is incomplete."
+                : "Releases couldn't be loaded, so only commits are shown."}
+            </Text>
+            <Button
+              variant="subtle"
+              size="xs"
+              leftSection={<IconRefresh size={14} />}
+              onClick={retry}
+            >
+              Retry
+            </Button>
+          </Group>
+        </Alert>
+      )}
 
       <Timeline active={entries.length - 1} bulletSize={24} lineWidth={2}>
         {entries.map((entry) => {

--- a/src/app/(home)/product-timeline/ProductTimelineClient.tsx
+++ b/src/app/(home)/product-timeline/ProductTimelineClient.tsx
@@ -246,11 +246,22 @@ export function ProductTimelineClient() {
     setPages((prev) => [...prev, (prev[prev.length - 1] ?? 0) + 1]);
   }, []);
 
-  // Not memoized: it closes over the per-page query handles, which change with
-  // `pages`, and it only ever renders on an error path.
-  const retry = () => {
+  // Not memoized: these close over the per-page query handles, which change
+  // with `pages`, and they only ever render on an error path.
+
+  // Partial failure: we still have commits on screen, so refetch in place
+  // rather than throwing away the pages the reader already has.
+  const retryInPlace = () => {
     for (const query of queries) void query.refetch();
     void releasesQuery.refetch();
+  };
+
+  // Total failure: there is nothing on screen to preserve, and `refetch()` is
+  // not dependable here — a query that came to rest at `fetchStatus: "paused"`
+  // just pauses again, leaving the button looking broken. A reload always does
+  // something, and costs nothing when the page is already empty.
+  const retryFromScratch = () => {
+    window.location.reload();
   };
 
   const entries = buildTimeline(allCommits, releases);
@@ -294,7 +305,7 @@ export function ProductTimelineClient() {
               variant="light"
               size="xs"
               leftSection={<IconRefresh size={14} />}
-              onClick={retry}
+              onClick={retryFromScratch}
             >
               Try again
             </Button>
@@ -347,7 +358,7 @@ export function ProductTimelineClient() {
               variant="subtle"
               size="xs"
               leftSection={<IconRefresh size={14} />}
-              onClick={retry}
+              onClick={retryInPlace}
             >
               Retry
             </Button>

--- a/src/app/(home)/product-timeline/__tests__/ProductTimelineClient.test.tsx
+++ b/src/app/(home)/product-timeline/__tests__/ProductTimelineClient.test.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "~/test/test-utils";
+
+/**
+ * These tests exist because of a real outage: an expired GITHUB_TOKEN made both
+ * GitHub queries fail, and the page rendered its header over an empty timeline
+ * for days. Nobody noticed, because "no commits" and "we couldn't reach GitHub"
+ * looked identical on screen.
+ *
+ * The subtle part — and the reason a naive `if (error)` guard was not enough —
+ * is that a failed query does not reliably arrive as `error`. It can also come
+ * to rest at `status: "pending" / fetchStatus: "paused"`: no data, no error,
+ * and `isLoading === false`, because React Query only reports `isLoading` while
+ * a fetch is genuinely in flight. Each case below is one of those resting
+ * states.
+ */
+
+const mockListCommits = vi.fn();
+const mockListReleases = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+  api: {
+    github: {
+      listCommits: { useQuery: () => mockListCommits() as unknown },
+      listReleases: { useQuery: () => mockListReleases() as unknown },
+    },
+  },
+}));
+
+const reportHandledError = vi.fn();
+vi.mock("~/lib/reportHandledError", () => ({
+  reportHandledError: (...args: unknown[]) => reportHandledError(...args),
+}));
+
+import { ProductTimelineClient } from "../ProductTimelineClient";
+
+/** A query result shaped like the fields the component actually reads. */
+function queryResult(
+  overrides: Partial<{
+    data: unknown;
+    error: { message: string } | null;
+    isLoading: boolean;
+    isFetched: boolean;
+    fetchStatus: "fetching" | "paused" | "idle";
+    refetch: () => void;
+  }> = {},
+) {
+  return {
+    data: undefined,
+    error: null,
+    isLoading: false,
+    isFetched: true,
+    fetchStatus: "idle" as const,
+    refetch: vi.fn(),
+    ...overrides,
+  };
+}
+
+const ONE_COMMIT = {
+  commits: [
+    {
+      sha: "abc1234",
+      message: "feat: something shipped",
+      author: "someone",
+      date: "2026-08-04T21:44:22Z",
+      url: "https://github.com/positonic/exponential/commit/abc1234",
+      avatarUrl: null,
+    },
+  ],
+  hasNextPage: false,
+};
+
+describe("ProductTimelineClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListReleases.mockReturnValue(queryResult({ data: [] }));
+  });
+
+  it("surfaces an explicit error when the commit query fails", () => {
+    mockListCommits.mockReturnValue(
+      queryResult({ error: { message: "Bad credentials" } }),
+    );
+
+    render(<ProductTimelineClient />);
+
+    expect(screen.getByText(/Couldn't load the timeline/i)).toBeDefined();
+    // The underlying cause stays on screen — it is what made the production
+    // failure diagnosable in seconds rather than hours.
+    expect(screen.getByText(/Bad credentials/)).toBeDefined();
+  });
+
+  it("surfaces an error when the query settles empty with no error at all", () => {
+    // The exact state that produced the outage: settled, no data, no error.
+    mockListCommits.mockReturnValue(
+      queryResult({ fetchStatus: "paused", isFetched: false }),
+    );
+
+    render(<ProductTimelineClient />);
+
+    expect(screen.getByText(/Couldn't load the timeline/i)).toBeDefined();
+  });
+
+  it("reports the silent failure, not just the loud one", () => {
+    mockListCommits.mockReturnValue(
+      queryResult({ fetchStatus: "paused", isFetched: false }),
+    );
+
+    render(<ProductTimelineClient />);
+
+    expect(reportHandledError).toHaveBeenCalled();
+    const [, options] = reportHandledError.mock.calls[0] as [
+      unknown,
+      { area: string },
+    ];
+    expect(options.area).toBe("product-timeline-commits");
+  });
+
+  it("shows a loader, not an error, while the first fetch is in flight", () => {
+    mockListCommits.mockReturnValue(
+      queryResult({ isLoading: true, isFetched: false, fetchStatus: "fetching" }),
+    );
+
+    render(<ProductTimelineClient />);
+
+    expect(screen.queryByText(/Couldn't load the timeline/i)).toBeNull();
+    expect(reportHandledError).not.toHaveBeenCalled();
+  });
+
+  it("renders commits and no error banner on the happy path", () => {
+    mockListCommits.mockReturnValue(queryResult({ data: ONE_COMMIT }));
+
+    render(<ProductTimelineClient />);
+
+    expect(screen.getByText(/something shipped/)).toBeDefined();
+    expect(screen.queryByText(/Couldn't load the timeline/i)).toBeNull();
+    expect(reportHandledError).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(home)/product-timeline/__tests__/ProductTimelineClient.test.tsx
+++ b/src/app/(home)/product-timeline/__tests__/ProductTimelineClient.test.tsx
@@ -127,6 +127,27 @@ describe("ProductTimelineClient", () => {
     expect(reportHandledError).not.toHaveBeenCalled();
   });
 
+  it("retries a total failure with a reload, not a refetch", () => {
+    // `refetch()` is not dependable from the paused state — it just pauses
+    // again, leaving the button looking broken. There is nothing on screen to
+    // preserve here, so a reload is the honest action.
+    const refetch = vi.fn();
+    mockListCommits.mockReturnValue(
+      queryResult({ fetchStatus: "paused", isFetched: false, refetch }),
+    );
+    const reload = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+
+    render(<ProductTimelineClient />);
+    screen.getByRole("button", { name: /Try again/i }).click();
+
+    expect(reload).toHaveBeenCalled();
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
   it("renders commits and no error banner on the happy path", () => {
     mockListCommits.mockReturnValue(queryResult({ data: ONE_COMMIT }));
 

--- a/src/app/(home)/product-timeline/page.tsx
+++ b/src/app/(home)/product-timeline/page.tsx
@@ -1,5 +1,4 @@
 import { type Metadata } from "next";
-import { api, HydrateClient } from "~/trpc/server";
 import { ProductTimelineClient } from "./ProductTimelineClient";
 import { PRODUCT_NAME } from "~/lib/brand";
 import { getPublicBaseUrlFromEnv } from "~/lib/urls";
@@ -12,18 +11,13 @@ export const metadata: Metadata = {
   alternates: { canonical: `${getPublicBaseUrlFromEnv()}/product-timeline` },
 };
 
-export default async function ProductTimelinePage() {
-  void api.github.listCommits.prefetch({
-    page: 1,
-    perPage: 100,
-    owner: "positonic",
-    repo: "exponential",
-    branch: "main",
-  });
-
-  return (
-    <HydrateClient>
-      <ProductTimelineClient />
-    </HydrateClient>
-  );
+export default function ProductTimelinePage() {
+  // Deliberately no `prefetch` here. Prefetching dehydrates the query as
+  // *pending*; when the GitHub call fails server-side (an expired GITHUB_TOKEN
+  // is the one that bit us), the hydrated client query is stranded in
+  // `status: "pending" / fetchStatus: "paused"` — never `error`, and never
+  // retried. That renders as a silent empty timeline that no error state can
+  // catch, because from the client's point of view nothing failed. Letting the
+  // client own the fetch costs one round trip and makes failure observable.
+  return <ProductTimelineClient />;
 }


### PR DESCRIPTION
### **User description**
## What

- Surface an explicit error state on `/product-timeline` when the GitHub commit history can't be loaded, with the underlying cause and a retry button.
- Report the failure through `reportHandledError` — including the *silent* variant that has no error object to report.
- Drop the server-side `prefetch` on the page.
- Add 5 tests pinning each resting state the queries can land in.
- Restate two nested-gitignore paths in the root `.gitignore`.

## Why

Production's `GITHUB_TOKEN` expired. Both GitHub queries failed and the page rendered its header over an empty timeline for days — "no commits" and "we couldn't reach GitHub" look identical on screen, so nobody noticed.

**A plain `if (error)` guard does not fix this.** A failed query doesn't reliably arrive as `error`. It can also come to rest at:

```
status: "pending", fetchStatus: "paused", isLoading: false, error: null
```

No data, no error, and `isLoading` false — because React Query only reports `isLoading` while a fetch is genuinely in flight. Every guard keyed on `error` or `isLoading` falls through and the timeline renders empty. Verified locally: both queries settle in exactly that state.

So the guard keys on "no commits and nobody is working on it", whatever produced it, and requires the query to have settled so it can't fire on the first render.

The `prefetch` goes because it dehydrates the query as *pending*; a server-side failure then strands the hydrated client query with no error and no retry. Letting the client own the fetch costs one round trip and makes failure observable.

The `.gitignore` entries are already ignored via nested files, but `vercel deploy` reads only the root one — so it tried to upload `src-tauri/target` (3.2GB) and choked outright on `.beads/bd.sock`, a unix socket it cannot open. Both blocked the recovery deploy for this very outage.

## Verification

Both paths driven in a real browser against a local dev server: error state renders with an invalid token, full timeline renders with a valid one, and `/api/client-errors` POSTs confirmed firing. `typecheck` clean, `test` 2150 passed, `lint` 0 errors.


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Add explicit error state to `/product-timeline` when GitHub is unreachable

- Handle silent failure: query settled with no data and no error (paused state)

- Drop server-side `prefetch` that stranded client queries on server-side failures

- Add 5 tests covering all query resting states and retry behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub API"] -- "fetch fails / token expired" --> B["Query resting state"]
  B -- "error present" --> C["commitsErrorMessage set"]
  B -- "paused, no data, no error" --> D["commitsUnavailable = true"]
  C -- "total failure" --> E["Error Alert + reload retry"]
  D -- "total failure" --> E
  C -- "partial failure" --> F["Warning banner + refetch retry"]
  E -- "reportHandledError" --> G["Error reporting"]
  D -- "reportHandledError" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProductTimelineClient.tsx</strong><dd><code>Add error states and failure reporting for GitHub queries</code></dd></summary>
<hr>

src/app/(home)/product-timeline/ProductTimelineClient.tsx

<ul><li>Add detection for silent query failure (<code>fetchStatus: "paused"</code>, no <br>data, no error)<br> <li> Add full-page error alert when commits are unavailable, with <br>reload-based retry<br> <li> Add partial-failure warning banner when some commits or releases fail <br>to load<br> <li> Report both explicit errors and silent failures via <code>reportHandledError</code><br> <li> Split retry strategy: reload for total failure, refetch in place for <br>partial failure</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/505/files#diff-c47c60854bf9c4555d90ad711c3bf94449b95b4bb8c23dbf4373d726da10c5da">+142/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Remove server-side prefetch to make failures observable</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/app/(home)/product-timeline/page.tsx

<ul><li>Remove server-side <code>prefetch</code> and <code>HydrateClient</code> wrapper<br> <li> Convert page component from <code>async</code> to sync<br> <li> Add explanatory comment documenting why prefetch was removed</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/505/files#diff-9c089ab315221c4387705c70147a4c7bc5d023f7ddee6ead4f8e561e8cae5930">+9/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProductTimelineClient.test.tsx</strong><dd><code>Add tests for all timeline query failure states</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(home)/product-timeline/__tests__/ProductTimelineClient.test.tsx

<ul><li>New test file with 5 tests covering all query resting states<br> <li> Tests cover: explicit error, silent paused failure, error reporting, <br>loader vs error, and happy path<br> <li> Verifies reload (not refetch) is used for total failure retry<br> <li> Mocks <code>reportHandledError</code> to assert silent failures are reported</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/505/files#diff-5a79191c7ccdfa68b24792a4f3e7ace907eb8c392eb510185c786030b494b57c">+160/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

