### PR TITLE
refactor: Keep untimed tasks off the agenda timeline

### DIFF
--- a/src/app/_components/actions/TodayLayout.tsx
+++ b/src/app/_components/actions/TodayLayout.tsx
@@ -128,7 +128,10 @@ export function TodayLayout({ tagIds }: TodayLayoutProps) {
     [calendarEventsQuery.data, partition.todays],
   );
 
-  const eventsCount = (calendarEventsQuery.data ?? []).length;
+  // Count what the rail actually draws, not the raw calendar payload — untimed
+  // actions are filtered out of `railBlocks`, and a header that counted the
+  // pre-filter total would promise rows that aren't there.
+  const eventsCount = railBlocks.length;
   const focusCount = railBlocks.filter((b) => b.kind === "focus").length;
 
   const dayLabel = useMemo(() => {

--- a/src/app/_components/actions/TodayLayout.tsx
+++ b/src/app/_components/actions/TodayLayout.tsx
@@ -130,9 +130,10 @@ export function TodayLayout({ tagIds }: TodayLayoutProps) {
 
   // Count what the rail actually draws, not the raw calendar payload — untimed
   // actions are filtered out of `railBlocks`, and a header that counted the
-  // pre-filter total would promise rows that aren't there.
-  const eventsCount = railBlocks.length;
+  // pre-filter total would promise rows that aren't there. Focus blocks are
+  // excluded because the header reports them separately.
   const focusCount = railBlocks.filter((b) => b.kind === "focus").length;
+  const eventsCount = railBlocks.length - focusCount;
 
   const dayLabel = useMemo(() => {
     const d = new Date();

--- a/src/app/_components/today-redesign/TodayDesktopShell.tsx
+++ b/src/app/_components/today-redesign/TodayDesktopShell.tsx
@@ -614,7 +614,7 @@ export function TodayDesktopShell({
 
             <AgendaRail
               dayLabel={dayLabel}
-              eventsCount={(calendarEventsQuery.data ?? []).length}
+              eventsCount={railBlocks.length}
               blocks={railBlocks}
               now={now}
             />

--- a/src/lib/actions/__tests__/railBlocks.test.ts
+++ b/src/lib/actions/__tests__/railBlocks.test.ts
@@ -105,8 +105,12 @@ describe("buildRailBlocks", () => {
     expect(block!.end).toBeCloseTo(10.75, 10);
   });
 
-  it("falls back to a 60-minute block when the action expresses no length", () => {
-    const [block] = buildRailBlocks({ actions: [action()] });
+  it("falls back to a 60-minute block when scheduledEnd is not after the start", () => {
+    // The only route left to the fallback: a length was stated, but a useless
+    // one. `hasUserChosenTime` lets it through; the resolver rescues it.
+    const [block] = buildRailBlocks({
+      actions: [action({ scheduledEnd: at(10, 0) })],
+    });
 
     expect(block!.start).toBe(10.5);
     expect(block!.end).toBe(11.5);
@@ -116,6 +120,39 @@ describe("buildRailBlocks", () => {
     expect(
       buildRailBlocks({ actions: [action({ scheduledStart: null })] }),
     ).toEqual([]);
+  });
+
+  it("skips actions with a scheduledStart but no stated length", () => {
+    expect(buildRailBlocks({ actions: [action()] })).toEqual([]);
+  });
+
+  it("keeps timed actions while dropping untimed ones alongside them", () => {
+    const blocks = buildRailBlocks({
+      actions: [
+        action({ id: "untimed-1" }),
+        action({ id: "untimed-2" }),
+        action({ id: "timed", duration: 30 }),
+      ],
+    });
+
+    expect(blocks.map((b) => b.id)).toEqual(["act-timed"]);
+  });
+
+  it("leaves calendar events alone — they carry their own start and end", () => {
+    const blocks = buildRailBlocks({
+      events: [
+        {
+          id: "ev1",
+          summary: "Standup",
+          start: { dateTime: at(9, 0).toISOString() },
+          end: { dateTime: at(9, 15).toISOString() },
+        },
+      ],
+      actions: [action()], // untimed, dropped
+    });
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ id: "ev1", start: 9, end: 9.25 });
   });
 
   it("maps calendar events to `cal` blocks and skips ones missing a bound", () => {

--- a/src/lib/actions/__tests__/scheduling.test.ts
+++ b/src/lib/actions/__tests__/scheduling.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { hasUserChosenTime } from "~/lib/actions/scheduling";
+
+const START = new Date(2026, 7, 5, 10, 30, 0, 0);
+const END = new Date(2026, 7, 5, 10, 40, 0, 0);
+
+describe("hasUserChosenTime", () => {
+  it("is false with no scheduledStart at all", () => {
+    expect(hasUserChosenTime({})).toBe(false);
+    expect(hasUserChosenTime({ scheduledStart: null })).toBe(false);
+  });
+
+  it("is false for a bare scheduledStart — the stamped-instant case", () => {
+    expect(hasUserChosenTime({ scheduledStart: START })).toBe(false);
+    expect(
+      hasUserChosenTime({ scheduledStart: START, scheduledEnd: null, duration: null }),
+    ).toBe(false);
+  });
+
+  it("is true when a duration states the length", () => {
+    expect(hasUserChosenTime({ scheduledStart: START, duration: 25 })).toBe(true);
+  });
+
+  it("is true when a scheduledEnd states the length", () => {
+    expect(hasUserChosenTime({ scheduledStart: START, scheduledEnd: END })).toBe(true);
+  });
+
+  it("accepts ISO strings on both ends", () => {
+    expect(
+      hasUserChosenTime({
+        scheduledStart: START.toISOString(),
+        scheduledEnd: END.toISOString(),
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores a non-positive duration but still honours a scheduledEnd", () => {
+    expect(hasUserChosenTime({ scheduledStart: START, duration: 0 })).toBe(false);
+    expect(
+      hasUserChosenTime({ scheduledStart: START, duration: 0, scheduledEnd: END }),
+    ).toBe(true);
+  });
+
+  it("is false without a start even when a length is stated", () => {
+    expect(hasUserChosenTime({ duration: 30 })).toBe(false);
+    expect(hasUserChosenTime({ scheduledEnd: END })).toBe(false);
+  });
+
+  it("narrows scheduledStart for the caller", () => {
+    const action: { scheduledStart?: Date | null; duration?: number | null } = {
+      scheduledStart: START,
+      duration: 30,
+    };
+    if (hasUserChosenTime(action)) {
+      // Compiles without an assertion — that is the point of the type guard.
+      expect(new Date(action.scheduledStart).getHours()).toBe(10);
+    } else {
+      throw new Error("expected the predicate to hold");
+    }
+  });
+});

--- a/src/lib/actions/railBlocks.ts
+++ b/src/lib/actions/railBlocks.ts
@@ -1,4 +1,5 @@
 import { hourFloat } from "~/lib/actions/dates";
+import { hasUserChosenTime, type TimeBlockFields } from "~/lib/actions/scheduling";
 
 /**
  * One positioned block on the Today agenda rail. `start`/`end` are hour floats
@@ -21,12 +22,9 @@ export interface RailCalendarEvent {
 }
 
 /** Structural shape of the Action fields the rail needs. */
-export interface RailSchedulableAction {
+export interface RailSchedulableAction extends TimeBlockFields {
   id: string;
   name: string;
-  scheduledStart?: Date | string | null;
-  scheduledEnd?: Date | string | null;
-  duration?: number | null;
 }
 
 /** Used only when an action expresses no length at all. */
@@ -90,7 +88,12 @@ export function buildRailBlocks({
   }
 
   for (const a of actions ?? []) {
-    if (!a.scheduledStart) continue;
+    // Only actions the user genuinely gave a time. A bare `scheduledStart` is
+    // usually an instant some code path stamped, not a commitment, and drawing
+    // those buried the rail in phantom hour-long blocks. Untimed tasks are
+    // omitted outright rather than shelved in a separate strip — they are
+    // already in the task list beside the rail, so nothing is lost.
+    if (!hasUserChosenTime(a)) continue;
     const start = new Date(a.scheduledStart);
     const durationMinutes = resolveActionDurationMinutes(a, start);
     blocks.push({

--- a/src/lib/actions/scheduling.ts
+++ b/src/lib/actions/scheduling.ts
@@ -1,0 +1,35 @@
+/**
+ * Scheduling semantics shared by the Today agenda rail and the task list, so
+ * the two can never disagree about what "scheduled" means.
+ */
+
+/** The Action fields that express a deliberate time-block. */
+export interface TimeBlockFields {
+  scheduledStart?: Date | string | null;
+  scheduledEnd?: Date | string | null;
+  duration?: number | null;
+}
+
+/**
+ * Did the user actually choose a time for this action?
+ *
+ * A `scheduledStart` on its own does not mean they did: several code paths
+ * stamp the current instant when a task lands on Today, which produces a start
+ * with no end, no duration, and no time anyone picked. Those are the bulk of
+ * the phantom blocks the agenda rail used to draw.
+ *
+ * A real time-block therefore needs a start *plus* a stated length — either a
+ * positive `duration` or a `scheduledEnd`. The length's validity is not this
+ * predicate's business; `resolveActionDurationMinutes` handles a `scheduledEnd`
+ * that doesn't sit after the start.
+ *
+ * Narrows `scheduledStart` to non-null so callers can build a Date from it
+ * without an assertion.
+ */
+export function hasUserChosenTime<T extends TimeBlockFields>(
+  action: T,
+): action is T & { scheduledStart: Date | string } {
+  if (!action.scheduledStart) return false;
+  if (action.duration != null && action.duration > 0) return true;
+  return action.scheduledEnd != null;
+}


### PR DESCRIPTION
### **User description**
## What

The agenda rail treated any action with a `scheduledStart` as a timed commitment. But a large share of today's actions carry a `scheduledStart` only because some code path stamped the current instant when the task landed on Today — no end, no duration, no time anyone chose. Live data from a single day showed six such actions with start times 1–20 seconds apart, each drawn as a full-hour block.

This adds `hasUserChosenTime` in `src/lib/actions/scheduling.ts`: a start *plus* a stated length — either a positive `duration` or a `scheduledEnd`. It's written as a type guard, so `buildRailBlocks` narrows `scheduledStart` to non-null without an assertion. It deliberately lives outside any component because a later ticket puts a scheduled/unscheduled indicator on task rows and must agree with the rail about what "scheduled" means.

Per the confirmed decision, untimed tasks are omitted from the rail entirely rather than shown in a separate "unscheduled" strip — they already appear in the task list beside the rail.

### On the header count

The criterion asked the header to reflect what is actually drawn rather than the pre-filter total, so it now counts rail blocks. This turned out to matter more than expected: in the fixture the old count read **"0 events" while the rail painted six blocks**, because it counted only the raw calendar payload and every block on screen was a task.

## Verification

25 unit tests across the predicate and the builder. Verified live on both surfaces against a seeded fixture spanning every shape:

| Action | Before | After |
|---|---|---|
| `scheduledStart` only, no length | drawn as 60 min | **not drawn** |
| `scheduledEnd` 10 min after start | drawn | drawn, unchanged |
| `duration` 15 vs conflicting `scheduledEnd` | drawn | drawn, unchanged |
| `duration` 45 only | drawn | drawn, unchanged |
| pre-existing fixture tasks with `duration` 60 | drawn | drawn, unchanged |

Header went from "0 events" to "5 events" against 5 blocks on screen. Desktop (`AgendaRail`) and mobile (`TimelineRail`) agree.

One honest gap: the fixture user has no Google Calendar connected, so "calendar events are unaffected" is covered by unit tests rather than a live observation. The event branch of the builder is untouched by this change.

## Acceptance criteria

- [x] A shared, unit-tested predicate determines whether an action has a user-chosen time
- [x] The predicate is exported from a location importable by both the agenda rail and the task list (not defined inside a component)
- [x] Actions with `scheduledStart` but no `scheduledEnd` and no `duration` produce no rail block, on desktop and mobile
- [x] Actions with `scheduledStart` + either `scheduledEnd` or `duration` still render as before
- [x] Calendar events are unaffected — they keep rendering from their own start/end
- [x] The rail's event count in the header reflects what is actually drawn, not the pre-filter total
- [x] `npm run check` passes (run as `npx tsc --noEmit` + `npx eslint` at an 8GB heap — the packaged scripts pin 4GB and OOM on this repo)

---

Ships: smooth.bamboo


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `hasUserChosenTime` predicate to filter untimed tasks from agenda rail

- Untimed actions (bare `scheduledStart` only) are now excluded from the rail

- Header event count now reflects what is actually drawn, not raw calendar payload

- 25 new unit tests covering the predicate and updated rail builder behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["scheduling.ts\n(new)"] -- "exports hasUserChosenTime\n& TimeBlockFields" --> B["railBlocks.ts"]
  B -- "filters untimed actions" --> C["buildRailBlocks()"]
  C -- "railBlocks.length" --> D["TodayLayout.tsx\neventsCount"]
  C -- "railBlocks.length" --> E["TodayDesktopShell.tsx\neventsCount"]
  F["scheduling.test.ts\n(new)"] -- "tests" --> A
  G["railBlocks.test.ts"] -- "updated tests" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scheduling.ts</strong><dd><code>New shared scheduling predicate for user-chosen time detection</code></dd></summary>
<hr>

src/lib/actions/scheduling.ts

<ul><li>New file introducing <code>TimeBlockFields</code> interface and <code>hasUserChosenTime</code> <br>type guard<br> <li> Predicate returns true only when a <code>scheduledStart</code> is paired with a <br>positive <code>duration</code> or a <code>scheduledEnd</code><br> <li> Acts as a type guard narrowing <code>scheduledStart</code> to non-null for callers<br> <li> Intended as shared source of truth for both the rail and task list</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/511/files#diff-d8509de5b2ad4abee4c5749904f3e588c3fbbdc191a94efe1cbab22caea53858">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>railBlocks.ts</strong><dd><code>Filter untimed actions from rail using hasUserChosenTime predicate</code></dd></summary>
<hr>

src/lib/actions/railBlocks.ts

<ul><li><code>RailSchedulableAction</code> now extends <code>TimeBlockFields</code> instead of <br>redeclaring fields<br> <li> <code>buildRailBlocks</code> replaces bare <code>!a.scheduledStart</code> check with <br><code>!hasUserChosenTime(a)</code><br> <li> Untimed actions are silently dropped from the rail rather than drawn <br>as phantom blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/511/files#diff-32bfa978c7ff493e7a2e673a77194da3befec7c3efd5cc3a96a6037f993d9f3c">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TodayLayout.tsx</strong><dd><code>Fix mobile header event count to reflect drawn rail blocks</code></dd></summary>
<hr>

src/app/_components/actions/TodayLayout.tsx

<ul><li><code>eventsCount</code> now derived from <code>railBlocks.length - focusCount</code> instead of <br>raw calendar data length<br> <li> Focus blocks excluded from count since the header reports them <br>separately<br> <li> Adds explanatory comment clarifying the counting rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/511/files#diff-ffdca587fa3ac939e4a439640e3c03dd4382f179fffeb9d85b63295aa06db50d">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TodayDesktopShell.tsx</strong><dd><code>Fix desktop header event count to use rail blocks length</code>&nbsp; </dd></summary>
<hr>

src/app/_components/today-redesign/TodayDesktopShell.tsx

<ul><li><code>eventsCount</code> prop to <code>AgendaRail</code> changed from raw calendar array length <br>to <code>railBlocks.length</code><br> <li> Ensures desktop header count matches what is actually rendered on the <br>rail</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/511/files#diff-00486f261f8e0fa50280355f8c7d48001ae5e904fdd67d21ce7ba20060bec597">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scheduling.test.ts</strong><dd><code>New unit tests for hasUserChosenTime predicate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/actions/__tests__/scheduling.test.ts

<ul><li>New test file with 8 unit tests for <code>hasUserChosenTime</code><br> <li> Covers: no start, bare start, duration-only, scheduledEnd-only, ISO <br>strings, zero duration, no start with length, and type narrowing</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/511/files#diff-4f201925b3196ca4ca853da8a3a6917ff6b64f9589fc5139f8c72f6df5b29cc7">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>railBlocks.test.ts</strong><dd><code>Update and expand rail builder tests for untimed action filtering</code></dd></summary>
<hr>

src/lib/actions/__tests__/railBlocks.test.ts

<ul><li>Updated fallback test: now requires a stated (but useless) <br><code>scheduledEnd</code> to reach the 60-min fallback path<br> <li> Added test: actions with bare <code>scheduledStart</code> and no length are skipped<br> <li> Added test: mixed timed/untimed actions — only timed ones appear in <br>output<br> <li> Added test: calendar events pass through unaffected even when untimed <br>actions are present</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/511/files#diff-f2f56a9c2242413e5a43a7e8b79cc2e16a52f5c32e9948ea96a2c27259deaf01">+39/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

