### PR TITLE
GitHub events reach the activity feed, and a per-workspace shipping timeline

### DIFF
--- a/scripts/backfill-github-activity-feed.ts
+++ b/scripts/backfill-github-activity-feed.ts
@@ -1,0 +1,252 @@
+/**
+ * One-off backfill: emit `WorkspaceActivityEvent` rows for `GitHubActivity`
+ * records that were ingested before the feed join existed.
+ *
+ * The webhook now appends a feed event alongside each `GitHubActivity` row (see
+ * `githubFeedEvent.ts`), but every row stored before that shipped is invisible
+ * to the activity feed, the heatmap, Week in Review and the workspace timeline.
+ * This walks the existing table and fills the gap.
+ *
+ * Faithful to the live path in two ways that matter:
+ *   - **Same altitude rules.** It reuses `toGitHubFeedEvent`, so suppressed
+ *     events stay suppressed and a day of `synchronize` churn doesn't get
+ *     retro-fitted into the feed.
+ *   - **One feed row per push, not per commit.** `GitHubActivity` stores a row
+ *     per commit; those are collapsed back into per-(repo, branch, day) pushes
+ *     first, matching what the webhook would have written at the time.
+ *
+ * Idempotent: existing `github*` events are read first and matched on
+ * `(entityType, entityId)`, so re-running adds nothing. Backfilled rows carry
+ * the original `eventTimestamp` as `createdAt`, so history lands on the day it
+ * happened rather than the day the script ran.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-github-activity-feed.ts                      # dry-run
+ *   npx tsx scripts/backfill-github-activity-feed.ts --apply              # write
+ *   npx tsx scripts/backfill-github-activity-feed.ts --workspace <id>     # scope
+ */
+
+import { PrismaClient, type Prisma } from "@prisma/client";
+import {
+  toGitHubFeedEvent,
+  type GitHubFeedInput,
+} from "../src/server/services/activity/githubFeedEvent";
+import { GITHUB_ENTITY_PREFIX } from "../src/server/services/activity/deriveActivitySource";
+
+const db = new PrismaClient();
+const apply = process.argv.includes("--apply");
+const workspaceArgIndex = process.argv.indexOf("--workspace");
+const workspaceId =
+  workspaceArgIndex >= 0 ? process.argv[workspaceArgIndex + 1] : undefined;
+
+const BATCH_SIZE = 500;
+
+interface PendingRow {
+  workspaceId: string;
+  integrationId: string;
+  entityType: string;
+  entityId: string;
+  action: string;
+  metadata: Prisma.InputJsonValue;
+  createdAt: Date;
+  authorLogin: string | null;
+}
+
+async function main() {
+  console.log(`Mode: ${apply ? "APPLY" : "DRY-RUN"}`);
+  console.log(`Scope: ${workspaceId ?? "all workspaces"}\n`);
+
+  const activities = await db.gitHubActivity.findMany({
+    where: workspaceId ? { workspaceId } : {},
+    orderBy: { eventTimestamp: "asc" },
+    select: {
+      workspaceId: true,
+      integrationId: true,
+      eventType: true,
+      eventAction: true,
+      repoFullName: true,
+      repoUrl: true,
+      branchName: true,
+      prNumber: true,
+      prTitle: true,
+      prUrl: true,
+      prAuthor: true,
+      prState: true,
+      prMergedAt: true,
+      prReviewState: true,
+      prReviewer: true,
+      commitSha: true,
+      commitMessage: true,
+      commitAuthor: true,
+      commitUrl: true,
+      eventTimestamp: true,
+    },
+  });
+
+  console.log(`Read ${activities.length} GitHubActivity rows`);
+
+  // Collapse commit rows into one push per (workspace, repo, branch, day) so the
+  // backfill produces the same altitude as the live webhook path.
+  const pushBuckets = new Map<string, typeof activities>();
+  const nonPush: typeof activities = [];
+
+  for (const row of activities) {
+    if (row.eventType !== "push") {
+      nonPush.push(row);
+      continue;
+    }
+    const day = row.eventTimestamp.toISOString().slice(0, 10);
+    const key = `${row.workspaceId}|${row.repoFullName}|${row.branchName ?? ""}|${day}`;
+    const bucket = pushBuckets.get(key);
+    if (bucket) bucket.push(row);
+    else pushBuckets.set(key, [row]);
+  }
+
+  console.log(
+    `→ ${nonPush.length} PR/review rows, ${pushBuckets.size} collapsed pushes ` +
+      `(from ${activities.length - nonPush.length} commit rows)\n`,
+  );
+
+  const pending: PendingRow[] = [];
+
+  for (const row of nonPush) {
+    const input: GitHubFeedInput = {
+      eventType: row.eventType as GitHubFeedInput["eventType"],
+      eventAction: row.eventAction,
+      repoFullName: row.repoFullName,
+      repoUrl: row.repoUrl,
+      branchName: row.branchName,
+      prNumber: row.prNumber,
+      prTitle: row.prTitle,
+      prUrl: row.prUrl,
+      prAuthor: row.prAuthor,
+      // The stored `prState` is the authority here: `eventAction` was recorded
+      // as "closed" for both merges and plain closes.
+      prMerged: row.prState === "merged" || row.prMergedAt != null,
+      prReviewState: row.prReviewState,
+      prReviewer: row.prReviewer,
+    };
+    const event = toGitHubFeedEvent(input);
+    if (!event) continue;
+    pending.push({
+      workspaceId: row.workspaceId,
+      integrationId: row.integrationId,
+      entityType: event.entityType,
+      entityId: event.entityId,
+      action: event.action,
+      metadata: event.metadata,
+      createdAt: row.eventTimestamp,
+      authorLogin: event.authorLogin,
+    });
+  }
+
+  for (const bucket of pushBuckets.values()) {
+    const head = bucket[bucket.length - 1]!;
+    const event = toGitHubFeedEvent({
+      eventType: "push",
+      repoFullName: head.repoFullName,
+      repoUrl: head.repoUrl,
+      branchName: head.branchName,
+      commitCount: bucket.length,
+      headCommitSha: head.commitSha,
+      headCommitMessage: head.commitMessage,
+      headCommitUrl: head.commitUrl,
+      commitAuthor: head.commitAuthor,
+    });
+    if (!event) continue;
+    pending.push({
+      workspaceId: head.workspaceId,
+      integrationId: head.integrationId,
+      entityType: event.entityType,
+      entityId: event.entityId,
+      action: event.action,
+      metadata: event.metadata,
+      createdAt: head.eventTimestamp,
+      authorLogin: event.authorLogin,
+    });
+  }
+
+  // Skip anything already present, so the script is safe to re-run.
+  const existing = await db.workspaceActivityEvent.findMany({
+    where: {
+      ...(workspaceId ? { workspaceId } : {}),
+      entityType: { startsWith: GITHUB_ENTITY_PREFIX },
+    },
+    select: { entityType: true, entityId: true },
+  });
+  const seen = new Set(existing.map((e) => `${e.entityType}|${e.entityId}`));
+  const fresh = pending.filter(
+    (p) => !seen.has(`${p.entityType}|${p.entityId}`),
+  );
+
+  console.log(
+    `${pending.length} candidate events, ${existing.length} already present, ` +
+      `${fresh.length} to insert\n`,
+  );
+
+  // Resolve GitHub logins to users once per (integration, login) pair rather
+  // than per row — a few thousand commits collapse to a handful of authors.
+  const loginPairs = new Set(
+    fresh
+      .filter((f) => f.authorLogin)
+      .map((f) => `${f.integrationId}|${f.authorLogin!}`),
+  );
+  const userByPair = new Map<string, string>();
+  for (const pair of loginPairs) {
+    const [integrationId, login] = pair.split("|");
+    const mapping = await db.integrationUserMapping.findUnique({
+      where: {
+        integrationId_externalUserId: {
+          integrationId: integrationId!,
+          externalUserId: login!,
+        },
+      },
+      select: { userId: true },
+    });
+    if (mapping) userByPair.set(pair, mapping.userId);
+  }
+  console.log(
+    `Resolved ${userByPair.size}/${loginPairs.size} GitHub logins to users\n`,
+  );
+
+  const byType = new Map<string, number>();
+  for (const row of fresh) {
+    byType.set(row.entityType, (byType.get(row.entityType) ?? 0) + 1);
+  }
+  for (const [type, count] of byType) console.log(`  ${type}: ${count}`);
+  console.log();
+
+  if (!apply) {
+    console.log("DRY-RUN — nothing written. Re-run with --apply.");
+    return;
+  }
+
+  let inserted = 0;
+  for (let i = 0; i < fresh.length; i += BATCH_SIZE) {
+    const batch = fresh.slice(i, i + BATCH_SIZE);
+    const result = await db.workspaceActivityEvent.createMany({
+      data: batch.map((row) => ({
+        workspaceId: row.workspaceId,
+        userId: row.authorLogin
+          ? (userByPair.get(`${row.integrationId}|${row.authorLogin}`) ?? null)
+          : null,
+        entityType: row.entityType,
+        entityId: row.entityId,
+        action: row.action,
+        metadata: row.metadata,
+        createdAt: row.createdAt,
+      })),
+    });
+    inserted += result.count;
+    console.log(`  inserted ${inserted}/${fresh.length}`);
+  }
+
+  console.log(`\nDone. Inserted ${inserted} activity events.`);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => void db.$disconnect());

--- a/src/app/(sidemenu)/w/[workspaceSlug]/product-timeline/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/product-timeline/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { WorkspaceShippingTimeline } from '~/app/_components/home/WorkspaceShippingTimeline';
+
+/**
+ * `/w/[workspaceSlug]/product-timeline` — the per-workspace sibling of the
+ * public `/product-timeline` changelog. Same idea, but scoped to one workspace,
+ * spanning every repo it tracks, and read from stored GitHub activity rather
+ * than a live GitHub API call.
+ *
+ * Note the sibling route `/w/[workspaceSlug]/timeline` is the *projects* Gantt
+ * view and is unrelated.
+ */
+export default function WorkspaceProductTimelinePage() {
+  return (
+    <div className="flex h-full flex-col text-text-primary">
+      <WorkspaceShippingTimeline />
+    </div>
+  );
+}

