### PR TITLE
feat: Scheduled / unscheduled indicator on task rows

### DIFF
--- a/src/app/_components/actions/components/ActionRow.module.css
+++ b/src/app/_components/actions/components/ActionRow.module.css
@@ -80,6 +80,16 @@
   color: var(--pri-urgent);
 }
 
+/* See the matching rule in today-desktop.css: the unscheduled marker is the
+   quietest thing on the row — icon only, no chip frame, no text. */
+.chipUnscheduled {
+  padding: 2px 4px;
+  background: transparent;
+  border-color: transparent;
+  color: var(--color-text-muted);
+  gap: 0;
+}
+
 .chipSuggest {
   background: color-mix(in srgb, var(--accent-meetings) 10%, transparent);
   border-color: color-mix(in srgb, var(--accent-meetings) 28%, transparent);

--- a/src/app/_components/actions/components/ActionRow.tsx
+++ b/src/app/_components/actions/components/ActionRow.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import { Tooltip } from "@mantine/core";
 import { IconCalendar, IconClock, IconSparkles } from "@tabler/icons-react";
 import { HTMLContent } from "../../HTMLContent";
+import { ScheduledIndicator } from "../../shared/ScheduledIndicator";
 import { ActiveTimerIndicator } from "../../ActiveTimerIndicator";
 import { TagBadgeList } from "../../TagBadge";
 import { formatAprDay, formatClockTime } from "~/lib/actions/dates";
@@ -62,7 +62,6 @@ export function ActionRow({
     : null;
   const due = action.dueDate ? new Date(action.dueDate) : null;
   const timeSource = scheduled ?? due;
-  const duration = (action as Action & { duration?: number | null }).duration;
 
   const tags = action.tags?.map((t) => t.tag) ?? [];
 
@@ -132,17 +131,12 @@ export function ActionRow({
                   {formatAprDay(due)}
                 </span>
               )}
-              {scheduled && (
-                <Tooltip
-                  label={`Scheduled${duration ? ` for ${duration} min` : ""}`}
-                  withArrow
-                >
-                  <span className={styles.chip}>
-                    <IconClock size={10} />
-                    {formatClockTime(scheduled)}
-                  </span>
-                </Tooltip>
-              )}
+              <ScheduledIndicator
+                action={action}
+                className={styles.chip}
+                unscheduledClassName={styles.chipUnscheduled}
+                iconSize={10}
+              />
             </>
           )}
           <ProjectChip

--- a/src/app/_components/shared/ScheduledIndicator.tsx
+++ b/src/app/_components/shared/ScheduledIndicator.tsx
@@ -1,0 +1,66 @@
+import { IconClock, IconClockOff } from "@tabler/icons-react";
+import { formatClockTime } from "~/lib/actions/dates";
+import { hasUserChosenTime, type TimeBlockFields } from "~/lib/actions/scheduling";
+
+interface ScheduledIndicatorProps {
+  action: TimeBlockFields;
+  /** The host row's chip class — each Today surface has its own. */
+  className?: string;
+  /** Extra class applied only in the unscheduled state. */
+  unscheduledClassName?: string;
+  iconSize?: number;
+}
+
+/**
+ * Marks a task row as holding a real time slot, or not.
+ *
+ * Deliberately the *same* `hasUserChosenTime` the agenda rail builds its blocks
+ * from, so the two can never disagree: a row showing the scheduled marker is
+ * exactly a row that draws a block on the rail.
+ *
+ * This replaces the bare clock-plus-time the rows used to render off
+ * `scheduledStart`. That was incidental — the clock happened to vanish for
+ * untimed tasks — where the distinction now reads as deliberate. The two states
+ * differ by icon shape rather than colour, and each carries its own label, so
+ * neither the marker nor its meaning depends on being able to see the hue.
+ *
+ * Scheduled rows keep the time as visible text; unscheduled rows are icon-only,
+ * because "no time" is the common case and a worded badge on most rows would
+ * compete with the due date, tag and reschedule control already there.
+ */
+export function ScheduledIndicator({
+  action,
+  className,
+  unscheduledClassName,
+  iconSize = 11,
+}: ScheduledIndicatorProps) {
+  const scheduled = hasUserChosenTime(action);
+
+  if (!scheduled) {
+    return (
+      <span
+        className={[className, unscheduledClassName].filter(Boolean).join(" ")}
+        role="img"
+        aria-label="Not scheduled"
+        title="Not scheduled — no time set"
+      >
+        <IconClockOff size={iconSize} />
+      </span>
+    );
+  }
+
+  const start = new Date(action.scheduledStart);
+  const time = formatClockTime(start);
+  const minutes = action.duration;
+  const label = minutes
+    ? `Scheduled for ${time}, ${minutes} min`
+    : `Scheduled for ${time}`;
+
+  return (
+    <span className={className} title={label}>
+      <IconClock size={iconSize} aria-hidden="true" />
+      <span className="sr-only">{label}</span>
+      <span aria-hidden="true">{time}</span>
+    </span>
+  );
+}

--- a/src/app/_components/shared/__tests__/ScheduledIndicator.test.tsx
+++ b/src/app/_components/shared/__tests__/ScheduledIndicator.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ScheduledIndicator } from "../ScheduledIndicator";
+import { hasUserChosenTime } from "~/lib/actions/scheduling";
+
+const START = new Date(2026, 7, 5, 10, 30, 0, 0);
+const END = new Date(2026, 7, 5, 10, 40, 0, 0);
+
+describe("ScheduledIndicator", () => {
+  it("marks a task with a duration as scheduled, showing the time", () => {
+    render(<ScheduledIndicator action={{ scheduledStart: START, duration: 30 }} />);
+
+    expect(screen.getByText("10:30 AM")).toBeDefined();
+    expect(screen.getByText("Scheduled for 10:30 AM, 30 min")).toBeDefined();
+    expect(screen.queryByLabelText("Not scheduled")).toBeNull();
+  });
+
+  it("marks a task with a scheduledEnd as scheduled", () => {
+    render(<ScheduledIndicator action={{ scheduledStart: START, scheduledEnd: END }} />);
+
+    expect(screen.getByText("Scheduled for 10:30 AM")).toBeDefined();
+  });
+
+  it("marks a bare scheduledStart as NOT scheduled", () => {
+    // The stamped-instant case — no length, so nobody chose this time.
+    render(<ScheduledIndicator action={{ scheduledStart: START }} />);
+
+    expect(screen.getByLabelText("Not scheduled")).toBeDefined();
+    expect(screen.queryByText("10:30 AM")).toBeNull();
+  });
+
+  it("marks a task with no schedule at all as NOT scheduled", () => {
+    render(<ScheduledIndicator action={{}} />);
+
+    expect(screen.getByLabelText("Not scheduled")).toBeDefined();
+  });
+
+  it("agrees with the rail's predicate for every shape", () => {
+    // The point of the ticket: the row and the rail cannot disagree.
+    const shapes = [
+      {},
+      { scheduledStart: START },
+      { scheduledStart: START, duration: 30 },
+      { scheduledStart: START, scheduledEnd: END },
+      { scheduledStart: START, duration: 0 },
+      { duration: 30 },
+    ];
+
+    for (const shape of shapes) {
+      const { unmount } = render(<ScheduledIndicator action={shape} />);
+      const isScheduled = screen.queryByLabelText("Not scheduled") === null;
+      expect(isScheduled).toBe(hasUserChosenTime(shape));
+      unmount();
+    }
+  });
+
+  it("conveys state without relying on colour", () => {
+    // Each state carries its own text: a label for unscheduled, and a
+    // screen-reader line plus visible time for scheduled.
+    const { unmount } = render(<ScheduledIndicator action={{}} />);
+    expect(screen.getByLabelText("Not scheduled")).toBeDefined();
+    unmount();
+
+    render(<ScheduledIndicator action={{ scheduledStart: START, duration: 15 }} />);
+    expect(screen.getByText("Scheduled for 10:30 AM, 15 min")).toBeDefined();
+  });
+
+  it("applies the host row's chip class, plus the unscheduled one when unset", () => {
+    const { container, unmount } = render(
+      <ScheduledIndicator
+        action={{ scheduledStart: START, duration: 30 }}
+        className="chip"
+        unscheduledClassName="chip--quiet"
+      />,
+    );
+    expect(container.querySelector("span")!.className).toBe("chip");
+    unmount();
+
+    const { container: bare } = render(
+      <ScheduledIndicator
+        action={{}}
+        className="chip"
+        unscheduledClassName="chip--quiet"
+      />,
+    );
+    expect(bare.querySelector("span")!.className).toBe("chip chip--quiet");
+  });
+});

