### PR TITLE
Add a select-all shortcut to the agent workspace picker

### DIFF
--- a/src/app/(sidemenu)/settings/agents/page.tsx
+++ b/src/app/(sidemenu)/settings/agents/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import {
   Alert,
+  Anchor,
   Badge,
   Button,
   Code,
@@ -123,6 +124,8 @@ export default function ExternalAgentsPage() {
   const grantAgent = agents.find((agent) => agent.id === grantAgentId);
   const grantedWorkspaceIds = new Set(grantAgent?.workspaces.map((ws) => ws.id) ?? []);
   const grantableWorkspaces = workspaces.filter((ws) => !grantedWorkspaceIds.has(ws.id));
+  const allGrantableSelected =
+    grantableWorkspaces.length > 0 && grantWorkspaceIds.length === grantableWorkspaces.length;
 
   const closeKeyModal = () => {
     setKeyModalAgentId(null);
@@ -379,16 +382,37 @@ export default function ExternalAgentsPage() {
               This agent is already in every workspace you can add it to.
             </Text>
           ) : (
-            <MultiSelect
-              label="Workspaces"
-              placeholder={grantWorkspaceIds.length > 0 ? undefined : 'Pick one or more workspaces'}
-              data={grantableWorkspaces.map((ws) => ({ value: ws.id, label: ws.name }))}
-              value={grantWorkspaceIds}
-              onChange={setGrantWorkspaceIds}
-              searchable
-              clearable
-              hidePickedOptions
-            />
+            <Stack gap={4}>
+              <Group justify="space-between" align="center" wrap="nowrap">
+                <Text size="sm" fw={500}>
+                  Workspaces
+                </Text>
+                <Anchor
+                  component="button"
+                  type="button"
+                  size="xs"
+                  onClick={() =>
+                    setGrantWorkspaceIds(
+                      allGrantableSelected ? [] : grantableWorkspaces.map((ws) => ws.id),
+                    )
+                  }
+                >
+                  {allGrantableSelected
+                    ? 'Clear all'
+                    : `Select all (${grantableWorkspaces.length})`}
+                </Anchor>
+              </Group>
+              <MultiSelect
+                aria-label="Workspaces"
+                placeholder={grantWorkspaceIds.length > 0 ? undefined : 'Pick one or more workspaces'}
+                data={grantableWorkspaces.map((ws) => ({ value: ws.id, label: ws.name }))}
+                value={grantWorkspaceIds}
+                onChange={setGrantWorkspaceIds}
+                searchable
+                clearable
+                hidePickedOptions
+              />
+            </Stack>
           )}
           <Group justify="flex-end">
             <Button variant="default" onClick={closeGrantModal}>

--- a/src/app/(sidemenu)/settings/agents/page.tsx
+++ b/src/app/(sidemenu)/settings/agents/page.tsx
@@ -124,8 +124,13 @@ export default function ExternalAgentsPage() {
   const grantAgent = agents.find((agent) => agent.id === grantAgentId);
   const grantedWorkspaceIds = new Set(grantAgent?.workspaces.map((ws) => ws.id) ?? []);
   const grantableWorkspaces = workspaces.filter((ws) => !grantedWorkspaceIds.has(ws.id));
+  // Membership, not a length match: the agent list can refetch while the modal is
+  // open, shrinking `grantableWorkspaces` while a now-ungrantable id lingers in the
+  // selection — the counts would agree without every workspace actually being picked.
+  const selectedWorkspaceIds = new Set(grantWorkspaceIds);
   const allGrantableSelected =
-    grantableWorkspaces.length > 0 && grantWorkspaceIds.length === grantableWorkspaces.length;
+    grantableWorkspaces.length > 0 &&
+    grantableWorkspaces.every((ws) => selectedWorkspaceIds.has(ws.id));
 
   const closeKeyModal = () => {
     setKeyModalAgentId(null);


### PR DESCRIPTION
### **User description**
## What

The **Add agent to workspaces** modal (`/settings/agents`) only offered a one-at-a-time `MultiSelect`, so granting an agent access to every workspace meant picking each one by hand. This adds a **Select all (N)** / **Clear all** toggle above the picker.

- The link counts only *grantable* workspaces — ones the agent isn't already in — so it never over-promises.
- It flips to **Clear all** once everything is selected, so one control does both directions.
- The `MultiSelect`'s own `label` prop is replaced by an explicit label row so the toggle can sit beside it; the field keeps an `aria-label` so it stays labelled for screen readers.

No server-side change — `externalAgent.grantWorkspaces` already accepts up to 100 ids and enforces that the caller holds non-viewer membership in every target workspace.

## Verification

Verified in the real app against the local `dev-fixture` workspace (`npm run dev:seed-fixture` + `npm run dev:session`), with a fixture agent and 4 workspaces:

- **Select all (4)** selects all four, the submit button becomes **Add to 4**, and the link flips to **Clear all**.
- **Clear all** empties the selection and the link flips back to **Select all (4)**.
- Submitting granted all four workspaces — the agent row then lists Fixture Gamma / Fixture Beta / Fixture Alpha / Dev Fixture.

`npx tsc --noEmit` and ESLint on the changed file are clean; pre-commit unit tests passed.


___

### **PR Type**
Enhancement


___

### **Description**
- Add "Select all (N)" / "Clear all" toggle to workspace picker modal

- Toggle uses membership check, not count, to detect all-selected state

- Replace `MultiSelect` label with explicit label row to accommodate toggle

- Preserve accessibility via `aria-label` on the `MultiSelect`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workspace Picker Modal"] -- "renders" --> B["Label Row (Group)"]
  B -- "left side" --> C["'Workspaces' Text Label"]
  B -- "right side" --> D["Anchor Toggle Button"]
  D -- "allGrantableSelected=true" --> E["'Clear all' → clears selection"]
  D -- "allGrantableSelected=false" --> F["'Select all (N)' → selects all grantable workspaces"]
  A -- "renders" --> G["MultiSelect (aria-label='Workspaces')"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Add select-all toggle to agent workspace picker UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/settings/agents/page.tsx

<ul><li>Import <code>Anchor</code> from Mantine for the toggle button<br> <li> Compute <code>selectedWorkspaceIds</code> set and <code>allGrantableSelected</code> boolean <br>using membership check<br> <li> Replace bare <code>MultiSelect</code> with a <code>Stack</code> containing an explicit label row <br>and the <code>MultiSelect</code><br> <li> Add <code>Anchor</code> toggle button showing "Select all (N)" or "Clear all" based <br>on selection state<br> <li> Switch <code>MultiSelect</code> from <code>label</code> prop to <code>aria-label</code> for screen reader <br>accessibility</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/508/files#diff-3286ab3f3a73e58efed3c720f43a6bf9554c520e2637bb0aeab65e9709ba92e4">+39/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