--- a/src/app/_components/home/WorkspaceShippingTimeline.tsx
+++ b/src/app/_components/home/WorkspaceShippingTimeline.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Anchor,
+  Badge,
+  Center,
+  Group,
+  Loader,
+  Select,
+  Stack,
+  Text,
+  Timeline,
+  Title,
+} from '@mantine/core';
+import {
+  IconAlertTriangle,
+  IconBrandGithub,
+  IconGitCommit,
+  IconGitMerge,
+} from '@tabler/icons-react';
+import { format, startOfDay } from 'date-fns';
+import { api } from '~/trpc/react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import {
+  COMMIT_CATEGORIES,
+  parseCommitMessage,
+  summarizeByCategory,
+  isMergeCommit,
+  type CommitCategory,
+} from '~/lib/changelog/commitCategories';
+
+type TimelineItem = {
+  id: string;
+  kind: 'pull_request' | 'push';
+  occurredAt: Date;
+  repoFullName: string;
+  repoUrl: string | null;
+  title: string;
+  url: string | null;
+  author: string | null;
+  branchName: string | null;
+  prNumber: number | null;
+  commitCount: number | null;
+};
+
+interface DayGroup {
+  date: Date;
+  items: TimelineItem[];
+}
+
+/**
+ * Group into local calendar days. Deliberately client-side and local-time, the
+ * same as the public product timeline — "what shipped Tuesday" means the
+ * reader's Tuesday, and grouping server-side in UTC would split a late evening
+ * of work across two headings for anyone west of Greenwich.
+ */
+function groupByDay(items: TimelineItem[]): DayGroup[] {
+  const groups = new Map<string, DayGroup>();
+  for (const item of items) {
+    const day = startOfDay(item.occurredAt);
+    const key = day.toISOString();
+    const existing = groups.get(key);
+    if (existing) existing.items.push(item);
+    else groups.set(key, { date: day, items: [item] });
+  }
+  return Array.from(groups.values()).sort(
+    (a, b) => b.date.getTime() - a.date.getTime(),
+  );
+}
+
+function categoryOf(item: TimelineItem): CommitCategory {
+  return parseCommitMessage(item.title).category;
+}
+
+/**
+ * `/w/[workspaceSlug]/product-timeline` — what this workspace shipped, across
+ * every repo it tracks.
+ *
+ * Reads stored GitHub activity rather than calling GitHub live, so it is
+ * workspace-scoped, spans every tracked repo, and does not blank out when a
+ * `GITHUB_TOKEN` expires. The trade-off is that it can only show what was
+ * ingested — hence the explicit "tracked repos" line and the unconfigured
+ * state, so an incomplete timeline never silently reads as a complete one.
+ */
+export function WorkspaceShippingTimeline() {
+  const { workspaceId, isLoading: workspaceLoading } = useWorkspace();
+  const [days, setDays] = useState('30');
+  const [repo, setRepo] = useState<string | null>(null);
+
+  const { data, isLoading } = api.workspace.getWorkspaceTimeline.useQuery(
+    {
+      workspaceId: workspaceId!,
+      days: Number(days),
+      ...(repo ? { repoFullName: repo } : {}),
+    },
+    { enabled: !!workspaceId },
+  );
+
+  const groups = useMemo(
+    () =>
+      groupByDay(
+        (data?.items ?? []).map((item) => ({
+          ...item,
+          occurredAt: new Date(item.occurredAt),
+        })),
+      ),
+    [data?.items],
+  );
+
+  if (workspaceLoading || isLoading) {
+    return (
+      <Center h={240}>
+        <Loader size="sm" />
+      </Center>
+    );
+  }
+
+  const trackedRepos = data?.trackedRepos ?? [];
+
+  return (
+    <Stack gap="lg" p="md">
+      <div>
+        <Title order={2} c="var(--color-text-primary)">
+          Shipped
+        </Title>
+        <Text size="sm" c="var(--color-text-muted)">
+          Merged pull requests and commits across this workspace&apos;s repos.
+        </Text>
+      </div>
+
+      {data?.isUnconfigured ? (
+        <Alert
+          icon={<IconAlertTriangle size={16} />}
+          color="yellow"
+          title="No repositories connected"
+        >
+          This workspace isn&apos;t tracking any GitHub repositories, so nothing
+          can appear here. Connect them in{' '}
+          <Anchor href="/settings/integrations" size="sm">
+            Settings → Integrations
+          </Anchor>
+          . Until a repo is registered, its webhooks are received and discarded.
+        </Alert>
+      ) : null}
+
+      <Group gap="sm" align="flex-end">
+        <Select
+          label="Period"
+          size="xs"
+          w={140}
+          value={days}
+          onChange={(value) => setDays(value ?? '30')}
+          data={[
+            { value: '7', label: 'Last 7 days' },
+            { value: '30', label: 'Last 30 days' },
+            { value: '90', label: 'Last 90 days' },
+          ]}
+          allowDeselect={false}
+        />
+        {trackedRepos.length > 1 ? (
+          <Select
+            label="Repository"
+            size="xs"
+            w={260}
+            value={repo}
+            onChange={setRepo}
+            placeholder="All repositories"
+            clearable
+            data={trackedRepos.map((r) => ({ value: r, label: r }))}
+          />
+        ) : null}
+      </Group>
+
+      {trackedRepos.length > 0 ? (
+        <Text size="xs" c="var(--color-text-muted)">
+          Tracking {trackedRepos.length}{' '}
+          {trackedRepos.length === 1 ? 'repository' : 'repositories'}:{' '}
+          {trackedRepos.join(', ')}
+        </Text>
+      ) : null}
+
+      {groups.length === 0 && !data?.isUnconfigured ? (
+        <Alert color="gray" icon={<IconBrandGithub size={16} />}>
+          Nothing recorded in this period. If work did ship, the webhook may not
+          be reaching this workspace — check Recent Deliveries on the GitHub App.
+        </Alert>
+      ) : null}
+
+      <Timeline
+        active={groups.length}
+        bulletSize={22}
+        lineWidth={2}
+        color="var(--color-brand-primary)"
+      >
+        {groups.map((group) => {
+          const merged = group.items.filter(
+            (item) => item.kind === 'pull_request',
+          );
+          const commits = group.items.filter((item) => item.kind === 'push');
+          const summary = summarizeByCategory(
+            group.items.map((item) => ({ message: item.title })),
+          );
+
+          return (
+            <Timeline.Item
+              key={group.date.toISOString()}
+              bullet={
+                merged.length > 0 ? (
+                  <IconGitMerge size={12} />
+                ) : (
+                  <IconGitCommit size={12} />
+                )
+              }
+              title={
+                <Group gap="xs">
+                  <Text fw={600} size="sm" c="var(--color-text-primary)">
+                    {format(group.date, 'EEEE, d MMMM yyyy')}
+                  </Text>
+                  {merged.length > 0 ? (
+                    <Badge size="xs" variant="light" color="green">
+                      {merged.length} merged
+                    </Badge>
+                  ) : null}
+                  {commits.length > 0 ? (
+                    <Badge size="xs" variant="light" color="gray">
+                      {commits.length}{' '}
+                      {commits.length === 1 ? 'commit' : 'commits'}
+                    </Badge>
+                  ) : null}
+                </Group>
+              }
+            >
+              <Group gap={4} mb="xs">
+                {summary.slice(0, 4).map(({ category, count }) => (
+                  <Badge
+                    key={category}
+                    size="xs"
+                    variant="dot"
+                    color={COMMIT_CATEGORIES[category].color}
+                  >
+                    {COMMIT_CATEGORIES[category].label} {count}
+                  </Badge>
+                ))}
+              </Group>
+
+              <Stack gap={6}>
+                {/* Merged PRs first — they're the headline of a shipping day.
+                    Merge commits are dropped from the commit list because the
+                    PR they merged is already shown above them. */}
+                {merged.map((item) => (
+                  <TimelineRow key={item.id} item={item} />
+                ))}
+                {commits
+                  .filter((item) => !isMergeCommit(item.title))
+                  .map((item) => (
+                    <TimelineRow key={item.id} item={item} />
+                  ))}
+              </Stack>
+            </Timeline.Item>
+          );
+        })}
+      </Timeline>
+
+      {data && data.items.length >= 500 ? (
+        <Text size="xs" c="var(--color-text-muted)">
+          Showing the most recent 500 events — narrow the period or pick a
+          single repository to see the rest.
+        </Text>
+      ) : null}
+    </Stack>
+  );
+}
+
+function TimelineRow({ item }: { item: TimelineItem }) {
+  const { text } = parseCommitMessage(item.title);
+  const category = categoryOf(item);
+
+  return (
+    <Group gap="xs" wrap="nowrap" align="baseline">
+      <Badge
+        size="xs"
+        variant="light"
+        color={COMMIT_CATEGORIES[category].color}
+        style={{ flexShrink: 0 }}
+      >
+        {COMMIT_CATEGORIES[category].label}
+      </Badge>
+      {item.url ? (
+        <Anchor
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          size="sm"
+          c="var(--color-text-primary)"
+        >
+          {text}
+        </Anchor>
+      ) : (
+        <Text size="sm" c="var(--color-text-primary)">
+          {text}
+        </Text>
+      )}
+      <Text size="xs" c="var(--color-text-muted)" style={{ flexShrink: 0 }}>
+        {item.prNumber ? `#${item.prNumber}` : null}
+        {item.author ? ` ${item.author}` : null}
+      </Text>
+      <Text size="xs" c="var(--color-text-muted)" style={{ flexShrink: 0 }}>
+        {item.repoFullName.split('/')[1] ?? item.repoFullName}
+      </Text>
+    </Group>
+  );
+}

