### PR TITLE
fix(settings): stop the agent-key modal from scrolling

### DIFF
--- a/src/app/(sidemenu)/settings/agents/page.tsx
+++ b/src/app/(sidemenu)/settings/agents/page.tsx
@@ -239,44 +239,48 @@ export default function ExternalAgentsPage() {
               </Button>
             </Group>
             {agent.keys.length > 0 && (
-              <Table>
-                <Table.Thead>
-                  <Table.Tr>
-                    <Table.Th>Label</Table.Th>
-                    <Table.Th>Key</Table.Th>
-                    <Table.Th>Last used</Table.Th>
-                    <Table.Th>Expires</Table.Th>
-                    <Table.Th />
-                  </Table.Tr>
-                </Table.Thead>
-                <Table.Tbody>
-                  {agent.keys.map((key) => (
-                    <Table.Tr key={key.id}>
-                      <Table.Td>{key.name}</Table.Td>
-                      <Table.Td>
-                        <Code>{key.keyPrefix}</Code>
-                      </Table.Td>
-                      <Table.Td>
-                        {key.lastUsedAt ? new Date(key.lastUsedAt).toLocaleString() : 'never'}
-                      </Table.Td>
-                      <Table.Td>
-                        {key.expiresAt ? new Date(key.expiresAt).toLocaleDateString() : '—'}
-                      </Table.Td>
-                      <Table.Td>
-                        <Tooltip label="Revoke — takes effect on the agent's next request">
-                          <ActionIcon
-                            variant="subtle"
-                            color="red"
-                            onClick={() => revokeKey.mutate({ agentId: agent.id, keyId: key.id })}
-                          >
-                            <IconTrash size={14} />
-                          </ActionIcon>
-                        </Tooltip>
-                      </Table.Td>
+              /* Without a scroll container the table overflows the page on narrow
+                 viewports, which inflates 100vw and pushes modals off-screen. */
+              <Table.ScrollContainer minWidth={480}>
+                <Table>
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th>Label</Table.Th>
+                      <Table.Th>Key</Table.Th>
+                      <Table.Th>Last used</Table.Th>
+                      <Table.Th>Expires</Table.Th>
+                      <Table.Th />
                     </Table.Tr>
-                  ))}
-                </Table.Tbody>
-              </Table>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {agent.keys.map((key) => (
+                      <Table.Tr key={key.id}>
+                        <Table.Td>{key.name}</Table.Td>
+                        <Table.Td>
+                          <Code>{key.keyPrefix}</Code>
+                        </Table.Td>
+                        <Table.Td>
+                          {key.lastUsedAt ? new Date(key.lastUsedAt).toLocaleString() : 'never'}
+                        </Table.Td>
+                        <Table.Td>
+                          {key.expiresAt ? new Date(key.expiresAt).toLocaleDateString() : '—'}
+                        </Table.Td>
+                        <Table.Td>
+                          <Tooltip label="Revoke — takes effect on the agent's next request">
+                            <ActionIcon
+                              variant="subtle"
+                              color="red"
+                              onClick={() => revokeKey.mutate({ agentId: agent.id, keyId: key.id })}
+                            >
+                              <IconTrash size={14} />
+                            </ActionIcon>
+                          </Tooltip>
+                        </Table.Td>
+                      </Table.Tr>
+                    ))}
+                  </Table.Tbody>
+                </Table>
+              </Table.ScrollContainer>
             )}
           </Stack>
         </Paper>
@@ -313,6 +317,7 @@ export default function ExternalAgentsPage() {
       <Modal
         opened={keyModalAgentId !== null}
         onClose={closeKeyModal}
+        size={generatedSecret ? 'lg' : 'md'}
         title={generatedSecret ? 'Copy your key now' : 'New agent key'}
       >
         {generatedSecret ? (
@@ -321,8 +326,19 @@ export default function ExternalAgentsPage() {
               This is the only time the key is shown. Store it in your agent&apos;s
               configuration — if you lose it, revoke it and create a new one.
             </Alert>
-            <Group wrap="nowrap" gap="xs">
-              <Code block style={{ flex: 1, wordBreak: 'break-all' }}>
+            <Group wrap="nowrap" align="flex-start" gap="xs">
+              {/* The key is a single unbroken token: without pre-wrap the <pre>
+                  keeps it on one line and grows its own scrollbar. */}
+              <Code
+                block
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  whiteSpace: 'pre-wrap',
+                  overflowWrap: 'anywhere',
+                  overflowX: 'hidden',
+                }}
+              >
                 {generatedSecret}
               </Code>
               <CopyButton value={generatedSecret}>


### PR DESCRIPTION
### **User description**
The "Copy your key now" modal was cramped and grew scrollbars, clipping the one value the user has to read in full.

### What was wrong

**The key block.** The display-once key is a single unbroken token, so the existing `wordBreak: 'break-all'` never applied — Mantine's `Code block` renders a `<pre>` with `white-space: pre`, which keeps the token on one line and gives the block its own horizontal scrollbar. Switched to `white-space: pre-wrap` + `overflow-wrap: anywhere` so it wraps, and widened the modal to `lg` while the secret is showing.

**The keys table, one level up.** Unwrapped, it overflowed the page on narrow viewports. That inflates `100vw` — which is what Mantine sizes modals against — so the modal itself rendered wider than the visible viewport and its copy button fell off-screen. Wrapped it in `Table.ScrollContainer` so the table scrolls inside its own box.

### Verification

Ran the real page against a seeded dev session and minted a key at both sizes.

Desktop (1280×720), measured on the live `<pre>`:
```
scrollW 550, clientW 550  → hOverflow false
scrollH 39,  clientH 39   → vOverflow false
whiteSpace "pre-wrap", modal 620px
```

Mobile (375×812) — the key wraps to two lines, modal fits the viewport, copy button visible:
```
keyHOverflow false, keyVOverflow false
modalW 338, modalRight 356, viewportW 375, copyBtnRight 340
pageHOverflow false   (was true before the table fix)
```

Pre-commit ran the full unit suite: 214 files, 2145 tests passing. `tsc --noEmit` and ESLint clean on the changed file.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix agent key modal scrolling and overflow issues

- Wrap keys table in `Table.ScrollContainer` to prevent page overflow on narrow viewports

- Fix `Code block` key display with `pre-wrap` and `overflow-wrap: anywhere` to prevent horizontal scrollbar

- Widen modal to `lg` size when displaying the generated secret


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Keys Table (narrow viewport)"] -- "wrapped in" --> B["Table.ScrollContainer minWidth=480"]
  B -- "prevents" --> C["Page horizontal overflow"]
  C -- "was inflating" --> D["100vw → modal off-screen"]
  E["Code block (pre element)"] -- "white-space: pre-wrap\noverflow-wrap: anywhere" --> F["Key wraps correctly"]
  G["Key Modal"] -- "size=lg when secret shown" --> H["More space for key display"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Fix key modal scrolling and table overflow on narrow viewports</code></dd></summary>
<hr>

src/app/(sidemenu)/settings/agents/page.tsx

<ul><li>Wrapped the agent keys table in <code>Table.ScrollContainer</code> with <br><code>minWidth={480}</code> to prevent page overflow on narrow viewports<br> <li> Updated <code>Code block</code> styles: replaced <code>wordBreak: 'break-all'</code> with <br><code>whiteSpace: 'pre-wrap'</code>, <code>overflowWrap: 'anywhere'</code>, <code>overflowX: 'hidden'</code>, <br>and <code>minWidth: 0</code> to properly wrap the key token<br> <li> Added <code>size={generatedSecret ? 'lg' : 'md'}</code> to the key modal so it <br>widens when displaying the generated secret<br> <li> Added <code>align="flex-start"</code> to the <code>Group</code> wrapping the key display to fix <br>alignment with the copy button</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/506/files#diff-3286ab3f3a73e58efed3c720f43a6bf9554c520e2637bb0aeab65e9709ba92e4">+55/-39</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

