### PR TITLE
fix: Short agenda blocks stay legible

### DIFF
--- a/src/app/_components/actions/components/TimelineRail.module.css
+++ b/src/app/_components/actions/components/TimelineRail.module.css
@@ -127,8 +127,24 @@
   color: var(--today-rail-focus-text);
 }
 
+.blockTitle {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .blockTime {
   font-size: 10px;
   opacity: 0.8;
   font-variant-numeric: tabular-nums;
+}
+
+/* See the matching rule in today-desktop.css: floored blocks are drawn taller
+   than their duration, so they need an edge to stay distinct from the next. */
+.block[data-floored="true"] {
+  padding-top: 3px;
+  padding-bottom: 3px;
+  outline: 1px solid var(--color-border-primary);
+  outline-offset: -1px;
 }

--- a/src/app/_components/actions/components/TimelineRail.tsx
+++ b/src/app/_components/actions/components/TimelineRail.tsx
@@ -1,5 +1,6 @@
 import { formatHourLabel, formatHourMinute12 } from "~/lib/actions/dates";
 import type { RailBlock } from "~/lib/actions/railBlocks";
+import { layoutRailBlock } from "~/lib/actions/railLayout";
 import styles from "./TimelineRail.module.css";
 
 export type { RailBlock };
@@ -57,22 +58,26 @@ export function TimelineRail({
           );
         })}
         {blocks.map((ev) => {
-          const clampedStart = Math.max(ev.start, start);
-          const clampedEnd = Math.min(ev.end, end);
-          if (clampedEnd <= clampedStart) return null;
+          const layout = layoutRailBlock(ev, {
+            rangeStart: start,
+            rangeEnd: end,
+            hourPx: hourHeight,
+          });
+          if (!layout) return null;
           return (
             <div
               key={ev.id}
               className={`${styles.block} ${blockClass[ev.kind]}`}
-              style={{
-                top: (clampedStart - start) * hourHeight + 2,
-                height: (clampedEnd - clampedStart) * hourHeight - 4,
-              }}
+              data-floored={layout.isFloored ? "true" : undefined}
+              style={{ top: layout.top + 2, height: layout.height }}
+              title={`${ev.title} · ${formatHourMinute12(ev.start)} – ${formatHourMinute12(ev.end)}`}
             >
-              <div>{ev.title}</div>
-              <div className={styles.blockTime}>
-                {formatHourMinute12(ev.start)} – {formatHourMinute12(ev.end)}
-              </div>
+              <div className={styles.blockTitle}>{ev.title}</div>
+              {layout.showMeta && (
+                <div className={styles.blockTime}>
+                  {formatHourMinute12(ev.start)} – {formatHourMinute12(ev.end)}
+                </div>
+              )}
             </div>
           );
         })}

--- a/src/app/_components/today-redesign/AgendaRail.tsx
+++ b/src/app/_components/today-redesign/AgendaRail.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { RailBlock } from "~/lib/actions/railBlocks";
+import { layoutRailBlock } from "~/lib/actions/railLayout";
 import { formatHourLabel, formatHourMinute12 } from "~/lib/actions/dates";
 import { stripHtml } from "~/lib/utils";
 
@@ -59,23 +60,27 @@ export function AgendaRail({ dayLabel, eventsCount, blocks, now }: AgendaRailPro
           )}
 
           {blocks.map((b) => {
-            const clampedStart = Math.max(b.start, START_HR);
-            const clampedEnd = Math.min(b.end, END_HR);
-            if (clampedEnd <= clampedStart) return null;
+            const layout = layoutRailBlock(b, {
+              rangeStart: START_HR,
+              rangeEnd: END_HR,
+              hourPx: HOUR_PX,
+            });
+            if (!layout) return null;
             const tone = b.kind === "cal" ? "blue" : "amber";
             return (
               <div
                 key={b.id}
                 className={`td-event td-event--${tone}`}
-                style={{
-                  top: (clampedStart - START_HR) * HOUR_PX,
-                  height: (clampedEnd - clampedStart) * HOUR_PX - 4,
-                }}
+                data-floored={layout.isFloored ? "true" : undefined}
+                style={{ top: layout.top, height: layout.height }}
+                title={`${stripHtml(b.title)} · ${formatHourMinute12(b.start)} – ${formatHourMinute12(b.end)}`}
               >
                 <div className="td-event__title">{stripHtml(b.title)}</div>
-                <div className="td-event__meta">
-                  {formatHourMinute12(b.start)} – {formatHourMinute12(b.end)}
-                </div>
+                {layout.showMeta && (
+                  <div className="td-event__meta">
+                    {formatHourMinute12(b.start)} – {formatHourMinute12(b.end)}
+                  </div>
+                )}
               </div>
             );
           })}