--- a/src/app/_components/home/activity/AggregatedActivityFeed.tsx
+++ b/src/app/_components/home/activity/AggregatedActivityFeed.tsx
@@ -66,10 +66,15 @@ export function AggregatedActivityFeed() {
   });
 
   // Derive available sources from loaded rows (no single workspace to query).
+  // GitHub contributes a single chip regardless of how many event types are
+  // present, mirroring the server-side `getActivitySources`.
   const providers = Array.from(
-    new Set(display.filter((e) => e.channel).map((e) => e.channel!.provider)),
+    new Set([
+      ...display.filter((e) => e.channel).map((e) => e.channel!.provider),
+      ...(display.some((e) => e.github) ? ['github'] : []),
+    ]),
   );
-  const hasInternal = display.some((e) => !e.channel);
+  const hasInternal = display.some((e) => !e.channel && !e.github);
 
   const hasMore = data?.nextCursor != null;
   const isEmpty = !isLoading && display.length === 0;

--- a/src/app/_components/home/activity/activity-home.css
+++ b/src/app/_components/home/activity/activity-home.css
@@ -956,6 +956,11 @@
 .wsa-feed__avatar--channel[data-provider='whatsapp'] {
   color: var(--color-brand-success);
 }
+/* GitHub rows reuse the squared-off source tile: the actor is a repo identity,
+   not a person, even when we managed to map the login to a user. */
+.wsa-feed__avatar--channel[data-provider='github'] {
+  color: var(--color-text-primary);
+}
 
 .wsa-feed__body {
   min-width: 0;
@@ -976,6 +981,22 @@
 .wsa-feed__entity {
   color: var(--color-text-primary);
   font-weight: 500;
+}
+/* Entity refs that link out (GitHub PRs/commits). Underline only on hover so a
+   feed full of external rows doesn't turn into a wall of underlines. */
+.wsa-feed__entity--link {
+  text-decoration: none;
+}
+.wsa-feed__entity--link:hover {
+  text-decoration: underline;
+}
+
+/* Repo/branch context chip on a GitHub row. Monospace so branch names and short
+   SHAs stay scannable against the prose of the sentence above. */
+.wsa-feed__branch {
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono, ui-monospace, monospace);
 }
 
 .wsa-feed__time {
@@ -1037,6 +1058,22 @@
 .wsa-feed__icon[data-kind='commented']      { color: var(--activity-accent-knowledge); }
 .wsa-feed__icon[data-kind='tracked']        { color: var(--activity-accent-ritual); }
 .wsa-feed__icon[data-kind='channel_summary'] { color: var(--color-brand-success); }
+.wsa-feed__icon[data-kind='github']         { color: var(--color-text-secondary); }
+/* A merged PR is the "work shipped" row — the same emphasis treatment as a
+   milestone, so shipping is visible when scanning a busy day. */
+.wsa-feed__icon[data-kind='shipped'] {
+  color: var(--activity-accent-milestone-contrast);
+  background: var(--activity-accent-milestone);
+}
+.wsa-feed__row[data-kind='shipped'] {
+  background: var(--activity-accent-milestone-soft);
+  border: 1px solid var(--activity-accent-milestone-border);
+  border-left-width: 3px;
+  border-radius: 8px;
+  padding-left: 10px;
+  padding-right: 10px;
+  margin: 4px 0;
+}
 
 /* Milestone (completed project) — a filled gold chip instead of a tinted glyph,
    so it reads as a celebration rather than another status change. */

--- a/src/app/_components/home/activity/activityRow.tsx
+++ b/src/app/_components/home/activity/activityRow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  IconBrandGithub,
   IconBrandSlack,
   IconBrandTelegram,
   IconBrandWhatsapp,
@@ -8,6 +9,7 @@ import {
   IconCirclePlus,
   IconClock,
   IconEdit,
+  IconGitMerge,
   IconMessageCircle,
   IconMessages,
   IconRefresh,
@@ -28,6 +30,8 @@ export const ICON_BY_KIND: Record<IconKind, TablerIcon> = {
   milestone: IconTrophy,
   tracked: IconClock,
   channel_summary: IconMessages,
+  github: IconBrandGithub,
+  shipped: IconGitMerge,
   fallback: IconRefresh,
 };
 
@@ -35,12 +39,15 @@ const PROVIDER_ICON: Record<string, TablerIcon> = {
   whatsapp: IconBrandWhatsapp,
   slack: IconBrandSlack,
   telegram: IconBrandTelegram,
+  github: IconBrandGithub,
 };
 
 const PROVIDER_LABEL: Record<string, string> = {
   whatsapp: 'WhatsApp',
   slack: 'Slack',
   telegram: 'Telegram',
+  // Explicit, because the generic capitalize fallback would render "Github".
+  github: 'GitHub',
 };
 
 /** Human label for a provider chip/actor, e.g. "whatsapp" → "WhatsApp". */
@@ -97,13 +104,21 @@ interface SentenceProps {
   entityRef: string;
   /** Renders the "agent" chip after the actor name (ADR-0049). */
   actorIsAgent?: boolean;
+  /** When set, `{entityRef}` renders as an external link to this URL. */
+  entityHref?: string | null;
 }
 
 /**
  * Render a sentence template into spans, replacing {actor} and {entityRef}
  * tokens with styled inline content.
  */
-function Sentence({ template, actor, entityRef, actorIsAgent = false }: SentenceProps) {
+function Sentence({
+  template,
+  actor,
+  entityRef,
+  actorIsAgent = false,
+  entityHref = null,
+}: SentenceProps) {
   const parts: Array<{ kind: 'text' | 'actor' | 'entity'; value: string }> = [];
   const regex = /\{(actor|entityRef)\}/g;
   let cursor = 0;
@@ -139,6 +154,22 @@ function Sentence({ template, actor, entityRef, actorIsAgent = false }: Sentence
           );
         }
         if (part.kind === 'entity') {
+          // External sources (GitHub) pass a href so the title itself is the
+          // link out. Internal rows keep a plain span — the feed is not a
+          // navigation surface for entities it already renders in-app.
+          if (entityHref) {
+            return (
+              <a
+                key={i}
+                href={entityHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="wsa-feed__entity wsa-feed__entity--link"
+              >
+                {part.value}
+              </a>
+            );
+          }
           return (
             <span key={i} className="wsa-feed__entity">
               {part.value}
@@ -166,6 +197,20 @@ export interface FeedRowEvent {
     projectId: string | null;
     projectSlug: string | null;
     projectName: string | null;
+  } | null;
+  github?: {
+    kind: string;
+    repoFullName: string;
+    repoUrl: string | null;
+    branchName: string | null;
+    prNumber: number | null;
+    prUrl: string | null;
+    author: string | null;
+    commitCount: number | null;
+    commitSha: string | null;
+    commitUrl: string | null;
+    reviewState: string | null;
+    merged: boolean;
   } | null;
 }
 
@@ -263,7 +308,82 @@ export function ActivityRow({
   }
 
   const Icon = ICON_BY_KIND[event.hint.iconKind] ?? IconRefresh;
-  const actorName = event.actor?.name ?? 'Someone';
+
+  // GitHub rows: the actor is often not an Exponential user (outside
+  // contributors, bots, or simply an unmapped login), so fall back to the GitHub
+  // login rather than the anonymous "Someone" — the login is the more useful
+  // identity here, and "Someone merged PR 497" helps nobody.
+  const github = event.github ?? null;
+  const actorName =
+    event.actor?.name ?? github?.author ?? 'Someone';
+
+  if (github) {
+    const href = github.prUrl ?? github.commitUrl ?? github.repoUrl;
+    const repoHref = github.repoUrl;
+    const commitLabel =
+      github.kind === 'push' && github.commitCount && github.commitCount > 1
+        ? `${github.commitCount} commits`
+        : null;
+
+    return (
+      <div className="wsa-feed__row" data-kind={event.hint.iconKind}>
+        <div
+          className="wsa-feed__avatar wsa-feed__avatar--channel"
+          data-provider="github"
+          aria-hidden="true"
+        >
+          <IconBrandGithub size={16} stroke={1.8} />
+        </div>
+        <div className="wsa-feed__body">
+          <Sentence
+            template={event.hint.template}
+            actor={actorName}
+            entityRef={event.entityRef}
+            actorIsAgent={event.actor?.isAgent ?? false}
+            entityHref={href}
+          />
+          <span className="wsa-feed__meta">
+            {repoHref ? (
+              <a
+                href={repoHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="wsa-feed__workspace"
+              >
+                {github.repoFullName}
+              </a>
+            ) : (
+              <span className="wsa-feed__workspace">{github.repoFullName}</span>
+            )}
+            {github.branchName ? (
+              <span className="wsa-feed__branch">{github.branchName}</span>
+            ) : null}
+            {commitLabel ? (
+              <span className="wsa-feed__branch">{commitLabel}</span>
+            ) : null}
+            {showWorkspaceBadge && event.workspace ? (
+              <Link
+                href={`/w/${event.workspace.slug}/activity`}
+                className="wsa-feed__workspace"
+              >
+                {event.workspace.name}
+              </Link>
+            ) : null}
+            <span className="wsa-feed__time">
+              {relativeTime(event.createdAt)}
+            </span>
+          </span>
+        </div>
+        <span
+          className="wsa-feed__icon"
+          data-kind={event.hint.iconKind}
+          aria-hidden="true"
+        >
+          <Icon size={14} stroke={1.8} />
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div className="wsa-feed__row" data-kind={event.hint.iconKind}>

--- a/src/app/_components/layout/NavLinks.tsx
+++ b/src/app/_components/layout/NavLinks.tsx
@@ -17,6 +17,7 @@ import {
   IconBriefcase,
   IconFileText,
   IconChartBar,
+  IconGitMerge,
   type Icon,
 } from "@tabler/icons-react";
 import { InboxCount } from "./InboxCount";
@@ -34,6 +35,7 @@ const ITEM_ICONS: Record<string, Icon> = {
   projects: IconStack2,
   products: IconLayoutGrid,
   metrics: IconChartBar,
+  shipped: IconGitMerge,
   pages: IconFileText,
   crm: IconUsers,
   agents: IconMessageChatbot,

--- a/src/lib/navLayout.ts
+++ b/src/lib/navLayout.ts
@@ -36,6 +36,7 @@ export const DEFAULT_NAV_LAYOUT: NavSection[] = [
       { id: 'projects', hidden: false },
       { id: 'products', hidden: false },
       { id: 'metrics', hidden: false },
+      { id: 'shipped', hidden: false },
       { id: 'pages', hidden: false },
     ],
   },
@@ -93,6 +94,14 @@ export const NAV_ITEM_CONFIG: Record<string, NavItemConfig> = {
     label: 'Metrics',
     href: (s) => `/w/${s}/metrics`,
     requiresPlugin: 'product',
+  },
+  // The per-workspace shipping timeline. Routed at `product-timeline` (the
+  // workspace sibling of the public changelog) rather than `timeline`, which is
+  // already the projects Gantt view.
+  shipped: {
+    label: 'Shipped',
+    href: (s) => `/w/${s}/product-timeline`,
+    matchSegments: ['product-timeline'],
   },
   pages: {
     label: 'Pages',

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -32,6 +32,11 @@ import {
   FEED_PAGE_SIZE,
 } from "~/server/services/activity/feed";
 import {
+  GITHUB_ENTITY_PREFIX,
+  GITHUB_SOURCE,
+} from "~/server/services/activity/deriveActivitySource";
+import { getWorkspaceTimeline } from "~/server/services/activity/workspaceTimeline";
+import {
   getOrGenerateWeeklyWorkDigest,
   DigestRateLimitError,
 } from "~/server/services/activity/weeklyWorkDigest/digest";
@@ -1932,6 +1937,37 @@ export const workspaceRouter = createTRPCRouter({
       });
     }),
 
+  // Per-workspace shipping timeline: merged PRs and commits across every repo
+  // the workspace tracks, read from stored `GitHubActivity` (not a live GitHub
+  // call). The per-workspace sibling of the public `/product-timeline`.
+  getWorkspaceTimeline: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        days: z.number().int().min(1).max(365).optional(),
+        repoFullName: z.string().optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const membership = await getWorkspaceMembership(
+        ctx.db,
+        ctx.session.user.id,
+        input.workspaceId,
+      );
+      if (!membership) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You are not a member of this workspace",
+        });
+      }
+
+      return getWorkspaceTimeline(ctx.db, {
+        workspaceId: input.workspaceId,
+        days: input.days,
+        repoFullName: input.repoFullName,
+      });
+    }),
+
   // Which Activity sources actually have events in a workspace, so the source
   // switcher only renders a chip for a source that exists (ADR-0023). Returns
   // `hasInternal` and the distinct list of channel providers present.
@@ -1965,10 +2001,15 @@ export const workspaceRouter = createTRPCRouter({
         }),
       ]);
 
+      // "Internal" is the Exponential stream — it must exclude every external
+      // origin, channel summaries AND GitHub, or the chip would claim events it
+      // doesn't show.
       const hasInternal = distinctTypes.some(
-        (t) => t.entityType !== "channel_summary",
+        (t) =>
+          t.entityType !== "channel_summary" &&
+          !t.entityType.startsWith(GITHUB_ENTITY_PREFIX),
       );
-      const providers = Array.from(
+      const channelProviders = Array.from(
         new Set(
           channelRows
             .map((r) =>
@@ -1981,6 +2022,14 @@ export const workspaceRouter = createTRPCRouter({
             .filter((p): p is string => typeof p === "string" && p.length > 0),
         ),
       );
+      // GitHub gets one chip covering all of its entity types, not one per
+      // push/PR/review.
+      const hasGitHub = distinctTypes.some((t) =>
+        t.entityType.startsWith(GITHUB_ENTITY_PREFIX),
+      );
+      const providers = hasGitHub
+        ? [...channelProviders, GITHUB_SOURCE]
+        : channelProviders;
 
       return { hasInternal, providers };
     }),

--- a/src/server/services/GitHubActivityService.ts
+++ b/src/server/services/GitHubActivityService.ts
@@ -1,5 +1,10 @@
 import { type PrismaClient } from "@prisma/client";
 import { db } from "~/server/db";
+import { recordActivity } from "./activity/recordActivity";
+import {
+  toGitHubFeedEvent,
+  type GitHubFeedInput,
+} from "./activity/githubFeedEvent";
 
 interface PushEventCommit {
   id: string;
@@ -297,6 +302,26 @@ export class GitHubActivityService {
       });
     }
 
+    // One feed row for the whole push, not one per commit — the commit-level
+    // rows above are for analytics. GitHub orders `commits` oldest-first, so the
+    // last entry is the head commit.
+    const head = data.commits[data.commits.length - 1];
+    await this.emitFeedEvent(
+      ctx,
+      {
+        eventType: "push",
+        repoFullName,
+        repoUrl: data.repository.html_url,
+        branchName,
+        commitCount: data.commits.length,
+        headCommitSha: head?.id.slice(0, 7) ?? null,
+        headCommitMessage: head?.message.split("\n")[0] ?? null,
+        headCommitUrl: head?.url ?? null,
+        commitAuthor: head?.author.username ?? head?.author.name ?? null,
+      },
+      head ? new Date(head.timestamp) : new Date(),
+    );
+
     console.log(
       `[GitHubActivity] Stored ${data.commits.length} commits from ${repoFullName}/${branchName}`,
     );
@@ -373,6 +398,30 @@ export class GitHubActivityService {
       },
     });
 
