### PR TITLE
Reach the local wiki from the command palette

### DIFF
--- a/e2e/local-wiki.spec.ts
+++ b/e2e/local-wiki.spec.ts
@@ -290,6 +290,60 @@ test("navigating away from an open editor does not carry the draft to the next p
   expect(await fileOnDisk(page, "index.md")).toBe(FILES["index.md"]!);
 });
 
+/**
+ * Opening the palette. Mantine's `mod+k` accepts either modifier, and
+ * `ControlOrMeta` lets this pass on a Linux CI runner and a Mac alike.
+ */
+async function openPalette(page: Page) {
+  await page.keyboard.press("ControlOrMeta+k");
+  return page.getByRole("dialog");
+}
+
+test("the command palette can reach the wiki, and its pages", async ({ page }) => {
+  await installWikiStub(page);
+  await page.goto("/wiki");
+  await expect(page.getByRole("heading", { name: "Local wiki" })).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  const palette = await openPalette(page);
+  // Scoped to the dialog throughout: the page behind it is the wiki, so
+  // "Local wiki" appears in its heading too.
+  await expect(palette.getByText("Local wiki", { exact: true })).toBeVisible();
+
+  // A word that appears in no filename and in no server-side entity — only
+  // inside a wiki page's body.
+  await palette.getByPlaceholder("Search, command, or ask Zoe…").fill("algorithm");
+
+  // Titled by the page's own heading rather than its filename.
+  await expect(palette.getByText("Ada Lovelace")).toBeVisible();
+  await expect(palette.getByText("Wrote the first algorithm intended for a machine.")).toBeVisible();
+
+  // The hits came off the disk, not out of the server's search.
+  expect((await calls(page)).some((c) => c.cmd === "wiki_search")).toBe(true);
+
+  await palette.getByText("Ada Lovelace").click();
+  await expect(page).toHaveURL(/\/wiki\/people\/ada$/);
+
+  await test.info().attach("wiki-command-palette", {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+});
+
+test("without a desktop shell the palette offers no wiki at all", async ({ page }) => {
+  // No stub: in a browser (and in the Electron shell) there is no wiki to
+  // reach, so neither the entry nor a local search may appear.
+  await page.goto("/wiki");
+  await expect(page.getByText("The local wiki lives on your machine")).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  const palette = await openPalette(page);
+  await expect(palette.getByPlaceholder("Search, command, or ask Zoe…")).toBeVisible();
+  await expect(palette.getByText("Local wiki", { exact: true })).toHaveCount(0);
+});
+
 test("in a browser, the wiki says where it actually lives", async ({ page }) => {
   // No stub: this is what a non-desktop visitor gets.
   await page.goto("/wiki");

--- a/src/app/_components/layout/CommandPalette.tsx
+++ b/src/app/_components/layout/CommandPalette.tsx
@@ -35,11 +35,15 @@ import {
   IconTrophy,
   IconUser,
   IconBuilding,
+  IconNotebook,
 } from '@tabler/icons-react';
 import { api } from '~/trpc/react';
 import type { RouterOutputs } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { useAgentModal } from '~/providers/AgentModalProvider';
+import { reportHandledError } from '~/lib/reportHandledError';
+import { useWikiBridge } from '~/lib/wiki/useWikiBridge';
+import { pageTitle, wikiHref, WIKI_ROUTE } from '~/lib/wiki/wikiLinks';
 import styles from '../home/WorkspaceHomeConceptD.module.css';
 
 type Mode = 'all' | 'projects' | 'tasks' | 'goals' | 'ai';
@@ -116,6 +120,13 @@ const MODE_TYPES: Record<Exclude<Mode, 'ai'>, SearchType[] | null> = {
 // the first keystroke.
 const MIN_SEARCH_LENGTH = 2;
 
+// Local wiki pages shown per search, matching the server search's per-type
+// limit so one source can't crowd out the other.
+const WIKI_RESULT_LIMIT = 5;
+
+/** One local wiki page, ready to render as a palette row. */
+type WikiRow = { path: string; title: string; line?: string };
+
 const SUGGESTED = [
   { icon: IconFlag, label: 'Run weekly plan', sub: 'Keystone ritual · 45 min' },
   { icon: IconTarget, label: 'Review Q2 OKR progress', sub: 'Summary from Zoe' },
@@ -145,6 +156,11 @@ export function CommandPalette() {
   const router = useRouter();
   const { workspaceId, workspaceSlug } = useWorkspace();
   const { openModal } = useAgentModal();
+
+  // The local wiki is a folder on this machine reached over the desktop
+  // shell's IPC. Null in a browser and in the Electron shell, which is what
+  // keeps every wiki row below out of those builds entirely.
+  const { bridge: wikiBridge } = useWikiBridge();
 
   const open = useCallback(() => setIsOpen(true), []);
   const close = useCallback(() => setIsOpen(false), []);
@@ -241,10 +257,78 @@ export function CommandPalette() {
     return { currentWorkspaceNav: current, otherWorkspaceNav: other.slice(0, 10) };
   }, [q, workspacesData, productEnabledByWorkspaceId, workspaceId]);
 
+  // Everywhere the palette can navigate to by name, before filtering. The
+  // wiki is not workspace-scoped — it lives at /wiki, one folder per machine
+  // — so it is listed independently of whether we are inside a workspace.
+  const navPages = useMemo(() => {
+    const rows = workspaceSlug
+      ? PAGES.map((p) => ({
+          key: `page-${p.path}`,
+          label: p.label,
+          icon: p.icon,
+          href: `/w/${workspaceSlug}/${p.path}`,
+        }))
+      : [];
+    if (wikiBridge) {
+      rows.push({ key: 'local-wiki', label: 'Local wiki', icon: IconBook2, href: WIKI_ROUTE });
+    }
+    return rows;
+  }, [workspaceSlug, wikiBridge]);
+
   const filteredPages = useMemo(
-    () => (workspaceSlug ? PAGES.filter((p) => !q || p.label.toLowerCase().includes(q)) : []),
-    [workspaceSlug, q],
+    () => navPages.filter((p) => !q || p.label.toLowerCase().includes(q)),
+    [navPages, q],
   );
+
+  /**
+   * Local wiki pages matching the query.
+   *
+   * **This deliberately does not go through `api.search.global`.** The wiki is
+   * device-local by construction: it is a folder of markdown on this machine
+   * that never leaves it, and that promise is the feature. Sending the query
+   * — let alone page contents — to the server to be searched there would break
+   * it. So the hits come from the shell's own grep over the files, and are
+   * merged into the palette's results here in the browser instead.
+   */
+  const [wikiRows, setWikiRows] = useState<WikiRow[]>([]);
+
+  useEffect(() => {
+    if (!wikiBridge || !isOpen || mode !== 'all' || debouncedQuery.length < MIN_SEARCH_LENGTH) {
+      setWikiRows([]);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const hits = (await wikiBridge.search(debouncedQuery)).slice(0, WIKI_RESULT_LIMIT);
+        // Title each hit by its own `# Heading` rather than its filename —
+        // "Ada Lovelace" reads better than "ada" in a list you scan. It costs
+        // one local read per hit, which is why it only runs for the handful
+        // that are about to be shown.
+        const rows = await Promise.all(
+          hits.map(async (hit): Promise<WikiRow> => {
+            let title = pageTitle(hit.path);
+            try {
+              title = pageTitle(hit.path, await wikiBridge.readPage(hit.path));
+            } catch {
+              // One unreadable page shouldn't cost the others their titles.
+            }
+            return { path: hit.path, title, line: hit.lines[0] };
+          }),
+        );
+        if (!cancelled) setWikiRows(rows);
+      } catch (e) {
+        if (cancelled) return;
+        setWikiRows([]);
+        // No query and no path in the report: this reporter files a Bug Ticket
+        // on the server, and wiki text is exactly what must not go there.
+        reportHandledError(e, { area: 'command-palette-wiki-search' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [wikiBridge, isOpen, mode, debouncedQuery]);
 
   // Results carry the query they were fetched for. While the next search is in
   // flight we keep the previous ones only if the typed query extends them —
@@ -282,11 +366,11 @@ export function CommandPalette() {
     const navRows: PaletteRow[] = [
       ...filteredPages.map((p) =>
         row({
-          key: `page-${p.path}`,
+          key: p.key,
           label: p.label,
           sub: 'Navigate',
           icon: p.icon,
-          href: `/w/${workspaceSlug}/${p.path}`,
+          href: p.href,
           accent: true,
         }),
       ),
@@ -330,6 +414,27 @@ export function CommandPalette() {
       });
     }
 
+    // Local wiki pages sit after the server's results rather than among them:
+    // they come from a different place entirely, and saying so is the point.
+    if (wikiRows.length > 0) {
+      sections.push({
+        key: 'local-wiki',
+        heading: 'Local wiki',
+        rows: wikiRows.map((page) =>
+          row({
+            key: `wiki-${page.path}`,
+            label: page.title,
+            // The matching line when there is one, else the path — enough to
+            // tell people/ada.md from characters/ada.md at a glance.
+            sub: page.line ?? page.path,
+            icon: IconNotebook,
+            href: wikiHref(page.path),
+            accent: false,
+          }),
+        ),
+      });
+    }
+
     // Other workspaces go last: matching one by name lists all of its
     // sections, which would otherwise bury the results you searched for.
     if (otherWorkspaceNav.length > 0) {
@@ -350,7 +455,7 @@ export function CommandPalette() {
     }
 
     return sections;
-  }, [filteredPages, currentWorkspaceNav, otherWorkspaceNav, resultsByType, workspaceSlug, workspaceId]);
+  }, [filteredPages, currentWorkspaceNav, otherWorkspaceNav, resultsByType, wikiRows, workspaceId]);
 
   const allResults = useMemo(
     () => resultSections.flatMap((section) => section.rows),
@@ -563,10 +668,10 @@ export function CommandPalette() {
                   const Icon = page.icon;
                   return (
                     <UnstyledButton
-                      key={page.path}
+                      key={page.key}
                       className={styles.resultRow}
                       data-highlighted={highlightedIndex === i ? 'true' : 'false'}
-                      onClick={() => navigate(`/w/${workspaceSlug}/${page.path}`)}
+                      onClick={() => navigate(page.href)}
                     >
                       <Icon
                         size={14}


### PR DESCRIPTION
### **User description**
## What

`Cmd+K` couldn't get to the local wiki at all. Two additions to `CommandPalette.tsx`, both gated on the desktop shell's IPC bridge being present — so neither appears in a browser or in the Electron shell:

- **A "Local wiki" entry under Navigate**, pointing at `/wiki`. Listed independently of the workspace, because the wiki isn't workspace-scoped — it's one folder per machine.
- **The wiki's own pages as a "Local wiki" results section**, titled by each page's own `# Heading` rather than its filename, with the matching line beneath it.

## The constraint worth naming

Page hits deliberately **do not** go through `api.search.global`. The wiki is device-local by construction and that promise is the feature — so the query never leaves the machine. Hits come from the shell's own grep over the files (`bridge.search()`) and are merged into the palette's results client-side. That reasoning is written into the code, not just here.

The error reporter is called with an area and nothing else for the same reason: it files a Bug Ticket server-side, and wiki text is exactly what must not go there.

## Also

Folded the existing `PAGES` rows and the new entry into one `navPages` list. The palette has two render paths — empty query and search — that each built their own href for a Navigate row; now they can't drift.

## Verification

- `npx playwright test` — 15 passed, including two new specs in `e2e/local-wiki.spec.ts`: one asserting the entry and the page hits against the fake `__TAURI_INTERNALS__`, one asserting that a browser with no shell gets neither.
- `npx tsc --noEmit` clean, ESLint clean on the changed file.

Screenshots of both states are attached to the `the command palette can reach the wiki, and its pages` spec.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add local wiki entry and page search to command palette

- Wiki search uses shell IPC bridge, never sends data to server

- Refactor `navPages` to unify page navigation rows and prevent drift

- Add two E2E specs covering desktop and browser wiki palette behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CommandPalette"] -- "useWikiBridge()" --> B["wikiBridge (IPC)"]
  B -- "bridge.search(query)" --> C["Wiki files on disk"]
  C -- "hits" --> D["wikiRows state"]
  D -- "rendered as" --> E["'Local wiki' section in palette"]
  A -- "navPages list" --> F["'Local wiki' Navigate entry"]
  F -- "href: /wiki" --> G["WIKI_ROUTE"]
  E -- "click row" --> H["wikiHref(path)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandPalette.tsx</strong><dd><code>Add wiki bridge search and navigation entry to palette</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/layout/CommandPalette.tsx

<ul><li>Import <code>IconNotebook</code>, <code>reportHandledError</code>, <code>useWikiBridge</code>, <code>pageTitle</code>, <br><code>wikiHref</code>, <code>WIKI_ROUTE</code><br> <li> Add <code>WIKI_RESULT_LIMIT</code> constant and <code>WikiRow</code> type<br> <li> Introduce <code>navPages</code> memo that includes a "Local wiki" entry when <br><code>wikiBridge</code> is present<br> <li> Refactor <code>filteredPages</code> to derive from <code>navPages</code> instead of raw <code>PAGES</code><br> <li> Add <code>wikiRows</code> state with a <code>useEffect</code> that queries <code>wikiBridge.search()</code> <br>and resolves page titles via <code>wikiBridge.readPage()</code><br> <li> Render a "Local wiki" results section after server results; fix <br>key/href usage in navigate rows</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/512/files#diff-0013838800caad36867dc467a14704c56996820c63a945eca5fdc33a7d4dfb45">+112/-7</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>local-wiki.spec.ts</strong><dd><code>Add E2E specs for wiki command palette integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/local-wiki.spec.ts

<ul><li>Add <code>openPalette</code> helper using <code>ControlOrMeta+k</code><br> <li> Add test asserting wiki entry and page hits appear in palette when <br>desktop shell stub is present<br> <li> Add test asserting no wiki entry or results appear without a desktop <br>shell</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/512/files#diff-fca70be4c7a0830f89c949759544952cbc9c265eed1a442b1b009cfeb1d4d893">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