--- a/src/app/_components/today-redesign/today-desktop.css
+++ b/src/app/_components/today-redesign/today-desktop.css
@@ -598,6 +598,17 @@ html[data-sidebar="closed"] .td-topbar {
   overflow: hidden;
 }
 
+/* A block shorter than its own contents is drawn at MIN_RAIL_BLOCK_PX, which
+   makes it taller than its duration and so liable to sit under the next one.
+   A hairline edge keeps consecutive short blocks readable as separate blocks
+   rather than one smear of colour. */
+.td-event[data-floored="true"] {
+  padding-top: 3px;
+  padding-bottom: 3px;
+  outline: 1px solid var(--td-hair-2);
+  outline-offset: -1px;
+}
+
 .td-event__title {
   font-size: 11.5px;
   font-weight: 600;

--- a/src/lib/actions/__tests__/railLayout.test.ts
+++ b/src/lib/actions/__tests__/railLayout.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  layoutRailBlock,
+  MIN_RAIL_BLOCK_PX,
+  RAIL_BLOCK_GAP_PX,
+  RAIL_META_MIN_PX,
+} from "~/lib/actions/railLayout";
+
+/** The desktop rail's geometry; the mobile one differs only in range. */
+const RAIL = { rangeStart: 7, rangeEnd: 20, hourPx: 48 };
+
+/** A block of `minutes` starting at `startHour`. */
+function block(startHour: number, minutes: number) {
+  return { start: startHour, end: startHour + minutes / 60 };
+}
+
+describe("layoutRailBlock", () => {
+  it("floors a 10-minute block to the minimum height", () => {
+    // 10min → 8px natural, minus the gap → 4px. That was the unreadable sliver.
+    const layout = layoutRailBlock(block(10.5, 10), RAIL);
+
+    expect(layout!.height).toBe(MIN_RAIL_BLOCK_PX);
+    expect(layout!.isFloored).toBe(true);
+  });
+
+  it("keeps a block's true position even when its height is floored", () => {
+    const layout = layoutRailBlock(block(10.5, 10), RAIL);
+
+    // 10:30 is 3.5h after the 7am range start → 168px. Unaffected by flooring.
+    expect(layout!.top).toBe(168);
+  });
+
+  it("leaves a full-hour block at its natural height", () => {
+    const layout = layoutRailBlock(block(11, 60), RAIL);
+
+    expect(layout!.height).toBe(48 - RAIL_BLOCK_GAP_PX);
+    expect(layout!.isFloored).toBe(false);
+  });
+
+  it("hides the meta line on short blocks and shows it on tall ones", () => {
+    expect(layoutRailBlock(block(10, 10), RAIL)!.showMeta).toBe(false);
+    expect(layoutRailBlock(block(10, 30), RAIL)!.showMeta).toBe(false);
+    expect(layoutRailBlock(block(10, 60), RAIL)!.showMeta).toBe(true);
+  });
+
+  it("switches the meta line on exactly at the threshold", () => {
+    // 60px/hour makes a minute exactly a pixel, so the boundary is expressible
+    // without floating-point slop: height = minutes - gap.
+    const perMinute = { rangeStart: 0, rangeEnd: 24, hourPx: 60 };
+    const atThreshold = RAIL_META_MIN_PX + RAIL_BLOCK_GAP_PX;
+
+    const on = layoutRailBlock(block(10, atThreshold), perMinute)!;
+    const below = layoutRailBlock(block(10, atThreshold - 1), perMinute)!;
+
+    expect(on.height).toBe(RAIL_META_MIN_PX);
+    expect(on.showMeta).toBe(true);
+    expect(below.height).toBe(RAIL_META_MIN_PX - 1);
+    expect(below.showMeta).toBe(false);
+  });
+
+  it("rounds away float noise from the hour-float arithmetic", () => {
+    // (38/60) * 60 is 37.99999999999997 in IEEE754. Unrounded that reaches the
+    // DOM as `height: 33.99999999999997px` and can flip the meta threshold.
+    const perMinute = { rangeStart: 0, rangeEnd: 24, hourPx: 60 };
+    const layout = layoutRailBlock(block(10, 38), perMinute)!;
+
+    expect(layout.height).toBe(34);
+    expect(Number.isInteger(layout.top)).toBe(true);
+  });
+
+  it("never returns a height below the floor, for any duration", () => {
+    for (const minutes of [1, 2, 5, 10, 15, 20, 25, 30, 45, 60, 120]) {
+      const layout = layoutRailBlock(block(9, minutes), RAIL);
+      expect(layout!.height).toBeGreaterThanOrEqual(MIN_RAIL_BLOCK_PX);
+    }
+  });
+
+  it("keeps consecutive short blocks at distinct positions", () => {
+    // Both are floored to the same height, so only `top` separates them —
+    // which is why the CSS gives floored blocks an edge.
+    const first = layoutRailBlock(block(10.5, 10), RAIL)!;
+    const second = layoutRailBlock(block(10.5 + 10 / 60, 10), RAIL)!;
+
+    expect(first.top).not.toBe(second.top);
+    expect(second.top).toBeGreaterThan(first.top);
+    expect(first.isFloored && second.isFloored).toBe(true);
+  });
+
+  it("drops blocks entirely outside the visible range", () => {
+    expect(layoutRailBlock(block(5, 30), RAIL)).toBeNull();
+    expect(layoutRailBlock(block(21, 30), RAIL)).toBeNull();
+    expect(layoutRailBlock({ start: 20, end: 22 }, RAIL)).toBeNull();
+  });
+
+  it("clamps a block that straddles the start of the range", () => {
+    const layout = layoutRailBlock({ start: 6, end: 8 }, RAIL);
+
+    expect(layout!.top).toBe(0);
+    expect(layout!.height).toBe(48 - RAIL_BLOCK_GAP_PX);
+  });
+
+  it("clamps a block that straddles the end of the range", () => {
+    const layout = layoutRailBlock({ start: 19, end: 23 }, RAIL);
+
+    expect(layout!.top).toBe((19 - 7) * 48);
+    expect(layout!.height).toBe(48 - RAIL_BLOCK_GAP_PX);
+  });
+
+  it("works against the mobile rail's range too", () => {
+    const mobile = { rangeStart: 6, rangeEnd: 22, hourPx: 48 };
+    const layout = layoutRailBlock(block(10.5, 10), mobile);
+
+    expect(layout!.top).toBe((10.5 - 6) * 48);
+    expect(layout!.height).toBe(MIN_RAIL_BLOCK_PX);
+  });
+});