+    const merged = Boolean(pr.merged_at);
+    await this.emitFeedEvent(
+      ctx,
+      {
+        eventType: "pull_request",
+        eventAction: data.action,
+        repoFullName,
+        repoUrl: data.repository.html_url,
+        branchName,
+        prNumber: pr.number,
+        prTitle: pr.title,
+        prUrl: pr.html_url,
+        prAuthor: pr.user.login,
+        prMerged: merged,
+      },
+      // Same reasoning as the GitHubActivity row above: use the PR's own
+      // timestamps so a late or replayed delivery doesn't misdate the feed.
+      data.action === "opened" && pr.created_at
+        ? new Date(pr.created_at)
+        : pr.merged_at
+          ? new Date(pr.merged_at)
+          : new Date(),
+    );
+
     console.log(
       `[GitHubActivity] Stored PR #${pr.number} ${data.action} from ${repoFullName}`,
     );
@@ -437,9 +486,78 @@ export class GitHubActivityService {
       },
     });
 
+    await this.emitFeedEvent(
+      ctx,
+      {
+        eventType: "pull_request_review",
+        eventAction: data.action,
+        repoFullName,
+        repoUrl: data.repository.html_url,
+        prNumber: pr.number,
+        prTitle: pr.title,
+        prUrl: pr.html_url,
+        prReviewState: review.state,
+        prReviewer: review.user.login,
+      },
+      new Date(review.submitted_at),
+    );
+
     console.log(
       `[GitHubActivity] Stored PR review (${review.state}) for #${pr.number} from ${repoFullName}`,
     );
