### PR TITLE
feat(goals): workspace Key Results toggle; remove Outcomes from the goal modal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,13 @@ SENTRY_WEBHOOK_SECRET=""
 SENTRY_WEBHOOK_TOKEN=""
 # Product that Sentry-filed bugs land in (defaults to the Exponential product).
 SENTRY_BUG_PRODUCT_ID=""
+# Set to file Bug Tickets for failures the app handled gracefully (a chat turn
+# that failed and offered Retry, a desktop bridge call that errored). Sentry
+# only ever sees what nobody caught, and only initialises on Vercel
+# prod/preview, so without this those failures are invisible — including every
+# one you hit running the desktop shell against localhost. Same destination and
+# dedup as Sentry-filed bugs; labelled "client-error" rather than "Sentry".
+CLIENT_ERROR_BUGS=""
 # Identity for the Errol system user that authors Sentry bugs (find-or-created lazily).
 SENTRY_BOT_EMAIL="errol@bots.exponential.im"
 SENTRY_BOT_NAME="Errol"

--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -24,10 +24,12 @@ jobs:
           ANTHROPIC.KEY: ${{ secrets.ANTHROPIC_KEY }}
           # Repo-level behaviour is version-controlled in .pr_agent.toml.
           # Model selection is kept here so the secret/model live together.
-          config.model: "anthropic/claude-sonnet-4-6"
+          config.model: "anthropic/claude-opus-5"
           # Point the fallback at another Anthropic model so PR-Agent never
           # falls back to OpenAI (which would require an OPENAI_API_KEY).
           config.fallback_models: '["anthropic/claude-sonnet-4-6"]'
+          # Needed if the image's litellm has no registry entry for the model.
+          config.custom_model_max_tokens: "200000"
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "true"
           github_action_config.auto_improve: "true"

--- a/.github/workflows/pr_agent_glm.yml
+++ b/.github/workflows/pr_agent_glm.yml
@@ -1,0 +1,49 @@
+name: PR Agent (GLM)
+# Second automated reviewer: the same qodo-ai/pr-agent action as pr_agent.yml,
+# pointed at GLM via OpenRouter instead of Anthropic. Two independent readers
+# applying the same house rules from .pr_agent.toml.
+#
+# No `issue_comment` trigger here (unlike pr_agent.yml) — manual `/review`
+# commands should reach one reviewer, not both.
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+jobs:
+  pr_agent_glm_job:
+    # Skip bot-triggered events so the two reviewers can't set each other off.
+    if: ${{ github.event.sender.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+    name: PR Agent review (GLM)
+    steps:
+      - name: PR Agent action step
+        id: pragent_glm
+        uses: qodo-ai/pr-agent@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Dotted, matching ANTHROPIC.KEY in pr_agent.yml — the action maps
+          # env vars to settings by literal dot, not by dunder.
+          OPENROUTER.KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # These env vars override the repo-root .pr_agent.toml, which is read
+          # by BOTH workflows. Anything that must differ per reviewer belongs
+          # here, not in that file.
+          config.model: "openrouter/z-ai/glm-5.2"
+          config.fallback_models: '["openrouter/z-ai/glm-4.7"]'
+          # GLM is not in litellm's registry under this name; without an
+          # explicit ceiling, token counting fails before the first call.
+          config.custom_model_max_tokens: "200000"
+          github_action_config.auto_review: "true"
+          github_action_config.auto_improve: "true"
+          # Off deliberately: pr_agent.yml already rewrites the PR body, and two
+          # agents writing the same description means last-writer-wins.
+          github_action_config.auto_describe: "false"
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'
+          # Off deliberately: PR-Agent finds its persistent comment by matching
+          # the body prefix, with no per-instance marker and no lock. Left on,
+          # this reviewer would update the Anthropic reviewer's comment in place
+          # instead of posting its own.
+          pr_reviewer.persistent_comment: "false"
+          pr_code_suggestions.persistent_comment: "false"

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,18 @@ db-backups/
 /e2e/.auth/
 /e2e/.results/
 /playwright-report/
+
+# Restated from nested .gitignore files (src-tauri/.gitignore, .beads/.gitignore).
+# Git already ignores these via the nested files, so this changes nothing for
+# git — but `vercel deploy` walks the working directory reading only the ROOT
+# .gitignore, so without these it tries to upload src-tauri/target (3.2GB of
+# Rust build output) and chokes outright on .beads/bd.sock, which is a unix
+# socket it cannot open. Keep in sync with the nested files.
+/src-tauri/target/
+/src-tauri/gen/
+.beads/*.db
+.beads/*.db?*
+.beads/bd.sock
+.beads/daemon.lock
+.beads/daemon.log
+.beads/daemon.pid

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -19,6 +19,46 @@ num_max_findings = 4
 # Don't re-post the whole review on every push; update the existing comment.
 persistent_comment = true
 final_update_message = false
+# Repo-specific rules the reviewer can't infer from the diff. Mirrors CLAUDE.md —
+# keep the two in sync when a rule changes.
+extra_instructions = """
+Flag violations of this repo's house rules, with the rule named:
+
+Styling — no hardcoded colors anywhere (hex literals, rgb()/rgba(), Tailwind
+arbitrary-value color classes, or inline style color values). Colors come from
+design tokens: semantic Tailwind classes (bg-background-primary, text-text-primary,
+border-border-primary) or CSS variables declared in src/styles/globals.css. A
+pre-commit hook rejects these, so catching them in review saves a round-trip.
+
+TypeScript / ESLint (these fail the build) — prefer `??` over `||` for defaulting;
+no `any`; every promise awaited or explicitly handled; no `await` on non-promises;
+type-only imports use `import type`; no unused variables or imports.
+
+Access control — permission logic belongs in the centralized service at
+src/server/services/access/. Flag any new inline permission check in a router or
+component that duplicates what requireActionAccess / requireWorkspaceMembership /
+buildActionAccessWhere already do. Flag list/bulk queries that filter by
+createdById alone where an access-scoped where-clause is required. Note that
+workspace membership does not imply edit rights — viewers and guests pass
+membership checks, so mutations that must exclude them need an explicit role check.
+
+Database — `prisma db push` is forbidden in any form (it has caused data loss here);
+schema changes require a migration file under prisma/migrations. Flag edits to
+schema.prisma that arrive without one. Do not suggest removing the safety guards,
+marker-table check, or row-count threshold in src/test/test-db.ts.
+
+Content — authored prose renders through MarkdownRenderer and is accepted through
+MarkdownInput / CommentInput. Flag direct react-markdown imports,
+dangerouslySetInnerHTML, a bare Textarea used for prose, or a new Tiptap editor.
+
+Workspace scoping — data is workspace-scoped. Flag new queries or mutations over
+Project / Goal / Outcome / Action that ignore workspaceId and could leak rows
+across workspaces.
+
+Tests — integration tests (*.integration.test.ts, real DB via testcontainers) are
+deliberately rare. Prefer mocked Prisma with createMockCaller. Flag a new
+integration test that doesn't genuinely need real DB behaviour.
+"""
 
 [pr_description]
 # Auto-generate a structured description + walkthrough.
@@ -30,3 +70,13 @@ generate_ai_title = false
 # Improvement suggestions ("/improve"). Keep the volume sane.
 num_code_suggestions = 4
 commitable_code_suggestions = false
+# Suggestions must themselves be committable here — a suggestion containing a hex
+# color or `||` defaulting would be rejected by the pre-commit hook or the build.
+extra_instructions = """
+Never suggest code that would fail this repo's own gates: no hardcoded colors (use
+semantic Tailwind classes or CSS variables), no `||` where `??` is meant, no `any`,
+no unhandled promises, no `import` of types without `import type`.
+Prefer Next.js `Link` over `useRouter().push()` for navigation, and Server
+Components over Client Components unless interactivity requires otherwise.
+Skip cosmetic suggestions — Prettier already formats this repo.
+"""

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -5,8 +5,13 @@
 [config]
 # Keep both the primary and fallback on Anthropic so PR-Agent never tries to
 # initialise an OpenAI client (which would require OPENAI_API_KEY).
-model = "anthropic/claude-sonnet-4-6"
+model = "anthropic/claude-opus-5"
 fallback_models = ["anthropic/claude-sonnet-4-6"]
+# Declared so PR-Agent can budget the diff even when the bundled litellm build
+# predates this model and has no registry entry for it (without this, an
+# unregistered model errors during token counting). This is only the ceiling —
+# the effective diff budget is PR-Agent's own max_model_tokens, 32k by default.
+custom_model_max_tokens = 200000
 # Markdown rendering of the model's suggestions.
 publish_output = true
 
@@ -15,7 +20,9 @@ publish_output = true
 require_score_review = false
 require_tests_review = true
 require_security_review = true
-num_max_findings = 4
+# Raised from 4: Opus 5 follows caps and severity filters literally, so a tight
+# limit discards findings it would otherwise surface.
+num_max_findings = 8
 # Don't re-post the whole review on every push; update the existing comment.
 persistent_comment = true
 final_update_message = false

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -146,6 +146,14 @@ _Avoid_: Today's plan (reserved — that's the narrower voice **Daily brief**), 
 The short, **speakable** morning summary built by `generateBriefingData` and surfaced by voice's `get_todays_plan` **coarse tool** and the web morning briefing. **Narrower than Today's actions on purpose**: it counts only **due-today** (`dueDate` in `[startOfDay, endOfDay]`) and **overdue-by-`dueDate`** actions plus low-progress projects — it does **not** include scheduled-today or inbox actions. So the **Daily brief** and **Today's actions** can legitimately disagree on what "today" contains (the brief omits a scheduled-but-not-due "Pay Malte"). This divergence is **known and accepted for now**; converging voice onto the **Today's actions** definition is deferred, not done. See [ADR-0034](docs/adr/0034-todays-actions-shared-partition.md).
 _Avoid_: Treating the brief as the source of truth for `/today`; "today's plan" for the `/today` list.
 
+**Overdue cohort**:
+A set of overdue **Actions** sharing one *exact* anchor instant (`scheduledStart`, else `dueDate`, to the millisecond) — the fingerprint of a single bulk write: a generated project plan, a template, an import. Hand-entered dates carry the millisecond the user hit save and effectively never collide, so ≥3 actions on one instant means one writer created them all. Surfaced by `action.getOverdueTriage`, which splits an overdue pile into **cohorts** and **loose** debt. The distinction matters because it changes the disposition: cohort members were never individually due and deserve **amnesty**; loose actions are real missed commitments. Typically most of a large overdue count is cohorts — 21 of 40 in the case that motivated this.
+_Avoid_: Batch, cluster, group (all used for unrelated concepts); "duplicate" (cohort members are distinct actions).
+
+**Amnesty**:
+Clearing an **Action**'s dates (`scheduledStart`, `scheduledEnd`, `dueDate`) so it returns to its **Project** backlog untimed, via `action.bulkDefer`. The counterpart to rescheduling, and the right move for an **Overdue cohort**: rescheduling says "still due, later" and re-inflicts the pile tomorrow, amnesty says "this was never really due — stop counting it against me". Deliberately a distinct verb from `action.bulkReschedule({ dueDate: null })` even though the row effect is identical, because intent is what callers and agent tool-discovery need to express. Kanban status is untouched — an Action can be untimed and still in progress.
+_Avoid_: Snooze (implies it comes back), dismiss/archive/delete (the Action stays ACTIVE and live), defer *as a user-facing word* (that's the procedure name, not the concept).
+
 ### Weekly planning
 
 **Weekly plan**:

--- a/content/docs/features/external-agents.md
+++ b/content/docs/features/external-agents.md
@@ -1,0 +1,74 @@
+---
+title: External Agents
+description: Connect third-party AI agents to Exponential as first-class team members with their own identity, scoped access, and revocable keys
+---
+
+## Overview
+
+External agents let you connect autonomous AI software — [Hermes Agent](https://hermes-agent.nousresearch.com/), MCP clients, custom scripts, anything that can send an HTTP request — to Exponential **as its own identity**, not as you.
+
+When your agent creates a task, the task says the *agent* created it. Your workspace's activity feed and members list show the agent with an **agent** badge, so everyone can see what the software did versus what you did.
+
+This is different from Zoe, Exponential's built-in assistant: Zoe works *with* you in a conversation and acts as you with your confirmation. An external agent works *for* you, on its own, under its own name.
+
+## How It Works
+
+1. **Create an agent** — give it a name ("Hermes", "Standup Bot").
+2. **Grant it workspaces** — the agent joins as a **member** of workspaces you choose. It can only join workspaces where you yourself have at least member access.
+3. **Create a key** — a secret starting with `exp_agent_`, shown exactly once. Put it in your agent software's configuration.
+4. **The agent works** — it authenticates with the key and sees only the workspaces you granted. Everything it does is attributed to it.
+
+## Setting Up
+
+### Create an Agent
+
+1. Go to **Settings → Agents**
+2. Click **New agent** and name it
+3. Click **Add** next to *Workspaces* and pick where it may work
+4. Click **New key**, label it (e.g. "laptop"), and **copy the key immediately** — it is never shown again
+
+### Point Your Software at Exponential
+
+Your agent authenticates by sending the key as a Bearer token:
+
+```
+Authorization: Bearer exp_agent_...
+```
+
+For agent software that runs shell commands (like Hermes), the simplest path is the [Exponential CLI](/docs/features/api-access) with the agent key as its token.
+
+## Access & Safety
+
+External agents are deliberately more limited than human members:
+
+- **Member role only.** An agent is always a workspace *member* — never an owner or admin. It cannot manage members, change workspace settings, or manage other agents.
+- **Your access is the ceiling.** An agent can never do more than you can. If you leave a workspace or are changed to viewer, your agents lose that workspace immediately and automatically.
+- **No credential minting.** Agents cannot create API tokens, connect integrations, or generate any other credentials.
+- **Revocation is instant.** Deleting a key blocks the agent on its very next request. Workspace admins can also remove an agent from the members list at any time, without touching your keys.
+
+## Keys
+
+- A key is shown **once**, at creation. Store it in your agent's config; if you lose it, revoke it and create a new one.
+- Each agent can hold up to 10 keys — create a second key and delete the first to rotate without downtime.
+- The Agents page shows each key's **last used** time, so you can spot stale or unexpected activity.
+
+## Attribution
+
+Everything an agent does is recorded under the agent's own name:
+
+- Tasks show the agent as creator, with source `agent`
+- The workspace **activity feed** shows the agent's actions with an agent badge
+- The **members list** shows the agent as a member with an agent badge
+
+Deleting an agent removes its keys and workspace access immediately; its past work stays attributed to it in your history.
+
+## FAQ
+
+**Can an agent be read-only?**
+Not yet. Agents always join as members. A read-only (viewer) tier is planned.
+
+**Can my whole team share one agent?**
+Agents are personal — each agent belongs to the user who created it, and its access is tied to that user's. Shared workspace-owned agents are under consideration.
+
+**Does this replace API tokens?**
+No — [API tokens](/docs/features/api-access) act *as you* and are right for webhooks and personal automation. Use an external agent when software should have its own identity and audit trail.

--- a/dev-docs/OBSERVABILITY.md
+++ b/dev-docs/OBSERVABILITY.md
@@ -57,6 +57,28 @@ announcements to **Zulip** (`sentryZulip.ts`) and **Matrix**
 `.env.example`); the room must be unencrypted and the bot joined. Recurring
 errors that dedup onto an existing ticket do not re-notify.
 
+### GlitchTip senders
+
+The same endpoints accept GlitchTip's **generic (Slack-compatible) webhook**,
+which other services in this org use. Two differences from Sentry, both
+handled automatically:
+
+- **No `Sentry-Hook-Resource` header.** Its absence is what selects the
+  GlitchTip parser (`normalizeGlitchtipPayload`), which reads the flat
+  `{alias, issue_id, project, attachments[0].title/title_link}` shape instead
+  of Sentry's nested `data.issue`. Only `issue.new` / `issue.regression` file
+  a ticket; resolutions are ignored. If `issue_id` is missing the id is
+  recovered from the issue URL.
+- **No HMAC.** GlitchTip cannot sign the body, and its Alert Rule UI accepts
+  only a URL — no custom headers — so the shared secret may travel as a
+  `?token=` query param. On the per-workspace route the token is the
+  integration's own secret. Prefer the `X-Webhook-Token` header where the
+  sender supports it: query strings are more likely to be captured in proxy
+  and access logs.
+
+Security boundary: presenting a `Sentry-Hook-Signature` commits the sender to
+HMAC. An invalid signature is always a 401 — a valid token never rescues it.
+
 Tickets are labelled `Sentry` + `bug`, and additionally `ai-fixable` when the
 issue's Sentry project is listed in `SENTRY_AI_FIXABLE_PROJECTS` — the
 allowlist exists because the webhook is org-wide and a bug from another

--- a/dev-docs/OBSERVABILITY.md
+++ b/dev-docs/OBSERVABILITY.md
@@ -79,6 +79,24 @@ handled automatically:
 Security boundary: presenting a `Sentry-Hook-Signature` commits the sender to
 HMAC. An invalid signature is always a 401 — a valid token never rescues it.
 
+### Telling services apart in one product
+
+A workspace has exactly one Sentry integration, pointing at one destination
+Product — so several codebases reporting into it would otherwise be
+indistinguishable. Each ticket therefore also gets a **source label** naming
+the service it came from:
+
+```
+…/api/webhooks/sentry/<webhookId>?token=<secret>&service=clear-pipeline
+```
+
+`?product=` is accepted as an alias, but note it does **not** choose the
+destination Product (that is fixed per integration) — it only labels. When
+neither is given the label falls back to the project slug in the payload, so
+Sentry's own projects (`exponential-frontend`, `mastra-agents`) self-label
+without any configuration. The value is reduced to a bounded `[a-z0-9-]` slug
+before use.
+
 Tickets are labelled `Sentry` + `bug`, and additionally `ai-fixable` when the
 issue's Sentry project is listed in `SENTRY_AI_FIXABLE_PROJECTS` — the
 allowlist exists because the webhook is org-wide and a bug from another

--- a/docs/ZOE_DAILY_BRIEFING.md
+++ b/docs/ZOE_DAILY_BRIEFING.md
@@ -97,22 +97,42 @@ boxes; only the first was ever true. Re-verify before trusting it again.
 
 ### What shipped instead
 
-The AI card on `/today` is a different implementation that bypasses everything
+The AI card on `/today` is a different implementation from the one designed
 above: `scheduling.getSchedulingSuggestions`
-(`src/server/api/routers/scheduling.ts`) → Mastra's `ashAgent`, rendered by
-`ZoePanel`. Three ways it diverges from this design, each worth knowing before
-you build on it:
+(`src/server/api/routers/scheduling.ts`), rendered by `ZoePanel`. It now writes
+to these tables, so the two paths have partly converged:
 
-- **It regenerates on page load** — a `useQuery` with `staleTime: 5min`, firing an
-  LLM round-trip per render. That is precisely the first entry under
-  [Gotchas](#gotchas) below.
-- **Nothing is persisted.** No `DailyBriefing` row, no `promptVersion`, no
-  `inputSnapshot`, no interaction log. Dismissal is React state and dies on
-  reload. So none of the metrics below can currently be computed, and there is
-  no replayable input for the autoresearch loop.
-- **It is not Zoe.** `ashAgent` is a tool-less GPT-4o lean-startup persona whose
-  instructions are overridden by a per-call system message. Model, prompt, and
-  persona are all unrelated to the branding on the card.
+- **It no longer regenerates on page load.** Each call builds a deterministic
+  `SuggestionInputSnapshot` (the overdue actions, calendar busy-intervals, and
+  already-scheduled actions the prompt reads), hashes it, and reuses today's
+  `DailyBriefing` row when the hash matches. The model is called only when the
+  input actually changed. This closes the first entry under
+  [Gotchas](#gotchas).
+- **Briefings are persisted** with `promptVersion`, `modelId`, `inputSnapshot`,
+  `outputText`, `outputStructured` and `latencyMs` — so the replayable input the
+  autoresearch loop needs now exists. `scheduling.recordBriefingInteraction`
+  writes `BriefingInteraction`, so acceptance and dismissal rates are
+  computable.
+- **It is Zoe now.** Generation was pointed at `ashAgent` — a tool-less GPT-4o
+  lean-startup persona whose instructions were overridden per call, so model,
+  prompt, and persona all disagreed with the branding on the card. It now calls
+  `zoeAgent`.
+
+Still divergent from the design above:
+
+- **`promptVersion` is `zoe-scheduling-v1`**, not `zoe-daily-vN` — this is the
+  scheduling-suggestions prompt, a different prompt from the "take on your day"
+  paragraph described here. Bump it on any change to
+  `SCHEDULING_SYSTEM_PROMPT` or `buildSchedulingPrompt`.
+- **No `zoeBriefing` router, no opt-in toggle, no admin page.** Generation is
+  still implicit rather than user-triggered — it happens on first render of a
+  day, not on a "Generate" click.
+- **`tokensIn` / `tokensOut` are unpopulated** — the Mastra generate endpoint's
+  response doesn't surface usage on this path yet, so cost metrics can't be
+  sliced.
+- **Dismissal is still React state** and dies on reload. Persisting *per
+  suggestion* needs an `actionId` on `BriefingInteraction`, i.e. a migration;
+  briefing-level interactions work today.
 
 ## Roadmap to the autoresearch loop
 

--- a/docs/ZOE_DAILY_BRIEFING.md
+++ b/docs/ZOE_DAILY_BRIEFING.md
@@ -1,7 +1,9 @@
 # Zoe Daily Briefing — Internal Reference
 
 > **Audience:** future-you + collaborators. Not user-facing. Not linked from any public docs site.
-> **Status:** v1 (logging infrastructure). Eval loop not yet built.
+> **Status:** **Design only — not implemented.** Everything below is the intended
+> design. Only the schema exists; see [Current state](#current-state) for what is
+> actually built, and what shipped instead.
 
 ## What this is
 
@@ -78,14 +80,39 @@ Computed by the admin page at `/admin/daily-briefing` (when built).
 
 **Pick one primary metric.** Default: top-1 execution rate. Acceptance rate is the fastest signal but easiest to goodhart.
 
-## Current state (v1)
+## Current state
 
-- [x] Schema: `DailyBriefing`, `BriefingInteraction`, `NavigationPreference.showDailyBriefing`
-- [x] Opt-in toggle in `/settings`
-- [x] tRPC router `zoeBriefing` (generate, getCurrent, refresh, recordInteraction)
-- [x] `DailyBriefingCard` on `/today` (renders when filter=today AND preference enabled)
-- [x] Admin page at `/admin/daily-briefing` for metrics
-- [ ] **Not built yet:** eval harness, fixture set, prompt variant scoring
+Verified 2026-08-04. An earlier revision of this file checked five of these
+boxes; only the first was ever true. Re-verify before trusting it again.
+
+- [x] Schema: `DailyBriefing` (`prisma/schema.prisma:1897`), `BriefingInteraction`
+      (`:1920`), `NavigationPreference.showDailyBriefing` (`:1888`) — **all three
+      exist and none is read or written anywhere in `src/`.** Dead tables.
+- [ ] Opt-in toggle in `/settings` — `showDailyBriefing` appears zero times in `src/`.
+- [ ] tRPC router `zoeBriefing` — does not exist. (`src/server/api/routers/briefing.ts`
+      is the unrelated data-aggregation router; there is no `zoeBriefing.ts`.)
+- [ ] `DailyBriefingCard` on `/today` — no such component.
+- [ ] Admin page at `/admin/daily-briefing` — no such route.
+- [ ] Eval harness, fixture set, prompt variant scoring.
+
+### What shipped instead
+
+The AI card on `/today` is a different implementation that bypasses everything
+above: `scheduling.getSchedulingSuggestions`
+(`src/server/api/routers/scheduling.ts`) → Mastra's `ashAgent`, rendered by
+`ZoePanel`. Three ways it diverges from this design, each worth knowing before
+you build on it:
+
+- **It regenerates on page load** — a `useQuery` with `staleTime: 5min`, firing an
+  LLM round-trip per render. That is precisely the first entry under
+  [Gotchas](#gotchas) below.
+- **Nothing is persisted.** No `DailyBriefing` row, no `promptVersion`, no
+  `inputSnapshot`, no interaction log. Dismissal is React state and dies on
+  reload. So none of the metrics below can currently be computed, and there is
+  no replayable input for the autoresearch loop.
+- **It is not Zoe.** `ashAgent` is a tool-less GPT-4o lean-startup persona whose
+  instructions are overridden by a per-call system message. Model, prompt, and
+  persona are all unrelated to the branding on the card.
 
 ## Roadmap to the autoresearch loop
 

--- a/docs/adr/0052-overdue-cohorts-and-amnesty.md
+++ b/docs/adr/0052-overdue-cohorts-and-amnesty.md
@@ -1,0 +1,107 @@
+# Overdue triage: bulk-write cohorts detected by exact instant, amnesty as its own verb
+
+## Status
+
+Accepted — 2026-08-04
+
+## Context
+
+A user opened `/today` to 40 overdue actions and reported being overwhelmed. The
+pile was not 40 missed commitments: **21 of the 40 were two bulk writes** — 17
+actions stamped `2026-07-25T08:29:55.483Z` across six projects, and 4 stamped
+`2026-07-23T07:00:00.000Z` — generated project plans that received one blanket
+date at creation. Only 19 were individually-dated debt.
+
+The only bulk affordance on the page is **"Reschedule all → Today"**
+(`action.bulkReschedule`), which sets `scheduledStart` to now for every selected
+action. Applied to this pile it moves 40 items forward 24 hours and re-inflicts
+them tomorrow — it treats a data-provenance artifact as a scheduling problem.
+Nothing in the product distinguishes "you missed this" from "nobody ever
+intended this to be due that day", so neither the user nor an agent can propose
+a disposition better than "move it all".
+
+This blocks the morning-agent work: an agent handed 40 undifferentiated overdue
+rows can only summarize them. The useful sentence — *"17 of these were written
+in one batch and were never individually due; want them back in their project
+backlogs?"* — requires a distinction the data model does not currently express.
+
+## Decision
+
+Add a **read** that classifies the pile and a **write** that expresses amnesty.
+
+- **Cohorts are detected by exact anchor instant.** `groupOverdueCohorts()` in
+  `~/lib/actions/triage.ts` groups overdue actions by their `overdueAnchor`
+  (`scheduledStart`, else `dueDate`) at **millisecond** equality; ≥3 members is
+  a cohort, everything else is `loose`. The heuristic is deliberately crude and
+  deliberately exact: a human dating actions one at a time carries the
+  millisecond they hit save, so collisions are effectively impossible, while a
+  single `createMany` writes one identical value to every row. No timestamp
+  metadata, no `source` sniffing, no model call — the fingerprint is already in
+  the data.
+
+- **`action.getOverdueTriage`** returns `{ totalOverdue, cohortCount, cohorts,
+  loose }`, each cohort carrying `stampedAt`, `count`, `daysOverdue`,
+  `projectNames`, and `actionIds` — enough for a caller to *explain* the cohort
+  before acting on it. It reuses `partitionActions()` for the overdue set, so it
+  and `/today` always describe the same pile ([ADR-0034](0034-todays-actions-shared-partition.md)).
+
+- **`action.bulkDefer` is a separate procedure from `bulkReschedule`**, despite
+  clearing the same columns that `bulkReschedule({ dueDate: null })` clears. The
+  row effect is identical; the *intent* is not, and intent is the thing callers
+  need to express — most of all agents, whose tool discovery is BM25 over tool
+  descriptions. A verb named "defer" with a description about untimed backlogs
+  is findable for "these were never due"; an overload of "reschedule" with a
+  null argument is not. It also gives the two operations independent activity
+  provenance.
+
+- **Amnesty touches dates only.** `kanbanStatus` is left alone: an action can be
+  untimed and still in progress on a board.
+
+- The suggestion generator (`scheduling.getSchedulingSuggestions`) is moved onto
+  `partitionActions()` in the same change. It selected overdue by `dueDate <
+  today` while the panel that renders it is *gated* on the client partition, so
+  the banner could appear over a pile it had nothing to say about, and it
+  ignored every scheduled-but-never-due action.
+
+## Considered alternatives
+
+- **Fuzzy clustering (same minute / same hour / same day).** Rejected — it
+  merges genuinely distinct decisions. Three actions dated across one working
+  day are three choices; three sharing a millisecond are one. Widening the
+  window trades a heuristic with essentially no false positives for one with
+  many, to catch bulk writes that are rare in practice (a `createMany` shares an
+  instant; only a slow scripted loop would not).
+- **Persist the provenance instead — a `batchId` written at creation.** The
+  honest fix, and not exclusive with this one, but it is schema + migration +
+  backfill and it cannot classify a single existing row. The anchor fingerprint
+  works on data already in the database, today. Revisit if cohort quality proves
+  insufficient.
+- **Use `Action.source` or `createdAt` proximity.** Rejected — `source` records
+  the channel (`app`, `notion`, `api`), not the write, and is identical across
+  hand-created and bulk-created actions from the same surface. `createdAt`
+  proximity has the fuzzy-window problem plus false positives from any busy
+  minute of manual entry.
+- **Let the LLM classify the pile.** Rejected as the primary mechanism — it is a
+  deterministic grouping over a timestamp, it must be right the same way every
+  time, and it should not cost a model call. The agent's job is to *propose the
+  disposition* from the grouping, which is genuinely judgement.
+- **Only add `getOverdueTriage`, reuse `bulkReschedule(null)` for the write.**
+  Rejected on discovery grounds above.
+
+## Consequences
+
+- New `~/lib/actions/triage.ts` (`groupOverdueCohorts`, `daysOverdue`,
+  `COHORT_MIN_SIZE`) with unit tests; pure and clock-injected like
+  `partitionActions`.
+- New `action.getOverdueTriage` and `action.bulkDefer`; `mastra.updateAction`
+  gains `scheduledStart` / `scheduledEnd` / `duration` — until now no agent
+  could write a "do date" at all, so no agent could move anything out of the
+  overdue bucket.
+- `scheduling.getSchedulingSuggestions` now fetches ACTIVE actions and
+  partitions in memory rather than filtering by `dueDate` in SQL, matching the
+  existing `getTodaysActions` pattern.
+- CONTEXT.md gains **Overdue cohort** and **Amnesty**. These become the shared
+  vocabulary for the CLI, SDK, MCP server, and Mastra tools that wrap this
+  contract.
+- The cohort threshold (3) and exact-instant rule are heuristics, recorded here
+  so a future reader knows they were chosen, not inherited.

--- a/docs/adr/0053-desktop-tabs-are-native-macos-window-tabs.md
+++ b/docs/adr/0053-desktop-tabs-are-native-macos-window-tabs.md
@@ -1,0 +1,105 @@
+# Desktop tabs are native macOS window tabs, under Safari-style chrome
+
+## Status
+
+Accepted — 2026-08-04
+
+> Note on numbering: the desktop-tabs PRD and tickets `cool.lark` / `lazy.lake`
+> cite this record as "ADR-0052". That number was taken by
+> [0052-overdue-cohorts-and-amnesty.md](0052-overdue-cohorts-and-amnesty.md)
+> before this file was written; this is the record they mean.
+
+## Context
+
+The Tauri shell (the desktop foray's daily driver) opens exactly one useful
+window. Following a link replaces what you were looking at, and anything
+stateful — a Zoe canvas mid-answer, a half-typed form — dies on navigation,
+because the app is a single route tree in a single webview. The V2 scope of the
+desktop feature is tabs.
+
+Constraints: no Tauri `unstable` feature (rules out multi-webview-in-one-window
+via `Window::add_child`), the Electron shell is not modified, and the web app
+must expose no tab affordance so tabs are unreachable from a browser by
+construction.
+
+## Decision
+
+**A tab is a real macOS window tab.** Every tab is its own `WebviewWindow`; all
+windows share one `tabbing_identifier`, and AppKit provides the tab bar,
+reordering, drag-out, the tab overview, and ⌘W. Each tab is a full live app
+instance, which is what makes backgrounded state survive without feature code.
+
+The `cool.lark` spike (built and inspected on release builds, 2026-08-04)
+forced three refinements the original design did not anticipate:
+
+1. **Merging must be explicit.** A shared `tabbing_identifier` only makes
+   windows *tabbable*; AppKit auto-merges only when the user's global
+   `AppleWindowTabbingMode` is `always`, and Apple's default is "In Full Screen
+   Only". The shell therefore calls `-[NSWindow addTabbedWindow:ordered:]`
+   (via `ns_window()` + `objc2`; neither tao nor tauri wraps it).
+
+2. **The chrome is Safari's, not Electron's.** The shell previously matched
+   Electron's `hiddenInset` overlay (`TitleBarStyle::Overlay`,
+   `hidden_title`, custom traffic-light position). On a real build the overlay
+   lost to the tab bar at every layer: tao implements
+   `traffic_light_position` by shrinking the titlebar container the tab bar
+   lives in (re-applied every `drawRect:`), so the bar was squashed and the
+   lights vanished; the full-size content view put the page under the chrome,
+   so scrolled content and the scrollbar showed through the titlebar row,
+   fixed-position modals opened underneath the tab bar, and the transparent
+   titlebar hit-tested through to the page, leaving the window undraggable
+   (tauri#9503). Each symptom had a workaround; the workarounds were a
+   machinery. A standard visible titlebar dissolves all of it: AppKit lays the
+   web view out *below* the chrome, and drag, zoom, scrollbars, and modals are
+   simply correct. `hidden_title(true)` keeps the empty titlebar row from
+   drawing a window title; tab labels are unaffected (they read
+   `NSWindow.tab.title`). The page-side consequence: the shell no longer
+   stamps `data-titlebar="overlay"`, so the 38px sidebar inset stays off and
+   the web app needs no inset at all.
+
+3. **Tab keys cannot be menu equivalents, and the menu must be extended, not
+   replaced.** AppKit matches non-⌘ key equivalents only after the responder
+   chain declines the key, and WKWebView consumes Tab — so ⌃Tab/⌃⇧Tab are
+   caught by a local `NSEvent` monitor (before webview dispatch), the way
+   Safari does it; the dispatched actions are AppKit's own
+   (`selectNextTab:` etc.). The menu is built by extending `Menu::default`:
+   a from-scratch menu has no submenu tagged `WINDOW_SUBMENU_ID`, so Tauri
+   never registers `NSApp.windowsMenu` and macOS silently loses the window
+   list. The tab-bar `+` button is AppKit's own, summoned by implementing
+   `newWindowForTab:` on the window class at runtime.
+
+The capability in `capabilities/remote.json` scopes to `["main", "tab-*"]`;
+tab windows are labelled `tab-<n>` from a counter, and the glob is the only
+place a label shape may be relied on. The `desktop_shell_info` bridge was
+verified working from inside a created tab on a release build.
+
+## Consequences
+
+- Backgrounded tabs keep running for free; session is shared (same WKWebView
+  data store), so no re-authentication per tab.
+- The Tauri shell's chrome now visibly diverges from the Electron shell's.
+  Accepted: Electron is expected to be retired, not kept in parity.
+- Tab labels all read "Exponential Beta" until URL-derived labels
+  (`tab_title`, the V2 ticket's action 2) land.
+- macOS-only by design. If a Windows/Linux shell ever happens, native tabbing
+  does not exist there and a different mechanism is required.
+
+## Rejected alternatives
+
+- **In-page tabs in the web app** (React or iframe, gated on `isTauri()`): a
+  `data-shell` check is a rule every future PR must respect; iframes also cost
+  a full app instance each plus duplicated chrome. The native mechanism makes
+  "no tabs in a browser" structural.
+- **A custom tab strip over multiple webviews in one window**: needs
+  `unstable`, plus reimplementing reorder/close/keyboard that AppKit provides.
+- **One shared sidebar with tabs swapping only the content pane**
+  (Notion-style): not expressible with native window tabs — a macOS tab *is* a
+  window — and every in-page route to it was rejected above. Raised and
+  declined during the spike.
+- **Keeping the overlay chrome and patching around the tab bar**: tried on
+  real builds during the spike (measured-inset push, body padding, modal CSS,
+  JS drag shim); every patch was another moving part and scroll-under-chrome
+  remained. This is the fallback the spike existed to evaluate, and the
+  evaluation said no.
+- **Reading `document.title` for tab labels**: effectively constant across
+  the authenticated app; every tab would read identically.

--- a/e2e/local-wiki.spec.ts
+++ b/e2e/local-wiki.spec.ts
@@ -297,3 +297,115 @@ test("in a browser, the wiki says where it actually lives", async ({ page }) => 
     timeout: FIRST_PAINT_TIMEOUT,
   });
 });
+
+/**
+ * A desktop shell whose wiki folder does not exist yet — what a first-time
+ * user actually meets. `initFails` makes `wiki_init` reject, standing in for
+ * the realistic failure: a folder the app may not write to.
+ */
+async function installUncreatedWikiStub(page: Page, { initFails = false } = {}) {
+  await page.addInitScript((failing: boolean) => {
+    const store: Record<string, string> = {};
+    let exists = false;
+    const calls: string[] = [];
+    (window as unknown as { __WIKI_CALLS__: string[] }).__WIKI_CALLS__ = calls;
+    const root = "/Users/dev/Documents/exponential-wiki";
+
+    (
+      window as unknown as {
+        __TAURI_INTERNALS__: {
+          invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+        };
+      }
+    ).__TAURI_INTERNALS__ = {
+      invoke: (cmd: string, args?: Record<string, unknown>) => {
+        calls.push(cmd);
+        switch (cmd) {
+          case "wiki_status":
+            // pageCount derived, not hardcoded: the real command counts the
+            // folder, and a stub that reports 0 pages while wiki_list_pages
+            // returns three is a lie the next reader would have to discover.
+            return Promise.resolve({
+              root,
+              exists,
+              git: exists,
+              pageCount: Object.keys(store).length,
+            });
+          case "wiki_init": {
+            if (failing) {
+              return Promise.reject(new Error("Permission denied (os error 13)"));
+            }
+            exists = true;
+            // The three fixed files `init_at` seeds.
+            store["index.md"] = "# Index\n";
+            store["schema.md"] = "# How this wiki works\n";
+            store["log.md"] = "# Log\n";
+            return Promise.resolve({ root, created: true, git: true });
+          }
+          case "wiki_list_pages":
+            return Promise.resolve(
+              Object.keys(store)
+                .sort()
+                .map((path) => ({ path, bytes: (store[path] ?? "").length })),
+            );
+          case "wiki_read_page":
+            return Promise.resolve(store[String(args?.path)] ?? "");
+          case "wiki_get_root":
+            return Promise.resolve(root);
+          default:
+            return Promise.reject(new Error(`unexpected command ${cmd}`));
+        }
+      },
+    };
+  }, initFails);
+}
+
+const commandsCalled = (page: Page) =>
+  page.evaluate(() => (window as unknown as { __WIKI_CALLS__: string[] }).__WIKI_CALLS__);
+
+test("with no wiki yet, arriving at /wiki offers to create one — and creates nothing on its own", async ({
+  page,
+}) => {
+  await installUncreatedWikiStub(page);
+  await page.goto("/wiki");
+
+  await expect(page.getByText("Create your local wiki")).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+  // It names the folder it would create before creating it.
+  await expect(page.getByText("/Users/dev/Documents/exponential-wiki")).toBeVisible();
+
+  // The guarantee worth protecting: a folder and a git repo appear in someone's
+  // Documents because they chose it, never as a side effect of navigation.
+  expect(await commandsCalled(page)).not.toContain("wiki_init");
+
+  await page.getByRole("button", { name: "Create wiki" }).click();
+
+  // Created, seeded, and listed. The visible result is asserted first: it's
+  // what the reader cares about, and waiting on it means the call log below
+  // is read after the handler has run rather than racing it.
+  await expect(page.getByRole("heading", { name: "Local wiki" })).toBeVisible();
+  // Asserted on the row's link target rather than its text: it pins that the
+  // seed is listed *and* points at the right page, and it can't be made
+  // ambiguous later by a breadcrumb or header repeating the filename.
+  for (const seed of ["index", "schema", "log"]) {
+    await expect(page.locator(`a[href="/wiki/${seed}"]`)).toBeVisible();
+  }
+  expect(await commandsCalled(page)).toContain("wiki_init");
+});
+
+test("a wiki that cannot be created says why", async ({ page }) => {
+  await installUncreatedWikiStub(page, { initFails: true });
+  await page.goto("/wiki");
+
+  await expect(page.getByText("Create your local wiki")).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+  await page.getByRole("button", { name: "Create wiki" }).click();
+
+  // The reason, not a spinner that never resolves. Scoped to <main>, since
+  // Next's route announcer is also a role="alert" living outside it.
+  await expect(page.getByRole("main").getByRole("alert")).toContainText("Permission denied");
+  // And the button comes back, so a fixed permission can be retried.
+  await expect(page.getByRole("button", { name: "Create wiki" })).toBeEnabled();
+});

--- a/e2e/local-wiki.spec.ts
+++ b/e2e/local-wiki.spec.ts
@@ -1,0 +1,299 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const FIRST_PAINT_TIMEOUT = 60_000;
+
+/**
+ * The local wiki surface, driven against a stand-in for the Tauri shell's IPC.
+ *
+ * The wiki itself is a folder on disk reached over `window.__TAURI_INTERNALS__`,
+ * which exists only inside the desktop shell — so CI (and a browser) would
+ * otherwise only ever see the "not available here" state. Installing a fake
+ * `invoke` before the page loads exercises everything above the IPC boundary:
+ * listing, search, wikilink resolution, and the read/edit/save round trip.
+ *
+ * What it deliberately does NOT cover is the Rust side (`src-tauri/src/wiki.rs`),
+ * which has its own tests. The contract between them is the command names and
+ * payload shapes asserted here.
+ */
+
+const FILES: Record<string, string> = {
+  "index.md":
+    "# Index\n\nThe map of this wiki.\n\n## Pages\n\n- [[people/ada]] — first programmer\n- [[people/hopper]] — not written yet\n\nSee [[schema]] for the conventions.\n",
+  "schema.md":
+    "# How this wiki works\n\nPages refer to each other with `[[wikilinks]]` — the link text is the page's\npath without the `.md`.\n",
+  "people/ada.md":
+    "# Ada Lovelace\n\nWrote the first algorithm intended for a machine.\nLinked from [[index]], and see [[people/hopper]].\n",
+};
+
+/**
+ * Install the fake shell bridge before any app code runs, and expose what it
+ * was asked to do so a test can assert on the writes.
+ */
+async function installWikiStub(page: Page, files: Record<string, string> = FILES) {
+  await page.addInitScript((seed: Record<string, string>) => {
+    const store: Record<string, string> = { ...seed };
+    const calls: { cmd: string; args?: Record<string, unknown> }[] = [];
+    (window as unknown as { __WIKI_CALLS__: typeof calls }).__WIKI_CALLS__ = calls;
+    (window as unknown as { __WIKI_FILES__: typeof store }).__WIKI_FILES__ = store;
+
+    const root = "/Users/dev/Documents/exponential-wiki";
+    (
+      window as unknown as {
+        __TAURI_INTERNALS__: {
+          invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+        };
+      }
+    ).__TAURI_INTERNALS__ = {
+      invoke: (cmd: string, args?: Record<string, unknown>) => {
+        calls.push({ cmd, args });
+        const bytes = (s: string) => new TextEncoder().encode(s).length;
+        switch (cmd) {
+          case "wiki_get_root":
+            return Promise.resolve(root);
+          case "wiki_status":
+            return Promise.resolve({
+              root,
+              exists: true,
+              git: true,
+              pageCount: Object.keys(store).length,
+            });
+          case "wiki_init":
+            return Promise.resolve({ root, created: false, git: true });
+          case "wiki_list_pages":
+            return Promise.resolve(
+              Object.keys(store)
+                .sort()
+                .map((path) => ({ path, bytes: bytes(store[path] ?? "") })),
+            );
+          case "wiki_read_page": {
+            const content = store[String(args?.path)];
+            return content === undefined
+              ? Promise.reject(new Error("page not found"))
+              : Promise.resolve(content);
+          }
+          case "wiki_write_page":
+            store[String(args?.path)] = String(args?.content);
+            return Promise.resolve(null);
+          case "wiki_commit_turn":
+            return Promise.resolve({ committed: true, sha: "abc1234" });
+          case "wiki_search": {
+            const q = String(args?.query).toLowerCase();
+            return Promise.resolve(
+              Object.keys(store)
+                .filter(
+                  (p) =>
+                    p.toLowerCase().includes(q) || (store[p] ?? "").toLowerCase().includes(q),
+                )
+                .map((p) => ({
+                  path: p,
+                  pathMatched: p.toLowerCase().includes(q),
+                  lines: (store[p] ?? "")
+                    .split("\n")
+                    .filter((l) => l.toLowerCase().includes(q))
+                    .slice(0, 3)
+                    .map((l) => l.trim()),
+                })),
+            );
+          }
+          default:
+            return Promise.reject(new Error(`unexpected command ${cmd}`));
+        }
+      },
+    };
+  }, files);
+}
+
+const calls = (page: Page) =>
+  page.evaluate(
+    () => (window as unknown as { __WIKI_CALLS__: { cmd: string }[] }).__WIKI_CALLS__,
+  );
+
+const fileOnDisk = (page: Page, path: string) =>
+  page.evaluate(
+    (p) => (window as unknown as { __WIKI_FILES__: Record<string, string> }).__WIKI_FILES__[p],
+    path,
+  );
+
+test("lists the wiki's pages, grouped by folder", async ({ page }) => {
+  await installWikiStub(page);
+  await page.goto("/wiki");
+
+  await expect(page.getByRole("heading", { name: "Local wiki" })).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+  await expect(page.getByText("/Users/dev/Documents/exponential-wiki")).toBeVisible();
+
+  // The spine sorts first, ahead of the alphabetically-earlier folder pages.
+  await expect(page.getByText("index.md", { exact: true })).toBeVisible();
+  await expect(page.getByText("schema.md", { exact: true })).toBeVisible();
+  await expect(page.getByText("people", { exact: true })).toBeVisible();
+  await expect(page.getByText("people/ada.md", { exact: true })).toBeVisible();
+
+  await test.info().attach("wiki-list", {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+});
+
+test("searching asks the shell, not the browser", async ({ page }) => {
+  await installWikiStub(page);
+  await page.goto("/wiki");
+  await expect(page.getByRole("heading", { name: "Local wiki" })).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  await page.getByPlaceholder("Search the wiki…").fill("algorithm");
+
+  // "algorithm" appears in no filename — only inside a page's text.
+  await expect(page.getByText("Wrote the first algorithm intended for a machine.")).toBeVisible();
+  expect((await calls(page)).some((c) => c.cmd === "wiki_search")).toBe(true);
+});
+
+test("wikilinks navigate, and unwritten ones are marked", async ({ page }) => {
+  await installWikiStub(page);
+  await page.goto("/wiki/index");
+
+  await expect(page.getByRole("heading", { name: "Index" })).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  // A link to a page that exists is an ordinary link; one to a page nobody has
+  // written carries the "missing" class the wiki styles as a red link.
+  const ada = page.locator("a.wiki-link", { hasText: "people/ada" });
+  const hopper = page.locator("a.wiki-link", { hasText: "people/hopper" });
+  await expect(ada).toBeVisible();
+  await expect(ada).not.toHaveClass(/wiki-link--missing/);
+  await expect(hopper).toHaveClass(/wiki-link--missing/);
+
+  // The syntax documented inside a code span on schema.md is not a link.
+  await page.goto("/wiki/schema");
+  await expect(page.getByRole("heading", { name: "How this wiki works" })).toBeVisible();
+  await expect(page.locator("code", { hasText: "[[wikilinks]]" })).toBeVisible();
+  await expect(page.locator("a.wiki-link")).toHaveCount(0);
+
+  await test.info().attach("wiki-page", {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+});
+
+test("following an unwritten link offers to write it", async ({ page }) => {
+  await installWikiStub(page);
+  await page.goto("/wiki/index");
+  await expect(page.getByRole("heading", { name: "Index" })).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  await page.locator("a.wiki-link--missing", { hasText: "people/hopper" }).click();
+
+  await expect(page).toHaveURL(/\/wiki\/people\/hopper$/);
+  await expect(page.getByText("Nobody has written this page yet")).toBeVisible();
+
+  await page.getByRole("button", { name: "Write it" }).click();
+  // Seeded from the filename so the page starts with a heading, per schema.md.
+  await expect(page.getByRole("textbox")).toHaveValue("# hopper\n\n");
+
+  await test.info().attach("wiki-missing-page", {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+});
+
+test("editing writes the exact bytes back and commits", async ({ page }) => {
+  await installWikiStub(page);
+  await page.goto("/wiki/people/ada");
+  await expect(page.getByRole("heading", { name: "Ada Lovelace" })).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  await page.getByRole("button", { name: "Edit" }).click();
+
+  const editor = page.getByRole("textbox");
+  // What you edit is the file — not a re-serialisation of it.
+  await expect(editor).toHaveValue(FILES["people/ada.md"]!);
+
+  const edited = `${FILES["people/ada.md"]!}\nAlso see [[decisions/why-postgres]].\n`;
+  await editor.fill(edited);
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect(page.getByRole("button", { name: "Edit" })).toBeVisible();
+
+  // The whole point: the wiki's own syntax survives a save untouched. A
+  // ProseMirror round trip escapes these into \[\[…\]\] and reflows the
+  // paragraphs, which is why this surface edits raw Markdown.
+  expect(await fileOnDisk(page, "people/ada.md")).toBe(edited);
+
+  const cmds = (await calls(page)).map((c) => c.cmd);
+  expect(cmds).toContain("wiki_write_page");
+  // Every write lands in git the same way a librarian turn does.
+  expect(cmds.indexOf("wiki_commit_turn")).toBeGreaterThan(cmds.indexOf("wiki_write_page"));
+
+  // The saved link now resolves in the rendered page.
+  await expect(page.locator("a.wiki-link", { hasText: "decisions/why-postgres" })).toBeVisible();
+});
+
+test("a page changed on disk mid-edit is not silently overwritten", async ({ page }) => {
+  await installWikiStub(page);
+  await page.goto("/wiki/people/ada");
+  await expect(page.getByRole("heading", { name: "Ada Lovelace" })).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  await page.getByRole("button", { name: "Edit" }).click();
+  await page.getByRole("textbox").fill("# Ada\n\nMy version.\n");
+
+  // The librarian files something to the same page while the editor is open.
+  await page.evaluate(() => {
+    (window as unknown as { __WIKI_FILES__: Record<string, string> }).__WIKI_FILES__[
+      "people/ada.md"
+    ] = "# Ada Lovelace\n\nThe librarian's version.\n";
+  });
+
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page.getByText("This page changed on disk")).toBeVisible();
+
+  // Backing out leaves the librarian's copy intact.
+  await page.getByRole("button", { name: "Keep what's on disk" }).click();
+  expect(await fileOnDisk(page, "people/ada.md")).toBe(
+    "# Ada Lovelace\n\nThe librarian's version.\n",
+  );
+});
+
+test("navigating away from an open editor does not carry the draft to the next page", async ({
+  page,
+}) => {
+  await installWikiStub(page);
+  await page.goto("/wiki/index");
+  await expect(page.getByRole("heading", { name: "Index" })).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  // Straight from one page to another — no trip through the list, which would
+  // unmount the view and hide the problem.
+  await page.locator("a.wiki-link", { hasText: "people/ada" }).click();
+  await expect(page.getByRole("heading", { name: "Ada Lovelace" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Edit" }).click();
+  await page.getByRole("textbox").fill("# Ada\n\nUnsaved edits to Ada.\n");
+
+  // Both pages are the same route with different params, so the view is
+  // reused rather than remounted. An editor left open must not follow.
+  await page.goBack();
+
+  await expect(page).toHaveURL(/\/wiki\/index$/);
+  await expect(page.getByRole("heading", { name: "Index" })).toBeVisible();
+  // Reading index.md, not editing it with Ada's text.
+  await expect(page.getByRole("button", { name: "Edit" })).toBeVisible();
+  await expect(page.getByRole("textbox")).toHaveCount(0);
+
+  // And Ada's unsaved draft never reached index.md.
+  expect(await fileOnDisk(page, "index.md")).toBe(FILES["index.md"]!);
+});
+
+test("in a browser, the wiki says where it actually lives", async ({ page }) => {
+  // No stub: this is what a non-desktop visitor gets.
+  await page.goto("/wiki");
+  await expect(page.getByText("The local wiki lives on your machine")).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+});

--- a/e2e/topbar-crumb.spec.ts
+++ b/e2e/topbar-crumb.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+
+const FIRST_PAINT_TIMEOUT = 60_000;
+
+/**
+ * Collapsed, the sidebar's re-open button is fixed in the top-left corner and
+ * the workspace crumb starts in that same gutter. With the topbar's default
+ * 40px padding the two overlapped (the folder icon began 4px *inside* the
+ * button's box); the crumb has to give it room.
+ */
+test("collapsed sidebar: the crumb clears the re-open button", async ({ page }) => {
+  await page.goto("/w/dev-fixture/projects");
+  await expect(page.getByText("Dev Fixture").first()).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  await page.getByLabel("Collapse menu").click();
+  const toggle = page.getByLabel("Open sidebar");
+  await toggle.waitFor();
+  // The crumb slides across on the same 300ms transition as the collapse.
+  await page.waitForTimeout(600);
+
+  // The crumb's leading folder icon is the left-most thing in the topbar.
+  const toggleBox = await toggle.boundingBox();
+  const crumbBox = await page.locator("svg.tabler-icon-folder").first().boundingBox();
+  expect(toggleBox).not.toBeNull();
+  expect(crumbBox).not.toBeNull();
+  expect(crumbBox!.x).toBeGreaterThanOrEqual(toggleBox!.x + toggleBox!.width);
+
+  await test.info().attach("collapsed-topbar", {
+    body: await page.screenshot({ clip: { x: 0, y: 0, width: 640, height: 120 } }),
+    contentType: "image/png",
+  });
+});

--- a/prisma/migrations/20260805092110_add_workspace_enable_key_results/migration.sql
+++ b/prisma/migrations/20260805092110_add_workspace_enable_key_results/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Workspace" ADD COLUMN     "enableKeyResults" BOOLEAN;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -378,6 +378,12 @@ model Workspace {
   // When on, creating a CRM contact enqueues an async web-search enrichment job
   // (drained by the enrich-pending-contacts cron → Mastra enrichmentAgent).
   enableAutoEnrichContacts Boolean    @default(false)
+  // Key Results / OKR UI. Nullable on purpose — unlike the flags above there is
+  // no single sensible default: null means "follow the workspace type"
+  // (team/org on, personal off), which is the behaviour that predates this
+  // column. Setting it true/false is an explicit per-workspace override, so a
+  // personal workspace can opt into KRs. Resolved in `useTerminology`.
+  enableKeyResults         Boolean?
 
   // Notion integration defaults: { defaultIntegrationId, defaultDatabaseId, fieldMappings, syncDirection, syncFrequency }
   notionDefaultConfig Json?

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +507,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]
@@ -837,12 +873,18 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever",
  "precomputed-hash",
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -979,6 +1021,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,13 +1051,16 @@ name = "exponential-beta"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "block2",
  "getrandom 0.3.4",
+ "objc2",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-deep-link",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
@@ -1022,6 +1073,12 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1049,6 +1106,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1126,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1300,6 +1369,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1566,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,6 +1587,15 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1777,6 +1876,20 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2098,6 +2211,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,6 +2270,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "num-conv"
@@ -2205,6 +2337,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2424,6 +2557,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,6 +2625,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -2694,6 +2848,18 @@ checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3734,6 +3900,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "tauri-plugin-deep-link"
 version = "2.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3969,6 +4150,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4303,6 +4498,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4568,6 +4774,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4687,6 +4963,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5174,6 +5456,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.19",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5243,6 +5543,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "yoke"
@@ -5329,6 +5646,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5393,6 +5730,21 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,19 @@ sha2 = "0.10"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "charset"] }
 url = "2"
 tauri-plugin-store = "2.4.4"
+# Cmd/Ctrl+L copies the frontmost tab's URL. Written from Rust, so it needs no
+# ACL grant and works on every platform the shell ever targets.
+tauri-plugin-clipboard-manager = "2"
+
+# Native window tabs (ADR-0053). Sharing a tabbing identifier only makes windows
+# *tabbable*; AppKit merges them automatically only when the user's global
+# AppleWindowTabbingMode is "always", and Apple's default is "In Full Screen
+# Only". Neither tao nor tauri exposes -[NSWindow addTabbedWindow:ordered:], so
+# the shell reaches for it through ns_window(). Already a transitive dep.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+# NSEvent local monitor blocks (⌃Tab has to be caught before WKWebView eats it).
+block2 = "0.6"
 
 [profile.dev]
 # The shell is a thin wrapper around a remote page; incremental debug builds are

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -18,6 +18,7 @@ fn main() {
                 "wiki_commit_turn",
                 "wiki_search",
                 "wiki_get_root",
+                "wiki_status",
                 "wiki_fetch_url",
                 "wiki_read_external",
             ]),

--- a/src-tauri/capabilities/remote.json
+++ b/src-tauri/capabilities/remote.json
@@ -25,6 +25,7 @@
     "allow-wiki-commit-turn",
     "allow-wiki-search",
     "allow-wiki-get-root",
+    "allow-wiki-status",
     "allow-wiki-fetch-url",
     "allow-wiki-read-external"
   ]

--- a/src-tauri/capabilities/remote.json
+++ b/src-tauri/capabilities/remote.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "remote-app",
   "description": "IPC surface granted to the Exponential web app loaded from its own origin. A remote page gets no usable Tauri bridge without this: `remote.urls` opts the origin in, and every command it may call must be granted below by name. Both apex and www are listed because exponential.im 301s to www — the webview's effective origin is the redirect target.",
-  "windows": ["main"],
+  "windows": ["main", "tab-*"],
   "remote": {
     "urls": [
       "https://exponential.im/*",

--- a/src-tauri/permissions/autogenerated/wiki_status.toml
+++ b/src-tauri/permissions/autogenerated/wiki_status.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-wiki-status"
+description = "Enables the wiki_status command without any pre-configured scope."
+commands.allow = ["wiki_status"]
+
+[[permission]]
+identifier = "deny-wiki-status"
+description = "Denies the wiki_status command without any pre-configured scope."
+commands.deny = ["wiki_status"]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -205,9 +205,17 @@ fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<()> {
 
     // Match the Electron shell's `hiddenInset` chrome: the traffic lights float
     // over the page instead of sitting in a separate title bar.
+    //
+    // `hidden_title` is part of that match, not a nicety: `Overlay` alone keeps
+    // drawing the window title, which lands on top of the page's own top-left
+    // chrome (the sidebar's workspace switcher). Electron's `hiddenInset` hides
+    // the title for us; Tauri needs to be told. The page still needs to keep its
+    // content clear of the traffic lights themselves — see `--titlebar-inset` in
+    // `src/app/_components/layout/sidebar.css`.
     #[cfg(target_os = "macos")]
     let builder = builder
         .title_bar_style(tauri::TitleBarStyle::Overlay)
+        .hidden_title(true)
         .traffic_light_position(tauri::LogicalPosition::new(16.0, 16.0));
 
     builder.build()?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,6 +112,7 @@ pub fn run() {
             wiki::wiki_commit_turn,
             wiki::wiki_search,
             wiki::wiki_get_root,
+            wiki::wiki_status,
             source::wiki_fetch_url,
             source::wiki_read_external,
         ])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -166,6 +166,41 @@ fn resolve_wiki_root(app: &tauri::AppHandle) {
         .expect("wiki root mutex poisoned") = Some(root);
 }
 
+/// Tells the page it is inside this shell, so it can keep its own chrome out
+/// from under the window controls.
+///
+/// The page cannot reliably work this out for itself. It used to sniff
+/// `window.__TAURI_INTERNALS__` from an inline `<head>` script, but on a remote
+/// page that global lands *after* the document's own head scripts run — so the
+/// check was made too early, found nothing, and the inset was silently skipped.
+/// IPC worked fine a moment later, which is what made the bug so quiet.
+///
+/// An initialization script has no such race: whenever it runs, setting the
+/// attribute is enough, because the CSS keyed off it applies the moment it
+/// appears. `documentElement` may not exist yet at injection time, hence the
+/// `DOMContentLoaded` retry.
+#[cfg(target_os = "macos")]
+const TITLEBAR_MARKER_SCRIPT: &str = r#"
+(function () {
+  function mark() {
+    var root = document && document.documentElement;
+    if (!root) return false;
+    root.setAttribute('data-shell', 'tauri');
+    root.setAttribute('data-titlebar', 'overlay');
+    return true;
+  }
+  try {
+    if (!mark()) {
+      document.addEventListener('DOMContentLoaded', mark);
+    }
+  } catch (e) {}
+})();
+"#;
+
+/// Non-macOS shells keep their native chrome, so there is nothing to mark.
+#[cfg(not(target_os = "macos"))]
+const TITLEBAR_MARKER_SCRIPT: &str = "";
+
 /// Create the single app window pointed at the remote web app.
 ///
 /// The window is built here rather than declared in `tauri.conf.json` because the
@@ -186,6 +221,7 @@ fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<()> {
         // The page is remote and takes a moment to paint; without this the window
         // opens as a white flash before the app's dark surface arrives.
         .background_color(window_background())
+        .initialization_script(TITLEBAR_MARKER_SCRIPT)
         .on_navigation(move |url| {
             if stays_in_app(url) {
                 return true;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -250,6 +250,10 @@ pub fn run() {
 /// written back to the store so the choice survives a restart — including a
 /// first run, where it pins the default rather than leaving it implicit and
 /// liable to move if the default ever changes.
+///
+/// An `EXPONENTIAL_WIKI_ROOT` override is the exception: it applies to the launch
+/// that set it and is never written back, so a throwaway test root cannot become
+/// the permanent setting. See `wiki::resolve_root_for_launch`.
 fn resolve_wiki_root(app: &tauri::AppHandle) {
     use tauri_plugin_store::StoreExt;
 
@@ -259,14 +263,16 @@ fn resolve_wiki_root(app: &tauri::AppHandle) {
         .and_then(|store| store.get(wiki::STORE_KEY))
         .and_then(|value| value.as_str().map(str::to_owned));
 
-    let root = wiki::resolve_root(stored);
+    let wiki::RootChoice { root, persist } = wiki::resolve_root_for_launch(stored);
 
-    if let Ok(store) = app.store(wiki::STORE_FILE) {
-        store.set(wiki::STORE_KEY, root.to_string_lossy().to_string());
-        // Best-effort: a wiki that works but forgets its location next launch
-        // beats refusing to start.
-        if let Err(e) = store.save() {
-            eprintln!("[wiki] could not persist the wiki root: {e}");
+    if persist {
+        if let Ok(store) = app.store(wiki::STORE_FILE) {
+            store.set(wiki::STORE_KEY, root.to_string_lossy().to_string());
+            // Best-effort: a wiki that works but forgets its location next launch
+            // beats refusing to start.
+            if let Err(e) = store.save() {
+                eprintln!("[wiki] could not persist the wiki root: {e}");
+            }
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,6 +85,97 @@ fn desktop_shell_info() -> ShellInfo {
     }
 }
 
+/// The app menu: Tauri's default, extended with tab items (ADR-0053).
+///
+/// The tab shortcuts have to be declared explicitly. AppKit is supposed to
+/// inject Show Next/Previous Tab into whatever submenu is registered as
+/// `NSApp.windowsMenu`, and the preconditions all hold — tao leaves
+/// `allowsAutomaticWindowTabbing` on, and Tauri does call
+/// `set_as_windows_menu_for_nsapp` for the submenu tagged `WINDOW_SUBMENU_ID` —
+/// but on a real build the injected items never reached the keyboard. The
+/// actions dispatched are AppKit's own, so the behaviour is Safari's — cycling
+/// wraps, the overview is the real overview — rather than a reimplementation.
+///
+/// Built by *extending* `Menu::default`, never by constructing a menu from
+/// scratch. A fresh menu has no submenu carrying `WINDOW_SUBMENU_ID`, so
+/// `set_as_windows_menu_for_nsapp` never fires and macOS silently loses the
+/// window list and its tab handling. Adding a tab shortcut that way would remove
+/// the others.
+///
+/// Cross-platform on purpose, even though tabs are macOS-only: Copy Page URL is
+/// wanted everywhere the shell might run, and `CmdOrCtrl` resolves per platform.
+/// (Linux's default menu has no File submenu, so the item is macOS/Windows —
+/// acceptable for a shell that only targets macOS today.)
+fn build_menu(app: &tauri::AppHandle) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
+    use tauri::menu::{Menu, MenuItem};
+
+    let menu = Menu::default(app)?;
+
+    // ⌘L. Safari focuses the address bar; with no address bar, copying the URL
+    // is the useful half of the gesture.
+    let copy_url = MenuItem::with_id(
+        app,
+        "copy-url",
+        "Copy Page URL",
+        true,
+        Some("CmdOrCtrl+L"),
+    )?;
+    if let Some(file) = submenu_named(&menu, "File") {
+        file.insert(&copy_url, 0)?;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use tauri::menu::PredefinedMenuItem;
+
+        let new_tab = MenuItem::with_id(app, "new-tab", "New Tab", true, Some("CmdOrCtrl+T"))?;
+        let next_tab = MenuItem::with_id(app, "next-tab", "Show Next Tab", true, Some("Ctrl+Tab"))?;
+        let prev_tab = MenuItem::with_id(
+            app,
+            "prev-tab",
+            "Show Previous Tab",
+            true,
+            Some("Ctrl+Shift+Tab"),
+        )?;
+        let overview = MenuItem::with_id(
+            app,
+            "tab-overview",
+            "Show All Tabs",
+            true,
+            Some("CmdOrCtrl+Shift+Backslash"),
+        )?;
+
+        // New Tab sits above Close Window in File, where Safari puts it.
+        if let Some(file) = submenu_named(&menu, "File") {
+            file.insert(&new_tab, 0)?;
+        }
+
+        if let Some(window) = menu
+            .get(tauri::menu::WINDOW_SUBMENU_ID)
+            .and_then(|item| item.as_submenu().cloned())
+        {
+            window.append(&PredefinedMenuItem::separator(app)?)?;
+            window.append(&next_tab)?;
+            window.append(&prev_tab)?;
+            window.append(&overview)?;
+        }
+    }
+
+    Ok(menu)
+}
+
+/// The default menu gives its submenus no ids except Window and Help, so File
+/// has to be found by the label the user reads.
+fn submenu_named(
+    menu: &tauri::menu::Menu<tauri::Wry>,
+    name: &str,
+) -> Option<tauri::menu::Submenu<tauri::Wry>> {
+    menu.items().ok()?.into_iter().find_map(|item| {
+        let submenu = item.as_submenu()?;
+        (submenu.text().ok()? == name).then(|| submenu.clone())
+    })
+}
+
 pub fn run() {
     tauri::Builder::default()
         // Single-instance must be registered first (plugin's own requirement).
@@ -99,6 +190,20 @@ pub fn run() {
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::default().build())
+        .plugin(tauri_plugin_clipboard_manager::init())
+        .menu(build_menu)
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            "copy-url" => copy_current_url(app),
+            #[cfg(target_os = "macos")]
+            "new-tab" => tabs::open(app),
+            #[cfg(target_os = "macos")]
+            "next-tab" => tabs::select_next(app),
+            #[cfg(target_os = "macos")]
+            "prev-tab" => tabs::select_previous(app),
+            #[cfg(target_os = "macos")]
+            "tab-overview" => tabs::toggle_overview(app),
+            _ => {}
+        })
         .manage(auth::LoginState::default())
         .manage(wiki::WikiRoot::default())
         .invoke_handler(tauri::generate_handler![
@@ -118,7 +223,12 @@ pub fn run() {
         ])
         .setup(|app| {
             resolve_wiki_root(app.handle());
-            build_main_window(app.handle())?;
+            let _main = build_main_window(app.handle())?;
+            #[cfg(target_os = "macos")]
+            {
+                install_tab_key_monitor(app.handle());
+                install_plus_button(app.handle(), &_main);
+            }
 
             let handle = app.handle().clone();
             app.deep_link().on_open_url(move |event| {
@@ -166,19 +276,19 @@ fn resolve_wiki_root(app: &tauri::AppHandle) {
         .expect("wiki root mutex poisoned") = Some(root);
 }
 
-/// Tells the page it is inside this shell, so it can keep its own chrome out
-/// from under the window controls.
+/// Tells the page it is inside this shell.
 ///
 /// The page cannot reliably work this out for itself. It used to sniff
 /// `window.__TAURI_INTERNALS__` from an inline `<head>` script, but on a remote
 /// page that global lands *after* the document's own head scripts run — so the
-/// check was made too early, found nothing, and the inset was silently skipped.
-/// IPC worked fine a moment later, which is what made the bug so quiet.
+/// check was made too early, found nothing, and the marking was silently
+/// skipped. IPC worked fine a moment later, which is what made the bug so
+/// quiet. An initialization script has no such race; `documentElement` may not
+/// exist yet at injection time, hence the `DOMContentLoaded` retry.
 ///
-/// An initialization script has no such race: whenever it runs, setting the
-/// attribute is enough, because the CSS keyed off it applies the moment it
-/// appears. `documentElement` may not exist yet at injection time, hence the
-/// `DOMContentLoaded` retry.
+/// With the Safari-style chrome this stamps only `data-shell` — the overlay-era
+/// `data-titlebar` marking (and the 38px sidebar inset it switched on) is
+/// deliberately gone, because the page no longer sits under any chrome.
 #[cfg(target_os = "macos")]
 const TITLEBAR_MARKER_SCRIPT: &str = r#"
 (function () {
@@ -186,7 +296,9 @@ const TITLEBAR_MARKER_SCRIPT: &str = r#"
     var root = document && document.documentElement;
     if (!root) return false;
     root.setAttribute('data-shell', 'tauri');
-    root.setAttribute('data-titlebar', 'overlay');
+    // Deliberately NOT stamping data-titlebar="overlay": with the Safari-style
+    // visible titlebar the page starts below the chrome, so the 38px inset that
+    // attribute switches on in sidebar.css would be pure dead space.
     return true;
   }
   try {
@@ -206,7 +318,205 @@ const TITLEBAR_MARKER_SCRIPT: &str = "";
 /// The window is built here rather than declared in `tauri.conf.json` because the
 /// URL is build-dependent (dev server vs production) and a `WebviewUrl::External`
 /// in static config cannot express that.
-fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<()> {
+fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<tauri::WebviewWindow> {
+    build_window(app, "main")
+}
+
+/// Native macOS window tabs (ADR-0053). Tab commands are sent to whichever
+/// window is frontmost.
+///
+/// `selectNextTab:`, `selectPreviousTab:` and `toggleTabOverview:` are AppKit's
+/// own actions, so the behaviour is Safari's by construction — cycling wraps,
+/// the overview is the real overview — rather than something reimplemented and
+/// approximately right.
+#[cfg(target_os = "macos")]
+mod tabs {
+    use objc2::runtime::AnyObject;
+
+    /// Labels are `tab-<n>` to match the capability glob. Nothing reads them.
+    static NEXT_LABEL: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(1);
+
+    pub fn next_label() -> String {
+        let n = NEXT_LABEL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        format!("tab-{n}")
+    }
+
+    fn ns_window(window: &tauri::WebviewWindow) -> Option<*mut AnyObject> {
+        window.ns_window().ok().map(|ptr| ptr as *mut AnyObject)
+    }
+
+    pub fn select_next(app: &tauri::AppHandle) {
+        if let Some(ns) = super::frontmost_window(app).as_ref().and_then(ns_window) {
+            unsafe {
+                let _: () = objc2::msg_send![ns, selectNextTab: std::ptr::null::<AnyObject>()];
+            }
+        }
+    }
+
+    pub fn select_previous(app: &tauri::AppHandle) {
+        if let Some(ns) = super::frontmost_window(app).as_ref().and_then(ns_window) {
+            unsafe {
+                let _: () = objc2::msg_send![ns, selectPreviousTab: std::ptr::null::<AnyObject>()];
+            }
+        }
+    }
+
+    pub fn toggle_overview(app: &tauri::AppHandle) {
+        if let Some(ns) = super::frontmost_window(app).as_ref().and_then(ns_window) {
+            unsafe {
+                let _: () = objc2::msg_send![ns, toggleTabOverview: std::ptr::null::<AnyObject>()];
+            }
+        }
+    }
+
+    /// Open a tab in the frontmost window's tab group.
+    ///
+    /// `addTabbedWindow:` rather than trusting the shared identifier: AppKit only
+    /// auto-merges when the user's global `AppleWindowTabbingMode` is `always`,
+    /// and Apple's default is "In Full Screen Only" — so without this an ordinary
+    /// user gets a detached window and no tab at all.
+    pub fn open(app: &tauri::AppHandle) {
+        let host = super::frontmost_window(app);
+        let Ok(created) = super::build_window(app, &next_label()) else {
+            return;
+        };
+        let (Some(host_ns), Some(created_ns)) =
+            (host.as_ref().and_then(ns_window), ns_window(&created))
+        else {
+            return;
+        };
+        // NSWindowOrderingMode::Above — new tab lands after the current one.
+        unsafe {
+            let _: () = objc2::msg_send![host_ns, addTabbedWindow: created_ns, ordered: 1isize];
+        }
+        let _ = created.set_focus();
+    }
+}
+
+/// The window the user is looking at, or any window as a fallback.
+///
+/// The fallback matters at startup and in menu handlers that can fire while no
+/// window reports focus; "some window" beats a silently dead menu item.
+fn frontmost_window(app: &tauri::AppHandle) -> Option<tauri::WebviewWindow> {
+    let windows = app.webview_windows();
+    windows
+        .values()
+        .find(|w| w.is_focused().unwrap_or(false))
+        .or_else(|| windows.values().next())
+        .cloned()
+}
+
+/// Cmd/Ctrl+L. In a browser that focuses the address bar; the shell has no
+/// address bar, so it copies the frontmost tab's URL instead — the half of ⌘L
+/// people actually want here (grabbing a link to the page they're on).
+fn copy_current_url(app: &tauri::AppHandle) {
+    use tauri_plugin_clipboard_manager::ClipboardExt;
+
+    let Some(window) = frontmost_window(app) else {
+        return;
+    };
+    let Ok(url) = window.url() else {
+        return;
+    };
+    if let Err(e) = app.clipboard().write_text(url.to_string()) {
+        eprintln!("[shell] could not copy the current URL: {e}");
+    }
+}
+
+/// ⌃Tab / ⌃⇧Tab, caught the way Safari catches them: before the web view sees
+/// the key.
+///
+/// These cannot be menu key equivalents. AppKit matches a non-⌘ equivalent only
+/// after the responder chain declines the key, and WKWebView consumes Tab —
+/// which is why the menu items alone (previous build) never fired. A local
+/// NSEvent monitor runs before dispatch, so it wins regardless of what the
+/// webview would do with the key. The menu items stay for discoverability; the
+/// monitor swallowing the event just means they are never reached by keyboard.
+#[cfg(target_os = "macos")]
+fn install_tab_key_monitor(app: &tauri::AppHandle) {
+    use objc2::runtime::AnyObject;
+
+    const KEY_DOWN_MASK: u64 = 1 << 10; // NSEventMaskKeyDown
+    const SHIFT: u64 = 1 << 17; // NSEventModifierFlagShift
+    const CONTROL: u64 = 1 << 18; // NSEventModifierFlagControl
+    const OPTION: u64 = 1 << 19; // NSEventModifierFlagOption
+    const COMMAND: u64 = 1 << 20; // NSEventModifierFlagCommand
+    const TAB_KEY_CODE: u16 = 48;
+
+    let handle = app.clone();
+    let block = block2::RcBlock::new(move |event: *mut AnyObject| -> *mut AnyObject {
+        let (key_code, flags): (u16, u64) = unsafe {
+            (
+                objc2::msg_send![event, keyCode],
+                objc2::msg_send![event, modifierFlags],
+            )
+        };
+        if key_code == TAB_KEY_CODE && flags & CONTROL != 0 && flags & (COMMAND | OPTION) == 0 {
+            if flags & SHIFT != 0 {
+                tabs::select_previous(&handle);
+            } else {
+                tabs::select_next(&handle);
+            }
+            return std::ptr::null_mut(); // swallowed — the webview never tabs focus
+        }
+        event
+    });
+
+    // The monitor and its block live for the life of the app; there is no
+    // teardown moment, so leaking both is the correct lifetime.
+    unsafe {
+        let _monitor: *mut AnyObject = objc2::msg_send![
+            objc2::class!(NSEvent),
+            addLocalMonitorForEventsMatchingMask: KEY_DOWN_MASK,
+            handler: &*block
+        ];
+    }
+    std::mem::forget(block);
+}
+
+/// The `+` at the right end of the tab bar.
+///
+/// AppKit draws Safari's plus button by itself the moment any responder in the
+/// window's chain implements `newWindowForTab:` — the button *is* that check.
+/// Neither tao nor tauri implements it, so it is added to the window's own class
+/// at runtime, once; the class is tao's window subclass, so every tab gets the
+/// button from the same patch.
+#[cfg(target_os = "macos")]
+static TAB_APP_HANDLE: OnceLock<tauri::AppHandle> = OnceLock::new();
+
+#[cfg(target_os = "macos")]
+fn install_plus_button(app: &tauri::AppHandle, window: &tauri::WebviewWindow) {
+    use objc2::runtime::AnyObject;
+
+    let _ = TAB_APP_HANDLE.set(app.clone());
+
+    extern "C-unwind" fn new_window_for_tab(
+        _this: *mut AnyObject,
+        _sel: objc2::runtime::Sel,
+        _sender: *mut AnyObject,
+    ) {
+        // Runs on the main thread — AppKit action dispatch, same as a menu item.
+        if let Some(app) = TAB_APP_HANDLE.get() {
+            tabs::open(app);
+        }
+    }
+
+    let Ok(ptr) = window.ns_window() else {
+        return;
+    };
+    unsafe {
+        let ns = ptr as *mut AnyObject;
+        let class: *mut objc2::runtime::AnyClass = objc2::msg_send![ns, class];
+        let imp = std::mem::transmute::<
+            extern "C-unwind" fn(*mut AnyObject, objc2::runtime::Sel, *mut AnyObject),
+            objc2::runtime::Imp,
+        >(new_window_for_tab);
+        // "v@:@" — returns void, takes self, _cmd, sender.
+        objc2::ffi::class_addMethod(class, objc2::sel!(newWindowForTab:), imp, c"v@:@".as_ptr());
+    }
+}
+
+fn build_window(app: &tauri::AppHandle, label: &str) -> tauri::Result<tauri::WebviewWindow> {
     let url = app_base_url()
         .parse()
         .unwrap_or_else(|e| panic!("{BASE_URL_ENV} is not a valid URL: {e}"));
@@ -214,7 +524,10 @@ fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<()> {
     let opener = app.clone();
     let new_window_opener = app.clone();
 
-    let builder = tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::External(url))
+    let builder = tauri::WebviewWindowBuilder::new(app, label, tauri::WebviewUrl::External(url))
+        // Also each tab's label, via NSWindow.tab.title. URL-derived per-tab
+        // titles are the V2 ticket's next action; until then every tab reads
+        // the same, which is the known gap, not a bug.
         .title("Exponential Beta")
         .inner_size(1400.0, 900.0)
         .min_inner_size(800.0, 600.0)
@@ -239,23 +552,33 @@ fn build_main_window(app: &tauri::AppHandle) -> tauri::Result<()> {
             tauri::webview::NewWindowResponse::Deny
         });
 
-    // Match the Electron shell's `hiddenInset` chrome: the traffic lights float
-    // over the page instead of sitting in a separate title bar.
+    // Safari-style chrome: a standard titlebar, with the web view laid out
+    // below it — NOT the Electron-matching overlay chrome this shell used
+    // before tabs. The cool.lark spike tried overlay + native tabs on a real
+    // build, and the overlay lost at every layer (ADR-0053):
     //
-    // `hidden_title` is part of that match, not a nicety: `Overlay` alone keeps
-    // drawing the window title, which lands on top of the page's own top-left
-    // chrome (the sidebar's workspace switcher). Electron's `hiddenInset` hides
-    // the title for us; Tauri needs to be told. The page still needs to keep its
-    // content clear of the traffic lights themselves — see `--titlebar-inset` in
-    // `src/app/_components/layout/sidebar.css`.
+    //   - `traffic_light_position` shrinks the titlebar container the tab bar
+    //     lives in (tao's inset hack re-runs every drawRect:), squashing the
+    //     bar and hiding the lights;
+    //   - the full-size content view puts the page under the chrome, so
+    //     scrolled content and the scrollbar showed through the titlebar row,
+    //     fixed-position modals opened under the tab bar, and the transparent
+    //     titlebar hit-tested through to the page, leaving the window
+    //     undraggable (tauri#9503);
+    //   - each had a workaround, and each workaround was another moving part.
+    //
+    // A visible titlebar dissolves all of it: AppKit lays content below the
+    // chrome, dragging/zoom/scrollbars behave natively, and the page needs no
+    // inset at all. `hidden_title` keeps the empty titlebar row from drawing a
+    // window title over its middle; tab labels are unaffected (they read
+    // NSWindow.tab.title, not the titlebar drawing).
     #[cfg(target_os = "macos")]
     let builder = builder
-        .title_bar_style(tauri::TitleBarStyle::Overlay)
         .hidden_title(true)
-        .traffic_light_position(tauri::LogicalPosition::new(16.0, 16.0));
+        .tabbing_identifier("im.exponential.beta.tabs");
 
-    builder.build()?;
-    Ok(())
+    let window = builder.build()?;
+    Ok(window)
 }
 
 /// Hand a URL to the user's default browser.

--- a/src-tauri/src/wiki.rs
+++ b/src-tauri/src/wiki.rs
@@ -40,7 +40,8 @@ pub struct WikiRoot(pub Mutex<Option<PathBuf>>);
 pub const STORE_FILE: &str = "wiki.json";
 /// Key within that store.
 pub const STORE_KEY: &str = "root";
-/// Dev override, read at startup and then persisted like any other choice.
+/// Dev override, read at startup. Applies to that launch only — see
+/// `resolve_root_for_launch` for why it is deliberately never persisted.
 pub const ROOT_ENV: &str = "EXPONENTIAL_WIKI_ROOT";
 
 /// Default location — visible in Finder on purpose. The wiki is the user's, and
@@ -60,13 +61,34 @@ pub fn default_root() -> PathBuf {
 /// on that origin. Configuring the root is therefore an out-of-band act (the env
 /// var, or a future native settings UI), never an in-page one.
 pub fn resolve_root(stored: Option<String>) -> PathBuf {
+    resolve_root_for_launch(stored).root
+}
+
+/// The root for this launch, and whether it is ours to remember.
+pub struct RootChoice {
+    pub root: PathBuf,
+    /// False for an env override: that path is this launch's business only.
+    pub persist: bool,
+}
+
+/// Same decision as `resolve_root`, plus whether the answer should be written
+/// back to the store.
+///
+/// The env override is deliberately **not** persisted. It used to be, and that
+/// turned a one-off `EXPONENTIAL_WIKI_ROOT=/tmp/scratch` test run into the
+/// permanent setting: every later launch read that path back out of the store,
+/// so the app believed a wiki existed, the first-run panel never appeared, and
+/// the librarian read and wrote a throwaway folder the user had forgotten about.
+/// A variable set for one command should not outlive it.
+pub fn resolve_root_for_launch(stored: Option<String>) -> RootChoice {
     if let Some(from_env) = std::env::var(ROOT_ENV).ok().filter(|v| !v.trim().is_empty()) {
-        return PathBuf::from(from_env);
+        return RootChoice { root: PathBuf::from(from_env), persist: false };
     }
-    match stored.filter(|v| !v.trim().is_empty()) {
+    let root = match stored.filter(|v| !v.trim().is_empty()) {
         Some(path) => PathBuf::from(path),
         None => default_root(),
-    }
+    };
+    RootChoice { root, persist: true }
 }
 
 fn current_root(state: &WikiRoot) -> PathBuf {
@@ -895,6 +917,28 @@ mod tests {
             PathBuf::from("/tmp/override-wiki"),
         );
         std::env::remove_var(ROOT_ENV);
+    }
+
+    #[test]
+    fn the_env_override_is_not_remembered() {
+        // Regression: it used to be written back to the store, so a single
+        // `EXPONENTIAL_WIKI_ROOT=/tmp/scratch` run silently repointed the wiki
+        // for good — the app then believed a wiki existed and never offered to
+        // create the real one.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var(ROOT_ENV, "/tmp/override-wiki");
+        let choice = resolve_root_for_launch(Some("/tmp/stored-wiki".into()));
+        assert_eq!(choice.root, PathBuf::from("/tmp/override-wiki"));
+        assert!(!choice.persist, "an env override must not outlive its launch");
+        std::env::remove_var(ROOT_ENV);
+    }
+
+    #[test]
+    fn a_root_the_user_chose_is_remembered() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var(ROOT_ENV);
+        assert!(resolve_root_for_launch(None).persist);
+        assert!(resolve_root_for_launch(Some("/tmp/my-wiki".into())).persist);
     }
 
     #[test]

--- a/src-tauri/src/wiki.rs
+++ b/src-tauri/src/wiki.rs
@@ -199,6 +199,44 @@ pub struct WikiPage {
     pub bytes: u64,
 }
 
+/// What the app needs to decide between "offer to create a wiki" and "chat".
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WikiStatus {
+    /// Where it would live, whether or not it does — the first-run panel names
+    /// this so the user knows what is about to appear on their disk.
+    pub root: String,
+    pub exists: bool,
+    /// Whether the folder is a git repo. False for a folder restored from a
+    /// backup that lost `.git`, which still counts as existing.
+    pub git: bool,
+    pub page_count: usize,
+}
+
+/// Report on the wiki **without creating it**.
+///
+/// The distinction from `wiki_init` is the whole point: creating a folder in
+/// someone's Documents should be something they chose, not a side effect of
+/// asking a question. This is what the first-run panel asks before offering the
+/// button, so it must stay free of side effects.
+#[tauri::command]
+pub fn wiki_status(state: tauri::State<WikiRoot>) -> WikiStatus {
+    let root = current_root(&state);
+    status_at(&root)
+}
+
+pub fn status_at(root: &Path) -> WikiStatus {
+    let exists = root.is_dir();
+    WikiStatus {
+        root: root.to_string_lossy().into_owned(),
+        exists,
+        git: exists && root.join(".git").exists(),
+        // `list_pages` on a missing folder is an empty list, not an error, so
+        // this is safe to call either way.
+        page_count: list_pages(root).map(|p| p.len()).unwrap_or(0),
+    }
+}
+
 /// Create the wiki if it isn't there yet, and report where it is.
 ///
 /// Idempotent, and that matters: this runs at the start of a chat turn, so it
@@ -598,6 +636,49 @@ mod tests {
         // Writing a new page must work; only *escaping* is refused.
         let wiki = TempWiki::new("new-page");
         assert!(resolve(&wiki.root, "brand/new/page.md").is_ok());
+    }
+
+    #[test]
+    fn status_does_not_create_the_wiki() {
+        // The load-bearing property: the first-run panel calls this to decide
+        // whether to offer the button, so if it created anything the button
+        // would be asking permission for something already done.
+        let root = std::env::temp_dir().join("exp-wiki-status-none");
+        let _ = std::fs::remove_dir_all(&root);
+
+        let status = status_at(&root);
+        assert!(!status.exists);
+        assert!(!status.git);
+        assert_eq!(status.page_count, 0);
+        assert!(!root.exists(), "asking must not create");
+        // It still reports where the wiki *would* go, because the panel names
+        // the path before the user agrees to it.
+        assert_eq!(status.root, root.to_string_lossy());
+    }
+
+    #[test]
+    fn status_sees_a_wiki_that_exists() {
+        let wiki = TempWiki::new("status-exists");
+        init_at(&wiki.root).expect("init");
+        write_page(&wiki.root, "people/ada.md", "# Ada").unwrap();
+
+        let status = status_at(&wiki.root);
+        assert!(status.exists);
+        assert!(status.git);
+        assert_eq!(status.page_count, 4, "three seeds plus the page");
+    }
+
+    #[test]
+    fn a_wiki_without_git_still_counts_as_existing() {
+        // A folder restored from a backup that lost .git is still the user's
+        // wiki; offering to "create" it again would be wrong.
+        let wiki = TempWiki::new("status-nogit");
+        init_at(&wiki.root).expect("init");
+        std::fs::remove_dir_all(wiki.root.join(".git")).unwrap();
+
+        let status = status_at(&wiki.root);
+        assert!(status.exists);
+        assert!(!status.git);
     }
 
     #[test]

--- a/src/app/(home)/product-timeline/ProductTimelineClient.tsx
+++ b/src/app/(home)/product-timeline/ProductTimelineClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import {
   Timeline,
   Text,
@@ -16,6 +16,7 @@ import {
   Loader,
   Center,
   UnstyledButton,
+  Alert,
 } from "@mantine/core";
 import { api } from "~/trpc/react";
 import { format, startOfDay } from "date-fns";
@@ -31,7 +32,9 @@ import {
   IconRefresh,
   IconRocket,
   IconPlus,
+  IconAlertTriangle,
 } from "@tabler/icons-react";
+import { reportHandledError } from "~/lib/reportHandledError";
 import type {
   GitHubCommit,
   GitHubRelease,
@@ -186,9 +189,80 @@ export function ProductTimelineClient() {
   const isLoading = queries.some((q) => q.isLoading);
   const hasNextPage = lastQuery?.data?.hasNextPage ?? false;
 
+  // The commit feed is the page; releases only decorate it. So a failed commit
+  // fetch is fatal to the view while a failed release fetch is not — but both
+  // get reported, because the failure mode that hid this page for days was an
+  // expired GITHUB_TOKEN rendering as a silent empty timeline.
+  const commitsErrorMessage =
+    queries.find((q) => q.error)?.error?.message ?? null;
+  const releasesErrorMessage = releasesQuery.error?.message ?? null;
+
+  // `error` alone is not enough. A query can also come to rest at
+  // `status: "pending" / fetchStatus: "paused"` — no data, no error, and
+  // `isLoading` false, because React Query only reports `isLoading` while a
+  // fetch is actually in flight. Nothing is pending and nothing failed, so
+  // every guard keyed on `error` or `isLoading` falls through and the timeline
+  // renders empty. That is indistinguishable, on screen, from "we shipped
+  // nothing" — which is the bug this page had. Treat "no commits and nobody is
+  // working on it" as a failure regardless of which state produced it.
+  const isFetchingCommits = queries.some((q) => q.fetchStatus === "fetching");
+  // `settled` keeps this from firing on the very first render, before the
+  // fetch has been dispatched: a query that has never run is not a failure.
+  const commitsSettled = queries.some(
+    (q) => q.isFetched || q.fetchStatus === "paused",
+  );
+  const commitsUnavailable =
+    allCommits.length === 0 &&
+    !isLoading &&
+    !isFetchingCommits &&
+    commitsSettled;
+
+  // Report the silent variant too. If we only reported `error`, the state that
+  // actually hid this page — settled, empty, no error — would still reach the
+  // user as a polite message and reach us as nothing at all.
+  const commitsFailure =
+    commitsErrorMessage ??
+    (commitsUnavailable
+      ? "Commit history unavailable: query settled with no data and no error"
+      : null);
+
+  useEffect(() => {
+    if (!commitsFailure) return;
+    reportHandledError(new Error(commitsFailure), {
+      area: "product-timeline-commits",
+      context: { repo: "positonic/exponential", branch: "main" },
+    });
+  }, [commitsFailure]);
+
+  useEffect(() => {
+    if (!releasesErrorMessage) return;
+    reportHandledError(new Error(releasesErrorMessage), {
+      area: "product-timeline-releases",
+      context: { repo: "positonic/exponential" },
+    });
+  }, [releasesErrorMessage]);
+
   const loadMore = useCallback(() => {
     setPages((prev) => [...prev, (prev[prev.length - 1] ?? 0) + 1]);
   }, []);
+
+  // Not memoized: these close over the per-page query handles, which change
+  // with `pages`, and they only ever render on an error path.
+
+  // Partial failure: we still have commits on screen, so refetch in place
+  // rather than throwing away the pages the reader already has.
+  const retryInPlace = () => {
+    for (const query of queries) void query.refetch();
+    void releasesQuery.refetch();
+  };
+
+  // Total failure: there is nothing on screen to preserve, and `refetch()` is
+  // not dependable here — a query that came to rest at `fetchStatus: "paused"`
+  // just pauses again, leaving the button looking broken. A reload always does
+  // something, and costs nothing when the page is already empty.
+  const retryFromScratch = () => {
+    window.location.reload();
+  };
 
   const entries = buildTimeline(allCommits, releases);
 
@@ -198,6 +272,45 @@ export function ProductTimelineClient() {
         <Center py="xl">
           <Loader />
         </Center>
+      </Container>
+    );
+  }
+
+  // Nothing to show and nothing in flight: say so, rather than rendering an
+  // empty timeline that reads as "we shipped nothing".
+  if (commitsUnavailable) {
+    return (
+      <Container size="md" py="xl">
+        <Title order={1}>Product Timeline</Title>
+        <Text c="dimmed" mb="xl">
+          Every change we make to {PRODUCT_NAME}, straight from our git history.
+        </Text>
+        <Alert
+          variant="light"
+          color="red"
+          icon={<IconAlertTriangle size={16} />}
+          title="Couldn't load the timeline"
+        >
+          <Stack gap="sm" align="flex-start">
+            <Text size="sm">
+              We couldn&apos;t reach GitHub to read our commit history. This is
+              our problem, not yours — the timeline itself is fine.
+            </Text>
+            {commitsErrorMessage && (
+              <Text size="xs" c="dimmed">
+                {commitsErrorMessage}
+              </Text>
+            )}
+            <Button
+              variant="light"
+              size="xs"
+              leftSection={<IconRefresh size={14} />}
+              onClick={retryFromScratch}
+            >
+              Try again
+            </Button>
+          </Stack>
+        </Alert>
       </Container>
     );
   }
@@ -224,6 +337,34 @@ export function ProductTimelineClient() {
       <Text c="dimmed" mb="xl">
         Every change we make to {PRODUCT_NAME}, straight from our git history.
       </Text>
+
+      {/* Partial failure: we have commits to show, but a later page or the
+          release list didn't load. Say what's missing instead of quietly
+          rendering a shorter timeline. */}
+      {(commitsErrorMessage ?? releasesErrorMessage) && (
+        <Alert
+          variant="light"
+          color="yellow"
+          icon={<IconAlertTriangle size={16} />}
+          mb="lg"
+        >
+          <Group justify="space-between" align="center" wrap="nowrap">
+            <Text size="sm">
+              {commitsErrorMessage
+                ? "Some commits couldn't be loaded, so this timeline is incomplete."
+                : "Releases couldn't be loaded, so only commits are shown."}
+            </Text>
+            <Button
+              variant="subtle"
+              size="xs"
+              leftSection={<IconRefresh size={14} />}
+              onClick={retryInPlace}
+            >
+              Retry
+            </Button>
+          </Group>
+        </Alert>
+      )}
 
       <Timeline active={entries.length - 1} bulletSize={24} lineWidth={2}>
         {entries.map((entry) => {

--- a/src/app/(home)/product-timeline/__tests__/ProductTimelineClient.test.tsx
+++ b/src/app/(home)/product-timeline/__tests__/ProductTimelineClient.test.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "~/test/test-utils";
+
+/**
+ * These tests exist because of a real outage: an expired GITHUB_TOKEN made both
+ * GitHub queries fail, and the page rendered its header over an empty timeline
+ * for days. Nobody noticed, because "no commits" and "we couldn't reach GitHub"
+ * looked identical on screen.
+ *
+ * The subtle part — and the reason a naive `if (error)` guard was not enough —
+ * is that a failed query does not reliably arrive as `error`. It can also come
+ * to rest at `status: "pending" / fetchStatus: "paused"`: no data, no error,
+ * and `isLoading === false`, because React Query only reports `isLoading` while
+ * a fetch is genuinely in flight. Each case below is one of those resting
+ * states.
+ */
+
+const mockListCommits = vi.fn();
+const mockListReleases = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+  api: {
+    github: {
+      listCommits: { useQuery: () => mockListCommits() as unknown },
+      listReleases: { useQuery: () => mockListReleases() as unknown },
+    },
+  },
+}));
+
+const reportHandledError = vi.fn();
+vi.mock("~/lib/reportHandledError", () => ({
+  reportHandledError: (...args: unknown[]) => reportHandledError(...args),
+}));
+
+import { ProductTimelineClient } from "../ProductTimelineClient";
+
+/** A query result shaped like the fields the component actually reads. */
+function queryResult(
+  overrides: Partial<{
+    data: unknown;
+    error: { message: string } | null;
+    isLoading: boolean;
+    isFetched: boolean;
+    fetchStatus: "fetching" | "paused" | "idle";
+    refetch: () => void;
+  }> = {},
+) {
+  return {
+    data: undefined,
+    error: null,
+    isLoading: false,
+    isFetched: true,
+    fetchStatus: "idle" as const,
+    refetch: vi.fn(),
+    ...overrides,
+  };
+}
+
+const ONE_COMMIT = {
+  commits: [
+    {
+      sha: "abc1234",
+      message: "feat: something shipped",
+      author: "someone",
+      date: "2026-08-04T21:44:22Z",
+      url: "https://github.com/positonic/exponential/commit/abc1234",
+      avatarUrl: null,
+    },
+  ],
+  hasNextPage: false,
+};
+
+describe("ProductTimelineClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListReleases.mockReturnValue(queryResult({ data: [] }));
+  });
+
+  it("surfaces an explicit error when the commit query fails", () => {
+    mockListCommits.mockReturnValue(
+      queryResult({ error: { message: "Bad credentials" } }),
+    );
+
+    render(<ProductTimelineClient />);
+
+    expect(screen.getByText(/Couldn't load the timeline/i)).toBeDefined();
+    // The underlying cause stays on screen — it is what made the production
+    // failure diagnosable in seconds rather than hours.
+    expect(screen.getByText(/Bad credentials/)).toBeDefined();
+  });
+
+  it("surfaces an error when the query settles empty with no error at all", () => {
+    // The exact state that produced the outage: settled, no data, no error.
+    mockListCommits.mockReturnValue(
+      queryResult({ fetchStatus: "paused", isFetched: false }),
+    );
+
+    render(<ProductTimelineClient />);
+
+    expect(screen.getByText(/Couldn't load the timeline/i)).toBeDefined();
+  });
+
+  it("reports the silent failure, not just the loud one", () => {
+    mockListCommits.mockReturnValue(
+      queryResult({ fetchStatus: "paused", isFetched: false }),
+    );
+
+    render(<ProductTimelineClient />);
+
+    expect(reportHandledError).toHaveBeenCalled();
+    const [, options] = reportHandledError.mock.calls[0] as [
+      unknown,
+      { area: string },
+    ];
+    expect(options.area).toBe("product-timeline-commits");
+  });
+
+  it("shows a loader, not an error, while the first fetch is in flight", () => {
+    mockListCommits.mockReturnValue(
+      queryResult({ isLoading: true, isFetched: false, fetchStatus: "fetching" }),
+    );
+
+    render(<ProductTimelineClient />);
+
+    expect(screen.queryByText(/Couldn't load the timeline/i)).toBeNull();
+    expect(reportHandledError).not.toHaveBeenCalled();
+  });
+
+  it("retries a total failure with a reload, not a refetch", () => {
+    // `refetch()` is not dependable from the paused state — it just pauses
+    // again, leaving the button looking broken. There is nothing on screen to
+    // preserve here, so a reload is the honest action.
+    const refetch = vi.fn();
+    mockListCommits.mockReturnValue(
+      queryResult({ fetchStatus: "paused", isFetched: false, refetch }),
+    );
+    const reload = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+
+    render(<ProductTimelineClient />);
+    screen.getByRole("button", { name: /Try again/i }).click();
+
+    expect(reload).toHaveBeenCalled();
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("renders commits and no error banner on the happy path", () => {
+    mockListCommits.mockReturnValue(queryResult({ data: ONE_COMMIT }));
+
+    render(<ProductTimelineClient />);
+
+    expect(screen.getByText(/something shipped/)).toBeDefined();
+    expect(screen.queryByText(/Couldn't load the timeline/i)).toBeNull();
+    expect(reportHandledError).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(home)/product-timeline/page.tsx
+++ b/src/app/(home)/product-timeline/page.tsx
@@ -1,5 +1,4 @@
 import { type Metadata } from "next";
-import { api, HydrateClient } from "~/trpc/server";
 import { ProductTimelineClient } from "./ProductTimelineClient";
 import { PRODUCT_NAME } from "~/lib/brand";
 import { getPublicBaseUrlFromEnv } from "~/lib/urls";
@@ -12,18 +11,13 @@ export const metadata: Metadata = {
   alternates: { canonical: `${getPublicBaseUrlFromEnv()}/product-timeline` },
 };
 
-export default async function ProductTimelinePage() {
-  void api.github.listCommits.prefetch({
-    page: 1,
-    perPage: 100,
-    owner: "positonic",
-    repo: "exponential",
-    branch: "main",
-  });
-
-  return (
-    <HydrateClient>
-      <ProductTimelineClient />
-    </HydrateClient>
-  );
+export default function ProductTimelinePage() {
+  // Deliberately no `prefetch` here. Prefetching dehydrates the query as
+  // *pending*; when the GitHub call fails server-side (an expired GITHUB_TOKEN
+  // is the one that bit us), the hydrated client query is stranded in
+  // `status: "pending" / fetchStatus: "paused"` — never `error`, and never
+  // retried. That renders as a silent empty timeline that no error state can
+  // catch, because from the client's point of view nothing failed. Letting the
+  // client own the fetch costs one round trip and makes failure observable.
+  return <ProductTimelineClient />;
 }

--- a/src/app/(sidemenu)/layout.tsx
+++ b/src/app/(sidemenu)/layout.tsx
@@ -25,6 +25,7 @@ import { ZoeDrawer, ZoeFab } from '~/app/_components/layout/ZoeDrawer';
 import { CommandPalette } from '~/app/_components/layout/CommandPalette';
 import { ColorSchemeScript } from '@mantine/core';
 import { ThemeInitScript } from '~/app/_components/layout/ThemeInitScript';
+import { DesktopChromeScript } from '~/app/_components/layout/DesktopChromeScript';
 import { MantineRootProvider } from '~/app/_components/layout/MantineRootProvider';
 import { SessionProvider } from "next-auth/react";
 import { WorkspaceProvider } from '~/providers/WorkspaceProvider';
@@ -59,6 +60,8 @@ export default async function RootLayout({
             the (possibly just-migrated) mantine-color-scheme-value key. */}
         <ThemeInitScript />
         <ColorSchemeScript defaultColorScheme="dark" />
+        {/* Reserves the top-left corner for the desktop shells' window controls. */}
+        <DesktopChromeScript />
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1" />
         <link rel="manifest" href="/manifest.webmanifest" />
         <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/app/(sidemenu)/settings/agents/page.tsx
+++ b/src/app/(sidemenu)/settings/agents/page.tsx
@@ -9,8 +9,8 @@ import {
   CopyButton,
   Group,
   Modal,
+  MultiSelect,
   Paper,
-  Select,
   Stack,
   Table,
   Text,
@@ -48,9 +48,14 @@ export default function ExternalAgentsPage() {
   const [keyModalAgentId, setKeyModalAgentId] = useState<string | null>(null);
   const [generatedSecret, setGeneratedSecret] = useState<string | null>(null);
   const [grantAgentId, setGrantAgentId] = useState<string | null>(null);
-  const [grantWorkspaceId, setGrantWorkspaceId] = useState<string | null>(null);
+  const [grantWorkspaceIds, setGrantWorkspaceIds] = useState<string[]>([]);
 
   const invalidate = () => utils.externalAgent.list.invalidate();
+
+  const closeGrantModal = () => {
+    setGrantAgentId(null);
+    setGrantWorkspaceIds([]);
+  };
 
   const createAgent = api.externalAgent.create.useMutation({
     onSuccess: async () => {
@@ -84,14 +89,13 @@ export default function ExternalAgentsPage() {
       notifications.show({ title: 'Could not revoke key', message: error.message, color: 'red' }),
   });
 
-  const grantWorkspace = api.externalAgent.grantWorkspace.useMutation({
+  const grantWorkspaces = api.externalAgent.grantWorkspaces.useMutation({
     onSuccess: async () => {
-      setGrantAgentId(null);
-      setGrantWorkspaceId(null);
+      closeGrantModal();
       await invalidate();
     },
     onError: (error) =>
-      notifications.show({ title: 'Could not add to workspace', message: error.message, color: 'red' }),
+      notifications.show({ title: 'Could not add to workspaces', message: error.message, color: 'red' }),
   });
 
   const revokeWorkspace = api.externalAgent.revokeWorkspace.useMutation({
@@ -113,6 +117,12 @@ export default function ExternalAgentsPage() {
       name: (value) => (value.trim().length === 0 ? 'Key label is required' : null),
     },
   });
+
+  // Only offer workspaces the agent isn't already in — re-granting is a no-op
+  // server-side, but listing them reads as if the agent lacked access.
+  const grantAgent = agents.find((agent) => agent.id === grantAgentId);
+  const grantedWorkspaceIds = new Set(grantAgent?.workspaces.map((ws) => ws.id) ?? []);
+  const grantableWorkspaces = workspaces.filter((ws) => !grantedWorkspaceIds.has(ws.id));
 
   const closeKeyModal = () => {
     setKeyModalAgentId(null);
@@ -353,47 +363,50 @@ export default function ExternalAgentsPage() {
         )}
       </Modal>
 
-      {/* Grant workspace */}
+      {/* Grant workspaces */}
       <Modal
         opened={grantAgentId !== null}
-        onClose={() => {
-          setGrantAgentId(null);
-          setGrantWorkspaceId(null);
-        }}
-        title="Add agent to workspace"
+        onClose={closeGrantModal}
+        title="Add agent to workspaces"
       >
         <Stack>
           <Text size="sm" c="dimmed">
             The agent joins as a member. You can only add it to workspaces where you have
             at least member access, and it loses access if you do.
           </Text>
-          <Select
-            label="Workspace"
-            placeholder="Pick a workspace"
-            data={workspaces.map((ws) => ({ value: ws.id, label: ws.name }))}
-            value={grantWorkspaceId}
-            onChange={setGrantWorkspaceId}
-          />
+          {grantableWorkspaces.length === 0 ? (
+            <Text size="sm" c="dimmed">
+              This agent is already in every workspace you can add it to.
+            </Text>
+          ) : (
+            <MultiSelect
+              label="Workspaces"
+              placeholder={grantWorkspaceIds.length > 0 ? undefined : 'Pick one or more workspaces'}
+              data={grantableWorkspaces.map((ws) => ({ value: ws.id, label: ws.name }))}
+              value={grantWorkspaceIds}
+              onChange={setGrantWorkspaceIds}
+              searchable
+              clearable
+              hidePickedOptions
+            />
+          )}
           <Group justify="flex-end">
-            <Button
-              variant="default"
-              onClick={() => {
-                setGrantAgentId(null);
-                setGrantWorkspaceId(null);
-              }}
-            >
+            <Button variant="default" onClick={closeGrantModal}>
               Cancel
             </Button>
             <Button
-              disabled={!grantWorkspaceId}
-              loading={grantWorkspace.isPending}
+              disabled={grantWorkspaceIds.length === 0}
+              loading={grantWorkspaces.isPending}
               onClick={() => {
-                if (grantAgentId && grantWorkspaceId) {
-                  grantWorkspace.mutate({ agentId: grantAgentId, workspaceId: grantWorkspaceId });
+                if (grantAgentId && grantWorkspaceIds.length > 0) {
+                  grantWorkspaces.mutate({
+                    agentId: grantAgentId,
+                    workspaceIds: grantWorkspaceIds,
+                  });
                 }
               }}
             >
-              Add
+              {grantWorkspaceIds.length > 1 ? `Add to ${grantWorkspaceIds.length}` : 'Add'}
             </Button>
           </Group>
         </Stack>

--- a/src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/pages/[id]/page.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { Skeleton, Text, TextInput } from '@mantine/core';
+import { ActionIcon, Skeleton, Text, TextInput, Tooltip } from '@mantine/core';
+import { useLocalStorage } from '@mantine/hooks';
+import { IconViewportNarrow, IconViewportWide } from '@tabler/icons-react';
 import type { JSONContent } from '@tiptap/core';
 import { api } from '~/trpc/react';
 import { PageDocument } from '~/app/_components/pages/PageDocument';
@@ -80,6 +82,12 @@ function PageTitle({
   );
 }
 
+/** Reading-column width preference. Pages default to the same centred column
+ * the published (/p/...) render uses; "Full width" is the opt-in. Stored per
+ * browser (not on the page) so it stays a reader-side view preference rather
+ * than something one editor imposes on everyone. */
+const FULL_WIDTH_STORAGE_KEY = 'pages:full-width';
+
 function PageEditorContent({
   pageId,
   workspaceSlug,
@@ -88,6 +96,11 @@ function PageEditorContent({
   workspaceSlug: string;
 }) {
   const { data: page, isLoading, error } = api.page.get.useQuery({ id: pageId });
+  const [fullWidth, setFullWidth] = useLocalStorage({
+    key: FULL_WIDTH_STORAGE_KEY,
+    defaultValue: false,
+  });
+  const widthClass = fullWidth ? 'w-full' : 'mx-auto w-full max-w-3xl';
   const utils = api.useUtils();
   const editorHandleRef = useRef<RichDocEditorHandle | null>(null);
 
@@ -120,7 +133,7 @@ function PageEditorContent({
 
   if (isLoading) {
     return (
-      <div className="w-full px-6 py-8">
+      <div className={`${widthClass} px-6 py-8`}>
         <Skeleton height={36} width={320} mb="xl" />
         <Skeleton height={400} />
       </div>
@@ -129,7 +142,7 @@ function PageEditorContent({
 
   if (error || !page) {
     return (
-      <div className="w-full px-6 py-8">
+      <div className={`${widthClass} px-6 py-8`}>
         <Text className="text-text-secondary">
           {error?.data?.code === 'FORBIDDEN'
             ? "You don't have access to this page."
@@ -140,12 +153,31 @@ function PageEditorContent({
   }
 
   return (
-    <div className="w-full px-6 py-8">
+    <div className={`${widthClass} px-6 py-8`}>
       <div className="mb-4 flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
           <PageTitle pageId={page.id} initialTitle={page.title} editable={page.canEdit} />
         </div>
         <div className="flex items-center gap-2">
+          <Tooltip label={fullWidth ? 'Use narrow width' : 'Use full width'}>
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              aria-label={fullWidth ? 'Use narrow width' : 'Use full width'}
+              aria-pressed={fullWidth}
+              // Value form, not the updater form: Mantine's setter writes to
+              // localStorage *inside* the state updater, and React replays
+              // updaters, which would persist the toggle a second time and
+              // land back on the old value.
+              onClick={() => setFullWidth(!fullWidth)}
+            >
+              {fullWidth ? (
+                <IconViewportNarrow size={18} />
+              ) : (
+                <IconViewportWide size={18} />
+              )}
+            </ActionIcon>
+          </Tooltip>
           <FavoriteButton
             entityType="page"
             entityId={`pages/${page.id}`}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx
@@ -40,6 +40,7 @@ import {
   IconSettings,
   IconPalette,
   IconLayoutList,
+  IconTarget,
   IconFlame,
   IconClock,
   IconPlus,
@@ -163,6 +164,10 @@ export default function WorkspaceSettingsPage() {
   const weeklyReviewBannerEnabled = workspaceData?.enableWeeklyReviewBanner ?? true;
   const emailNotificationsEnabled = workspaceData?.enableEmailNotifications ?? true;
   const autoEnrichContactsEnabled = workspaceData?.enableAutoEnrichContacts ?? false;
+  // null = never set, so fall back to the workspace-type default (same
+  // resolution as useTerminology: team/org on, personal off).
+  const keyResultsEnabled =
+    workspaceData?.enableKeyResults ?? (workspaceData?.type !== 'personal');
   const currentHomeLayout = validateHomeLayout(workspaceData?.homeLayout);
 
   const featureSuccess = (message: string) => () => {
@@ -234,6 +239,12 @@ export default function WorkspaceSettingsPage() {
       autoEnrichContactsEnabled
         ? 'Contact auto-enrichment has been disabled'
         : 'Contact auto-enrichment has been enabled'
+    ),
+  });
+
+  const updateKeyResultsMutation = api.workspace.update.useMutation({
+    onSuccess: featureSuccess(
+      keyResultsEnabled ? 'Key results have been disabled' : 'Key results have been enabled'
     ),
   });
 
@@ -578,6 +589,7 @@ export default function WorkspaceSettingsPage() {
     advancedActionsEnabled,
     detailedActionsEnabled,
     bountiesEnabled,
+    keyResultsEnabled,
     dailyPlanBannerEnabled,
     weeklyReviewBannerEnabled,
     emailNotificationsEnabled,
@@ -1085,6 +1097,18 @@ export default function WorkspaceSettingsPage() {
               onToggle={(checked) => {
                 if (!workspaceId) return;
                 updateBountiesMutation.mutate({ workspaceId, enableBounties: checked });
+              }}
+            />
+            <FeatureRow
+              icon={IconTarget}
+              tag="Product"
+              title="Key Results"
+              description="Track measurable key results against goals, with start and target values, units, and periods. On by default for team workspaces."
+              enabled={keyResultsEnabled}
+              disabled={!canEdit || updateKeyResultsMutation.isPending}
+              onToggle={(checked) => {
+                if (!workspaceId) return;
+                updateKeyResultsMutation.mutate({ workspaceId, enableKeyResults: checked });
               }}
             />
             <FeatureRow

--- a/src/app/(sidemenu)/wiki/[...path]/page.tsx
+++ b/src/app/(sidemenu)/wiki/[...path]/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+import { segmentsToPath } from "~/lib/wiki/wikiLinks";
+import { WikiPageView } from "../_components/WikiPageView";
+
+/**
+ * One wiki page, addressed by its path without the extension — `/wiki/people/ada`
+ * is `people/ada.md`. That's the same handle `[[people/ada]]` uses, so a link in
+ * the prose and a link in the URL bar mean the same thing.
+ */
+export default function LocalWikiPageRoute() {
+  const params = useParams<{ path?: string[] }>();
+  const path = segmentsToPath(params?.path);
+
+  if (!path) return null;
+
+  return (
+    <main className="flex h-full flex-col text-text-primary">
+      {/* Keyed by path so one page's view is never reused for another. The App
+          Router already remounts on a changed dynamic segment, but this view
+          holds an unsaved draft: if that guarantee ever softened, a Save would
+          write the page you left into the page you arrived at. Cheap to state
+          outright rather than inherit. */}
+      <WikiPageView key={path} path={path} />
+    </main>
+  );
+}

--- a/src/app/(sidemenu)/wiki/_components/WikiListContent.tsx
+++ b/src/app/(sidemenu)/wiki/_components/WikiListContent.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Alert, Skeleton, Text, TextInput } from "@mantine/core";
+import { useDebouncedValue } from "@mantine/hooks";
+import {
+  IconBook2,
+  IconFolder,
+  IconNotebook,
+  IconSearch,
+} from "@tabler/icons-react";
+
+import { LocalWikiFirstRun } from "~/app/_components/LocalWikiFirstRun";
+import type { SearchHit, WikiPage, WikiStatus } from "~/lib/localWiki";
+import { reportHandledError } from "~/lib/reportHandledError";
+import { pageFolder, pageTitle, wikiHref } from "~/lib/wiki/wikiLinks";
+import { useRefreshOnFocus, useWikiBridge } from "~/lib/wiki/useWikiBridge";
+
+/**
+ * The three fixed files `schema.md` names — the wiki's spine. They sort first
+ * because they're where a reader starts, not because of their filenames.
+ */
+const SPINE = ["index.md", "schema.md", "log.md"];
+
+interface Group {
+  folder: string | null;
+  pages: WikiPage[];
+}
+
+function groupPages(pages: WikiPage[]): Group[] {
+  const byFolder = new Map<string | null, WikiPage[]>();
+  for (const page of pages) {
+    const folder = pageFolder(page.path);
+    const bucket = byFolder.get(folder);
+    if (bucket) bucket.push(page);
+    else byFolder.set(folder, [page]);
+  }
+
+  const root = (byFolder.get(null) ?? []).slice().sort((a, b) => {
+    const ai = SPINE.indexOf(a.path);
+    const bi = SPINE.indexOf(b.path);
+    if (ai !== -1 || bi !== -1) return (ai === -1 ? SPINE.length : ai) - (bi === -1 ? SPINE.length : bi);
+    return a.path.localeCompare(b.path);
+  });
+
+  const folders = [...byFolder.keys()]
+    .filter((f): f is string => f !== null)
+    .sort((a, b) => a.localeCompare(b))
+    .map((folder) => ({ folder, pages: byFolder.get(folder) ?? [] }));
+
+  return root.length > 0 ? [{ folder: null, pages: root }, ...folders] : folders;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  return `${(bytes / 1024).toFixed(1)} kB`;
+}
+
+/**
+ * Above this many pages we stop reading every file just to title the list, and
+ * fall back to filenames. A personal wiki is small by design — `schema.md`
+ * banks on that, and so does search being plain grep — so this is a guard
+ * against a pathological folder, not an expected path.
+ */
+const TITLE_READ_LIMIT = 300;
+
+function PageRow({ page, title }: { page: WikiPage; title?: string }) {
+  return (
+    <Link
+      href={wikiHref(page.path)}
+      className="group flex items-center justify-between gap-4 rounded-[10px] border border-border-primary bg-background-secondary px-[18px] py-3 transition-colors hover:border-border-focus hover:bg-surface-hover"
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <IconNotebook size={15} className="shrink-0 text-text-muted" aria-hidden />
+        <div className="min-w-0 flex-1">
+          <Text className="truncate text-[14.5px] font-semibold text-text-primary">
+            {title ?? pageTitle(page.path)}
+          </Text>
+          <Text className="truncate font-mono text-xs text-text-muted">{page.path}</Text>
+        </div>
+      </div>
+      <Text className="shrink-0 text-xs text-text-muted">{formatBytes(page.bytes)}</Text>
+    </Link>
+  );
+}
+
+function SearchResults({
+  hits,
+  titles,
+}: {
+  hits: SearchHit[];
+  titles: ReadonlyMap<string, string>;
+}) {
+  if (hits.length === 0) {
+    return (
+      <div className="rounded-[10px] border border-border-primary bg-background-secondary px-6 py-12 text-center">
+        <Text className="text-text-secondary">Nothing in the wiki matches that.</Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {hits.map((hit) => (
+        <Link
+          key={hit.path}
+          href={wikiHref(hit.path)}
+          className="flex flex-col gap-1 rounded-[10px] border border-border-primary bg-background-secondary px-[18px] py-3 transition-colors hover:border-border-focus hover:bg-surface-hover"
+        >
+          <div className="flex items-center gap-2">
+            <IconNotebook size={15} className="shrink-0 text-text-muted" aria-hidden />
+            <Text className="truncate text-[14.5px] font-semibold text-text-primary">
+              {titles.get(hit.path) ?? pageTitle(hit.path)}
+            </Text>
+            {hit.pathMatched ? (
+              <Text className="shrink-0 text-xs text-text-muted">name matches</Text>
+            ) : null}
+          </div>
+          {hit.lines.length > 0 ? (
+            <div className="flex flex-col gap-0.5 pl-[23px]">
+              {hit.lines.map((line, i) => (
+                <Text key={i} className="truncate font-mono text-xs text-text-secondary">
+                  {line}
+                </Text>
+              ))}
+            </div>
+          ) : null}
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Everything the librarian has filed on this machine.
+ *
+ * Reads the wiki straight off disk through the Tauri bridge — no tRPC, no
+ * server round trip, because the wiki is device-local by construction and
+ * nothing in it should reach Exponential's servers.
+ *
+ * Search goes to the shell's `wiki_search` (real grep over the files) rather
+ * than filtering titles in the browser: the wiki's contents are what you want
+ * to search, and the pages aren't loaded here.
+ */
+export function WikiListContent() {
+  const { bridge, ready } = useWikiBridge();
+
+  const [status, setStatus] = useState<WikiStatus | null>(null);
+  const [pages, setPages] = useState<WikiPage[] | null>(null);
+  /** Page path → its own heading, filled in after the list paints. */
+  const [titles, setTitles] = useState<ReadonlyMap<string, string>>(new Map());
+  const [error, setError] = useState<string | null>(null);
+
+  const [search, setSearch] = useState("");
+  const [debouncedSearch] = useDebouncedValue(search, 200);
+  const [hits, setHits] = useState<SearchHit[] | null>(null);
+
+  const load = useCallback(async () => {
+    if (!bridge) return;
+    try {
+      const next = await bridge.status();
+      setStatus(next);
+      const list = next.exists ? await bridge.listPages() : [];
+      setPages(list);
+      setError(null);
+
+      // Title each page by its own `# Heading` — what the librarian actually
+      // writes, and far more readable than a filename. `list_pages` doesn't
+      // carry it, so it costs one read per page; the list is already on screen
+      // by then, and the filenames stand in until these land.
+      if (list.length > 0 && list.length <= TITLE_READ_LIMIT) {
+        const resolved = await Promise.all(
+          list.map(async (page) => {
+            try {
+              return [page.path, pageTitle(page.path, await bridge.readPage(page.path))] as const;
+            } catch {
+              // One unreadable page shouldn't cost the whole list its titles.
+              return [page.path, pageTitle(page.path)] as const;
+            }
+          }),
+        );
+        setTitles(new Map(resolved));
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      reportHandledError(e, { area: "local-wiki-list" });
+    }
+  }, [bridge]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // The librarian writes these same files from the chat drawer, and the shell
+  // has no change event yet, so re-read whenever the window comes back.
+  useRefreshOnFocus(useCallback(() => void load(), [load]));
+
+  useEffect(() => {
+    const query = debouncedSearch.trim();
+    if (!bridge || !query) {
+      setHits(null);
+      return;
+    }
+    let cancelled = false;
+    bridge
+      .search(query)
+      .then((found) => {
+        if (!cancelled) setHits(found);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+        reportHandledError(e, { area: "local-wiki-search" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [bridge, debouncedSearch]);
+
+  const groups = useMemo(() => groupPages(pages ?? []), [pages]);
+
+  if (!ready) {
+    return (
+      <div className="w-full px-6 py-8">
+        <Skeleton height={40} width={220} mb="lg" />
+        <Skeleton height={280} />
+      </div>
+    );
+  }
+
+  // The wiki is a folder on this machine reached over the shell's IPC. In a
+  // browser there is no such folder, and pretending otherwise would be worse
+  // than saying so.
+  if (!bridge) {
+    return (
+      <div className="w-full px-6 py-8">
+        <div className="mx-auto max-w-md rounded-[10px] border border-border-primary bg-background-secondary px-6 py-12 text-center">
+          <IconBook2 size={28} className="mx-auto text-text-muted" aria-hidden />
+          <Text className="mt-3 font-semibold text-text-primary">
+            The local wiki lives on your machine
+          </Text>
+          <Text className="mt-2 text-sm text-text-secondary">
+            It&apos;s a folder of markdown files the librarian keeps, so it&apos;s only
+            reachable from the desktop app.
+          </Text>
+        </div>
+      </div>
+    );
+  }
+
+  if (status && !status.exists) {
+    return <LocalWikiFirstRun status={status} onCreate={async () => {
+      await bridge.init();
+      await load();
+    }} />;
+  }
+
+  return (
+    <div className="w-full px-6 py-8">
+      <div className="mb-1 flex items-center gap-2">
+        <IconBook2 size={22} className="text-text-secondary" aria-hidden />
+        <Text component="h1" size="xl" fw={700} className="text-text-primary">
+          Local wiki
+        </Text>
+      </div>
+      {status ? (
+        <Text className="mb-5 break-all font-mono text-xs text-text-muted">
+          {status.root}
+          {status.git ? "" : " — no git history (git was unavailable)"}
+        </Text>
+      ) : null}
+
+      <TextInput
+        leftSection={<IconSearch size={14} />}
+        placeholder="Search the wiki…"
+        value={search}
+        onChange={(e) => setSearch(e.currentTarget.value)}
+        size="sm"
+        mb="md"
+        className="max-w-sm"
+      />
+
+      {error ? (
+        <Alert color="red" mb="md" title="Couldn't read the wiki">
+          {error}
+        </Alert>
+      ) : null}
+
+      {hits !== null ? (
+        <SearchResults hits={hits} titles={titles} />
+      ) : pages === null ? (
+        <div className="flex flex-col gap-2">
+          <Skeleton height={56} />
+          <Skeleton height={56} />
+          <Skeleton height={56} />
+        </div>
+      ) : pages.length === 0 ? (
+        <div className="rounded-[10px] border border-border-primary bg-background-secondary px-6 py-12 text-center">
+          <Text className="text-text-secondary">
+            Nothing filed yet. Ask the librarian something worth remembering.
+          </Text>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-6">
+          {groups.map((group) => (
+            <div key={group.folder ?? "__root"} className="flex flex-col gap-2">
+              {group.folder ? (
+                <div className="flex items-center gap-1.5">
+                  <IconFolder size={14} className="text-text-muted" aria-hidden />
+                  <Text className="font-mono text-xs text-text-muted">{group.folder}</Text>
+                </div>
+              ) : null}
+              {group.pages.map((page) => (
+                <PageRow key={page.path} page={page} title={titles.get(page.path)} />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(sidemenu)/wiki/_components/WikiPageView.tsx
+++ b/src/app/(sidemenu)/wiki/_components/WikiPageView.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Alert, Button, Group, Skeleton, Text } from "@mantine/core";
+import { modals } from "@mantine/modals";
+import { notifications } from "@mantine/notifications";
+import { IconArrowLeft, IconDeviceFloppy, IconPencil } from "@tabler/icons-react";
+import type { PluggableList } from "unified";
+
+import { MarkdownInput } from "~/app/_components/shared/MarkdownInput";
+import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
+import { reportHandledError } from "~/lib/reportHandledError";
+import { pageTitle, remarkWikiLinks, WIKI_ROUTE } from "~/lib/wiki/wikiLinks";
+import { useRefreshOnFocus, useWikiBridge } from "~/lib/wiki/useWikiBridge";
+import styles from "./wiki.module.css";
+
+/** What a page that doesn't exist yet starts as, once you choose to write it. */
+function seedFor(path: string): string {
+  return `# ${pageTitle(path)}\n\n`;
+}
+
+/**
+ * One page of the local wiki: read it, or edit its Markdown.
+ *
+ * **Editing is raw Markdown on purpose.** The obvious move was to reuse
+ * `RichDocEditor`, which already reads Markdown in and writes Markdown out. It
+ * does not survive contact with this content: round-tripping through the
+ * ProseMirror schema escapes `[[wikilinks]]` into `\[\[wikilinks\]\]` — killing
+ * the wiki's entire navigation model — reflows hard-wrapped paragraphs onto one
+ * line, and rewrites `_emphasis_` as `*emphasis*`. In a git-versioned folder
+ * that an agent also writes to, that turns every save into an unreadable diff
+ * and breaks links the librarian relies on. The file on disk is canonical here,
+ * so what you edit is the file, byte for byte.
+ */
+export function WikiPageView({ path }: { path: string }) {
+  const router = useRouter();
+  const { bridge, ready } = useWikiBridge();
+
+  const [content, setContent] = useState<string | null>(null);
+  const [missing, setMissing] = useState(false);
+  const [knownPaths, setKnownPaths] = useState<ReadonlySet<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+
+  const [draft, setDraft] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  /** What was last read from (or written to) disk — the base for a stale check. */
+  const baseline = useRef<string | null>(null);
+  const editing = draft !== null;
+
+  const load = useCallback(async () => {
+    if (!bridge) return;
+    try {
+      const pages = await bridge.listPages();
+      setKnownPaths(new Set(pages.map((p) => p.path)));
+
+      if (!pages.some((p) => p.path === path)) {
+        setMissing(true);
+        setContent(null);
+        setError(null);
+        baseline.current = null;
+        return;
+      }
+
+      const text = await bridge.readPage(path);
+      setMissing(false);
+      setContent(text);
+      baseline.current = text;
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      reportHandledError(e, { area: "local-wiki-page", context: { path } });
+    }
+  }, [bridge, path]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Don't clobber an open draft with what the librarian just wrote; only
+  // refresh the read view.
+  useRefreshOnFocus(
+    useCallback(() => {
+      if (draft === null) void load();
+    }, [draft, load]),
+  );
+
+  const write = useCallback(
+    async (next: string) => {
+      if (!bridge) return;
+      setSaving(true);
+      try {
+        await bridge.writePage(path, next);
+        // Same door the librarian uses, so `git log` stays the one record of
+        // what changed — including anything else left uncommitted, since
+        // `wiki_commit_turn` stages the whole tree by design.
+        await bridge.commitTurn(`Edit ${path}`);
+        baseline.current = next;
+        setContent(next);
+        setMissing(false);
+        setDraft(null);
+        setError(null);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        reportHandledError(e, { area: "local-wiki-write", context: { path } });
+        notifications.show({
+          color: "red",
+          title: "Couldn't save",
+          message: e instanceof Error ? e.message : String(e),
+        });
+      } finally {
+        setSaving(false);
+      }
+    },
+    [bridge, path],
+  );
+
+  const save = useCallback(async () => {
+    if (!bridge || draft === null) return;
+
+    // The librarian may have written this page while it was open. Re-read
+    // before overwriting, and let the reader decide — losing an agent's edit
+    // silently is exactly the failure a git-backed wiki should never have.
+    let onDisk: string | null = null;
+    try {
+      onDisk = await bridge.readPage(path);
+    } catch {
+      onDisk = null; // Not there — a new page. Nothing to clobber.
+    }
+
+    if (onDisk !== null && baseline.current !== null && onDisk !== baseline.current) {
+      modals.openConfirmModal({
+        title: "This page changed on disk",
+        children: (
+          <Text size="sm">
+            The librarian (or something else) wrote to {path} while you were editing.
+            Saving now replaces what&apos;s there. Your version is still in the editor
+            if you&apos;d rather merge it by hand.
+          </Text>
+        ),
+        labels: { confirm: "Overwrite", cancel: "Keep what's on disk" },
+        confirmProps: { color: "red" },
+        onConfirm: () => void write(draft),
+      });
+      return;
+    }
+
+    await write(draft);
+  }, [bridge, draft, path, write]);
+
+  /**
+   * Keep wikilink navigation inside the app. The shared renderer emits plain
+   * anchors, and letting one through would reload the whole web app inside the
+   * shell.
+   */
+  const onBodyClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+      const anchor = (e.target as HTMLElement).closest("a");
+      const href = anchor?.getAttribute("href");
+      if (!href?.startsWith(`${WIKI_ROUTE}/`)) return;
+      e.preventDefault();
+      router.push(href);
+    },
+    [router],
+  );
+
+  const remarkPlugins = useMemo<PluggableList>(
+    () => [[remarkWikiLinks, knownPaths]],
+    [knownPaths],
+  );
+
+  if (!ready || (bridge && content === null && !missing && !error)) {
+    return (
+      <div className="mx-auto w-full max-w-3xl px-6 py-8">
+        <Skeleton height={32} width={280} mb="xl" />
+        <Skeleton height={360} />
+      </div>
+    );
+  }
+
+  if (!bridge) {
+    return (
+      <div className="mx-auto w-full max-w-3xl px-6 py-8">
+        <Text className="text-text-secondary">
+          The local wiki is only reachable from the desktop app.
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-6 py-8">
+      <Link
+        href={WIKI_ROUTE}
+        className="mb-4 inline-flex items-center gap-1.5 text-sm text-text-muted transition-colors hover:text-text-primary"
+      >
+        <IconArrowLeft size={14} aria-hidden />
+        Local wiki
+      </Link>
+
+      <Group justify="space-between" align="flex-start" mb="md" wrap="nowrap">
+        {/* The file's own `# Heading` is the page's title and renders below, so
+            the header carries the thing the document can't tell you: which file
+            this is. Repeating the heading here would just say it twice. */}
+        <Text className="min-w-0 truncate font-mono text-sm text-text-secondary">{path}</Text>
+
+        {missing && !editing ? null : editing ? (
+          <Group gap="xs" wrap="nowrap">
+            <Button variant="subtle" color="gray" onClick={() => setDraft(null)} disabled={saving}>
+              Cancel
+            </Button>
+            <Button
+              leftSection={<IconDeviceFloppy size={16} />}
+              onClick={() => void save()}
+              loading={saving}
+            >
+              Save
+            </Button>
+          </Group>
+        ) : (
+          <Button
+            variant="default"
+            leftSection={<IconPencil size={16} />}
+            onClick={() => setDraft(content ?? "")}
+          >
+            Edit
+          </Button>
+        )}
+      </Group>
+
+      {error ? (
+        <Alert color="red" mb="md" title="Something went wrong">
+          {error}
+        </Alert>
+      ) : null}
+
+      {missing && !editing ? (
+        <div className="rounded-[10px] border border-border-primary bg-background-secondary px-6 py-12 text-center">
+          <Text className="font-semibold text-text-primary">
+            Nobody has written this page yet
+          </Text>
+          <Text className="mx-auto mt-2 max-w-md text-sm text-text-secondary">
+            A link to a page that doesn&apos;t exist is how the wiki marks something
+            worth writing down.
+          </Text>
+          <Button className="mt-6" onClick={() => setDraft(seedFor(path))}>
+            Write it
+          </Button>
+        </div>
+      ) : editing ? (
+        <div
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+              e.preventDefault();
+              void save();
+            }
+          }}
+        >
+          <MarkdownInput
+            value={draft}
+            onChange={(value) => setDraft(value)}
+            minRows={20}
+            maxRows={60}
+            placeholder="Markdown. [[wikilinks]] point at other pages."
+            hint={
+              <Text className="text-xs text-text-muted">
+                Saved to {path} and committed to the wiki&apos;s git history. ⌘↵ to save.
+              </Text>
+            }
+          />
+        </div>
+      ) : (
+        <div className={styles.body} onClick={onBodyClick}>
+          <MarkdownRenderer
+            content={content ?? ""}
+            variant="prose"
+            extraRemarkPlugins={remarkPlugins}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(sidemenu)/wiki/_components/wiki.module.css
+++ b/src/app/(sidemenu)/wiki/_components/wiki.module.css
@@ -1,0 +1,23 @@
+/**
+ * Wiki-page presentation. Only what the shared MarkdownRenderer can't express:
+ * the "red link" style for a page that doesn't exist yet.
+ */
+
+/*
+ * A link to a page nobody has written. Per `schema.md` this is a normal and
+ * useful thing to find in the wiki — it marks work worth doing — so it stays
+ * clickable (following it offers to create the page) but reads as unwritten
+ * rather than as an ordinary link.
+ *
+ * Two classes deep, so it outranks the renderer's single-class link utilities.
+ */
+.body :global(.wiki-link--missing) {
+  color: var(--color-text-muted);
+  text-decoration-style: dashed;
+  text-decoration-color: var(--color-text-muted);
+}
+
+.body :global(.wiki-link--missing:hover) {
+  color: var(--color-text-secondary);
+  text-decoration-color: var(--color-text-secondary);
+}

--- a/src/app/(sidemenu)/wiki/page.tsx
+++ b/src/app/(sidemenu)/wiki/page.tsx
@@ -1,0 +1,17 @@
+import { WikiListContent } from "./_components/WikiListContent";
+
+/**
+ * The local wiki index.
+ *
+ * Deliberately NOT under `/w/[workspaceSlug]` — the wiki is a folder on this
+ * device, with no workspace, no members and no sharing. Nesting it under a
+ * workspace slug would imply an ownership that doesn't exist, and it would
+ * inherit workspace-membership gating that means nothing for a local folder.
+ */
+export default function LocalWikiPage() {
+  return (
+    <main className="flex h-full flex-col text-text-primary">
+      <WikiListContent />
+    </main>
+  );
+}

--- a/src/app/_components/CreateGoalModal.tsx
+++ b/src/app/_components/CreateGoalModal.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { Modal, Button, Group, TextInput, Select, Text, Textarea, MultiSelect, NumberInput, Stack, ActionIcon, Card, Badge, Accordion } from '@mantine/core';
+import { Modal, Button, Group, TextInput, Select, Text, Textarea, NumberInput, Stack, ActionIcon, Card, Badge, Accordion } from '@mantine/core';
 import { IconPlus, IconTrash, IconX } from '@tabler/icons-react';
 import { useDisclosure } from '@mantine/hooks';
 import { useState, useEffect, useMemo } from "react";
 import { api } from "~/trpc/react";
 import { UnifiedDatePicker } from './UnifiedDatePicker';
 import { CreateProjectModal } from './CreateProjectModal';
-import { CreateOutcomeModal } from './CreateOutcomeModal';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { notifications } from '@mantine/notifications';
 import { useTerminology } from '~/hooks/useTerminology';
@@ -45,7 +44,6 @@ interface CreateGoalModalProps {
     status?: string;
     lifeDomainId: number | null;
     parentGoalId?: number | null;
-    outcomes?: { id: string; description: string }[];
     workspaceId?: string | null;
     driUserId?: string | null;
   };
@@ -66,9 +64,6 @@ export function CreateGoalModal({ children, goal, trigger, projectId, defaultWor
   const [dueDate, setDueDate] = useState<Date | null>(goal?.dueDate ?? null);
   const [lifeDomainId, setLifeDomainId] = useState<number | null>(goal?.lifeDomainId ?? null);
   const [selectedProjectId, setSelectedProjectId] = useState<string | undefined>(projectId);
-  const [selectedOutcomeIds, setSelectedOutcomeIds] = useState<string[]>(
-    goal?.outcomes?.map(o => o.id) ?? []
-  );
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(
     goal?.workspaceId ?? defaultWorkspaceId ?? null
   );
@@ -96,7 +91,6 @@ export function CreateGoalModal({ children, goal, trigger, projectId, defaultWor
     { workspaceId: workspace?.id },
     { enabled: !!workspace },
   );
-  const { data: outcomes } = api.outcome.getMyOutcomes.useQuery();
   const { data: workspaces } = api.workspace.list.useQuery();
   const { data: periods } = api.okr.getPeriods.useQuery();
   const { data: currentUser } = api.user.getCurrentUser.useQuery();
@@ -292,7 +286,6 @@ export function CreateGoalModal({ children, goal, trigger, projectId, defaultWor
     setPeriod(defaultPeriod ?? null);
     setLifeDomainId(null);
     setSelectedProjectId(undefined);
-    setSelectedOutcomeIds([]);
     setSelectedWorkspaceId(defaultWorkspaceId ?? null);
     setDriUserId(currentUser?.id ?? null);
     // Reset key results state
@@ -411,7 +404,6 @@ export function CreateGoalModal({ children, goal, trigger, projectId, defaultWor
       setDueDate(goal.dueDate);
       setPeriod(goal.period ?? null);
       setLifeDomainId(goal.lifeDomainId);
-      setSelectedOutcomeIds(goal.outcomes?.map(o => o.id) ?? []);
       setSelectedWorkspaceId(goal.workspaceId ?? null);
       setDriUserId(goal.driUserId ?? null);
     }
@@ -513,7 +505,6 @@ export function CreateGoalModal({ children, goal, trigger, projectId, defaultWor
               status: (status as "planned" | "active" | "completed" | "archived") ?? undefined,
               lifeDomainId: lifeDomainId ?? undefined,
               projectId: selectedProjectId,
-              outcomeIds: selectedOutcomeIds.length > 0 ? selectedOutcomeIds : undefined,
               driUserId: driUserId ?? currentUser?.id,
               workspaceId: selectedWorkspaceId ?? undefined,
               parentGoalId: parentGoalId ? Number(parentGoalId) : undefined,
@@ -621,29 +612,6 @@ export function CreateGoalModal({ children, goal, trigger, projectId, defaultWor
             autosize
           />
 
-          <MultiSelect
-            label="Linked Outcomes"
-            placeholder={`Select outcomes that support this ${terminology.goal.toLowerCase()}`}
-            data={outcomes?.map(o => ({ value: o.id, label: o.description })) ?? []}
-            value={selectedOutcomeIds}
-            onChange={setSelectedOutcomeIds}
-            searchable
-            clearable
-            mt="md"
-          />
-          <CreateOutcomeModal onSuccess={(id) => setSelectedOutcomeIds(prev => [...prev, id])}>
-            <Button
-              variant="subtle"
-              size="xs"
-              leftSection={<IconPlus size={14} />}
-              mt={4}
-              className="text-text-secondary hover:text-text-primary"
-            >
-              Create outcome
-            </Button>
-          </CreateOutcomeModal>
-
-          
           <div className="mt-4">
             <Text size="sm" fw={500} mb={4}>Due date (optional)</Text>
             <UnifiedDatePicker

--- a/src/app/_components/GoalsTable.tsx
+++ b/src/app/_components/GoalsTable.tsx
@@ -138,7 +138,6 @@ export const GoalsTable: FC<GoalsTableProps> = ({ goals }) => {
                           dueDate: goal.dueDate,
                           period: goal.period,
                           lifeDomainId: goal.lifeDomainId,
-                          outcomes: goal.outcomes,
                         }}
                         trigger={
                           <ActionIcon

--- a/src/app/_components/LocalWikiFirstRun.tsx
+++ b/src/app/_components/LocalWikiFirstRun.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+
+import type { WikiStatus } from "~/lib/localWiki";
+
+/**
+ * What you see when you pick the Local wiki librarian and don't have a wiki yet.
+ *
+ * It exists because the wiki used to appear as a side effect of asking a
+ * question — `wiki_init` ran at the start of every turn, so a folder and a git
+ * repo materialised in your Documents because you typed something. Creating
+ * files on someone's machine should be a decision they made, so this names the
+ * path and waits.
+ *
+ * It is also the only thing that tells you what the librarian *is* before you
+ * talk to it.
+ */
+export function LocalWikiFirstRun({
+  status,
+  onCreate,
+}: {
+  status: WikiStatus;
+  onCreate: () => Promise<void>;
+}) {
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const create = async () => {
+    setCreating(true);
+    setError(null);
+    try {
+      await onCreate();
+    } catch (e) {
+      // Most likely an unwritable folder. Show what actually went wrong rather
+      // than a spinner that never resolves.
+      setError(e instanceof Error ? e.message : String(e));
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center p-8">
+      <div className="max-w-md text-center">
+        <h2 className="text-lg font-medium text-text-primary">Create your local wiki</h2>
+
+        <p className="mt-3 text-sm leading-relaxed text-text-secondary">
+          A folder of markdown files, versioned with git, that the librarian reads and
+          writes on this machine. Ask it things and it answers from what it has filed;
+          tell it something worth keeping and it writes it down.
+        </p>
+
+        <p className="mt-3 text-sm leading-relaxed text-text-secondary">
+          Nothing in it is sent to Exponential&apos;s servers — only your messages and
+          whatever the librarian quotes back reach the model.
+        </p>
+
+        <p className="mt-4 break-all font-mono text-xs text-text-muted">{status.root}</p>
+
+        <button
+          type="button"
+          onClick={() => void create()}
+          disabled={creating}
+          className="mt-6 rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+        >
+          {creating ? "Creating…" : "Create wiki"}
+        </button>
+
+        {error && (
+          <p className="mt-4 text-sm text-red-500" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -38,10 +38,12 @@ import {
   LOCAL_WIKI_AGENT_NAME,
   buildWikiClientTools,
   getWikiBridge,
+  type WikiStatus,
 } from '~/lib/localWiki';
 import { preprocessAgentMarkdown, linkifyBareUrls } from '~/lib/chat/agentMarkdown';
 import { failureCopy } from '~/lib/chat/failureCopy';
 import { applyToolRefreshInvalidations } from './agent/toolRefreshInvalidation';
+import { LocalWikiFirstRun } from './LocalWikiFirstRun';
 
 // Module-level constants to avoid re-creation on every render
 const VIDEO_PATTERN = /\[Video ([a-zA-Z0-9_-]+)\]/g;
@@ -675,6 +677,30 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
   // The one call to our own backend a local-wiki turn makes. Everything after it
   // goes browser → Mastra directly, so wiki content never reaches Vercel.
   const mintAgentToken = api.mastra.mintAgentToken.useMutation();
+
+  // Whether this machine has a wiki yet. `undefined` means we haven't looked —
+  // which is the state on every surface that isn't the Tauri shell, since there
+  // is nothing to look at.
+  const [wikiStatus, setWikiStatus] = useState<WikiStatus | undefined>(undefined);
+  const localWikiSelected = defaultAgentId === LOCAL_WIKI_AGENT_ID;
+
+  // Ask (without creating) whenever the librarian is selected. Re-checked on
+  // selection rather than cached for the session, so deleting the wiki folder by
+  // hand brings the panel back instead of leaving the chat pointing at nothing.
+  useEffect(() => {
+    if (!localWikiSelected) {
+      setWikiStatus(undefined);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const status = await getWikiBridge()?.status();
+      if (!cancelled) setWikiStatus(status);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [localWikiSelected]);
   // Server-side /api/chat/stream now logs interactions (with full token/cache
   // data) and surfaces the row id back via the meta frame. The previous
   // client-side logInteraction.mutateAsync was removed to fix double-logging.
@@ -1298,10 +1324,11 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
 
       const streamResult = wikiBridge
         ? await (async () => {
-            // Idempotent, and cheap enough to do every turn — it guarantees the
-            // folder, its git repo and the seeded conventions exist before the
-            // librarian is asked to read them.
-            await wikiBridge.init();
+            // Deliberately no init() here. The wiki comes into being when the
+            // user presses the button in the first-run panel, and nowhere else —
+            // creating a folder in someone's Documents as a side effect of
+            // sending a message is not a decision they made. The panel replaces
+            // the composer until it exists, so a turn can only start once it does.
             const { token, mastraUrl } = await mintAgentToken.mutateAsync();
             return streamLocalWikiChat(
               createLocalWikiStreamer(mastraUrl, token),
@@ -1497,6 +1524,17 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
         </div>
       )}
 
+      {/* First run: the wiki does not exist until the user asks for it. */}
+      {localWikiSelected && wikiStatus && !wikiStatus.exists ? (
+        <LocalWikiFirstRun
+          status={wikiStatus}
+          onCreate={async () => {
+            await getWikiBridge()?.init();
+            setWikiStatus(await getWikiBridge()?.status());
+          }}
+        />
+      ) : (
+        <>
       {/* Messages Area */}
       <MessageList messages={messages} conversationId={conversationId} isStreaming={isStreaming} onRetry={retryTurn} />
       
@@ -1664,6 +1702,8 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
           </div>
         )}
       </div>
+        </>
+      )}
 
     </div>
   );

--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
-import * as Sentry from '@sentry/nextjs';
 import { api } from "~/trpc/react";
 import DOMPurify from 'dompurify';
 import ReactMarkdown from 'react-markdown';
@@ -31,6 +30,7 @@ import { useAgentModal, type ChatMessage, type PageContext } from '~/providers/A
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { trimByTokenBudget } from '~/lib/trim-conversation';
 import { classifyStreamError, describeStreamError } from '~/lib/chat/streamProtocol';
+import { reportHandledError } from '~/lib/reportHandledError';
 import { cardFromToolCalls } from '~/lib/chat/cardFromToolCalls';
 import { streamChatResponse, type ChatStreamUpdate } from '~/lib/chat/streamChatResponse';
 import { createLocalWikiStreamer, streamLocalWikiChat } from '~/lib/chat/streamLocalWikiChat';
@@ -713,7 +713,7 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
         status = await getWikiBridge()?.status();
       } catch (error) {
         console.error('[ManyChat] wiki_status failed — cannot tell if a wiki exists', error);
-        Sentry.captureException(error, { tags: { area: 'local-wiki-status' } });
+        reportHandledError(error, { area: 'local-wiki-status' });
       }
       if (!cancelled) setWikiStatus(status);
     })();
@@ -1490,15 +1490,22 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
       //    it as a normal answer with a subtle "ended early" + Retry footer.
       //  • !hadContent → nothing usable arrived. Convert the empty placeholder
       //    into a calm, single-line error with a Retry button.
-      // Nothing else reports this. The catch above swallows the error, so
-      // Sentry's automatic capture (unhandled errors only) never sees it — which
-      // is how a turn failing on "your credit balance is too low" produced no
-      // trace anywhere: not in Sentry, and so not in the Bug tickets the Sentry
-      // webhook files. Sentry only initialises on Vercel prod/preview, so this
-      // is a no-op in local dev.
-      Sentry.captureException(error, {
-        tags: { area: 'chat-stream', failureKind: kind, agentId: targetAgentId ?? 'unknown' },
-        extra: { hadContent, projectId, conversationId, attempt },
+      // Nothing else reports this. The catch above handles the error — rightly,
+      // the user gets a calm message and a Retry — but handling it is exactly
+      // why Sentry's automatic capture never saw it, and so why a turn failing
+      // on "your credit balance is too low" left no trace anywhere. Reported
+      // explicitly instead: to Sentry, and to a Bug Ticket, which unlike Sentry
+      // also works when the app is running against a local server.
+      reportHandledError(error, {
+        area: 'chat-stream',
+        kind,
+        context: {
+          agentId: targetAgentId ?? 'unknown',
+          hadContent: String(hadContent),
+          attempt: String(attempt),
+          ...(projectId ? { projectId } : {}),
+          conversationId,
+        },
       });
 
       const severity: 'error' | 'incomplete' = hadContent ? 'incomplete' : 'error';

--- a/src/app/_components/ManyChat.tsx
+++ b/src/app/_components/ManyChat.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react';
+import * as Sentry from '@sentry/nextjs';
 import { api } from "~/trpc/react";
 import DOMPurify from 'dompurify';
 import ReactMarkdown from 'react-markdown';
@@ -29,7 +30,7 @@ import { DraftFeaturesReviewCard } from './DraftFeaturesReviewCard';
 import { useAgentModal, type ChatMessage, type PageContext } from '~/providers/AgentModalProvider';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { trimByTokenBudget } from '~/lib/trim-conversation';
-import { classifyStreamError } from '~/lib/chat/streamProtocol';
+import { classifyStreamError, describeStreamError } from '~/lib/chat/streamProtocol';
 import { cardFromToolCalls } from '~/lib/chat/cardFromToolCalls';
 import { streamChatResponse, type ChatStreamUpdate } from '~/lib/chat/streamChatResponse';
 import { createLocalWikiStreamer, streamLocalWikiChat } from '~/lib/chat/streamLocalWikiChat';
@@ -370,23 +371,32 @@ const MessageList = memo(function MessageList({ messages, conversationId, isStre
                     </div>
                   )}
                   {message.failure && (
-                    <div className="mt-1.5 flex items-center gap-2 text-text-muted text-xs">
-                      {/* Show the failure note when the main block above isn't
-                          already showing it: always for 'incomplete' (the block
-                          shows the partial answer), and for a contentless error. */}
-                      {(message.failure.severity === 'incomplete' || message.content === '') && (
-                        <span>{failureCopy(message.failure.kind, message.failure.severity)}</span>
-                      )}
-                      {message.failure.canRetry && message.failure.retryText && (
-                        <Button
-                          size="compact-xs"
-                          variant="subtle"
-                          color="gray"
-                          leftSection={<IconRefresh size={13} />}
-                          onClick={() => onRetry(message.failure!.retryText!)}
-                        >
-                          Try again
-                        </Button>
+                    <div className="mt-1.5 text-text-muted text-xs">
+                      <div className="flex items-center gap-2">
+                        {/* Show the failure note when the main block above isn't
+                            already showing it: always for 'incomplete' (the block
+                            shows the partial answer), and for a contentless error. */}
+                        {(message.failure.severity === 'incomplete' || message.content === '') && (
+                          <span>{failureCopy(message.failure.kind, message.failure.severity)}</span>
+                        )}
+                        {message.failure.canRetry && message.failure.retryText && (
+                          <Button
+                            size="compact-xs"
+                            variant="subtle"
+                            color="gray"
+                            leftSection={<IconRefresh size={13} />}
+                            onClick={() => onRetry(message.failure!.retryText!)}
+                          >
+                            Try again
+                          </Button>
+                        )}
+                      </div>
+                      {/* The thrown error's own words. Small and secondary, but
+                          present: without it a specific, fixable cause (an expired
+                          key, an empty credit balance) is indistinguishable from a
+                          passing network blip. */}
+                      {message.failure.detail && (
+                        <div className="mt-1 break-words opacity-70">{message.failure.detail}</div>
                       )}
                     </div>
                   )}
@@ -694,7 +704,17 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
     }
     let cancelled = false;
     void (async () => {
-      const status = await getWikiBridge()?.status();
+      // A rejected `wiki_status` used to leave this undefined for good, which
+      // renders as "the wiki exists" — the first-run panel is gated on a
+      // *known* absent wiki. The user then talks to a librarian with nothing to
+      // read. Say so instead of failing invisibly.
+      let status: WikiStatus | undefined;
+      try {
+        status = await getWikiBridge()?.status();
+      } catch (error) {
+        console.error('[ManyChat] wiki_status failed — cannot tell if a wiki exists', error);
+        Sentry.captureException(error, { tags: { area: 'local-wiki-status' } });
+      }
       if (!cancelled) setWikiStatus(status);
     })();
     return () => {
@@ -1470,12 +1490,24 @@ export default function ManyChat({ initialMessages, githubSettings, buttons, pro
       //    it as a normal answer with a subtle "ended early" + Retry footer.
       //  • !hadContent → nothing usable arrived. Convert the empty placeholder
       //    into a calm, single-line error with a Retry button.
+      // Nothing else reports this. The catch above swallows the error, so
+      // Sentry's automatic capture (unhandled errors only) never sees it — which
+      // is how a turn failing on "your credit balance is too low" produced no
+      // trace anywhere: not in Sentry, and so not in the Bug tickets the Sentry
+      // webhook files. Sentry only initialises on Vercel prod/preview, so this
+      // is a no-op in local dev.
+      Sentry.captureException(error, {
+        tags: { area: 'chat-stream', failureKind: kind, agentId: targetAgentId ?? 'unknown' },
+        extra: { hadContent, projectId, conversationId, attempt },
+      });
+
       const severity: 'error' | 'incomplete' = hadContent ? 'incomplete' : 'error';
       const failure: NonNullable<Message['failure']> = {
         severity,
         kind,
         canRetry: kind !== 'auth',
         retryText: text,
+        detail: describeStreamError(error),
       };
 
       setMessages((prev) => {

--- a/src/app/_components/ProjectOverviewLegacy.tsx
+++ b/src/app/_components/ProjectOverviewLegacy.tsx
@@ -240,7 +240,6 @@ export function ProjectOverviewLegacy({ project, goals, outcomes }: ProjectOverv
                       dueDate: goal.dueDate,
                       period: goal.period ?? null,
                       lifeDomainId: goal.lifeDomainId,
-                      outcomes: goal.outcomes,
                     }}
                     trigger={
                       <div className={styles.rowBody}>

--- a/src/app/_components/TodayOverview.tsx
+++ b/src/app/_components/TodayOverview.tsx
@@ -268,7 +268,6 @@ export function TodayOverview({ focus = "today", dateRange, workspaceId }: Today
                     dueDate: goal.dueDate,
                     period: goal.period ?? null,
                     lifeDomainId: goal.lifeDomainId,
-                    outcomes: goal.outcomes,
                   }}
                   trigger={
                     <div className="cursor-pointer rounded-md p-2 hover:bg-surface-hover">

--- a/src/app/_components/actions/hooks/useBulkActionMutations.ts
+++ b/src/app/_components/actions/hooks/useBulkActionMutations.ts
@@ -24,6 +24,14 @@ interface BulkDeleteInput {
   onError?: () => void;
 }
 
+interface BulkDeferInput {
+  actionIds: string[];
+  /** When true, fires `dailyPlan.markProcessedOverdue` after success. */
+  fromOverdue?: boolean;
+  onSuccess?: (data: { count: number }) => void;
+  onError?: () => void;
+}
+
 interface BulkAssignProjectInput {
   actionIds: string[];
   projectId: string;
@@ -34,6 +42,7 @@ interface BulkAssignProjectInput {
 interface UseBulkActionMutationsResult {
   bulkReschedule: (input: BulkRescheduleInput) => void;
   bulkDelete: (input: BulkDeleteInput) => void;
+  bulkDefer: (input: BulkDeferInput) => void;
   bulkAssignProject: (input: BulkAssignProjectInput) => void;
   isMutating: boolean;
 }
@@ -70,8 +79,15 @@ export function useBulkActionMutations(
     onSettled: invalidateAll,
   });
 
+  const defer = api.action.bulkDefer.useMutation({
+    onSettled: invalidateAll,
+  });
+
   const isMutating =
-    reschedule.isPending || remove.isPending || assignProject.isPending;
+    reschedule.isPending ||
+    remove.isPending ||
+    assignProject.isPending ||
+    defer.isPending;
 
   return {
     bulkReschedule: ({
@@ -101,6 +117,32 @@ export function useBulkActionMutations(
             notifications.show({
               title: "Reschedule failed",
               message: "Could not reschedule the selected actions.",
+              color: "red",
+            });
+            onError?.();
+          },
+        },
+      );
+    },
+
+    bulkDefer: ({ actionIds, fromOverdue, onSuccess, onError }) => {
+      if (actionIds.length === 0) return;
+      defer.mutate(
+        { actionIds },
+        {
+          onSuccess: (data) => {
+            notifications.show({
+              title: "Back in the backlog",
+              message: `${data.count} action${data.count === 1 ? "" : "s"} no longer counted as overdue. They're still in their projects, just undated.`,
+              color: "green",
+            });
+            if (fromOverdue) markProcessedOverdue.mutate({});
+            onSuccess?.(data);
+          },
+          onError: () => {
+            notifications.show({
+              title: "Could not defer",
+              message: "The selected actions were left unchanged.",
               color: "red",
             });
             onError?.();

--- a/src/app/_components/home/zoe-canvas/ZoeCanvas.module.css
+++ b/src/app/_components/home/zoe-canvas/ZoeCanvas.module.css
@@ -105,3 +105,13 @@
   font-size: 12px;
   margin-top: 6px;
 }
+
+/* The underlying error message, under the calm copy: present enough to act on,
+   quiet enough not to read as the answer. */
+.failureDetail {
+  color: var(--color-text-muted);
+  font-size: 12px;
+  margin-top: 4px;
+  opacity: 0.7;
+  overflow-wrap: break-word;
+}

--- a/src/app/_components/home/zoe-canvas/ZoeCanvas.tsx
+++ b/src/app/_components/home/zoe-canvas/ZoeCanvas.tsx
@@ -116,6 +116,11 @@ export function ZoeCanvas({ messages, isStreaming, onDismiss, onRetry }: ZoeCanv
                   )}
                 </div>
               )}
+              {/* The thrown error's own words — same treatment as the drawer,
+                  so a specific cause isn't only visible on one surface. */}
+              {message.failure?.detail && (
+                <div className={classes.failureDetail}>{message.failure.detail}</div>
+              )}
               {message.card?.kind === 'draft-actions' && (
                 <DraftActionsReviewCard transcriptionId={message.card.transcriptionId} />
               )}

--- a/src/app/_components/home/zoe-canvas/useCanvasEngagement.ts
+++ b/src/app/_components/home/zoe-canvas/useCanvasEngagement.ts
@@ -4,7 +4,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '~/trpc/react';
 import { useAgentModal, type ChatMessage } from '~/providers/AgentModalProvider';
 import { streamChatResponse, type ChatStreamCoreMessage } from '~/lib/chat/streamChatResponse';
-import { classifyStreamError } from '~/lib/chat/streamProtocol';
+import { classifyStreamError, describeStreamError } from '~/lib/chat/streamProtocol';
+import { reportHandledError } from '~/lib/reportHandledError';
 import { cardFromToolCalls } from '~/lib/chat/cardFromToolCalls';
 import { trimByTokenBudget } from '~/lib/trim-conversation';
 import { applyToolRefreshInvalidations } from '~/app/_components/agent/toolRefreshInvalidation';
@@ -258,6 +259,16 @@ export function useCanvasEngagement({
 
         setIsStreaming(false);
 
+        // A dismissal is the user's own doing, not a fault — reporting those
+        // would fill the tracker with people changing their minds.
+        if (!wasDismissed) {
+          reportHandledError(error, {
+            area: 'zoe-canvas-stream',
+            kind,
+            context: { hadContent: String(hadContent), attempt: String(attempt) },
+          });
+        }
+
         // One abort rule (ADR-0040): a dismissal mid-stream marks the turn
         // `incomplete` — the existing partial-answer + Retry treatment, visible
         // in the drawer where the thread lives on.
@@ -266,7 +277,7 @@ export function useCanvasEngagement({
         patchTrailingAi(last => ({
           agentName: severity === 'error' ? (last.agentName ?? 'Assistant') : last.agentName,
           content: severity === 'error' ? '' : last.content,
-          failure: { severity, kind, canRetry: kind !== 'auth', retryText: trimmedText },
+          failure: { severity, kind, canRetry: kind !== 'auth', retryText: trimmedText, detail: describeStreamError(error) },
         }));
       } finally {
         if (abortRef.current === abortController) abortRef.current = null;

--- a/src/app/_components/layout/CommandPalette.tsx
+++ b/src/app/_components/layout/CommandPalette.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import { useHotkeys } from '@mantine/hooks';
+import { useHotkeys, useDebouncedValue } from '@mantine/hooks';
 import {
   Modal,
   TextInput,
@@ -30,14 +30,22 @@ import {
   IconBook2,
   IconCalendarEvent,
   IconUsers,
+  IconTicket,
+  IconBulb,
+  IconTrophy,
+  IconUser,
+  IconBuilding,
 } from '@tabler/icons-react';
 import { api } from '~/trpc/react';
-import { stripHtml } from '~/lib/utils';
+import type { RouterOutputs } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { useAgentModal } from '~/providers/AgentModalProvider';
 import styles from '../home/WorkspaceHomeConceptD.module.css';
 
 type Mode = 'all' | 'projects' | 'tasks' | 'goals' | 'ai';
+
+type SearchResult = RouterOutputs['search']['global']['results'][number];
+type SearchType = SearchResult['type'];
 
 const MODES: { id: Mode; label: string; icon: React.ElementType }[] = [
   { id: 'all', label: 'All', icon: IconSparkles },
@@ -53,6 +61,8 @@ const PAGES = [
   { label: 'Tasks', path: 'projects-tasks', icon: IconSquareRoundedCheck },
   { label: 'Goals', path: 'goals', icon: IconTarget },
 ];
+
+const PAGE_LABELS = new Set(PAGES.map((p) => p.label.toLowerCase()));
 
 // Workspace-scoped sections surfaced when searching by workspace name.
 const WORKSPACE_SECTIONS: {
@@ -72,6 +82,40 @@ const WORKSPACE_SECTIONS: {
   { label: 'Calendar', icon: IconCalendar, href: () => `/calendar` },
 ];
 
+// How each entity type from search.global is presented, in the order the
+// sections appear. Two of the router's types are deliberately absent:
+// `workspace`, because a matching workspace already surfaces below with all of
+// its sub-pages, and `epic`, which has no detail route to navigate to.
+const RESULT_SECTIONS: { type: SearchType; label: string; icon: React.ElementType }[] = [
+  { type: 'project', label: 'Projects', icon: IconStack2 },
+  { type: 'action', label: 'Tasks', icon: IconSquareRoundedCheck },
+  { type: 'ticket', label: 'Tickets', icon: IconTicket },
+  { type: 'goal', label: 'Goals', icon: IconTarget },
+  { type: 'keyResult', label: 'Key results', icon: IconTrophy },
+  { type: 'outcome', label: 'Outcomes', icon: IconFlag },
+  { type: 'feature', label: 'Features', icon: IconBulb },
+  { type: 'product', label: 'Products', icon: IconLayoutGrid },
+  { type: 'page', label: 'Pages', icon: IconBook2 },
+  { type: 'meeting', label: 'Meetings', icon: IconCalendarEvent },
+  { type: 'contact', label: 'Contacts', icon: IconUser },
+  { type: 'organization', label: 'Organizations', icon: IconBuilding },
+];
+
+// Which entity types each filter chip keeps. `all` keeps everything.
+const MODE_TYPES: Record<Exclude<Mode, 'ai'>, SearchType[] | null> = {
+  all: null,
+  tasks: ['action', 'ticket'],
+  projects: ['project', 'product'],
+  goals: ['goal', 'keyResult', 'outcome'],
+};
+
+// Each search fans out to one `contains` query per entity type, and none of
+// those columns are trigram-indexed, so a query that matches nothing scans
+// every table. One character matches almost everything and tells you almost
+// nothing, so it isn't worth the round trip — navigation still filters from
+// the first keystroke.
+const MIN_SEARCH_LENGTH = 2;
+
 const SUGGESTED = [
   { icon: IconFlag, label: 'Run weekly plan', sub: 'Keystone ritual · 45 min' },
   { icon: IconTarget, label: 'Review Q2 OKR progress', sub: 'Summary from Zoe' },
@@ -79,12 +123,25 @@ const SUGGESTED = [
   { icon: IconCalendar, label: 'Plan my day', sub: 'Ask Zoe' },
 ] as const;
 
+type PaletteRow = {
+  key: string;
+  label: string;
+  sub: string;
+  icon: React.ElementType;
+  href: string;
+  /** Navigation rows are tinted; entity results stay muted. */
+  accent: boolean;
+  /** Position in the flat result list, for keyboard highlighting. */
+  index: number;
+};
+
 export function CommandPalette() {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [mode, setMode] = useState<Mode>('all');
   const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const { workspaceId, workspaceSlug } = useWorkspace();
   const { openModal } = useAgentModal();
@@ -104,26 +161,23 @@ export function CommandPalette() {
     }
   }, [isOpen]);
 
-  const showProjects = mode === 'all' || mode === 'projects';
-  const showTasks = mode === 'all' || mode === 'tasks';
-  const showGoals = mode === 'all' || mode === 'goals';
+  const trimmedQuery = query.trim();
+  const q = trimmedQuery.toLowerCase();
+  const [debouncedQuery] = useDebouncedValue(trimmedQuery, 180);
 
-  const { data: projectsData, isLoading: projectsLoading } = api.project.getAll.useQuery(
-    { workspaceId: workspaceId ?? undefined },
-    { enabled: !!workspaceId && isOpen && showProjects },
+  // One server-side search covering every entity type the app knows about,
+  // scoped to the workspace you are in, each block carrying the same access
+  // rules as that entity's own list endpoint.
+  const { data: searchData, isFetching: searchFetching } = api.search.global.useQuery(
+    { query: debouncedQuery, workspaceId: workspaceId ?? undefined, limit: 5 },
+    {
+      enabled: isOpen && mode !== 'ai' && debouncedQuery.length >= MIN_SEARCH_LENGTH,
+      // Keep the previous matches on screen while the next query is in flight,
+      // instead of blanking the list on every keystroke.
+      placeholderData: (previous) => previous,
+      staleTime: 30_000,
+    },
   );
-
-  const { data: actionsData, isLoading: actionsLoading } = api.action.getAll.useQuery(
-    { workspaceId: workspaceId ?? undefined },
-    { enabled: !!workspaceId && isOpen && showTasks },
-  );
-
-  const { data: goalsData, isLoading: goalsLoading } = api.goal.getAllMyGoals.useQuery(
-    { workspaceId: workspaceId ?? undefined },
-    { enabled: !!workspaceId && isOpen && showGoals },
-  );
-
-  const q = query.toLowerCase();
 
   // All workspaces the user can navigate to (for workspace-name search).
   const { data: workspacesData } = api.workspace.list.useQuery(undefined, {
@@ -150,103 +204,168 @@ export function CommandPalette() {
     return map;
   }, [workspacesData, pluginResults]);
 
-  const filteredWorkspaceNav = useMemo(() => {
-    if (!q) return [];
-    const results: { label: string; href: string; icon: React.ElementType }[] = [];
+  // Workspace sections split by where they belong in the list: the workspace
+  // you are in sits with the other navigation at the top, every other
+  // workspace goes below the results as somewhere to switch to.
+  const { currentWorkspaceNav, otherWorkspaceNav } = useMemo(() => {
+    const current: { label: string; href: string; icon: React.ElementType }[] = [];
+    const other: { label: string; href: string; icon: React.ElementType }[] = [];
+    if (!q) return { currentWorkspaceNav: current, otherWorkspaceNav: other };
+
     for (const w of workspacesData ?? []) {
       const productEnabled = productEnabledByWorkspaceId.get(w.id) ?? false;
+      const workspaceMatches = w.name.toLowerCase().includes(q);
+      const isCurrent = w.id === workspaceId;
       for (const section of WORKSPACE_SECTIONS) {
         if (section.requiresProduct && !productEnabled) continue;
-        const label = `${w.name} - ${section.label}`;
-        if (!label.toLowerCase().includes(q)) continue;
-        results.push({ label, href: section.href(w.slug), icon: section.icon });
+        if (isCurrent) {
+          // Inside your own workspace you navigate by section name. Matching
+          // its name too would list all nine sections above the results you
+          // actually searched for — and you are already in it.
+          if (PAGE_LABELS.has(section.label.toLowerCase())) continue;
+          if (!section.label.toLowerCase().includes(q)) continue;
+          current.push({ label: section.label, href: section.href(w.slug), icon: section.icon });
+        } else {
+          // Other workspaces are reached by name: "syntrofi" lists that
+          // workspace's sections. Matching on section name here turned a
+          // search for "projects" into one row per workspace you belong to.
+          if (!workspaceMatches) continue;
+          other.push({
+            label: `${w.name} - ${section.label}`,
+            href: section.href(w.slug),
+            icon: section.icon,
+          });
+        }
       }
     }
-    return results.slice(0, 12);
-  }, [q, workspacesData, productEnabledByWorkspaceId]);
-
-  const filteredProjects = useMemo(
-    () =>
-      showProjects
-        ? (projectsData ?? []).filter((p) => !q || p.name.toLowerCase().includes(q)).slice(0, 4)
-        : [],
-    [showProjects, projectsData, q],
-  );
-
-  const filteredActions = useMemo(
-    () =>
-      showTasks
-        ? (actionsData ?? [])
-            .filter((a) => q && stripHtml(a.name).toLowerCase().includes(q))
-            .slice(0, 4)
-        : [],
-    [showTasks, actionsData, q],
-  );
-
-  const filteredGoals = useMemo(
-    () =>
-      showGoals
-        ? (goalsData ?? []).filter((g) => q && g.title.toLowerCase().includes(q)).slice(0, 3)
-        : [],
-    [showGoals, goalsData, q],
-  );
+    return { currentWorkspaceNav: current, otherWorkspaceNav: other.slice(0, 10) };
+  }, [q, workspacesData, productEnabledByWorkspaceId, workspaceId]);
 
   const filteredPages = useMemo(
     () => (workspaceSlug ? PAGES.filter((p) => !q || p.label.toLowerCase().includes(q)) : []),
     [workspaceSlug, q],
   );
 
+  // Results carry the query they were fetched for. While the next search is in
+  // flight we keep the previous ones only if the typed query extends them —
+  // narrowing "fix" to "fixt" holds its results, starting a new word drops
+  // them rather than showing matches for something you are no longer typing.
+  const shownResults = useMemo(() => {
+    if (!searchData) return [];
+    return trimmedQuery.toLowerCase().startsWith(searchData.query.toLowerCase())
+      ? searchData.results
+      : [];
+  }, [searchData, trimmedQuery]);
+
+  const resultsByType = useMemo(() => {
+    const allowed = mode === 'ai' ? null : MODE_TYPES[mode];
+    const byType = new Map<SearchType, SearchResult[]>();
+    for (const result of shownResults) {
+      // Every row in the palette navigates somewhere; entities without a
+      // detail route are dropped rather than rendered as dead ends.
+      if (!result.url) continue;
+      if (allowed && !allowed.includes(result.type)) continue;
+      const bucket = byType.get(result.type);
+      if (bucket) bucket.push(result);
+      else byType.set(result.type, [result]);
+    }
+    return byType;
+  }, [shownResults, mode]);
+
+  // Sections in render order, each row carrying its position in the flat list
+  // so keyboard highlighting and rendering cannot drift apart.
+  const resultSections = useMemo(() => {
+    const sections: { key: string; heading: string; rows: PaletteRow[] }[] = [];
+    let index = 0;
+    const row = (r: Omit<PaletteRow, 'index'>): PaletteRow => ({ ...r, index: index++ });
+
+    const navRows: PaletteRow[] = [
+      ...filteredPages.map((p) =>
+        row({
+          key: `page-${p.path}`,
+          label: p.label,
+          sub: 'Navigate',
+          icon: p.icon,
+          href: `/w/${workspaceSlug}/${p.path}`,
+          accent: true,
+        }),
+      ),
+      ...currentWorkspaceNav.map((w, i) =>
+        row({
+          key: `workspace-nav-${i}`,
+          label: w.label,
+          sub: 'Navigate',
+          icon: w.icon,
+          href: w.href,
+          accent: true,
+        }),
+      ),
+    ];
+    if (navRows.length > 0) {
+      sections.push({ key: 'navigate', heading: 'Navigate', rows: navRows });
+    }
+
+    for (const section of RESULT_SECTIONS) {
+      const items = resultsByType.get(section.type) ?? [];
+      if (items.length === 0) continue;
+      sections.push({
+        key: section.type,
+        heading: section.label,
+        rows: items.map((item) =>
+          row({
+            key: `${section.type}-${item.id}`,
+            label: item.title,
+            // On routes with no workspace context (/calendar, a recording)
+            // the search spans workspaces, so name the one each result lives
+            // in — otherwise two same-named meetings are indistinguishable.
+            sub:
+              item.workspace && item.workspace.id !== workspaceId
+                ? item.workspace.name
+                : item.subtitle ?? section.label,
+            icon: section.icon,
+            href: item.url ?? '',
+            accent: false,
+          }),
+        ),
+      });
+    }
+
+    // Other workspaces go last: matching one by name lists all of its
+    // sections, which would otherwise bury the results you searched for.
+    if (otherWorkspaceNav.length > 0) {
+      sections.push({
+        key: 'other-workspaces',
+        heading: 'Other workspaces',
+        rows: otherWorkspaceNav.map((w, i) =>
+          row({
+            key: `other-workspace-${i}`,
+            label: w.label,
+            sub: 'Workspace',
+            icon: w.icon,
+            href: w.href,
+            accent: true,
+          }),
+        ),
+      });
+    }
+
+    return sections;
+  }, [filteredPages, currentWorkspaceNav, otherWorkspaceNav, resultsByType, workspaceSlug, workspaceId]);
+
   const allResults = useMemo(
-    () => [
-      ...filteredPages.map((p) => ({
-        type: 'page' as const,
-        label: p.label,
-        sub: 'Navigate',
-        icon: p.icon,
-        href: `/w/${workspaceSlug}/${p.path}`,
-      })),
-      ...filteredWorkspaceNav.map((w) => ({
-        type: 'workspace-nav' as const,
-        label: w.label,
-        sub: 'Workspace',
-        icon: w.icon,
-        href: w.href,
-      })),
-      ...filteredProjects.map((p) => ({
-        type: 'project' as const,
-        label: p.name,
-        sub: p.progress > 0 ? `${Math.round(p.progress)}% done` : 'Project',
-        icon: IconStack2,
-        href: `/w/${workspaceSlug}/projects/${p.slug}`,
-      })),
-      ...filteredActions.map((a) => ({
-        type: 'task' as const,
-        label: stripHtml(a.name),
-        sub: 'Task',
-        icon: IconSquareRoundedCheck,
-        href: `/w/${workspaceSlug}/projects-tasks`,
-      })),
-      ...filteredGoals.map((g) => ({
-        type: 'goal' as const,
-        label: g.title,
-        sub: 'Goal',
-        icon: IconTarget,
-        href: `/w/${workspaceSlug}/goals/${g.id}`,
-      })),
-    ],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filteredPages, filteredWorkspaceNav, filteredProjects, filteredActions, filteredGoals, workspaceSlug],
+    () => resultSections.flatMap((section) => section.rows),
+    [resultSections],
   );
 
-  const showNoResults =
-    q.length > 0 &&
-    filteredProjects.length === 0 &&
-    filteredActions.length === 0 &&
-    filteredGoals.length === 0 &&
-    filteredWorkspaceNav.length === 0 &&
-    filteredPages.length === 0;
+  // True from the first searchable keystroke until results for that exact
+  // query land, so a slow search never flashes "No matches" — and a query too
+  // short to search never flashes a skeleton for a request that won't be made.
+  const isSearching =
+    q.length >= MIN_SEARCH_LENGTH && (debouncedQuery !== trimmedQuery || searchFetching);
 
-  const isLoading = (showProjects && projectsLoading) || (showTasks && actionsLoading) || (showGoals && goalsLoading);
+  const showSkeleton = isSearching && allResults.length === 0;
+  const showNoResults =
+    q.length >= MIN_SEARCH_LENGTH && !isSearching && allResults.length === 0;
 
   const navigate = useCallback(
     (path: string) => {
@@ -284,9 +403,58 @@ export function CommandPalette() {
     [highlightedIndex, allResults, q, close, navigate, handleAskZoe],
   );
 
+  // Switching filter chips rebuilds the list, so a held index would point at
+  // an unrelated row.
   useEffect(() => {
     setHighlightedIndex(null);
-  }, [query]);
+  }, [query, mode]);
+
+  // The results area scrolls, and twelve sections overflow it easily — without
+  // this, arrowing past the fold moves the selection somewhere you can't see
+  // and Enter navigates to a row you never read.
+  useEffect(() => {
+    if (highlightedIndex === null) return;
+    listRef.current
+      ?.querySelector(`[data-palette-index="${highlightedIndex}"]`)
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex]);
+
+  const renderRow = (row: PaletteRow) => {
+    const Icon = row.icon;
+    return (
+      <UnstyledButton
+        key={row.key}
+        className={styles.resultRow}
+        data-palette-index={row.index}
+        data-highlighted={highlightedIndex === row.index ? 'true' : 'false'}
+        onClick={() => navigate(row.href)}
+      >
+        <Icon
+          size={14}
+          stroke={1.75}
+          style={{
+            color: row.accent ? 'var(--brand-400)' : 'var(--color-text-muted)',
+            flexShrink: 0,
+          }}
+        />
+        <Text
+          size="sm"
+          style={{
+            flex: 1,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            color: 'var(--color-text-primary)',
+          }}
+        >
+          {row.label}
+        </Text>
+        <Text size="xs" style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}>
+          {row.sub}
+        </Text>
+      </UnstyledButton>
+    );
+  };
 
   return (
     <Modal
@@ -368,8 +536,8 @@ export function CommandPalette() {
         })}
       </Group>
 
-      <div style={{ marginTop: 20 }}>
-        {isLoading ? (
+      <div ref={listRef} style={{ marginTop: 20, maxHeight: '52vh', overflowY: 'auto' }}>
+        {showSkeleton ? (
           Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} height={36} mb={4} radius="sm" />
           ))
@@ -447,44 +615,28 @@ export function CommandPalette() {
             })}
           </>
         ) : (
-          allResults.map((result, i) => {
-            const Icon = result.icon;
-            return (
-              <UnstyledButton
-                key={`${result.type}-${i}`}
-                className={styles.resultRow}
-                data-highlighted={highlightedIndex === i ? 'true' : 'false'}
-                onClick={() => navigate(result.href)}
+          <>
+            {resultSections.map((section, i) => (
+              <div key={section.key} style={{ marginTop: i === 0 ? 0 : 14 }}>
+                <div className={styles.colHeading}>{section.heading}</div>
+                {section.rows.map(renderRow)}
+              </div>
+            ))}
+            {/* Below the minimum the search hasn't run, so say so rather than
+                leaving an empty panel that reads as "nothing found". */}
+            {q.length < MIN_SEARCH_LENGTH && (
+              <Text
+                size="xs"
+                style={{
+                  color: 'var(--color-text-muted)',
+                  padding: resultSections.length > 0 ? '14px 0 0' : '24px 0',
+                  textAlign: resultSections.length > 0 ? 'left' : 'center',
+                }}
               >
-                <Icon
-                  size={14}
-                  stroke={1.75}
-                  style={{
-                    color:
-                      result.type === 'page' || result.type === 'workspace-nav'
-                        ? 'var(--brand-400)'
-                        : 'var(--color-text-muted)',
-                    flexShrink: 0,
-                  }}
-                />
-                <Text
-                  size="sm"
-                  style={{
-                    flex: 1,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    color: 'var(--color-text-primary)',
-                  }}
-                >
-                  {result.label}
-                </Text>
-                <Text size="xs" style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}>
-                  {result.sub}
-                </Text>
-              </UnstyledButton>
-            );
-          })
+                Keep typing to search…
+              </Text>
+            )}
+          </>
         )}
       </div>
     </Modal>

--- a/src/app/_components/layout/DesktopChromeScript.tsx
+++ b/src/app/_components/layout/DesktopChromeScript.tsx
@@ -1,0 +1,32 @@
+// Marks the document with the desktop shell hosting it, before first paint.
+//
+// Both shells use the macOS overlay title bar (Electron `hiddenInset`, Tauri
+// `TitleBarStyle::Overlay`), so the traffic lights float over the page's
+// top-left corner — which is the sidebar's workspace switcher. CSS reserves
+// room for them off `data-titlebar="overlay"`; doing it here rather than in a
+// client component keeps the sidebar from painting once in the wrong place and
+// then jumping.
+//
+// Detection mirrors `~/lib/platform.ts` and is duplicated as a string on
+// purpose: this runs in <head>, ahead of any bundle. Both globals are injected
+// before page scripts (Electron's preload, Tauri's init script), and a miss
+// just means no inset — never a broken layout.
+export function DesktopChromeScript() {
+  const script = `
+    try {
+      var shell = window.__TAURI_INTERNALS__ ? 'tauri'
+        : (window.electron ? 'electron' : null);
+      if (shell) {
+        var root = document.documentElement;
+        root.setAttribute('data-shell', shell);
+        // The overlay title bar is a macOS arrangement; other platforms keep
+        // their native chrome and need no inset.
+        if (/Mac/i.test(navigator.userAgent)) {
+          root.setAttribute('data-titlebar', 'overlay');
+        }
+      }
+    } catch (e) {}
+  `;
+
+  return <script dangerouslySetInnerHTML={{ __html: script }} />;
+}

--- a/src/app/_components/layout/DesktopChromeScript.tsx
+++ b/src/app/_components/layout/DesktopChromeScript.tsx
@@ -1,26 +1,26 @@
 // Marks the document with the desktop shell hosting it, as early as possible.
 //
-// Both shells use the macOS overlay title bar (Electron `hiddenInset`, Tauri
-// `TitleBarStyle::Overlay`), so the traffic lights float over the page's
-// top-left corner — which is the sidebar's workspace switcher. CSS reserves
-// room for them off `data-titlebar="overlay"`; running here rather than in a
-// client component keeps the sidebar from painting in the wrong place and then
-// jumping.
+// The Electron shell uses the macOS overlay title bar (`hiddenInset`), so the
+// traffic lights float over the page's top-left corner — which is the
+// sidebar's workspace switcher. CSS reserves room for them off
+// `data-titlebar="overlay"`; running here rather than in a client component
+// keeps the sidebar from painting in the wrong place and then jumping.
+//
+// The overlay stamp is Electron-ONLY. The tabbed Tauri shell (ADR-0053) uses
+// Safari-style chrome — a visible titlebar with the webview laid out below it —
+// and needs no inset at all; it stamps `data-shell` itself from an
+// initialization script (`TITLEBAR_MARKER_SCRIPT` in `src-tauri/src/lib.rs`)
+// and deliberately does not stamp `data-titlebar`. Stamping overlay here on
+// detecting Tauri would resurrect a 38px dead inset in that shell, so don't.
+// (Pre-tab Tauri binaries older than PR 482 relied on this fallback for their
+// overlay inset; they lose it, and the answer is to update the app.)
 //
 // Detection mirrors `~/lib/platform.ts` and is duplicated as a string on
 // purpose: this runs in <head>, ahead of any bundle.
 //
-// It retries because a single early check is not enough. Electron's preload
-// defines `window.electron` before any page script, but Tauri injects
-// `__TAURI_INTERNALS__` into a *remote* page after the document's own head
-// scripts have run — so the first check finds nothing, and the shipped version
-// of this file gave up there and left the inset at 0px. The bug was invisible:
-// IPC worked moments later, so nothing else looked wrong.
-//
-// The Tauri shell now stamps the attributes itself from an initialization
-// script (see `TITLEBAR_MARKER_SCRIPT` in `src-tauri/src/lib.rs`), which is the
-// race-free path. These retries stay as the fallback for a shell binary older
-// than that change, and for Electron. Marking twice is harmless — same values.
+// It retries because a single early check is not enough: Electron's preload
+// defines `window.electron` before any page script, but on a slow bridge the
+// first check can still miss. Marking twice is harmless — same values.
 export function DesktopChromeScript() {
   const script = `
     (function () {
@@ -30,9 +30,9 @@ export function DesktopChromeScript() {
         if (!shell) return false;
         var root = document.documentElement;
         root.setAttribute('data-shell', shell);
-        // The overlay title bar is a macOS arrangement; other platforms keep
-        // their native chrome and need no inset.
-        if (/Mac/i.test(navigator.userAgent)) {
+        // Overlay inset is Electron-only (macOS arrangement); the tabbed Tauri
+        // shell sits below a real titlebar and must NOT get the inset.
+        if (shell === 'electron' && /Mac/i.test(navigator.userAgent)) {
           root.setAttribute('data-titlebar', 'overlay');
         }
         return true;

--- a/src/app/_components/layout/DesktopChromeScript.tsx
+++ b/src/app/_components/layout/DesktopChromeScript.tsx
@@ -1,22 +1,33 @@
-// Marks the document with the desktop shell hosting it, before first paint.
+// Marks the document with the desktop shell hosting it, as early as possible.
 //
 // Both shells use the macOS overlay title bar (Electron `hiddenInset`, Tauri
 // `TitleBarStyle::Overlay`), so the traffic lights float over the page's
 // top-left corner — which is the sidebar's workspace switcher. CSS reserves
-// room for them off `data-titlebar="overlay"`; doing it here rather than in a
-// client component keeps the sidebar from painting once in the wrong place and
-// then jumping.
+// room for them off `data-titlebar="overlay"`; running here rather than in a
+// client component keeps the sidebar from painting in the wrong place and then
+// jumping.
 //
 // Detection mirrors `~/lib/platform.ts` and is duplicated as a string on
-// purpose: this runs in <head>, ahead of any bundle. Both globals are injected
-// before page scripts (Electron's preload, Tauri's init script), and a miss
-// just means no inset — never a broken layout.
+// purpose: this runs in <head>, ahead of any bundle.
+//
+// It retries because a single early check is not enough. Electron's preload
+// defines `window.electron` before any page script, but Tauri injects
+// `__TAURI_INTERNALS__` into a *remote* page after the document's own head
+// scripts have run — so the first check finds nothing, and the shipped version
+// of this file gave up there and left the inset at 0px. The bug was invisible:
+// IPC worked moments later, so nothing else looked wrong.
+//
+// The Tauri shell now stamps the attributes itself from an initialization
+// script (see `TITLEBAR_MARKER_SCRIPT` in `src-tauri/src/lib.rs`), which is the
+// race-free path. These retries stay as the fallback for a shell binary older
+// than that change, and for Electron. Marking twice is harmless — same values.
 export function DesktopChromeScript() {
   const script = `
-    try {
-      var shell = window.__TAURI_INTERNALS__ ? 'tauri'
-        : (window.electron ? 'electron' : null);
-      if (shell) {
+    (function () {
+      function mark() {
+        var shell = window.__TAURI_INTERNALS__ ? 'tauri'
+          : (window.electron ? 'electron' : null);
+        if (!shell) return false;
         var root = document.documentElement;
         root.setAttribute('data-shell', shell);
         // The overlay title bar is a macOS arrangement; other platforms keep
@@ -24,8 +35,21 @@ export function DesktopChromeScript() {
         if (/Mac/i.test(navigator.userAgent)) {
           root.setAttribute('data-titlebar', 'overlay');
         }
+        return true;
       }
-    } catch (e) {}
+
+      try {
+        if (mark()) return;
+        // Bounded: a shell that has not identified itself within ~2s of load
+        // is not going to, and we stop rather than poll forever.
+        var tries = 0;
+        var timer = setInterval(function () {
+          if (mark() || ++tries > 40) clearInterval(timer);
+        }, 50);
+        document.addEventListener('DOMContentLoaded', mark);
+        window.addEventListener('load', mark);
+      } catch (e) {}
+    })();
   `;
 
   return <script dangerouslySetInnerHTML={{ __html: script }} />;

--- a/src/app/_components/layout/NavLinks.tsx
+++ b/src/app/_components/layout/NavLinks.tsx
@@ -12,6 +12,7 @@ import {
   IconMessageChatbot,
   IconMicrophone,
   IconBook,
+  IconBook2,
   IconRoute,
   IconBriefcase,
   IconFileText,
@@ -20,6 +21,8 @@ import {
 } from "@tabler/icons-react";
 import { InboxCount } from "./InboxCount";
 import { TodayCount } from "./TodayCount";
+import { useLocalWikiAvailable } from "~/lib/wiki/useWikiBridge";
+import { WIKI_ROUTE } from "~/lib/wiki/wikiLinks";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
 import { parseNavLayout, NAV_ITEM_CONFIG } from "~/lib/navLayout";
@@ -105,6 +108,7 @@ function SectionDivider() {
 export function NavLinks(): React.ReactElement {
   const { workspaceSlug, workspaceId, userRole } = useWorkspace();
   const isGuest = userRole === 'guest';
+  const localWikiAvailable = useLocalWikiAvailable();
 
   const { data: preferences } = api.navigationPreference.getPreferences.useQuery(
     undefined,
@@ -126,6 +130,13 @@ export function NavLinks(): React.ReactElement {
       <NavLink href="/today" icon={IconClock} count={<TodayCount />}>
         Today
       </NavLink>
+      {/* Desktop shell only, and global — the wiki belongs to the device, not
+          to a workspace. Absent in a browser, where its IPC doesn't exist. */}
+      {localWikiAvailable && (
+        <NavLink href={WIKI_ROUTE} icon={IconBook2}>
+          Local wiki
+        </NavLink>
+      )}
 
       {workspaceSlug && !isGuest && (
         <>

--- a/src/app/_components/layout/Sidebar.tsx
+++ b/src/app/_components/layout/Sidebar.tsx
@@ -41,7 +41,7 @@ export default function Sidebar({ session, domain = 'forceflow.com' }: { session
       <button
         onClick={() => setIsMenuOpen(!isMenuOpen)}
         className={`
-          fixed top-[calc(0.5rem+env(safe-area-inset-top))] left-3 z-[100] p-1.5 rounded-md
+          sb-toggle fixed left-3 z-[100] p-1.5 rounded-md
           hover:bg-surface-hover transition-all duration-200
           ${isMenuOpen ? 'opacity-0 pointer-events-none' : 'opacity-100'}
         `}

--- a/src/app/_components/layout/WorkspaceTopbar.module.css
+++ b/src/app/_components/layout/WorkspaceTopbar.module.css
@@ -6,6 +6,20 @@
   border-bottom: 1px solid var(--color-border-primary);
   flex-shrink: 0;
   gap: 8px;
+  /* Matches the 300ms sidebar collapse, so the crumb slides across with it
+     instead of jumping when the gutter below appears/disappears. */
+  transition: padding-left 300ms ease-in-out;
+}
+
+/* Collapsed, the sidebar's re-open button parks in this row's left gutter
+   (fixed, 12px from the viewport edge, ~32px wide) and the 40px padding
+   leaves the crumb almost touching it. On sm+ the topbar is edge-to-edge,
+   so it owns that corner and has to give the button its own space; below
+   640px <main>'s own padding already keeps the two apart. */
+@media (min-width: 640px) {
+  :global(html[data-sidebar='closed']) .topbar {
+    padding-left: 60px;
+  }
 }
 
 .crumb {

--- a/src/app/_components/layout/WorkspaceTopbar.module.css
+++ b/src/app/_components/layout/WorkspaceTopbar.module.css
@@ -30,9 +30,21 @@
   color: var(--color-text-secondary);
 }
 
-.crumbCurrent {
+/* The workspace name links back to the workspace root. It keeps the emphasised
+   look of the leading crumb, so hover has to be an underline rather than the
+   colour shift the dimmer .crumbLink crumbs use. */
+.crumbRoot {
   color: var(--color-text-primary);
   font-weight: 500;
+  text-decoration: none;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.crumbRoot:hover {
+  text-decoration: underline;
 }
 
 .crumbSep {

--- a/src/app/_components/layout/WorkspaceTopbar.tsx
+++ b/src/app/_components/layout/WorkspaceTopbar.tsx
@@ -23,17 +23,39 @@ const PAGE_LABELS: Record<string, string> = {
   inbox: 'Inbox',
 };
 
-function getCurrentPageLabel(pathname: string, workspaceSlug: string): string {
+/**
+ * The section crumb: the label for the area we're in, plus where it links.
+ *
+ * `href` is null when there is nowhere to go — either we're already on the
+ * section's own index (the crumb is the current page), or we're on a global
+ * route like `/recording/{id}`, where the leading segment isn't guaranteed to
+ * have an index page to land on. Every `/w/{slug}/{segment}` does have one.
+ */
+function getSectionCrumb(
+  pathname: string,
+  workspaceSlug: string,
+): { label: string; href: string | null } {
   const prefix = `/w/${workspaceSlug}/`;
-  let segment = '';
-  if (pathname.startsWith(prefix)) {
-    segment = pathname.slice(prefix.length).split('/')[0] ?? '';
-  } else {
-    // Global routes like /today, /inbox: take the first non-empty path segment.
-    segment = pathname.replace(/^\//, '').split('/')[0] ?? '';
-  }
-  if (!segment) return '';
-  return PAGE_LABELS[segment] ?? segment.charAt(0).toUpperCase() + segment.slice(1);
+  // The workspace root redirects onwards, so it has no section of its own —
+  // without this it would parse as the segment "w" and render a "W" crumb.
+  if (pathname === `/w/${workspaceSlug}`) return { label: '', href: null };
+
+  const underWorkspace = pathname.startsWith(prefix);
+  const rest = underWorkspace
+    ? pathname.slice(prefix.length)
+    : // Global routes like /today, /inbox: take the first non-empty segment.
+      pathname.replace(/^\//, '');
+
+  const parts = rest.split('/').filter(Boolean);
+  const segment = parts[0] ?? '';
+  if (!segment) return { label: '', href: null };
+
+  const label =
+    PAGE_LABELS[segment] ?? segment.charAt(0).toUpperCase() + segment.slice(1);
+  const href =
+    underWorkspace && parts.length > 1 ? `${prefix}${segment}` : null;
+
+  return { label, href };
 }
 
 /** Extract the page id when on a page-detail route (`/w/{slug}/pages/{id}`). */
@@ -60,7 +82,7 @@ export function WorkspaceTopbar() {
 
   if (!workspace || !workspaceSlug) return null;
 
-  const pageLabel = getCurrentPageLabel(pathname, workspaceSlug);
+  const section = getSectionCrumb(pathname, workspaceSlug);
 
   return (
     <div className={styles.topbar}>
@@ -69,15 +91,15 @@ export function WorkspaceTopbar() {
         <Link href={`/w/${workspaceSlug}`} className={styles.crumbRoot}>
           {workspace.name}
         </Link>
-        {pageLabel && (
+        {section.label && (
           <>
             <span className={styles.crumbSep}>/</span>
-            {pageDetailId ? (
-              <Link href={`/w/${workspaceSlug}/pages`} className={styles.crumbLink}>
-                {pageLabel}
+            {section.href ? (
+              <Link href={section.href} className={styles.crumbLink}>
+                {section.label}
               </Link>
             ) : (
-              <span>{pageLabel}</span>
+              <span>{section.label}</span>
             )}
           </>
         )}

--- a/src/app/_components/layout/WorkspaceTopbar.tsx
+++ b/src/app/_components/layout/WorkspaceTopbar.tsx
@@ -66,7 +66,9 @@ export function WorkspaceTopbar() {
     <div className={styles.topbar}>
       <div className={styles.crumb}>
         <IconFolder size={14} stroke={1.75} style={{ color: 'var(--color-text-muted)' }} />
-        <span className={styles.crumbCurrent}>{workspace.name}</span>
+        <Link href={`/w/${workspaceSlug}`} className={styles.crumbRoot}>
+          {workspace.name}
+        </Link>
         {pageLabel && (
           <>
             <span className={styles.crumbSep}>/</span>

--- a/src/app/_components/layout/__tests__/WorkspaceTopbar.test.tsx
+++ b/src/app/_components/layout/__tests__/WorkspaceTopbar.test.tsx
@@ -52,6 +52,58 @@ describe('WorkspaceTopbar', () => {
     expect(screen.getByText('Products')).toBeInTheDocument();
   });
 
+  it('links the section crumb to its index when we are below it', () => {
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByRole('link', { name: 'Products' })).toHaveAttribute(
+      'href',
+      '/w/syntrofi/products',
+    );
+  });
+
+  it('leaves the section crumb as text on the section index itself', () => {
+    mockUsePathname.mockReturnValue('/w/syntrofi/products');
+
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByText('Products')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Products' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('still links a page-detail route back to the pages index', () => {
+    mockUsePathname.mockReturnValue('/w/syntrofi/pages/page-1');
+
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByRole('link', { name: 'Pages' })).toHaveAttribute(
+      'href',
+      '/w/syntrofi/pages',
+    );
+  });
+
+  it('shows no section crumb at the workspace root', () => {
+    mockUsePathname.mockReturnValue('/w/syntrofi');
+
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByRole('link', { name: 'Syntrofi' })).toBeInTheDocument();
+    expect(screen.queryByText('W')).not.toBeInTheDocument();
+  });
+
+  it('leaves the section crumb as text on global routes', () => {
+    // Global segments like `/recording/{id}` have no index page to land on.
+    mockUsePathname.mockReturnValue('/recording/abc123');
+
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByText('Recording')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Recording' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('renders nothing without a workspace', () => {
     mockUseWorkspace.mockReturnValue({ workspace: null, workspaceSlug: null });
 

--- a/src/app/_components/layout/__tests__/WorkspaceTopbar.test.tsx
+++ b/src/app/_components/layout/__tests__/WorkspaceTopbar.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '~/test/test-utils';
+import '@testing-library/jest-dom/vitest';
+import { WorkspaceTopbar } from '../WorkspaceTopbar';
+
+const { mockUseWorkspace, mockUsePathname } = vi.hoisted(() => ({
+  mockUseWorkspace: vi.fn(),
+  mockUsePathname: vi.fn(() => '/w/syntrofi/products/exponential/features'),
+}));
+
+vi.mock('~/providers/WorkspaceProvider', () => ({
+  useWorkspace: () => mockUseWorkspace(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    page: { parentCrumb: { useQuery: () => ({ data: undefined }) } },
+  },
+}));
+
+describe('WorkspaceTopbar', () => {
+  beforeEach(() => {
+    mockUseWorkspace.mockReset();
+    mockUseWorkspace.mockReturnValue({
+      workspace: { name: 'Syntrofi' },
+      workspaceSlug: 'syntrofi',
+    });
+    mockUsePathname.mockReturnValue('/w/syntrofi/products/exponential/features');
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('links the workspace name back to the workspace root', () => {
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByRole('link', { name: 'Syntrofi' })).toHaveAttribute(
+      'href',
+      '/w/syntrofi',
+    );
+  });
+
+  it('keeps the workspace link on deep routes, alongside the section crumb', () => {
+    render(<WorkspaceTopbar />);
+
+    expect(screen.getByRole('link', { name: 'Syntrofi' })).toBeInTheDocument();
+    expect(screen.getByText('Products')).toBeInTheDocument();
+  });
+
+  it('renders nothing without a workspace', () => {
+    mockUseWorkspace.mockReturnValue({ workspace: null, workspaceSlug: null });
+
+    render(<WorkspaceTopbar />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/_components/layout/sidebar.css
+++ b/src/app/_components/layout/sidebar.css
@@ -55,15 +55,16 @@ html[data-titlebar="overlay"] {
   }
 }
 
-/* Collapsed, the main column inherits the top-left corner from the sidebar —
-   window controls and all — so the inset has to move with it. Margin rather
-   than padding: it stacks on whatever responsive padding <main> has at this
-   breakpoint instead of replacing it, and rides the same 300ms transition as
-   the collapse, so the content slides down with the sidebar rather than
-   snapping. */
-html[data-titlebar="overlay"][data-sidebar="closed"] .sidebar-offset {
-  margin-top: var(--titlebar-inset);
-}
+/* Collapsing the sidebar used to drop the whole main column by the inset, on the
+   grounds that it inherited the top-left corner and the traffic lights with it.
+   Removed: the re-open button below carries its own inset, so it still clears
+   the controls, and dropping the entire column was a visible lurch to buy
+   clearance for one button. */
+
+/* The tabbed Tauri shell (V2) uses a visible native titlebar — Safari-style —
+   so the page starts below the chrome and needs no inset at all. It stamps
+   data-shell="tauri" but deliberately NOT data-titlebar="overlay"; only the
+   Electron shell and the pre-tabs Tauri shell take the 38px above. */
 
 /* ============================================================
    Create Action - soft tinted CTA

--- a/src/app/_components/layout/sidebar.css
+++ b/src/app/_components/layout/sidebar.css
@@ -3,7 +3,28 @@
    .app-sidebar; this file uses only var().
    ============================================================ */
 
+/* ============================================================
+   Desktop-shell title bar inset
+
+   The Electron and Tauri shells both use the macOS overlay title
+   bar, so the traffic lights float over the page's top-left
+   corner — right where the sidebar header sits. DesktopChromeScript
+   stamps data-titlebar="overlay" on <html> before first paint;
+   everything anchored to the top-left leaves room for the controls
+   when it is set, and is untouched in the browser.
+   ============================================================ */
+:root {
+  --titlebar-inset: 0px;
+}
+
+html[data-titlebar="overlay"] {
+  /* Traffic lights sit at (16, 16) and are ~14px tall — clear them
+     plus a little breathing room. */
+  --titlebar-inset: 38px;
+}
+
 .app-sidebar {
+  padding-top: var(--titlebar-inset);
   background: var(--sb-bg);
   border-right: 1px solid var(--sb-hair);
   font-family: var(--sb-font);
@@ -13,6 +34,12 @@
 
 .app-sidebar .sb-workspace-divider {
   border-bottom: 1px solid var(--sb-hair);
+}
+
+/* Re-open button, shown in the same corner once the sidebar is closed —
+   so it has to clear the window controls too. */
+.sb-toggle {
+  top: calc(0.5rem + env(safe-area-inset-top) + var(--titlebar-inset));
 }
 
 /* ============================================================
@@ -26,6 +53,16 @@
   html[data-sidebar="closed"] .sidebar-offset {
     margin-left: 0;
   }
+}
+
+/* Collapsed, the main column inherits the top-left corner from the sidebar —
+   window controls and all — so the inset has to move with it. Margin rather
+   than padding: it stacks on whatever responsive padding <main> has at this
+   breakpoint instead of replacing it, and rides the same 300ms transition as
+   the collapse, so the content slides down with the sidebar rather than
+   snapping. */
+html[data-titlebar="overlay"][data-sidebar="closed"] .sidebar-offset {
+  margin-top: var(--titlebar-inset);
 }
 
 /* ============================================================

--- a/src/app/_components/shared/MarkdownRenderer.tsx
+++ b/src/app/_components/shared/MarkdownRenderer.tsx
@@ -70,10 +70,13 @@ function buildComponents(
 
   // Shared inline elements (identical across variants)
   const inlineComponents: Partial<Components> = {
-    a: ({ href, children }) => (
+    // `className` carries any classes a remark plugin tagged the link with
+    // (e.g. an unresolved wikilink), so a host can style those links without
+    // the renderer knowing what they mean.
+    a: ({ href, children, className }) => (
       <a
         href={href}
-        className="text-blue-500 underline decoration-blue-500/30 underline-offset-2 transition-colors hover:decoration-blue-500"
+        className={`text-blue-500 underline decoration-blue-500/30 underline-offset-2 transition-colors hover:decoration-blue-500 ${normalizeClassName(className)}`.trimEnd()}
         target={href?.startsWith("http") ? "_blank" : undefined}
         rel={href?.startsWith("http") ? "noopener noreferrer" : undefined}
       >
@@ -348,6 +351,13 @@ interface MarkdownRendererProps {
   mentionNames?: string[];
   /** Owner-only image delete handler (compact surfaces, e.g. comments). */
   onDeleteImage?: (url: string) => void;
+  /**
+   * Extra remark plugins, appended after the built-in ones. For syntax that
+   * belongs to one surface rather than to the app's canonical Markdown — the
+   * local wiki's `[[wikilinks]]`, say. Keeps that surface from importing
+   * react-markdown itself, which ADR-0017 forbids.
+   */
+  extraRemarkPlugins?: PluggableList;
   className?: string;
 }
 
@@ -357,6 +367,7 @@ export function MarkdownRenderer({
   softBreaks,
   mentionNames,
   onDeleteImage,
+  extraRemarkPlugins,
   className,
 }: MarkdownRendererProps) {
   // Tolerate legacy HTML on read (sanitised). New writes are always Markdown.
@@ -381,6 +392,7 @@ export function MarkdownRenderer({
   if (mentionNames && mentionNames.length > 0) {
     remarkPlugins.push([remarkMentions, mentionNames]);
   }
+  if (extraRemarkPlugins?.length) remarkPlugins.push(...extraRemarkPlugins);
 
   const body = (
     <ReactMarkdown

--- a/src/app/_components/today-redesign/TodayDesktopShell.tsx
+++ b/src/app/_components/today-redesign/TodayDesktopShell.tsx
@@ -13,6 +13,7 @@ import { useDetailedActionsEnabled } from "~/hooks/useDetailedActionsEnabled";
 import { useDayRollover } from "~/hooks/useDayRollover";
 import { formatRelativeDueAge, hourFloat } from "~/lib/actions/dates";
 import { overdueAnchor } from "~/lib/actions/partition";
+import { groupOverdueCohorts } from "~/lib/actions/triage";
 import type { Action } from "~/lib/actions/types";
 import { CreateActionModal } from "../CreateActionModal";
 import { EditActionModal } from "../EditActionModal";
@@ -141,7 +142,12 @@ export function TodayDesktopShell({
 
   // ---- Mutations -----------------------------------------------------------
   const { updateAction } = useActionMutations({ viewName: "today" });
-  const { bulkReschedule, bulkDelete } = useBulkActionMutations({
+  const {
+    bulkReschedule,
+    bulkDelete,
+    bulkDefer,
+    isMutating: isBulkMutating,
+  } = useBulkActionMutations({
     viewName: "today",
   });
   const handleComplete = (id: string) => {
@@ -265,6 +271,23 @@ export function TodayDesktopShell({
       fromOverdue: true,
     });
   }, [bulkReschedule, partition.overdue]);
+
+  // Most large overdue piles are a few bulk writes, not a lot of missed
+  // commitments. Computed client-side from the same `partition.overdue` the
+  // rows below render, using the same pure function as `action.getOverdueTriage`
+  // and the agent tools — so the page, the endpoint, and Zoe cannot disagree,
+  // and it costs no extra fetch (ADR-0052).
+  const overdueTriage = useMemo(
+    () => groupOverdueCohorts(partition.overdue, { today }),
+    [partition.overdue, today],
+  );
+
+  const handleDeferCohort = useCallback(
+    (actionIds: string[]) => {
+      bulkDefer({ actionIds, fromOverdue: true });
+    },
+    [bulkDefer],
+  );
 
   // ---- Bulk selection -----------------------------------------------------
   const selection = useBulkSelection(
@@ -469,6 +492,48 @@ export function TodayDesktopShell({
                             Reschedule all → Today
                           </button>
                         )}
+                      </div>
+                    )}
+                    {overdueOpen && overdueTriage.cohorts.length > 0 && !bulkMode && (
+                      <div className="td-amnesty">
+                        <p className="td-amnesty__lede">
+                          {overdueTriage.cohortCount} of these{" "}
+                          {overdueTriage.totalOverdue} were created in one go —
+                          they were probably never really due on that date.
+                        </p>
+                        {overdueTriage.cohorts.map((cohort) => (
+                          <div
+                            key={cohort.stampedAt.toISOString()}
+                            className="td-amnesty__cohort"
+                          >
+                            <div className="td-amnesty__detail">
+                              <span className="td-amnesty__count">
+                                {cohort.count} actions
+                              </span>
+                              <span className="td-amnesty__meta">
+                                {cohort.daysOverdue === 1
+                                  ? "dated yesterday"
+                                  : `dated ${cohort.daysOverdue}d ago`}
+                                {cohort.projectNames.length > 0 &&
+                                  ` · ${cohort.projectNames.slice(0, 3).join(", ")}`}
+                                {cohort.projectNames.length > 3 &&
+                                  ` +${cohort.projectNames.length - 3} more`}
+                              </span>
+                            </div>
+                            <button
+                              type="button"
+                              className="td-amnesty__action"
+                              disabled={isBulkMutating}
+                              onClick={() => handleDeferCohort(cohort.actionIds)}
+                            >
+                              Back to backlog
+                            </button>
+                          </div>
+                        ))}
+                        <p className="td-amnesty__note">
+                          Nothing is deleted — they stay in their projects,
+                          just without a date.
+                        </p>
                       </div>
                     )}
                     {overdueOpen &&

--- a/src/app/_components/today-redesign/today-desktop.css
+++ b/src/app/_components/today-redesign/today-desktop.css
@@ -638,3 +638,79 @@ html[data-sidebar="closed"] .td-topbar {
    the redesign. (Used by the original top bar in DoPageContent
    when filter !== 'today'.)
    ============================================================ */
+
+/* ---- Overdue amnesty ----------------------------------------------------
+   Surfaces bulk-written cohorts inside the overdue section. A large overdue
+   count is usually a few batch writes, not a lot of missed commitments, and
+   "Reschedule all → Today" is the wrong move for those — it re-inflicts the
+   pile tomorrow. See ADR-0052. */
+.td-amnesty {
+  padding: 12px 24px 14px;
+  border-bottom: 1px solid var(--td-hair);
+  background: var(--td-prio-urgent-10);
+}
+
+.td-amnesty__lede {
+  margin: 0 0 10px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--td-text);
+}
+
+.td-amnesty__cohort {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 0;
+}
+
+.td-amnesty__detail {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.td-amnesty__count {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--td-text);
+  white-space: nowrap;
+}
+
+.td-amnesty__meta {
+  font-size: 11px;
+  color: var(--td-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.td .td-amnesty__action {
+  margin-left: auto;
+  flex-shrink: 0;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid var(--td-prio-urgent-dim);
+  color: var(--td-prio-urgent);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+  cursor: pointer;
+}
+
+.td .td-amnesty__action:hover:not(:disabled) {
+  background: var(--td-prio-urgent-10);
+}
+
+.td .td-amnesty__action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.td-amnesty__note {
+  margin: 8px 0 0;
+  font-size: 10.5px;
+  color: var(--td-muted);
+}

--- a/src/app/_components/today-redesign/today-desktop.css
+++ b/src/app/_components/today-redesign/today-desktop.css
@@ -45,6 +45,19 @@
   border-bottom: 1px solid var(--td-hair);
   white-space: nowrap;
   flex-shrink: 0;
+  /* Matches the sidebar's own collapse animation, so the title slides aside
+     rather than jumping when the corner button appears. */
+  transition: padding-left 300ms ease-in-out;
+}
+
+/* Collapsed, the sidebar leaves a fixed re-open button in the window's
+   top-left corner (x 12–44). This page goes full-bleed, so its bar starts at
+   the very edge of the content column and is the one header the button lands
+   on — 20px puts the title straight under it. WorkspaceTopbar sidesteps this
+   with a flat 40px; here the extra space is only spent while the button is
+   actually there. */
+html[data-sidebar="closed"] .td-topbar {
+  padding-left: 52px;
 }
 
 .td-topbar__title {

--- a/src/app/api/client-errors/__tests__/route.test.ts
+++ b/src/app/api/client-errors/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the handled-client-error route. The route reads only
+ * `request.json()`, so a tiny fake request is enough. Auth, the DB and the
+ * ingest service are mocked so the route's own decisions — the env gate, the
+ * kind filter, the rate limit, and never failing loudly — are what's under test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.hoisted(() => {
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+vi.mock("~/server/db", () => ({ db: {} }));
+
+const { ingestSentryBug, auth } = vi.hoisted(() => ({
+  ingestSentryBug: vi.fn(),
+  auth: vi.fn(),
+}));
+vi.mock("~/server/services/sentry/SentryBugService", () => ({ ingestSentryBug }));
+vi.mock("~/server/auth", () => ({ auth }));
+
+import { POST } from "../route";
+
+function fakeRequest(body: unknown): NextRequest {
+  return { json: () => Promise.resolve(body) } as unknown as NextRequest;
+}
+
+const report = {
+  area: "chat-stream",
+  kind: "model",
+  message: "Your credit balance is too low",
+};
+
+/** Each test gets its own user so the module-level rate limiter can't bleed. */
+let userSeq = 0;
+function signedIn(): void {
+  userSeq += 1;
+  auth.mockResolvedValue({ user: { id: `user-${userSeq}` } });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.CLIENT_ERROR_BUGS = "1";
+  ingestSentryBug.mockResolvedValue({ created: true, ticketId: "ticket-1" });
+  signedIn();
+});
+
+afterEach(() => {
+  delete process.env.CLIENT_ERROR_BUGS;
+});
+
+describe("POST /api/client-errors", () => {
+  it("files a bug for a reportable failure", async () => {
+    const res = await POST(fakeRequest(report));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ filed: true, ticketId: "ticket-1" });
+    const [, bug, options] = ingestSentryBug.mock.calls[0]!;
+    expect(bug.title).toContain("Your credit balance is too low");
+    expect(options.body).toContain("never reached Sentry");
+    // Labelled as what it is, so the "Sentry" label keeps meaning Sentry.
+    expect(options.labels.map((l: { slug: string }) => l.slug)).toEqual([
+      "client-error",
+      "bug",
+    ]);
+  });
+
+  it("stays off unless the environment opts in", async () => {
+    delete process.env.CLIENT_ERROR_BUGS;
+
+    expect(await (await POST(fakeRequest(report))).json()).toEqual({
+      filed: false,
+      reason: "disabled",
+    });
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("refuses an unauthenticated report", async () => {
+    auth.mockResolvedValue(null);
+
+    const res = await POST(fakeRequest(report));
+
+    expect(res.status).toBe(401);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("does not file a dropped connection", async () => {
+    const res = await POST(fakeRequest({ ...report, kind: "transport" }));
+
+    expect(await res.json()).toEqual({ filed: false, reason: "not-reportable" });
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed report", async () => {
+    const res = await POST(fakeRequest({ area: "chat-stream" }));
+
+    expect(res.status).toBe(400);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("stops a runaway client after the per-user ceiling", async () => {
+    // 20 distinct errors are plausible; the 21st in an hour is a loop.
+    for (let i = 0; i < 20; i += 1) {
+      await POST(fakeRequest({ ...report, message: `failure number ${i}` }));
+    }
+    expect(ingestSentryBug).toHaveBeenCalledTimes(20);
+
+    const res = await POST(fakeRequest({ ...report, message: "one too many" }));
+
+    expect(await res.json()).toEqual({ filed: false, reason: "rate-limited" });
+    expect(ingestSentryBug).toHaveBeenCalledTimes(20);
+  });
+
+  it("never turns a reporting failure into a second failure", async () => {
+    ingestSentryBug.mockRejectedValue(new Error("product not found"));
+
+    const res = await POST(fakeRequest(report));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ filed: false, reason: "ingest-failed" });
+  });
+});

--- a/src/app/api/client-errors/route.ts
+++ b/src/app/api/client-errors/route.ts
@@ -1,0 +1,112 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { ingestSentryBug } from "~/server/services/sentry/SentryBugService";
+import {
+  buildClientErrorBody,
+  buildClientErrorBug,
+  shouldFileClientError,
+  type ClientErrorReport,
+} from "~/server/services/clientErrors/clientErrorBug";
+
+/**
+ * Files a failure the browser handled gracefully as a Bug Ticket.
+ *
+ * The counterpart to `/api/webhooks/sentry`: that route covers errors Sentry
+ * saw, and Sentry sees only what nobody caught. Everything the app handles well
+ * — a chat turn that renders "try again", a bridge call that logs and carries
+ * on — produced no issue and therefore no ticket. The catch stays; this is how
+ * it gets reported.
+ *
+ * Authenticated by the user's own session rather than an HMAC, which is the
+ * reason this is a separate route and not the webhook: the webhook's signing
+ * secret cannot be shipped to a browser.
+ *
+ * Off unless `CLIENT_ERROR_BUGS` is set. Filing tickets from client reports is
+ * a per-environment decision — the destination product is shared, and a
+ * misbehaving build could otherwise fill someone's tracker.
+ */
+
+const ReportSchema = z.object({
+  area: z.string().min(1).max(64),
+  kind: z.string().max(32).optional(),
+  message: z.string().min(1).max(2000),
+  context: z.record(z.string().max(64), z.string().max(500)).optional(),
+});
+
+/**
+ * Per-user ceiling on tickets *created* per window.
+ *
+ * Repeats of one fault already collapse — the ingest service dedups on the
+ * fingerprint — so this only bites when a single user produces many *distinct*
+ * errors, which is the runaway case worth stopping.
+ *
+ * In-memory, so it is per server instance and resets on deploy. That is weaker
+ * than it looks on serverless, and deliberately not a database round-trip on a
+ * path whose whole job is to be cheap and best-effort. Dedup is the real
+ * defence; this is the backstop.
+ */
+const MAX_REPORTS_PER_WINDOW = 20;
+const WINDOW_MS = 60 * 60 * 1000;
+const recentByUser = new Map<string, { count: number; resetAt: number }>();
+
+function overRateLimit(userId: string, now: number): boolean {
+  const entry = recentByUser.get(userId);
+  if (!entry || now >= entry.resetAt) {
+    recentByUser.set(userId, { count: 1, resetAt: now + WINDOW_MS });
+    return false;
+  }
+  entry.count += 1;
+  return entry.count > MAX_REPORTS_PER_WINDOW;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!process.env.CLIENT_ERROR_BUGS) {
+    // Not an error: the reporter is fire-and-forget and must not care.
+    return NextResponse.json({ filed: false, reason: "disabled" });
+  }
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let report: ClientErrorReport;
+  try {
+    report = ReportSchema.parse(await request.json());
+  } catch {
+    return NextResponse.json({ error: "Invalid report" }, { status: 400 });
+  }
+
+  if (!shouldFileClientError(report.kind)) {
+    return NextResponse.json({ filed: false, reason: "not-reportable" });
+  }
+
+  if (overRateLimit(session.user.id, Date.now())) {
+    console.warn(`[client-errors] rate limit hit for user ${session.user.id}`);
+    return NextResponse.json({ filed: false, reason: "rate-limited" });
+  }
+
+  try {
+    const result = await ingestSentryBug(db, buildClientErrorBug(report), {
+      body: buildClientErrorBody(report),
+      labels: CLIENT_ERROR_LABELS,
+    });
+    return NextResponse.json({ filed: result.created, ticketId: result.ticketId });
+  } catch (error) {
+    // Reporting a failure must never become a second failure the user sees.
+    console.error("[client-errors] could not file a bug:", error);
+    return NextResponse.json({ filed: false, reason: "ingest-failed" });
+  }
+}
+
+/**
+ * "bug" so it sits with the Sentry-filed ones; "client-error" instead of
+ * "Sentry" so the Sentry label keeps meaning the thing it says.
+ */
+const CLIENT_ERROR_LABELS = [
+  { name: "client-error", slug: "client-error", color: "avatar-orange" },
+  { name: "bug", slug: "bug", color: "avatar-red" },
+] as const;

--- a/src/app/api/cron/daily-plan-reminder/route.ts
+++ b/src/app/api/cron/daily-plan-reminder/route.ts
@@ -2,15 +2,32 @@ import { type NextRequest, NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { db } from "~/server/db";
 import { sendPushToUser } from "~/server/services/notifications/WebPushService";
-import { startOfDay, endOfDay } from "date-fns";
+import { partitionActions } from "~/lib/actions/partition";
+import { groupOverdueCohorts } from "~/lib/actions/triage";
+import { buildMorningNudge } from "~/server/services/morningNudge";
 
 /**
- * Cron endpoint: sends a morning push notification to all users with push subscriptions.
- * Tells them how many actions they have planned for today.
+ * Cron endpoint: the morning nudge.
+ *
+ * Describes what is actually on the user's plate, using the same partition the
+ * /today page renders ([ADR-0034]) and the same cohort analysis as
+ * `action.getOverdueTriage` ([ADR-0052]).
+ *
+ * This used to count `DailyPlanAction` rows — a *fourth* definition of "today",
+ * populated only when someone ran the /daily-plan wizard. Users who never ran
+ * the wizard got "No actions planned yet. Start your day by planning what to
+ * focus on." every single morning while dozens of real actions sat overdue, and
+ * the notification never mentioned overdue work at all.
+ *
+ * Deliberately no LLM here: this is a one-line push that fires for every user
+ * with a subscription, and a template gets the numbers right at zero cost and
+ * zero latency. The generated briefing is a separate, user-triggered path
+ * (`scheduling.getSchedulingSuggestions`).
  *
  * Call via: GET /api/cron/daily-plan-reminder
  * Vercel cron or external scheduler, protected by CRON_SECRET.
  */
+
 export async function GET(_request: NextRequest) {
   try {
     const headersList = await headers();
@@ -33,35 +50,46 @@ export async function GET(_request: NextRequest) {
     });
 
     const today = new Date();
-    const dayStart = startOfDay(today);
-    const dayEnd = endOfDay(today);
-
     const results = [];
 
     for (const user of usersWithPush) {
-      // Count today's planned actions
-      const actionCount = await db.dailyPlanAction.count({
+      // Same ownership rule as action.getTodaysActions: created-by-me with no
+      // assignees, or assigned to me. Cross-workspace, like /today.
+      const actions = await db.action.findMany({
         where: {
-          dailyPlan: {
-            userId: user.id,
-            date: {
-              gte: dayStart,
-              lte: dayEnd,
-            },
-          },
+          OR: [
+            { createdById: user.id, assignees: { none: {} } },
+            { assignees: { some: { userId: user.id } } },
+          ],
+          status: "ACTIVE",
+        },
+        select: {
+          id: true,
+          name: true,
+          status: true,
+          priority: true,
+          scheduledStart: true,
+          dueDate: true,
+          projectId: true,
+          completedAt: true,
+          project: { select: { name: true } },
         },
       });
 
-      const firstName = user.name?.split(" ")[0] ?? "there";
-      const body =
-        actionCount > 0
-          ? `You have ${actionCount} action${actionCount === 1 ? "" : "s"} planned for today. Let's go!`
-          : `No actions planned yet. Start your day by planning what to focus on.`;
+      const { overdue, todays } = partitionActions(actions, { today });
+      const triage = groupOverdueCohorts(overdue, { today });
+
+      const { title, body } = buildMorningNudge({
+        firstName: user.name?.split(" ")[0] ?? "there",
+        todayCount: todays.length,
+        overdueCount: overdue.length,
+        cohortCount: triage.cohortCount,
+      });
 
       const pushResult = await sendPushToUser(
         user.id,
         {
-          title: `Good morning, ${firstName}!`,
+          title,
           body,
           tag: "daily-plan",
           url: "/today",
@@ -71,7 +99,9 @@ export async function GET(_request: NextRequest) {
 
       results.push({
         userId: user.id,
-        actionCount,
+        todayCount: todays.length,
+        overdueCount: overdue.length,
+        cohortCount: triage.cohortCount,
         ...pushResult,
       });
     }

--- a/src/app/api/webhooks/sentry/[webhookId]/__tests__/route.test.ts
+++ b/src/app/api/webhooks/sentry/[webhookId]/__tests__/route.test.ts
@@ -40,6 +40,8 @@ function fakeRequest(opts: {
   resource?: string;
   signature?: string;
   tokenQuery?: string;
+  service?: string;
+  product?: string;
 }): NextRequest {
   const headers = new Map<string, string>();
   if (opts.signature !== undefined)
@@ -48,6 +50,8 @@ function fakeRequest(opts: {
     headers.set("sentry-hook-resource", opts.resource);
   const searchParams = new URLSearchParams();
   if (opts.tokenQuery !== undefined) searchParams.set("token", opts.tokenQuery);
+  if (opts.service !== undefined) searchParams.set("service", opts.service);
+  if (opts.product !== undefined) searchParams.set("product", opts.product);
   return {
     headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
     nextUrl: { searchParams },
@@ -88,7 +92,9 @@ describe("POST /api/webhooks/sentry/[webhookId]", () => {
     expect(res.status).toBe(200);
     expect(ingestSentryBug).toHaveBeenCalledTimes(1);
     // Routed to the per-workspace product, not the global default.
-    expect(ingestSentryBug.mock.calls[0]![2]).toEqual({ productId: "prod-1" });
+    expect(ingestSentryBug.mock.calls[0]![2]).toMatchObject({
+      productId: "prod-1",
+    });
   });
 
   it("returns 404 for an unknown webhookId and does not ingest", async () => {
@@ -182,8 +188,36 @@ describe("POST /api/webhooks/sentry/[webhookId]", () => {
       expect(arg.issueId).toBe("555");
       expect(arg.projectSlug).toBe("clear-pipeline");
       // Routed to this tenant's configured product, as for signed requests.
-      expect(ingestSentryBug.mock.calls[0]![2]).toEqual({
+      expect(ingestSentryBug.mock.calls[0]![2]).toMatchObject({
         productId: "prod-1",
+      });
+    });
+
+    it("passes ?service= through for source labelling", async () => {
+      await POST(
+        fakeRequest({
+          body: glitchtipBody,
+          tokenQuery: SECRET,
+          service: "clear-pipeline",
+        }),
+        ctx,
+      );
+      expect(ingestSentryBug.mock.calls[0]![2]).toMatchObject({
+        sourceSlug: "clear-pipeline",
+      });
+    });
+
+    it("accepts ?product= as an alias for ?service=", async () => {
+      await POST(
+        fakeRequest({
+          body: glitchtipBody,
+          tokenQuery: SECRET,
+          product: "clear-api",
+        }),
+        ctx,
+      );
+      expect(ingestSentryBug.mock.calls[0]![2]).toMatchObject({
+        sourceSlug: "clear-api",
       });
     });
 

--- a/src/app/api/webhooks/sentry/[webhookId]/__tests__/route.test.ts
+++ b/src/app/api/webhooks/sentry/[webhookId]/__tests__/route.test.ts
@@ -39,14 +39,18 @@ function fakeRequest(opts: {
   body: string;
   resource?: string;
   signature?: string;
+  tokenQuery?: string;
 }): NextRequest {
   const headers = new Map<string, string>();
   if (opts.signature !== undefined)
     headers.set("sentry-hook-signature", opts.signature);
   if (opts.resource !== undefined)
     headers.set("sentry-hook-resource", opts.resource);
+  const searchParams = new URLSearchParams();
+  if (opts.tokenQuery !== undefined) searchParams.set("token", opts.tokenQuery);
   return {
     headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+    nextUrl: { searchParams },
     text: () => Promise.resolve(opts.body),
   } as unknown as NextRequest;
 }
@@ -153,5 +157,63 @@ describe("POST /api/webhooks/sentry/[webhookId]", () => {
     );
     expect(res.status).toBe(200);
     expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  describe("unsigned GlitchTip requests", () => {
+    const glitchtipBody = JSON.stringify({
+      alias: "issue.new",
+      issue_id: 555,
+      project: "clear-pipeline",
+      attachments: [{ title: "OperationalError: connection reset" }],
+    });
+
+    it("accepts the integration's own secret as a query token", async () => {
+      const res = await POST(
+        fakeRequest({ body: glitchtipBody, tokenQuery: SECRET }),
+        ctx,
+      );
+
+      expect(res.status).toBe(200);
+      expect(ingestSentryBug).toHaveBeenCalledTimes(1);
+      const arg = ingestSentryBug.mock.calls[0]![1] as unknown as {
+        issueId: string;
+        projectSlug: string;
+      };
+      expect(arg.issueId).toBe("555");
+      expect(arg.projectSlug).toBe("clear-pipeline");
+      // Routed to this tenant's configured product, as for signed requests.
+      expect(ingestSentryBug.mock.calls[0]![2]).toEqual({
+        productId: "prod-1",
+      });
+    });
+
+    it("rejects a wrong query token with 401", async () => {
+      const res = await POST(
+        fakeRequest({ body: glitchtipBody, tokenQuery: "not-the-secret" }),
+        ctx,
+      );
+      expect(res.status).toBe(401);
+      expect(ingestSentryBug).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unsigned request carrying no token at all", async () => {
+      const res = await POST(fakeRequest({ body: glitchtipBody }), ctx);
+      expect(res.status).toBe(401);
+      expect(ingestSentryBug).not.toHaveBeenCalled();
+    });
+
+    it("never lets a valid token rescue a request whose signature is invalid", async () => {
+      // Security boundary: offering a signature commits the sender to HMAC.
+      const res = await POST(
+        fakeRequest({
+          body: glitchtipBody,
+          signature: "deadbeef",
+          tokenQuery: SECRET,
+        }),
+        ctx,
+      );
+      expect(res.status).toBe(401);
+      expect(ingestSentryBug).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/api/webhooks/sentry/[webhookId]/route.ts
+++ b/src/app/api/webhooks/sentry/[webhookId]/route.ts
@@ -133,7 +133,15 @@ export async function POST(
       );
     }
 
-    const result = await ingestSentryBug(db, bug, { productId });
+    // Which codebase the error came from, for labelling. `service` is the
+    // canonical name; `product` is accepted as an alias because it reads
+    // naturally in a URL — note it does *not* choose the destination Product,
+    // which is fixed per integration.
+    const sourceSlug =
+      request.nextUrl.searchParams.get("service") ??
+      request.nextUrl.searchParams.get("product");
+
+    const result = await ingestSentryBug(db, bug, { productId, sourceSlug });
     console.log(
       `[sentry webhook ${webhookId}] issue ${bug.issueId} -> ticket ${result.ticketId} (created=${result.created})`,
     );

--- a/src/app/api/webhooks/sentry/[webhookId]/route.ts
+++ b/src/app/api/webhooks/sentry/[webhookId]/route.ts
@@ -2,8 +2,9 @@ import { type NextRequest, NextResponse } from "next/server";
 import { db } from "~/server/db";
 import { ingestSentryBug } from "~/server/services/sentry/SentryBugService";
 import {
-  normalizeSentryPayload,
+  normalizeIssueWebhook,
   verifySentrySignature,
+  verifyWebhookToken,
 } from "~/server/services/sentry/sentryPayload";
 import { getDecryptedKey } from "~/server/utils/credentialHelper";
 
@@ -17,9 +18,19 @@ import { getDecryptedKey } from "~/server/utils/credentialHelper";
  * integration's stored secret, and files the issue as a Bug Ticket in the
  * workspace's chosen destination Product (`providerConfig.productId`).
  *
- * Unlike the global route, there is no shared env secret and no unauthenticated
- * mode — a configured integration always has a secret, so every request must
- * carry a valid `Sentry-Hook-Signature`.
+ * Unlike the global route there is no shared env secret and no unauthenticated
+ * mode: a configured integration always has a secret, and every request must
+ * prove knowledge of it one of two ways.
+ *
+ *  - **Sentry** signs the raw body — `Sentry-Hook-Signature` must verify by
+ *    HMAC against the integration's secret. Whenever a signature is present it
+ *    must be valid; there is no falling back to the weaker gate.
+ *  - **GlitchTip's generic webhook** cannot sign and cannot set headers (its
+ *    Alert Rule UI takes only a URL), so it may instead present the same
+ *    secret verbatim as a `?token=` query param, compared constant-time. This
+ *    is strictly weaker — it proves the sender knows the secret but not that
+ *    the body is untampered, and query strings are more prone to landing in
+ *    proxy logs — so it is accepted only when no signature was offered.
  */
 export async function POST(
   request: NextRequest,
@@ -69,9 +80,29 @@ export async function POST(
       );
     }
 
-    if (!signature || !verifySentrySignature(rawBody, signature, secret)) {
-      console.error(`[sentry webhook ${webhookId}] invalid signature`);
-      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    if (signature) {
+      // A signature was offered: it must verify. No fallback to the token gate.
+      if (!verifySentrySignature(rawBody, signature, secret)) {
+        console.error(`[sentry webhook ${webhookId}] invalid signature`);
+        return NextResponse.json(
+          { error: "Invalid signature" },
+          { status: 401 },
+        );
+      }
+    } else {
+      // Unsigned (GlitchTip): the same secret must be presented verbatim.
+      const provided =
+        request.headers.get("x-webhook-token") ??
+        request.nextUrl.searchParams.get("token");
+      if (!provided || !verifyWebhookToken(provided, secret)) {
+        console.error(
+          `[sentry webhook ${webhookId}] unsigned request with invalid or missing token`,
+        );
+        return NextResponse.json(
+          { error: "Invalid signature" },
+          { status: 401 },
+        );
+      }
     }
 
     if (integration.status !== "ACTIVE") {
@@ -81,17 +112,13 @@ export async function POST(
       );
     }
 
-    if (!resource) {
-      return NextResponse.json(
-        { error: "Missing Sentry-Hook-Resource header" },
-        { status: 400 },
-      );
-    }
-
-    const bug = normalizeSentryPayload(resource, JSON.parse(rawBody) as unknown);
+    // No resource header ⇒ treat as GlitchTip's generic webhook.
+    const bug = normalizeIssueWebhook(resource, JSON.parse(rawBody) as unknown);
     if (!bug) {
       // Not an event we file as a bug (installation, comment, resolved, etc.).
-      return NextResponse.json({ message: `Ignored Sentry ${resource} event` });
+      return NextResponse.json({
+        message: `Ignored ${resource ?? "glitchtip"} event`,
+      });
     }
 
     const config = integration.providerConfig as { productId?: string } | null;

--- a/src/app/api/webhooks/sentry/__tests__/route.test.ts
+++ b/src/app/api/webhooks/sentry/__tests__/route.test.ts
@@ -36,14 +36,21 @@ function fakeRequest(opts: {
   body: string;
   resource?: string;
   signature?: string;
+  tokenHeader?: string;
+  tokenQuery?: string;
 }): NextRequest {
   const headers = new Map<string, string>();
   if (opts.signature !== undefined)
     headers.set("sentry-hook-signature", opts.signature);
   if (opts.resource !== undefined)
     headers.set("sentry-hook-resource", opts.resource);
+  if (opts.tokenHeader !== undefined)
+    headers.set("x-webhook-token", opts.tokenHeader);
+  const searchParams = new URLSearchParams();
+  if (opts.tokenQuery !== undefined) searchParams.set("token", opts.tokenQuery);
   return {
     headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+    nextUrl: { searchParams },
     text: () => Promise.resolve(opts.body),
   } as unknown as NextRequest;
 }
@@ -93,5 +100,109 @@ describe("POST /api/webhooks/sentry", () => {
     expect(ingestSentryBug).toHaveBeenCalledTimes(1);
     const arg = ingestSentryBug.mock.calls[0]![1] as unknown as { issueId: string };
     expect(arg.issueId).toBe("42");
+  });
+});
+
+/**
+ * GlitchTip's generic webhook: no `Sentry-Hook-Resource` header, a flat body,
+ * and a secret that can only travel in the URL. Token auth only — HMAC is not
+ * available to it — so these tests run with the secret gate off.
+ */
+describe("POST /api/webhooks/sentry (GlitchTip generic webhook)", () => {
+  const TOKEN = "glitchtip-shared-token";
+
+  const glitchtipBody = JSON.stringify({
+    alias: "issue.new",
+    text: "GlitchTip Alert",
+    issue_id: 777,
+    project: "clear-api",
+    attachments: [
+      {
+        title: "TypeError: cannot read property of undefined",
+        title_link: "https://glitchtip.example.com/org/clear-api/issues/777",
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    delete process.env.SENTRY_WEBHOOK_SECRET;
+    process.env.SENTRY_WEBHOOK_TOKEN = TOKEN;
+  });
+
+  it("accepts the shared secret as a query param and files the issue", async () => {
+    const res = await POST(
+      fakeRequest({ body: glitchtipBody, tokenQuery: TOKEN }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(ingestSentryBug).toHaveBeenCalledTimes(1);
+    const arg = ingestSentryBug.mock.calls[0]![1] as unknown as {
+      issueId: string;
+      title: string;
+      url: string;
+      projectSlug: string;
+    };
+    expect(arg.issueId).toBe("777");
+    // The attachment title is the real error; `text` is boilerplate.
+    expect(arg.title).toBe("TypeError: cannot read property of undefined");
+    expect(arg.projectSlug).toBe("clear-api");
+    expect(arg.url).toBe(
+      "https://glitchtip.example.com/org/clear-api/issues/777",
+    );
+  });
+
+  it("still accepts the token in the header (preferred over the query param)", async () => {
+    const res = await POST(
+      fakeRequest({ body: glitchtipBody, tokenHeader: TOKEN }),
+    );
+    expect(res.status).toBe(200);
+    expect(ingestSentryBug).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a wrong query token with 401 and does not ingest", async () => {
+    const res = await POST(
+      fakeRequest({ body: glitchtipBody, tokenQuery: "wrong-token" }),
+    );
+    expect(res.status).toBe(401);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("ignores a resolution event rather than filing a ticket for it", async () => {
+    const body = JSON.stringify({
+      alias: "issue.resolved",
+      issue_id: 777,
+      attachments: [{ title: "TypeError: already fixed" }],
+    });
+    const res = await POST(fakeRequest({ body, tokenQuery: TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
+  });
+
+  it("recovers the issue id from the issue URL when issue_id is absent", async () => {
+    const body = JSON.stringify({
+      alias: "issue.new",
+      attachments: [
+        {
+          title: "RangeError: out of range",
+          title_link: "https://glitchtip.example.com/org/clear-mvp/issues/12345",
+        },
+      ],
+    });
+    const res = await POST(fakeRequest({ body, tokenQuery: TOKEN }));
+
+    expect(res.status).toBe(200);
+    const arg = ingestSentryBug.mock.calls[0]![1] as unknown as {
+      issueId: string;
+    };
+    expect(arg.issueId).toBe("12345");
+  });
+
+  it("ignores a payload with no recoverable issue id", async () => {
+    const body = JSON.stringify({ alias: "issue.new", text: "no id anywhere" });
+    const res = await POST(fakeRequest({ body, tokenQuery: TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(ingestSentryBug).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/webhooks/sentry/route.ts
+++ b/src/app/api/webhooks/sentry/route.ts
@@ -77,7 +77,13 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    const result = await ingestSentryBug(db, bug);
+    // Which codebase the error came from, for labelling (`service`, or
+    // `product` as an alias). Does not affect the destination product.
+    const sourceSlug =
+      request.nextUrl.searchParams.get("service") ??
+      request.nextUrl.searchParams.get("product");
+
+    const result = await ingestSentryBug(db, bug, { sourceSlug });
     console.log(
       `[sentry webhook] issue ${bug.issueId} -> ticket ${result.ticketId} (created=${result.created})`,
     );

--- a/src/app/api/webhooks/sentry/route.ts
+++ b/src/app/api/webhooks/sentry/route.ts
@@ -2,26 +2,35 @@ import { type NextRequest, NextResponse } from "next/server";
 import { db } from "~/server/db";
 import { ingestSentryBug } from "~/server/services/sentry/SentryBugService";
 import {
-  normalizeSentryPayload,
+  normalizeIssueWebhook,
   verifySentrySignature,
   verifyWebhookToken,
 } from "~/server/services/sentry/sentryPayload";
 
 /**
- * Sentry → Exponential bug webhook (ADR-0027).
+ * Sentry / GlitchTip → Exponential bug webhook (ADR-0027).
  *
- * Configure a Sentry internal integration to POST here on the `issue` (created)
- * resource. Each new Sentry issue becomes a Bug Ticket (`type: BUG`,
- * `status: BACKLOG`) in the configured product, authored by the Errol system
- * user. Recurring errors are collapsed onto one ticket in a later slice (dedup).
+ * Each new issue becomes a Bug Ticket (`type: BUG`, `status: BACKLOG`) in the
+ * configured product, authored by the Errol system user. Recurring errors are
+ * collapsed onto one ticket (dedup on the issue id).
+ *
+ * Two senders, distinguished by the `Sentry-Hook-Resource` header:
+ *  - **Sentry** sends the header plus a nested `{action, data.issue}` body.
+ *  - **GlitchTip's generic webhook** sends no header and a flat, Slack-styled
+ *    body. Its Alert Rule UI accepts only a URL — no custom headers — so the
+ *    shared secret may also travel as a `?token=` query param.
  *
  * Auth: two independent gates, each active only when its env var is set.
- *  - `SENTRY_WEBHOOK_TOKEN`: a shared secret the sender echoes in the
- *    `X-Webhook-Token` header. For senders that can set headers but can't sign
- *    the body (e.g. Glitchtip, which has no HMAC signing yet).
+ *  - `SENTRY_WEBHOOK_TOKEN`: a shared secret echoed in the `X-Webhook-Token`
+ *    header, or (for GlitchTip) the `token` query param. The header is
+ *    preferred: query strings are far more likely to be captured in proxy and
+ *    access logs, so the param exists only because GlitchTip allows nothing
+ *    else.
  *  - `SENTRY_WEBHOOK_SECRET`: real Sentry signs the raw body with HMAC-SHA256
  *    using the integration's Client Secret and sends it in
  *    `Sentry-Hook-Signature`. Verification is one-way, like the GitHub webhook.
+ *    GlitchTip cannot sign, so a GlitchTip-only deployment should configure
+ *    the token and leave the secret unset.
  * If both are set, both must pass; if neither is set, the endpoint is open
  * (logged). Configure at least one in any internet-facing deployment.
  */
@@ -33,7 +42,9 @@ export async function POST(request: NextRequest) {
 
     const token = process.env.SENTRY_WEBHOOK_TOKEN;
     if (token) {
-      const provided = request.headers.get("x-webhook-token");
+      const provided =
+        request.headers.get("x-webhook-token") ??
+        request.nextUrl.searchParams.get("token");
       if (!provided || !verifyWebhookToken(provided, token)) {
         console.error("[sentry webhook] invalid or missing webhook token");
         return NextResponse.json({ error: "Invalid token" }, { status: 401 });
@@ -57,17 +68,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!resource) {
-      return NextResponse.json(
-        { error: "Missing Sentry-Hook-Resource header" },
-        { status: 400 },
-      );
-    }
-
-    const bug = normalizeSentryPayload(resource, JSON.parse(rawBody) as unknown);
+    // No resource header ⇒ treat as GlitchTip's generic webhook.
+    const bug = normalizeIssueWebhook(resource, JSON.parse(rawBody) as unknown);
     if (!bug) {
       // Not an event we file as a bug (installation, comment, resolved, etc.).
-      return NextResponse.json({ message: `Ignored Sentry ${resource} event` });
+      return NextResponse.json({
+        message: `Ignored ${resource ?? "glitchtip"} event`,
+      });
     }
 
     const result = await ingestSentryBug(db, bug);

--- a/src/hooks/useTerminology.ts
+++ b/src/hooks/useTerminology.ts
@@ -100,6 +100,11 @@ const teamTerminology: Terminology = {
  *
  * - Personal workspaces: Human-friendly language (Goals, Weekly Focus)
  * - Team/Organization workspaces: Professional OKR terminology (Objectives, Key Results)
+ *
+ * Key Results are the one part of this that is separately switchable: the
+ * `enableKeyResults` workspace setting overrides the type-based default, so a
+ * personal workspace can turn them on (and a team can turn them off) without
+ * changing any of the other wording.
  */
 export function useTerminology(): Terminology {
   const { workspace } = useWorkspace();
@@ -111,8 +116,25 @@ export function useTerminology(): Terminology {
   }
 
   const isPersonal = workspace.type === 'personal';
+  const base = isPersonal ? personalTerminology : teamTerminology;
 
-  return isPersonal ? personalTerminology : teamTerminology;
+  // null = no explicit setting, so fall back to the workspace-type default.
+  const keyResultsEnabled = workspace.enableKeyResults ?? !isPersonal;
+  if (keyResultsEnabled === base.showKeyResults) {
+    return base;
+  }
+
+  // The override only moves the KR flags and labels — goals stay "Goals" in a
+  // personal workspace even with Key Results switched on.
+  return {
+    ...base,
+    keyResult: keyResultsEnabled ? 'Key Result' : '',
+    keyResults: keyResultsEnabled ? 'Key Results' : '',
+    okr: keyResultsEnabled ? 'OKR' : '',
+    okrs: keyResultsEnabled ? 'OKRs' : '',
+    showOkrFeatures: keyResultsEnabled,
+    showKeyResults: keyResultsEnabled,
+  };
 }
 
 /**

--- a/src/lib/actions/__tests__/triage.test.ts
+++ b/src/lib/actions/__tests__/triage.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { partitionActions } from "../partition";
+import {
+  COHORT_MIN_SIZE,
+  daysOverdue,
+  groupOverdueCohorts,
+  type TriageableAction,
+} from "../triage";
+
+// A fixed "today" so the suite is deterministic regardless of the wall clock.
+const TODAY = new Date("2026-08-04T09:00:00.000Z");
+
+function action(overrides: Partial<TriageableAction> = {}): TriageableAction {
+  return {
+    id: Math.random().toString(36).slice(2),
+    name: "an action",
+    status: "ACTIVE",
+    priority: "Quick",
+    scheduledStart: null,
+    dueDate: null,
+    projectId: null,
+    completedAt: null,
+    project: null,
+    ...overrides,
+  };
+}
+
+/** N actions sharing one exact instant — the signature of a bulk write. */
+function bulk(
+  n: number,
+  stamp: string,
+  overrides: Partial<TriageableAction> = {},
+): TriageableAction[] {
+  return Array.from({ length: n }, (_, i) =>
+    action({ id: `bulk-${stamp}-${i}`, dueDate: new Date(stamp), ...overrides }),
+  );
+}
+
+describe("groupOverdueCohorts", () => {
+  it("groups actions sharing an exact instant into one cohort", () => {
+    const stamp = "2026-07-25T08:29:55.483Z";
+    const { cohorts, loose } = groupOverdueCohorts(bulk(17, stamp), {
+      today: TODAY,
+    });
+
+    expect(cohorts).toHaveLength(1);
+    expect(cohorts[0]!.count).toBe(17);
+    expect(cohorts[0]!.stampedAt.toISOString()).toBe(stamp);
+    expect(cohorts[0]!.daysOverdue).toBe(10);
+    expect(loose).toHaveLength(0);
+  });
+
+  it("leaves individually-dated actions loose even when they share a calendar day", () => {
+    // Same day, different instants — a human dating things one at a time.
+    const sameDay = [
+      action({ id: "a", dueDate: new Date("2026-07-25T08:29:55.483Z") }),
+      action({ id: "b", dueDate: new Date("2026-07-25T11:02:13.001Z") }),
+      action({ id: "c", dueDate: new Date("2026-07-25T16:44:09.777Z") }),
+    ];
+
+    const { cohorts, loose } = groupOverdueCohorts(sameDay, { today: TODAY });
+
+    expect(cohorts).toHaveLength(0);
+    expect(loose.map((a) => a.id).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it(`needs ${COHORT_MIN_SIZE} members before a shared instant counts as a cohort`, () => {
+    const pair = bulk(COHORT_MIN_SIZE - 1, "2026-07-25T08:29:55.483Z");
+    expect(groupOverdueCohorts(pair, { today: TODAY }).cohorts).toHaveLength(0);
+
+    const trio = bulk(COHORT_MIN_SIZE, "2026-07-25T08:29:55.483Z");
+    expect(groupOverdueCohorts(trio, { today: TODAY }).cohorts).toHaveLength(1);
+  });
+
+  it("separates multiple bulk writes and orders them biggest first", () => {
+    const overdue = [
+      ...bulk(4, "2026-07-23T07:00:00.000Z"),
+      ...bulk(17, "2026-07-25T08:29:55.483Z"),
+      action({ id: "solo", dueDate: new Date("2026-07-30T22:00:00.000Z") }),
+    ];
+
+    const triage = groupOverdueCohorts(overdue, { today: TODAY });
+
+    expect(triage.totalOverdue).toBe(22);
+    expect(triage.cohorts.map((c) => c.count)).toEqual([17, 4]);
+    expect(triage.cohortCount).toBe(21);
+    expect(triage.loose.map((a) => a.id)).toEqual(["solo"]);
+  });
+
+  it("reports the distinct projects a cohort spans, so it can be explained", () => {
+    const overdue = [
+      ...bulk(2, "2026-07-25T08:29:55.483Z", {
+        project: { name: "Net Worth Baseline" },
+      }),
+      ...bulk(2, "2026-07-25T08:29:55.483Z", {
+        project: { name: "Tax Reserve System" },
+      }),
+    ];
+    // Both helpers stamp ids by index, so de-dupe ids before grouping.
+    const unique = overdue.map((a, i) => ({ ...a, id: `a${i}` }));
+
+    const { cohorts } = groupOverdueCohorts(unique, { today: TODAY });
+
+    expect(cohorts).toHaveLength(1);
+    expect(cohorts[0]!.projectNames.sort()).toEqual([
+      "Net Worth Baseline",
+      "Tax Reserve System",
+    ]);
+  });
+
+  it("keys the cohort on scheduledStart when present (schedule wins, as in partitionActions)", () => {
+    // Identical scheduledStart, differing dueDates: still one bulk write.
+    const overdue = Array.from({ length: 3 }, (_, i) =>
+      action({
+        id: `s${i}`,
+        scheduledStart: new Date("2026-07-25T08:29:55.483Z"),
+        dueDate: new Date(`2026-07-2${i + 1}T12:00:00.000Z`),
+      }),
+    );
+
+    const { cohorts } = groupOverdueCohorts(overdue, { today: TODAY });
+
+    expect(cohorts).toHaveLength(1);
+    expect(cohorts[0]!.count).toBe(3);
+  });
+
+  it("orders loose debt oldest first", () => {
+    const overdue = [
+      action({ id: "recent", dueDate: new Date("2026-08-02T12:00:00.000Z") }),
+      action({ id: "ancient", dueDate: new Date("2026-06-01T12:00:00.000Z") }),
+      action({ id: "middling", dueDate: new Date("2026-07-15T12:00:00.000Z") }),
+    ];
+
+    const { loose } = groupOverdueCohorts(overdue, { today: TODAY });
+
+    expect(loose.map((a) => a.id)).toEqual(["ancient", "middling", "recent"]);
+  });
+
+  it("consumes partitionActions output directly (the real call path)", () => {
+    // A mixed pile: a bulk-dated plan, one real overdue item, one due today,
+    // one completed. Only the overdue ones should reach triage.
+    const all = [
+      ...bulk(3, "2026-07-25T08:29:55.483Z"),
+      action({ id: "real", dueDate: new Date("2026-07-30T09:00:00.000Z") }),
+      action({ id: "today", dueDate: new Date("2026-08-04T09:00:00.000Z") }),
+      action({
+        id: "done",
+        status: "COMPLETED",
+        dueDate: new Date("2026-07-01T09:00:00.000Z"),
+      }),
+    ];
+
+    const { overdue } = partitionActions(all, { today: TODAY });
+    const triage = groupOverdueCohorts(overdue, { today: TODAY });
+
+    expect(triage.totalOverdue).toBe(4);
+    expect(triage.cohorts).toHaveLength(1);
+    expect(triage.cohorts[0]!.count).toBe(3);
+    expect(triage.loose.map((a) => a.id)).toEqual(["real"]);
+  });
+});
+
+describe("daysOverdue", () => {
+  it("counts whole days from the anchor to today", () => {
+    expect(
+      daysOverdue({ scheduledStart: null, dueDate: new Date("2026-07-25T08:29:55.483Z") }, TODAY),
+    ).toBe(10);
+  });
+
+  it("prefers scheduledStart over dueDate, matching overdueAnchor", () => {
+    expect(
+      daysOverdue(
+        {
+          scheduledStart: new Date("2026-08-01T08:00:00.000Z"),
+          dueDate: new Date("2026-06-01T08:00:00.000Z"),
+        },
+        TODAY,
+      ),
+    ).toBe(3);
+  });
+
+  it("returns 0 when there is no anchor at all", () => {
+    expect(daysOverdue({ scheduledStart: null, dueDate: null }, TODAY)).toBe(0);
+  });
+});

--- a/src/lib/actions/triage.ts
+++ b/src/lib/actions/triage.ts
@@ -1,0 +1,137 @@
+import { overdueAnchor, type PartitionableAction } from "~/lib/actions/partition";
+
+/**
+ * Minimum members before a shared anchor instant counts as a bulk write rather
+ * than coincidence. Two actions can plausibly land on the same instant (a
+ * two-item paste); three is already implausible by hand.
+ */
+export const COHORT_MIN_SIZE = 3;
+
+export interface TriageableAction extends PartitionableAction {
+  name: string;
+  project?: { name: string | null } | null;
+}
+
+export interface OverdueCohort<T> {
+  /** The exact instant every member is stamped with. */
+  stampedAt: Date;
+  daysOverdue: number;
+  count: number;
+  /** Distinct project names represented, for explaining the cohort to a human. */
+  projectNames: string[];
+  actionIds: string[];
+  actions: T[];
+}
+
+export interface OverdueTriage<T> {
+  totalOverdue: number;
+  /** How many of `totalOverdue` sit inside a cohort. */
+  cohortCount: number;
+  cohorts: OverdueCohort<T>[];
+  /** Individually-dated overdue actions — real debt, worth reading one by one. */
+  loose: T[];
+}
+
+function startOfDay(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+/**
+ * Whole days between an action's overdue anchor and today. 0 when it has no
+ * anchor (which `partitionActions` never produces for the overdue bucket).
+ */
+export function daysOverdue(
+  a: Pick<PartitionableAction, "scheduledStart" | "dueDate">,
+  today: Date,
+): number {
+  const anchor = overdueAnchor(a);
+  if (!anchor) return 0;
+  return Math.round(
+    (startOfDay(today).getTime() - anchor.getTime()) / (24 * 60 * 60 * 1000),
+  );
+}
+
+/**
+ * Split an overdue pile into bulk-written **cohorts** and individually-dated
+ * **loose** debt.
+ *
+ * A large overdue count is usually not a large number of missed commitments.
+ * It is a handful of bulk writes — a generated project plan, a template, an
+ * import — each stamping every row it created with one identical timestamp.
+ * Those actions were never individually due, so rescheduling them forward just
+ * re-inflicts the pile tomorrow; the honest disposition is to un-date them
+ * (`action.bulkDefer`).
+ *
+ * Exact-instant equality is the fingerprint. Hand-entered dates carry the
+ * millisecond the user hit save and effectively never collide, so a shared
+ * instant across {@link COHORT_MIN_SIZE}+ actions means one writer wrote them
+ * all at once.
+ *
+ * Pure: callers pass `today` so results are deterministic and testable.
+ */
+export function groupOverdueCohorts<T extends TriageableAction>(
+  overdue: T[],
+  options: { today: Date },
+): OverdueTriage<T> {
+  const { today } = options;
+
+  const byAnchor = new Map<number, T[]>();
+  const undated: T[] = [];
+  for (const a of overdue) {
+    const raw = a.scheduledStart ?? a.dueDate;
+    if (!raw) {
+      undated.push(a);
+      continue;
+    }
+    const key = new Date(raw).getTime();
+    const bucket = byAnchor.get(key);
+    if (bucket) bucket.push(a);
+    else byAnchor.set(key, [a]);
+  }
+
+  const cohorts: OverdueCohort<T>[] = [];
+  const loose: T[] = [...undated];
+
+  for (const [key, members] of byAnchor) {
+    if (members.length < COHORT_MIN_SIZE) {
+      loose.push(...members);
+      continue;
+    }
+    const projectNames = [
+      ...new Set(
+        members
+          .map((m) => m.project?.name)
+          .filter((n): n is string => Boolean(n)),
+      ),
+    ];
+    cohorts.push({
+      stampedAt: new Date(key),
+      daysOverdue: daysOverdue(members[0]!, today),
+      count: members.length,
+      projectNames,
+      actionIds: members.map((m) => m.id),
+      actions: members,
+    });
+  }
+
+  // Biggest cohort first — that is the one worth offering amnesty on.
+  cohorts.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return a.stampedAt.getTime() - b.stampedAt.getTime();
+  });
+  // Oldest real debt first.
+  loose.sort((a, b) => {
+    const diff = daysOverdue(b, today) - daysOverdue(a, today);
+    if (diff !== 0) return diff;
+    return a.id.localeCompare(b.id);
+  });
+
+  return {
+    totalOverdue: overdue.length,
+    cohortCount: cohorts.reduce((n, c) => n + c.count, 0),
+    cohorts,
+    loose,
+  };
+}

--- a/src/lib/chat/__tests__/streamProtocol.test.ts
+++ b/src/lib/chat/__tests__/streamProtocol.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   parseChatStreamBuffer,
   classifyStreamError,
+  describeStreamError,
 } from '../streamProtocol';
 
 const toolFrame = (payload: Record<string, unknown>) =>
@@ -195,5 +196,52 @@ describe('classifyStreamError', () => {
 
   it('classifies non-Error throwables as unknown', () => {
     expect(classifyStreamError('nope')).toEqual({ kind: 'unknown', retryable: false });
+  });
+
+  it('classifies provider billing and quota refusals as model errors', () => {
+    // The exact sentence the Anthropic API returns, which used to fall through
+    // to `unknown` and render as "Something went wrong handling that request."
+    expect(
+      classifyStreamError(
+        new Error(
+          'Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.',
+        ),
+      ),
+    ).toEqual({ kind: 'model', retryable: false });
+    expect(classifyStreamError(new Error('You exceeded your current quota'))).toEqual({
+      kind: 'model',
+      retryable: false,
+    });
+  });
+});
+
+describe('describeStreamError', () => {
+  it('returns the error message so the cause reaches the user', () => {
+    expect(describeStreamError(new Error('Your credit balance is too low'))).toBe(
+      'Your credit balance is too low',
+    );
+  });
+
+  it('keeps only the first line, dropping any stack the provider appended', () => {
+    expect(describeStreamError(new Error('Boom\n    at postToApi (index.mjs:1)'))).toBe('Boom');
+  });
+
+  it('caps a runaway message rather than filling the bubble', () => {
+    // Short words, so the masker doesn't take it for one long credential.
+    const detail = describeStreamError(new Error('very bad thing '.repeat(40)));
+    expect(detail).toHaveLength(241);
+    expect(detail?.endsWith('…')).toBe(true);
+  });
+
+  it('masks a credential the provider echoed back', () => {
+    const secret = 'ff_live_' + 'a'.repeat(40);
+    const detail = describeStreamError(new Error(`Invalid API key ${secret}`));
+    expect(detail).not.toContain(secret);
+    expect(detail).toContain('Invalid API key');
+  });
+
+  it('has nothing to add for an empty or non-Error throwable', () => {
+    expect(describeStreamError(new Error('   '))).toBeUndefined();
+    expect(describeStreamError(undefined)).toBeUndefined();
   });
 });

--- a/src/lib/chat/streamProtocol.ts
+++ b/src/lib/chat/streamProtocol.ts
@@ -15,6 +15,10 @@
  * consumes the chat stream (the Zoe drawer via ManyChat, the Zoe canvas).
  */
 
+// Pure regex helper, no server dependencies — imported rather than reimplemented
+// so client-shown error text is masked by exactly the rule the server logs use.
+import { maskTokenLike } from '~/server/utils/redactToolArgs';
+
 // One agent tool invocation, accumulated from __exp_tool__ frames.
 export interface ToolCall {
   id: string;
@@ -150,8 +154,47 @@ export function classifyStreamError(error: unknown): { kind: StreamFailureKind; 
   ) {
     return { kind: 'transport', retryable: true };
   }
+  // Provider-level refusals (billing, quota, rate limits). These arrive as a
+  // plain sentence from the model vendor — "Your credit balance is too low to
+  // access the Anthropic API" — with none of the words matched above, so they
+  // used to land in `unknown` and render as "Something went wrong", hiding the
+  // one fact that would have fixed it.
+  if (
+    text.includes('credit balance') ||
+    text.includes('quota') ||
+    text.includes('billing') ||
+    text.includes('insufficient_quota') ||
+    text.includes('rate limit')
+  ) {
+    return { kind: 'model', retryable: false };
+  }
   if (text.includes('mastra') || text.includes('agent')) {
     return { kind: 'model', retryable: false };
   }
   return { kind: 'unknown', retryable: false };
+}
+
+/**
+ * The thrown error's own words, for display beneath the calm copy.
+ *
+ * Returns undefined when there's nothing worth showing. Capped because some
+ * provider errors carry a whole stack trace, and a chat bubble is not a log
+ * viewer.
+ *
+ * Masked with the same rule the server applies before an error message reaches
+ * a log (`maskTokenLike`), because free-form provider text can echo a
+ * credential back — "Invalid API key ff_live_…". The server-mediated path goes
+ * further and shows the user nothing but a generic line
+ * (`formatUserFacingStreamError`); that stays as it is. This is for errors
+ * thrown at *this* end, where the alternative is not a safer message but no
+ * message at all.
+ */
+export function describeStreamError(error: unknown): string | undefined {
+  const raw =
+    error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  // Providers often append a stack after the sentence; the first line is the
+  // part a human reads.
+  const message = maskTokenLike(raw.split('\n')[0]?.trim() ?? '');
+  if (!message) return undefined;
+  return message.length > 240 ? `${message.slice(0, 240)}…` : message;
 }

--- a/src/lib/docs/navigation.ts
+++ b/src/lib/docs/navigation.ts
@@ -24,6 +24,7 @@ import {
   IconBuildingSkyscraper,
   IconUsers,
   IconRobot,
+  IconRobotFace,
   IconKey,
   IconPlayerPlay,
   IconLayoutNavbar,
@@ -181,6 +182,11 @@ export const docsNavigation: DocNavSection[] = [
         title: "API Access",
         href: "/docs/features/api-access",
         icon: IconKey,
+      },
+      {
+        title: "External Agents",
+        href: "/docs/features/external-agents",
+        icon: IconRobotFace,
       },
       {
         title: "Settings",

--- a/src/lib/localWiki.ts
+++ b/src/lib/localWiki.ts
@@ -27,6 +27,15 @@ export interface WikiInfo {
   git: boolean;
 }
 
+/** Whether there is a wiki yet, and where it would go if not. */
+export interface WikiStatus {
+  /** Where it lives, or would live — the first-run panel names this. */
+  root: string;
+  exists: boolean;
+  git: boolean;
+  pageCount: number;
+}
+
 export interface WikiPage {
   /** Path relative to the wiki root — the handle every other call takes. */
   path: string;
@@ -38,7 +47,15 @@ export interface WikiPage {
  * ask (a browser, or the Electron shell).
  */
 export interface WikiBridge {
-  /** Create the wiki if absent. Idempotent; safe to call every turn. */
+  /**
+   * Report on the wiki **without creating it**.
+   *
+   * The distinction from `init` is the point: creating a folder in someone's
+   * Documents should be something they chose. This is what the first-run panel
+   * asks before offering to create anything.
+   */
+  status: () => Promise<WikiStatus>;
+  /** Create the wiki. Idempotent, so pressing the button twice is harmless. */
   init: () => Promise<WikiInfo>;
   listPages: () => Promise<WikiPage[]>;
   readPage: (path: string) => Promise<string>;
@@ -113,6 +130,7 @@ export function getWikiBridge(): WikiBridge | null {
   if (!invoke) return null;
 
   return {
+    status: async () => (await invoke("wiki_status")) as WikiStatus,
     init: async () => (await invoke("wiki_init")) as WikiInfo,
     listPages: async () => ((await invoke("wiki_list_pages")) ?? []) as WikiPage[],
     readPage: async (path: string) => {

--- a/src/lib/reportHandledError.ts
+++ b/src/lib/reportHandledError.ts
@@ -1,0 +1,87 @@
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Report a failure the app handled gracefully.
+ *
+ * The gap this fills: Sentry's automatic capture only sees errors *nobody*
+ * caught, so every `catch` that logs a line and renders a calm message was
+ * invisible — no Sentry issue, and therefore none of the Bug Tickets the Sentry
+ * webhook files (ADR-0027). The graceful handling is right; the silence was
+ * not.
+ *
+ * Two destinations, on purpose:
+ *  - **Sentry**, which does the grouping, release tracking and alerting, but
+ *    only initialises on Vercel prod/preview — so it is silent for anyone
+ *    running the desktop shell against a local server.
+ *  - **A Bug Ticket**, via `/api/client-errors`, which works wherever the app
+ *    runs and lands the failure in the tracker where it gets triaged.
+ *
+ * Best-effort by construction: reporting an error must never raise one. Every
+ * failure here is swallowed, because a reporter that throws would take out the
+ * error path it was meant to illuminate.
+ */
+/**
+ * Readable text for whatever was thrown.
+ *
+ * Not just `String(error)`: a rejected IPC call or a fetch wrapper can throw a
+ * plain object, and stringifying that gives "[object Object]" — a ticket titled
+ * with which is worse than no ticket, because it looks like signal.
+ */
+function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (typeof error === "number" || typeof error === "boolean") return String(error);
+  if (typeof error === "object" && error !== null) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+    try {
+      return JSON.stringify(error).slice(0, 500);
+    } catch {
+      // Circular, or a getter that throws.
+      return "";
+    }
+  }
+  return "";
+}
+
+export function reportHandledError(
+  error: unknown,
+  options: {
+    /** Where this happened — `chat-stream`, `local-wiki-status`, … Becomes the ticket's culprit and part of its dedup key. */
+    area: string;
+    /** The classification the caller already made, if any. Governs whether a ticket is filed at all. */
+    kind?: string;
+    /** Extra context rendered in the ticket body and attached to the Sentry event. Strings only, so nothing unserializable slips in. */
+    context?: Record<string, string>;
+  },
+): void {
+  const { area, kind, context } = options;
+
+  try {
+    Sentry.captureException(error, {
+      tags: { area, ...(kind ? { failureKind: kind } : {}) },
+      ...(context ? { extra: context } : {}),
+    });
+  } catch {
+    // A Sentry SDK that isn't initialised, or a transport that refuses.
+  }
+
+  const message = messageOf(error);
+  if (!message.trim()) return;
+
+  // Fire-and-forget. `keepalive` so a report survives the navigation that a
+  // fatal-looking error often triggers.
+  try {
+    void fetch("/api/client-errors", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ area, kind, message: message.slice(0, 2000), context }),
+      keepalive: true,
+    }).catch(() => {
+      // Offline, blocked, or the endpoint is off. Nothing to do — this path
+      // exists to make failures visible, not to add one.
+    });
+  } catch {
+    // `fetch` missing entirely (SSR, an exotic webview).
+  }
+}

--- a/src/lib/wiki/__tests__/wikiLinks.test.ts
+++ b/src/lib/wiki/__tests__/wikiLinks.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from "vitest";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import type { Root } from "mdast";
+
+import {
+  applyWikiLinks,
+  collectWikiLinks,
+  pageFolder,
+  pageTitle,
+  pathToTarget,
+  segmentsToPath,
+  targetToPath,
+  wikiHref,
+  WIKI_LINK_CLASS,
+  WIKI_LINK_MISSING_CLASS,
+} from "../wikiLinks";
+
+interface MdNode {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MdNode[];
+  data?: { hProperties?: Record<string, unknown> };
+}
+
+const parse = (md: string) =>
+  unified().use(remarkParse).parse(md) as unknown as MdNode;
+
+/** Every link node in the tree, depth-first. */
+function links(tree: MdNode): MdNode[] {
+  const out: MdNode[] = [];
+  const walk = (node: MdNode) => {
+    if (node.type === "link") out.push(node);
+    node.children?.forEach(walk);
+  };
+  walk(tree);
+  return out;
+}
+
+/** The tree's text content, so we can assert nothing was lost. */
+function text(tree: MdNode): string {
+  if (typeof tree.value === "string" && !tree.children) return tree.value;
+  return (tree.children ?? []).map(text).join("");
+}
+
+const KNOWN = new Set(["index.md", "schema.md", "people/ada.md"]);
+
+describe("wiki paths", () => {
+  it("maps a target to a path and back", () => {
+    expect(targetToPath("people/ada")).toBe("people/ada.md");
+    expect(pathToTarget("people/ada.md")).toBe("people/ada");
+  });
+
+  it("is idempotent in both directions", () => {
+    expect(targetToPath("people/ada.md")).toBe("people/ada.md");
+    expect(pathToTarget("people/ada")).toBe("people/ada");
+  });
+
+  it("builds a URL under /wiki, encoding each segment", () => {
+    expect(wikiHref("people/ada.md")).toBe("/wiki/people/ada");
+    expect(wikiHref("notes/a b")).toBe("/wiki/notes/a%20b");
+  });
+
+  it("rejoins catch-all route segments into a path", () => {
+    expect(segmentsToPath(["people", "ada"])).toBe("people/ada.md");
+    expect(segmentsToPath([])).toBeNull();
+    expect(segmentsToPath(undefined)).toBeNull();
+  });
+
+  it("titles a page by its first heading, else its filename", () => {
+    expect(pageTitle("people/ada.md", "# Ada Lovelace\n\nnotes")).toBe("Ada Lovelace");
+    expect(pageTitle("people/ada-lovelace.md")).toBe("ada lovelace");
+    // A heading further down is not the title.
+    expect(pageTitle("notes.md", "intro\n\n# Later heading")).toBe("Later heading");
+  });
+
+  it("does not take a title from inside a fenced code block", () => {
+    const md = "```bash\n# install the thing\nbrew install thing\n```\n\n# Real Title\n";
+    expect(pageTitle("tools/thing.md", md)).toBe("Real Title");
+    // With no heading outside the fence, fall back to the filename.
+    expect(pageTitle("tools/thing.md", "```bash\n# install\n```\n")).toBe("thing");
+  });
+
+  it("reports the folder a page sits in", () => {
+    expect(pageFolder("people/ada.md")).toBe("people");
+    expect(pageFolder("index.md")).toBeNull();
+  });
+});
+
+describe("applyWikiLinks", () => {
+  it("turns a wikilink into a link to the page", () => {
+    const tree = parse("See [[people/ada]] for more.");
+    applyWikiLinks(tree, KNOWN);
+
+    const [link] = links(tree);
+    expect(link?.url).toBe("/wiki/people/ada");
+    expect(text(tree)).toBe("See people/ada for more.");
+  });
+
+  it("marks a link whose page does not exist yet", () => {
+    const tree = parse("See [[people/hopper]].");
+    applyWikiLinks(tree, KNOWN);
+
+    const className = links(tree)[0]?.data?.hProperties?.className;
+    expect(className).toEqual([WIKI_LINK_CLASS, WIKI_LINK_MISSING_CLASS]);
+  });
+
+  it("does not mark a link whose page exists", () => {
+    const tree = parse("See [[schema]].");
+    applyWikiLinks(tree, KNOWN);
+
+    expect(links(tree)[0]?.data?.hProperties?.className).toEqual([WIKI_LINK_CLASS]);
+  });
+
+  it("handles several links in one paragraph, keeping the text between them", () => {
+    const tree = parse("Seeded [[index]] and [[schema]].");
+    applyWikiLinks(tree, KNOWN);
+
+    expect(links(tree).map((l) => l.url)).toEqual(["/wiki/index", "/wiki/schema"]);
+    expect(text(tree)).toBe("Seeded index and schema.");
+  });
+
+  it("leaves code spans alone — schema.md documents the syntax in one", () => {
+    const tree = parse("Pages refer to each other with `[[wikilinks]]`.");
+    applyWikiLinks(tree, KNOWN);
+
+    expect(links(tree)).toHaveLength(0);
+    expect(text(tree)).toContain("[[wikilinks]]");
+  });
+
+  it("leaves fenced code blocks alone", () => {
+    const tree = parse("```\nsee [[index]]\n```");
+    applyWikiLinks(tree, KNOWN);
+
+    expect(links(tree)).toHaveLength(0);
+  });
+
+  it("does not nest a link inside an existing link", () => {
+    const tree = parse("[a [[index]] b](https://example.com)");
+    applyWikiLinks(tree, KNOWN);
+
+    expect(links(tree).map((l) => l.url)).toEqual(["https://example.com"]);
+  });
+
+  it("finds links inside list items and headings", () => {
+    const tree = parse("## About [[index]]\n\n- see [[schema]]\n");
+    applyWikiLinks(tree, KNOWN);
+
+    expect(links(tree).map((l) => l.url)).toEqual(["/wiki/index", "/wiki/schema"]);
+  });
+
+  it("ignores an empty link and leaves the text intact", () => {
+    const tree = parse("nothing [[]] here");
+    applyWikiLinks(tree, KNOWN);
+
+    expect(links(tree)).toHaveLength(0);
+    expect(text(tree)).toBe("nothing [[]] here");
+  });
+
+  // An empty match is skipped without advancing the write cursor, so the text
+  // around it is only ever emitted by a later slice. Easy to break by
+  // "tidying" that cursor handling; these pin every ordering.
+  it.each([
+    "see [[index]] and [[]] end",
+    "[[]] then [[index]]",
+    "a [[index]] b [[]] c [[schema]] d",
+    "[[]][[index]][[]]",
+  ])("loses no text around an empty link: %s", (source) => {
+    const tree = parse(source);
+    applyWikiLinks(tree, KNOWN);
+
+    // Rendered links drop their brackets; everything else survives verbatim.
+    expect(text(tree)).toBe(source.replace(/\[\[(index|schema)]]/g, "$1"));
+  });
+
+  it("does not treat a bracket pair spanning a line break as a link", () => {
+    const tree = parse("open [[\nclosed]]");
+    applyWikiLinks(tree, KNOWN);
+
+    expect(links(tree)).toHaveLength(0);
+  });
+
+  it("tolerates whitespace and a leading ./ in the target", () => {
+    const tree = parse("see [[ ./people/ada ]]");
+    applyWikiLinks(tree, KNOWN);
+
+    expect(links(tree)[0]?.url).toBe("/wiki/people/ada");
+  });
+
+  it("resolves a target written with its .md extension", () => {
+    const tree = parse("see [[people/ada.md]]");
+    applyWikiLinks(tree, KNOWN);
+
+    const [link] = links(tree);
+    expect(link?.url).toBe("/wiki/people/ada");
+    expect(link?.data?.hProperties?.className).toEqual([WIKI_LINK_CLASS]);
+  });
+});
+
+describe("collectWikiLinks", () => {
+  it("lists every target once, in first-seen order", () => {
+    expect(collectWikiLinks("[[b]] then [[a]] then [[b]]")).toEqual(["b", "a"]);
+  });
+
+  it("returns nothing for a document with no links", () => {
+    expect(collectWikiLinks("plain prose")).toEqual([]);
+  });
+});

--- a/src/lib/wiki/useWikiBridge.ts
+++ b/src/lib/wiki/useWikiBridge.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getWikiBridge, type WikiBridge } from "~/lib/localWiki";
+
+/**
+ * The local wiki bridge for this device, resolved after mount.
+ *
+ * Resolved in an effect rather than during render because the answer differs
+ * between the server (always null) and the Tauri shell, and branching on it
+ * during render would hydrate a mismatch. `ready` distinguishes "we have not
+ * looked yet" from "we looked and there is no wiki here" — the two want very
+ * different UI.
+ */
+export function useWikiBridge(): { bridge: WikiBridge | null; ready: boolean } {
+  const [bridge, setBridge] = useState<WikiBridge | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    setBridge(getWikiBridge());
+    setReady(true);
+  }, []);
+
+  return { bridge, ready };
+}
+
+/**
+ * Whether this device can host a local wiki at all — for surfaces that only
+ * need to know whether to offer it (the sidebar entry), not to talk to it.
+ */
+export function useLocalWikiAvailable(): boolean {
+  return useWikiBridge().bridge !== null;
+}
+
+/**
+ * Run `refresh` whenever the window regains focus.
+ *
+ * The librarian writes to the same files this UI is showing, from a chat in
+ * another part of the app, and the shell has no change notification yet. Focus
+ * is the cheap approximation: come back to the window and you see what the
+ * librarian filed.
+ */
+export function useRefreshOnFocus(refresh: () => void): void {
+  useEffect(() => {
+    const onFocus = () => refresh();
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [refresh]);
+}

--- a/src/lib/wiki/wikiLinks.ts
+++ b/src/lib/wiki/wikiLinks.ts
@@ -1,0 +1,202 @@
+/**
+ * The local wiki's `[[wikilink]]` syntax, and the mapping between a page's path
+ * on disk and its URL in the app.
+ *
+ * Wikilinks are how the wiki is navigated — by the librarian and, once there is
+ * a viewer, by a person. `src-tauri/seeds/schema.md` defines them: the link text
+ * is the page's path without the `.md`, so `[[people/ada]]` points at
+ * `people/ada.md`. A link to a page that does **not** exist yet is not a broken
+ * link; it marks something worth writing. So unresolved links render distinctly
+ * rather than being hidden or dropped, and clicking one offers to create it.
+ *
+ * The transform core (`applyWikiLinks`) is a pure mdast walk — no DOM, no React,
+ * no Tauri — so it is trivially unit-testable. `remarkWikiLinks` is the thin
+ * unified attacher the renderer uses. Doing this on the AST rather than by
+ * string replacement matters: `schema.md` documents the syntax *inside code
+ * spans*, and a naive replace would rewrite the documentation of the feature.
+ */
+import type { Plugin } from "unified";
+import type { Root } from "mdast";
+
+interface MdNode {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MdNode[];
+  data?: { hName?: string; hProperties?: Record<string, unknown> };
+}
+
+/** Every wiki URL lives under this prefix; it is not workspace-scoped. */
+export const WIKI_ROUTE = "/wiki";
+
+export const WIKI_LINK_CLASS = "wiki-link";
+/** Marks a link whose page does not exist yet — the wiki's "red link". */
+export const WIKI_LINK_MISSING_CLASS = "wiki-link--missing";
+
+/** `[[people/ada]]`, but never across a line break. */
+const WIKI_LINK_RE = /\[\[([^[\]\n]+)]]/g;
+
+/** `people/ada` → `people/ada.md`. Idempotent. */
+export function targetToPath(target: string): string {
+  const clean = normalizeTarget(target);
+  return clean.endsWith(".md") ? clean : `${clean}.md`;
+}
+
+/** `people/ada.md` → `people/ada`. Idempotent. */
+export function pathToTarget(path: string): string {
+  const clean = normalizeTarget(path);
+  return clean.endsWith(".md") ? clean.slice(0, -".md".length) : clean;
+}
+
+/** The app URL for a page, from either a target or a path. */
+export function wikiHref(targetOrPath: string): string {
+  const segments = pathToTarget(targetOrPath).split("/").filter(Boolean);
+  if (segments.length === 0) return WIKI_ROUTE;
+  return `${WIKI_ROUTE}/${segments.map(encodeURIComponent).join("/")}`;
+}
+
+/**
+ * The wiki path for a catch-all route's segments. Next has already decoded
+ * them, so this only re-joins and re-attaches the extension.
+ */
+export function segmentsToPath(segments: string[] | undefined): string | null {
+  if (!segments || segments.length === 0) return null;
+  const joined = segments.filter(Boolean).join("/");
+  return joined ? targetToPath(joined) : null;
+}
+
+/**
+ * What to call a page in a list: its first heading if it has one, else its
+ * filename. The heading is what the librarian actually writes (`schema.md` asks
+ * for one), and it reads better than a slug.
+ */
+export function pageTitle(path: string, content?: string): string {
+  // Fenced blocks first: a page that opens with a shell snippet would otherwise
+  // be titled by its first comment line.
+  const prose = content?.replace(/^```[\s\S]*?^```/gm, "");
+  const heading = prose ? /^#\s+(.+)$/m.exec(prose)?.[1]?.trim() : undefined;
+  if (heading) return heading;
+  const base = pathToTarget(path).split("/").pop() ?? path;
+  return base.replace(/[-_]/g, " ");
+}
+
+/** The folder a page sits in, or null for a page at the wiki root. */
+export function pageFolder(path: string): string | null {
+  const segments = path.split("/");
+  return segments.length > 1 ? segments.slice(0, -1).join("/") : null;
+}
+
+function normalizeTarget(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^\.\//, "")
+    .replace(/^\/+/, "");
+}
+
+/**
+ * Split one text value on its wikilinks, or null when it has none (so the
+ * caller can leave the node untouched rather than rebuild an identical one).
+ */
+function splitWikiLinks(value: string, known: ReadonlySet<string>): MdNode[] | null {
+  WIKI_LINK_RE.lastIndex = 0;
+  let match = WIKI_LINK_RE.exec(value);
+  if (!match) return null;
+
+  const out: MdNode[] = [];
+  let cursor = 0;
+
+  while (match) {
+    const [full, rawTarget] = match;
+    const target = normalizeTarget(rawTarget ?? "");
+
+    if (!target) {
+      // `[[]]` is not a link. Leave it as the literal text it is.
+      match = WIKI_LINK_RE.exec(value);
+      continue;
+    }
+
+    if (match.index > cursor) {
+      out.push({ type: "text", value: value.slice(cursor, match.index) });
+    }
+
+    const exists = known.has(targetToPath(target));
+    out.push({
+      type: "link",
+      url: wikiHref(target),
+      children: [{ type: "text", value: pathToTarget(target) }],
+      data: {
+        hProperties: {
+          className: exists
+            ? [WIKI_LINK_CLASS]
+            : [WIKI_LINK_CLASS, WIKI_LINK_MISSING_CLASS],
+        },
+      },
+    });
+
+    cursor = match.index + full.length;
+    match = WIKI_LINK_RE.exec(value);
+  }
+
+  if (out.length === 0) return null;
+  if (cursor < value.length) {
+    out.push({ type: "text", value: value.slice(cursor) });
+  }
+  return out;
+}
+
+/**
+ * Rewrite `[[wikilinks]]` into mdast link nodes, in place.
+ *
+ * `known` holds the page paths that exist (`people/ada.md`), so an unresolved
+ * link can be marked rather than silently rendered as if it led somewhere.
+ */
+export function applyWikiLinks(tree: MdNode, known: ReadonlySet<string>): void {
+  function walk(node: MdNode): void {
+    const children = node.children;
+    if (!children) return;
+
+    const out: MdNode[] = [];
+    let rewrote = false;
+
+    for (const child of children) {
+      if (child.type === "text" && typeof child.value === "string") {
+        const pieces = splitWikiLinks(child.value, known);
+        if (pieces) {
+          out.push(...pieces);
+          rewrote = true;
+          continue;
+        }
+      }
+      out.push(child);
+      // Never descend into a link: markdown has no nested links, and a
+      // wikilink inside one is text the author meant literally.
+      if (child.type !== "link") walk(child);
+    }
+
+    if (rewrote) node.children = out;
+  }
+
+  walk(tree);
+}
+
+/** All wikilink targets in a document, deduped, in first-seen order. */
+export function collectWikiLinks(markdown: string): string[] {
+  const found: string[] = [];
+  const seen = new Set<string>();
+  WIKI_LINK_RE.lastIndex = 0;
+  let match = WIKI_LINK_RE.exec(markdown);
+  while (match) {
+    const target = normalizeTarget(match[1] ?? "");
+    if (target && !seen.has(target)) {
+      seen.add(target);
+      found.push(target);
+    }
+    match = WIKI_LINK_RE.exec(markdown);
+  }
+  return found;
+}
+
+export const remarkWikiLinks: Plugin<[ReadonlySet<string>?], Root> =
+  (known = new Set<string>()) =>
+  (tree) =>
+    applyWikiLinks(tree as unknown as MdNode, known);

--- a/src/plugins/product/server/routers/__tests__/ticket.test.ts
+++ b/src/plugins/product/server/routers/__tests__/ticket.test.ts
@@ -107,6 +107,32 @@ function stubMembership(dbMock: DeepMockProxy<PrismaClient>, isMember: boolean) 
   );
 }
 
+/**
+ * Stub workspace membership *per user*: only `memberIds` belong to
+ * `workspaceId`.
+ *
+ * The plain `stubMembership` above answers the same way for everybody, which
+ * is fine while the caller is the only user being resolved. The assignee guard
+ * resolves a second user through the very same `workspaceUser.findUnique`, so
+ * these tests need a stub that can say "the caller is a member, the assignee
+ * is not" — otherwise the interesting case is unreachable.
+ */
+function stubMembershipByUser(
+  dbMock: DeepMockProxy<PrismaClient>,
+  memberIds: string[],
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dbMock.workspaceUser.findUnique.mockImplementation((args: any) => {
+    const userId = args?.where?.userId_workspaceId?.userId as string | undefined;
+    return Promise.resolve(
+      userId && memberIds.includes(userId)
+        ? { role: "member", workspaceId }
+        : null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) as any;
+  });
+}
+
 /** Stub the product lookup that `loadProductWithAccess` runs. */
 function stubProductLookup(dbMock: DeepMockProxy<PrismaClient>) {
   dbMock.product.findUnique.mockResolvedValue(
@@ -246,5 +272,157 @@ describe("ticket router — cross-workspace link guard (mocked)", () => {
       where: { id: "epic-1" },
       select: { workspaceId: true },
     });
+  });
+});
+
+/**
+ * `assigneeId` is the same class of hole as the epic/feature/cycle/scope links
+ * above, but it resolves to a `User` rather than to a workspace — and
+ * `ticket.getById` returns that user's `name` and `email`. Left unguarded, any
+ * authenticated user could assign an arbitrary CUID to a ticket in their own
+ * product and read a stranger's email straight back out.
+ */
+describe("ticket router — assignee containment guard (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+  const outsiderId = "user-outsider";
+
+  /** Stub the pre-update ticket load in `loadTicketWithAccess`. */
+  function stubTicketLoad(id = "ticket-1") {
+    dbMock.ticket.findUnique.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id, productId, status: "BACKLOG", product: { workspaceId } } as any,
+    );
+  }
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    stubProductLookup(dbMock);
+    // The caller belongs to the workspace; the outsider does not.
+    stubMembershipByUser(dbMock, [callerId]);
+  });
+
+  it("refuses to create a ticket assigned to a non-member", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.ticket.create({
+        productId,
+        title: "Harvest an email",
+        assigneeId: outsiderId,
+      }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Assignee not found in this workspace",
+    });
+
+    expect(dbMock.ticket.create).not.toHaveBeenCalled();
+  });
+
+  it("allows an assignee who belongs to the product's workspace", async () => {
+    stubMembershipByUser(dbMock, [callerId, "user-colleague"]);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    // As with the epic case, the create path continues into
+    // createTicketWithNumber (counter + transaction), which this mock DB does
+    // not model — reaching past the guard is the assertion.
+    await caller.product.ticket
+      .create({ productId, title: "Own colleague", assigneeId: "user-colleague" })
+      .catch((err: unknown) => {
+        expect(err).not.toMatchObject({
+          message: "Assignee not found in this workspace",
+        });
+      });
+  });
+
+  it("admits a team-based member, matching who can read the ticket", async () => {
+    // Not a direct WorkspaceUser, but reachable via a team linked to the
+    // workspace — the second path in getWorkspaceMembership, and the same one
+    // that lets this user read the ticket at all.
+    dbMock.teamUser.findFirst.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { role: "member", team: { workspaceId } } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.product.ticket
+      .create({ productId, title: "Team member", assigneeId: "user-team" })
+      .catch((err: unknown) => {
+        expect(err).not.toMatchObject({
+          message: "Assignee not found in this workspace",
+        });
+      });
+  });
+
+  it("refuses to update a ticket onto a non-member assignee", async () => {
+    stubTicketLoad();
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.ticket.update({ id: "ticket-1", assigneeId: outsiderId }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Assignee not found in this workspace",
+    });
+
+    expect(dbMock.ticket.update).not.toHaveBeenCalled();
+  });
+
+  it("still allows clearing the assignee (null is not a lookup)", async () => {
+    stubTicketLoad();
+    dbMock.ticket.update.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "ticket-1", assigneeId: null } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.product.ticket.update({ id: "ticket-1", assigneeId: null });
+
+    expect(dbMock.ticket.update).toHaveBeenCalled();
+  });
+
+  it("refuses a bulkUpdate that assigns a non-member", async () => {
+    dbMock.ticket.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "ticket-1", status: "BACKLOG", product: { workspaceId } } as any,
+    ]);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.ticket.bulkUpdate({
+        ids: ["ticket-1"],
+        assigneeId: outsiderId,
+      }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Assignee not found in this workspace",
+    });
+
+    expect(dbMock.ticket.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("refuses a bulkUpdate linking an epic from another workspace", async () => {
+    // bulkUpdate writes epicId/cycleId too, and was never covered by the
+    // cross-workspace link guard the create/update paths got.
+    dbMock.ticket.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "ticket-1", status: "BACKLOG", product: { workspaceId } } as any,
+    ]);
+    dbMock.epic.findUnique.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { workspaceId: "ws-other" } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.ticket.bulkUpdate({
+        ids: ["ticket-1"],
+        epicId: "epic-foreign",
+      }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Epic not found in this workspace",
+    });
+
+    expect(dbMock.ticket.updateMany).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/product/server/routers/__tests__/ticket.test.ts
+++ b/src/plugins/product/server/routers/__tests__/ticket.test.ts
@@ -192,3 +192,59 @@ describe("ticket router — list Area filter (mocked)", () => {
     expect(findManyWhere(dbMock)).toMatchObject({ tags: { some: { tagId: areaTagId } } });
   });
 });
+
+describe("ticket router — cross-workspace link guard (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    stubProductLookup(dbMock);
+    stubMembership(dbMock, true);
+  });
+
+  it("refuses to create a ticket linked to an epic in another workspace", async () => {
+    dbMock.epic.findUnique.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { workspaceId: "ws-other" } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.ticket.create({
+        productId,
+        title: "Borrowed epic",
+        epicId: "epic-foreign",
+      }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Epic not found in this workspace",
+    });
+
+    expect(dbMock.ticket.create).not.toHaveBeenCalled();
+  });
+
+  it("allows an epic from the product's own workspace", async () => {
+    dbMock.epic.findUnique.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { workspaceId } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    // The create path continues into createTicketWithNumber (counter +
+    // transaction), which this mock DB does not model — reaching past the
+    // guard is the assertion, so any later failure is not a guard rejection.
+    await caller.product.ticket
+      .create({ productId, title: "Own epic", epicId: "epic-1" })
+      .catch((err: unknown) => {
+        expect(err).not.toMatchObject({
+          message: "Epic not found in this workspace",
+        });
+      });
+
+    expect(dbMock.epic.findUnique).toHaveBeenCalledWith({
+      where: { id: "epic-1" },
+      select: { workspaceId: true },
+    });
+  });
+});

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { loadProductWithAccess, assertWorkspaceMember } from "./product";
+import { assertWorkspaceScopedRefs } from "~/server/services/access";
 import type { PrismaClient } from "@prisma/client";
 import { recordActivity } from "~/server/services/activity/recordActivity";
 import { createTicketWithNumber } from "../services/createTicket";
@@ -345,6 +346,15 @@ export const ticketRouter = createTRPCRouter({
         input.productId,
       );
 
+      // A linked epic/feature/cycle/scope must live in the product's own
+      // workspace, or its fields leak back through this ticket's includes.
+      await assertWorkspaceScopedRefs(ctx.db, ctx.session.user.id, product.workspaceId, {
+        epicId: input.epicId,
+        featureId: input.featureId,
+        cycleId: input.cycleId,
+        scopeId: input.scopeId,
+      });
+
       // If templateId provided, load its body as the starting body (unless body already given)
       let body = input.body;
       if (!body && input.templateId) {
@@ -419,6 +429,20 @@ export const ticketRouter = createTRPCRouter({
         ctx.db,
         ctx.session.user.id,
         input.id,
+      );
+
+      // Same-workspace guard as create — `rest` is spread straight into the
+      // update, so a foreign epic/feature/cycle/scope id would otherwise stick.
+      await assertWorkspaceScopedRefs(
+        ctx.db,
+        ctx.session.user.id,
+        previousTicket.product.workspaceId,
+        {
+          epicId: input.epicId,
+          featureId: input.featureId,
+          cycleId: input.cycleId,
+          scopeId: input.scopeId,
+        },
       );
 
       const { id, ...rest } = input;

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -2,7 +2,10 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { loadProductWithAccess, assertWorkspaceMember } from "./product";
-import { assertWorkspaceScopedRefs } from "~/server/services/access";
+import {
+  assertWorkspaceScopedRefs,
+  assertAssignableUser,
+} from "~/server/services/access";
 import type { PrismaClient } from "@prisma/client";
 import { recordActivity } from "~/server/services/activity/recordActivity";
 import { createTicketWithNumber } from "../services/createTicket";
@@ -355,6 +358,15 @@ export const ticketRouter = createTRPCRouter({
         scopeId: input.scopeId,
       });
 
+      // Same reasoning for the assignee, whose name and email come back through
+      // `getById`'s include: only someone who could already read this ticket
+      // may be assigned it.
+      await assertAssignableUser(
+        ctx.db,
+        product.workspaceId,
+        input.assigneeId,
+      );
+
       // If templateId provided, load its body as the starting body (unless body already given)
       let body = input.body;
       if (!body && input.templateId) {
@@ -443,6 +455,12 @@ export const ticketRouter = createTRPCRouter({
           cycleId: input.cycleId,
           scopeId: input.scopeId,
         },
+      );
+
+      await assertAssignableUser(
+        ctx.db,
+        previousTicket.product.workspaceId,
+        input.assigneeId,
       );
 
       const { id, ...rest } = input;
@@ -575,6 +593,18 @@ export const ticketRouter = createTRPCRouter({
       );
       for (const workspaceId of workspaceIds) {
         await assertWorkspaceMember(ctx.db, ctx.session.user.id, workspaceId);
+
+        // The same link and assignee guards as `create`/`update` — this path
+        // writes the identical foreign keys and its tickets are read back
+        // through the identical includes. The patch applies uniformly, so a
+        // reference must be valid in *every* workspace the selection spans.
+        await assertWorkspaceScopedRefs(
+          ctx.db,
+          ctx.session.user.id,
+          workspaceId,
+          { epicId: input.epicId, cycleId: input.cycleId },
+        );
+        await assertAssignableUser(ctx.db, workspaceId, input.assigneeId);
       }
 
       const data: Record<string, unknown> = Object.fromEntries(fields);

--- a/src/providers/AgentModalProvider.tsx
+++ b/src/providers/AgentModalProvider.tsx
@@ -59,6 +59,17 @@ export interface ChatMessage {
     kind: 'transport' | 'idle-timeout' | 'auth' | 'model' | 'unknown';
     canRetry: boolean;
     retryText?: string;
+    /**
+     * What actually went wrong, in the words of whatever threw — shown beneath
+     * the calm copy above.
+     *
+     * Added because the copy alone is a dead end when the cause is real and
+     * specific: a provider that says "your credit balance is too low" rendered
+     * as "Something went wrong handling that request" leaves the user (and
+     * anyone they report it to) with nothing to act on. Undefined when there is
+     * nothing to add beyond the copy.
+     */
+    detail?: string;
   };
 }
 

--- a/src/providers/WorkspaceProvider.tsx
+++ b/src/providers/WorkspaceProvider.tsx
@@ -36,6 +36,9 @@ interface Workspace {
   logoUrl: string | null;
   type: string;
   homeLayout: HomeLayout;
+  // null = follow the workspace type (team/org on, personal off). See the
+  // column comment in schema.prisma and the resolution in useTerminology.
+  enableKeyResults: boolean | null;
   members?: WorkspaceMember[];
 }
 

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -3,6 +3,7 @@ import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 import { actionRouter } from "./routers/action";
 import { adminRouter } from "./routers/admin";
 import { projectRouter } from "./routers/project";
+import { searchRouter } from "./routers/search";
 import { toolRouter } from "./routers/tool";
 import { videoRouter } from "~/server/api/routers/video";
 import { goalRouter } from "./routers/goal";
@@ -95,6 +96,7 @@ import { pageCommentRouter } from "./routers/pageComment";
 export const appRouter = createTRPCRouter({
   post: postRouter,
   project: projectRouter,
+  search: searchRouter,
   action: actionRouter,
   admin: adminRouter,
   tools: toolRouter,

--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -634,6 +634,16 @@ describe("action router (mocked)", () => {
         { userId: callerId, workspaceId: wsId, role: "member" } as any,
       );
 
+      // `create` authorises a caller-supplied workspaceId before writing, so
+      // the caller needs a writing role to reach the instrumentation at all.
+      dbMock.workspaceUser.findUnique.mockResolvedValue({
+        userId: callerId,
+        workspaceId: wsId,
+        role: "member",
+        joinedAt: new Date(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
       const caller = createMockCaller({ userId: callerId, db: dbMock });
 
       await expect(
@@ -884,6 +894,250 @@ describe("action router (mocked)", () => {
       await caller.action.assign({ actionId, userIds: [callerId] });
 
       expect(dbMock.actionAssignee.createMany).toHaveBeenCalled();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // create / update — workspace write authorisation
+  //
+  // `workspaceId` is free-form input on both mutations. Before this suite
+  // existed, `create` only checked access inside `if (input.projectId)`, so
+  // a caller supplying `workspaceId` alone wrote straight through to
+  // `db.action.create` with no membership check at all.
+  // ────────────────────────────────────────────────────────────────────
+  describe("workspace write authorisation", () => {
+    const callerId = "caller-1";
+
+    /** Caller reaches the workspace by no path at all. */
+    function stubNoMembership() {
+      dbMock.workspaceUser.findUnique.mockResolvedValue(null);
+      dbMock.teamUser.findFirst.mockResolvedValue(null);
+    }
+
+    /** Caller holds `role` via a direct WorkspaceUser row. */
+    function stubWorkspaceRole(workspaceId: string, role: string) {
+      dbMock.workspaceUser.findUnique.mockResolvedValue({
+        userId: callerId,
+        workspaceId,
+        role,
+        joinedAt: new Date(),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.teamUser.findFirst.mockResolvedValue(null);
+    }
+
+    describe("create", () => {
+      it("refuses a workspaceId the caller has no membership in", async () => {
+        stubNoMembership();
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+        await expect(
+          caller.action.create({ name: "Injected", workspaceId: "w-foreign" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        // The whole point: no row lands in the foreign workspace.
+        expect(dbMock.action.create).not.toHaveBeenCalled();
+      });
+
+      it("refuses a workspace the caller is only a viewer of", async () => {
+        // Membership alone is not authority to write — `viewer` is read-only.
+        stubWorkspaceRole("w1", "viewer");
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+        await expect(
+          caller.action.create({ name: "Read-only", workspaceId: "w1" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        expect(dbMock.action.create).not.toHaveBeenCalled();
+      });
+
+      it("lets a workspace member create, persisting the workspaceId", async () => {
+        stubWorkspaceRole("w1", "member");
+        dbMock.action.create.mockResolvedValue({
+          id: "a1",
+          name: "Mine",
+          workspaceId: "w1",
+          project: null,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+        await caller.action.create({ name: "Mine", workspaceId: "w1" });
+
+        const data = dbMock.action.create.mock.calls[0]![0]!.data;
+        expect(data).toMatchObject({ workspaceId: "w1", createdById: callerId });
+      });
+
+      it("takes the workspace from the project, ignoring a foreign workspaceId", async () => {
+        // Caller genuinely owns the project (isCreator ⇒ canEditProject), but
+        // names someone else's workspace. The project must win, or project
+        // edit rights become a laundering route into any workspace.
+        dbMock.project.findUnique.mockResolvedValue({
+          createdById: callerId,
+          teamId: null,
+          workspaceId: "w-legit",
+          isPublic: false,
+          isRestricted: false,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        dbMock.projectMember.findFirst.mockResolvedValue(null);
+        dbMock.action.findFirst.mockResolvedValue(null);
+        stubNoMembership();
+        dbMock.action.create.mockResolvedValue({
+          id: "a1",
+          name: "Scoped",
+          workspaceId: "w-legit",
+          project: null,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+        await caller.action.create({
+          name: "Scoped",
+          projectId: "p1",
+          workspaceId: "w-foreign",
+        });
+
+        const data = dbMock.action.create.mock.calls[0]![0]!.data;
+        expect(data).toMatchObject({ workspaceId: "w-legit" });
+      });
+    });
+
+    describe("update", () => {
+      /** Caller is the action's creator, so `canEditAction` passes. */
+      function stubOwnedAction() {
+        dbMock.action.findUnique.mockResolvedValue({
+          createdById: callerId,
+          projectId: null,
+          assignees: [],
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+      }
+
+      it("refuses moving an action into a workspace the caller isn't in", async () => {
+        // Editing the action where it lives ≠ permission to relocate it.
+        stubOwnedAction();
+        stubNoMembership();
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+        await expect(
+          caller.action.update({ id: "a1", workspaceId: "w-foreign" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        expect(dbMock.action.update).not.toHaveBeenCalled();
+      });
+
+      it("refuses moving an action into a project the caller can't edit", async () => {
+        stubOwnedAction();
+        dbMock.project.findUnique.mockResolvedValue({
+          createdById: "someone-else",
+          teamId: null,
+          workspaceId: "w-foreign",
+          isPublic: false,
+          isRestricted: false,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        dbMock.projectMember.findFirst.mockResolvedValue(null);
+        stubNoMembership();
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+        await expect(
+          caller.action.update({ id: "a1", projectId: "p-foreign" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        expect(dbMock.action.update).not.toHaveBeenCalled();
+      });
+
+      it("refuses moving an action into a project the caller can't edit (epic guard unreached)", async () => {
+        // Regression guard for ordering: the project check must fire before
+        // anything downstream consumes the re-targeted workspace.
+        stubOwnedAction();
+        dbMock.project.findUnique.mockResolvedValue({
+          createdById: "someone-else",
+          teamId: null,
+          workspaceId: "w-foreign",
+          isPublic: false,
+          isRestricted: false,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        dbMock.projectMember.findFirst.mockResolvedValue(null);
+        stubNoMembership();
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+        await expect(
+          caller.action.update({
+            id: "a1",
+            projectId: "p-foreign",
+            epicId: "e-foreign",
+          }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        expect(dbMock.action.update).not.toHaveBeenCalled();
+      });
+
+      it("allows clearing the workspace without a membership probe", async () => {
+        // Detaching an action the caller can already edit grants no access.
+        stubOwnedAction();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        dbMock.action.update.mockResolvedValue({ id: "a1", workspaceId: null } as any);
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+        await caller.action.update({ id: "a1", workspaceId: null });
+
+        expect(dbMock.action.update).toHaveBeenCalled();
+        expect(dbMock.workspaceUser.findUnique).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("ensureDailyPlanPromptAction", () => {
+      it("refuses a workspaceId the caller has no membership in", async () => {
+        // Called on every app load, and writes a row into whatever workspace
+        // it is handed — same hole as `create`, same guard.
+        stubNoMembership();
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+        await expect(
+          caller.action.ensureDailyPlanPromptAction({ workspaceId: "w-foreign" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+        expect(dbMock.action.create).not.toHaveBeenCalled();
+        // Refused before even probing for an existing prompt action.
+        expect(dbMock.action.findFirst).not.toHaveBeenCalled();
+      });
+
+      it("lets a workspace member through", async () => {
+        stubWorkspaceRole("w1", "member");
+        dbMock.action.findFirst.mockResolvedValue(null);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        dbMock.action.create.mockResolvedValue({ id: "a1" } as any);
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+        const result = await caller.action.ensureDailyPlanPromptAction({
+          workspaceId: "w1",
+        });
+
+        expect(result).toMatchObject({ created: true, actionId: "a1" });
+        const data = dbMock.action.create.mock.calls[0]![0]!.data;
+        expect(data).toMatchObject({ workspaceId: "w1" });
+      });
+
+      it("needs no membership probe when no workspaceId is given", async () => {
+        dbMock.action.findFirst.mockResolvedValue(null);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        dbMock.action.create.mockResolvedValue({ id: "a1" } as any);
+
+        const caller = createMockCaller({ userId: callerId, db: dbMock });
+        await caller.action.ensureDailyPlanPromptAction({});
+
+        expect(dbMock.workspaceUser.findUnique).not.toHaveBeenCalled();
+        expect(dbMock.action.create).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -626,6 +626,13 @@ describe("action router (mocked)", () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
       dbMock.action.create.mockResolvedValue(created);
+      // `create` now verifies membership before writing into an explicit
+      // workspace, so this fixture has to make the caller a member — the
+      // subject under test here is the instrumentation catch, not access.
+      dbMock.workspaceUser.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { userId: callerId, workspaceId: wsId, role: "member" } as any,
+      );
 
       const caller = createMockCaller({ userId: callerId, db: dbMock });
 
@@ -723,6 +730,160 @@ describe("action router (mocked)", () => {
       const where = dbMock.action.findMany.mock.calls[0]![0]!.where!;
       expect(where).toMatchObject({ createdById: callerId });
       expect(where).not.toHaveProperty("OR");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // create — workspace containment
+  // ────────────────────────────────────────────────────────────────────
+  describe("create workspace containment", () => {
+    const callerId = "caller-1";
+    const workspaceId = "w1";
+
+    /** Only `memberIds` belong to `workspaceId`. */
+    function stubMembers(memberIds: string[]) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dbMock.workspaceUser.findUnique.mockImplementation((args: any) => {
+        const userId = args?.where?.userId_workspaceId?.userId as
+          | string
+          | undefined;
+        return Promise.resolve(
+          userId && memberIds.includes(userId)
+            ? { userId, workspaceId, role: "member", joinedAt: new Date() }
+            : null,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ) as any;
+      });
+      dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+    }
+
+    it("refuses to plant an action in a workspace the caller is not in", async () => {
+      // No projectId, so nothing else in `create` ever looks at workspaceId —
+      // it was spread straight into the row, and the `created` activity event
+      // fired into that workspace's feed.
+      stubMembers([]);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await expect(
+        caller.action.create({ name: "Trespass", workspaceId }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      expect(dbMock.action.create).not.toHaveBeenCalled();
+    });
+
+    it("allows a member to create an action in their own workspace", async () => {
+      stubMembers([callerId]);
+      dbMock.action.create.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: "a1", name: "Mine", workspaceId, project: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.create({ name: "Mine", workspaceId });
+
+      expect(dbMock.action.create).toHaveBeenCalled();
+    });
+
+    it("needs no membership probe when no workspaceId is supplied", async () => {
+      dbMock.action.create.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: "a1", name: "Personal", workspaceId: null, project: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.create({ name: "Personal" });
+
+      expect(dbMock.workspaceUser.findUnique).not.toHaveBeenCalled();
+      expect(dbMock.action.create).toHaveBeenCalled();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // assign — assignee containment on project-less, team-less actions
+  // ────────────────────────────────────────────────────────────────────
+  describe("assign assignee containment", () => {
+    const callerId = "caller-1";
+    const workspaceId = "w1";
+    const outsiderId = "user-outsider";
+    const actionId = "a1";
+
+    /** An action with neither project nor team — the branch that used to
+     *  allow assigning literally any user id. */
+    function stubUnscopedAction(opts?: { workspaceId?: string | null }) {
+      dbMock.action.findUnique.mockResolvedValue({
+        id: actionId,
+        name: "Loose end",
+        projectId: null,
+        project: null,
+        teamId: null,
+        team: null,
+        workspaceId: opts?.workspaceId ?? null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      // Caller passes buildActionAccessWhere (they created it).
+      dbMock.action.findFirst.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: actionId } as any,
+      );
+    }
+
+    it("refuses an arbitrary user id, which used to leak their email back", async () => {
+      stubUnscopedAction();
+      dbMock.workspaceUser.findUnique.mockResolvedValue(null as never);
+      dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+      dbMock.team.findFirst.mockResolvedValue(null as never);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await expect(
+        caller.action.assign({ actionId, userIds: [outsiderId] }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+      expect(dbMock.actionAssignee.createMany).not.toHaveBeenCalled();
+    });
+
+    it("does not name the rejected user in the error", async () => {
+      stubUnscopedAction();
+      dbMock.workspaceUser.findUnique.mockResolvedValue(null as never);
+      dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+      dbMock.team.findFirst.mockResolvedValue(null as never);
+      // If the router still looked the user up to build the message, this
+      // identity would end up in the error string.
+      dbMock.user.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { name: "Ada Lovelace", email: "ada@example.com" } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const err = await caller.action
+        .assign({ actionId, userIds: [outsiderId] })
+        .catch((e: unknown) => e);
+
+      expect(String((err as Error).message)).not.toContain("ada@example.com");
+      expect(String((err as Error).message)).not.toContain("Ada Lovelace");
+    });
+
+    it("still allows a member of the action's workspace", async () => {
+      stubUnscopedAction({ workspaceId });
+      dbMock.workspaceUser.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { role: "member", workspaceId } as any,
+      );
+      dbMock.actionAssignee.findMany.mockResolvedValue([]);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.assign({ actionId, userIds: ["user-colleague"] });
+
+      expect(dbMock.actionAssignee.createMany).toHaveBeenCalled();
+    });
+
+    it("still allows self-assignment on a context-less action", async () => {
+      stubUnscopedAction();
+      dbMock.actionAssignee.findMany.mockResolvedValue([]);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.assign({ actionId, userIds: [callerId] });
+
+      expect(dbMock.actionAssignee.createMany).toHaveBeenCalled();
     });
   });
 });

--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -744,6 +744,302 @@ describe("action router (mocked)", () => {
   });
 
   // ────────────────────────────────────────────────────────────────────
+  // getAssignableUsersForContext
+  //
+  // Read-side counterpart to the workspaceId write guards: the procedure
+  // returns id/name/email/image for every member of `effectiveWorkspaceId`.
+  // A caller-supplied `workspaceId` therefore has to be membership-checked,
+  // or any logged-in user could hand over a workspace CUID and harvest the
+  // full roster. A workspace derived from an authorised project must NOT be
+  // re-checked — workspace guests have no WorkspaceUser row.
+  // ────────────────────────────────────────────────────────────────────
+  describe("getAssignableUsersForContext", () => {
+    const callerId = "caller-1";
+    const workspaceId = "w1";
+
+    /** getWorkspaceMembership probes workspaceUser.findUnique first, then
+     *  falls back to teamUser.findFirst. Stub both to control membership. */
+    function stubMembership(isMember: boolean) {
+      dbMock.workspaceUser.findUnique.mockResolvedValue(
+        isMember
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ? ({ userId: callerId, workspaceId, role: "member", joinedAt: new Date() } as any)
+          : null,
+      );
+      dbMock.teamUser.findFirst.mockResolvedValue(null);
+    }
+
+    it("rejects a non-member who supplies a bare workspaceId", async () => {
+      stubMembership(false);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      await expect(
+        caller.action.getAssignableUsersForContext({ workspaceId }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      // The roster must never be read for a non-member.
+      expect(dbMock.workspaceUser.findMany).not.toHaveBeenCalled();
+    });
+
+    it("returns the roster to a workspace member", async () => {
+      stubMembership(true);
+      dbMock.team.findMany.mockResolvedValue([]);
+      dbMock.workspaceUser.findMany.mockResolvedValue([
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { user: { id: "u2", name: "Colleague", email: "u2@test.com", image: null } } as any,
+      ]);
+      dbMock.user.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: callerId, name: "Me", email: "caller-1@test.com", image: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.action.getAssignableUsersForContext({ workspaceId });
+
+      expect(dbMock.workspaceUser.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ workspaceId }) }),
+      );
+      expect(result.assignableUsers.map((u) => u.id).sort()).toEqual([callerId, "u2"]);
+    });
+
+    it("skips the membership probe when the workspace comes from an authorised project", async () => {
+      // A workspace guest: ProjectMember on p1, but no WorkspaceUser row and
+      // no team access. Project access alone must carry them through.
+      stubMembership(false);
+      dbMock.project.findUnique.mockResolvedValue({
+        id: "p1",
+        name: "Guest project",
+        workspaceId,
+        isRestricted: false,
+        isPublic: false,
+        createdById: "someone-else",
+        teamId: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dbMock.projectMember.findFirst.mockResolvedValue({ role: "editor" } as any);
+      dbMock.team.findMany.mockResolvedValue([]);
+      dbMock.workspaceUser.findMany.mockResolvedValue([]);
+      dbMock.projectMember.findMany.mockResolvedValue([]);
+      dbMock.user.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: callerId, name: "Me", email: "caller-1@test.com", image: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.action.getAssignableUsersForContext({
+        projectId: "p1",
+        // Deliberately also passed: the project's workspace wins, and the
+        // guest is not rejected for failing a membership probe on it.
+        workspaceId,
+      });
+
+      expect(result.actionContext.hasProject).toBe(true);
+      expect(dbMock.workspaceUser.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ workspaceId }) }),
+      );
+    });
+
+    it("withholds the workspace roster on a merely-public project", async () => {
+      // `hasProjectAccess` is true for ANY authenticated caller when the
+      // project is public, so the project must not be allowed to vouch for the
+      // workspace — otherwise a public project id is just a second door to the
+      // same roster this guard exists to close.
+      stubMembership(false);
+      dbMock.project.findUnique.mockResolvedValue({
+        id: "p1",
+        name: "Public project",
+        workspaceId,
+        isRestricted: false,
+        isPublic: true,
+        createdById: "someone-else",
+        teamId: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.projectMember.findFirst.mockResolvedValue(null);
+      dbMock.team.findMany.mockResolvedValue([]);
+      dbMock.projectMember.findMany.mockResolvedValue([]);
+      dbMock.user.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: callerId, name: "Me", email: "caller-1@test.com", image: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.action.getAssignableUsersForContext({
+        projectId: "p1",
+      });
+
+      expect(dbMock.workspaceUser.findMany).not.toHaveBeenCalled();
+      expect(result.assignableUsers.map((u) => u.id)).toEqual([callerId]);
+    });
+
+    it("still rejects a bare workspaceId even when a public project is passed", async () => {
+      // The public project can't vouch for the workspace, so the explicit
+      // membership check takes over — and the caller is not a member.
+      stubMembership(false);
+      dbMock.project.findUnique.mockResolvedValue({
+        id: "p1",
+        name: "Public project",
+        workspaceId: null,
+        isRestricted: false,
+        isPublic: true,
+        createdById: "someone-else",
+        teamId: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.projectMember.findFirst.mockResolvedValue(null);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      await expect(
+        caller.action.getAssignableUsersForContext({ projectId: "p1", workspaceId }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+      expect(dbMock.workspaceUser.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // getAssignableUsers
+  //
+  // Same disclosure, reached via actionId: the procedure used to check only
+  // that the action existed, then returned the whole workspace + project
+  // roster to any authenticated caller.
+  // ────────────────────────────────────────────────────────────────────
+  describe("getAssignableUsers", () => {
+    const callerId = "caller-1";
+
+    it("rejects a caller with no access to the action", async () => {
+      // Someone else's project-less action: not creator, not assignee, no
+      // project to inherit access from.
+      dbMock.action.findUnique.mockResolvedValue({
+        id: "a1",
+        createdById: "someone-else",
+        projectId: null,
+        assignees: [],
+        project: null,
+        team: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      await expect(
+        caller.action.getAssignableUsers({ actionId: "a1" }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+      expect(dbMock.workspaceUser.findMany).not.toHaveBeenCalled();
+      expect(dbMock.projectMember.findMany).not.toHaveBeenCalled();
+    });
+
+    it("reports a missing action the same way as a forbidden one", async () => {
+      // The two must be indistinguishable, or the error code confirms which
+      // action CUIDs exist.
+      dbMock.action.findUnique.mockResolvedValue(null);
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+
+      await expect(
+        caller.action.getAssignableUsers({ actionId: "does-not-exist" }),
+      ).rejects.toMatchObject({
+        code: "NOT_FOUND",
+        message: "Action not found or access denied",
+      });
+    });
+
+    it("returns the roster to the action's creator", async () => {
+      dbMock.action.findUnique.mockResolvedValue({
+        id: "a1",
+        createdById: callerId,
+        projectId: "p1",
+        assignees: [],
+        project: {
+          id: "p1",
+          name: "Proj",
+          workspaceId: "w1",
+          isRestricted: false,
+          createdById: callerId,
+        },
+        team: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      // getProjectAccess's own probe: caller created the project, so they are
+      // an insider and inherit the workspace roster.
+      dbMock.project.findUnique.mockResolvedValue({
+        createdById: callerId,
+        teamId: null,
+        workspaceId: "w1",
+        isPublic: false,
+        isRestricted: false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.projectMember.findFirst.mockResolvedValue(null);
+      dbMock.team.findMany.mockResolvedValue([]);
+      dbMock.workspaceUser.findMany.mockResolvedValue([
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { user: { id: "u2", name: "Colleague", email: "u2@test.com", image: null } } as any,
+      ]);
+      dbMock.projectMember.findMany.mockResolvedValue([]);
+      dbMock.user.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: callerId, name: "Me", email: "caller-1@test.com", image: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.action.getAssignableUsers({ actionId: "a1" });
+
+      expect(result.assignableUsers.map((u) => u.id).sort()).toEqual([callerId, "u2"]);
+    });
+
+    it("withholds the workspace roster on a merely-public project", async () => {
+      // A stranger holding a bounty action id from the unauthenticated
+      // /api/bounties feed passes canViewAction via `isPublic`. They must not
+      // inherit the workspace's member list (names + emails) with it.
+      dbMock.action.findUnique.mockResolvedValue({
+        id: "a1",
+        createdById: "someone-else",
+        projectId: "p1",
+        assignees: [],
+        project: {
+          id: "p1",
+          name: "Public bounty project",
+          workspaceId: "w1",
+          isRestricted: false,
+          createdById: "someone-else",
+        },
+        team: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.project.findUnique.mockResolvedValue({
+        createdById: "someone-else",
+        teamId: null,
+        workspaceId: "w1",
+        isPublic: true,
+        isRestricted: false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      // Not a project member, not a workspace member, not in any team.
+      dbMock.projectMember.findFirst.mockResolvedValue(null);
+      dbMock.workspaceUser.findUnique.mockResolvedValue(null);
+      dbMock.teamUser.findFirst.mockResolvedValue(null);
+      dbMock.team.findMany.mockResolvedValue([]);
+      dbMock.projectMember.findMany.mockResolvedValue([]);
+      dbMock.user.findUnique.mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: callerId, name: "Me", email: "caller-1@test.com", image: null } as any,
+      );
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      const result = await caller.action.getAssignableUsers({ actionId: "a1" });
+
+      // The roster query must never run, and the caller sees only themselves.
+      expect(dbMock.workspaceUser.findMany).not.toHaveBeenCalled();
+      expect(result.assignableUsers.map((u) => u.id)).toEqual([callerId]);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────
   // create — workspace containment
   // ────────────────────────────────────────────────────────────────────
   describe("create workspace containment", () => {

--- a/src/server/api/routers/__tests__/epic.test.ts
+++ b/src/server/api/routers/__tests__/epic.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for the `epic` router's access gating.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety"). Covers the 2026-08-04 audit fixes:
+ * `getById` must require workspace membership (it previously returned any epic
+ * to any authenticated user), and the gate must be the centralized
+ * `getWorkspaceMembership` resolver so team-based workspace members are
+ * admitted, matching the ticket/feature/product routers.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const WORKSPACE_ID = "ws-1";
+const USER_ID = "user-1";
+const EPIC = { id: "epic-1", name: "Payments", workspaceId: WORKSPACE_ID };
+
+type MembershipKind = "direct" | "team" | "none";
+
+// getWorkspaceMembership → direct WorkspaceUser lookup, then team fallback
+function mockMembership(dbMock: DeepMockProxy<PrismaClient>, kind: MembershipKind) {
+  dbMock.workspaceUser.findUnique.mockResolvedValue(
+    kind === "direct"
+      ? ({ role: "member", workspaceId: WORKSPACE_ID } as never)
+      : null,
+  );
+  dbMock.teamUser.findFirst.mockResolvedValue(
+    kind === "team"
+      ? ({ role: "member", team: { workspaceId: WORKSPACE_ID } } as never)
+      : null,
+  );
+}
+
+describe("epic router access gating (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  describe("getById", () => {
+    it("denies a non-member even when the epic exists (the audit gap)", async () => {
+      mockMembership(dbMock, "none");
+      dbMock.epic.findUnique.mockResolvedValue(EPIC as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(caller.epic.getById({ id: EPIC.id })).rejects.toMatchObject({
+        code: "FORBIDDEN",
+      });
+    });
+
+    it("admits a team-based workspace member", async () => {
+      mockMembership(dbMock, "team");
+      dbMock.epic.findUnique.mockResolvedValue(EPIC as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(caller.epic.getById({ id: EPIC.id })).resolves.toMatchObject({
+        id: EPIC.id,
+      });
+    });
+
+    it("still 404s on a missing epic before any membership check", async () => {
+      dbMock.epic.findUnique.mockResolvedValue(null as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(caller.epic.getById({ id: "nope" })).rejects.toMatchObject({
+        code: "NOT_FOUND",
+      });
+      expect(dbMock.workspaceUser.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("list", () => {
+    it("admits a team-based workspace member (previously direct-only)", async () => {
+      mockMembership(dbMock, "team");
+      dbMock.epic.findMany.mockResolvedValue([EPIC] as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.epic.list({ workspaceId: WORKSPACE_ID }),
+      ).resolves.toMatchObject([{ id: EPIC.id }]);
+    });
+
+    it("denies a non-member", async () => {
+      mockMembership(dbMock, "none");
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.epic.list({ workspaceId: WORKSPACE_ID }),
+      ).rejects.toBeInstanceOf(TRPCError);
+      expect(dbMock.epic.findMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/api/routers/__tests__/externalAgentGrant.test.ts
+++ b/src/server/api/routers/__tests__/externalAgentGrant.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for the grant-time half of the ADR-0049 delegation invariant:
+ * `externalAgent.grantWorkspaces`.
+ *
+ * The revoke-time half (cascades on owner removal/demotion) is covered by
+ * `src/server/services/__tests__/externalAgentAccess.test.ts`. This file covers
+ * the other direction — an owner can never delegate access they don't hold, and
+ * an agent never lands above `member`.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const OWNER_ID = "owner-1";
+const AGENT_ID = "agent-1";
+const SHADOW_ID = "shadow-1";
+
+function caller(db: DeepMockProxy<PrismaClient>) {
+  return createMockCaller({ userId: OWNER_ID, db: db as unknown as PrismaClient });
+}
+
+/** The owner is a human (humanOnlyProcedure) and owns the agent. */
+function arrangeOwner(db: DeepMockProxy<PrismaClient>) {
+  db.user.findUnique.mockResolvedValue({ isAgent: false } as never);
+  db.externalAgent.findFirst.mockResolvedValue({
+    id: AGENT_ID,
+    ownerId: OWNER_ID,
+    shadowUserId: SHADOW_ID,
+  } as never);
+  db.$transaction.mockResolvedValue([] as never);
+}
+
+/** Owner memberships as `workspaceUser.findMany` would return them. */
+function memberships(rows: Array<{ workspaceId: string; role: string }>) {
+  return rows.map((r) => ({ userId: OWNER_ID, ...r })) as never;
+}
+
+describe("externalAgent.grantWorkspaces", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+    arrangeOwner(db);
+  });
+
+  it("grants every workspace the owner can delegate, always at role member", async () => {
+    db.workspaceUser.findMany.mockResolvedValue(
+      memberships([
+        { workspaceId: "ws-1", role: "owner" },
+        { workspaceId: "ws-2", role: "admin" },
+        { workspaceId: "ws-3", role: "member" },
+      ]),
+    );
+
+    const result = await caller(db).externalAgent.grantWorkspaces({
+      agentId: AGENT_ID,
+      workspaceIds: ["ws-1", "ws-2", "ws-3"],
+    });
+
+    expect(result).toEqual({ granted: 3 });
+    expect(db.workspaceUser.upsert).toHaveBeenCalledTimes(3);
+    // ADR-0049 §3: agents hold `member` and nothing else — never the owner's
+    // own admin/owner role in the workspace they were granted from.
+    for (const workspaceId of ["ws-1", "ws-2", "ws-3"]) {
+      expect(db.workspaceUser.upsert).toHaveBeenCalledWith({
+        where: { userId_workspaceId: { userId: SHADOW_ID, workspaceId } },
+        create: { userId: SHADOW_ID, workspaceId, role: "member" },
+        update: { role: "member" },
+      });
+    }
+    expect(db.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects the whole batch when the owner is only a viewer in one workspace", async () => {
+    db.workspaceUser.findMany.mockResolvedValue(
+      memberships([
+        { workspaceId: "ws-1", role: "member" },
+        { workspaceId: "ws-2", role: "viewer" },
+      ]),
+    );
+    db.workspace.findMany.mockResolvedValue([{ name: "Coaching" }] as never);
+
+    await expect(
+      caller(db).externalAgent.grantWorkspaces({
+        agentId: AGENT_ID,
+        workspaceIds: ["ws-1", "ws-2"],
+      }),
+    ).rejects.toThrow(/Coaching/);
+
+    // All-or-nothing: the delegable workspace in the batch is not written either.
+    expect(db.workspaceUser.upsert).not.toHaveBeenCalled();
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects workspaces the owner reaches without a membership row (team / guest access)", async () => {
+    // `workspace.list` surfaces team-based and project-guest workspaces, so the
+    // picker can offer one the owner holds no `WorkspaceUser` row in at all.
+    db.workspaceUser.findMany.mockResolvedValue(
+      memberships([{ workspaceId: "ws-1", role: "member" }]),
+    );
+    db.workspace.findMany.mockResolvedValue([{ name: "Threshold" }] as never);
+
+    await expect(
+      caller(db).externalAgent.grantWorkspaces({
+        agentId: AGENT_ID,
+        workspaceIds: ["ws-1", "ws-team-only"],
+      }),
+    ).rejects.toThrow(/Threshold/);
+
+    expect(db.workspaceUser.upsert).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates repeated ids instead of tripping the all-or-nothing check", async () => {
+    db.workspaceUser.findMany.mockResolvedValue(
+      memberships([{ workspaceId: "ws-1", role: "member" }]),
+    );
+
+    const result = await caller(db).externalAgent.grantWorkspaces({
+      agentId: AGENT_ID,
+      workspaceIds: ["ws-1", "ws-1", "ws-1"],
+    });
+
+    expect(result).toEqual({ granted: 1 });
+    expect(db.workspaceUser.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-granting a workspace the agent already holds is an idempotent upsert", async () => {
+    db.workspaceUser.findMany.mockResolvedValue(
+      memberships([{ workspaceId: "ws-1", role: "admin" }]),
+    );
+
+    await expect(
+      caller(db).externalAgent.grantWorkspaces({
+        agentId: AGENT_ID,
+        workspaceIds: ["ws-1"],
+      }),
+    ).resolves.toEqual({ granted: 1 });
+
+    expect(db.workspaceUser.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ update: { role: "member" } }),
+    );
+  });
+
+  it("refuses an agent the caller does not own, before touching memberships", async () => {
+    db.externalAgent.findFirst.mockResolvedValue(null);
+
+    await expect(
+      caller(db).externalAgent.grantWorkspaces({
+        agentId: "someone-elses-agent",
+        workspaceIds: ["ws-1"],
+      }),
+    ).rejects.toThrow(/Agent not found/);
+
+    expect(db.workspaceUser.findMany).not.toHaveBeenCalled();
+    expect(db.workspaceUser.upsert).not.toHaveBeenCalled();
+  });
+
+  it("bounds the batch size", async () => {
+    await expect(
+      caller(db).externalAgent.grantWorkspaces({
+        agentId: AGENT_ID,
+        workspaceIds: Array.from({ length: 101 }, (_, i) => `ws-${i}`),
+      }),
+    ).rejects.toThrow();
+
+    expect(db.workspaceUser.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/api/routers/__tests__/search.test.ts
+++ b/src/server/api/routers/__tests__/search.test.ts
@@ -91,7 +91,10 @@ vi.mock("~/lib/blob", () => ({
 
 // ── Imports of code under test (must come AFTER vi.mock calls) ───────
 import { createMockCaller } from "~/test/trpc-helpers";
-import { buildActionAccessWhere } from "~/server/services/access";
+import {
+  buildActionAccessWhere,
+  buildWorkspaceAccessWhere,
+} from "~/server/services/access";
 
 const callerId = "user-1";
 const workspaceId = "ws-1";
@@ -180,6 +183,16 @@ describe("search router — global (mocked)", () => {
     expect(where?.status).toEqual({ notIn: ["DELETED", "DRAFT"] });
     // Access scoping comes from buildActionAccessWhere, not a hand-rolled copy.
     expect(where?.OR).toEqual(buildActionAccessWhere(callerId).OR);
+  });
+
+  it("scopes epics to direct-or-team workspace membership, like the epic router", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.search.global({ query: "brew" });
+
+    const epicWhere = dbMock.epic.findMany.mock.calls[0]?.[0]?.where;
+    // Access scoping comes from buildWorkspaceAccessWhere (direct OR
+    // team-based membership), not a hand-rolled direct-members-only copy.
+    expect(epicWhere?.workspace).toEqual({ is: buildWorkspaceAccessWhere(callerId) });
   });
 
   it("workspace-scoped search filters projects/goals to the workspace for members", async () => {

--- a/src/server/api/routers/__tests__/search.test.ts
+++ b/src/server/api/routers/__tests__/search.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for the `search` router's `global` procedure.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` instead of a real
+ * database, so they run in milliseconds and CANNOT touch any real DB. Mirrors
+ * the test layout from `ticket.test.ts` / `problem.test.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+// Seed env vars before any module imports — `vi.hoisted` runs before regular
+// top-level statements. Mirrors ticket.test.ts.
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+// ── Stub heavy/IO modules pulled in by the wider router tree ─────────
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    constructor(_opts?: any) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({
+    auth: () => null,
+    handlers: {},
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+// ── dbMock plumbing ─────────────────────────────────────────────────
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = {
+  current: null,
+};
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) {
+    dbHolder.current = mockDeep<PrismaClient>();
+  }
+  return dbHolder.current;
+}
+
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+// ── Stub side-effect-heavy modules used by sibling routers ───────────
+vi.mock("~/server/services/notifications/EmailNotificationService", () => ({
+  sendAssignmentNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/lib/blob", () => ({
+  uploadToBlob: vi.fn().mockResolvedValue({ url: "blob://test" }),
+}));
+
+// ── Imports of code under test (must come AFTER vi.mock calls) ───────
+import { createMockCaller } from "~/test/trpc-helpers";
+import { buildActionAccessWhere } from "~/server/services/access";
+
+const callerId = "user-1";
+const workspaceId = "ws-1";
+const workspaceRef = { id: workspaceId, slug: "clear", name: "CLEAR" };
+
+function stubEmptyResults(dbMock: DeepMockProxy<PrismaClient>) {
+  dbMock.workspace.findMany.mockResolvedValue([]);
+  dbMock.project.findMany.mockResolvedValue([]);
+  dbMock.action.findMany.mockResolvedValue([]);
+  dbMock.goal.findMany.mockResolvedValue([]);
+  dbMock.keyResult.findMany.mockResolvedValue([]);
+  dbMock.outcome.findMany.mockResolvedValue([]);
+  dbMock.ticket.findMany.mockResolvedValue([]);
+  dbMock.feature.findMany.mockResolvedValue([]);
+  dbMock.epic.findMany.mockResolvedValue([]);
+  dbMock.knowledgePage.findMany.mockResolvedValue([]);
+  dbMock.transcriptionSession.findMany.mockResolvedValue([]);
+  dbMock.crmContact.findMany.mockResolvedValue([]);
+  dbMock.crmOrganization.findMany.mockResolvedValue([]);
+  dbMock.product.findMany.mockResolvedValue([]);
+}
+
+describe("search router — global (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    stubEmptyResults(dbMock);
+  });
+
+  it("merges typed results across entities and strips HTML from action titles", async () => {
+    dbMock.workspace.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: workspaceId, name: "CLEAR", slug: "clear" } as any,
+    ]);
+    dbMock.project.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "p1", name: "Onionpress Proposal", slug: "onion-p1", status: "ACTIVE", workspace: workspaceRef } as any,
+    ]);
+    dbMock.action.findMany.mockResolvedValue([
+      {
+        id: "a1",
+        name: 'Watch <a href="https://example.com">Brewster talk</a>',
+        kanbanStatus: "TODO",
+        workspace: null,
+        project: { name: "Onionpress Proposal", workspace: workspaceRef },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    ]);
+    dbMock.goal.findMany.mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 7, title: "Trusted decision layer", status: "active", workspace: workspaceRef } as any,
+    ]);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const res = await caller.search.global({ query: "brew" });
+
+    expect(res.query).toBe("brew");
+    expect(res.results.map((r) => r.type)).toEqual([
+      "workspace",
+      "project",
+      "action",
+      "goal",
+    ]);
+
+    const action = res.results.find((r) => r.type === "action");
+    expect(action?.title).toBe("Watch Brewster talk");
+    expect(action?.workspace).toEqual(workspaceRef);
+    expect(action?.url).toBe("/w/clear/actions/a1");
+
+    const goal = res.results.find((r) => r.type === "goal");
+    expect(goal?.id).toBe("7");
+    expect(goal?.url).toBe("/w/clear/goals/7");
+
+    const project = res.results.find((r) => r.type === "project");
+    expect(project?.url).toBe("/w/clear/projects/onion-p1");
+  });
+
+  it("scopes actions via the canonical bulk resolver, excludes DELETED/DRAFT, matches name case-insensitively", async () => {
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.search.global({ query: "brew" });
+
+    const where = dbMock.action.findMany.mock.calls[0]?.[0]?.where;
+    expect(where?.name).toEqual({ contains: "brew", mode: "insensitive" });
+    expect(where?.status).toEqual({ notIn: ["DELETED", "DRAFT"] });
+    // Access scoping comes from buildActionAccessWhere, not a hand-rolled copy.
+    expect(where?.OR).toEqual(buildActionAccessWhere(callerId).OR);
+  });
+
+  it("workspace-scoped search filters projects/goals to the workspace for members", async () => {
+    // Direct membership: not a guest, getWorkspaceMembership succeeds.
+    dbMock.workspaceUser.findUnique.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { userId: callerId, workspaceId, role: "member" } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.search.global({ query: "brew", workspaceId });
+
+    const projectWhere = dbMock.project.findMany.mock.calls[0]?.[0]?.where;
+    expect(projectWhere?.workspaceId).toBe(workspaceId);
+    // Members get the full access clause, not the guest-only clause.
+    expect(projectWhere?.projectMembers).toBeUndefined();
+
+    const goalWhere = dbMock.goal.findMany.mock.calls[0]?.[0]?.where;
+    expect(goalWhere?.workspaceId).toBe(workspaceId);
+  });
+
+  it("workspace-scoped search returns no goals and only shared projects for guests", async () => {
+    // No direct membership, no team membership, but a ProjectMember row:
+    // the "guest" shape from isWorkspaceGuest.
+    dbMock.workspaceUser.findUnique.mockResolvedValue(null);
+    dbMock.teamUser.findFirst.mockResolvedValue(null);
+    dbMock.projectMember.findFirst.mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: "pm-1" } as any,
+    );
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const res = await caller.search.global({ query: "brew", workspaceId });
+
+    const projectWhere = dbMock.project.findMany.mock.calls[0]?.[0]?.where;
+    expect(projectWhere?.projectMembers).toEqual({ some: { userId: callerId } });
+
+    expect(dbMock.goal.findMany).not.toHaveBeenCalled();
+    expect(res.results.filter((r) => r.type === "goal")).toEqual([]);
+  });
+});

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { Prisma } from "@prisma/client";
+import type { Prisma, PrismaClient } from "@prisma/client";
 import {
   createTRPCRouter,
   protectedProcedure,
@@ -10,7 +10,7 @@ import { parseActionInput } from "~/server/services/parsing";
 import { ScoringService } from "~/server/services/ScoringService";
 import { startOfDay } from "date-fns";
 import { validateScheduledTimes } from "~/lib/dateUtils";
-import { findUserByEmailInWorkspace, getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
+import { findUserByEmailInWorkspace, getWorkspaceMembership, canEditWorkspaceContent } from "~/server/services/access/resolvers/workspaceResolver";
 import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs, canAssignToUnscopedAction } from "~/server/services/access";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import { uploadToBlob } from "~/lib/blob";
@@ -27,6 +27,33 @@ import { recordActivity } from "~/server/services/activity/recordActivity";
 import { partitionActions } from "~/lib/actions/partition";
 import { groupOverdueCohorts, daysOverdue } from "~/lib/actions/triage";
 
+/**
+ * Guard a caller-supplied `workspaceId` on a write.
+ *
+ * `workspaceId` arrives as free-form input on `create`/`update`, so membership
+ * is never implied by having reached the mutation: without this check any
+ * authenticated user could inject rows into an arbitrary workspace's task list
+ * by guessing its CUID.
+ *
+ * Membership alone isn't sufficient either — `viewer` is a read-only role — so
+ * this asserts `canEditWorkspaceContent` (member and above). Project-only
+ * members ("guests") have no WorkspaceUser row and are refused here by design;
+ * their writes are authorised through the project path instead, which is why
+ * callers must skip this check for a workspace derived from the project.
+ */
+async function assertCanWriteToWorkspace(
+  db: PrismaClient,
+  userId: string,
+  workspaceId: string,
+) {
+  const membership = await getWorkspaceMembership(db, userId, workspaceId);
+  if (!canEditWorkspaceContent(membership?.role ?? null)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You don't have permission to add actions to this workspace",
+    });
+  }
+}
 
 export const actionRouter = createTRPCRouter({
   getAll: protectedProcedure
@@ -441,29 +468,39 @@ export const actionRouter = createTRPCRouter({
       // unchecked value plants the action — and the `created` activity event
       // fired for it further down — inside a workspace the caller has no
       // relationship to, where that workspace's members then see it in their
-      // feed. The project branch above only gates the *project*; when no
-      // projectId is supplied nothing else looks at this field at all.
-      if (input.workspaceId) {
-        const membership = await getWorkspaceMembership(
+      // feed. The project branch above only gates the *project*.
+      //
+      // A project dictates its own workspace, so it takes precedence over any
+      // caller-supplied `workspaceId`. The old precedence ran the other way,
+      // which let a caller attach a project they can genuinely edit while
+      // naming a foreign workspace, laundering the row into that workspace.
+      // `input.workspaceId` therefore only applies when there is no project, or
+      // when the project is personal (no workspace of its own).
+      const targetWorkspaceId = projectWorkspaceId ?? input.workspaceId ?? null;
+
+      // Authorise the destination workspace whenever it came from the caller
+      // rather than from the project. Skipping the project-derived case keeps
+      // project-only members ("guests") working — `canEditProject` above is
+      // their authorisation, and a bare `input.workspaceId` check would refuse
+      // them, since a guest has no WorkspaceUser row but every client sends
+      // workspaceId alongside projectId.
+      if (targetWorkspaceId && targetWorkspaceId !== projectWorkspaceId) {
+        await assertCanWriteToWorkspace(
           ctx.db,
           ctx.session.user.id,
-          input.workspaceId,
+          targetWorkspaceId,
         );
-        if (!membership) {
-          throw new TRPCError({
-            code: "FORBIDDEN",
-            message: "You don't have access to this workspace",
-          });
-        }
       }
 
       // A linked epic must live in the action's own workspace, or its name and
-      // status leak back through the `epic` include below.
+      // status leak back through the `epic` include below (PR 481). Resolved
+      // against `targetWorkspaceId` — the workspace the action will actually
+      // land in — rather than a caller-supplied id that may not be it.
       if (input.epicId) {
         await assertWorkspaceScopedRefs(
           ctx.db,
           ctx.session.user.id,
-          input.workspaceId ?? projectWorkspaceId,
+          targetWorkspaceId,
           { epicId: input.epicId },
         );
       }
@@ -471,16 +508,15 @@ export const actionRouter = createTRPCRouter({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const actionData: any = {
         ...input,
+        // Overrides the `workspaceId` spread from `...input`, which is exactly
+        // the field that was previously written through unchecked.
+        workspaceId: targetWorkspaceId ?? undefined,
         createdById: ctx.session.user.id,
         ...(input.isBounty ? { bountyStatus: "OPEN" } : {}),
         // External-agent principals stamp their surface (ADR-0049); the *who*
         // is createdById (the agent's shadow user), the *how* is source.
         ...(ctx.tokenType === "agent-key" ? { source: "agent" } : {}),
       };
-
-      if (input.projectId && !input.workspaceId && projectWorkspaceId) {
-        actionData.workspaceId = projectWorkspaceId;
-      }
 
       if (input.projectId) {
         actionData.kanbanStatus = "TODO";
@@ -549,6 +585,14 @@ export const actionRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
+
+      // Same free-form `workspaceId` as `create`, and it lands in the same
+      // place — `db.action.create` below — so it needs the same guard. Without
+      // it, any authenticated user can drop a prompt action into an arbitrary
+      // workspace's task list by guessing its CUID.
+      if (input?.workspaceId) {
+        await assertCanWriteToWorkspace(ctx.db, userId, input.workspaceId);
+      }
 
       const today = startOfDay(new Date());
       const tomorrow = new Date(today);
@@ -672,15 +716,47 @@ export const actionRouter = createTRPCRouter({
         validateScheduledTimes(resolvedStart, resolvedEnd);
       }
 
-      // Sync workspaceId when projectId changes
+      // Re-targeting the action. `projectId` and `workspaceId` are both
+      // free-form input, and `canEditAction` above only proves the caller may
+      // edit the action where it currently lives — not that they may move it
+      // somewhere else. Each destination needs its own authorisation.
       if (updateData.projectId) {
-        const newProject = await ctx.db.project.findUnique({
-          where: { id: updateData.projectId },
-          select: { workspaceId: true },
-        });
+        const [targetProjectAccess, newProject] = await Promise.all([
+          getProjectAccess(ctx.db, ctx.session.user.id, updateData.projectId),
+          ctx.db.project.findUnique({
+            where: { id: updateData.projectId },
+            select: { workspaceId: true },
+          }),
+        ]);
+
+        if (!canEditProject(targetProjectAccess)) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "You don't have permission to move this action to that project",
+          });
+        }
+
+        // Sync workspaceId from the project, which wins over any caller-supplied
+        // value (same precedence as `create`). Only a personal project — one
+        // with no workspace — leaves `input.workspaceId` in play.
         if (newProject?.workspaceId) {
           updateData.workspaceId = newProject.workspaceId;
+        } else if (updateData.workspaceId) {
+          await assertCanWriteToWorkspace(
+            ctx.db,
+            ctx.session.user.id,
+            updateData.workspaceId,
+          );
         }
+      } else if (updateData.workspaceId) {
+        // Moving the action into a workspace by id alone. `null` falls through
+        // unchecked on purpose: detaching an action the caller can already edit
+        // grants no access to anything.
+        await assertCanWriteToWorkspace(
+          ctx.db,
+          ctx.session.user.id,
+          updateData.workspaceId,
+        );
       }
 
       // Same-workspace guard as create, resolved against the workspace the

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -11,7 +11,7 @@ import { ScoringService } from "~/server/services/ScoringService";
 import { startOfDay } from "date-fns";
 import { validateScheduledTimes } from "~/lib/dateUtils";
 import { findUserByEmailInWorkspace, getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
-import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs } from "~/server/services/access";
+import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs, canAssignToUnscopedAction } from "~/server/services/access";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import { uploadToBlob } from "~/lib/blob";
 import { emitNotification } from "~/server/services/notifications/emit/emitNotification";
@@ -434,6 +434,26 @@ export const actionRouter = createTRPCRouter({
           nextKanbanOrder = maxOrderAcrossBoard.kanbanOrder + 1;
         } else {
           nextKanbanOrder = 1;
+        }
+      }
+
+      // `input.workspaceId` is spread straight into the create below, so an
+      // unchecked value plants the action — and the `created` activity event
+      // fired for it further down — inside a workspace the caller has no
+      // relationship to, where that workspace's members then see it in their
+      // feed. The project branch above only gates the *project*; when no
+      // projectId is supplied nothing else looks at this field at all.
+      if (input.workspaceId) {
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          ctx.session.user.id,
+          input.workspaceId,
+        );
+        if (!membership) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "You don't have access to this workspace",
+          });
         }
       }
 
@@ -1799,21 +1819,28 @@ export const actionRouter = createTRPCRouter({
             (member: { userId: string }) => member.userId === userId,
           );
         }
-        // No project or team - allow assignment to any user
+        // No project and no team: this used to allow assigning ANY user id,
+        // and the include below returns `user.email` — the same PII leak the
+        // ticket assignee guard closes. Fall back to the action's workspace
+        // and the caller's teams, which is exactly what the picker offers.
         else {
-          canAssign = true;
+          canAssign = await canAssignToUnscopedAction(
+            ctx.db,
+            ctx.session.user.id,
+            action.workspaceId,
+            userId,
+          );
         }
 
         if (!canAssign) {
-          const user = await ctx.db.user.findUnique({
-            where: { id: userId },
-            select: { name: true, email: true },
+          // Deliberately does NOT name the rejected user. The old message
+          // looked them up and echoed `name ?? email` back, which handed the
+          // caller a stranger's identity on exactly the path where they had
+          // just been told they have no relationship to them.
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: `Assignee not found in this ${action.projectId ? "project" : action.teamId ? "team" : "workspace"}`,
           });
-          const userName = user?.name ?? user?.email ?? userId;
-
-          throw new Error(
-            `User ${userName} cannot be assigned to this action. They must be a member of the ${action.projectId ? "project" : "team"}.`,
-          );
         }
       }
 
@@ -2007,21 +2034,24 @@ export const actionRouter = createTRPCRouter({
               (member: { userId: string }) => member.userId === userId,
             );
           }
-          // No project or team - allow assignment to any user
+          // Same fallback as `assign`: no project and no team means the
+          // action's workspace and the caller's teams decide, not "anyone".
           else {
-            canAssign = true;
+            canAssign = await canAssignToUnscopedAction(
+              ctx.db,
+              ctx.session.user.id,
+              action.workspaceId,
+              userId,
+            );
           }
 
           if (!canAssign) {
-            const user = await ctx.db.user.findUnique({
-              where: { id: userId },
-              select: { name: true, email: true },
+            // Names the action (the caller owns it) but never the rejected
+            // user — see the matching guard in `assign`.
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: `Assignee not found in this ${action.projectId ? "project" : action.teamId ? "team" : "workspace"} (action "${action.name}")`,
             });
-            const userName = user?.name ?? user?.email ?? userId;
-
-            throw new Error(
-              `User ${userName} cannot be assigned to action "${action.name}". They must be a member of the ${action.projectId ? "project" : "team"}.`,
-            );
           }
         }
       }

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -11,7 +11,7 @@ import { ScoringService } from "~/server/services/ScoringService";
 import { startOfDay } from "date-fns";
 import { validateScheduledTimes } from "~/lib/dateUtils";
 import { findUserByEmailInWorkspace, getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
-import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere } from "~/server/services/access";
+import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs } from "~/server/services/access";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import { uploadToBlob } from "~/lib/blob";
 import { emitNotification } from "~/server/services/notifications/emit/emitNotification";
@@ -437,6 +437,17 @@ export const actionRouter = createTRPCRouter({
         }
       }
 
+      // A linked epic must live in the action's own workspace, or its name and
+      // status leak back through the `epic` include below.
+      if (input.epicId) {
+        await assertWorkspaceScopedRefs(
+          ctx.db,
+          ctx.session.user.id,
+          input.workspaceId ?? projectWorkspaceId,
+          { epicId: input.epicId },
+        );
+      }
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const actionData: any = {
         ...input,
@@ -650,6 +661,20 @@ export const actionRouter = createTRPCRouter({
         if (newProject?.workspaceId) {
           updateData.workspaceId = newProject.workspaceId;
         }
+      }
+
+      // Same-workspace guard as create, resolved against the workspace the
+      // action will have *after* any projectId-driven move above.
+      if (updateData.epicId) {
+        await assertWorkspaceScopedRefs(
+          ctx.db,
+          ctx.session.user.id,
+          updateData.workspaceId ??
+            currentAction?.workspaceId ??
+            currentAction?.project?.workspaceId ??
+            null,
+          { epicId: updateData.epicId },
+        );
       }
 
       // Set completedAt timestamp when completing, clear when uncompleting

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -25,6 +25,7 @@ import {
 } from "~/server/services/projectActivity";
 import { recordActivity } from "~/server/services/activity/recordActivity";
 import { partitionActions } from "~/lib/actions/partition";
+import { groupOverdueCohorts, daysOverdue } from "~/lib/actions/triage";
 
 
 export const actionRouter = createTRPCRouter({
@@ -1059,6 +1060,94 @@ export const actionRouter = createTRPCRouter({
       };
     }),
 
+  // Why is the overdue pile the size it is? `getTodaysActions` answers "what is
+  // overdue"; this answers "what kind of overdue", which is what anyone (human
+  // or agent) needs before proposing a disposition.
+  //
+  // The signal is the anchor timestamp. A human dating actions one at a time
+  // produces distinct times; a bulk write — a generated project plan, an
+  // import, a template — stamps every row with a single millisecond-identical
+  // value. So actions sharing an exact anchor are a **cohort**: almost
+  // certainly never individually due, and the right disposition is amnesty
+  // (`bulkDefer`), not another reschedule. Everything else is `loose` — real,
+  // individually-dated debt worth actually looking at.
+  getOverdueTriage: protectedProcedure
+    .input(
+      z
+        .object({
+          workspaceId: z.string().optional(),
+        })
+        .optional(),
+    )
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      // Same ownership and scoping rules as getTodaysActions, so the triage
+      // view and the /today page always describe the same pile.
+      const actions = await ctx.db.action.findMany({
+        where: {
+          AND: [
+            {
+              OR: [
+                { createdById: userId, assignees: { none: {} } },
+                { assignees: { some: { userId } } },
+              ],
+            },
+            ...(input?.workspaceId
+              ? [
+                  {
+                    OR: [
+                      { workspaceId: input.workspaceId },
+                      { project: { workspaceId: input.workspaceId } },
+                    ],
+                  },
+                ]
+              : []),
+          ],
+          status: "ACTIVE",
+        },
+        select: {
+          id: true,
+          name: true,
+          status: true,
+          priority: true,
+          scheduledStart: true,
+          dueDate: true,
+          projectId: true,
+          completedAt: true,
+          project: { select: { name: true } },
+        },
+      });
+
+      const today = new Date();
+      const { overdue } = partitionActions(actions, { today });
+      const triage = groupOverdueCohorts(overdue, { today });
+
+      const toRow = (a: (typeof overdue)[number]) => ({
+        id: a.id,
+        name: a.name,
+        priority: a.priority,
+        scheduledStart: a.scheduledStart,
+        dueDate: a.dueDate,
+        projectName: a.project?.name ?? null,
+        daysOverdue: daysOverdue(a, today),
+      });
+
+      return {
+        totalOverdue: triage.totalOverdue,
+        cohortCount: triage.cohortCount,
+        cohorts: triage.cohorts.map((c) => ({
+          stampedAt: c.stampedAt,
+          daysOverdue: c.daysOverdue,
+          count: c.count,
+          projectNames: c.projectNames,
+          actionIds: c.actionIds,
+          actions: c.actions.map(toRow),
+        })),
+        loose: triage.loose.map(toRow),
+      };
+    }),
+
   getByDateRange: protectedProcedure
     .input(
       z.object({
@@ -1483,6 +1572,69 @@ export const actionRouter = createTRPCRouter({
       return {
         count: input.actionIds.length,
         actionIds: input.actionIds,
+      };
+    }),
+
+  // Amnesty: un-date actions back to their project backlog.
+  //
+  // Deliberately distinct from `bulkReschedule({ dueDate: null })`, which has
+  // the same effect on the rows. The difference is intent, and intent is what
+  // callers (and agents doing tool discovery) need to express: rescheduling
+  // says "this is still due, later"; deferring says "this was never really due
+  // — stop counting it against me". Most large overdue piles are the second
+  // case (a project plan bulk-stamped with one date), and rescheduling them
+  // just re-inflicts the pile tomorrow.
+  //
+  // Only the dates are touched. Kanban status is left alone on purpose: an
+  // action can be untimed and still be IN_PROGRESS on a board.
+  bulkDefer: protectedProcedure
+    .input(z.object({
+      actionIds: z.array(z.string()).min(1).max(200),
+    }))
+    .mutation(async ({ ctx, input }) => {
+      // Snapshot before clearing so the activity rows record what was lost.
+      const toDefer = await ctx.db.action.findMany({
+        where: {
+          id: { in: input.actionIds },
+          ...buildActionAccessWhere(ctx.session.user.id),
+        },
+        select: { id: true, projectId: true, dueDate: true, scheduledStart: true },
+      });
+
+      const result = await ctx.db.action.updateMany({
+        where: {
+          id: { in: toDefer.map((a) => a.id) },
+          ...buildActionAccessWhere(ctx.session.user.id),
+        },
+        data: {
+          scheduledStart: null,
+          scheduledEnd: null,
+          dueDate: null,
+        },
+      });
+
+      const projectScoped = toDefer.filter((a) => a.projectId !== null);
+      if (projectScoped.length > 0) {
+        void Promise.all(
+          projectScoped.map((a) =>
+            logProjectActivity(ctx.db, {
+              projectId: a.projectId!,
+              actionId: a.id,
+              type: PROJECT_ACTIVITY_TYPES.DUE_DATE_CHANGED,
+              fromValue: (a.dueDate ?? a.scheduledStart)?.toISOString() ?? null,
+              toValue: null,
+              changedById: ctx.session.user.id,
+            }),
+          ),
+        ).catch((err: unknown) => {
+          console.error("[projectActivity] bulkDefer:", err);
+        });
+      }
+
+      return {
+        count: result.count,
+        actionIds: toDefer.map((a) => a.id),
+        message: `Deferred ${result.count} action${result.count === 1 ? '' : 's'} back to the backlog`,
       };
     }),
 

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -11,7 +11,7 @@ import { ScoringService } from "~/server/services/ScoringService";
 import { startOfDay } from "date-fns";
 import { validateScheduledTimes } from "~/lib/dateUtils";
 import { findUserByEmailInWorkspace, getWorkspaceMembership, canEditWorkspaceContent } from "~/server/services/access/resolvers/workspaceResolver";
-import { getActionAccess, canEditAction, getProjectAccess, hasProjectAccess, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs, canAssignToUnscopedAction } from "~/server/services/access";
+import { getActionAccess, canViewAction, canEditAction, getProjectAccess, hasProjectAccess, isProjectInsider, canEditProject, buildActionAccessWhere, assertWorkspaceScopedRefs, canAssignToUnscopedAction } from "~/server/services/access";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import { uploadToBlob } from "~/lib/blob";
 import { emitNotification } from "~/server/services/notifications/emit/emitNotification";
@@ -2155,17 +2155,33 @@ export const actionRouter = createTRPCRouter({
       actionId: z.string(),
     }))
     .query(async ({ ctx, input }) => {
-      // Get the action to verify it exists and get context
-      const action = await ctx.db.action.findUnique({
-        where: { id: input.actionId },
-        include: {
-          project: true,
-          team: true,
-        },
-      });
+      // Get the action to verify it exists and get context. The access probe
+      // runs alongside it — both are independent reads keyed off actionId.
+      const [action, access] = await Promise.all([
+        ctx.db.action.findUnique({
+          where: { id: input.actionId },
+          include: {
+            project: true,
+            team: true,
+          },
+        }),
+        getActionAccess(ctx.db, ctx.session.user.id, input.actionId),
+      ]);
 
-      if (!action) {
-        throw new Error("Action not found");
+      // Without this, naming any action id returned its whole assignable
+      // roster — every workspace and project member, emails included — to any
+      // logged-in caller. View access is the right bar: assignment itself is
+      // separately gated on canEditAction, and a viewer legitimately needs the
+      // roster to render existing assignees.
+      //
+      // Missing and forbidden collapse into the same NOT_FOUND deliberately:
+      // distinguishable responses would confirm which action CUIDs exist. Same
+      // rule as `getById` above and as `assignability.ts`.
+      if (!action || !access || !canViewAction(access)) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Action not found or access denied",
+        });
       }
 
       // Collect assignable users from multiple sources
@@ -2206,7 +2222,13 @@ export const actionRouter = createTRPCRouter({
       // 2. Get workspace members (if action belongs to a project in a workspace).
       //    On restricted projects, only owner/admin workspace roles are eligible
       //    (they are escape-hatch project editors).
-      if (action.project?.workspaceId) {
+      //
+      //    Gated on `isProjectInsider`, NOT `canViewAction`: a public project
+      //    satisfies the view gate for any authenticated caller, and bounty
+      //    action ids for public projects are published by the unauthenticated
+      //    /api/bounties feed. Public visibility grants the project, never the
+      //    workspace roster behind it.
+      if (action.project?.workspaceId && access.isProjectInsider) {
         const workspaceUsers = await ctx.db.workspaceUser.findMany({
           where: {
             workspaceId: action.project.workspaceId,
@@ -2285,6 +2307,10 @@ export const actionRouter = createTRPCRouter({
     }))
     .query(async ({ ctx, input }) => {
       let project: { id: string; name: string; workspaceId: string | null; isRestricted: boolean } | null = null;
+      // Whether the caller reached the project by a membership path rather than
+      // by its `isPublic` flag. Only an insider inherits the workspace roster
+      // below — see the precedence comment further down.
+      let projectInsider = false;
       if (input.projectId) {
         const access = await getProjectAccess(ctx.db, ctx.session.user.id, input.projectId);
         if (!hasProjectAccess(access)) {
@@ -2293,13 +2319,43 @@ export const actionRouter = createTRPCRouter({
             message: "You don't have access to this project",
           });
         }
+        projectInsider = isProjectInsider(access);
         project = await ctx.db.project.findUnique({
           where: { id: input.projectId },
           select: { id: true, name: true, workspaceId: true, isRestricted: true },
         });
       }
 
-      const effectiveWorkspaceId = project?.workspaceId ?? input.workspaceId ?? null;
+      // Workspace precedence, and why the two paths are gated differently:
+      // a workspace reached *through* a project the caller is an insider on is
+      // already covered by the project check above, and must NOT be re-checked
+      // — workspace guests (project-only members with no WorkspaceUser row)
+      // would fail a membership probe and lose the roster on their own
+      // projects.
+      // `isProjectInsider`, not `hasProjectAccess`: the latter is satisfied by
+      // a merely *public* project, so inheriting the workspace from it would
+      // hand the whole roster to any authenticated caller holding a public
+      // project id — the same leak this guard exists to close.
+      // A caller-supplied `workspaceId` has no such backing, so it needs an
+      // explicit check: without one, any logged-in user who knows or guesses a
+      // workspace CUID got back every member's id, name, email and avatar.
+      // Plain membership is the bar — this is a read, so viewers pass.
+      let effectiveWorkspaceId = projectInsider ? (project?.workspaceId ?? null) : null;
+      if (!effectiveWorkspaceId && input.workspaceId) {
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          ctx.session.user.id,
+          input.workspaceId,
+        );
+        if (!membership) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "You don't have access to this workspace",
+          });
+        }
+        effectiveWorkspaceId = input.workspaceId;
+      }
+
       const isRestrictedProject = project?.isRestricted ?? false;
 
       const userMap = new Map<string, { id: string; name: string | null; email: string | null; image: string | null }>();

--- a/src/server/api/routers/epic.ts
+++ b/src/server/api/routers/epic.ts
@@ -1,10 +1,31 @@
 import { z } from "zod";
+import type { PrismaClient } from "@prisma/client";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
+import { getWorkspaceMembership } from "~/server/services/access";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 
 const epicStatusSchema = z.enum(["OPEN", "IN_PROGRESS", "DONE", "CANCELLED"]);
 const epicPrioritySchema = z.enum(["HIGH", "MEDIUM", "LOW", "NONE"]);
+
+/**
+ * Ensure the caller is a member of the workspace (directly or via a team).
+ * Throws FORBIDDEN otherwise.
+ */
+async function assertWorkspaceMember(
+  db: PrismaClient,
+  userId: string,
+  workspaceId: string,
+) {
+  const membership = await getWorkspaceMembership(db, userId, workspaceId);
+  if (!membership) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You must be a member of this workspace",
+    });
+  }
+  return membership;
+}
 
 export const epicRouter = createTRPCRouter({
   // List all epics for a workspace
@@ -16,21 +37,7 @@ export const epicRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
-      const member = await ctx.db.workspaceUser.findUnique({
-        where: {
-          userId_workspaceId: {
-            userId: ctx.session.user.id,
-            workspaceId: input.workspaceId,
-          },
-        },
-      });
-
-      if (!member) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "You must be a member of this workspace",
-        });
-      }
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, input.workspaceId);
 
       return ctx.db.epic.findMany({
         where: {
@@ -85,6 +92,8 @@ export const epicRouter = createTRPCRouter({
         });
       }
 
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, epic.workspaceId);
+
       return epic;
     }),
 
@@ -101,21 +110,7 @@ export const epicRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const member = await ctx.db.workspaceUser.findUnique({
-        where: {
-          userId_workspaceId: {
-            userId: ctx.session.user.id,
-            workspaceId: input.workspaceId,
-          },
-        },
-      });
-
-      if (!member) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "You must be a member of this workspace to create epics",
-        });
-      }
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, input.workspaceId);
 
       return ctx.db.epic.create({
         data: {
@@ -157,21 +152,7 @@ export const epicRouter = createTRPCRouter({
         });
       }
 
-      const member = await ctx.db.workspaceUser.findUnique({
-        where: {
-          userId_workspaceId: {
-            userId: ctx.session.user.id,
-            workspaceId: epic.workspaceId,
-          },
-        },
-      });
-
-      if (!member) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "You must be a member of this workspace to update epics",
-        });
-      }
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, epic.workspaceId);
 
       return ctx.db.epic.update({
         where: { id },
@@ -194,21 +175,11 @@ export const epicRouter = createTRPCRouter({
         });
       }
 
-      const member = await ctx.db.workspaceUser.findUnique({
-        where: {
-          userId_workspaceId: {
-            userId: ctx.session.user.id,
-            workspaceId: epic.workspaceId,
-          },
-        },
-      });
-
-      if (!member) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message: "You must be a member of this workspace to delete epics",
-        });
-      }
+      const member = await assertWorkspaceMember(
+        ctx.db,
+        ctx.session.user.id,
+        epic.workspaceId,
+      );
 
       const canDelete =
         member.role === "owner" ||

--- a/src/server/api/routers/externalAgent.ts
+++ b/src/server/api/routers/externalAgent.ts
@@ -181,44 +181,56 @@ export const externalAgentRouter = createTRPCRouter({
       return { success: true };
     }),
 
-  grantWorkspace: humanOnlyProcedure
-    .input(z.object({ agentId: z.string(), workspaceId: z.string() }))
+  grantWorkspaces: humanOnlyProcedure
+    // `.max` is a sanity bound, not a product limit — it caps the `IN` clause and
+    // the `$transaction` batch, both sized directly by this input.
+    .input(z.object({ agentId: z.string(), workspaceIds: z.array(z.string()).min(1).max(100) }))
     .mutation(async ({ ctx, input }) => {
       const agent = await requireOwnedAgent(ctx.db, input.agentId, ctx.session.user.id);
+      const workspaceIds = [...new Set(input.workspaceIds)];
 
       // Delegation invariant, grant-time half: the owner must hold at least
-      // `member` in the target workspace themselves. A viewer cannot delegate
-      // member-level access (ADR-0049).
-      const ownerMembership = await ctx.db.workspaceUser.findUnique({
-        where: {
-          userId_workspaceId: {
-            userId: ctx.session.user.id,
-            workspaceId: input.workspaceId,
-          },
-        },
+      // `member` in every target workspace themselves. A viewer cannot delegate
+      // member-level access (ADR-0049). All-or-nothing — a partial grant would
+      // read as a full one in the UI.
+      const ownerMemberships = await ctx.db.workspaceUser.findMany({
+        where: { userId: ctx.session.user.id, workspaceId: { in: workspaceIds } },
       });
-      if (!ownerMembership || ownerMembership.role === "viewer") {
+      const delegable = new Set(
+        ownerMemberships.filter((m) => m.role !== "viewer").map((m) => m.workspaceId),
+      );
+      if (delegable.size !== workspaceIds.length) {
+        // Name the offenders — the picker is fed by `workspace.list`, which also
+        // surfaces team-based and project-guest workspaces where the owner holds
+        // no `WorkspaceUser` row at all. Without names, recovering from a
+        // rejected batch means bisecting the selection by hand.
+        const rejected = await ctx.db.workspace.findMany({
+          where: { id: { in: workspaceIds.filter((id) => !delegable.has(id)) } },
+          select: { name: true },
+        });
+        const names = rejected.map((w) => w.name).join(", ");
         throw new TRPCError({
           code: "FORBIDDEN",
-          message: "You need at least member access in a workspace to add your agent to it",
+          message: names
+            ? `You need at least member access to add your agent to ${names} — nothing was granted`
+            : "You need at least member access in every workspace you add your agent to — nothing was granted",
         });
       }
 
-      return ctx.db.workspaceUser.upsert({
-        where: {
-          userId_workspaceId: {
-            userId: agent.shadowUserId,
-            workspaceId: input.workspaceId,
-          },
-        },
-        // Agents only ever hold `member` (ADR-0049).
-        create: {
-          userId: agent.shadowUserId,
-          workspaceId: input.workspaceId,
-          role: "member",
-        },
-        update: { role: "member" },
-      });
+      await ctx.db.$transaction(
+        workspaceIds.map((workspaceId) =>
+          ctx.db.workspaceUser.upsert({
+            where: {
+              userId_workspaceId: { userId: agent.shadowUserId, workspaceId },
+            },
+            // Agents only ever hold `member` (ADR-0049).
+            create: { userId: agent.shadowUserId, workspaceId, role: "member" },
+            update: { role: "member" },
+          }),
+        ),
+      );
+
+      return { granted: workspaceIds.length };
     }),
 
   revokeWorkspace: humanOnlyProcedure

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -4325,6 +4325,13 @@ export const mastraRouter = createTRPCRouter({
       priority: z.enum(PRIORITY_VALUES).optional(),
       status: z.enum(['ACTIVE', 'COMPLETED', 'CANCELLED']).optional(),
       dueDate: z.string().nullable().optional(), // ISO string
+      // The "do date" and its block. Without these an agent can propose a time
+      // but never move the action to it — the /today partition keys off
+      // scheduledStart (schedule wins over dueDate), so rescheduling anything
+      // out of the overdue bucket requires writing this field.
+      scheduledStart: z.string().nullable().optional(), // ISO string
+      scheduledEnd: z.string().nullable().optional(), // ISO string
+      duration: z.number().int().positive().nullable().optional(), // minutes
     }))
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
@@ -4366,6 +4373,19 @@ export const mastraRouter = createTRPCRouter({
       if (fields.priority !== undefined) updateData.priority = fields.priority;
       if (fields.dueDate !== undefined) {
         updateData.dueDate = fields.dueDate ? new Date(fields.dueDate) : null;
+      }
+      if (fields.scheduledStart !== undefined) {
+        updateData.scheduledStart = fields.scheduledStart
+          ? new Date(fields.scheduledStart)
+          : null;
+      }
+      if (fields.scheduledEnd !== undefined) {
+        updateData.scheduledEnd = fields.scheduledEnd
+          ? new Date(fields.scheduledEnd)
+          : null;
+      }
+      if (fields.duration !== undefined) {
+        updateData.duration = fields.duration;
       }
 
       // Handle status change
@@ -4415,6 +4435,9 @@ export const mastraRouter = createTRPCRouter({
           status: action.status,
           priority: action.priority,
           dueDate: action.dueDate?.toISOString(),
+          scheduledStart: action.scheduledStart?.toISOString(),
+          scheduledEnd: action.scheduledEnd?.toISOString(),
+          duration: action.duration,
           projectId: action.projectId,
           project: action.project,
         },

--- a/src/server/api/routers/scheduling.ts
+++ b/src/server/api/routers/scheduling.ts
@@ -6,6 +6,7 @@ import { AutoSchedulingService } from "~/server/services/AutoSchedulingService";
 import { generateAgentJWT } from "~/server/utils/jwt";
 import { addMinutes, format } from "date-fns";
 import { setTimeInUserTimezone, validateScheduledTimes } from "~/lib/dateUtils";
+import { partitionActions } from "~/lib/actions/partition";
 
 const MASTRA_API_URL = process.env.MASTRA_API_URL;
 
@@ -349,15 +350,21 @@ export const schedulingRouter = createTRPCRouter({
       const endDate = new Date(today);
       endDate.setDate(endDate.getDate() + input.days);
 
-      // 1. Fetch overdue actions with projects and outcomes
-      const overdueActions = await ctx.db.action.findMany({
+      // 1. Fetch overdue actions with projects and outcomes.
+      //
+      // Overdue is resolved through the shared `partitionActions()` rule
+      // (ADR-0034) rather than a local `dueDate < today` filter. The panel that
+      // renders these suggestions is *gated* on the client partition, so a
+      // narrower rule here meant the banner could appear on a pile it then had
+      // nothing to say about — and it silently ignored every scheduled-but-
+      // never-due action, which is the most common overdue shape.
+      const candidates = await ctx.db.action.findMany({
         where: {
           OR: [
             { createdById: userId, assignees: { none: {} } },
             { assignees: { some: { userId: userId } } },
           ],
           status: "ACTIVE",
-          dueDate: { lt: today },
           ...(input.actionIds ? { id: { in: input.actionIds } } : {}),
           ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
         },
@@ -372,11 +379,11 @@ export const schedulingRouter = createTRPCRouter({
             },
           },
         },
-        orderBy: [
-          { dueDate: "asc" }, // Oldest overdue first
-        ],
-        take: 20, // Limit to 20 overdue actions to avoid huge prompts
       });
+
+      // Partition sorts overdue by priority, then oldest debt first.
+      const overdueActions = partitionActions(candidates, { today: now }).overdue
+        .slice(0, 20); // Cap to avoid huge prompts
 
       if (overdueActions.length === 0) {
         return { suggestions: [], calendarConnected: true };

--- a/src/server/api/routers/scheduling.ts
+++ b/src/server/api/routers/scheduling.ts
@@ -7,6 +7,14 @@ import { generateAgentJWT } from "~/server/utils/jwt";
 import { addMinutes, format } from "date-fns";
 import { setTimeInUserTimezone, validateScheduledTimes } from "~/lib/dateUtils";
 import { partitionActions } from "~/lib/actions/partition";
+import {
+  BRIEFING_INTERACTION_TYPES,
+  briefingDate,
+  buildInputSnapshot,
+  findReusableBriefing,
+  persistBriefing,
+  snapshotHash,
+} from "~/server/services/schedulingBriefing";
 
 const MASTRA_API_URL = process.env.MASTRA_API_URL;
 
@@ -429,7 +437,41 @@ export const schedulingRouter = createTRPCRouter({
         orderBy: { scheduledStart: "asc" },
       });
 
-      // 4. Build the prompt and call Mastra agent
+      // 4. Reuse today's briefing when nothing the prompt reads has changed.
+      //
+      // This query used to call the model on every /today render (a useQuery
+      // with a 5-minute staleTime), which is exactly what
+      // docs/ZOE_DAILY_BRIEFING.md's first Gotcha forbids: briefings cost
+      // seconds and thousands of tokens, so they must not regenerate on page
+      // load. Suggestions are advice about a set of actions and a calendar; if
+      // neither moved, the advice is the same. Persisting also gives the eval
+      // loop the replayable inputSnapshot it was designed around.
+      const snapshot = buildInputSnapshot({
+        days: input.days,
+        overdueActions,
+        calendarEvents,
+        scheduledActions,
+      });
+      const hash = snapshotHash(snapshot);
+      const date = briefingDate(now);
+
+      const reusable = await findReusableBriefing(ctx.db, {
+        userId,
+        workspaceId: input.workspaceId,
+        date,
+        hash,
+      });
+      if (reusable) {
+        console.log(`[scheduling] reusing briefing ${reusable.id} (snapshot unchanged)`);
+        return {
+          suggestions: reusable.suggestions as SchedulingSuggestion[],
+          calendarConnected,
+          overdueCount: overdueActions.length,
+          briefingId: reusable.id,
+        };
+      }
+
+      // 5. Build the prompt and call Mastra agent
       const userPrompt = buildSchedulingPrompt(
         overdueActions,
         calendarEvents,
@@ -442,11 +484,17 @@ export const schedulingRouter = createTRPCRouter({
         return { suggestions: [], calendarConnected, overdueCount: overdueActions.length };
       }
 
+      const startedAt = Date.now();
+
       try {
         const agentJWT = generateAgentJWT(ctx.session.user, 30);
 
         const response = await fetch(
-          `${MASTRA_API_URL}/api/agents/ashAgent/generate`,
+          // zoeAgent, not ashAgent: these suggestions are shown to the user
+          // under Zoe's name. ashAgent is a tool-less lean-startup persona
+          // whose instructions were being overridden per call anyway, so the
+          // branding, model, and prompt all disagreed with the surface.
+          `${MASTRA_API_URL}/api/agents/zoeAgent/generate`,
           {
             method: "POST",
             headers: {
@@ -483,10 +531,23 @@ export const schedulingRouter = createTRPCRouter({
         const validActionIds = new Set(overdueActions.map((a) => a.id));
         const validSuggestions = suggestions.filter((s) => validActionIds.has(s.actionId));
 
+        const briefingId = await persistBriefing(ctx.db, {
+          userId,
+          workspaceId: input.workspaceId,
+          date,
+          modelId: "zoeAgent",
+          snapshot,
+          hash,
+          outputText: responseText,
+          suggestions: validSuggestions,
+          latencyMs: Date.now() - startedAt,
+        });
+
         return {
           suggestions: validSuggestions,
           calendarConnected,
           overdueCount: overdueActions.length,
+          briefingId,
         };
       } catch (error) {
         if (error instanceof TRPCError) throw error;
@@ -495,6 +556,35 @@ export const schedulingRouter = createTRPCRouter({
         // Return empty suggestions instead of failing - the UI can still function without AI suggestions
         return { suggestions: [], calendarConnected, overdueCount: overdueActions.length };
       }
+    }),
+
+  // How a briefing was received. Without this, none of the metrics in
+  // docs/ZOE_DAILY_BRIEFING.md can be computed — acceptance rate, dismissal
+  // rate, and top-1 execution rate all read from BriefingInteraction, a table
+  // that existed but was never written to.
+  recordBriefingInteraction: protectedProcedure
+    .input(
+      z.object({
+        briefingId: z.string(),
+        type: z.enum(BRIEFING_INTERACTION_TYPES),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Scope to the caller's own briefings — briefingId is a client-supplied
+      // id, so an unscoped write would let anyone append to anyone's metrics.
+      const briefing = await ctx.db.dailyBriefing.findFirst({
+        where: { id: input.briefingId, userId: ctx.session.user.id },
+        select: { id: true },
+      });
+      if (!briefing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Briefing not found" });
+      }
+
+      await ctx.db.briefingInteraction.create({
+        data: { briefingId: briefing.id, type: input.type },
+      });
+
+      return { success: true };
     }),
 
   // Auto-schedule a single task

--- a/src/server/api/routers/search.ts
+++ b/src/server/api/routers/search.ts
@@ -1,0 +1,526 @@
+import { z } from "zod";
+import type { PrismaClient } from "@prisma/client";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import {
+  buildActionAccessWhere,
+  buildKnowledgePageAccessWhere,
+  buildProjectAccessWhere,
+  buildTranscriptionAccessWhere,
+  buildWorkspaceAccessWhere,
+  buildWorkspaceVisibilityWhere,
+  getWorkspaceMembership,
+  isWorkspaceGuest,
+} from "~/server/services/access";
+import { stripHtml } from "~/lib/utils";
+import { ticketUrlId } from "~/lib/fun-ids";
+
+/**
+ * Global search — the server-side equivalent of the Cmd+K palette
+ * (CommandPalette.tsx), exposed so the CLI, MCP server, and other API
+ * consumers get the same results the app shows. Each entity block mirrors
+ * the access scoping of that entity's canonical list procedure; when adding
+ * a block, copy the where-clause semantics from the router named in its
+ * comment rather than inventing new scoping.
+ */
+
+export interface SearchResult {
+  type:
+    | "workspace"
+    | "project"
+    | "action"
+    | "goal"
+    | "keyResult"
+    | "outcome"
+    | "ticket"
+    | "feature"
+    | "epic"
+    | "page"
+    | "meeting"
+    | "contact"
+    | "organization"
+    | "product";
+  id: string;
+  title: string;
+  subtitle: string | null;
+  workspace: { id: string; slug: string; name: string } | null;
+  url: string | null;
+}
+
+const searchInput = z.object({
+  query: z.string().trim().min(1).max(200),
+  workspaceId: z.string().optional(),
+  /** Max results per entity type. */
+  limit: z.number().int().min(1).max(25).default(10),
+});
+
+type SearchArgs = {
+  db: PrismaClient;
+  userId: string;
+  q: string;
+  workspaceId?: string;
+  limit: number;
+};
+
+const insensitive = (q: string) => ({ contains: q, mode: "insensitive" as const });
+
+// Mirrors workspace.list (buildWorkspaceVisibilityWhere).
+async function searchWorkspaces({ db, userId, q, limit }: SearchArgs): Promise<SearchResult[]> {
+  const workspaces = await db.workspace.findMany({
+    where: { AND: [buildWorkspaceVisibilityWhere(userId), { name: insensitive(q) }] },
+    select: { id: true, name: true, slug: true },
+    take: limit,
+  });
+  return workspaces.map((w) => ({
+    type: "workspace",
+    id: w.id,
+    title: w.name,
+    subtitle: null,
+    workspace: { id: w.id, slug: w.slug, name: w.name },
+    url: `/w/${w.slug}/home`,
+  }));
+}
+
+// Mirrors project.getAll (buildProjectAccessWhere, guest scope when
+// workspace-scoped).
+async function searchProjects({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const isGuest = workspaceId ? await isWorkspaceGuest(db, userId, workspaceId) : false;
+  const accessWhere = isGuest
+    ? { projectMembers: { some: { userId } } }
+    : buildProjectAccessWhere(userId);
+
+  const projects = await db.project.findMany({
+    where: {
+      ...(workspaceId ? { workspaceId } : {}),
+      ...accessWhere,
+      name: insensitive(q),
+    },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      status: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return projects.map((p) => ({
+    type: "project",
+    id: p.id,
+    title: p.name,
+    subtitle: p.status,
+    workspace: p.workspace,
+    url: p.workspace ? `/w/${p.workspace.slug}/projects/${p.slug}` : null,
+  }));
+}
+
+// Mirrors action.searchByTitle: the canonical bulk resolver
+// (buildActionAccessWhere) rather than getAll's deliberately personal scope —
+// per the access-control rule that bulk permission scoping goes through the
+// centralized resolver. Matches on the raw name (names can contain HTML; the
+// stored markup is stripped from the returned title, so a query can in rare
+// cases match markup that is not visible in the title).
+async function searchActions({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const actions = await db.action.findMany({
+    where: {
+      ...buildActionAccessWhere(userId),
+      ...(workspaceId
+        ? { AND: [{ OR: [{ workspaceId }, { project: { workspaceId } }] }] }
+        : {}),
+      status: { notIn: ["DELETED", "DRAFT"] },
+      name: insensitive(q),
+    },
+    select: {
+      id: true,
+      name: true,
+      kanbanStatus: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+      project: {
+        select: {
+          name: true,
+          workspace: { select: { id: true, slug: true, name: true } },
+        },
+      },
+    },
+    take: limit,
+  });
+  return actions.map((a) => {
+    const workspace = a.workspace ?? a.project?.workspace ?? null;
+    return {
+      type: "action" as const,
+      id: a.id,
+      title: stripHtml(a.name),
+      subtitle: a.project?.name ?? a.kanbanStatus,
+      workspace,
+      url: workspace ? `/w/${workspace.slug}/actions/${a.id}` : null,
+    };
+  });
+}
+
+// Mirrors goal.getAllMyGoals: all goals of workspaces the caller belongs to,
+// plus personally-owned goals when searching across workspaces.
+async function searchGoals({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  if (workspaceId) {
+    const membership = await getWorkspaceMembership(db, userId, workspaceId);
+    if (!membership) return [];
+  }
+  const goals = await db.goal.findMany({
+    where: {
+      ...(workspaceId
+        ? { workspaceId }
+        : {
+            // Strict membership (direct or team), matching the
+            // getWorkspaceMembership gate — guests don't see workspace goals.
+            OR: [
+              { userId },
+              { workspace: { is: buildWorkspaceAccessWhere(userId) } },
+            ],
+          }),
+      title: insensitive(q),
+    },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return goals.map((g) => ({
+    type: "goal",
+    id: String(g.id),
+    title: g.title,
+    subtitle: g.status,
+    workspace: g.workspace,
+    url: g.workspace ? `/w/${g.workspace.slug}/goals/${g.id}` : null,
+  }));
+}
+
+// Mirrors okr.getByObjective's workspace mode: all workspace OKRs are visible
+// to members; otherwise personally-owned key results.
+async function searchKeyResults({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  if (workspaceId) {
+    const membership = await getWorkspaceMembership(db, userId, workspaceId);
+    if (!membership) return [];
+  }
+  const keyResults = await db.keyResult.findMany({
+    where: {
+      ...(workspaceId
+        ? { workspaceId }
+        : {
+            OR: [
+              { userId },
+              { workspace: { is: buildWorkspaceAccessWhere(userId) } },
+            ],
+          }),
+      title: insensitive(q),
+    },
+    select: {
+      id: true,
+      title: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return keyResults.map((kr) => ({
+    type: "keyResult",
+    id: kr.id,
+    title: kr.title,
+    subtitle: null,
+    workspace: kr.workspace,
+    // Deep link into the OKR drawer, as FavouritesNav does.
+    url: kr.workspace ? `/w/${kr.workspace.slug}/goals?tab=okrs&drawer=keyResult:${kr.id}` : null,
+  }));
+}
+
+// Mirrors outcome list scoping: strictly owner-scoped (no workspace-wide
+// sharing on the canonical list).
+async function searchOutcomes({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const outcomes = await db.outcome.findMany({
+    where: {
+      userId,
+      ...(workspaceId ? { workspaceId } : {}),
+      description: insensitive(q),
+    },
+    select: {
+      id: true,
+      description: true,
+      type: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return outcomes.map((o) => ({
+    type: "outcome",
+    id: o.id,
+    title: o.description,
+    subtitle: o.type,
+    workspace: o.workspace,
+    url: o.workspace ? `/w/${o.workspace.slug}/outcomes` : null,
+  }));
+}
+
+// Mirrors ticket.list's assertWorkspaceMember gate (direct or team-based
+// workspace membership via the ticket's product; guests denied).
+async function searchTickets({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const tickets = await db.ticket.findMany({
+    where: {
+      product: {
+        ...(workspaceId ? { workspaceId } : {}),
+        workspace: { is: buildWorkspaceAccessWhere(userId) },
+      },
+      OR: [
+        { title: insensitive(q) },
+        { shortId: insensitive(q) },
+        // An all-digits query also matches the ticket's sequential number.
+        ...(/^\d+$/.test(q) && parseInt(q, 10) > 0
+          ? [{ number: parseInt(q, 10) }]
+          : []),
+      ],
+    },
+    select: {
+      id: true,
+      title: true,
+      number: true,
+      shortId: true,
+      status: true,
+      product: {
+        select: { slug: true, workspace: { select: { id: true, slug: true, name: true } } },
+      },
+    },
+    take: limit,
+  });
+  return tickets.map((t) => ({
+    type: "ticket",
+    id: t.id,
+    title: t.title,
+    subtitle: `${t.shortId ?? (t.number > 0 ? `#${t.number}` : "")} ${t.status}`.trim(),
+    workspace: t.product.workspace,
+    url: `/w/${t.product.workspace.slug}/products/${t.product.slug}/tickets/${t.shortId ?? ticketUrlId(t)}`,
+  }));
+}
+
+// Same workspace-membership-via-product gate as tickets.
+async function searchFeatures({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const features = await db.feature.findMany({
+    where: {
+      product: {
+        ...(workspaceId ? { workspaceId } : {}),
+        workspace: { is: buildWorkspaceAccessWhere(userId) },
+      },
+      name: insensitive(q),
+    },
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      product: {
+        select: { slug: true, workspace: { select: { id: true, slug: true, name: true } } },
+      },
+    },
+    take: limit,
+  });
+  return features.map((f) => ({
+    type: "feature",
+    id: f.id,
+    title: f.name,
+    subtitle: f.status,
+    workspace: f.product.workspace,
+    url: `/w/${f.product.workspace.slug}/products/${f.product.slug}/features/${f.id}`,
+  }));
+}
+
+// Mirrors the epic router's gate: DIRECT workspace membership only (team-based
+// members are denied there, so they are denied here too).
+async function searchEpics({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const epics = await db.epic.findMany({
+    where: {
+      ...(workspaceId ? { workspaceId } : {}),
+      workspace: { members: { some: { userId } } },
+      name: insensitive(q),
+    },
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return epics.map((e) => ({
+    type: "epic",
+    id: e.id,
+    title: e.name,
+    subtitle: e.status,
+    workspace: e.workspace,
+    // Epics have no dedicated detail route; they surface inside kanban views.
+    url: null,
+  }));
+}
+
+// Mirrors page.list (buildKnowledgePageAccessWhere, ADR-0033).
+async function searchPages({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const pages = await db.knowledgePage.findMany({
+    where: {
+      AND: [
+        buildKnowledgePageAccessWhere(userId),
+        ...(workspaceId ? [{ workspaceId }] : []),
+        { title: insensitive(q) },
+      ],
+    },
+    select: {
+      id: true,
+      title: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return pages.map((p) => ({
+    type: "page",
+    id: p.id,
+    title: p.title,
+    subtitle: null,
+    workspace: p.workspace,
+    url: `/w/${p.workspace.slug}/pages/${p.id}`,
+  }));
+}
+
+// Mirrors transcription list (buildTranscriptionAccessWhere), unarchived only.
+async function searchMeetings({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const sessions = await db.transcriptionSession.findMany({
+    where: {
+      AND: [
+        buildTranscriptionAccessWhere(userId),
+        { archivedAt: null },
+        ...(workspaceId ? [{ OR: [{ workspaceId }, { project: { workspaceId } }] }] : []),
+        { title: insensitive(q) },
+      ],
+    },
+    select: {
+      id: true,
+      title: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+      project: { select: { workspace: { select: { id: true, slug: true, name: true } } } },
+    },
+    take: limit,
+  });
+  return sessions.map((s) => ({
+    type: "meeting",
+    id: s.id,
+    title: s.title ?? "Untitled meeting",
+    subtitle: null,
+    workspace: s.workspace ?? s.project?.workspace ?? null,
+    url: `/recording/${s.id}`,
+  }));
+}
+
+// Mirrors the CRM routers' gate: DIRECT workspace membership only.
+async function searchContacts({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const contacts = await db.crmContact.findMany({
+    where: {
+      ...(workspaceId ? { workspaceId } : {}),
+      workspace: { members: { some: { userId } } },
+      OR: [{ firstName: insensitive(q) }, { lastName: insensitive(q) }],
+    },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return contacts.map((c) => ({
+    type: "contact",
+    id: c.id,
+    title: [c.firstName, c.lastName].filter(Boolean).join(" ") || "Unnamed contact",
+    subtitle: null,
+    workspace: c.workspace,
+    url: `/w/${c.workspace.slug}/crm/contacts/${c.id}`,
+  }));
+}
+
+// Same direct-membership gate as contacts.
+async function searchOrganizations({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const organizations = await db.crmOrganization.findMany({
+    where: {
+      ...(workspaceId ? { workspaceId } : {}),
+      workspace: { members: { some: { userId } } },
+      name: insensitive(q),
+    },
+    select: {
+      id: true,
+      name: true,
+      industry: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return organizations.map((o) => ({
+    type: "organization",
+    id: o.id,
+    title: o.name,
+    subtitle: o.industry,
+    workspace: o.workspace,
+    url: `/w/${o.workspace.slug}/crm/organizations/${o.id}`,
+  }));
+}
+
+// Mirrors product.list's assertWorkspaceMember gate (direct or team-based).
+async function searchProducts({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
+  const products = await db.product.findMany({
+    where: {
+      ...(workspaceId ? { workspaceId } : {}),
+      workspace: { is: buildWorkspaceAccessWhere(userId) },
+      name: insensitive(q),
+    },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      workspace: { select: { id: true, slug: true, name: true } },
+    },
+    take: limit,
+  });
+  return products.map((p) => ({
+    type: "product",
+    id: p.id,
+    title: p.name,
+    subtitle: null,
+    workspace: p.workspace,
+    url: `/w/${p.workspace.slug}/products/${p.slug}`,
+  }));
+}
+
+export const searchRouter = createTRPCRouter({
+  global: protectedProcedure.input(searchInput).query(async ({ ctx, input }) => {
+    const args: SearchArgs = {
+      db: ctx.db,
+      userId: ctx.session.user.id,
+      q: input.query,
+      workspaceId: input.workspaceId,
+      limit: input.limit,
+    };
+
+    const groups = await Promise.all([
+      searchWorkspaces(args),
+      searchProjects(args),
+      searchActions(args),
+      searchGoals(args),
+      searchKeyResults(args),
+      searchOutcomes(args),
+      searchTickets(args),
+      searchFeatures(args),
+      searchEpics(args),
+      searchPages(args),
+      searchMeetings(args),
+      searchContacts(args),
+      searchOrganizations(args),
+      searchProducts(args),
+    ]);
+
+    return {
+      query: input.query,
+      results: groups.flat(),
+    };
+  }),
+});

--- a/src/server/api/routers/search.ts
+++ b/src/server/api/routers/search.ts
@@ -329,13 +329,13 @@ async function searchFeatures({ db, userId, q, workspaceId, limit }: SearchArgs)
   }));
 }
 
-// Mirrors the epic router's gate: DIRECT workspace membership only (team-based
-// members are denied there, so they are denied here too).
+// Mirrors the epic router's gate: direct or team-based workspace membership
+// (getWorkspaceMembership; guests denied).
 async function searchEpics({ db, userId, q, workspaceId, limit }: SearchArgs): Promise<SearchResult[]> {
   const epics = await db.epic.findMany({
     where: {
       ...(workspaceId ? { workspaceId } : {}),
-      workspace: { members: { some: { userId } } },
+      workspace: { is: buildWorkspaceAccessWhere(userId) },
       name: insensitive(q),
     },
     select: {

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -353,6 +353,7 @@ export const workspaceRouter = createTRPCRouter({
         enableWeeklyReviewBanner: z.boolean().optional(),
         enableEmailNotifications: z.boolean().optional(),
         enableAutoEnrichContacts: z.boolean().optional(),
+        enableKeyResults: z.boolean().optional(),
         homeLayout: z.enum(["command", "activity", "coaching"]).optional(),
       })
     )
@@ -388,6 +389,7 @@ export const workspaceRouter = createTRPCRouter({
           enableWeeklyReviewBanner: input.enableWeeklyReviewBanner,
           enableEmailNotifications: input.enableEmailNotifications,
           enableAutoEnrichContacts: input.enableAutoEnrichContacts,
+          enableKeyResults: input.enableKeyResults,
           homeLayout: input.homeLayout,
         },
       });

--- a/src/server/services/__tests__/morningNudge.test.ts
+++ b/src/server/services/__tests__/morningNudge.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { buildMorningNudge } from "~/server/services/morningNudge";
+
+describe("buildMorningNudge", () => {
+  it("greets by first name", () => {
+    const { title } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 3,
+      overdueCount: 0,
+      cohortCount: 0,
+    });
+    expect(title).toBe("Good morning, James!");
+  });
+
+  it("says so plainly when nothing is overdue", () => {
+    const { body } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 3,
+      overdueCount: 0,
+      cohortCount: 0,
+    });
+    expect(body).toBe("3 actions scheduled today. Nothing overdue — nice.");
+  });
+
+  it("handles a completely empty day without claiming nothing is planned", () => {
+    const { body } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 0,
+      overdueCount: 0,
+      cohortCount: 0,
+    });
+    expect(body).toBe("Nothing scheduled today, and nothing overdue.");
+  });
+
+  it("leads with the reframe when most of the overdue pile was bulk-created", () => {
+    // The real case: 6 scheduled, 43 overdue, 21 of them from two bulk writes.
+    const { body } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 6,
+      overdueCount: 43,
+      cohortCount: 22,
+    });
+    expect(body).toContain("43 overdue");
+    expect(body).toContain("22 of those were created in one batch");
+  });
+
+  it("does NOT soften the number when the overdue pile is mostly real debt", () => {
+    const { body } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 6,
+      overdueCount: 43,
+      cohortCount: 4,
+    });
+    expect(body).toBe("6 actions scheduled today, and 43 overdue.");
+    expect(body).not.toContain("one batch");
+  });
+
+  it("treats an exact half as real debt — the reframe needs a majority", () => {
+    const { body } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 0,
+      overdueCount: 10,
+      cohortCount: 5,
+    });
+    expect(body).not.toContain("one batch");
+  });
+
+  it("singularises a single action", () => {
+    const { body } = buildMorningNudge({
+      firstName: "James",
+      todayCount: 1,
+      overdueCount: 0,
+      cohortCount: 0,
+    });
+    expect(body).toContain("1 action scheduled today");
+    expect(body).not.toContain("1 actions");
+  });
+});

--- a/src/server/services/access/__tests__/assignability.test.ts
+++ b/src/server/services/access/__tests__/assignability.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for the assignability guards.
+ *
+ * Sibling to workspaceRefs.test.ts. `assigneeId` opens the same kind of
+ * sideways read path as the epic/feature/cycle/scope links, except the row it
+ * points at is a `User` — and the includes on `ticket.getById` and
+ * `action.assign` return that user's `name` and `email`. The rule under test:
+ * you may only assign someone who could already read the thing.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import {
+  assertAssignableUser,
+  canAssignToUnscopedAction,
+} from "../assignability";
+
+const CALLER_ID = "user-caller";
+const MEMBER_ID = "user-member";
+const OUTSIDER_ID = "user-outsider";
+const WORKSPACE_ID = "ws-1";
+
+/** Only `memberIds` hold a direct WorkspaceUser row for WORKSPACE_ID. */
+function stubDirectMembers(
+  db: DeepMockProxy<PrismaClient>,
+  memberIds: string[],
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db.workspaceUser.findUnique.mockImplementation((args: any) => {
+    const userId = args?.where?.userId_workspaceId?.userId as string | undefined;
+    return Promise.resolve(
+      userId && memberIds.includes(userId)
+        ? { role: "member", workspaceId: WORKSPACE_ID }
+        : null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) as any;
+  });
+}
+
+describe("assertAssignableUser", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = mockDeep<PrismaClient>();
+    mockReset(db);
+  });
+
+  it("skips null/undefined so unassigning stays allowed", async () => {
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, null),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, undefined),
+    ).resolves.toBeUndefined();
+    expect(db.workspaceUser.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("accepts a direct workspace member", async () => {
+    stubDirectMembers(db, [MEMBER_ID]);
+
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, MEMBER_ID),
+    ).resolves.toBeUndefined();
+  });
+
+  it("accepts a team-based member — the same path that lets them read", async () => {
+    stubDirectMembers(db, []);
+    db.teamUser.findFirst.mockResolvedValue({
+      role: "member",
+      team: { workspaceId: WORKSPACE_ID },
+    } as never);
+
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, MEMBER_ID),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a user with no membership at all", async () => {
+    stubDirectMembers(db, []);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, OUTSIDER_ID),
+    ).rejects.toBeInstanceOf(TRPCError);
+  });
+
+  it("rejects as NOT_FOUND, so the error is not an existence oracle", async () => {
+    stubDirectMembers(db, []);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, OUTSIDER_ID),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Assignee not found in this workspace",
+    });
+  });
+
+  it("rejects a workspace guest: project-only access cannot read tickets", async () => {
+    // A guest has a ProjectMember row but no WorkspaceUser and no team, so
+    // getWorkspaceMembership returns null — deliberately, since the same
+    // resolver gates every ticket read.
+    stubDirectMembers(db, []);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+    db.projectMember.findFirst.mockResolvedValue({ id: "pm-1" } as never);
+
+    await expect(
+      assertAssignableUser(db, WORKSPACE_ID, OUTSIDER_ID),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});
+
+describe("canAssignToUnscopedAction", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = mockDeep<PrismaClient>();
+    mockReset(db);
+  });
+
+  it("always allows self-assignment, even with no workspace", async () => {
+    await expect(
+      canAssignToUnscopedAction(db, CALLER_ID, null, CALLER_ID),
+    ).resolves.toBe(true);
+    expect(db.team.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("allows a member of the action's workspace", async () => {
+    stubDirectMembers(db, [MEMBER_ID]);
+
+    await expect(
+      canAssignToUnscopedAction(db, CALLER_ID, WORKSPACE_ID, MEMBER_ID),
+    ).resolves.toBe(true);
+  });
+
+  it("allows a user who shares a team with the caller", async () => {
+    stubDirectMembers(db, []);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+    db.team.findFirst.mockResolvedValue({ id: "team-1" } as never);
+
+    await expect(
+      canAssignToUnscopedAction(db, CALLER_ID, null, MEMBER_ID),
+    ).resolves.toBe(true);
+  });
+
+  it("refuses a stranger — no workspace, no shared team", async () => {
+    stubDirectMembers(db, []);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+    db.team.findFirst.mockResolvedValue(null as never);
+
+    await expect(
+      canAssignToUnscopedAction(db, CALLER_ID, null, OUTSIDER_ID),
+    ).resolves.toBe(false);
+  });
+
+  it("refuses a stranger even when the action has a workspace", async () => {
+    stubDirectMembers(db, [CALLER_ID]);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+    db.team.findFirst.mockResolvedValue(null as never);
+
+    await expect(
+      canAssignToUnscopedAction(db, CALLER_ID, WORKSPACE_ID, OUTSIDER_ID),
+    ).resolves.toBe(false);
+  });
+});

--- a/src/server/services/access/__tests__/workspaceRefs.test.ts
+++ b/src/server/services/access/__tests__/workspaceRefs.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for the cross-workspace link guard.
+ *
+ * Covers the sideways route to the 2026-08-04 epic audit finding: a ticket or
+ * action in workspace A must not be able to point at an epic (or feature,
+ * cycle, scope) in workspace B, because the pointed-at row's fields come back
+ * inside the pointing row's own include.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import { assertWorkspaceScopedRefs } from "../workspaceRefs";
+
+const USER_ID = "user-1";
+const WORKSPACE_ID = "ws-1";
+const OTHER_WORKSPACE_ID = "ws-2";
+
+describe("assertWorkspaceScopedRefs", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = mockDeep<PrismaClient>();
+    mockReset(db);
+  });
+
+  it("is a no-op when no references are supplied", async () => {
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, {}),
+    ).resolves.toBeUndefined();
+    expect(db.epic.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("skips null/undefined references so unlinking stays allowed", async () => {
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, {
+        epicId: null,
+        featureId: undefined,
+      }),
+    ).resolves.toBeUndefined();
+    expect(db.epic.findUnique).not.toHaveBeenCalled();
+    expect(db.feature.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("accepts an epic in the same workspace", async () => {
+    db.epic.findUnique.mockResolvedValue({ workspaceId: WORKSPACE_ID } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { epicId: "epic-1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects an epic from another workspace without confirming it exists", async () => {
+    db.epic.findUnique.mockResolvedValue({
+      workspaceId: OTHER_WORKSPACE_ID,
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { epicId: "epic-foreign" }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Epic not found in this workspace",
+    });
+  });
+
+  it("rejects an epic id that does not exist at all", async () => {
+    db.epic.findUnique.mockResolvedValue(null as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { epicId: "nope" }),
+    ).rejects.toBeInstanceOf(TRPCError);
+  });
+
+  // A workspace-less action (no workspaceId, no project) has no containment
+  // rule to apply, so membership in the reference's workspace is the check.
+  // EditActionModal offers the context workspace's epics for these actions.
+  it("accepts a reference for a workspace-less row when the caller is a member", async () => {
+    db.epic.findUnique.mockResolvedValue({ workspaceId: WORKSPACE_ID } as never);
+    db.workspaceUser.findUnique.mockResolvedValue({
+      role: "member",
+      workspaceId: WORKSPACE_ID,
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, null, { epicId: "epic-1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a reference for a workspace-less row when the caller is not a member", async () => {
+    db.epic.findUnique.mockResolvedValue({
+      workspaceId: OTHER_WORKSPACE_ID,
+    } as never);
+    db.workspaceUser.findUnique.mockResolvedValue(null as never);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, null, { epicId: "epic-foreign" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("admits a team-based member on the workspace-less path", async () => {
+    db.epic.findUnique.mockResolvedValue({ workspaceId: WORKSPACE_ID } as never);
+    db.workspaceUser.findUnique.mockResolvedValue(null as never);
+    db.teamUser.findFirst.mockResolvedValue({
+      role: "member",
+      team: { workspaceId: WORKSPACE_ID },
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, null, { epicId: "epic-1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not consult membership when the pointing row has a workspace", async () => {
+    db.epic.findUnique.mockResolvedValue({
+      workspaceId: OTHER_WORKSPACE_ID,
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { epicId: "epic-1" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    // Containment is the whole rule here — being a member of the epic's
+    // workspace must not let you link it into a different workspace's ticket.
+    expect(db.workspaceUser.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("resolves a feature through its product's workspace", async () => {
+    db.feature.findUnique.mockResolvedValue({
+      product: { workspaceId: OTHER_WORKSPACE_ID },
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { featureId: "feat-1" }),
+    ).rejects.toMatchObject({ message: "Feature not found in this workspace" });
+  });
+
+  it("resolves a cycle through its List row", async () => {
+    db.list.findUnique.mockResolvedValue({
+      workspaceId: OTHER_WORKSPACE_ID,
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { cycleId: "cycle-1" }),
+    ).rejects.toMatchObject({ message: "Cycle not found in this workspace" });
+  });
+
+  it("resolves a scope through feature → product → workspace", async () => {
+    db.featureScope.findUnique.mockResolvedValue({
+      feature: { product: { workspaceId: WORKSPACE_ID } },
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, { scopeId: "scope-1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects when any one of several references is foreign", async () => {
+    db.epic.findUnique.mockResolvedValue({ workspaceId: WORKSPACE_ID } as never);
+    db.feature.findUnique.mockResolvedValue({
+      product: { workspaceId: WORKSPACE_ID },
+    } as never);
+    db.list.findUnique.mockResolvedValue({
+      workspaceId: OTHER_WORKSPACE_ID,
+    } as never);
+
+    await expect(
+      assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, {
+        epicId: "epic-1",
+        featureId: "feat-1",
+        cycleId: "cycle-foreign",
+      }),
+    ).rejects.toMatchObject({ message: "Cycle not found in this workspace" });
+  });
+});

--- a/src/server/services/access/assignability.ts
+++ b/src/server/services/access/assignability.ts
@@ -1,0 +1,105 @@
+/**
+ * Assignability guards.
+ *
+ * Sibling to `workspaceRefs.ts`: same class of hole, different target. A write
+ * that accepts a foreign key opens a *read* path, because the pointed-at row's
+ * fields come back inside the pointing row's own `include`.
+ *
+ * For `assigneeId` the pointed-at row is a `User`, and the include returns
+ * `name` and `email`. So without this guard an authenticated user can create a
+ * ticket in their own product, set `assigneeId` to an arbitrary user CUID, read
+ * the ticket back through `ticket.getById`, and harvest that user's email — a
+ * user-enumeration / PII disclosure path that needs only a valid CUID.
+ *
+ * The rule, one line: **you may only assign someone who could already read the
+ * thing you are assigning them to.** Assignment is not a capability grant — it
+ * cannot reach further than the reader set, or it becomes a way to pull a
+ * stranger's identity into a workspace they have nothing to do with.
+ *
+ * Two consequences worth stating, because both were open questions:
+ *
+ *  - **Workspace guests are not assignable to tickets.** A guest (project-only
+ *    `ProjectMember`, no `WorkspaceUser` row) is refused by
+ *    `getWorkspaceMembership`, which is the same resolver behind
+ *    `assertWorkspaceMember` — the gate on every ticket read. A guest therefore
+ *    cannot open the ticket at all, so assigning one is both useless and a
+ *    leak. Excluding them keeps the assignable set a subset of the reader set.
+ *  - **External-agent shadow users need no exception.** ADR-0049 gives each
+ *    agent's shadow user ordinary `WorkspaceUser` rows, granted by the owner,
+ *    so they pass through `getWorkspaceMembership` unchanged.
+ *
+ * Rejections are NOT_FOUND rather than FORBIDDEN so the error cannot be used as
+ * an oracle confirming that a given CUID belongs to a real user somewhere.
+ */
+
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+import { getWorkspaceMembership } from "./resolvers/workspaceResolver";
+
+/**
+ * Throw unless `assigneeId` may be assigned work inside `workspaceId`.
+ *
+ * A `null` or `undefined` assignee means "not being set" (or "being cleared")
+ * and is skipped — unassigning is always allowed.
+ *
+ * Used by the ticket router, where the workspace is never ambiguous: a ticket's
+ * workspace comes from its product. Actions, whose scope can be a project, a
+ * team, or nothing at all, use `canAssignToUnscopedAction` below.
+ */
+export async function assertAssignableUser(
+  db: PrismaClient,
+  workspaceId: string,
+  assigneeId: string | null | undefined,
+): Promise<void> {
+  if (!assigneeId) return;
+
+  const membership = await getWorkspaceMembership(db, assigneeId, workspaceId);
+  if (!membership) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Assignee not found in this workspace",
+    });
+  }
+}
+
+/**
+ * May `candidateId` be assigned to an action that has neither a project nor a
+ * team?
+ *
+ * `action.assign` validates candidates against the action's project or team,
+ * but fell through to an unconditional `true` when the action had neither —
+ * and then returned `assignees.user.email`, reopening the same leak.
+ *
+ * The replacement mirrors exactly what `getAssignableUsers` offers the picker
+ * for such an action, so the server enforces what the UI already presents:
+ * yourself (1), members of the action's workspace (2), and users who share a
+ * team with you (3). Nothing wider.
+ */
+export async function canAssignToUnscopedAction(
+  db: PrismaClient,
+  callerId: string,
+  workspaceId: string | null,
+  candidateId: string,
+): Promise<boolean> {
+  // 1. Self-assignment is always legitimate and leaks nothing new.
+  if (candidateId === callerId) return true;
+
+  // 2. Members of the action's own workspace, when it has one.
+  if (workspaceId) {
+    const membership = await getWorkspaceMembership(db, candidateId, workspaceId);
+    if (membership) return true;
+  }
+
+  // 3. Users who share a team with the caller — the picker's fallback for an
+  //    action with no workspace context at all.
+  const sharedTeam = await db.team.findFirst({
+    where: {
+      AND: [
+        { members: { some: { userId: candidateId } } },
+        { members: { some: { userId: callerId } } },
+      ],
+    },
+    select: { id: true },
+  });
+  return sharedTeam !== null;
+}

--- a/src/server/services/access/index.ts
+++ b/src/server/services/access/index.ts
@@ -103,3 +103,7 @@ export {
   buildKnowledgePageAccessWhere,
 } from "./resolvers/knowledgePageResolver";
 export type { KnowledgePageAccessInfo } from "./resolvers/knowledgePageResolver";
+
+// Cross-workspace link guards (epic/feature/cycle/scope foreign keys)
+export { assertWorkspaceScopedRefs } from "./workspaceRefs";
+export type { WorkspaceScopedRefs } from "./workspaceRefs";

--- a/src/server/services/access/index.ts
+++ b/src/server/services/access/index.ts
@@ -77,6 +77,7 @@ export { getTeamMembership, getUserTeams } from "./resolvers/teamResolver";
 export {
   getProjectAccess,
   hasProjectAccess,
+  isProjectInsider,
   canEditProject,
   canManageProjectMembers,
   buildProjectAccessWhere,

--- a/src/server/services/access/index.ts
+++ b/src/server/services/access/index.ts
@@ -107,3 +107,9 @@ export type { KnowledgePageAccessInfo } from "./resolvers/knowledgePageResolver"
 // Cross-workspace link guards (epic/feature/cycle/scope foreign keys)
 export { assertWorkspaceScopedRefs } from "./workspaceRefs";
 export type { WorkspaceScopedRefs } from "./workspaceRefs";
+
+// Assignability guards (assigneeId / ActionAssignee foreign keys to User)
+export {
+  assertAssignableUser,
+  canAssignToUnscopedAction,
+} from "./assignability";

--- a/src/server/services/access/resolvers/actionResolver.ts
+++ b/src/server/services/access/resolvers/actionResolver.ts
@@ -12,13 +12,19 @@
 
 import type { PrismaClient } from "@prisma/client";
 import type { Permission } from "../types";
-import { getProjectAccess, hasProjectAccess, canEditProject } from "./projectResolver";
+import { getProjectAccess, hasProjectAccess, canEditProject, isProjectInsider } from "./projectResolver";
 
 interface ActionAccessInfo {
   isCreator: boolean;
   isAssignee: boolean;
   hasProjectAccess: boolean;
   canEditProject: boolean;
+  /**
+   * Project access via a membership path, NOT mere `isPublic` visibility.
+   * Use this — never `hasProjectAccess` — to gate anything that exposes the
+   * workspace around the action (member rosters, org-wide data).
+   */
+  isProjectInsider: boolean;
 }
 
 export async function getActionAccess(
@@ -51,6 +57,7 @@ export async function getActionAccess(
     isAssignee,
     hasProjectAccess: projectAccess ? hasProjectAccess(projectAccess) : false,
     canEditProject: projectAccess ? canEditProject(projectAccess) : false,
+    isProjectInsider: projectAccess ? isProjectInsider(projectAccess) : false,
   };
 }
 

--- a/src/server/services/access/resolvers/projectResolver.ts
+++ b/src/server/services/access/resolvers/projectResolver.ts
@@ -125,6 +125,32 @@ export function hasProjectAccess(access: ProjectAccess): boolean {
   return access.isTeamMember || access.isWorkspaceMember;
 }
 
+/**
+ * Does this access carry a *membership* path to the project, rather than mere
+ * public visibility?
+ *
+ * `hasProjectAccess` short-circuits to true for ANY authenticated caller when
+ * the project is public, which makes it the wrong gate for anything that
+ * exposes the organisation *around* the project — workspace member rosters,
+ * sibling projects, workspace settings. Public visibility grants the project,
+ * never the workspace behind it.
+ *
+ * Concretely: bounty action ids for public projects are served by the
+ * unauthenticated `/api/bounties` feed, and public projects are SEO-indexed via
+ * the sitemap. So "caller passed hasProjectAccess" can mean nothing more than
+ * "caller read a public URL and signed up".
+ *
+ * This is `hasProjectAccess` minus the `isPublic` short-circuit.
+ */
+export function isProjectInsider(access: ProjectAccess): boolean {
+  if (access.isCreator) return true;
+  if (access.isMember) return true;
+  if (access.isRestricted) {
+    return isWorkspaceEscapeHatch(access);
+  }
+  return access.isTeamMember || access.isWorkspaceMember;
+}
+
 /** Check if user can edit a project */
 export function canEditProject(access: ProjectAccess): boolean {
   if (access.isCreator) return true;

--- a/src/server/services/access/workspaceRefs.ts
+++ b/src/server/services/access/workspaceRefs.ts
@@ -1,0 +1,142 @@
+/**
+ * Cross-workspace link guards.
+ *
+ * Tickets and actions carry optional foreign keys to workspace-scoped rows
+ * (epic, feature, cycle, scope). The routers gate the *pointing* row — the
+ * ticket's product workspace, the action's project — but a foreign key is a
+ * second read path: the pointed-at row's fields come back inside the pointing
+ * row's own `include`.
+ *
+ * So without this guard, a member of workspace A can create a ticket in their
+ * own product, set `epicId` to an epic in workspace B, and read that epic's
+ * name and status back through `ticket.getById`. That is the 2026-08-04 epic
+ * audit finding (`epic.getById` had no membership check) reachable sideways.
+ *
+ * Every workspace-scoped reference must therefore live in the same workspace
+ * as the row pointing at it. Mismatches raise NOT_FOUND rather than FORBIDDEN
+ * so the error does not confirm that the id exists in some other workspace.
+ */
+
+import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+import { getWorkspaceMembership } from "./resolvers/workspaceResolver";
+
+/**
+ * Workspace-scoped rows a ticket or action can reference. A `null` or
+ * `undefined` value means "not being set" and is skipped — unlinking is
+ * always allowed.
+ */
+export interface WorkspaceScopedRefs {
+  epicId?: string | null;
+  featureId?: string | null;
+  cycleId?: string | null;
+  scopeId?: string | null;
+}
+
+/**
+ * Throw unless the caller may link every supplied reference.
+ *
+ * `workspaceId` is the effective workspace of the pointing row:
+ *
+ *  - When set, the reference must live in that same workspace (containment).
+ *    Tickets always take this path — a ticket's workspace comes from its
+ *    product, so a reference from anywhere else is incoherent.
+ *  - When null — an action with no workspace and no project — containment is
+ *    undefined, so fall back to the security requirement itself: the caller
+ *    must be a member of the reference's own workspace. `EditActionModal`
+ *    offers the context workspace's epics for such actions, so rejecting
+ *    outright would break a supported flow.
+ */
+export async function assertWorkspaceScopedRefs(
+  db: PrismaClient,
+  userId: string,
+  workspaceId: string | null,
+  refs: WorkspaceScopedRefs,
+): Promise<void> {
+  const lookups: Array<Promise<{ label: string; refWorkspaceId: string | null }>> =
+    [];
+
+  if (refs.epicId) {
+    lookups.push(
+      db.epic
+        .findUnique({
+          where: { id: refs.epicId },
+          select: { workspaceId: true },
+        })
+        .then((row) => ({
+          label: "Epic",
+          refWorkspaceId: row?.workspaceId ?? null,
+        })),
+    );
+  }
+
+  if (refs.featureId) {
+    lookups.push(
+      db.feature
+        .findUnique({
+          where: { id: refs.featureId },
+          select: { product: { select: { workspaceId: true } } },
+        })
+        .then((row) => ({
+          label: "Feature",
+          refWorkspaceId: row?.product.workspaceId ?? null,
+        })),
+    );
+  }
+
+  // A "cycle" is a List row (Ticket.cycle → List, relation "TicketCycle").
+  if (refs.cycleId) {
+    lookups.push(
+      db.list
+        .findUnique({
+          where: { id: refs.cycleId },
+          select: { workspaceId: true },
+        })
+        .then((row) => ({
+          label: "Cycle",
+          refWorkspaceId: row?.workspaceId ?? null,
+        })),
+    );
+  }
+
+  if (refs.scopeId) {
+    lookups.push(
+      db.featureScope
+        .findUnique({
+          where: { id: refs.scopeId },
+          select: {
+            feature: { select: { product: { select: { workspaceId: true } } } },
+          },
+        })
+        .then((row) => ({
+          label: "Scope",
+          refWorkspaceId: row?.feature.product.workspaceId ?? null,
+        })),
+    );
+  }
+
+  if (lookups.length === 0) return;
+
+  for (const { label, refWorkspaceId } of await Promise.all(lookups)) {
+    if (!refWorkspaceId) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: `${label} not found in this workspace`,
+      });
+    }
+
+    if (refWorkspaceId === workspaceId) continue;
+
+    // Pointing row has no workspace of its own: membership in the
+    // reference's workspace is the check that matters.
+    if (workspaceId === null) {
+      const membership = await getWorkspaceMembership(db, userId, refWorkspaceId);
+      if (membership) continue;
+    }
+
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: `${label} not found in this workspace`,
+    });
+  }
+}

--- a/src/server/services/clientErrors/__tests__/clientErrorBug.test.ts
+++ b/src/server/services/clientErrors/__tests__/clientErrorBug.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  buildClientErrorBody,
+  buildClientErrorBug,
+  fingerprintClientError,
+  shouldFileClientError,
+} from "../clientErrorBug";
+
+const report = (over: Partial<Parameters<typeof buildClientErrorBug>[0]> = {}) => ({
+  area: "chat-stream",
+  kind: "model",
+  message: "Your credit balance is too low to access the Anthropic API.",
+  ...over,
+});
+
+describe("shouldFileClientError", () => {
+  it("files the kinds that mean something is broken", () => {
+    expect(shouldFileClientError("model")).toBe(true);
+    expect(shouldFileClientError("unknown")).toBe(true);
+    // No classification at all: nobody decided it was benign.
+    expect(shouldFileClientError(undefined)).toBe(true);
+  });
+
+  it("ignores the kinds that are the network or the user's session", () => {
+    expect(shouldFileClientError("transport")).toBe(false);
+    expect(shouldFileClientError("idle-timeout")).toBe(false);
+    expect(shouldFileClientError("auth")).toBe(false);
+  });
+});
+
+describe("fingerprintClientError", () => {
+  it("collapses repeats of the same fault onto one id", () => {
+    expect(fingerprintClientError(report())).toBe(fingerprintClientError(report()));
+  });
+
+  it("ignores the digits that differ between occurrences", () => {
+    // A request id or a byte count must not split one fault into many tickets.
+    expect(fingerprintClientError(report({ message: "Upload failed after 1423 bytes" }))).toBe(
+      fingerprintClientError(report({ message: "Upload failed after 87 bytes" })),
+    );
+  });
+
+  it("keeps genuinely different faults apart", () => {
+    const credit = fingerprintClientError(report());
+    const other = fingerprintClientError(report({ message: "Model overloaded" }));
+    const elsewhere = fingerprintClientError(report({ area: "zoe-canvas-stream" }));
+    expect(new Set([credit, other, elsewhere]).size).toBe(3);
+  });
+
+  it("names the origin in the id, so a client bug is recognisable as one", () => {
+    expect(fingerprintClientError(report())).toMatch(/^client:chat-stream:[0-9a-f]{12}$/);
+  });
+});
+
+describe("buildClientErrorBug", () => {
+  it("titles the ticket with where it broke and what it said", () => {
+    const bug = buildClientErrorBug(report());
+    expect(bug.title).toBe(
+      "chat-stream: Your credit balance is too low to access the Anthropic API.",
+    );
+    expect(bug.culprit).toBe("chat-stream");
+    expect(bug.level).toBe("error");
+  });
+
+  it("leaves projectSlug null so the AI fixer is not pointed at a stackless report", () => {
+    expect(buildClientErrorBug(report()).projectSlug).toBeNull();
+  });
+
+  it("masks a credential the error echoed back", () => {
+    const secret = "sk_live_" + "b".repeat(40);
+    const bug = buildClientErrorBug(report({ message: `Invalid key ${secret}` }));
+    expect(bug.title).not.toContain(secret);
+  });
+
+  it("caps a runaway message so the title stays a title", () => {
+    const bug = buildClientErrorBug(report({ message: "no ".repeat(200) }));
+    expect(bug.title.length).toBeLessThan(200);
+  });
+});
+
+describe("buildClientErrorBody", () => {
+  it("says where the report came from, rather than claiming Sentry saw it", () => {
+    const body = buildClientErrorBody(report());
+    expect(body).toContain("never reached Sentry");
+    expect(body).not.toContain("Reported automatically from Sentry");
+  });
+
+  it("renders the context a triager needs", () => {
+    const body = buildClientErrorBody(report({ context: { agentId: "localWikiAgent" } }));
+    expect(body).toContain("**Failure kind:** model");
+    expect(body).toContain("**agentId:** localWikiAgent");
+  });
+
+  it("masks credentials in context values too", () => {
+    const secret = "tok_" + "c".repeat(40);
+    const body = buildClientErrorBody(report({ context: { url: `https://x.test/${secret}` } }));
+    expect(body).not.toContain(secret);
+  });
+});

--- a/src/server/services/clientErrors/clientErrorBug.ts
+++ b/src/server/services/clientErrors/clientErrorBug.ts
@@ -1,0 +1,122 @@
+import crypto from "crypto";
+
+import { maskTokenLike } from "~/server/utils/redactToolArgs";
+import type { SentryBug } from "~/server/services/sentry/sentryPayload";
+
+/**
+ * Turning a *handled* client-side failure into a Bug Ticket.
+ *
+ * The Sentry webhook (ADR-0027) only ever sees errors Sentry itself saw, and
+ * Sentry only sees what nobody caught. Every failure the app handles gracefully
+ * — a chat turn that renders a calm "try again", a bridge call that logs and
+ * carries on — was therefore invisible: no Sentry issue, so no Bug Ticket, so
+ * nothing to triage. That is the gap this closes.
+ *
+ * Deliberately *not* done by having the browser call the Sentry webhook route:
+ * that route authenticates by HMAC over the raw body using the integration's
+ * client secret, which cannot live in a webview, and it would mean fabricating
+ * Sentry issue ids and permalinks that lead nowhere. This files the same shape
+ * through the same ingest service, honestly labelled as what it is.
+ */
+
+/** A failure the client handled, reported for triage. */
+export interface ClientErrorReport {
+  /** Where in the app it happened — `chat-stream`, `local-wiki-status`, … */
+  area: string;
+  /** The classification the UI already made, when it made one. */
+  kind?: string;
+  /** The thrown error's message. Masked and capped before it lands anywhere. */
+  message: string;
+  /** Optional context: the agent, the route, the surface. Values are capped. */
+  context?: Record<string, string>;
+}
+
+/** Longest error text carried into a ticket title. */
+const MAX_TITLE_CHARS = 160;
+/** Longest single context value rendered in the body. */
+const MAX_CONTEXT_CHARS = 200;
+
+/**
+ * Failure kinds worth a ticket.
+ *
+ * A dropped connection on a train is not a defect, and filing it would bury the
+ * ones that are — the tracker is for things a person can fix. `auth` is
+ * excluded for the same reason: an expired session is the app working as
+ * designed. What's left is the model/provider refusing, and the genuinely
+ * unclassified, which is exactly the bucket today's "Something went wrong"
+ * belonged to.
+ */
+const REPORTABLE_KINDS = new Set(["model", "unknown"]);
+
+export function shouldFileClientError(kind: string | undefined): boolean {
+  // No classification at all means nobody decided this was benign.
+  return kind === undefined || REPORTABLE_KINDS.has(kind);
+}
+
+/**
+ * Stable id for "this error, again".
+ *
+ * The ingest service dedups on it, so the fingerprint decides whether a
+ * recurring failure collapses onto one ticket or files a hundred. Built from
+ * the area, the kind and the *message*, so two different faults in the same
+ * component stay separate — at the cost of a message carrying a request id
+ * splitting into many. Numbers are stripped for exactly that reason.
+ */
+export function fingerprintClientError(report: ClientErrorReport): string {
+  const normalized = maskTokenLike(report.message)
+    .toLowerCase()
+    // Ids, timestamps, byte counts — the parts that differ between two
+    // occurrences of the same fault.
+    .replace(/\d+/g, "#")
+    .trim();
+  const digest = crypto
+    .createHash("sha1")
+    .update(`${report.area}|${report.kind ?? ""}|${normalized}`)
+    .digest("hex")
+    .slice(0, 12);
+  return `client:${report.area}:${digest}`;
+}
+
+/** Trim a string for display, marking the cut so nobody reads it as complete. */
+function cap(text: string, max: number): string {
+  const clean = text.replace(/\s+/g, " ").trim();
+  return clean.length > max ? `${clean.slice(0, max)}…` : clean;
+}
+
+/**
+ * Normalize a report into the shape the bug ingest already understands.
+ *
+ * `projectSlug` is deliberately null: it is what gates the `ai-fixable` label,
+ * and a handled client error has no stack and no Sentry issue to work from, so
+ * pointing the fixer at one would waste a run. A human triages these.
+ */
+export function buildClientErrorBug(report: ClientErrorReport): SentryBug {
+  const message = cap(maskTokenLike(report.message), MAX_TITLE_CHARS);
+  return {
+    issueId: fingerprintClientError(report),
+    title: `${report.area}: ${message || "handled error with no message"}`,
+    level: "error",
+    culprit: report.area,
+    url: null,
+    shortId: null,
+    projectSlug: null,
+  };
+}
+
+/**
+ * The ticket body. Separate from `buildBugBody` because that one opens with
+ * "Reported automatically from Sentry", which would be untrue here.
+ */
+export function buildClientErrorBody(report: ClientErrorReport): string {
+  const lines: string[] = [
+    "Reported automatically from the app — a failure the UI handled gracefully, so it never reached Sentry.",
+    "",
+    `- **Area:** ${report.area}`,
+  ];
+  if (report.kind) lines.push(`- **Failure kind:** ${report.kind}`);
+  for (const [key, value] of Object.entries(report.context ?? {})) {
+    lines.push(`- **${key}:** ${cap(maskTokenLike(value), MAX_CONTEXT_CHARS)}`);
+  }
+  lines.push("", "```", cap(maskTokenLike(report.message), 1000), "```");
+  return lines.join("\n");
+}

--- a/src/server/services/morningNudge.ts
+++ b/src/server/services/morningNudge.ts
@@ -1,0 +1,57 @@
+/**
+ * Phrasing for the morning push notification.
+ *
+ * Split out of the cron route so it can be unit-tested without importing the
+ * route module, which pulls in the Prisma client and therefore the whole env.
+ */
+
+export interface MorningNudge {
+  title: string;
+  body: string;
+}
+
+/**
+ * Pure, so the phrasing is testable without a database or a clock.
+ *
+ * Leads with the reframe when most of the overdue pile is bulk-written. "43
+ * overdue" is a number that produces avoidance; "21 of those were created in
+ * one batch" is a number that produces a decision.
+ */
+export function buildMorningNudge(args: {
+  firstName: string;
+  todayCount: number;
+  overdueCount: number;
+  cohortCount: number;
+}): MorningNudge {
+  const { firstName, todayCount, overdueCount, cohortCount } = args;
+  const title = `Good morning, ${firstName}!`;
+
+  const todayPart =
+    todayCount > 0
+      ? `${todayCount} action${todayCount === 1 ? "" : "s"} scheduled today`
+      : "Nothing scheduled today";
+
+  if (overdueCount === 0) {
+    return {
+      title,
+      body:
+        todayCount > 0
+          ? `${todayPart}. Nothing overdue — nice.`
+          : `${todayPart}, and nothing overdue.`,
+    };
+  }
+
+  // Only reframe when the bulk-written share is the majority. Below that the
+  // overdue count really is mostly real commitments, and softening it would lie.
+  if (cohortCount > overdueCount / 2) {
+    return {
+      title,
+      body: `${todayPart}, and ${overdueCount} overdue — but ${cohortCount} of those were created in one batch and were probably never really due. Worth two minutes to clear out.`,
+    };
+  }
+
+  return {
+    title,
+    body: `${todayPart}, and ${overdueCount} overdue.`,
+  };
+}

--- a/src/server/services/schedulingBriefing.ts
+++ b/src/server/services/schedulingBriefing.ts
@@ -1,0 +1,193 @@
+import crypto from "crypto";
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * Bump on every change to SCHEDULING_SYSTEM_PROMPT or buildSchedulingPrompt,
+ * including whitespace. Metrics are sliced by this, and a reused version
+ * silently merges two different prompts' results.
+ *
+ * See docs/ZOE_DAILY_BRIEFING.md.
+ */
+export const SCHEDULING_PROMPT_VERSION = "zoe-scheduling-v1";
+
+/**
+ * A briefing is reusable for the rest of the calendar day as long as the input
+ * it was generated from is unchanged. Suggestions are advice about a set of
+ * actions and a calendar; if neither moved, regenerating produces the same
+ * advice at real token cost.
+ */
+export interface SuggestionInputSnapshot {
+  days: number;
+  /** Sorted; ids + the fields the prompt actually reads. */
+  overdue: Array<{
+    id: string;
+    name: string;
+    dueDate: string | null;
+    scheduledStart: string | null;
+    projectName: string | null;
+  }>;
+  /** Sorted; only the busy intervals matter for scheduling. */
+  calendar: Array<{ start: string; end: string }>;
+  scheduled: Array<{ id: string; scheduledStart: string | null }>;
+}
+
+function iso(d: Date | string | null | undefined): string | null {
+  if (!d) return null;
+  return new Date(d).toISOString();
+}
+
+/**
+ * Google calendar times are `{ dateTime }` for timed events and `{ date }` for
+ * all-day ones. Both matter to the snapshot: an all-day event still blocks a
+ * day even though it has no time.
+ */
+type CalendarTime = { dateTime?: string; date?: string; timeZone?: string };
+
+function calendarIso(t: CalendarTime | string | Date | null | undefined): string {
+  if (!t) return "";
+  if (typeof t === "string" || t instanceof Date) return iso(t) ?? "";
+  return iso(t.dateTime ?? t.date) ?? "";
+}
+
+/**
+ * Build a deterministic snapshot of everything the prompt sees. Deterministic
+ * matters twice: it is the cache key, and it is the replayable input the
+ * autoresearch loop scores candidate prompts against — so the ordering must not
+ * depend on query order.
+ */
+export function buildInputSnapshot(args: {
+  days: number;
+  overdueActions: Array<{
+    id: string;
+    name: string;
+    dueDate: Date | null;
+    scheduledStart: Date | null;
+    project?: { name: string } | null;
+  }>;
+  calendarEvents: Array<{
+    start?: CalendarTime | string | Date | null;
+    end?: CalendarTime | string | Date | null;
+  }>;
+  scheduledActions: Array<{ id: string; scheduledStart: Date | null }>;
+}): SuggestionInputSnapshot {
+  return {
+    days: args.days,
+    overdue: args.overdueActions
+      .map((a) => ({
+        id: a.id,
+        name: a.name,
+        dueDate: iso(a.dueDate),
+        scheduledStart: iso(a.scheduledStart),
+        projectName: a.project?.name ?? null,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+    calendar: args.calendarEvents
+      .map((e) => ({ start: calendarIso(e.start), end: calendarIso(e.end) }))
+      .sort((a, b) => a.start.localeCompare(b.start) || a.end.localeCompare(b.end)),
+    scheduled: args.scheduledActions
+      .map((a) => ({ id: a.id, scheduledStart: iso(a.scheduledStart) }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+  };
+}
+
+export function snapshotHash(snapshot: SuggestionInputSnapshot): string {
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(snapshot))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/** Midnight UTC for the @db.Date column, so one row per user per calendar day. */
+export function briefingDate(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+interface StoredOutput {
+  snapshotHash: string;
+  suggestions: unknown[];
+}
+
+/**
+ * Today's briefing for this user, if one was generated from an identical input.
+ * Returns null when absent or stale, which is the signal to call the model.
+ */
+export async function findReusableBriefing(
+  db: PrismaClient,
+  args: {
+    userId: string;
+    workspaceId?: string | null;
+    date: Date;
+    hash: string;
+  },
+): Promise<{ id: string; suggestions: unknown[] } | null> {
+  const existing = await db.dailyBriefing.findFirst({
+    where: {
+      userId: args.userId,
+      date: args.date,
+      promptVersion: SCHEDULING_PROMPT_VERSION,
+      ...(args.workspaceId ? { workspaceId: args.workspaceId } : {}),
+    },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, outputStructured: true },
+  });
+
+  if (!existing?.outputStructured) return null;
+
+  const stored = existing.outputStructured as unknown as StoredOutput;
+  if (stored?.snapshotHash !== args.hash) return null;
+
+  return { id: existing.id, suggestions: stored.suggestions ?? [] };
+}
+
+export async function persistBriefing(
+  db: PrismaClient,
+  args: {
+    userId: string;
+    workspaceId?: string | null;
+    date: Date;
+    modelId: string;
+    snapshot: SuggestionInputSnapshot;
+    hash: string;
+    outputText: string;
+    suggestions: unknown[];
+    latencyMs?: number;
+  },
+): Promise<string | null> {
+  try {
+    const row = await db.dailyBriefing.create({
+      data: {
+        userId: args.userId,
+        workspaceId: args.workspaceId ?? null,
+        date: args.date,
+        promptVersion: SCHEDULING_PROMPT_VERSION,
+        modelId: args.modelId,
+        inputSnapshot: args.snapshot as unknown as object,
+        outputText: args.outputText,
+        outputStructured: {
+          snapshotHash: args.hash,
+          suggestions: args.suggestions,
+        } as unknown as object,
+        latencyMs: args.latencyMs,
+      },
+      select: { id: true },
+    });
+    return row.id;
+  } catch (error) {
+    // Persistence is telemetry, never the point of the request. A failure here
+    // costs a cache entry, not the user's suggestions.
+    console.error("[schedulingBriefing] failed to persist briefing:", error);
+    return null;
+  }
+}
+
+export const BRIEFING_INTERACTION_TYPES = [
+  "viewed",
+  "accepted",
+  "dismissed",
+  "refreshed",
+  "thumbs_up",
+  "thumbs_down",
+] as const;
+
+export type BriefingInteractionType = (typeof BRIEFING_INTERACTION_TYPES)[number];

--- a/src/server/services/sentry/SentryBugService.ts
+++ b/src/server/services/sentry/SentryBugService.ts
@@ -121,9 +121,9 @@ async function labelTicket(
   ticketId: string,
   workspaceId: string,
   authorId: string,
-  extraLabels: readonly { name: string; slug: string; color: string }[] = [],
+  labels: readonly { name: string; slug: string; color: string }[],
 ): Promise<void> {
-  for (const label of [...TICKET_LABELS, ...extraLabels]) {
+  for (const label of labels) {
     try {
       const tag = await db.tag.upsert({
         where: { slug_workspaceId: { slug: label.slug, workspaceId } },
@@ -160,7 +160,22 @@ export interface IngestResult {
 export async function ingestSentryBug(
   db: PrismaClient,
   bug: SentryBug,
-  options?: { productId?: string; sourceSlug?: string | null },
+  options?: {
+    productId?: string;
+    sourceSlug?: string | null;
+    /**
+     * Ticket body, when the caller isn't Sentry. Defaults to `buildBugBody`,
+     * which opens with "Reported automatically from Sentry" — true for the
+     * webhook, a lie for anything else (see `clientErrorBug`).
+     */
+    body?: string;
+    /**
+     * Labels in place of the default "Sentry" + "bug" pair. A handled client
+     * error is a bug, but it did not come from Sentry, and filtering on that
+     * label should keep meaning what it says.
+     */
+    labels?: readonly { name: string; slug: string; color: string }[];
+  },
 ): Promise<IngestResult> {
   // Destination precedence: an explicit per-workspace product (from a
   // workspace-scoped Sentry integration) wins; otherwise fall back to the
@@ -205,27 +220,27 @@ export async function ingestSentryBug(
     workspaceId: product.workspaceId,
     createdById: errol.id,
     title: bug.title,
-    body: buildBugBody(bug),
+    body: options?.body ?? buildBugBody(bug),
     type: "BUG",
     status: "BACKLOG",
     // Priority is left unset — a human assigns it during triage.
+    // `sentryIssueId` stays the key for non-Sentry origins too: it is the dedup
+    // path queried above, and a second path would mean a second lookup for no
+    // gain. The value's `client:` prefix says where it came from.
     links: { sentryIssueId: bug.issueId, sentryUrl: bug.url },
   });
 
-  // Tag it with the workspace's "Sentry" and "bug" labels so these are filterable.
+  // Tag it so these are filterable. `labelTicket` now takes the complete set
+  // rather than prepending its own, so the origin's labels are named here.
   const source = sourceLabel(options?.sourceSlug ?? bug.projectSlug);
-  await labelTicket(
-    db,
-    ticket.id,
-    product.workspaceId,
-    errol.id,
-    [
-      ...(isAiFixableProject(bug.projectSlug) ? [AI_FIXABLE_LABEL] : []),
-      // Which codebase this came from. An explicit `?service=` wins; otherwise
-      // fall back to the slug the sender put in the payload.
-      ...(source ? [source] : []),
-    ],
-  );
+  await labelTicket(db, ticket.id, product.workspaceId, errol.id, [
+    // "Sentry" + "bug" unless the caller is not Sentry and says otherwise.
+    ...(options?.labels ?? TICKET_LABELS),
+    ...(isAiFixableProject(bug.projectSlug) ? [AI_FIXABLE_LABEL] : []),
+    // Which codebase this came from. An explicit `?service=` wins; otherwise
+    // fall back to the slug the sender put in the payload.
+    ...(source ? [source] : []),
+  ]);
 
   // Announce the new bug in Zulip (best-effort) with a deep link to the ticket.
   // Only on creation — recurring errors that dedup above do not re-notify.

--- a/src/server/services/sentry/SentryBugService.ts
+++ b/src/server/services/sentry/SentryBugService.ts
@@ -51,6 +51,40 @@ const TICKET_LABELS = [
 // gate is status READY_TO_PLAN (see .github/workflows/ai-bug-fixer.yml) — this
 // label alone does not start a run, so a human still triages the ticket out of
 // BACKLOG before any agent touches it.
+/**
+ * Colour for the per-service source label (see {@link sourceLabel}).
+ */
+const SOURCE_LABEL_COLOR = "avatar-blue";
+
+/** Upper bound on a generated label slug, so a hostile value can't bloat a tag. */
+const SOURCE_SLUG_MAX_LENGTH = 32;
+
+/**
+ * Build a label identifying which service an error came from, so a single
+ * destination product can carry bugs from several codebases and still be
+ * filterable (`clear-api` vs `clear-pipeline` …).
+ *
+ * The value arrives either from the webhook's `?service=` query param or, when
+ * absent, from the sender's own project slug. Both are attacker-influencable in
+ * principle — the token gate makes them semi-trusted at best — so the string is
+ * reduced to a bounded `[a-z0-9-]` slug rather than used verbatim.
+ */
+export function sourceLabel(
+  raw: string | null | undefined,
+): { name: string; slug: string; color: string } | null {
+  if (!raw) return null;
+  const slug = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, SOURCE_SLUG_MAX_LENGTH)
+    // A trailing dash can survive the truncation above.
+    .replace(/-+$/g, "");
+  if (!slug) return null;
+  return { name: slug, slug, color: SOURCE_LABEL_COLOR };
+}
+
 const AI_FIXABLE_LABEL = {
   name: "ai-fixable",
   slug: "ai-fixable",
@@ -126,7 +160,7 @@ export interface IngestResult {
 export async function ingestSentryBug(
   db: PrismaClient,
   bug: SentryBug,
-  options?: { productId?: string },
+  options?: { productId?: string; sourceSlug?: string | null },
 ): Promise<IngestResult> {
   // Destination precedence: an explicit per-workspace product (from a
   // workspace-scoped Sentry integration) wins; otherwise fall back to the
@@ -179,12 +213,18 @@ export async function ingestSentryBug(
   });
 
   // Tag it with the workspace's "Sentry" and "bug" labels so these are filterable.
+  const source = sourceLabel(options?.sourceSlug ?? bug.projectSlug);
   await labelTicket(
     db,
     ticket.id,
     product.workspaceId,
     errol.id,
-    isAiFixableProject(bug.projectSlug) ? [AI_FIXABLE_LABEL] : [],
+    [
+      ...(isAiFixableProject(bug.projectSlug) ? [AI_FIXABLE_LABEL] : []),
+      // Which codebase this came from. An explicit `?service=` wins; otherwise
+      // fall back to the slug the sender put in the payload.
+      ...(source ? [source] : []),
+    ],
   );
 
   // Announce the new bug in Zulip (best-effort) with a deep link to the ticket.

--- a/src/server/services/sentry/__tests__/SentryBugService.test.ts
+++ b/src/server/services/sentry/__tests__/SentryBugService.test.ts
@@ -27,7 +27,7 @@ vi.mock("../sentryZulip", () => ({
 
 import { createTicketWithNumber } from "~/plugins/product/server/services/createTicket";
 import { notifyZulipOfSentryBug } from "../sentryZulip";
-import { ingestSentryBug } from "../SentryBugService";
+import { ingestSentryBug, sourceLabel } from "../SentryBugService";
 import { type SentryBug } from "../sentryPayload";
 
 const dbMock: DeepMockProxy<PrismaClient> = mockDeep<PrismaClient>();
@@ -162,7 +162,9 @@ describe("ingestSentryBug", () => {
   it("find-or-creates the 'Sentry' and 'bug' workspace labels and attaches them", async () => {
     await ingestSentryBug(dbMock, bug);
 
-    expect(dbMock.tag.upsert).toHaveBeenCalledTimes(2);
+    // Two standard labels plus the source label derived from the project slug
+    // (see the "source label" suite below).
+    expect(dbMock.tag.upsert).toHaveBeenCalledTimes(3);
     expect(dbMock.tag.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { slug_workspaceId: { slug: "sentry", workspaceId: "ws-1" } },
@@ -185,7 +187,7 @@ describe("ingestSentryBug", () => {
         }),
       }),
     );
-    expect(dbMock.ticketTag.upsert).toHaveBeenCalledTimes(2);
+    expect(dbMock.ticketTag.upsert).toHaveBeenCalledTimes(3);
     expect(dbMock.ticketTag.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { ticketId_tagId: { ticketId: "ticket-1", tagId: "tag-1" } },
@@ -258,5 +260,78 @@ describe("ingestSentryBug", () => {
       expect(createTicketWithNumber).toHaveBeenCalledTimes(1);
       expect(result).toEqual({ created: true, ticketId: "ticket-1" });
     });
+  });
+
+  describe("source label", () => {
+    /** Slugs passed to tag.upsert for the current call. */
+    function labelSlugs(): (string | undefined)[] {
+      return dbMock.tag.upsert.mock.calls.map(
+        (c) => c[0].where.slug_workspaceId?.slug,
+      );
+    }
+
+    it("labels the ticket from an explicit ?service= value", async () => {
+      await ingestSentryBug(dbMock, bug, { sourceSlug: "clear-pipeline" });
+      expect(labelSlugs()).toContain("clear-pipeline");
+    });
+
+    it("falls back to the sender's project slug when none is given", async () => {
+      await ingestSentryBug(dbMock, bug);
+      // `bug.projectSlug` is exponential-frontend in this fixture.
+      expect(labelSlugs()).toContain("exponential-frontend");
+    });
+
+    it("prefers the explicit value over the payload's project slug", async () => {
+      await ingestSentryBug(dbMock, bug, { sourceSlug: "clear-api" });
+      const slugs = labelSlugs();
+      expect(slugs).toContain("clear-api");
+      expect(slugs).not.toContain("exponential-frontend");
+    });
+
+    it("adds no source label when neither is available", async () => {
+      await ingestSentryBug(
+        dbMock,
+        { ...bug, projectSlug: null },
+        { sourceSlug: null },
+      );
+      // Only the two standard labels.
+      expect(labelSlugs()).toEqual(["sentry", "bug"]);
+    });
+  });
+});
+
+describe("sourceLabel", () => {
+  it("passes through an already-clean slug", () => {
+    expect(sourceLabel("clear-pipeline")).toEqual({
+      name: "clear-pipeline",
+      slug: "clear-pipeline",
+      color: "avatar-blue",
+    });
+  });
+
+  it("normalizes case and separators", () => {
+    expect(sourceLabel("  CLEAR Context_Pipeline  ")?.slug).toBe(
+      "clear-context-pipeline",
+    );
+  });
+
+  it("strips characters that would be unsafe or ugly in a tag", () => {
+    expect(sourceLabel("../../etc/passwd")?.slug).toBe("etc-passwd");
+    expect(sourceLabel("<script>alert(1)</script>")?.slug).toBe(
+      "script-alert-1-script",
+    );
+  });
+
+  it("bounds the length and leaves no trailing dash", () => {
+    const slug = sourceLabel("a".repeat(40) + " tail")!.slug;
+    expect(slug).toHaveLength(32);
+    expect(slug.endsWith("-")).toBe(false);
+  });
+
+  it("returns null for empty or punctuation-only input", () => {
+    expect(sourceLabel(null)).toBeNull();
+    expect(sourceLabel("")).toBeNull();
+    expect(sourceLabel("   ")).toBeNull();
+    expect(sourceLabel("---")).toBeNull();
   });
 });

--- a/src/server/services/sentry/sentryPayload.ts
+++ b/src/server/services/sentry/sentryPayload.ts
@@ -51,6 +51,110 @@ interface SentryWebhookBody {
 }
 
 /**
+ * Minimal view of a GlitchTip *generic* (Slack-compatible) webhook body.
+ *
+ * GlitchTip has two outbound webhook modes. Its Sentry-compatible mode sends
+ * the nested `{action, data.issue}` shape handled above; its generic mode —
+ * the one its Alert Rule UI offers by default — sends this flat, Slack-styled
+ * shape instead, with no `Sentry-Hook-Resource` header.
+ */
+interface GlitchtipWebhookBody {
+  /** Event type slug, e.g. "issue.new" / "issue.resolved". Sometimes a bot name. */
+  alias?: string;
+  /** Human-readable summary; often boilerplate like "GlitchTip Alert". */
+  text?: string;
+  /** GlitchTip sends the issue id at the top level. */
+  issue_id?: string | number;
+  /** Project slug as a bare string (Sentry nests it under `project.slug`). */
+  project?: string | { slug?: string };
+  culprit?: string;
+  level?: string;
+  /** Slack-style content — the real error title/link live here. */
+  attachments?: {
+    title?: string;
+    title_link?: string;
+    text?: string;
+  }[];
+}
+
+/**
+ * Aliases we file a bug for. Anything else dotted (`issue.resolved`,
+ * `issue.archived`, …) is ignored. Dedup makes a mistake here cheap — a second
+ * event for a known issue id collapses onto the existing ticket — but not
+ * filing on resolutions keeps the backlog honest.
+ */
+const GLITCHTIP_NEW_ISSUE_ALIASES = ["issue.new", "issue.regression"];
+
+/** Trailing issue id in a GlitchTip issue URL: `…/issues/12345`. */
+const GLITCHTIP_ISSUE_URL = /\/issues\/(\d+)/;
+
+/**
+ * Turn a GlitchTip generic-webhook body into a normalized {@link SentryBug}, or
+ * `null` if it isn't a new-issue event we file.
+ */
+export function normalizeGlitchtipPayload(body: unknown): SentryBug | null {
+  const payload = (body ?? {}) as GlitchtipWebhookBody;
+
+  // `alias` is the event type when dotted. Some GlitchTip versions put a bot
+  // name there instead, so only *dotted* values are treated as a filter —
+  // otherwise we'd ignore every event on a deployment that sends "GlitchTip".
+  const alias = payload.alias;
+  if (
+    typeof alias === "string" &&
+    alias.includes(".") &&
+    !GLITCHTIP_NEW_ISSUE_ALIASES.includes(alias)
+  ) {
+    return null;
+  }
+
+  const attachment = payload.attachments?.[0];
+  const url = attachment?.title_link ?? null;
+
+  // Prefer the explicit id; fall back to parsing the issue URL so this still
+  // works on versions that omit `issue_id`. Without either we have no dedup
+  // key, so the event is not fileable.
+  const issueId =
+    payload.issue_id !== undefined && payload.issue_id !== null
+      ? String(payload.issue_id)
+      : (GLITCHTIP_ISSUE_URL.exec(url ?? "")?.[1] ?? null);
+  if (!issueId) return null;
+
+  // The attachment title carries the actual error; `text` is often boilerplate.
+  const title = attachment?.title ?? payload.text ?? "Untitled GlitchTip issue";
+
+  const projectSlug =
+    typeof payload.project === "string"
+      ? payload.project
+      : (payload.project?.slug ?? null);
+
+  return {
+    issueId,
+    title,
+    level: payload.level ?? null,
+    culprit: payload.culprit ?? null,
+    url,
+    // GlitchTip's generic payload has no Sentry-style short id.
+    shortId: null,
+    projectSlug,
+  };
+}
+
+/**
+ * Normalize an inbound issue webhook from either sender.
+ *
+ * Sentry always sends a `Sentry-Hook-Resource` header; GlitchTip's generic
+ * webhook sends none, so its absence is the discriminator.
+ */
+export function normalizeIssueWebhook(
+  resource: string | null,
+  body: unknown,
+): SentryBug | null {
+  return resource
+    ? normalizeSentryPayload(resource, body)
+    : normalizeGlitchtipPayload(body);
+}
+
+/**
  * Verify a Sentry integration-platform webhook signature.
  *
  * Sentry signs the raw request body with HMAC-SHA256 using the integration's

--- a/src/server/services/tags/TagAssignmentService.ts
+++ b/src/server/services/tags/TagAssignmentService.ts
@@ -1,6 +1,10 @@
 import type { PrismaClient, Tag } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
-import { canEditAction, getActionAccess } from "~/server/services/access";
+import {
+  canEditAction,
+  getActionAccess,
+  getWorkspaceMembership,
+} from "~/server/services/access";
 
 export type TagEntityType = "action" | "ticket" | "feature" | "epic";
 
@@ -127,9 +131,9 @@ async function requireWorkspaceMember(
   userId: string,
   workspaceId: string,
 ): Promise<void> {
-  const membership = await db.workspaceUser.findUnique({
-    where: { userId_workspaceId: { userId, workspaceId } },
-  });
+  // Centralized resolver: direct OR team-based membership. A hand-rolled
+  // workspaceUser lookup here used to deny team-based members.
+  const membership = await getWorkspaceMembership(db, userId, workspaceId);
   if (!membership) {
     throw new TRPCError({
       code: "FORBIDDEN",


### PR DESCRIPTION
### **User description**
## Summary

Two related changes to the goal modal, split into one commit each.

**1. Remove "Linked Outcomes" from the goal modal.** The multi-select was easy to mistake for key results. `Outcome` is free-text prose with an optional due date; `KeyResult` carries start/target values, a unit, and a period. Having both in one form obscured the distinction.

**2. Add a Key Results toggle to workspace settings.** Key Results visibility was derived solely from `workspace.type`, so a personal workspace had no way to reach them — the setting didn't exist, `workspace.update` doesn't accept a `type` change, and the create-workspace page only offers team/organization. The only escape hatches were a brand-new workspace or a direct DB write.

## Database change

```sql
ALTER TABLE "Workspace" ADD COLUMN "enableKeyResults" BOOLEAN;
```

`enableKeyResults` is **nullable on purpose**, unlike the other `enable*` flags which are all `Boolean @default(...)`. There is no single correct default because it differs by workspace type:

- `null` → follow the workspace type (team/org on, personal off) — the behaviour that predates the column
- `true` / `false` → explicit per-workspace override

So the migration adds a column with no default and touches zero rows. Every existing workspace keeps its current behaviour with no backfill.

`useTerminology` resolves it as `enableKeyResults ?? !isPersonal` and moves **only** the KR flags and labels — a personal workspace with Key Results on still says "Goal", not "Objective".

## Outcome links are preserved

`updateGoal` only writes outcomes when `outcomeIds` is defined, and the modal no longer sends it — so saving a goal leaves its existing outcome links intact. They remain visible on the home dashboard via `OutcomesByGoal`. `outcomeIds` stays in the router input since it's reachable via the SDK/agents.

## Verification

Verified against a seeded **personal** workspace (`fixture-alpha`, `type: personal`, `enableKeyResults: null`) on a local dev DB:

| Step | Result |
|---|---|
| Settings → Features | Key Results row renders, off; badge `3/6` → `3/7` |
| Goal modal before | Key Results absent (reproduces the reported behaviour) |
| Toggle on | `workspace.update` → 200; DB reads `enableKeyResults: true` |
| Goal modal after | Key Results section + "Add key result" button present |
| Team workspace | unchanged at `null` |

Also confirmed the goal modal no longer renders anything matching `/outcome/i`, and that goal wording stays personal ("What's your goal?", "Parent Goal", "Create Goal").

`tsc --noEmit` clean, ESLint clean, unit tests pass via the pre-commit hook.

## Note on the base branch

Targets `develop` because it carries a migration. `develop` was 40 commits behind `main` and 13 ahead; this branch is based on `main`, so merging it also brings `develop` current. Verified conflict-free against `develop` with `git merge-tree`.


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- New `search.global` tRPC router with per-entity access scoping

- Command palette rewired to server-side search, sections, scroll

- Action router hardening: workspace write guards, roster leaks, assignee PII

- Local wiki surface with explicit first-run creation plus E2E tests

- Overdue triage cohorts and `bulkDefer` amnesty mutation

- Workspace `enableKeyResults` flag; Outcomes removed from goal modal


___

### Diagram Walkthrough


```mermaid
flowchart LR
  palette["CommandPalette"] -- "debounced query" --> search["search.global router"]
  search -- "per-entity access where-clauses" --> db["Prisma"]
  actionRouter["action router"] -- "assertCanWriteToWorkspace" --> guard["workspace write guard"]
  actionRouter -- "canViewAction / isProjectInsider" --> roster["assignable users"]
  actionRouter -- "getOverdueTriage + bulkDefer" --> triage["overdue cohorts"]
  wiki["/wiki pages"] -- "wiki_status / wiki_init" --> shell["Tauri IPC"]
  workspace["Workspace"] -- "enableKeyResults" --> terminology["useTerminology"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>search.ts</strong><dd><code>New global search router across fourteen entity types</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-8e2eb893e53f741f2d3019aa28559a3d29775df802c1921a49c131a2ac642dc8">+526/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CommandPalette.tsx</strong><dd><code>Rewire palette to server search with sections and scrolling</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-0013838800caad36867dc467a14704c56996820c63a945eca5fdc33a7d4dfb45">+294/-142</a></td>

</tr>

<tr>
  <td><strong>CreateGoalModal.tsx</strong><dd><code>Remove linked Outcomes multi-select from goal modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-04d3453bb612a7fd7cd225b1c97a8455d5bd9073547a7de2b1541b18b4df147d">+1/-33</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>layout.tsx</strong><dd><code>Add DesktopChromeScript for window control spacing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-3ef9e8f31a7c161af580053addacb71c9b6d07c4b67a82c41fb31764cd80ea11">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Local wiki list page with first-run creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-7910da40a98c3858595c73db04ff5d66008e1bd9b3e0b926e1a115145ed79f4c">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Wiki page route for reading and editing markdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-07ee2fc108769caba0f89fb9ccbbf5e7b4248a3fde0d1efe4d1f3df1a4eae232">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WikiListContent.tsx</strong><dd><code>Wiki list UI grouped by folder with search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-148304fd3261082ca08a04d0f29e28b3945a0b10de073b437fe3ac230367e63d">+323/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>WikiPageView.tsx</strong><dd><code>Wiki page view with raw markdown editor and conflict guard</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-b5e50d52eb4e8d7f8b16846fd4265db6f8e0ca77563e6e2c9adfe258229e705b">+286/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>wikiLinks.ts</strong><dd><code>Wikilink parsing and resolution helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-6008bb62e7aa13e2f7d864e0bc78b66e1a473430959afaac5904f07a28f9f118">+202/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useWikiBridge.ts</strong><dd><code>Hook wrapping the desktop shell wiki IPC commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-2bd78e481de42cba9f8b680f603f77c57adce9ed828ac0ad3402d2906ad0bb6b">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LocalWikiFirstRun.tsx</strong><dd><code>First-run panel that creates the wiki on demand</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-980800c8e04e7d012bb7646fdbff3a0487154ceb0c57f872e482b23a18b0c63a">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>triage.ts</strong><dd><code>Group overdue actions into bulk-stamped cohorts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-c0552adcc7c16473d790eb0d43d0c603f8ebe83fbb294e806e00547e1d7f26cf">+137/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>action.ts</strong><dd><code>Workspace write guards, roster gating, overdue triage, bulkDefer</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-5b198a3cc9e3495e32e4dcdf28771f225d15998a0c3ab9de63ef7f12941d1dbb">+384/-45</a></td>

</tr>

<tr>
  <td><strong>workspaceRefs.ts</strong><dd><code>Assert cross-entity refs stay inside the workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-1dde13ac84147ebc7b832c39ae20aa7b9970df02b0eeda8c926c1f28248c7ba1">+142/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>assignability.ts</strong><dd><code>Assignability rules for project-less, team-less actions</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-bdbb80f0cf7e89b02f6ebbd79c1a83be82c9f3c287b36b0bd06f631f868f0c06">+105/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>action.test.ts</strong><dd><code>Extensive tests for action access and workspace containment</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-1f49e232606ea60cceb17f43536f374c6e1ad7e88b96115c502088f6e4556999">+711/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>local-wiki.spec.ts</strong><dd><code>E2E coverage for local wiki via stubbed Tauri IPC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-fca70be4c7a0830f89c949759544952cbc9c265eed1a442b1b009cfeb1d4d893">+411/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>migration.sql</strong><dd><code>Add nullable `enableKeyResults` column to Workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-d4d5002e1994c2012c2cbb41f2345589c71e5b305f6db20ddb6af5a993769ebb">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>wiki.module.css</strong><dd><code>Styles for wiki list, page, and wikilinks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-ad5f2ad8d917167d6d2c1e01ebb1f4fe251da526273c1ad5ac2c93385a16f9d0">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>0052-overdue-cohorts-and-amnesty.md</strong><dd><code>ADR for overdue cohorts and amnesty semantics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-99c2b5edee01890464ba7ef18e47abd5a3f5a3614a883cb6a35b616876000f5b">+107/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>83 files</summary><table>
<tr>
  <td><strong>.env.example</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr_agent.yml</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-fc2b2ed01cad745cb09e9c20e7c91db7f4f1eb9796abb84bbdce7dd0f77dace8">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr_agent_glm.yml</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-bb0b232f5e7f558ea33c510e85e574a370c3844e624c3a259f3123928710c06b">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.pr_agent.toml</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+60/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CONTEXT.md</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>external-agents.md</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-12f7e6daee00e9eb7e5d6f54a4a841c044468fa3078ad6965203a35f0c6b29b6">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OBSERVABILITY.md</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-e608379e40bafc9cc6a526c79545546dac14663e40ebdbc6733813229078f1a6">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ZOE_DAILY_BRIEFING.md</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-6eb58da2cff8fc9b43b052a5bb672ddecea8cf01e0c43d66aa5ea0bb7189830b">+56/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0053-desktop-tabs-are-native-macos-window-tabs.md</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-a7f8b855bf063e544b80e21422088658942e29dbebf3964f91b54a70a4f92494">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>topbar-crumb.spec.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-732eec2bb9843de871493c023ffbca2a8b946cd77a1e75acf166c1412f98b42f">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schema.prisma</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>build.rs</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-7d1ef5b0b986fee369d8f5fa4361f21fa3075601e5416738ba4f4d1ea5dfb2ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remote.json</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-ccb4581457f281d685bf28be1cdf9c3dd911459508f59b4aecc48ebea72c5e44">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wiki_status.toml</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-dbfbdf6942db36ef7d1d4275e03b318aa19ade68ed8f30c11dc89b3c19c32b61">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c">+390/-16</a></td>

</tr>

<tr>
  <td><strong>wiki.rs</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-c76367aec524f64c600801f6cccf9d93a2e5200c880815f90f56cf232b8fc8d7">+129/-4</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ProductTimelineClient.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-c47c60854bf9c4555d90ad711c3bf94449b95b4bb8c23dbf4373d726da10c5da">+142/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ProductTimelineClient.test.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-5a79191c7ccdfa68b24792a4f3e7ace907eb8c392eb510185c786030b494b57c">+160/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-9c089ab315221c4387705c70147a4c7bc5d023f7ddee6ead4f8e561e8cae5930">+9/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-3286ab3f3a73e58efed3c720f43a6bf9554c520e2637bb0aeab65e9709ba92e4">+44/-31</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-6b79b72a995acbd10cc157f1131181cd7ed46fc478f1fd996884e2c162db08b2">+36/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-0ac5e4711f55c32c32d6519fc8c97fef283b6baff89a3712fee47cbc4ddc65f7">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GoalsTable.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-0424714baa1e35e27223a847b8a266605cea40099710ddf98682e3b0b0edf6dd">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ManyChat.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-6f0e68ce865b0629e85c68dbd985a102db9f321cea87620c205f1863eece6ed4">+101/-22</a></td>

</tr>

<tr>
  <td><strong>ProjectOverviewLegacy.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-14d2a4cb61deddcfb7ecdddb1835e940bf1da7efbb4aaad2cd282d7eec2cf19d">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TodayOverview.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-cc01f6ce74cd0cb4aa1e2fefdff93c24fa80ff0ae970ef70e81a611e976ee787">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useBulkActionMutations.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-acd7c4db9f6159e98b50b08d4c55281038927aa7ddb76739c5dc4a25109e1ef1">+43/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ZoeCanvas.module.css</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-e3e496179e8e8b245c99289bb2fc4c05d1ebda70a4a3e290cd73b75b7fbe6c9a">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ZoeCanvas.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-17d63c82eb858f5f10c45da2c25e8d40fa49c2bcc5f5ee241a7c37117ab844bb">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useCanvasEngagement.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-37a04847b8d4387cc6f7ab379cf60dd50aef6f6ad1074e2a69ac02ac1e45b76c">+13/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DesktopChromeScript.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-d84d9fac2757835aed5ff59d1d527112cfb1f639c43859d89a46de6e029b0f2a">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NavLinks.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-5018b59b9e3f1a773c11830789f52173c574b75eb78be6424cecfe6e685ccb7c">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Sidebar.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-bf54b61d058d58b72a794df8066a0e435dbec01152a2de910a1587b33e382afa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WorkspaceTopbar.module.css</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-501873cc092689ba177f70a73db57f18484c8dcea8ac01b52fc14033a4517d66">+27/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WorkspaceTopbar.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-0a3f487ebf1dec7561a7040706f2d2946ef04831b491257afd67d3982e7af848">+41/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>WorkspaceTopbar.test.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-4854f3ec81555c8238a725f325fffcde100587585b2328e99b6a684f7ae1f686">+113/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>sidebar.css</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-4cfb15b78919917b546cf1fa120557eb91a368e4f54dd898a87569104f7917e2">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MarkdownRenderer.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-982e749a9dbc62ab3830f8aee144ad608878d098da2db51270cb62d38c11d90a">+14/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TodayDesktopShell.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-00486f261f8e0fa50280355f8c7d48001ae5e904fdd67d21ce7ba20060bec597">+66/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>today-desktop.css</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-45f4d56a944c3cacf41abd758375ac279636bccf7bd58d4d3d52ed7eabbf093d">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>route.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-1ac676f81d7fc3c06b717d4286401b3afbebae1cfbcd7cc26c8aa8b4053907d0">+125/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>route.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-3bc56054ba0c2f04a6cb68971c2573e9f99efc01821865c43046202c8b2b3517">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>route.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-192bd7fca1d11d8f79af6bf0fed8eeddbac28ef0598154c3da9f4283f9ffe1a7">+52/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>route.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-1312a845a0e138d23bd62cc13e9130a16c85028f3e0f4418533eefc801327448">+97/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>route.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-83be8ca30c49e84204f569f47f565e51c47589b5cc5735455ffa592497762967">+52/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>route.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-abe5deece2f81b9af4f33700bc50cf55a2245a1b9fe221489967a2ce023103ac">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>route.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-546031f2a49c647572b89c88c0f6710a2601b261f41c538c408759e83d3c5911">+33/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useTerminology.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-5b5a7dad439a24f7657b5d9ae5bd1adc5dfb5b3e4b7567efff2dc9bb498cbe8b">+23/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>triage.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-d00bfa85fd9868acc8a00687c3d989217ccdc40658c4127dccda2fb90d32534c">+185/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>streamProtocol.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-cfc32a4de076d5708d4623ced457b8525c10a33e54197c297c3b7e9cb8e72114">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>streamProtocol.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-9f328aba9385ac4a48cfffc01f2f5436997fc1206974864755b745f18701ba6d">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>navigation.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-567fa2f0c7ae8b48e513eb1dcf5db8a75e069a791f9720079ac7482d870b22e6">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>localWiki.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-e26d7a1d853f45ef05efd3a482d3ae30793fe02feea92a6e87e731d169def149">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reportHandledError.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-1fddfce4da933fae1b52e0d0ae35c8d139649f037f13c651d5d636a782669afb">+87/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wikiLinks.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-d2d75212b87f3a029928b8737d17ccd5b44de4c1f6948e878bac41a3b79b2338">+209/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ticket.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-66527097b6bcfccf7a0834b7eb1748adc3c1d1c4757849b6b03fcd4a6da75849">+234/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ticket.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-2c667429b802690451b0f2771795cba4b39b00fb9a8b2cca853b1f95497032c5">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AgentModalProvider.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-91b32ce785a23a94025446165797b003d893890e876b862e7382e7546609f198">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WorkspaceProvider.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-70dd13cf0331a2ac0e9598222ed57439e8ab23e644331e582ac7a193df6c31c0">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>root.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-6a8cad7e52067d5afa93671900c038e0e0a9526f8f0e3bd10985cecf4295b4fc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>epic.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-c5cde11d8e655b5486e4a715f6e4d88ebc8117e7ca41855ccf21bc1850c99768">+156/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>externalAgentGrant.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-5376e1b6dcc26eed1f436c4695963cd94311c0b6f29474c91312ecf8858ffbed">+231/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>search.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-1418f51be20f3b84b307919114b069b418ca595159877c6cef4e2f916b24cb4e">+236/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>epic.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-737ea566df8468c7d11217c4cc278a1c8954e62773ed3f28048bcfdd22492fd5">+31/-60</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>externalAgent.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-67eb49ec4dfa3a0ac06a49f9b975f4c8b8618a9db9d3249ea4731e804c167e81">+40/-28</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mastra.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-afd76ed5d04839b106766464d541d99c9b1d0e8b28477ea826c7dcf52db960bb">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scheduling.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-db70bb3cd16c278776c6ed2831db82e964c41043e8aa663aa68cd5a3c25fef18">+106/-9</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workspace.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-b94d59060e1c78a6a505a0a58d90bb366e921cdd053126776199f6abcee0f846">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>morningNudge.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-9470c0ae6aa456751368455aab3b25a74d4388574e636631c13c7331364713c1">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>assignability.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-fd77abbdd831cdaba905d58c6337714078a27ada3c19c689fff0a5815beb4751">+168/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workspaceRefs.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-55d126822bfc9904bc7c15dd55b8e04cbcca32320b6d694553eeb652031f0a82">+176/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-74fa8db7237706b8a79d9f10fdaee87b9805928dd72cb942e4b2d489a2215dc3">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>actionResolver.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-5ca7b6d1c9f10b26c1e357f56ed464319b1d4aad72e932539354a15777afde4d">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>projectResolver.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-17c0b8c351e8144da4502acb11e73ac3a1436dda4c6b1a842de5c8ebfd877ff8">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>clientErrorBug.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-42b32606e668c04cb9631ed5c4a1a1f6a17dad20db78053c871d240a5ade5878">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>clientErrorBug.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-7dd49c5a49d00e019cd569ef8ae589d452da963be08aadfd8d1978602f93e254">+122/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>morningNudge.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-e66a680383f4dfec5b24c51ebff16ddfa0219e66137af35d2c030f258409f743">+57/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>schedulingBriefing.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-9e985f9d749b2f1c937ffb87995f168fce0af0a27e1317afc591ac3747db197b">+193/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SentryBugService.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-0dde9dcd8c1aed7f46faacd632832d501d8a805f9f8bb05920ab17f981832881">+67/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SentryBugService.test.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-29ee86568c94bca33dc56fc3965ab98ad30ea4dbf454324d4d8bfe3cf5bb42b7">+78/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sentryPayload.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-9fb183a5f05420e895fb352bdada266a8673a9bbb23b30673fd7cbe24ed3cedb">+104/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TagAssignmentService.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/517/files#diff-86cc8925e1dc09502ba36ce8e11ad3534683570eb6a74af7e987f34fc33f3642">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

