### PR TITLE
chore: stop format-on-save from reformatting the whole repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,11 @@ dev-debug.log
 node_modules/
 # Environment variables
 # Editor directories and files
-.vscode
+# settings.json is tracked on purpose — it turns format-on-save off, which this
+# repo needs (see prettier.config.js). Git cannot re-include a file whose parent
+# directory is excluded, hence `.vscode/*` rather than `.vscode`.
+.vscode/*
+!.vscode/settings.json
 *.suo
 *.ntvs*
 *.njsproj

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  // This repo is NOT Prettier-formatted. ~1350 of its ~1400 source files differ
+  // from prettier.config.js, and nothing enforces it — not CI, not the
+  // pre-commit hook. With format-on-save on, opening any file and saving it
+  // rewrites most of that file, burying the actual change in an unrelated
+  // reformat (a one-line fix in a settings page produced a ~150-line diff).
+  //
+  // Off until someone formats the repo in one deliberate pass. See CLAUDE.md.
+  "editor.formatOnSave": false,
+  "editor.formatOnPaste": false
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,16 @@ This project uses enhanced ESLint integration with immediate feedback and build-
 - `npm run lint` - Run ESLint only
 - `npm run lint:fix` - Auto-fix ESLint issues
 - `npm run typecheck` - Run TypeScript type checking only
-- `npm run format:write` - Format code with Prettier
-- `npm run format:check` - Check code formatting
+- `npm run format:write` - ⚠️ Format code with Prettier — **rewrites ~1350 files, see below**
+- `npm run format:check` - Check code formatting (currently fails on nearly the whole repo)
+
+**⚠️ This repo is NOT Prettier-formatted.** Nothing enforces `prettier.config.js` — it is
+absent from CI and from `.husky/pre-commit` — and ~1350 of the repo's ~1400 source files
+differ from it. Do NOT run `format:write`, and do NOT enable editor format-on-save
+(`.vscode/settings.json` turns it off): formatting a file you were only editing buries the
+real change in a ~150-line reformat and conflicts with every open branch. Match the
+surrounding style by hand instead. Formatting the repo is worth doing, but as its own PR
+with a `.git-blame-ignore-revs` entry and a CI gate — not as cleanup inside a feature PR.
 
 **MANDATORY ESLint Rules** (build will FAIL if violated):
 - Use `??` instead of `||` for nullish coalescing

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,20 @@
-/** @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions} */
+/**
+ * NOT APPLIED REPO-WIDE — do not run this as cleanup alongside another change.
+ *
+ * Nothing enforces this config: it is absent from CI and from .husky/pre-commit,
+ * and ~1350 of the repo's ~1400 source files differ from it. The mismatch is not
+ * a mistuned option — printWidth 80 (the default) already fits the existing code
+ * better than 100 or 120 do. The code has simply never been formatted.
+ *
+ * So `npm run format:write` rewrites nearly every file in the repo. Treat it as a
+ * deliberate standalone campaign, landed on its own with a .git-blame-ignore-revs
+ * entry and a CI gate to stop the drift returning — not as a tidy-up in a feature
+ * PR, where it buries the real change and conflicts with every open branch.
+ *
+ * Editor format-on-save is disabled in .vscode/settings.json for the same reason.
+ *
+ * @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions}
+ */
 export default {
   plugins: ["prettier-plugin-tailwindcss"],
 };


### PR DESCRIPTION
### **User description**
Follow-up to #506, where a one-line fix in the agent settings page produced a ~150-line Prettier diff. I assumed that was file-local. It isn't.

### What's actually going on

`prettier.config.js` describes a standard this repo does not follow:

- **1354 of ~1400 source files** fail `prettier --check`.
- Nothing enforces it — it's absent from CI **and** from `.husky/pre-commit`.
- So `prettier-plugin-tailwindcss`, the only thing the config configures, has **never actually run**.

I checked whether it was just mistuned. It isn't — the current default is already the closest fit:

| printWidth | files differing (`src/**`) |
|---|---|
| **80 (current default)** | **1309** |
| 90 | 1342 |
| 100 | 1412 |
| 110 | 1461 |
| 120 | 1491 |

The code has simply never been formatted. That makes the config a footgun rather than a standard: with format-on-save enabled, touching any file rewrites most of it.

### What this PR does

Turns format-on-save off at the workspace level, and says plainly — in all three places someone might look (`prettier.config.js`, `CLAUDE.md`, `.vscode/settings.json`) — that the repo is unformatted and `format:write` is not cleanup.

**No files are reformatted.** No source code is touched at all.

Tracking `.vscode/settings.json` requires `.vscode/*` rather than `.vscode`, since git cannot re-include a file whose parent directory is excluded. Verified that this exposes exactly one file and nothing else:

```
$ git ls-files --others --exclude-standard | grep vscode
.vscode/settings.json          # launch.json, extensions.json, etc. stay ignored
```

### What this PR deliberately does not do

Format the repo. That's the real fix, but it would collide with all **5 open PRs and 45 worktrees** currently in flight. It deserves its own PR at a quiet moment, with a `.git-blame-ignore-revs` entry and a CI gate so the drift can't return — which is now written down in `prettier.config.js` for whoever picks it up.


___

### **PR Type**
Documentation, Other


___

### **Description**
- Disable editor format-on-save in `.vscode/settings.json`

- Add prominent warning to `CLAUDE.md` about unformatted repo state

- Expand `prettier.config.js` comment explaining formatting is not enforced

- Prevent accidental mass-reformats that bury real changes in PRs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["prettier.config.js"] -- "expanded warning comment" --> B["Documents ~1350 files differ"]
  C[".vscode/settings.json"] -- "formatOnSave: false" --> D["Prevents accidental reformats"]
  E["CLAUDE.md"] -- "⚠️ warning added" --> F["Instructs devs not to run format:write"]
  B -- "referenced by" --> F
  D -- "referenced by" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prettier.config.js</strong><dd><code>Add detailed warning comment about unenforced Prettier config</code></dd></summary>
<hr>

prettier.config.js

<ul><li>Replaced single-line JSDoc comment with a detailed block comment<br> <li> Explains that the config is not enforced by CI or pre-commit hooks<br> <li> Warns that <code>format:write</code> rewrites ~1350 files and should not be used as <br>cleanup<br> <li> Recommends a dedicated formatting PR with <code>.git-blame-ignore-revs</code> entry</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/509/files#diff-e42472dd65561fe56344281078077fb924cddca92821eadfbc2318cca3f89c9a">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Document unformatted repo state and formatting risks in CLAUDE.md</code></dd></summary>
<hr>

CLAUDE.md

<ul><li>Updated <code>format:write</code> entry with ⚠️ warning about rewriting ~1350 files<br> <li> Added <code>format:check</code> note that it currently fails on nearly the whole <br>repo<br> <li> Added prominent warning block explaining the repo is not <br>Prettier-formatted<br> <li> Instructs developers to match surrounding style manually instead of <br>formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/509/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.json</strong><dd><code>Disable VS Code format-on-save to prevent mass reformats</code>&nbsp; </dd></summary>
<hr>

.vscode/settings.json

<ul><li>New file added to version control (previously gitignored)<br> <li> Disables <code>editor.formatOnSave</code> and <code>editor.formatOnPaste</code> for the <br>workspace<br> <li> Includes comment explaining why format-on-save is turned off<br> <li> References <code>CLAUDE.md</code> for further context</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/509/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