+  }
+
+  /**
+   * Append the feed row for a GitHub event, alongside the `GitHubActivity` row
+   * that analytics reads. See `githubFeedEvent.ts` for why this is a write-time
+   * append rather than a read-side union, and which events are suppressed.
+   *
+   * Failures are swallowed by `recordActivity` — a feed row is instrumentation,
+   * and must never fail the webhook that recorded the underlying activity.
+   */
+  private async emitFeedEvent(
+    ctx: { workspaceId: string; integrationId: string },
+    input: GitHubFeedInput,
+    occurredAt: Date,
+  ): Promise<void> {
+    const event = toGitHubFeedEvent(input);
+    if (!event) return; // below feed altitude — recorded, deliberately not shown
+
+    await recordActivity(this.prisma, {
+      workspaceId: ctx.workspaceId,
+      // Attribute to the Exponential user behind the GitHub login when the
+      // integration knows the pairing; otherwise leave the actor null and let
+      // the feed render the raw login from metadata (ADR-0023 does the same for
+      // channels, where the actor is the channel rather than a person).
+      userId: await this.resolveUserForLogin(
+        ctx.integrationId,
+        event.authorLogin,
+      ),
+      entityType: event.entityType,
+      entityId: event.entityId,
+      action: event.action,
+      metadata: event.metadata,
+      occurredAt,
+    });
+  }
+
+  /**
+   * Map a GitHub login to an Exponential user via `IntegrationUserMapping`.
+   * Returns null when no pairing exists — the common case for outside
+   * contributors and bots.
+   */
+  private async resolveUserForLogin(
+    integrationId: string,
+    login: string | null,
+  ): Promise<string | null> {
+    if (!login) return null;
+    const mapping = await this.prisma.integrationUserMapping.findUnique({
+      where: {
+        integrationId_externalUserId: { integrationId, externalUserId: login },
+      },
+      select: { userId: true },
+    });
+    return mapping?.userId ?? null;
   }
 
   /**

--- a/src/server/services/activity/__tests__/feed.test.ts
+++ b/src/server/services/activity/__tests__/feed.test.ts
@@ -98,4 +98,81 @@ describe("getActivityFeed — channel summaries + source filter", () => {
     expect(call.where).not.toHaveProperty("entityType");
     expect(call.where).not.toHaveProperty("metadata");
   });
+
+  // The regression this guards: "internal" used to mean "not a channel
+  // summary", which quietly filed every merged PR under the Exponential chip
+  // once GitHub started writing feed rows.
+  it("excludes GitHub rows from internal, not just channel summaries", async () => {
+    db.workspaceActivityEvent.findMany.mockResolvedValue([] as never);
+
+    await getActivityFeed(db, { workspaceId: WORKSPACE_ID, source: "internal" });
+
+    expect(db.workspaceActivityEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          entityType: { not: "channel_summary" },
+          NOT: { entityType: { startsWith: "github" } },
+        }),
+      }),
+    );
+  });
+
+  it("selects only GitHub rows when source is github", async () => {
+    db.workspaceActivityEvent.findMany.mockResolvedValue([] as never);
+
+    await getActivityFeed(db, { workspaceId: WORKSPACE_ID, source: "github" });
+
+    expect(db.workspaceActivityEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          workspaceId: WORKSPACE_ID,
+          entityType: { startsWith: "github" },
+        }),
+      }),
+    );
+  });
+
+  it("resolves a github row into a GitHubRef the row component can render", async () => {
+    db.workspaceActivityEvent.findMany.mockResolvedValue([
+      {
+        id: "evt-gh",
+        createdAt: new Date("2026-08-04T19:54:42.000Z"),
+        entityType: "github_pull_request",
+        // Two-digit PR number on purpose: the repo's hardcoded-colour
+        // pre-commit check reads a hash followed by 3-8 hex digits as a colour
+        // literal, so a three-digit PR ref here would fail the commit.
+        entityId: "positonic/exponential#64",
+        action: "completed",
+        metadata: {
+          title: "feat: grant agents access to multiple workspaces at once",
+          repoFullName: "positonic/exponential",
+          repoUrl: "https://github.com/positonic/exponential",
+          branchName: "feat/agent-workspaces",
+          prNumber: 497,
+          prUrl: "https://github.com/positonic/exponential/pull/497",
+          author: "positonic",
+          merged: true,
+        },
+        user: null,
+      },
+    ] as never);
+
+    const { events } = await getActivityFeed(db, { workspaceId: WORKSPACE_ID });
+
+    expect(events[0]!.source).toBe("github");
+    expect(events[0]!.channel).toBeNull();
+    expect(events[0]!.github).toEqual(
+      expect.objectContaining({
+        kind: "pull_request",
+        repoFullName: "positonic/exponential",
+        prNumber: 497,
+        author: "positonic",
+        merged: true,
+      }),
+    );
+    // The PR title, not the raw entity id, is what the sentence renders.
+    expect(events[0]!.entityRef).toBe(
+      "feat: grant agents access to multiple workspaces at once",
+    );
+  });
 });

--- a/src/server/services/activity/__tests__/githubFeedEvent.test.ts
+++ b/src/server/services/activity/__tests__/githubFeedEvent.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { toGitHubFeedEvent } from "../githubFeedEvent";
+import { deriveActivitySource } from "../deriveActivitySource";
+
+const repo = "positonic/exponential";
+
+function prInput(overrides: Record<string, unknown> = {}) {
+  return {
+    eventType: "pull_request" as const,
+    eventAction: "opened",
+    repoFullName: repo,
+    repoUrl: `https://github.com/${repo}`,
+    branchName: "feat/thing",
+    prNumber: 497,
+    prTitle: "feat: grant agents access to multiple workspaces at once",
+    prUrl: `https://github.com/${repo}/pull/497`,
+    prAuthor: "positonic",
+    prMerged: false,
+    ...overrides,
+  };
+}
+
+describe("toGitHubFeedEvent — pull requests", () => {
+  it("maps an opened PR to a created event", () => {
+    const event = toGitHubFeedEvent(prInput());
+    expect(event).not.toBeNull();
+    expect(event!.entityType).toBe("github_pull_request");
+    expect(event!.action).toBe("created");
+    expect(event!.authorLogin).toBe("positonic");
+  });
+
+  it("maps a merged PR to completed — the 'work shipped' signal", () => {
+    const event = toGitHubFeedEvent(
+      prInput({ eventAction: "closed", prMerged: true }),
+    );
+    expect(event!.action).toBe("completed");
+    expect(event!.metadata).toMatchObject({ merged: true });
+  });
+
+  it("distinguishes an unmerged close from a merge", () => {
+    const event = toGitHubFeedEvent(
+      prInput({ eventAction: "closed", prMerged: false }),
+    );
+    expect(event!.action).toBe("status_changed");
+    expect(event!.metadata).toMatchObject({ merged: false });
+  });
+
+  it.each(["synchronize", "edited", "labeled", "ready_for_review", "assigned"])(
+    "suppresses the low-signal %s action",
+    (eventAction) => {
+      expect(toGitHubFeedEvent(prInput({ eventAction }))).toBeNull();
+    },
+  );
+
+  it("carries the PR title as the feed's entity label", () => {
+    const event = toGitHubFeedEvent(prInput());
+    expect(event!.metadata).toMatchObject({
+      title: "feat: grant agents access to multiple workspaces at once",
+      prNumber: 497,
+      prUrl: `https://github.com/${repo}/pull/497`,
+    });
+  });
+
+  it("is keyed per repo+PR so two repos' #1 don't collide", () => {
+    const a = toGitHubFeedEvent(prInput());
+    const b = toGitHubFeedEvent(prInput({ repoFullName: "positonic/mastra" }));
+    expect(a!.entityId).not.toBe(b!.entityId);
+  });
+});
+
+describe("toGitHubFeedEvent — pushes", () => {
+  const pushInput = (commitCount: number) => ({
+    eventType: "push" as const,
+    repoFullName: repo,
+    branchName: "main",
+    commitCount,
+    headCommitSha: "b8b334e",
+    headCommitMessage: "refactor: Keep untimed tasks off the agenda timeline",
+    headCommitUrl: `https://github.com/${repo}/commit/b8b334e`,
+    commitAuthor: "positonic",
+  });
+
+  it("emits one event for the whole push, carrying the commit count", () => {
+    const event = toGitHubFeedEvent(pushInput(20));
+    expect(event!.entityType).toBe("github_push");
+    expect(event!.metadata).toMatchObject({ commitCount: 20 });
+  });
+
+  it("suppresses commit-less pushes (branch create/delete)", () => {
+    expect(toGitHubFeedEvent(pushInput(0))).toBeNull();
+  });
+
+  it("labels the row with the head commit subject", () => {
+    const event = toGitHubFeedEvent(pushInput(3));
+    expect(event!.metadata).toMatchObject({
+      title: "refactor: Keep untimed tasks off the agenda timeline",
+    });
+  });
+});
+
+describe("toGitHubFeedEvent — reviews", () => {
+  const reviewInput = (eventAction: string) => ({
+    eventType: "pull_request_review" as const,
+    eventAction,
+    repoFullName: repo,
+    prNumber: 497,
+    prTitle: "feat: grant agents access",
+    prUrl: `https://github.com/${repo}/pull/497`,
+    prReviewState: "approved",
+    prReviewer: "andi",
+  });
+
+  it("maps a submitted review to a comment event, attributed to the reviewer", () => {
+    const event = toGitHubFeedEvent(reviewInput("submitted"));
+    expect(event!.action).toBe("commented");
+    expect(event!.authorLogin).toBe("andi");
+    expect(event!.metadata).toMatchObject({ reviewState: "approved" });
+  });
+
+  it("suppresses review edits and dismissals", () => {
+    expect(toGitHubFeedEvent(reviewInput("edited"))).toBeNull();
+    expect(toGitHubFeedEvent(reviewInput("dismissed"))).toBeNull();
+  });
+});
+
+describe("every emitted entity type resolves to the github source", () => {
+  it("keeps the write side and the source derivation in agreement", () => {
+    const events = [
+      toGitHubFeedEvent(prInput()),
+      toGitHubFeedEvent(prInput({ eventAction: "closed", prMerged: true })),
+      toGitHubFeedEvent({
+        eventType: "push",
+        repoFullName: repo,
+        branchName: "main",
+        commitCount: 1,
+        headCommitSha: "abc1234",
+      }),
+      toGitHubFeedEvent({
+        eventType: "pull_request_review",
+        eventAction: "submitted",
+        repoFullName: repo,
+        prNumber: 1,
+        prReviewer: "andi",
+      }),
+    ];
+
+    for (const event of events) {
+      expect(event).not.toBeNull();
+      expect(deriveActivitySource({ entityType: event!.entityType })).toBe(
+        "github",
+      );
+    }
+  });
+});

--- a/src/server/services/activity/deriveActivitySource.ts
+++ b/src/server/services/activity/deriveActivitySource.ts
@@ -16,6 +16,16 @@
 /** Fallback source for a `channel_summary` row missing a provider in metadata. */
 export const CHANNEL_SOURCE_FALLBACK = "channel";
 
