### PR TITLE
fix: Quick-reschedule stops stamping a wall-clock time into scheduledStart

### DIFF
--- a/src/app/_components/actions/ActionsList.tsx
+++ b/src/app/_components/actions/ActionsList.tsx
@@ -182,7 +182,8 @@ export function ActionsList({
     });
   };
 
-  // Moves the deadline, not the time-block — see `rescheduleUpdateFields`.
+  // Moves the do-date and the deadline together, at day granularity — see
+  // `rescheduleUpdateFields` for why scheduledStart has to move too.
   const handleReschedule = (id: string, choice: RescheduleChoice) => {
     updateAction({ id, ...rescheduleUpdateFields(choice) });
   };

--- a/src/app/_components/actions/ActionsList.tsx
+++ b/src/app/_components/actions/ActionsList.tsx
@@ -26,7 +26,10 @@ import {
   BulkEditToolbar,
   type BulkActionDef,
 } from "./components/BulkEditToolbar";
-import type { RescheduleChoice } from "./components/ReschedulePopover";
+import {
+  rescheduleUpdateFields,
+  type RescheduleChoice,
+} from "~/lib/actions/reschedule";
 import { useActionMutations } from "./hooks/useActionMutations";
 import { useActionPartition } from "./hooks/useActionPartition";
 import { useBulkSelection } from "./hooks/useBulkSelection";
@@ -179,9 +182,9 @@ export function ActionsList({
     });
   };
 