--- a/src/lib/actions/railLayout.ts
+++ b/src/lib/actions/railLayout.ts
@@ -1,0 +1,81 @@
+import type { RailBlock } from "~/lib/actions/railBlocks";
+
+/**
+ * Geometry for the Today agenda rail, shared by the desktop rail
+ * (`AgendaRail`) and the mobile one (`TimelineRail`) so the two can't drift.
+ */
+
+/**
+ * Floor for a block's rendered height. The rail draws an hour as 48px, so a
+ * 10-minute block is 8px — less than its own padding, which clipped the title
+ * to a sliver of colour. 22px is the smallest height that fits one line of
+ * title text plus the block's vertical padding.
+ */
+export const MIN_RAIL_BLOCK_PX = 22;
+
+/**
+ * Below this rendered height a block shows its title only. Padding plus a
+ * title line plus a time line needs roughly 34px; the title is the part that
+ * matters, and the time is already implied by the block's position against the
+ * hour gutter.
+ */
+export const RAIL_META_MIN_PX = 34;
+
+/** Breathing room between stacked blocks, subtracted from the natural height. */
+export const RAIL_BLOCK_GAP_PX = 4;
+
+export interface RailBlockLayout {
+  /** Offset from the top of the rail, in px. Always the block's true start. */
+  top: number;
+  /** Rendered height in px — floored at `MIN_RAIL_BLOCK_PX`. */
+  height: number;
+  /** Whether there is room for the secondary time line. */
+  showMeta: boolean;
+  /** True when the floor kicked in, i.e. the block is drawn taller than it is. */
+  isFloored: boolean;
+}
+
+export interface RailLayoutOptions {
+  /** First hour drawn on the rail. */
+  rangeStart: number;
+  /** Last hour drawn on the rail. */
+  rangeEnd: number;
+  /** Pixels per hour. */
+  hourPx: number;
+  gapPx?: number;
+}
+
+/**
+ * Place one block on the rail, or `null` when it falls entirely outside the
+ * visible range.
+ *
+ * Only the *height* is floored — `top` always reflects the block's true start
+ * time, so a short block still sits at the right place against the gutter even
+ * though it is drawn taller than its duration.
+ */
+export function layoutRailBlock(
+  block: Pick<RailBlock, "start" | "end">,
+  { rangeStart, rangeEnd, hourPx, gapPx = RAIL_BLOCK_GAP_PX }: RailLayoutOptions,
+): RailBlockLayout | null {
+  const clampedStart = Math.max(block.start, rangeStart);
+  const clampedEnd = Math.min(block.end, rangeEnd);
+  if (clampedEnd <= clampedStart) return null;
+
+  // Hour floats come from dividing minutes by 60, so multiplying back by
+  // hourPx leaves float noise — a 38px block computes as 37.99999999999997.
+  // Left alone that both flips the `showMeta` threshold at its boundary and
+  // sends absurd style strings to the DOM.
+  const naturalHeight = roundPx((clampedEnd - clampedStart) * hourPx - gapPx);
+  const height = Math.max(naturalHeight, MIN_RAIL_BLOCK_PX);
+
+  return {
+    top: roundPx((clampedStart - rangeStart) * hourPx),
+    height,
+    showMeta: height >= RAIL_META_MIN_PX,
+    isFloored: height > naturalHeight,
+  };
+}
+
+function roundPx(px: number): number {
+  return Math.round(px * 100) / 100;
+}