+/**
+ * Entity-type prefix marking a row as GitHub-origin. Shared with the feed's
+ * `source` filter so the read-side `where` clause and this derivation can never
+ * disagree about what counts as GitHub.
+ */
+export const GITHUB_ENTITY_PREFIX = "github";
+
+/** The single source chip all GitHub event types collapse to. */
+export const GITHUB_SOURCE = "github";
+
 export interface ActivitySourceInput {
   entityType: string;
   metadata?: unknown;
@@ -27,10 +37,12 @@ export function deriveActivitySource(event: ActivitySourceInput): string {
     return provider ?? CHANNEL_SOURCE_FALLBACK;
   }
 
-  // GitHub events live in their own table today and are not yet merged into the
-  // feed, but the mapping is spec'd for when they are (one `github` chip).
-  if (event.entityType.startsWith("github")) {
-    return "github";
+  // GitHub events keep their own `GitHubActivity` table (distinct shape + a
+  // second consumer, SprintAnalytics) but also append a `WorkspaceActivityEvent`
+  // so they reach the shared surfaces — see githubFeedEvent.ts. Every entity
+  // type they emit carries this prefix, and they all collapse to one chip.
+  if (event.entityType.startsWith(GITHUB_ENTITY_PREFIX)) {
+    return GITHUB_SOURCE;
   }
 
   return "internal";

--- a/src/server/services/activity/feed.ts
+++ b/src/server/services/activity/feed.ts
@@ -4,7 +4,11 @@ import {
   resolveFeedHint,
   type FeedRenderHint,
 } from "./feedRenderHints";
-import { deriveActivitySource } from "./deriveActivitySource";
+import {
+  deriveActivitySource,
+  GITHUB_ENTITY_PREFIX,
+  GITHUB_SOURCE,
+} from "./deriveActivitySource";
 
 /**
  * Channel-summary detail (ADR-0023) attached to `channel_summary` rows so the
@@ -19,6 +23,32 @@ export interface ChannelSummaryRef {
   projectId: string | null;
   projectSlug: string | null;
   projectName: string | null;
+}
+
+/**
+ * GitHub detail attached to `github*` rows so the feed can render the commit or
+ * PR as its own kind of row — repo + branch context, the author's GitHub login
+ * as the actor when no `User` is mapped, and a deep link out to GitHub. `null`
+ * on every other event type.
+ */
+export interface GitHubRef {
+  /** `push` | `pull_request` | `pull_request_review`, derived from entityType. */
+  kind: string;
+  repoFullName: string;
+  repoUrl: string | null;
+  branchName: string | null;
+  prNumber: number | null;
+  prUrl: string | null;
+  /** GitHub login. Used as the actor label when `actor` is null. */
+  author: string | null;
+  /** Push only — how many commits the push carried. */
+  commitCount: number | null;
+  commitSha: string | null;
+  commitUrl: string | null;
+  /** Review only — `approved`, `changes_requested`, `commented`. */
+  reviewState: string | null;
+  /** True when a pull_request row represents a merge, not just a close. */
+  merged: boolean;
 }
 
 /**
@@ -58,6 +88,8 @@ export interface ActivityFeedEvent {
   source: string;
   /** Channel-summary detail; `null` unless `entityType === "channel_summary"`. */
   channel: ChannelSummaryRef | null;
+  /** GitHub detail; `null` unless the row is GitHub-origin. */
+  github: GitHubRef | null;
 }
 
 export interface ActivityFeedPage {
@@ -109,6 +141,45 @@ function readMetaString(metadata: unknown, key: string): string | null {
   return null;
 }
 
+/** Read a numeric field off a Json metadata blob, or null. */
+function readMetaNumber(metadata: unknown, key: string): number | null {
+  if (metadata && typeof metadata === "object" && !Array.isArray(metadata)) {
+    const value = (metadata as Record<string, unknown>)[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+/** Read a boolean field off a Json metadata blob, defaulting to false. */
+function readMetaBoolean(metadata: unknown, key: string): boolean {
+  if (metadata && typeof metadata === "object" && !Array.isArray(metadata)) {
+    return (metadata as Record<string, unknown>)[key] === true;
+  }
+  return false;
+}
+
+/**
+ * Build the `GitHubRef` for a GitHub-origin row. The entity type carries the
+ * event kind (`github_push` → `push`), everything else rides in metadata as
+ * written by `toGitHubFeedEvent`.
+ */
+function toGitHubRef(entityType: string, metadata: unknown): GitHubRef {
+  return {
+    kind: entityType.replace(`${GITHUB_ENTITY_PREFIX}_`, ""),
+    repoFullName: readMetaString(metadata, "repoFullName") ?? "",
+    repoUrl: readMetaString(metadata, "repoUrl"),
+    branchName: readMetaString(metadata, "branchName"),
+    prNumber: readMetaNumber(metadata, "prNumber"),
+    prUrl: readMetaString(metadata, "prUrl"),
+    author: readMetaString(metadata, "author"),
+    commitCount: readMetaNumber(metadata, "commitCount"),
+    commitSha: readMetaString(metadata, "commitSha"),
+    commitUrl: readMetaString(metadata, "commitUrl"),
+    reviewState: readMetaString(metadata, "reviewState"),
+    merged: readMetaBoolean(metadata, "merged"),
+  };
+}
+
 /**
  * Translate a `source` filter into a Prisma `where` fragment. `undefined`/`all`
  * → no constraint; `internal` → everything except channel summaries; any other
@@ -119,7 +190,17 @@ function sourceWhere(
 ): Prisma.WorkspaceActivityEventWhereInput {
   if (!source || source === "all") return {};
   if (source === "internal") {
-    return { entityType: { not: "channel_summary" } };
+    // "Internal" means things that happened inside Exponential, so it must
+    // exclude BOTH external origins — channel summaries and GitHub. Excluding
+    // only channel summaries would quietly file every merged PR under
+    // "internal" and make the chip a lie.
+    return {
+      entityType: { not: "channel_summary" },
+      NOT: { entityType: { startsWith: GITHUB_ENTITY_PREFIX } },
+    };
+  }
+  if (source === GITHUB_SOURCE) {
+    return { entityType: { startsWith: GITHUB_ENTITY_PREFIX } };
   }
   return {
     entityType: "channel_summary",
@@ -192,6 +273,10 @@ async function toFeedEvents(
       workspace: row.workspace ?? null,
       source,
       channel,
+      github:
+        source === GITHUB_SOURCE
+          ? toGitHubRef(row.entityType, row.metadata)
+          : null,
     };
   });
 }

--- a/src/server/services/activity/feedRenderHints.ts
+++ b/src/server/services/activity/feedRenderHints.ts
@@ -22,6 +22,8 @@ export type IconKind =
   | "milestone"
   | "tracked"
   | "channel_summary"
+  | "github"
+  | "shipped"
   | "fallback";
 
 export interface FeedRenderHint {
@@ -164,6 +166,35 @@ const HINTS: Record<string, FeedRenderHint> = {
   [key("ticket_sync_run", "reverted")]: {
     template: "{actor} reverted a ticket sync: {entityRef}",
     iconKind: "status_changed",
+  },
+
+  // GitHub events. Like channel summaries, the feed gives these a bespoke row
+  // (GitHub mark + the author's login as the actor), but the hint still drives
+  // the icon kind and is the fallback for generic renderers such as the weekly
+  // digest. `{entityRef}` resolves to the PR title / head-commit subject.
+  //
+  // A merged PR is the one event that means *work shipped*, so it gets its own
+  // emphasized "shipped" kind rather than sharing the generic GitHub mark — it
+  // is the row you should be able to find by scanning.
+  [key("github_pull_request", "created")]: {
+    template: "{actor} opened {entityRef}",
+    iconKind: "github",
+  },
+  [key("github_pull_request", "completed")]: {
+    template: "{actor} merged {entityRef}",
+    iconKind: "shipped",
+  },
+  [key("github_pull_request", "status_changed")]: {
+    template: "{actor} closed {entityRef}",
+    iconKind: "github",
+  },
+  [key("github_pull_request_review", "commented")]: {
+    template: "{actor} reviewed {entityRef}",
+    iconKind: "github",
+  },
+  [key("github_push", "created")]: {
+    template: "{actor} pushed {entityRef}",
+    iconKind: "github",
   },
 
   // Channel activity summaries (ADR-0023). The feed renders these rows with a

--- a/src/server/services/activity/githubFeedEvent.ts
+++ b/src/server/services/activity/githubFeedEvent.ts
@@ -1,0 +1,187 @@
+/**
+ * Maps a GitHub webhook event onto the `WorkspaceActivityEvent` shape the
+ * workspace activity feed reads.
+ *
+ * Why a mapping and not a read-side union: `GitHubActivity` keeps its own table
+ * because it passes ADR-0001's test — a distinct shape *and* a second consumer
+ * (`SprintAnalyticsService`). ADR-0023 settled how such a table reaches the
+ * shared surfaces: it appends one `WorkspaceActivityEvent` alongside its own
+ * row, exactly as channel summaries do, so the aggregated feed, the heatmap and
+ * the weekly digest light up for free and pagination stays on a single table.
+ * The **Activity source** chip stays derived read-side from `entityType`
+ * (`deriveActivitySource`) — never a new column.
+ *
+ * ## Feed altitude
+ *
+ * Not every webhook earns a feed row. Following ADR-0042 (one `synced` event per
+ * sync run, not one per ticket), this module is the single place that decides
+ * what is signal:
+ *
+ *   - **A push is one row, not one per commit.** `GitHubActivity` stores a row
+ *     per commit for analytics; the feed gets a single event carrying the commit
+ *     count. A 20-commit merge push should not evict the rest of the day.
+ *   - **Only meaningful PR transitions.** `opened`, `merged` and `closed` are
+ *     signal. `synchronize`, `edited`, `labeled`, `ready_for_review` and friends
+ *     are the churn of an open PR and are suppressed — they return `null`.
+ *   - **Reviews only when submitted**, not on edit/dismiss.
+ *
+ * Returning `null` means "recorded in GitHubActivity, deliberately absent from
+ * the feed" — it is not an error.
+ */
+
+import type { Prisma } from "@prisma/client";
+import type { ActivityAction } from "./recordActivity";
+
+/** Entity types this module emits. All share the `github` source prefix. */
+export type GitHubEntityType =
+  | "github_push"
+  | "github_pull_request"
+  | "github_pull_request_review";
+
+/** The subset of a GitHub webhook payload the feed cares about. */
+export interface GitHubFeedInput {
+  eventType: "push" | "pull_request" | "pull_request_review";
+  /** GitHub's `action` field — `opened`, `closed`, `submitted`, … */
+  eventAction?: string | null;
+  repoFullName: string;
+  repoUrl?: string | null;
+  branchName?: string | null;
+
+  /** Pull-request fields. */
+  prNumber?: number | null;
+  prTitle?: string | null;
+  prUrl?: string | null;
+  prAuthor?: string | null;
+  /** True when this `closed` event actually merged the PR. */
+  prMerged?: boolean;
+  prReviewState?: string | null;
+  prReviewer?: string | null;
+
+  /** Push fields. A push event summarizes its whole commit list. */
+  commitCount?: number;
+  headCommitSha?: string | null;
+  headCommitMessage?: string | null;
+  headCommitUrl?: string | null;
+  commitAuthor?: string | null;
+}
+
+export interface GitHubFeedEvent {
+  entityType: GitHubEntityType;
+  action: ActivityAction;
+  /** Stable id for the underlying GitHub object (PR node id, commit sha, …). */
+  entityId: string;
+  /**
+   * Feed metadata. `title` is what `describeEntityRef` renders as `{entityRef}`;
+   * the rest drives the bespoke GitHub row (deep link, author chip, counts).
+   */
+  metadata: Prisma.InputJsonValue;
+  /**
+   * GitHub login of whoever caused the event, for actor attribution. Resolved to
+   * a real `User` by the caller via `IntegrationUserMapping` when a mapping
+   * exists; otherwise the feed renders the login itself.
+   */
+  authorLogin: string | null;
+}
+
+/** PR actions that earn a feed row, and the activity action each maps to. */
+function pullRequestAction(
+  input: GitHubFeedInput,
+): ActivityAction | null {
+  switch (input.eventAction) {
+    case "opened":
+    case "reopened":
+      return "created";
+    case "closed":
+      // The single highest-signal event in the whole stream: work shipped.
+      // An unmerged close is a decision, not a shipment — hence the split.
+      return input.prMerged ? "completed" : "status_changed";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build the feed event for one GitHub webhook, or `null` when the event is
+ * deliberately below the feed's altitude (see the module docblock).
+ */
+export function toGitHubFeedEvent(
+  input: GitHubFeedInput,
+): GitHubFeedEvent | null {
+  switch (input.eventType) {
+    case "pull_request": {
+      const action = pullRequestAction(input);
+      if (!action) return null;
+      if (input.prNumber == null) return null;
+
+      return {
+        entityType: "github_pull_request",
+        action,
+        entityId: `${input.repoFullName}#${input.prNumber}`,
+        authorLogin: input.prAuthor ?? null,
+        metadata: {
+          title: input.prTitle ?? `PR #${input.prNumber}`,
+          repoFullName: input.repoFullName,
+          repoUrl: input.repoUrl ?? null,
+          branchName: input.branchName ?? null,
+          prNumber: input.prNumber,
+          prUrl: input.prUrl ?? null,
+          author: input.prAuthor ?? null,
+          merged: input.prMerged ?? false,
+        },
+      };
+    }
+
+    case "pull_request_review": {
+      if (input.eventAction !== "submitted") return null;
+      if (input.prNumber == null) return null;
+
+      return {
+        entityType: "github_pull_request_review",
+        action: "commented",
+        entityId: `${input.repoFullName}#${input.prNumber}:review`,
+        authorLogin: input.prReviewer ?? null,
+        metadata: {
+          title: input.prTitle ?? `PR #${input.prNumber}`,
+          repoFullName: input.repoFullName,
+          repoUrl: input.repoUrl ?? null,
+          prNumber: input.prNumber,
+          prUrl: input.prUrl ?? null,
+          author: input.prReviewer ?? null,
+          reviewState: input.prReviewState ?? null,
+        },
+      };
+    }
+
+    case "push": {
+      const commitCount = input.commitCount ?? 0;
+      // Branch creates/deletes arrive as pushes with no commits. Nothing shipped.
+      if (commitCount === 0) return null;
+
+      const branch = input.branchName ?? "unknown";
+      const headline =
+        input.headCommitMessage ??
+        `${commitCount} commit${commitCount === 1 ? "" : "s"}`;
+
+      return {
+        entityType: "github_push",
+        action: "created",
+        // Keyed on the head commit so a redelivered push dedups naturally.
+        entityId: input.headCommitSha ?? `${input.repoFullName}@${branch}`,
+        authorLogin: input.commitAuthor ?? null,
+        metadata: {
+          title: headline,
+          repoFullName: input.repoFullName,
+          repoUrl: input.repoUrl ?? null,
+          branchName: branch,
+          commitCount,
+          commitSha: input.headCommitSha ?? null,
+          commitUrl: input.headCommitUrl ?? null,
+          author: input.commitAuthor ?? null,
+        },
+      };
+    }
+
+    default:
+      return null;
+  }
+}

--- a/src/server/services/activity/recordActivity.ts
+++ b/src/server/services/activity/recordActivity.ts
@@ -37,7 +37,14 @@ export type ActivityEntityType =
   | "meeting"
   | "time_entry"
   | "channel_summary"
-  | "ticket_sync_run";
+  | "ticket_sync_run"
+  // GitHub events (see githubFeedEvent.ts). These mirror rows already written to
+  // the `GitHubActivity` table; the prefix is load-bearing, since
+  // `deriveActivitySource` maps any `github*` entity type to the `github` source
+  // chip. Emitted at feed altitude — one row per push, not per commit.
+  | "github_push"
+  | "github_pull_request"
+  | "github_pull_request_review";
 
 export interface RecordActivityInput {
   workspaceId: string;
@@ -51,6 +58,16 @@ export interface RecordActivityInput {
   entityId: string;
   action: ActivityAction;
   metadata?: Prisma.InputJsonValue;
+  /**
+   * When the event actually happened, if that differs from now. Defaults to
+   * insert time, which is right for in-app writes (the mutation *is* the event).
+   *
+   * External sources need the override: a GitHub webhook can be delivered late
+   * or replayed, and a backfill inserts months of history in one pass. Without
+   * this, a replayed PR merge would jump to the top of the feed and a backfill
+   * would stack every historical event on the day it ran.
+   */
+  occurredAt?: Date;
 }
 
 /**
@@ -94,6 +111,7 @@ export async function recordActivity(
         entityId: input.entityId,
         action: input.action,
         metadata: input.metadata,
+        ...(input.occurredAt ? { createdAt: input.occurredAt } : {}),
       },
     });
     return true;

--- a/src/server/services/activity/workspaceTimeline.ts
+++ b/src/server/services/activity/workspaceTimeline.ts
@@ -1,0 +1,159 @@
+/**
+ * Workspace shipping timeline — the per-workspace sibling of the public
+ * `/product-timeline` page.
+ *
+ * The public page calls the GitHub API live, hardcoded to `positonic/exponential`,
+ * and stores nothing. That is right for a marketing changelog and wrong for a
+ * workspace view, which needs to be:
+ *
+ *   - **Workspace-scoped**, so access control is the workspace membership check
+ *     rather than "this repo is public".
+ *   - **Multi-repo**, because a workspace's shipping is spread across every repo
+ *     it tracks — a timeline showing only one of four under-reports by design.
+ *   - **Independent of a live GitHub token.** An expired `GITHUB_TOKEN` should
+ *     degrade the public changelog, not blank a page inside the product.
+ *
+ * So this reads the `GitHubActivity` rows the webhook already stores. The
+ * consequence worth stating: the timeline can only show what was ingested. A
+ * repo that isn't registered in `WorkspaceRepository` has its webhooks dropped
+ * (see `findIntegrationForRepo`), and will silently be missing here — which is
+ * why {@link getWorkspaceTimeline} also reports the repos it *does* know about,
+ * so the UI can say "these repos" rather than implying completeness.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+/** One shipped thing: a merged PR, or a push to a branch. */
+export interface TimelineItem {
+  id: string;
+  kind: "pull_request" | "push";
+  occurredAt: Date;
+  repoFullName: string;
+  repoUrl: string | null;
+  title: string;
+  url: string | null;
+  author: string | null;
+  branchName: string | null;
+  /** PR only. */
+  prNumber: number | null;
+  /** Push only — commits in that push. */
+  commitCount: number | null;
+}
+
+export interface WorkspaceTimeline {
+  items: TimelineItem[];
+  /**
+   * Repos this workspace actually tracks. Rendered by the UI so an incomplete
+   * timeline reads as "we're watching these three repos" rather than as the
+   * whole truth.
+   */
+  trackedRepos: string[];
+  /** True when the workspace tracks no repos at all — nothing can ever appear. */
+  isUnconfigured: boolean;
+}
+
+/** How far back the timeline reaches by default. */
+export const TIMELINE_DEFAULT_DAYS = 30;
+const MAX_ITEMS = 500;
+
+/**
+ * Read a workspace's shipping timeline. Access is NOT enforced here — the
+ * caller resolves membership first, matching the convention in
+ * `getAggregatedActivityFeed`.
+ *
+ * Merged PRs and pushes are both included: a PR merge is the headline, but work
+ * pushed straight to a branch (or to `main`) is shipping too, and a workspace
+ * whose repos don't use PRs would otherwise see an empty page.
+ */
+export async function getWorkspaceTimeline(
+  db: PrismaClient,
+  args: {
+    workspaceId: string;
+    days?: number;
+    /** Restrict to one repo; omit for every repo the workspace tracks. */
+    repoFullName?: string;
+  },
+): Promise<WorkspaceTimeline> {
+  const days = args.days ?? TIMELINE_DEFAULT_DAYS;
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+  const [tracked, rows] = await Promise.all([
+    db.workspaceRepository.findMany({
+      where: { workspaceId: args.workspaceId },
+      select: { fullName: true },
+      orderBy: { fullName: "asc" },
+    }),
+    db.gitHubActivity.findMany({
+      where: {
+        workspaceId: args.workspaceId,
+        eventTimestamp: { gte: since },
+        ...(args.repoFullName ? { repoFullName: args.repoFullName } : {}),
+        // Merged PRs and commits only. An opened PR is work in flight, and a
+        // review is commentary — neither belongs on a "what shipped" timeline.
+        OR: [
+          { eventType: "pull_request", prState: "merged" },
+          { eventType: "push" },
+        ],
+      },
+      orderBy: { eventTimestamp: "desc" },
+      take: MAX_ITEMS,
+      select: {
+        id: true,
+        eventType: true,
+        eventTimestamp: true,
+        repoFullName: true,
+        repoUrl: true,
+        branchName: true,
+        prNumber: true,
+        prTitle: true,
+        prUrl: true,
+        prAuthor: true,
+        commitSha: true,
+        commitMessage: true,
+        commitUrl: true,
+        commitAuthor: true,
+      },
+    }),
+  ]);
+
+  const items: TimelineItem[] = rows.map((row) => {
+    if (row.eventType === "pull_request") {
+      return {
+        id: row.id,
+        kind: "pull_request" as const,
+        occurredAt: row.eventTimestamp,
+        repoFullName: row.repoFullName,
+        repoUrl: row.repoUrl,
+        title: row.prTitle ?? `PR #${row.prNumber ?? "?"}`,
+        url: row.prUrl,
+        author: row.prAuthor,
+        branchName: row.branchName,
+        prNumber: row.prNumber,
+        commitCount: null,
+      };
+    }
+    return {
+      id: row.id,
+      kind: "push" as const,
+      occurredAt: row.eventTimestamp,
+      repoFullName: row.repoFullName,
+      repoUrl: row.repoUrl,
+      title: row.commitMessage ?? row.commitSha ?? "commit",
+      url: row.commitUrl,
+      author: row.commitAuthor,
+      branchName: row.branchName,
+      prNumber: null,
+      // GitHubActivity stores one row per commit, so each push row here IS one
+      // commit — the aggregated per-push count lives on the feed event instead.
+      commitCount: 1,
+    };
+  });
+
+  const trackedRepos = tracked.map((t) => t.fullName);
+
+  return {
+    items,
+    trackedRepos,
+    isUnconfigured: trackedRepos.length === 0,
+  };
+}


### PR DESCRIPTION
### **User description**
Yesterday's 25 merged PRs showed up on the Syntrofi home page as "154 events logged, no tasks completed". This fixes the reason, and adds the per-workspace view.

## Why nothing showed up

Three pipelines that didn't talk to each other:

1. **The feed is blind to git.** `feed.ts` reads `WorkspaceActivityEvent`; those rows are written by in-app CRUD and channel summaries only. A merged PR wrote nothing.
2. **GitHub data was already being ingested — into a table nothing read.** `GitHubActivity` is workspace-scoped, populated by the webhook, and consumed only by `SprintAnalyticsService`. `deriveActivitySource` has mapped `github*` → a `github` chip since ADR-0023 and says in as many words that these rows "are not yet merged into the feed".
3. **`/product-timeline` bypasses both** — a public marketing page calling the GitHub API live, hardcoded to `positonic/exponential`.

## What this does

**Commit 1 — the feed join.** ADR-0023 already settled the shape: a table that earns its own storage reaches the shared surfaces by *appending* one `WorkspaceActivityEvent` alongside its own row, exactly as channel summaries do. That keeps pagination on one table and lights up the feed, heatmap, Week in Review and product Overview at once.

`githubFeedEvent.ts` is the single place deciding what is signal:
- one row per push, **not per commit**
- only `opened` / `merged` / `closed` PRs — `synchronize`, `edited`, `labeled` are suppressed
- reviews only when `submitted`

A merged PR maps to `completed` and gets an emphasized "shipped" row.

Two bugs fixed in passing:
- `internal` as a source meant "not a channel summary", which would have filed every merged PR under the Exponential chip. It now excludes both external origins. (Test added — this is the subtle one.)
- `recordActivity` gained an `occurredAt` override, so replayed webhooks and backfilled history land at their real event time instead of jumping to the top of the feed. No schema change; `createdAt` was already settable.

Authors resolve to real users via `IntegrationUserMapping` where a pairing exists, and otherwise render the GitHub login — outside contributors and bots would all read as "Someone".

**Commit 2 — `/w/[slug]/product-timeline`.** The workspace sibling of the public changelog, reading stored activity rather than calling GitHub live, so it is workspace-scoped, spans every tracked repo, and doesn't blank out when a `GITHUB_TOKEN` expires. Routed at `product-timeline` because `/w/[slug]/timeline` is already the projects Gantt view. Surfaced as "Shipped" under Deliver.

## Before this helps: check the ingest

This can only show what was ingested. `findIntegrationForRepo` resolves a webhook to a workspace via `WorkspaceRepository`; **if a repo isn't registered there, every delivery is silently dropped** (`GitHubActivityService.ts:254` logs and returns). Worth confirming in Settings → Integrations for `positonic/exponential` — and for `mastra`, `exponential-cli` and `exponential-sdk`, since yesterday's work spanned all four.

Rather than let an incomplete timeline read as complete, the page names the repos it is tracking and says so explicitly when a workspace tracks none.

## Backfill

`scripts/backfill-github-activity-feed.ts` emits feed events for rows ingested before this existed. Reuses the same altitude rules, collapses stored per-commit rows back into per-push events, idempotent on `(entityType, entityId)`. Dry-run by default.

```bash
npx tsx scripts/backfill-github-activity-feed.ts            # dry-run
npx tsx scripts/backfill-github-activity-feed.ts --apply
```

## Verification

Typecheck clean, 2220 unit tests pass, 16 new tests on the mapping + 3 on the source filter. Verified end-to-end against a local dev-fixture workspace with seeded GitHub activity: timeline renders day groups across two repos, the backfill produced 7 events from 8 rows (correctly collapsing 3 commits into 2 pushes), re-running inserted 0, and `?source=github` filters the feed to `github` / `shipped` rows.

Pre-existing failure, not from this branch: `workspaceHomeStats.integration.test.ts` has a date-dependent `isToday` assertion that fails identically on unmodified `main`.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Emit `WorkspaceActivityEvent` rows for GitHub webhooks
  - New `githubFeedEvent.ts` decides feed altitude
  - Per-push (not per-commit) rows; noisy PR/review actions suppressed
  - Author resolved via `IntegrationUserMapping`, falls back to login

- Feed/UI support for GitHub rows and `github` source chip
  - `GitHubRef` metadata, linked entity refs, "shipped" emphasis
  - Fixes `internal` source leaking GitHub events

- New per-workspace shipping timeline page and tRPC endpoint

- Idempotent backfill script plus new unit tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  webhook["GitHub webhook"] --> svc["GitHubActivityService"]
  svc --> gha["GitHubActivity table"]
  svc -- "toGitHubFeedEvent()" --> rec["recordActivity (occurredAt)"]
  rec --> wae["WorkspaceActivityEvent"]
  wae --> feed["Activity feed / heatmap / digest"]
  gha --> tl["getWorkspaceTimeline"]
  tl --> page["/w/[slug]/product-timeline"]
  backfill["backfill script"] --> wae
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>githubFeedEvent.ts</strong><dd><code>New mapper deciding which GitHub events reach the feed</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-6dc1d39ac49a41ca4fe1fa56930ab50394ada1a590a1e8c31a9e38b5a0983469">+187/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>GitHubActivityService.ts</strong><dd><code>Emit feed events for pushes, PRs and reviews</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-49fbbae3723cb07f72097bdd871dc9efaa7447c9d5353f9634a5822ff7596fa2">+118/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>feed.ts</strong><dd><code>Add GitHubRef resolution and github source filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-534acf3f64bafa21234f271ab348b5773103f28e109b14b2961ca9f579257d8b">+87/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>deriveActivitySource.ts</strong><dd><code>Export shared GitHub prefix and source constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-2fcef6dee316a6de0612a9917a6a34839445a9d0f33ea5e9e76e3a3d7fe474de">+16/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>recordActivity.ts</strong><dd><code>Support occurredAt override and GitHub entity types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-ec0497c5f380dd634d83d42ccd858ac179924cb0a17770a0b08e4650d53ba356">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>feedRenderHints.ts</strong><dd><code>Add GitHub sentence templates and shipped icon kind</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-0ac3c61aee5e71e9b01643e40ecb972e63ef7f3dac140e646e5fd790b8034991">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>workspaceTimeline.ts</strong><dd><code>New service reading stored GitHub activity per workspace</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-410db2a07e1536e0e5e91ef79c541e856ddd63457a925cdbe640b0301f3c5bed">+159/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workspace.ts</strong><dd><code>Add getWorkspaceTimeline and fix internal/github source chips</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-b94d59060e1c78a6a505a0a58d90bb366e921cdd053126776199f6abcee0f846">+51/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WorkspaceShippingTimeline.tsx</strong><dd><code>New workspace shipping timeline UI component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-74257b2310d04ffc8e70adbb845f0ae9c6307dda1b8dbeef9345affc7f0edc5d">+314/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>New per-workspace product timeline route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-da555b471e6aa88bdb0b08dae07817d7b680c575b62b86bfbd0d45b01c30d296">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>activityRow.tsx</strong><dd><code>Render bespoke GitHub feed rows with external links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-b3a6bfc4ab512ee3eea8f0dcd58154b305ae8f7ea67b5f1d0b3e6b9a1ea3cba8">+122/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>NavLinks.tsx</strong><dd><code>Add merge icon for the Shipped nav item</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-5018b59b9e3f1a773c11830789f52173c574b75eb78be6424cecfe6e685ccb7c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backfill-github-activity-feed.ts</strong><dd><code>Idempotent backfill of feed events from GitHubActivity</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-54ecb772d4d9298c4cc99b10cfffbf6be6cb98156b5487de9505604f1abc247f">+252/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>AggregatedActivityFeed.tsx</strong><dd><code>Derive github chip and exclude it from internal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-83a13472df52375f3d106bce39a0ab835ae9099d6589c08749c5b2feb8f6be2c">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>activity-home.css</strong><dd><code>Styles for GitHub rows, branch chips and shipped emphasis</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-5beeb9c22f8d175d4ad28e182edaa5daeab76de2e983441ebda704ccd505591a">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>navLayout.ts</strong><dd><code>Register "Shipped" nav item and route matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-ea5c60e81eaff1d38b9e4f29e13b084b84800f3f8380aa32355b0fc91fce9d79">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>githubFeedEvent.test.ts</strong><dd><code>Tests for PR, push and review mapping and suppression</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-1f35cdd58c319211bed42998145ce1566150cebc292e025bcc3bc0eb4db523cd">+154/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>feed.test.ts</strong><dd><code>Tests for github source filtering and GitHubRef resolution</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/518/files#diff-100864579f854180f382628b1b13d60e808f368c94d0e2673a51490db629ee30">+77/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