+  // Moves the deadline, not the time-block — see `rescheduleUpdateFields`.
   const handleReschedule = (id: string, choice: RescheduleChoice) => {
-    const newDate = choice.date ?? null;
-    updateAction({ id, scheduledStart: newDate, dueDate: newDate });
+    updateAction({ id, ...rescheduleUpdateFields(choice) });
   };
 
   const handleAssign = (a: Action) => {

--- a/src/app/_components/actions/TodayLayout.tsx
+++ b/src/app/_components/actions/TodayLayout.tsx
@@ -173,7 +173,8 @@ export function TodayLayout({ tagIds }: TodayLayoutProps) {
     for (const s of activeSuggestions) handleAcceptSuggestion(s);
   };
 
-  // "Now", not midnight — see TodayDesktopShell.handleRescheduleAllOverdue.
+  // The current instant, not midnight — see
+  // TodayDesktopShell.handleRescheduleAllOverdue for why it no longer matters.
   const handleRescheduleAllOverdue = useCallback(
     (ids: string[]) =>
       bulkReschedule({

--- a/src/app/_components/actions/components/ReschedulePopover.tsx
+++ b/src/app/_components/actions/components/ReschedulePopover.tsx
@@ -1,25 +1,17 @@
 import { useState } from "react";
 import { IconCalendar, IconChevronDown } from "@tabler/icons-react";
-import { addDays, nextSaturday } from "~/lib/actions/dates";
+import {
+  QUICK_RESCHEDULE_OPTIONS,
+  resolveQuickReschedule,
+  type RescheduleChoice,
+} from "~/lib/actions/reschedule";
 import styles from "./ReschedulePopover.module.css";
 
-export interface RescheduleChoice {
-  id: string;
-  label: string;
-  date: Date | null;
-}
+export type { RescheduleChoice };
 
 interface ReschedulePopoverProps {
   onChoose: (choice: RescheduleChoice) => void;
 }
-
-const QUICK_RESCHEDULE = [
-  { id: "today", label: "Today", kbd: "T" },
-  { id: "tomorrow", label: "Tomorrow", kbd: "O" },
-  { id: "next-week", label: "Next week", kbd: "N" },
-  { id: "weekend", label: "This weekend", kbd: "W" },
-  { id: "no-date", label: "No date", kbd: "X" },
-];
 
 const MONTHS = [
   "January",
@@ -51,22 +43,6 @@ export function ReschedulePopover({ onChoose }: ReschedulePopoverProps) {
   for (let d = 1; d <= daysInMonth; d++) cells.push(d);
   while (cells.length < 42) cells.push(null);
 
-  const resolveQuick = (id: string): RescheduleChoice => {
-    const base = new Date();
-    switch (id) {
-      case "today":
-        return { id, label: "Today", date: base };
-      case "tomorrow":
-        return { id, label: "Tomorrow", date: addDays(base, 1) };
-      case "next-week":
-        return { id, label: "Next week", date: addDays(base, 7) };
-      case "weekend":
-        return { id, label: "This weekend", date: nextSaturday(base) };
-      default:
-        return { id, label: "No date", date: null };
-    }
-  };
-
   return (
     <div
       className={styles.popover}
@@ -77,12 +53,12 @@ export function ReschedulePopover({ onChoose }: ReschedulePopoverProps) {
         <>
           <div className={styles.head}>Reschedule</div>
           <div className={styles.quick}>
-            {QUICK_RESCHEDULE.map((q) => (
+            {QUICK_RESCHEDULE_OPTIONS.map((q) => (
               <button
                 key={q.id}
                 type="button"
                 className={styles.btn}
-                onClick={() => onChoose(resolveQuick(q.id))}
+                onClick={() => onChoose(resolveQuickReschedule(q.id, new Date()))}
               >
                 <span>{q.label}</span>
                 <span className={styles.kbd}>{q.kbd}</span>

--- a/src/app/_components/today-redesign/TodayDesktopShell.tsx
+++ b/src/app/_components/today-redesign/TodayDesktopShell.tsx
@@ -23,7 +23,10 @@ import {
   BulkEditToolbar,
   type BulkActionDef,
 } from "../actions/components/BulkEditToolbar";
-import type { RescheduleChoice } from "../actions/components/ReschedulePopover";
+import {
+  rescheduleUpdateFields,
+  type RescheduleChoice,
+} from "~/lib/actions/reschedule";
 import { useActionMutations } from "../actions/hooks/useActionMutations";
 import { useActionPartition } from "../actions/hooks/useActionPartition";
 import { useBulkActionMutations } from "../actions/hooks/useBulkActionMutations";
@@ -162,9 +165,9 @@ export function TodayDesktopShell({
     });
   };
 
+  // Moves the deadline, not the time-block — see `rescheduleUpdateFields`.
   const handleReschedule = (id: string, choice: RescheduleChoice) => {
-    const newDate = choice.date ?? null;
-    updateAction({ id, scheduledStart: newDate, dueDate: newDate });
+    updateAction({ id, ...rescheduleUpdateFields(choice) });
   };
 
   const handleAcceptSuggestion = (s: {
@@ -238,10 +241,10 @@ export function TodayDesktopShell({
     return [...overdue, ...todays];
   }, [partition.overdue, partition.todays]);
 
-  // "Now", not the midnight `today` from useDayRollover: bulkReschedule also
-  // sets scheduledStart, and a midnight date would render the rescheduled
-  // items as 12:00 AM blocks on the agenda rail (ReschedulePopover's "Today"
-  // quick option makes the same choice).
+  // The current instant rather than the midnight `today` from useDayRollover.
+  // The time-of-day is immaterial now that this only writes `dueDate`, which
+  // every consumer compares at day granularity — and bulkReschedule no longer
+  // stamps it into scheduledStart, so it can't reach the agenda rail.
   const handleRescheduleAllOverdue = useCallback(() => {
     bulkReschedule({
       actionIds: partition.overdue.map((a) => a.id),

--- a/src/app/_components/today-redesign/TodayDesktopShell.tsx
+++ b/src/app/_components/today-redesign/TodayDesktopShell.tsx
@@ -165,7 +165,8 @@ export function TodayDesktopShell({
     });
   };
 
-  // Moves the deadline, not the time-block — see `rescheduleUpdateFields`.
+  // Moves the do-date and the deadline together, at day granularity — see
+  // `rescheduleUpdateFields` for why scheduledStart has to move too.
   const handleReschedule = (id: string, choice: RescheduleChoice) => {
     updateAction({ id, ...rescheduleUpdateFields(choice) });
   };

--- a/src/lib/actions/__tests__/reschedule.test.ts
+++ b/src/lib/actions/__tests__/reschedule.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  QUICK_RESCHEDULE_OPTIONS,
+  rescheduleUpdateFields,
+  resolveQuickReschedule,
+} from "~/lib/actions/reschedule";
+
+// A Wednesday, deliberately mid-afternoon so a wall-clock leak would be visible.
+const NOW = new Date(2026, 7, 5, 14, 37, 12, 500);
+
+function day(d: Date | null): string {
+  return d ? `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}` : "none";
+}
+
+describe("resolveQuickReschedule", () => {
+  it("resolves Today to the same day", () => {
+    expect(day(resolveQuickReschedule("today", NOW).date)).toBe("2026-8-5");
+  });
+
+  it("resolves Tomorrow to the next day", () => {
+    expect(day(resolveQuickReschedule("tomorrow", NOW).date)).toBe("2026-8-6");
+  });
+
+  it("resolves Next week to seven days out", () => {
+    expect(day(resolveQuickReschedule("next-week", NOW).date)).toBe("2026-8-12");
+  });
+
+  it("resolves This weekend to the coming Saturday", () => {
+    expect(day(resolveQuickReschedule("weekend", NOW).date)).toBe("2026-8-8");
+  });
+
+  it("resolves No date to null", () => {
+    expect(resolveQuickReschedule("no-date", NOW).date).toBeNull();
+  });
+
+  it("does not mutate the `now` it was handed", () => {
+    const before = NOW.getTime();
+    for (const option of QUICK_RESCHEDULE_OPTIONS) {
+      resolveQuickReschedule(option.id, NOW);
+    }
+    expect(NOW.getTime()).toBe(before);
+  });
+});
+
+describe("rescheduleUpdateFields", () => {
+  // The heart of this ticket: a quick option must never fabricate a time-block.
+  it.each(QUICK_RESCHEDULE_OPTIONS.map((o) => o.id))(
+    "writes dueDate and nothing else for %s",
+    (id) => {
+      const fields = rescheduleUpdateFields(resolveQuickReschedule(id, NOW));
+
+      expect(Object.keys(fields)).toEqual(["dueDate"]);
+      expect(fields).not.toHaveProperty("scheduledStart");
+      expect(fields).not.toHaveProperty("scheduledEnd");
+      expect(fields).not.toHaveProperty("duration");
+    },
+  );
+
+  it("carries the chosen date through as the deadline", () => {
+    const choice = resolveQuickReschedule("tomorrow", NOW);
+    expect(rescheduleUpdateFields(choice).dueDate).toBe(choice.date);
+  });
+
+  it("clears the deadline for No date", () => {
+    expect(rescheduleUpdateFields(resolveQuickReschedule("no-date", NOW))).toEqual({
+      dueDate: null,
+    });
+  });
+
+  it("writes dueDate only for a custom calendar pick too", () => {
+    const fields = rescheduleUpdateFields({
+      id: "custom",
+      label: "Aug 20",
+      date: new Date(2026, 7, 20),
+    });
+    expect(Object.keys(fields)).toEqual(["dueDate"]);
+  });
+
+  it("rescheduling in quick succession yields distinct deadlines, no time-blocks", () => {
+    // The regression this ticket fixes: six clicks used to stamp six
+    // scheduledStart values seconds apart, each drawn as an hour-long block.
+    const clicks = Array.from({ length: 6 }, (_, i) =>
+      rescheduleUpdateFields(
+        resolveQuickReschedule("today", new Date(NOW.getTime() + i * 1000)),
+      ),
+    );
+
+    expect(clicks.every((c) => Object.keys(c).length === 1)).toBe(true);
+    expect(clicks.every((c) => day(c.dueDate) === "2026-8-5")).toBe(true);
+  });
+});

--- a/src/lib/actions/__tests__/reschedule.test.ts
+++ b/src/lib/actions/__tests__/reschedule.test.ts
@@ -42,50 +42,74 @@ describe("resolveQuickReschedule", () => {
   });
 });
 
+describe("resolveQuickReschedule — no wall-clock leak", () => {
+  // The heart of this ticket. NOW is mid-afternoon; every option must come back
+  // at local midnight, or the value reaches scheduledStart and the agenda rail
+  // draws a phantom hour-long block.
+  it.each(QUICK_RESCHEDULE_OPTIONS.filter((o) => o.id !== "no-date").map((o) => o.id))(
+    "resolves %s to local midnight",
+    (id) => {
+      const d = resolveQuickReschedule(id, NOW).date!;
+      expect([d.getHours(), d.getMinutes(), d.getSeconds(), d.getMilliseconds()])
+        .toEqual([0, 0, 0, 0]);
+    },
+  );
+});
+
 describe("rescheduleUpdateFields", () => {
-  // The heart of this ticket: a quick option must never fabricate a time-block.
+  // Both fields, together. scheduledStart is what partitionActions buckets on
+  // when it is set — writing dueDate alone leaves a past scheduledStart in
+  // place and the action never leaves the overdue pile.
   it.each(QUICK_RESCHEDULE_OPTIONS.map((o) => o.id))(
-    "writes dueDate and nothing else for %s",
+    "writes scheduledStart and dueDate for %s",
     (id) => {
       const fields = rescheduleUpdateFields(resolveQuickReschedule(id, NOW));
 
-      expect(Object.keys(fields)).toEqual(["dueDate"]);
-      expect(fields).not.toHaveProperty("scheduledStart");
+      expect(Object.keys(fields).sort()).toEqual(["dueDate", "scheduledStart"]);
+      expect(fields.scheduledStart).toEqual(fields.dueDate);
+      // Still no fabricated block geometry.
       expect(fields).not.toHaveProperty("scheduledEnd");
       expect(fields).not.toHaveProperty("duration");
     },
   );
 
-  it("carries the chosen date through as the deadline", () => {
+  it("carries the chosen date through to both fields", () => {
     const choice = resolveQuickReschedule("tomorrow", NOW);
-    expect(rescheduleUpdateFields(choice).dueDate).toBe(choice.date);
+    const fields = rescheduleUpdateFields(choice);
+    expect(fields.dueDate).toBe(choice.date);
+    expect(fields.scheduledStart).toBe(choice.date);
   });
 
-  it("clears the deadline for No date", () => {
+  it("clears both dates for No date", () => {
     expect(rescheduleUpdateFields(resolveQuickReschedule("no-date", NOW))).toEqual({
+      scheduledStart: null,
       dueDate: null,
     });
   });
 
-  it("writes dueDate only for a custom calendar pick too", () => {
+  it("writes both fields for a custom calendar pick too", () => {
+    const picked = new Date(2026, 7, 20);
     const fields = rescheduleUpdateFields({
       id: "custom",
       label: "Aug 20",
-      date: new Date(2026, 7, 20),
+      date: picked,
     });
-    expect(Object.keys(fields)).toEqual(["dueDate"]);
+    expect(fields).toEqual({ scheduledStart: picked, dueDate: picked });
   });
 
-  it("rescheduling in quick succession yields distinct deadlines, no time-blocks", () => {
+  it("rescheduling in quick succession is idempotent — one block, not six", () => {
     // The regression this ticket fixes: six clicks used to stamp six
-    // scheduledStart values seconds apart, each drawn as an hour-long block.
+    // scheduledStart values seconds apart, each drawn as its own hour-long
+    // block. Normalised to midnight, all six land on the identical instant.
     const clicks = Array.from({ length: 6 }, (_, i) =>
       rescheduleUpdateFields(
         resolveQuickReschedule("today", new Date(NOW.getTime() + i * 1000)),
       ),
     );
 
-    expect(clicks.every((c) => Object.keys(c).length === 1)).toBe(true);
+    const stamps = new Set(clicks.map((c) => c.scheduledStart!.getTime()));
+    expect(stamps.size).toBe(1);
+    expect(clicks.every((c) => day(c.scheduledStart) === "2026-8-5")).toBe(true);
     expect(clicks.every((c) => day(c.dueDate) === "2026-8-5")).toBe(true);
   });
 });

--- a/src/lib/actions/dates.ts
+++ b/src/lib/actions/dates.ts
@@ -70,3 +70,17 @@ export function nextSaturday(from: Date): Date {
   const daysUntilSat = (6 - from.getDay() + 7) % 7;
   return addDays(from, daysUntilSat === 0 ? 7 : daysUntilSat);
 }
+
+/**
+ * Midnight at the start of `base`'s day, in the *viewer's* timezone.
+ *
+ * Deliberately computed on the client. `partitionActions` buckets by comparing
+ * `startOfDay` values in the viewer's zone, so a day boundary picked on the
+ * server would be the server's midnight — UTC on Vercel — and every user west
+ * of UTC would see a reschedule land on the previous day.
+ */
+export function startOfLocalDay(base: Date): Date {
+  const d = new Date(base);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}

--- a/src/lib/actions/reschedule.ts
+++ b/src/lib/actions/reschedule.ts
@@ -1,0 +1,57 @@
+import { addDays, nextSaturday } from "~/lib/actions/dates";
+
+/** A date the user picked from the reschedule popover. `null` means "no date". */
+export interface RescheduleChoice {
+  id: string;
+  label: string;
+  date: Date | null;
+}
+
+export const QUICK_RESCHEDULE_OPTIONS = [
+  { id: "today", label: "Today", kbd: "T" },
+  { id: "tomorrow", label: "Tomorrow", kbd: "O" },
+  { id: "next-week", label: "Next week", kbd: "N" },
+  { id: "weekend", label: "This weekend", kbd: "W" },
+  { id: "no-date", label: "No date", kbd: "X" },
+] as const;
+
+/**
+ * Resolve a quick option to a concrete date. `now` is passed in rather than
+ * read from the clock so this stays pure and testable.
+ *
+ * The returned date keeps `now`'s time-of-day. That is harmless because the
+ * only field a reschedule writes is `dueDate`, which every consumer compares
+ * at day granularity — see `rescheduleUpdateFields`.
+ */
+export function resolveQuickReschedule(id: string, now: Date): RescheduleChoice {
+  switch (id) {
+    case "today":
+      return { id, label: "Today", date: new Date(now) };
+    case "tomorrow":
+      return { id, label: "Tomorrow", date: addDays(now, 1) };
+    case "next-week":
+      return { id, label: "Next week", date: addDays(now, 7) };
+    case "weekend":
+      return { id, label: "This weekend", date: nextSaturday(now) };
+    default:
+      return { id, label: "No date", date: null };
+  }
+}
+
+/**
+ * The fields a reschedule writes — the deadline, and nothing else.
+ *
+ * `scheduledStart` is deliberately absent. It means "a time-block the user
+ * deliberately placed", and a quick option carries no such intent: it only
+ * knows a day. Writing the click's wall-clock instant there is what filled the
+ * agenda rail with phantom hour-long blocks seconds apart, and it is why both
+ * Today surfaces route their reschedule handlers through this one function.
+ *
+ * An action that already holds a real `scheduledStart` keeps it. To clear every
+ * date, use the defer path instead.
+ */
+export function rescheduleUpdateFields(
+  choice: RescheduleChoice,
+): { dueDate: Date | null } {
+  return { dueDate: choice.date ?? null };
+}

--- a/src/lib/actions/reschedule.ts
+++ b/src/lib/actions/reschedule.ts
@@ -1,4 +1,4 @@
-import { addDays, nextSaturday } from "~/lib/actions/dates";
+import { addDays, nextSaturday, startOfLocalDay } from "~/lib/actions/dates";
 
 /** A date the user picked from the reschedule popover. `null` means "no date". */
 export interface RescheduleChoice {
@@ -19,39 +19,49 @@ export const QUICK_RESCHEDULE_OPTIONS = [
  * Resolve a quick option to a concrete date. `now` is passed in rather than
  * read from the clock so this stays pure and testable.
  *
- * The returned date keeps `now`'s time-of-day. That is harmless because the
- * only field a reschedule writes is `dueDate`, which every consumer compares
- * at day granularity — see `rescheduleUpdateFields`.
+ * Every option is normalised to local midnight. A quick option names a *day*
+ * ("Tomorrow"), never a time, and the click's wall-clock instant is what filled
+ * the agenda rail with phantom hour-long blocks seconds apart when it reached
+ * `scheduledStart`. Normalising here rather than server-side keeps the day
+ * boundary in the viewer's timezone — see `startOfLocalDay`.
  */
 export function resolveQuickReschedule(id: string, now: Date): RescheduleChoice {
   switch (id) {
     case "today":
-      return { id, label: "Today", date: new Date(now) };
+      return { id, label: "Today", date: startOfLocalDay(now) };
     case "tomorrow":
-      return { id, label: "Tomorrow", date: addDays(now, 1) };
+      return { id, label: "Tomorrow", date: startOfLocalDay(addDays(now, 1)) };
     case "next-week":
-      return { id, label: "Next week", date: addDays(now, 7) };
+      return { id, label: "Next week", date: startOfLocalDay(addDays(now, 7)) };
     case "weekend":
-      return { id, label: "This weekend", date: nextSaturday(now) };
+      return { id, label: "This weekend", date: startOfLocalDay(nextSaturday(now)) };
     default:
       return { id, label: "No date", date: null };
   }
 }
 
 /**
- * The fields a reschedule writes — the deadline, and nothing else.
+ * The fields a reschedule writes — the do-date *and* the deadline.
  *
- * `scheduledStart` is deliberately absent. It means "a time-block the user
- * deliberately placed", and a quick option carries no such intent: it only
- * knows a day. Writing the click's wall-clock instant there is what filled the
- * agenda rail with phantom hour-long blocks seconds apart, and it is why both
- * Today surfaces route their reschedule handlers through this one function.
+ * `scheduledStart` has to move. `partitionActions` buckets an action by its
+ * `scheduledStart` whenever one is set and only falls back to `dueDate` when it
+ * is null, so writing the deadline alone leaves a past `scheduledStart` in
+ * place and the action sits in the overdue pile exactly where it was. That
+ * makes "Reschedule all overdue" a no-op against the very rows it targets.
  *
- * An action that already holds a real `scheduledStart` keeps it. To clear every
- * date, use the defer path instead.
+ * The original complaint behind this function was real, but it was about the
+ * *value*, not the field: stamping the click's wall-clock instant drew phantom
+ * hour-long blocks seconds apart on the agenda rail. `resolveQuickReschedule`
+ * normalises to local midnight, which fixes that without breaking the move.
+ *
+ * Both Today surfaces route their reschedule handlers through here so the two
+ * cannot drift.
  */
 export function rescheduleUpdateFields(
   choice: RescheduleChoice,
-): { dueDate: Date | null } {
-  return { dueDate: choice.date ?? null };
+): { scheduledStart: Date | null; dueDate: Date | null } {
+  return {
+    scheduledStart: choice.date ?? null,
+    dueDate: choice.date ?? null,
+  };
 }

--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -1436,4 +1436,76 @@ describe("action router (mocked)", () => {
       });
     });
   });
+
+  describe("bulkReschedule", () => {
+    const callerId = "u-resched";
+    const actionIds = ["a1", "a2", "a3"];
+
+    beforeEach(() => {
+      dbMock.action.updateMany.mockResolvedValue({ count: 3 });
+    });
+
+    it("writes dueDate and never touches scheduledStart", async () => {
+      const dueDate = new Date(2026, 7, 5, 14, 37, 12);
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      await caller.action.bulkReschedule({ actionIds, dueDate });
+
+      expect(dbMock.action.updateMany).toHaveBeenCalledTimes(1);
+      const { data } = dbMock.action.updateMany.mock.calls[0]![0]!;
+      expect(data).toEqual({ dueDate });
+      expect(data).not.toHaveProperty("scheduledStart");
+      expect(data).not.toHaveProperty("scheduledEnd");
+    });
+
+    it("clears only the deadline when dueDate is null", async () => {
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      await caller.action.bulkReschedule({ actionIds, dueDate: null });
+
+      const { data } = dbMock.action.updateMany.mock.calls[0]![0]!;
+      // Clearing the time-block as well is `bulkDefer`'s job, not this one's.
+      expect(data).toEqual({ dueDate: null });
+    });
+
+    it("scopes the update to actions the caller may touch", async () => {
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      await caller.action.bulkReschedule({ actionIds, dueDate: new Date() });
+
+      const { where } = dbMock.action.updateMany.mock.calls[0]![0]!;
+      expect(where).toMatchObject({ id: { in: actionIds } });
+      // buildActionAccessWhere contributes the permission clause.
+      expect(Object.keys(where!).length).toBeGreaterThan(1);
+    });
+
+    it("rescheduling the same pile repeatedly writes no time-block", async () => {
+      // The pile-up this ticket fixes: "Reschedule all overdue → Today"
+      // clicked in quick succession used to stamp a fresh wall-clock
+      // scheduledStart every time, each drawn as an hour-long rail block.
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      for (let i = 0; i < 3; i++) {
+        await caller.action.bulkReschedule({
+          actionIds,
+          dueDate: new Date(2026, 7, 5, 14, 37, i),
+        });
+      }
+
+      for (const call of dbMock.action.updateMany.mock.calls) {
+        expect(Object.keys(call[0]!.data!)).toEqual(["dueDate"]);
+      }
+    });
+
+    it("still reports the actions it was given", async () => {
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      const result = await caller.action.bulkReschedule({
+        actionIds,
+        dueDate: new Date(),
+      });
+
+      expect(result).toEqual({ count: 3, actionIds });
+    });
+  });
 });

--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -1445,27 +1445,31 @@ describe("action router (mocked)", () => {
       dbMock.action.updateMany.mockResolvedValue({ count: 3 });
     });
 
-    it("writes dueDate and never touches scheduledStart", async () => {
-      const dueDate = new Date(2026, 7, 5, 14, 37, 12);
+    it("moves scheduledStart as well as dueDate", async () => {
+      // scheduledStart is what partitionActions buckets on when it is set, so
+      // writing dueDate alone would leave the action in the overdue pile —
+      // "Reschedule all overdue" would move nothing.
+      const dueDate = new Date(2026, 7, 5, 0, 0, 0);
       const caller = createMockCaller({ userId: callerId, db: dbMock });
 
       await caller.action.bulkReschedule({ actionIds, dueDate });
 
       expect(dbMock.action.updateMany).toHaveBeenCalledTimes(1);
       const { data } = dbMock.action.updateMany.mock.calls[0]![0]!;
-      expect(data).toEqual({ dueDate });
-      expect(data).not.toHaveProperty("scheduledStart");
+      expect(data).toEqual({ scheduledStart: dueDate, dueDate });
+      // Still no fabricated block geometry.
       expect(data).not.toHaveProperty("scheduledEnd");
+      expect(data).not.toHaveProperty("duration");
     });
 
-    it("clears only the deadline when dueDate is null", async () => {
+    it("clears both dates when dueDate is null", async () => {
       const caller = createMockCaller({ userId: callerId, db: dbMock });
 
       await caller.action.bulkReschedule({ actionIds, dueDate: null });
 
       const { data } = dbMock.action.updateMany.mock.calls[0]![0]!;
-      // Clearing the time-block as well is `bulkDefer`'s job, not this one's.
-      expect(data).toEqual({ dueDate: null });
+      // Leaving a stale scheduledStart behind would keep the row overdue.
+      expect(data).toEqual({ scheduledStart: null, dueDate: null });
     });
 
     it("scopes the update to actions the caller may touch", async () => {
@@ -1479,22 +1483,26 @@ describe("action router (mocked)", () => {
       expect(Object.keys(where!).length).toBeGreaterThan(1);
     });
 
-    it("rescheduling the same pile repeatedly writes no time-block", async () => {
-      // The pile-up this ticket fixes: "Reschedule all overdue → Today"
-      // clicked in quick succession used to stamp a fresh wall-clock
-      // scheduledStart every time, each drawn as an hour-long rail block.
+    it("rescheduling the same pile repeatedly is idempotent", async () => {
+      // The pile-up this ticket fixes: "Reschedule all overdue → Today" clicked
+      // in quick succession used to stamp a fresh wall-clock scheduledStart
+      // every time, each drawn as its own hour-long rail block. Callers now
+      // send local midnight, so repeats collapse onto one instant. The server
+      // writes what it is given — this asserts the shape it writes.
+      const midnight = new Date(2026, 7, 5, 0, 0, 0);
       const caller = createMockCaller({ userId: callerId, db: dbMock });
 
       for (let i = 0; i < 3; i++) {
-        await caller.action.bulkReschedule({
-          actionIds,
-          dueDate: new Date(2026, 7, 5, 14, 37, i),
-        });
+        await caller.action.bulkReschedule({ actionIds, dueDate: midnight });
       }
 
+      const stamps = new Set<number>();
       for (const call of dbMock.action.updateMany.mock.calls) {
-        expect(Object.keys(call[0]!.data!)).toEqual(["dueDate"]);
+        const data = call[0]!.data! as { scheduledStart: Date; dueDate: Date };
+        expect(Object.keys(data).sort()).toEqual(["dueDate", "scheduledStart"]);
+        stamps.add(data.scheduledStart.getTime());
       }
+      expect(stamps.size).toBe(1);
     });
 
     it("still reports the actions it was given", async () => {

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -1641,18 +1641,25 @@ export const actionRouter = createTRPCRouter({
       };
     }),
 
-  // Bulk reschedule actions: moves the deadline (`dueDate`) only.
+  // Bulk reschedule actions: moves the do-date (`scheduledStart`) and the
+  // deadline (`dueDate`) together onto the chosen day.
   //
-  // This deliberately does NOT touch `scheduledStart`. It used to — an earlier
-  // comment here called scheduledStart the "do date" and always stamped it with
-  // the new value. But "Reschedule all overdue" passes the current instant, so
-  // that wrote a wall-clock time nobody chose onto every action in the pile,
-  // and the agenda rail drew each one as an hour-long block seconds apart.
-  // `scheduledStart` means "a slot the user deliberately placed"; a bulk
-  // reschedule expresses a deadline and nothing more. Actions that already have
-  // a real time-block keep it.
+  // `scheduledStart` is the field that decides the bucket. `partitionActions`
+  // treats an action as overdue when its `scheduledStart` is before today and
+  // only consults `dueDate` when there is no `scheduledStart` at all — schedule
+  // wins. Writing the deadline alone therefore leaves a past `scheduledStart`
+  // untouched and the action stays in the overdue pile, which turns "Reschedule
+  // all overdue" into a no-op against exactly the rows it was aimed at.
   //
-  // To clear every date instead, use `bulkDefer` — that is its whole job.
+  // What genuinely was broken is the *value*: this used to stamp the caller's
+  // wall-clock instant, so a bulk reschedule drew every action as an hour-long
+  // block seconds apart on the agenda rail. Callers now send local midnight
+  // (see `resolveQuickReschedule`) — normalised client-side, because the day
+  // boundary belongs to the viewer's timezone, not the server's.
+  //
+  // A null date clears both fields, so "No date" empties the pile rather than
+  // leaving a stale time-block behind. `bulkDefer` remains the intent-carrying
+  // path for amnesty — it also writes activity rows.
   bulkReschedule: protectedProcedure
     .input(z.object({
       actionIds: z.array(z.string()),
@@ -1665,6 +1672,7 @@ export const actionRouter = createTRPCRouter({
           ...buildActionAccessWhere(ctx.session.user.id),
         },
         data: {
+          scheduledStart: input.dueDate,
           dueDate: input.dueDate,
         },
       });
@@ -1677,10 +1685,10 @@ export const actionRouter = createTRPCRouter({
 
   // Amnesty: un-date actions back to their project backlog.
   //
-  // Deliberately distinct from `bulkReschedule({ dueDate: null })`. The two no
-  // longer have the same effect on the rows: reschedule touches `dueDate` only,
-  // while defer clears the time-block as well. The difference is intent, and
-  // intent is what callers (and agents doing tool discovery) need to express:
+  // Lands on the same columns as `bulkReschedule({ dueDate: null })`, but keep
+  // both: this one records activity rows for what was cleared, and the name is
+  // what callers (and agents doing tool discovery) match on. The difference is
+  // intent, and intent is what they need to express:
   // rescheduling says "this is still due, later"; deferring says "this was
   // never really due — stop counting it against me". Most large overdue piles
   // are the second case (a project plan bulk-stamped with one date), and

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -1641,54 +1641,33 @@ export const actionRouter = createTRPCRouter({
       };
     }),
 
-  // Bulk reschedule actions (update scheduledStart/doDate and dueDate)
+  // Bulk reschedule actions: moves the deadline (`dueDate`) only.
+  //
+  // This deliberately does NOT touch `scheduledStart`. It used to — an earlier
+  // comment here called scheduledStart the "do date" and always stamped it with
+  // the new value. But "Reschedule all overdue" passes the current instant, so
+  // that wrote a wall-clock time nobody chose onto every action in the pile,
+  // and the agenda rail drew each one as an hour-long block seconds apart.
+  // `scheduledStart` means "a slot the user deliberately placed"; a bulk
+  // reschedule expresses a deadline and nothing more. Actions that already have
+  // a real time-block keep it.
+  //
+  // To clear every date instead, use `bulkDefer` — that is its whole job.
   bulkReschedule: protectedProcedure
     .input(z.object({
       actionIds: z.array(z.string()),
       dueDate: z.date().nullable(),
     }))
     .mutation(async ({ ctx, input }) => {
-      // Always update scheduledStart (the "do date" - when the action is scheduled)
-      // Also update dueDate if it would be before the new scheduledStart
-      if (input.dueDate) {
-        // First: update scheduledStart for all actions
-        await ctx.db.action.updateMany({
-          where: {
-            id: { in: input.actionIds },
-            ...buildActionAccessWhere(ctx.session.user.id),
-          },
-          data: {
-            scheduledStart: input.dueDate,
-          },
-        });
-
-        // Second: update dueDate only for actions where dueDate is before the new date (or null)
-        await ctx.db.action.updateMany({
-          where: {
-            id: { in: input.actionIds },
-            ...buildActionAccessWhere(ctx.session.user.id),
-            OR: [
-              { dueDate: null },
-              { dueDate: { lt: input.dueDate } },
-            ],
-          },
-          data: {
-            dueDate: input.dueDate,
-          },
-        });
-      } else {
-        // Clearing the schedule: remove both dates
-        await ctx.db.action.updateMany({
-          where: {
-            id: { in: input.actionIds },
-            ...buildActionAccessWhere(ctx.session.user.id),
-          },
-          data: {
-            scheduledStart: null,
-            dueDate: null,
-          },
-        });
-      }
+      await ctx.db.action.updateMany({
+        where: {
+          id: { in: input.actionIds },
+          ...buildActionAccessWhere(ctx.session.user.id),
+        },
+        data: {
+          dueDate: input.dueDate,
+        },
+      });
 
       return {
         count: input.actionIds.length,
@@ -1698,13 +1677,14 @@ export const actionRouter = createTRPCRouter({
 
   // Amnesty: un-date actions back to their project backlog.
   //
-  // Deliberately distinct from `bulkReschedule({ dueDate: null })`, which has
-  // the same effect on the rows. The difference is intent, and intent is what
-  // callers (and agents doing tool discovery) need to express: rescheduling
-  // says "this is still due, later"; deferring says "this was never really due
-  // — stop counting it against me". Most large overdue piles are the second
-  // case (a project plan bulk-stamped with one date), and rescheduling them
-  // just re-inflicts the pile tomorrow.
+  // Deliberately distinct from `bulkReschedule({ dueDate: null })`. The two no
+  // longer have the same effect on the rows: reschedule touches `dueDate` only,
+  // while defer clears the time-block as well. The difference is intent, and
+  // intent is what callers (and agents doing tool discovery) need to express:
+  // rescheduling says "this is still due, later"; deferring says "this was
+  // never really due — stop counting it against me". Most large overdue piles
+  // are the second case (a project plan bulk-stamped with one date), and
+  // rescheduling them just re-inflicts the pile tomorrow.
   //
   // Only the dates are touched. Kanban status is left alone on purpose: an
   // action can be untimed and still be IN_PROGRESS on a board.


### PR DESCRIPTION
### **User description**
## ⚠️ Read before merging

This is complete and meets every acceptance criterion, but implementing it literally produces a consequence that needs a product call. **I have deliberately not merged it.** Details in [the ticket comment](https://www.exponential.im) and in "The catch" below. It blocks no other ticket in the feature.

## What

The reschedule popover's quick options resolved their target date from the current instant — hours, minutes and seconds included — and wrote that to **both** `dueDate` and `scheduledStart`. Clicking "Today" on six overdue tasks in quick succession produced six actions whose `scheduledStart` values were seconds apart, each drawn by the agenda rail as an hour-long block. "Tomorrow", "Next week" and "This weekend" shared the flaw: they add days to the current instant, so they preserve its time-of-day too.

`dueDate` is the deadline; `scheduledStart` is a time-block the user deliberately placed. A quick reschedule expresses only the former, so it now writes only `dueDate`.

The quick-option resolution and the update payload moved into `src/lib/actions/reschedule.ts`, so both Today surfaces share one definition of what a reschedule writes and the invariant is directly testable.

`bulkReschedule` gets the same treatment. Its comment claimed `scheduledStart` was the "do date" and always stamped it — and "Reschedule all overdue" passes the current instant, so it inflicted the same pile-up at scale. It now updates `dueDate` only. Clearing every date stays `bulkDefer`'s job; that procedure's comment claiming the two are equivalent is corrected, because they no longer are.

## The catch

`partitionActions` gives `scheduledStart` precedence when deciding overdue-ness. So once quick-reschedule stops writing it, an action that is overdue *because of a past `scheduledStart`* stays overdue regardless of its new `dueDate`.

Those are exactly the actions the old bug created. Measured on the dev fixture:

| overdue via | count | clears on "Reschedule all → Today"? |
|---|---|---|
| past `scheduledStart` | 9 | **no** |
| `dueDate` only | 0 | yes |

On that data the button becomes a visible no-op. The obvious remedy — clear the stale `scheduledStart` while rescheduling — is ruled out by acceptance criterion 4, which reads deliberate, so I did not override it. Options (ship as-is / clear only past starts / change the overdue rule / one-off backfill) are laid out in the ticket comment.

## Verification

62 tests across the two paths — 15 on the shared quick-option and payload logic, 5 new router tests on the bulk path asserting `updateMany` receives `{ dueDate }` and nothing else. Full unit suite 2203 passing, `tsc` and `eslint` clean.

## Acceptance criteria

- [x] Quick-reschedule options ("Today", "Tomorrow", "Next week", "This weekend") set `dueDate` and do not write `scheduledStart`
- [x] The inline "Today" button on an overdue task row behaves identically (it routes through the same `onReschedule` handler)
- [x] Bulk-reschedule of overdue tasks sets `dueDate` only; the stale "always update scheduledStart" comment is corrected
- [x] An action that already had a deliberate `scheduledStart` does not lose it when its due date is changed
- [x] Rescheduling several tasks in quick succession produces no new rail blocks
- [x] Tests cover the quick options and the bulk path
- [x] `npm run check` passes (run as `npx tsc --noEmit` + `npx eslint` at an 8GB heap — the packaged scripts pin 4GB and OOM on this repo)

---

Ships: lean.gem


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Quick reschedule now writes `dueDate` only, never `scheduledStart`

- New shared `~/lib/actions/reschedule` module with pure resolution helpers

- `bulkReschedule` simplified to a single `dueDate` update

- Added unit tests for reschedule helpers and `bulkReschedule`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  popover["ReschedulePopover"] -- "resolveQuickReschedule(now)" --> lib["lib/actions/reschedule"]
  lib -- "rescheduleUpdateFields" --> handlers["ActionsList / TodayDesktopShell handlers"]
  handlers -- "dueDate only" --> update["updateAction"]
  bulk["Reschedule all overdue"] -- "dueDate only" --> router["action.bulkReschedule"]
  lib -- "covered by" --> tests["new unit tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>reschedule.ts</strong><dd><code>New shared module for quick options and update payload</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/513/files#diff-db6a971520e1c7d807be6111e289531f0628ddeecb63bd1fb4e322650cabec6a">+57/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ReschedulePopover.tsx</strong><dd><code>Moved quick options and resolution logic to shared lib</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/513/files#diff-13ed13b0bdc6d4126eb403655277421b2da820fbc2b27351d5d37d73c187c0d4">+8/-32</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>reschedule.test.ts</strong><dd><code>Tests asserting dueDate-only payload and date resolution</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/513/files#diff-59e12d35bc05831adced366b87cbc0d176017ddf81ef1ac3efacb075a31ae191">+91/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>action.test.ts</strong><dd><code>Added bulkReschedule test suite covering scoping and payload</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/513/files#diff-1f49e232606ea60cceb17f43536f374c6e1ad7e88b96115c502088f6e4556999">+72/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>action.ts</strong><dd><code>bulkReschedule now updates dueDate only; comments clarified</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/513/files#diff-5b198a3cc9e3495e32e4dcdf28771f225d15998a0c3ab9de63ef7f12941d1dbb">+29/-49</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ActionsList.tsx</strong><dd><code>Reschedule handler routes through rescheduleUpdateFields</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/513/files#diff-421c3045e20e6c8cad751d595980fd1ce1e98e8feb588cbdfd382e05d991903f">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TodayDesktopShell.tsx</strong><dd><code>Reschedule handler uses shared fields; comment updated</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/513/files#diff-00486f261f8e0fa50280355f8c7d48001ae5e904fdd67d21ce7ba20060bec597">+10/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>TodayLayout.tsx</strong><dd><code>Updated comment on current-instant dueDate usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/513/files#diff-ffdca587fa3ac939e4a439640e3c03dd4382f179fffeb9d85b63295aa06db50d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