### PR DESCRIPTION
### **User description**
## What

Now that rail blocks reflect their true length (ultra.blaze), short ones became unreadable. The rail draws an hour as 48px, so a 10-minute block is 8px tall — less than its own padding — while its contents (padding, a title line, a time line) need roughly 32px. The overflow was clipped, leaving a sliver of colour with no legible text.

`layoutRailBlock` in `src/lib/actions/railLayout.ts` is now the shared geometry for both rails. It floors the rendered height at 22px and reports whether there is room for the secondary time line (below ~34px there isn't). The title is the information that matters; the time is already implied by the block's position against the hour gutter, and it stays available as a `title` attribute for hover.

Only the *height* is floored — `top` still reflects the true start, so a short block sits at the right place against the gutter even though it's drawn taller than its duration. That makes consecutive short blocks overlap, so floored blocks get a hairline edge (`--td-hair-2` / `--color-border-primary`, no new colours) and read as separate blocks rather than one smear.

### One thing worth a look

Hour floats come from dividing minutes by 60, so multiplying back by the hour height leaves float noise — a 38px block computes as `37.99999999999997`. Unrounded that both flips the meta threshold at its boundary and reaches the DOM as `height: 33.99999999999997px`. Heights and offsets are now rounded; there's a test pinning it.

## Verification

12 unit tests on the geometry. Verified live on both surfaces against a seeded fixture:

| Block | Rendered | Time line | Floored |
|---|---|---|---|
| Standup, 9:00–9:10 | 22px @ top 96 | hidden | yes |
| Handoff notes, 9:10–9:20 | 22px @ top 104 | hidden | yes |
| 10-minute standup prep, 10:30–10:40 | 22px @ top 168 | hidden | yes |
| Duration wins, 12:00–12:15 | 22px @ top 240 | hidden | yes |
| Deep work, 14:00–14:45 | 32px | hidden | no |
| Design review, 11:00–12:00 | 44px | shown | no |

Desktop (1440px, `AgendaRail`) and mobile (390px, `TimelineRail`) produce identical heights and flooring; only the range start differs, as before. The 9:00/9:10 pair confirms the distinctness case — 8px apart, both floored, both titles readable, separated by the edge.

Note the 2 PM pair in the screenshot still overlaps illegibly. Those genuinely collide rather than being floor-induced, and lane layout is perky.glyph's job.

## Acceptance criteria

- [x] Blocks have a minimum rendered height (~22px) regardless of duration
- [x] Blocks below roughly 34px hide the time/meta line and show the title only
- [x] The title never renders clipped mid-line — it either fits or ellipsises on one line (mobile gained the `nowrap`/ellipsis rules desktop already had)
- [x] A block's vertical *position* still reflects its true start time; only its height is floored
- [x] Consecutive short blocks remain visually distinct from one another
- [x] Applied to both the desktop agenda rail and the mobile timeline rail
- [x] No hardcoded colours introduced — the pre-commit hook confirms it
- [x] `npm run check` passes (run as `npx tsc --noEmit` + `npx eslint` at an 8GB heap — the packaged scripts pin 4GB and OOM on this repo)

---

Ships: macro.pulsar


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Add shared `layoutRailBlock` geometry helper

- Floor block height at 22px, hide time line

- Round px to remove float noise

- Hairline outline for floored blocks; 12 unit tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["railLayout.ts<br/>layoutRailBlock"] -- "top/height/showMeta/isFloored" --> B["AgendaRail (desktop)"]
  A -- "shared geometry" --> C["TimelineRail (mobile)"]
  B -- "data-floored" --> D["today-desktop.css hairline"]
  C -- "data-floored" --> E["TimelineRail.module.css hairline"]
  A -- "pinned by" --> F["railLayout.test.ts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>railLayout.ts</strong><dd><code>New shared rail block layout geometry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/actions/railLayout.ts

<ul><li>New shared rail geometry module with <code>layoutRailBlock</code><br> <li> Exports <code>MIN_RAIL_BLOCK_PX</code>, <code>RAIL_META_MIN_PX</code>, <code>RAIL_BLOCK_GAP_PX</code><br> <li> Clamps blocks to range, floors height, computes <code>showMeta</code>/<code>isFloored</code><br> <li> Rounds px values to 2 decimals to remove IEEE754 noise</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/515/files#diff-70ad5d3649e41218b216b2a7eb156038c5d0bb334340dc0d880f07ca72b44661">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AgendaRail.tsx</strong><dd><code>Desktop rail uses shared layout helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/today-redesign/AgendaRail.tsx

<ul><li>Replaces inline clamp/height math with <code>layoutRailBlock</code><br> <li> Renders meta time line only when <code>showMeta</code><br> <li> Adds <code>data-floored</code> attribute and <code>title</code> tooltip with time range</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/515/files#diff-9a3b1e331d5b710d540ef5f8c575b709a278c30b1bf56f29a1e4e78c7130714c">+15/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TimelineRail.tsx</strong><dd><code>Mobile rail uses shared layout helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/actions/components/TimelineRail.tsx

<ul><li>Uses <code>layoutRailBlock</code> instead of local clamping arithmetic<br> <li> Conditionally renders <code>blockTime</code> based on <code>showMeta</code><br> <li> Adds <code>data-floored</code> attribute, <code>title</code> tooltip and <code>blockTitle</code> class</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/515/files#diff-b3a98e5d831e9862d469f7f2c9a2e332999034d80c9e746c248a8a063869ccdb">+16/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>railLayout.test.ts</strong><dd><code>Unit tests for rail block geometry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/actions/__tests__/railLayout.test.ts

<ul><li>12 unit tests covering flooring, positioning and clamping<br> <li> Pins meta threshold boundary and float-noise rounding<br> <li> Verifies both desktop and mobile rail ranges</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/515/files#diff-e6505e30435d5ed341acd6df821302c4a01d6f476574d09510114b086d6f47cc">+116/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TimelineRail.module.css</strong><dd><code>Styles for title truncation and floored blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/actions/components/TimelineRail.module.css

<ul><li>Adds <code>.blockTitle</code> with bold weight and ellipsis truncation<br> <li> Adds <code>[data-floored="true"]</code> outline and tighter padding</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/515/files#diff-6edd40783711ce99e5dcd04c6f5c7a373766aec5d4a066511575620c4dc8d876">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>today-desktop.css</strong><dd><code>Hairline edge for floored desktop events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/today-redesign/today-desktop.css

<ul><li>Adds <code>.td-event[data-floored="true"]</code> hairline outline rule<br> <li> Reduces vertical padding for floored blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/515/files#diff-45f4d56a944c3cacf41abd758375ac279636bccf7bd58d4d3d52ed7eabbf093d">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

