### PR TITLE
fix: Rail blocks use the task's real length, not a 60-minute default

### DIFF
--- a/src/app/_components/actions/TodayLayout.tsx
+++ b/src/app/_components/actions/TodayLayout.tsx
@@ -9,11 +9,12 @@ import { useActionDeepLink } from "~/hooks/useActionDeepLink";
 import { useDetailedActionsEnabled } from "~/hooks/useDetailedActionsEnabled";
 import { useDayRollover } from "~/hooks/useDayRollover";
 import { addDays, hourFloat } from "~/lib/actions/dates";
+import { buildRailBlocks, type RailBlock } from "~/lib/actions/railBlocks";
 import type { Action } from "~/lib/actions/types";
 import { CreateActionModal } from "../CreateActionModal";
 import { MobileFAB } from "../today-mobile/MobileFAB";
 import { ActionsList } from "./ActionsList";
-import { TimelineRail, type RailBlock } from "./components/TimelineRail";
+import { TimelineRail } from "./components/TimelineRail";
 import { ZoePanel } from "./components/ZoePanel";
 import { useActionMutations } from "./hooks/useActionMutations";
 import { useBulkActionMutations } from "./hooks/useBulkActionMutations";
@@ -118,38 +119,14 @@ export function TodayLayout({ tagIds }: TodayLayoutProps) {
   void suggestionProposalByActionId;
 
   // Rail blocks (calendar events + scheduled actions)
-  const railBlocks: RailBlock[] = useMemo(() => {
-    const blocks: RailBlock[] = [];
-    for (const ev of calendarEventsQuery.data ?? []) {
-      const startStr = ev.start?.dateTime ?? ev.start?.date;
-      const endStr = ev.end?.dateTime ?? ev.end?.date;
-      if (!startStr || !endStr) continue;
-      const s = new Date(startStr);
-      const e = new Date(endStr);
-      blocks.push({
-        id: ev.id,
-        title: ev.summary || "Untitled",
-        start: hourFloat(s),
-        end: hourFloat(e),
-        kind: "cal",
-      });
-    }
-    for (const a of partition.todays) {
-      if (!a.scheduledStart) continue;
-      const s = new Date(a.scheduledStart);
-      const durationMinutes =
-        (a as ActionData & { duration?: number | null }).duration ?? 60;
-      const e = new Date(s.getTime() + durationMinutes * 60_000);
-      blocks.push({
-        id: `act-${a.id}`,
-        title: a.name,
-        start: hourFloat(s),
-        end: hourFloat(e),
-        kind: "task",
-      });
-    }
-    return blocks;
-  }, [calendarEventsQuery.data, partition.todays]);
+  const railBlocks: RailBlock[] = useMemo(
+    () =>
+      buildRailBlocks({
+        events: calendarEventsQuery.data,
+        actions: partition.todays,
+      }),
+    [calendarEventsQuery.data, partition.todays],
+  );
 
   const eventsCount = (calendarEventsQuery.data ?? []).length;
   const focusCount = railBlocks.filter((b) => b.kind === "focus").length;

--- a/src/app/_components/actions/components/TimelineRail.tsx
+++ b/src/app/_components/actions/components/TimelineRail.tsx
@@ -1,13 +1,8 @@
 import { formatHourLabel, formatHourMinute12 } from "~/lib/actions/dates";
+import type { RailBlock } from "~/lib/actions/railBlocks";
 import styles from "./TimelineRail.module.css";
 
-export interface RailBlock {
-  id: string;
-  title: string;
-  start: number;
-  end: number;
-  kind: "cal" | "task" | "focus";
-}
+export type { RailBlock };
 
 interface TimelineRailProps {
   dayLabel: string;

--- a/src/app/_components/today-redesign/AgendaRail.tsx
+++ b/src/app/_components/today-redesign/AgendaRail.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { RailBlock } from "../actions/components/TimelineRail";
+import type { RailBlock } from "~/lib/actions/railBlocks";
 import { formatHourLabel, formatHourMinute12 } from "~/lib/actions/dates";
 import { stripHtml } from "~/lib/utils";
 

--- a/src/app/_components/today-redesign/TodayDesktopShell.tsx
+++ b/src/app/_components/today-redesign/TodayDesktopShell.tsx
@@ -28,7 +28,7 @@ import { useActionMutations } from "../actions/hooks/useActionMutations";
 import { useActionPartition } from "../actions/hooks/useActionPartition";
 import { useBulkActionMutations } from "../actions/hooks/useBulkActionMutations";
 import { useBulkSelection } from "../actions/hooks/useBulkSelection";
-import type { RailBlock } from "../actions/components/TimelineRail";
+import { buildRailBlocks, type RailBlock } from "~/lib/actions/railBlocks";
 import { ScoreRing } from "./ScoreRing";
 import { AgendaRail } from "./AgendaRail";
 import { TaskRow } from "./TaskRow";
@@ -211,35 +211,14 @@ export function TodayDesktopShell({
   }, [actionIdFromUrl, filteredActions]);
 
   // ---- Rail blocks ---------------------------------------------------------
-  const railBlocks: RailBlock[] = useMemo(() => {
-    const blocks: RailBlock[] = [];
-    for (const ev of calendarEventsQuery.data ?? []) {
-      const startStr = ev.start?.dateTime ?? ev.start?.date;
-      const endStr = ev.end?.dateTime ?? ev.end?.date;
-      if (!startStr || !endStr) continue;
-      blocks.push({
-        id: ev.id,
-        title: ev.summary || "Untitled",
-        start: hourFloat(new Date(startStr)),
-        end: hourFloat(new Date(endStr)),
-        kind: "cal",
-      });
-    }
-    for (const a of partition.todays) {
-      if (!a.scheduledStart) continue;
-      const s = new Date(a.scheduledStart);
-      const durationMinutes =
-        (a as ActionData & { duration?: number | null }).duration ?? 60;
-      blocks.push({
-        id: `act-${a.id}`,
-        title: a.name,
-        start: hourFloat(s),
-        end: hourFloat(new Date(s.getTime() + durationMinutes * 60_000)),
-        kind: "task",
-      });
-    }
-    return blocks;
-  }, [calendarEventsQuery.data, partition.todays]);
+  const railBlocks: RailBlock[] = useMemo(
+    () =>
+      buildRailBlocks({
+        events: calendarEventsQuery.data,
+        actions: partition.todays,
+      }),
+    [calendarEventsQuery.data, partition.todays],
+  );
 
   // ---- Day label -----------------------------------------------------------
   const dayLabel = useMemo(() => {

--- a/src/lib/actions/__tests__/railBlocks.test.ts
+++ b/src/lib/actions/__tests__/railBlocks.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRailBlocks,
+  DEFAULT_RAIL_BLOCK_MINUTES,
+  resolveActionDurationMinutes,
+  type RailSchedulableAction,
+} from "~/lib/actions/railBlocks";
+
+/** Local-time Date so `hourFloat` (which reads local getters) is deterministic. */
+function at(hour: number, minute = 0): Date {
+  return new Date(2026, 7, 5, hour, minute, 0, 0);
+}
+
+function action(overrides: Partial<RailSchedulableAction> = {}): RailSchedulableAction {
+  return {
+    id: "a1",
+    name: "Write the thing",
+    scheduledStart: at(10, 30),
+    ...overrides,
+  };
+}
+
+describe("resolveActionDurationMinutes", () => {
+  it("uses `duration` when set", () => {
+    expect(
+      resolveActionDurationMinutes({ duration: 25, scheduledEnd: null }, at(10, 30)),
+    ).toBe(25);
+  });
+
+  it("uses the scheduledStart→scheduledEnd span when only `scheduledEnd` is set", () => {
+    expect(
+      resolveActionDurationMinutes(
+        { duration: null, scheduledEnd: at(10, 40) },
+        at(10, 30),
+      ),
+    ).toBe(10);
+  });
+
+  it("falls back to 60 minutes when neither is set", () => {
+    expect(
+      resolveActionDurationMinutes({ duration: null, scheduledEnd: null }, at(10, 30)),
+    ).toBe(DEFAULT_RAIL_BLOCK_MINUTES);
+  });
+
+  it("prefers `duration` over a conflicting `scheduledEnd`", () => {
+    // Matches convertActionToCalendarItem's precedence in the calendar's
+    // overlap utility: duration wins.
+    expect(
+      resolveActionDurationMinutes(
+        { duration: 15, scheduledEnd: at(12, 0) },
+        at(10, 30),
+      ),
+    ).toBe(15);
+  });
+
+  it("accepts ISO strings for scheduledEnd", () => {
+    expect(
+      resolveActionDurationMinutes(
+        { duration: null, scheduledEnd: at(11, 0).toISOString() },
+        at(10, 30),
+      ),
+    ).toBe(30);
+  });
+
+  it("falls back to the default when scheduledEnd is not after the start", () => {
+    expect(
+      resolveActionDurationMinutes(
+        { duration: null, scheduledEnd: at(10, 0) },
+        at(10, 30),
+      ),
+    ).toBe(DEFAULT_RAIL_BLOCK_MINUTES);
+  });
+
+  it("ignores a non-positive duration and falls through", () => {
+    expect(
+      resolveActionDurationMinutes(
+        { duration: 0, scheduledEnd: at(10, 45) },
+        at(10, 30),
+      ),
+    ).toBe(15);
+  });
+});
+
+describe("buildRailBlocks", () => {
+  it("renders a 10:30–10:40 action as a 10-minute block", () => {
+    const [block] = buildRailBlocks({
+      actions: [action({ scheduledEnd: at(10, 40) })],
+    });
+
+    expect(block).toMatchObject({
+      id: "act-a1",
+      title: "Write the thing",
+      start: 10.5,
+      kind: "task",
+    });
+    expect(block!.end).toBeCloseTo(10 + 40 / 60, 10);
+  });
+
+  it("uses `duration` when it conflicts with scheduledEnd", () => {
+    const [block] = buildRailBlocks({
+      actions: [action({ duration: 15, scheduledEnd: at(12, 0) })],
+    });
+
+    expect(block!.start).toBe(10.5);
+    expect(block!.end).toBeCloseTo(10.75, 10);
+  });
+
+  it("falls back to a 60-minute block when the action expresses no length", () => {
+    const [block] = buildRailBlocks({ actions: [action()] });
+
+    expect(block!.start).toBe(10.5);
+    expect(block!.end).toBe(11.5);
+  });
+
+  it("skips actions with no scheduledStart", () => {
+    expect(
+      buildRailBlocks({ actions: [action({ scheduledStart: null })] }),
+    ).toEqual([]);
+  });
+
+  it("maps calendar events to `cal` blocks and skips ones missing a bound", () => {
+    const blocks = buildRailBlocks({
+      events: [
+        {
+          id: "ev1",
+          summary: "Standup",
+          start: { dateTime: at(9, 0).toISOString() },
+          end: { dateTime: at(9, 15).toISOString() },
+        },
+        {
+          id: "ev2",
+          summary: "No end",
+          start: { dateTime: at(9, 0).toISOString() },
+          end: null,
+        },
+      ],
+    });
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ id: "ev1", title: "Standup", kind: "cal" });
+    expect(blocks[0]!.end).toBe(9.25);
+  });
+
+  it("titles an untitled calendar event", () => {
+    const [block] = buildRailBlocks({
+      events: [
+        {
+          id: "ev1",
+          summary: null,
+          start: { dateTime: at(9, 0).toISOString() },
+          end: { dateTime: at(10, 0).toISOString() },
+        },
+      ],
+    });
+
+    expect(block!.title).toBe("Untitled");
+  });
+
+  it("returns an empty list for empty or missing input", () => {
+    expect(buildRailBlocks({})).toEqual([]);
+    expect(buildRailBlocks({ events: null, actions: null })).toEqual([]);
+  });
+});

--- a/src/lib/actions/railBlocks.ts
+++ b/src/lib/actions/railBlocks.ts
@@ -1,0 +1,106 @@
+import { hourFloat } from "~/lib/actions/dates";
+
+/**
+ * One positioned block on the Today agenda rail. `start`/`end` are hour floats
+ * (e.g. 10.5 === 10:30) in local time, matching `hourFloat`.
+ */
+export interface RailBlock {
+  id: string;
+  title: string;
+  start: number;
+  end: number;
+  kind: "cal" | "task" | "focus";
+}
+
+/** Structural shape of a Google Calendar event as `calendar.getTodayEvents` returns it. */
+export interface RailCalendarEvent {
+  id: string;
+  summary?: string | null;
+  start?: { dateTime?: string | null; date?: string | null } | null;
+  end?: { dateTime?: string | null; date?: string | null } | null;
+}
+
+/** Structural shape of the Action fields the rail needs. */
+export interface RailSchedulableAction {
+  id: string;
+  name: string;
+  scheduledStart?: Date | string | null;
+  scheduledEnd?: Date | string | null;
+  duration?: number | null;
+}
+
+/** Used only when an action expresses no length at all. */
+export const DEFAULT_RAIL_BLOCK_MINUTES = 60;
+
+const MS_MINUTE = 60_000;
+
+/**
+ * How long a scheduled action's rail block is, in minutes.
+ *
+ * Precedence matches `convertActionToCalendarItem` in the calendar's overlap
+ * utility — `duration` wins over `scheduledEnd` when both are set, because
+ * `duration` is what the scheduling UI writes when the user states a length.
+ * Falls back to `DEFAULT_RAIL_BLOCK_MINUTES` when neither yields a positive
+ * span, so a malformed `scheduledEnd` can't collapse the block to nothing.
+ */
+export function resolveActionDurationMinutes(
+  action: Pick<RailSchedulableAction, "scheduledStart" | "scheduledEnd" | "duration">,
+  start: Date,
+): number {
+  if (action.duration != null && action.duration > 0) return action.duration;
+
+  if (action.scheduledEnd) {
+    const end = new Date(action.scheduledEnd);
+    const spanMinutes = (end.getTime() - start.getTime()) / MS_MINUTE;
+    if (Number.isFinite(spanMinutes) && spanMinutes > 0) return spanMinutes;
+  }
+
+  return DEFAULT_RAIL_BLOCK_MINUTES;
+}
+
+export interface BuildRailBlocksInput {
+  events?: RailCalendarEvent[] | null;
+  actions?: RailSchedulableAction[] | null;
+}
+
+/**
+ * The single source of truth for the Today agenda rail's blocks — shared by the
+ * desktop shell (`TodayDesktopShell`) and the mobile layout (`TodayLayout`) so
+ * the two surfaces can't drift.
+ *
+ * Pure: it reads no clock and no query cache, so it is directly testable.
+ */
+export function buildRailBlocks({
+  events,
+  actions,
+}: BuildRailBlocksInput): RailBlock[] {
+  const blocks: RailBlock[] = [];
+
+  for (const ev of events ?? []) {
+    const startStr = ev.start?.dateTime ?? ev.start?.date;
+    const endStr = ev.end?.dateTime ?? ev.end?.date;
+    if (!startStr || !endStr) continue;
+    blocks.push({
+      id: ev.id,
+      title: ev.summary || "Untitled",
+      start: hourFloat(new Date(startStr)),
+      end: hourFloat(new Date(endStr)),
+      kind: "cal",
+    });
+  }
+
+  for (const a of actions ?? []) {
+    if (!a.scheduledStart) continue;
+    const start = new Date(a.scheduledStart);
+    const durationMinutes = resolveActionDurationMinutes(a, start);
+    blocks.push({
+      id: `act-${a.id}`,
+      title: a.name,
+      start: hourFloat(start),
+      end: hourFloat(new Date(start.getTime() + durationMinutes * MS_MINUTE)),
+      kind: "task",
+    });
+  }
+
+  return blocks;
+}

--- a/src/lib/actions/railBlocks.ts
+++ b/src/lib/actions/railBlocks.ts
@@ -44,7 +44,7 @@ const MS_MINUTE = 60_000;
  * span, so a malformed `scheduledEnd` can't collapse the block to nothing.
  */
 export function resolveActionDurationMinutes(
-  action: Pick<RailSchedulableAction, "scheduledStart" | "scheduledEnd" | "duration">,
+  action: Pick<RailSchedulableAction, "scheduledEnd" | "duration">,
   start: Date,
 ): number {
   if (action.duration != null && action.duration > 0) return action.duration;


### PR DESCRIPTION
### **User description**
## What

The Today agenda rail drew every task block as 60 minutes long unless the action happened to carry a `duration`. It never consulted `scheduledEnd`, so a task genuinely scheduled 10:30–10:40 was drawn as a full hour and the rail claimed far more of the day than the user actually committed.

The block-building logic was also **duplicated verbatim** in the desktop Today shell and the mobile Today layout, so the same bug lived in two places. This extracts a single shared builder — `buildRailBlocks` in `src/lib/actions/railBlocks.ts` — that both surfaces call, and fixes the length resolution there. Subsequent tickets in this feature hook into the same builder.

Length now resolves as `duration` → the `scheduledStart`..`scheduledEnd` span → a 60-minute fallback, matching the precedence already used by the calendar's `convertActionToCalendarItem`. A `scheduledEnd` that isn't strictly after the start falls through to the default rather than collapsing the block to nothing.

`RailBlock` moved from `TimelineRail.tsx` to the shared module; `TimelineRail` re-exports it so existing imports keep working.

## Verification

Unit tests cover all three resolution paths plus the conflicting-values case (14 tests). Verified in the running app against a seeded fixture on both surfaces — desktop (1440px, `AgendaRail`) and mobile (390px, `TimelineRail`) rendered identical, honest lengths:

| Action | Rendered |
|---|---|
| `scheduledEnd` 10:40, no duration | 10:30 AM – 10:40 AM |
| `duration` 15 vs `scheduledEnd` 13:30 | 12:00 PM – 12:15 PM (duration wins) |
| `duration` 45 only | 2:00 PM – 2:45 PM |
| neither set | 4:00 PM – 5:00 PM (fallback) |

## Acceptance criteria

- [x] A single shared helper builds rail blocks from calendar events + scheduled actions; the desktop and mobile Today surfaces both call it and no longer construct blocks inline
- [x] Block length resolves as: `duration` if set, else the span from `scheduledStart` to `scheduledEnd` if set, else a 60-minute fallback
- [x] A task with `scheduledStart` 10:30 and `scheduledEnd` 10:40 renders as a 10-minute block on both desktop and mobile
- [x] A task with a `duration` and a conflicting `scheduledEnd` uses `duration` (matching the existing calendar utility's precedence)
- [x] Unit tests cover all three resolution paths plus the conflicting-values case
- [x] `npm run check` passes (run as `npx tsc --noEmit` + `npx next lint` with an 8GB heap — the packaged scripts pin 4GB and OOM on this repo)

---

Ships: ultra.blaze


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Extract shared `buildRailBlocks` helper to eliminate duplicated block-building logic

- Fix rail blocks using hardcoded 60-minute duration instead of `scheduledEnd`

- Duration resolves as `duration` → `scheduledStart`..`scheduledEnd` span → 60-min fallback

- Add 14 unit tests covering all resolution paths and edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TodayLayout.tsx\n(mobile)"] -- "calls" --> C["buildRailBlocks()\n~/lib/actions/railBlocks.ts"]
  B["TodayDesktopShell.tsx\n(desktop)"] -- "calls" --> C
  C -- "uses" --> D["resolveActionDurationMinutes()\nduration → scheduledEnd → 60min fallback"]
  C -- "exports" --> E["RailBlock interface"]
  E -- "re-exported by" --> F["TimelineRail.tsx"]
  G["railBlocks.test.ts\n14 unit tests"] -- "tests" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>railBlocks.ts</strong><dd><code>New shared rail block builder with correct duration resolution</code></dd></summary>
<hr>

src/lib/actions/railBlocks.ts

<ul><li>New shared module defining <code>RailBlock</code>, <code>RailCalendarEvent</code>, <br><code>RailSchedulableAction</code> interfaces<br> <li> Implements <code>resolveActionDurationMinutes</code> with <code>duration</code> → <code>scheduledEnd</code> <br>span → 60-min fallback precedence<br> <li> Implements <code>buildRailBlocks</code> as the single source of truth for both <br>desktop and mobile Today surfaces<br> <li> Exports <code>DEFAULT_RAIL_BLOCK_MINUTES</code> constant for use in tests</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/507/files#diff-32bfa978c7ff493e7a2e673a77194da3befec7c3efd5cc3a96a6037f993d9f3c">+106/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TimelineRail.tsx</strong><dd><code>Move RailBlock interface to shared module, re-export for compatibility</code></dd></summary>
<hr>

src/app/_components/actions/components/TimelineRail.tsx

<ul><li>Removes local <code>RailBlock</code> interface definition<br> <li> Imports <code>RailBlock</code> type from <code>~/lib/actions/railBlocks</code> and re-exports it <br>for backward compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/507/files#diff-b3a98e5d831e9862d469f7f2c9a2e332999034d80c9e746c248a8a063869ccdb">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>railBlocks.test.ts</strong><dd><code>Comprehensive unit tests for rail block builder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/actions/__tests__/railBlocks.test.ts

<ul><li>New test file with 14 unit tests for <code>resolveActionDurationMinutes</code> and <br><code>buildRailBlocks</code><br> <li> Covers all three resolution paths: <code>duration</code>, <code>scheduledEnd</code> span, and <br>60-min fallback<br> <li> Tests edge cases: conflicting values, ISO string inputs, non-positive <br>duration, missing <code>scheduledStart</code><br> <li> Tests calendar event mapping including untitled events and missing <br>bounds</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/507/files#diff-f2f56a9c2242413e5a43a7e8b79cc2e16a52f5c32e9948ea96a2c27259deaf01">+163/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TodayLayout.tsx</strong><dd><code>Replace inline block logic with shared buildRailBlocks call</code></dd></summary>
<hr>

src/app/_components/actions/TodayLayout.tsx

<ul><li>Replaces inline duplicated rail block building logic with a call to <br><code>buildRailBlocks</code><br> <li> Imports <code>buildRailBlocks</code> and <code>RailBlock</code> from shared <br><code>~/lib/actions/railBlocks</code> module<br> <li> Removes <code>RailBlock</code> import from <code>TimelineRail</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/507/files#diff-ffdca587fa3ac939e4a439640e3c03dd4382f179fffeb9d85b63295aa06db50d">+10/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TodayDesktopShell.tsx</strong><dd><code>Replace inline block logic with shared buildRailBlocks call</code></dd></summary>
<hr>

src/app/_components/today-redesign/TodayDesktopShell.tsx

<ul><li>Replaces inline duplicated rail block building logic with a call to <br><code>buildRailBlocks</code><br> <li> Imports <code>buildRailBlocks</code> and <code>RailBlock</code> from shared <br><code>~/lib/actions/railBlocks</code> module<br> <li> Removes <code>RailBlock</code> import from <code>TimelineRail</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/507/files#diff-00486f261f8e0fa50280355f8c7d48001ae5e904fdd67d21ce7ba20060bec597">+9/-30</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AgendaRail.tsx</strong><dd><code>Update RailBlock import to use shared module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/today-redesign/AgendaRail.tsx

<ul><li>Updates <code>RailBlock</code> import source from <code>TimelineRail</code> to <br><code>~/lib/actions/railBlocks</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/507/files#diff-9a3b1e331d5b710d540ef5f8c575b709a278c30b1bf56f29a1e4e78c7130714c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