--- a/src/app/_components/today-redesign/TaskRow.tsx
+++ b/src/app/_components/today-redesign/TaskRow.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
-import { IconAlertCircle, IconCalendar, IconClock } from "@tabler/icons-react";
+import { IconAlertCircle, IconCalendar } from "@tabler/icons-react";
 import type { Action } from "~/lib/actions/types";
 import { toVisualPriority } from "~/lib/actions/priority";
-import { formatAprDay, formatClockTime } from "~/lib/actions/dates";
+import { formatAprDay } from "~/lib/actions/dates";
 import { stripHtml } from "~/lib/utils";
 import { HTMLContent } from "../HTMLContent";
+import { ScheduledIndicator } from "../shared/ScheduledIndicator";
 import {
   ReschedulePopover,
   type RescheduleChoice,
@@ -43,7 +44,6 @@ export function TaskRow({
   const isDone = action.status === "COMPLETED" || action.status === "DONE";
   const visualPrio = toVisualPriority(action.priority, isOverdue);
 
-  const scheduled = action.scheduledStart ? new Date(action.scheduledStart) : null;
   const due = action.dueDate ? new Date(action.dueDate) : null;
 
   const tags = action.tags?.map((t) => t.tag) ?? [];
@@ -115,12 +115,11 @@ export function TaskRow({
               </span>
             )
           )}
-          {scheduled && (
-            <span className="td-task__meta-item">
-              <IconClock size={11} />
-              {formatClockTime(scheduled)}
-            </span>
-          )}
+          <ScheduledIndicator
+            action={action}
+            className="td-task__meta-item"
+            unscheduledClassName="td-task__meta-item--unscheduled"
+          />
           {primaryTag ? (
             <TagChip
               label={primaryTag.name}

--- a/src/app/_components/today-redesign/today-desktop.css
+++ b/src/app/_components/today-redesign/today-desktop.css
@@ -416,6 +416,15 @@ html[data-sidebar="closed"] .td-topbar {
 
 .td-task__meta-item--overdue { color: var(--td-prio-urgent); }
 
+/* "No time set" is the common case, so its marker is the quietest thing on the
+   row — icon only, dimmed, and it steps back further next to a scheduled row's
+   clock-plus-time. The state is carried by the icon's shape and its label, not
+   by this colour. */
+.td-task__meta-item--unscheduled {
+  color: var(--td-faint);
+  gap: 0;
+}
+
 .td-task__reschedule {
   position: relative;
   display: inline-flex;


### PR DESCRIPTION
### **User description**
## What

Now that untimed tasks stay off the agenda rail (smooth.bamboo), the task list is the only place they're visible — so the list has to show at a glance which tasks hold a real time slot and which are simply due today.

`ScheduledIndicator` (`src/app/_components/shared/ScheduledIndicator.tsx`) derives its state from the **same** `hasUserChosenTime` the rail builds its blocks from. Not a parallel implementation — the identical function, so the two can't drift.

Following the ticket's steer, it **absorbs** the clock-plus-time the rows already rendered rather than sitting beside it as a second icon. That clock keyed off `scheduledStart` alone, which made it an incidental signal — it happened to vanish for untimed tasks. Now the distinction is deliberate.

- **Scheduled** → clock icon + the time as visible text, e.g. "10:30 AM", labelled `Scheduled for 10:30 AM, 30 min`.
- **Unscheduled** → a dimmed `IconClockOff`, icon-only, labelled `Not scheduled`.

Unscheduled is icon-only because "no time" is the common case; a worded badge on most rows would compete with the due date, tag and reschedule control already there. The two states differ by **icon shape**, and each carries its own text label — so neither the marker nor its meaning depends on seeing the hue.

## Verification

7 component tests, including one that asserts the indicator's state matches `hasUserChosenTime` across every field shape — that's the anti-drift guarantee. Verified live on both surfaces:

| Row | Indicator |
|---|---|
| `scheduledStart` + `duration` 30 | "Scheduled for 2:00 PM, 30 min" |
| `scheduledStart` + `scheduledEnd`, no duration | "Scheduled for 9:00 AM" |
| bare `scheduledStart` (the stamped-instant case) | "Not scheduled" |
| no schedule at all | "Not scheduled" |

On the third criterion, the precise guarantee is that row and rail call one function, so they classify identically. The row indicator naturally covers rows outside today's set (overdue, upcoming) that the rail doesn't draw at all.

I nudged the desktop unscheduled colour from `--td-dim` (18% alpha) to `--td-faint` (32%) after looking at it — 18% was too close to invisible for something conveying state. Still quieter than the due date beside it. No new colours.

## Acceptance criteria

- [x] Each task row shows an indicator distinguishing scheduled from unscheduled
- [x] The indicator derives from the shared predicate introduced in smooth.bamboo, not a local re-implementation
- [x] A task showing the scheduled marker is exactly a task that renders a block on the agenda rail (same predicate, asserted by test)
- [x] The indicator has an accessible label; it does not rely on colour alone to convey state
- [x] It does not visually compete with the existing due-date, time and tag elements
- [x] Applied to desktop (`TaskRow`) and mobile (`ActionRow`) task rows
- [x] No hardcoded colours introduced — the pre-commit hook confirms it
- [x] `npm run check` passes (run as `npx tsc --noEmit` + `npx eslint` at an 8GB heap — the packaged scripts pin 4GB and OOM on this repo)

---

Ships: clear.ingot


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- New shared `ScheduledIndicator` component for task rows

- Derives state from rail's `hasUserChosenTime` predicate

- Replaces incidental clock chip in both row surfaces

- Adds CSS for dimmed unscheduled marker; 7 tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  P["hasUserChosenTime (scheduling)"] -- "shared predicate" --> SI["ScheduledIndicator"]
  SI -- "scheduled: IconClock + time" --> S["Scheduled state"]
  SI -- "unscheduled: IconClockOff, dimmed" --> U["Unscheduled state"]
  SI --> AR["ActionRow"]
  SI --> TR["TaskRow"]
  AR --> C1["ActionRow.module.css chipUnscheduled"]
  TR --> C2["today-desktop.css meta-item--unscheduled"]
  SI --> T["ScheduledIndicator.test.tsx"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ScheduledIndicator.tsx</strong><dd><code>New shared ScheduledIndicator component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/shared/ScheduledIndicator.tsx

<ul><li>New component rendering scheduled vs unscheduled marker<br> <li> Uses <code>hasUserChosenTime</code> so rows match the agenda rail<br> <li> Scheduled: <code>IconClock</code> + visible time + <code>sr-only</code> label including duration<br> <li> Unscheduled: dimmed <code>IconClockOff</code>, icon-only with <code>aria-label</code>/<code>title</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/519/files#diff-491c9492f26288a121dfea3d4438caffa8717881d4bd813ecd07142d88e3da2e">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TaskRow.tsx</strong><dd><code>Use ScheduledIndicator in TaskRow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/today-redesign/TaskRow.tsx

<ul><li>Replaces <code>scheduledStart</code>-based clock chip with <code>ScheduledIndicator</code><br> <li> Removes local <code>scheduled</code> date and unused imports<br> <li> Passes chip and unscheduled class names</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/519/files#diff-0c5b98153957c60a3d9c518f75ad63fbe874d5e0741018e0349b65f6a1f91ffe">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ActionRow.tsx</strong><dd><code>Use ScheduledIndicator in ActionRow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/actions/components/ActionRow.tsx

<ul><li>Replaces tooltip clock chip with <code>ScheduledIndicator</code><br> <li> Drops <code>Tooltip</code> import and local <code>duration</code> cast<br> <li> Passes chip classes and <code>iconSize={10}</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/519/files#diff-c2bc2eff6e38933ed731df45c13cc1b526df6faf85818bec4ef7ece32ae966f3">+7/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ScheduledIndicator.test.tsx</strong><dd><code>Tests for the scheduled indicator states</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/shared/__tests__/ScheduledIndicator.test.tsx

<ul><li>7 tests covering duration, <code>scheduledEnd</code>, bare start, and empty shapes<br> <li> Asserts parity with <code>hasUserChosenTime</code> across field shapes<br> <li> Verifies non-colour-dependent text labels and class composition</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/519/files#diff-e4c9b4d05dd3185ead1835b88e3761458dd2cbc3c91cfa34678b363364b3bba8">+88/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>today-desktop.css</strong><dd><code>Style for unscheduled meta item</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/today-redesign/today-desktop.css

<ul><li>Adds <code>.td-task__meta-item--unscheduled</code> rule with faint colour<br> <li> Comment explaining quiet, icon-only treatment</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/519/files#diff-45f4d56a944c3cacf41abd758375ac279636bccf7bd58d4d3d52ed7eabbf093d">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ActionRow.module.css</strong><dd><code>Style for unscheduled chip variant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/actions/components/ActionRow.module.css

<ul><li>Adds <code>.chipUnscheduled</code> class: transparent frame, muted colour, no gap<br> <li> Comment cross-referencing the today-desktop rule</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/519/files#diff-82c171b091b3cb13271c53ef197856bb9a8bce1fb990e00c887965b571182702">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

