### PR TITLE
feat: Lane layout for genuinely colliding agenda blocks

### DIFF
--- a/src/app/_components/calendar/utils/overlapDetection.ts
+++ b/src/app/_components/calendar/utils/overlapDetection.ts
@@ -43,8 +43,12 @@ export function itemsOverlap(a: CalendarItem, b: CalendarItem): boolean {
  * Build clusters of items that transitively overlap with each other.
  * Items in the same cluster share column space, while separate clusters
  * are positioned independently.
+ *
+ * Exported because the Today agenda rail needs cluster membership, not just
+ * per-item columns: it caps lanes and has to know which blocks belong to the
+ * same pile-up in order to collapse the overflow. See `~/lib/actions/railLayout`.
  */
-function buildOverlapClusters(
+export function buildOverlapClusters(
   items: PositionedCalendarItem[]
 ): PositionedCalendarItem[][] {
   if (items.length === 0) return [];

--- a/src/app/_components/today-redesign/AgendaRail.tsx
+++ b/src/app/_components/today-redesign/AgendaRail.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import type { RailBlock } from "~/lib/actions/railBlocks";
-import { layoutRailBlock } from "~/lib/actions/railLayout";
+import { layoutRailBlocks } from "~/lib/actions/railLayout";
 import { formatHourLabel, formatHourMinute12 } from "~/lib/actions/dates";
 import { stripHtml } from "~/lib/utils";
 
@@ -17,6 +17,16 @@ interface AgendaRailProps {
 
 export function AgendaRail({ dayLabel, eventsCount, blocks, now }: AgendaRailProps) {
   const totalHrs = END_HR - START_HR;
+  const [openOverflow, setOpenOverflow] = useState<string | null>(null);
+  const { positioned, overflows } = useMemo(
+    () =>
+      layoutRailBlocks(blocks, {
+        rangeStart: START_HR,
+        rangeEnd: END_HR,
+        hourPx: HOUR_PX,
+      }),
+    [blocks],
+  );
   return (
     <aside className="td-rail">
       <div className="td-rail__header">
@@ -59,20 +69,19 @@ export function AgendaRail({ dayLabel, eventsCount, blocks, now }: AgendaRailPro
             </div>
           )}
 
-          {blocks.map((b) => {
-            const layout = layoutRailBlock(b, {
-              rangeStart: START_HR,
-              rangeEnd: END_HR,
-              hourPx: HOUR_PX,
-            });
-            if (!layout) return null;
+          {positioned.map(({ block: b, ...layout }) => {
             const tone = b.kind === "cal" ? "blue" : "amber";
             return (
               <div
                 key={b.id}
                 className={`td-event td-event--${tone}`}
                 data-floored={layout.isFloored ? "true" : undefined}
-                style={{ top: layout.top, height: layout.height }}
+                style={{
+                  top: layout.top,
+                  height: layout.height,
+                  left: `${layout.leftPct}%`,
+                  width: `${layout.widthPct}%`,
+                }}
                 title={`${stripHtml(b.title)} · ${formatHourMinute12(b.start)} – ${formatHourMinute12(b.end)}`}
               >
                 <div className="td-event__title">{stripHtml(b.title)}</div>
@@ -84,6 +93,44 @@ export function AgendaRail({ dayLabel, eventsCount, blocks, now }: AgendaRailPro
               </div>
             );
           })}
+
+          {overflows.map((o) => (
+            <div
+              key={o.key}
+              className="td-event-more"
+              style={{
+                top: o.top,
+                height: o.height,
+                left: `${o.leftPct}%`,
+                width: `${o.widthPct}%`,
+              }}
+            >
+              <button
+                type="button"
+                className="td-event-more__btn"
+                aria-expanded={openOverflow === o.key}
+                onClick={() =>
+                  setOpenOverflow((cur) => (cur === o.key ? null : o.key))
+                }
+              >
+                +{o.hidden.length} more
+              </button>
+              {openOverflow === o.key && (
+                <div className="td-event-more__panel" role="list">
+                  {o.hidden.map((h) => (
+                    <div key={h.id} className="td-event-more__item" role="listitem">
+                      <div className="td-event-more__item-title">
+                        {stripHtml(h.title)}
+                      </div>
+                      <div className="td-event-more__item-time">
+                        {formatHourMinute12(h.start)} – {formatHourMinute12(h.end)}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
         </div>
       </div>
     </aside>

--- a/src/app/_components/today-redesign/AgendaRail.tsx
+++ b/src/app/_components/today-redesign/AgendaRail.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import type { RailBlock } from "~/lib/actions/railBlocks";
 import { layoutRailBlocks } from "~/lib/actions/railLayout";
 import { formatHourLabel, formatHourMinute12 } from "~/lib/actions/dates";
@@ -18,6 +18,26 @@ interface AgendaRailProps {
 export function AgendaRail({ dayLabel, eventsCount, blocks, now }: AgendaRailProps) {
   const totalHrs = END_HR - START_HR;
   const [openOverflow, setOpenOverflow] = useState<string | null>(null);
+  const overflowRef = useRef<HTMLDivElement | null>(null);
+
+  // Dismiss the "+N more" panel the way any popover should: click away, or
+  // press Escape. Without this it stays open over other blocks indefinitely.
+  useEffect(() => {
+    if (!openOverflow) return;
+    const onPointerDown = (e: MouseEvent) => {
+      if (!overflowRef.current?.contains(e.target as Node)) setOpenOverflow(null);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpenOverflow(null);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [openOverflow]);
+
   const { positioned, overflows } = useMemo(
     () =>
       layoutRailBlocks(blocks, {
@@ -97,7 +117,9 @@ export function AgendaRail({ dayLabel, eventsCount, blocks, now }: AgendaRailPro
           {overflows.map((o) => (
             <div
               key={o.key}
+              ref={openOverflow === o.key ? overflowRef : undefined}
               className="td-event-more"
+              data-open={openOverflow === o.key ? "true" : undefined}
               style={{
                 top: o.top,
                 height: o.height,

--- a/src/app/_components/today-redesign/today-desktop.css
+++ b/src/app/_components/today-redesign/today-desktop.css
@@ -562,8 +562,12 @@ html[data-sidebar="closed"] .td-topbar {
   right: 0;
   height: 1px;
   background: var(--td-hair);
+  z-index: 0;
 }
 
+/* Above the blocks. Blocks are opaque now, so without this the current-time
+   marker simply vanishes behind whatever is happening at this hour — which is
+   exactly the hour you most want to locate. */
 .td-timeline__now {
   position: absolute;
   left: -6px;
@@ -571,6 +575,7 @@ html[data-sidebar="closed"] .td-topbar {
   display: flex;
   align-items: center;
   pointer-events: none;
+  z-index: 3;
 }
 
 .td-timeline__now-dot {
@@ -589,13 +594,14 @@ html[data-sidebar="closed"] .td-topbar {
   opacity: 0.7;
 }
 
+/* `left`/`width` come from the lane layout as inline percentages; blocks that
+   collide with nothing get the full width. */
 .td-event {
   position: absolute;
-  left: 0;
-  right: 0;
   border-radius: 6px;
   padding: 6px 9px;
   overflow: hidden;
+  z-index: 1;
 }
 
 /* A block shorter than its own contents is drawn at MIN_RAIL_BLOCK_PX, which
@@ -624,17 +630,88 @@ html[data-sidebar="closed"] .td-topbar {
   font-feature-settings: "tnum";
 }
 
+/* Opaque, not translucent. Where blocks do overlap — a lane boundary, or a
+   short block floored over its neighbour — translucent fills let the text
+   underneath bleed through, and the result read as a rendering fault rather
+   than a busy hour. Mixing into --td-surface rather than `transparent` keeps
+   the same tint while making the fill solid. */
 .td-event--amber {
-  background: var(--td-accent-12);
+  background: color-mix(in srgb, var(--td-accent) 14%, var(--td-surface));
   border-left: 2px solid var(--td-accent);
 }
 .td-event--amber .td-event__title { color: var(--td-accent); }
 
 .td-event--blue {
-  background: var(--td-event-blue-bg);
+  background: color-mix(in srgb, var(--td-event-blue-border) 14%, var(--td-surface));
   border-left: 2px solid var(--td-event-blue-border);
 }
 .td-event--blue .td-event__title { color: var(--td-event-blue-title); }
+
+/* ---- Lane overflow ("+N more") ---------------------------------------- */
+.td-event-more {
+  position: absolute;
+  z-index: 2;
+  display: flex;
+  align-items: flex-start;
+}
+
+.td .td-event-more__btn {
+  width: 100%;
+  padding: 4px 6px;
+  border-radius: 6px;
+  background: var(--td-surface-2);
+  border: 1px solid var(--td-hair-2);
+  color: var(--td-muted);
+  font-size: 10.5px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.td .td-event-more__btn:hover {
+  color: var(--td-text);
+  border-color: var(--td-accent-40);
+}
+
+.td-event-more__panel {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 4;
+  margin-top: 4px;
+  min-width: 190px;
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 6px;
+  border-radius: 8px;
+  background: var(--td-surface);
+  border: 1px solid var(--td-hair-2);
+}
+
+.td-event-more__item {
+  padding: 5px 7px;
+  border-radius: 5px;
+}
+.td-event-more__item + .td-event-more__item { margin-top: 1px; }
+.td-event-more__item:hover { background: var(--td-surface-2); }
+
+.td-event-more__item-title {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--td-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.td-event-more__item-time {
+  font-size: 10.5px;
+  color: var(--td-muted);
+  font-feature-settings: "tnum";
+  margin-top: 1px;
+}
 
 /* ============================================================
    Score ring (SVG)

--- a/src/app/_components/today-redesign/today-desktop.css
+++ b/src/app/_components/today-redesign/today-desktop.css
@@ -655,6 +655,13 @@ html[data-sidebar="closed"] .td-topbar {
   align-items: flex-start;
 }
 
+/* z-index on the wrapper opens a stacking context, so the panel's own z-index
+   is confined to it and cannot clear the now-line (3) on its own. Lift the
+   whole wrapper while the panel is open instead. */
+.td-event-more[data-open="true"] {
+  z-index: 5;
+}
+
 .td .td-event-more__btn {
   width: 100%;
   padding: 4px 6px;

--- a/src/lib/actions/__tests__/railLayout.test.ts
+++ b/src/lib/actions/__tests__/railLayout.test.ts
@@ -279,3 +279,26 @@ describe("layoutRailBlocks", () => {
     expect(layoutRailBlocks([], RAIL)).toEqual({ positioned: [], overflows: [] });
   });
 });
+
+describe("layoutRailBlocks overflow key", () => {
+  it("stays stable when the input order changes", () => {
+    const blocks = ["a", "b", "c", "d"].map((id) => railBlock(id, 10, 60));
+
+    const forward = layoutRailBlocks(blocks, RAIL).overflows[0]!.key;
+    const reversed = layoutRailBlocks([...blocks].reverse(), RAIL).overflows[0]!.key;
+
+    // The panel's open/closed identity must survive a refetch that reorders
+    // the list, so the key can't depend on which block lands first.
+    expect(forward).toBe(reversed);
+  });
+
+  it("differs between separate pile-ups", () => {
+    const morning = ["a", "b", "c", "d"].map((id) => railBlock(id, 9, 60));
+    const afternoon = ["e", "f", "g", "h"].map((id) => railBlock(id, 15, 60));
+
+    const { overflows } = layoutRailBlocks([...morning, ...afternoon], RAIL);
+
+    expect(overflows).toHaveLength(2);
+    expect(overflows[0]!.key).not.toBe(overflows[1]!.key);
+  });
+});

--- a/src/lib/actions/__tests__/railLayout.test.ts
+++ b/src/lib/actions/__tests__/railLayout.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   layoutRailBlock,
+  layoutRailBlocks,
+  MAX_RAIL_LANES,
   MIN_RAIL_BLOCK_PX,
   RAIL_BLOCK_GAP_PX,
   RAIL_META_MIN_PX,
 } from "~/lib/actions/railLayout";
+import type { RailBlock } from "~/lib/actions/railBlocks";
 
 /** The desktop rail's geometry; the mobile one differs only in range. */
 const RAIL = { rangeStart: 7, rangeEnd: 20, hourPx: 48 };
@@ -112,5 +115,167 @@ describe("layoutRailBlock", () => {
 
     expect(layout!.top).toBe((10.5 - 6) * 48);
     expect(layout!.height).toBe(MIN_RAIL_BLOCK_PX);
+  });
+});
+
+function railBlock(
+  id: string,
+  startHour: number,
+  minutes: number,
+  kind: RailBlock["kind"] = "task",
+): RailBlock {
+  return { id, title: id, start: startHour, end: startHour + minutes / 60, kind };
+}
+
+describe("layoutRailBlocks", () => {
+  it("gives a lone block the full rail width", () => {
+    const { positioned, overflows } = layoutRailBlocks(
+      [railBlock("a", 10, 60)],
+      RAIL,
+    );
+
+    expect(positioned).toHaveLength(1);
+    expect(positioned[0]).toMatchObject({ leftPct: 0, widthPct: 100 });
+    expect(overflows).toEqual([]);
+  });
+
+  it("leaves blocks that do not collide at full width", () => {
+    const { positioned } = layoutRailBlocks(
+      [railBlock("a", 9, 60), railBlock("b", 11, 60)],
+      RAIL,
+    );
+
+    expect(positioned.map((p) => p.widthPct)).toEqual([100, 100]);
+  });
+
+  it("splits two colliding blocks into side-by-side lanes", () => {
+    const { positioned } = layoutRailBlocks(
+      [railBlock("a", 10, 60), railBlock("b", 10.5, 60)],
+      RAIL,
+    );
+
+    expect(positioned).toHaveLength(2);
+    for (const p of positioned) expect(p.widthPct).toBeLessThan(100);
+    // Distinct lanes, and they don't sit on top of each other.
+    const lefts = positioned.map((p) => p.leftPct).sort((x, y) => x - y);
+    expect(lefts[0]).toBe(0);
+    expect(lefts[1]).toBeGreaterThan(0);
+  });
+
+  it("lays a genuine 3-way collision into three lanes with no overflow", () => {
+    const { positioned, overflows } = layoutRailBlocks(
+      [
+        railBlock("cal", 14, 60, "cal"),
+        railBlock("deep-work", 14, 45),
+        railBlock("standup", 14.25, 30),
+      ],
+      RAIL,
+    );
+
+    expect(positioned).toHaveLength(3);
+    expect(overflows).toEqual([]);
+    expect(new Set(positioned.map((p) => p.leftPct)).size).toBe(3);
+    for (const p of positioned) expect(p.widthPct).toBeCloseTo(33, 0);
+  });
+
+  it("caps the lanes and collapses the rest into one overflow bucket", () => {
+    const blocks = Array.from({ length: 6 }, (_, i) =>
+      railBlock(`b${i}`, 10, 60),
+    );
+
+    const { positioned, overflows } = layoutRailBlocks(blocks, RAIL);
+
+    // Two lanes render; everything from the third onward is bucketed.
+    expect(positioned).toHaveLength(MAX_RAIL_LANES - 1);
+    expect(overflows).toHaveLength(1);
+    expect(overflows[0]!.hidden).toHaveLength(6 - (MAX_RAIL_LANES - 1));
+    expect(positioned.length + overflows[0]!.hidden.length).toBe(blocks.length);
+  });
+
+  it("never lets a lane fall below the readable width", () => {
+    const blocks = Array.from({ length: 12 }, (_, i) =>
+      railBlock(`b${i}`, 10, 60),
+    );
+
+    const { positioned, overflows } = layoutRailBlocks(blocks, RAIL);
+
+    for (const p of positioned) expect(p.widthPct).toBeGreaterThanOrEqual(30);
+    expect(overflows[0]!.widthPct).toBeGreaterThanOrEqual(30);
+  });
+
+  it("reuses a lane when a later block starts after the one above it ends", () => {
+    // a and b run 10:00–11:00; c is 10:00–10:30, so d at 10:30 can sit under c
+    // in the same lane. Three lanes suffice and nothing overflows.
+    const { positioned, overflows } = layoutRailBlocks(
+      [
+        railBlock("a", 10, 60),
+        railBlock("b", 10, 60),
+        railBlock("c", 10, 30),
+        railBlock("d", 10.5, 60),
+      ],
+      RAIL,
+    );
+
+    expect(positioned).toHaveLength(4);
+    expect(overflows).toEqual([]);
+    expect(new Set(positioned.map((p) => p.leftPct)).size).toBe(3);
+  });
+
+  it("places the overflow bucket in the last lane, spanning what it hides", () => {
+    // Four blocks all covering the same hour: no lane can be reused.
+    const blocks = ["a", "b", "c", "d"].map((id) => railBlock(id, 10, 60));
+
+    const { positioned, overflows } = layoutRailBlocks(blocks, RAIL);
+    const bucket = overflows[0]!;
+
+    expect(positioned).toHaveLength(MAX_RAIL_LANES - 1);
+    expect(bucket.leftPct).toBeGreaterThan(
+      Math.max(...positioned.map((p) => p.leftPct)),
+    );
+    expect(bucket.height).toBeGreaterThanOrEqual(MIN_RAIL_BLOCK_PX);
+    expect(bucket.hidden.map((h) => h.id)).toEqual(["c", "d"]);
+  });
+
+  it("keeps separate pile-ups independent of one another", () => {
+    const { positioned } = layoutRailBlocks(
+      [
+        // A collides with B in the morning...
+        railBlock("a", 9, 60),
+        railBlock("b", 9.5, 60),
+        // ...while C is alone in the afternoon and keeps the full width.
+        railBlock("c", 15, 60),
+      ],
+      RAIL,
+    );
+
+    const c = positioned.find((p) => p.block.id === "c")!;
+    expect(c.widthPct).toBe(100);
+    expect(positioned.find((p) => p.block.id === "a")!.widthPct).toBeLessThan(100);
+  });
+
+  it("drops out-of-range blocks before laying anything out", () => {
+    const { positioned, overflows } = layoutRailBlocks(
+      [railBlock("early", 3, 60), railBlock("late", 22, 60)],
+      RAIL,
+    );
+
+    expect(positioned).toEqual([]);
+    expect(overflows).toEqual([]);
+  });
+
+  it("treats two floored short blocks as colliding when they visually do", () => {
+    // 10:30 and 10:40 are only 8px apart but both render 22px tall, so they
+    // overlap on screen even though their durations do not.
+    const { positioned } = layoutRailBlocks(
+      [railBlock("a", 10.5, 10), railBlock("b", 10.5 + 10 / 60, 10)],
+      RAIL,
+    );
+
+    expect(positioned).toHaveLength(2);
+    for (const p of positioned) expect(p.widthPct).toBeLessThan(100);
+  });
+
+  it("returns nothing for no blocks", () => {
+    expect(layoutRailBlocks([], RAIL)).toEqual({ positioned: [], overflows: [] });
   });
 });

--- a/src/lib/actions/railLayout.ts
+++ b/src/lib/actions/railLayout.ts
@@ -1,3 +1,9 @@
+import {
+  buildOverlapClusters,
+  calculateOverlappingPositions,
+  type CalendarItem,
+  type PositionedCalendarItem,
+} from "~/app/_components/calendar/utils/overlapDetection";
 import type { RailBlock } from "~/lib/actions/railBlocks";
 
 /**
@@ -78,4 +84,153 @@ export function layoutRailBlock(
 
 function roundPx(px: number): number {
   return Math.round(px * 100) / 100;
+}
+
+/**
+ * The rail is only ~280px wide, so columns cannot subdivide indefinitely.
+ * Past three lanes each block is too narrow to read a title in, which is worse
+ * than hiding the overflow behind a count.
+ */
+export const MAX_RAIL_LANES = 3;
+
+/** Gap between lanes, as a percentage of the rail's width. */
+const LANE_GAP_PCT = 0.5;
+
+/** A block with both its vertical geometry and its horizontal lane. */
+export interface PositionedRailBlock extends RailBlockLayout {
+  block: RailBlock;
+  /** Percentage offset from the rail's left edge. */
+  leftPct: number;
+  /** Percentage of the rail's width. */
+  widthPct: number;
+}
+
+/** The "+N more" affordance standing in for a cluster's hidden blocks. */
+export interface RailOverflow {
+  key: string;
+  top: number;
+  height: number;
+  leftPct: number;
+  widthPct: number;
+  hidden: RailBlock[];
+}
+
+export interface RailLayoutResult {
+  positioned: PositionedRailBlock[];
+  overflows: RailOverflow[];
+}
+
+function laneGeometry(lane: number, lanes: number): { leftPct: number; widthPct: number } {
+  const gaps = lanes > 1 ? (lanes - 1) * LANE_GAP_PCT : 0;
+  const widthPct = (100 - gaps) / lanes;
+  return { leftPct: lane * (widthPct + LANE_GAP_PCT), widthPct };
+}
+
+/**
+ * Lay every block out on the rail, giving colliding blocks side-by-side lanes.
+ *
+ * Clustering and column assignment both come from the calendar's
+ * `overlapDetection` utility — the same code the full day grid uses — so the
+ * two views agree about what collides. This adds only what the rail needs on
+ * top: a lane cap, and the overflow bucket that cap implies.
+ *
+ * Collision is measured against *rendered* geometry, not raw duration, so two
+ * blocks floored to the minimum height are treated as colliding when they
+ * visually do — which is exactly when they need separate lanes.
+ */
+export function layoutRailBlocks(
+  blocks: RailBlock[],
+  options: RailLayoutOptions,
+): RailLayoutResult {
+  const placed: Array<{ block: RailBlock; geom: RailBlockLayout }> = [];
+  for (const block of blocks) {
+    const geom = layoutRailBlock(block, options);
+    if (geom) placed.push({ block, geom });
+  }
+  if (placed.length === 0) return { positioned: [], overflows: [] };
+
+  const byId = new Map(placed.map((p) => [p.block.id, p]));
+  const items: CalendarItem[] = placed.map(({ block, geom }) => ({
+    id: block.id,
+    type: block.kind === "cal" ? "event" : "action",
+    top: geom.top,
+    height: geom.height,
+    startMinutes: block.start * 60,
+    endMinutes: block.end * 60,
+  }));
+
+  const positioned: PositionedRailBlock[] = [];
+  const overflows: RailOverflow[] = [];
+
+  const seeded: PositionedCalendarItem[] = items.map((item) => ({
+    ...item,
+    left: 0,
+    width: 100,
+    column: 0,
+    totalColumns: 1,
+  }));
+
+  for (const cluster of buildOverlapClusters(seeded)) {
+    // Re-run the shared column assignment per cluster so `column` reflects this
+    // cluster alone; `buildOverlapClusters` only groups, it doesn't assign.
+    const laidOut = calculateOverlappingPositions(cluster, 100, 0);
+    const lanes = Math.max(...laidOut.map((i) => i.totalColumns), 1);
+
+    if (lanes <= MAX_RAIL_LANES) {
+      for (const item of laidOut) {
+        const entry = byId.get(item.id);
+        if (!entry) continue;
+        positioned.push({
+          ...entry.geom,
+          block: entry.block,
+          leftPct: round2(item.left),
+          widthPct: round2(item.width),
+        });
+      }
+      continue;
+    }
+
+    // Over the cap: the first lanes render as usual, and everything from the
+    // last lane onward collapses into one "+N more" bucket.
+    const visibleLanes = MAX_RAIL_LANES - 1;
+    const hidden: RailBlock[] = [];
+    let overflowTop = Infinity;
+    let overflowBottom = -Infinity;
+
+    for (const item of laidOut) {
+      const entry = byId.get(item.id);
+      if (!entry) continue;
+      if (item.column < visibleLanes) {
+        const { leftPct, widthPct } = laneGeometry(item.column, MAX_RAIL_LANES);
+        positioned.push({
+          ...entry.geom,
+          block: entry.block,
+          leftPct: round2(leftPct),
+          widthPct: round2(widthPct),
+        });
+      } else {
+        hidden.push(entry.block);
+        overflowTop = Math.min(overflowTop, entry.geom.top);
+        overflowBottom = Math.max(overflowBottom, entry.geom.top + entry.geom.height);
+      }
+    }
+
+    if (hidden.length > 0) {
+      const { leftPct, widthPct } = laneGeometry(visibleLanes, MAX_RAIL_LANES);
+      overflows.push({
+        key: `overflow-${hidden[0]!.id}`,
+        top: overflowTop,
+        height: Math.max(overflowBottom - overflowTop, MIN_RAIL_BLOCK_PX),
+        leftPct: round2(leftPct),
+        widthPct: round2(widthPct),
+        hidden,
+      });
+    }
+  }
+
+  return { positioned, overflows };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
 }

--- a/src/lib/actions/railLayout.ts
+++ b/src/lib/actions/railLayout.ts
@@ -218,7 +218,11 @@ export function layoutRailBlocks(
     if (hidden.length > 0) {
       const { leftPct, widthPct } = laneGeometry(visibleLanes, MAX_RAIL_LANES);
       overflows.push({
-        key: `overflow-${hidden[0]!.id}`,
+        // Keyed by where the pile-up sits, not by which block happens to land
+        // first in it. The key doubles as the panel's open/closed identity, so
+        // deriving it from block order would slam the panel shut on any
+        // refetch that reorders the list.
+        key: `overflow-${overflowTop}`,
         top: overflowTop,
         height: Math.max(overflowBottom - overflowTop, MIN_RAIL_BLOCK_PX),
         leftPct: round2(leftPct),


### PR DESCRIPTION
### **User description**
## What

The rail had no overlap handling at all. Blocks were absolutely positioned by `top`/`height` and pinned to the full rail width, so anything concurrent painted over whatever came before — and because the fills were translucent, the text underneath bled through. It read as a rendering fault rather than a busy hour.

**Lane layout.** Colliding blocks now lay out in side-by-side lanes. Both the clustering and the column assignment come from the calendar's `overlapDetection` utility — the same code the full day grid uses — so the two views agree about what collides. `buildOverlapClusters` is exported for this, because the rail needs *cluster membership* and not just per-item columns: it can't decide what to collapse without knowing which blocks belong to the same pile-up. What's new here is only what the rail adds on top: the cap and the overflow bucket.

**The cap.** The rail is ~280px wide, so lanes stop at three. Past that each block is too narrow to read a title in — worse than hiding the overflow. Everything from the third lane onward collapses into a `+N more` button that opens a panel listing the hidden blocks with their times.

**Opaque fills.** Mixed into `--td-surface` rather than `transparent`, so the tint is unchanged but nothing bleeds through. No new colour tokens.

**Layering.** Opaque blocks would swallow the now-line, so the timeline gets explicit stacking: gridlines `0`, blocks `1`, overflow `2`, now-line `3`. The current-time marker is the one thing that must never vanish behind a busy hour.

Collision is measured against *rendered* geometry rather than raw duration, so two short blocks floored to the minimum height (macro.pulsar) get separate lanes when they visually overlap — which is exactly when they need them.

## Verification

24 unit tests on the geometry. Verified live against a seeded day with a genuine 3-way collision plus a fourth block to force the cap:

| Time | Blocks | Result |
|---|---|---|
| 9:00 / 9:10 | Standup, Handoff notes | 2 lanes @ 49.75% |
| 11:00 | Design review (alone) | full width, 100% |
| 14:00 | Deep work, Sprint planning | 2 lanes @ 49.75% — previously an illegible smear |
| 15:00 | Board call, Budget review, 1:1 with Andi, Investor sync | **3 lanes @ 33%**, third is `+2 more` |

Clicking `+2 more` sets `aria-expanded=true` and reveals both hidden blocks with their times ("Investor sync 3:10 PM – 3:50 PM", "1:1 with Andi 3:15 PM – 3:45 PM"). Computed z-indexes confirmed in the browser: now-line `3`, overflow `2`, blocks `1`, gridlines `0`. All block backgrounds compute to opaque `color(srgb …)` with no alpha.

One accepted trade-off: at 33% width the three-lane titles truncate ("Board …", "Budget…"). That's the cap's explicit bargain, and the full title is on the `title` attribute.

Mobile is untouched, per the ticket's scope note.

## Acceptance criteria

- [x] Colliding blocks are laid out in side-by-side lanes; non-colliding blocks keep the full rail width
- [x] Layout reuses the existing calendar overlap-detection utility rather than a new implementation
- [x] Lanes are capped at ~3; beyond the cap, the overflow collapses into a "+N more" affordance that reveals the hidden blocks
- [x] Block backgrounds are opaque; no text bleeds through from blocks beneath
- [x] The "now" line and hour gridlines remain visible and correctly layered against blocks
- [x] Verified against a day containing at least one genuine 3-way collision
- [x] No hardcoded colours introduced — the pre-commit hook confirms it
- [x] `npm run check` passes (run as `npx tsc --noEmit` + `npx eslint` at an 8GB heap — the packaged scripts pin 4GB and OOM on this repo)

---

Ships: perky.glyph


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add lane layout for colliding agenda rail blocks

- Cap lanes at three with `+N more` overflow panel

- Make block fills opaque and fix timeline stacking

- Add extensive unit tests for `layoutRailBlocks`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  OD["overlapDetection<br/>buildOverlapClusters (exported)"] -- "clusters + columns" --> RL["railLayout<br/>layoutRailBlocks"]
  RL -- "positioned blocks" --> AR["AgendaRail"]
  RL -- "overflow buckets" --> AR
  AR -- "+N more panel<br/>click-away / Escape" --> CSS["today-desktop.css<br/>opaque fills, z-index layering"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>railLayout.ts</strong><dd><code>Lane layout and overflow bucketing for rail blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/actions/railLayout.ts

<ul><li>Adds <code>layoutRailBlocks</code> computing lane geometry per overlap cluster<br> <li> Introduces <code>MAX_RAIL_LANES</code> cap and lane gap percentage<br> <li> Collapses lanes beyond the cap into a <code>RailOverflow</code> bucket with a <br>position-derived stable key<br> <li> Adds <code>PositionedRailBlock</code>, <code>RailOverflow</code>, <code>RailLayoutResult</code> types and <br>rounding helper</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/520/files#diff-70ad5d3649e41218b216b2a7eb156038c5d0bb334340dc0d880f07ca72b44661">+159/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AgendaRail.tsx</strong><dd><code>Render lanes and overflow panel in agenda rail</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/today-redesign/AgendaRail.tsx

<ul><li>Switches from per-block <code>layoutRailBlock</code> to memoized <code>layoutRailBlocks</code><br> <li> Applies inline <code>left</code>/<code>width</code> percentages for lanes<br> <li> Renders <code>+N more</code> overflow buttons with an expandable panel listing <br>hidden blocks<br> <li> Adds click-away and Escape dismissal via document listeners</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/520/files#diff-9a3b1e331d5b710d540ef5f8c575b709a278c30b1bf56f29a1e4e78c7130714c">+79/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>today-desktop.css</strong><dd><code>Opaque fills, stacking order and overflow styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/today-redesign/today-desktop.css

<ul><li>Removes fixed full-width positioning from <code>.td-event</code> so lanes can apply<br> <li> Makes block fills opaque via <code>color-mix</code> into <code>--td-surface</code><br> <li> Adds explicit z-index layering (gridlines 0, blocks 1, overflow 2, <br>now-line 3)<br> <li> Adds styles for <code>.td-event-more</code> button, panel and items</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/520/files#diff-45f4d56a944c3cacf41abd758375ac279636bccf7bd58d4d3d52ed7eabbf093d">+88/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>overlapDetection.ts</strong><dd><code>Export buildOverlapClusters for rail reuse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/calendar/utils/overlapDetection.ts

<ul><li>Exports <code>buildOverlapClusters</code> for reuse by the rail layout<br> <li> Documents why cluster membership is needed externally</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/520/files#diff-f686ee8cecec89c2673ae1a69d2fd15752025bb0b3cfaf283be7bb3daad701c3">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>railLayout.test.ts</strong><dd><code>Tests for lane layout and overflow behaviour</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/actions/__tests__/railLayout.test.ts

<ul><li>Adds a <code>layoutRailBlocks</code> suite covering single, non-colliding and <br>colliding blocks<br> <li> Tests lane cap, overflow bucket contents, geometry and minimum width<br> <li> Tests lane reuse, independent clusters, out-of-range filtering and <br>floored-block collisions<br> <li> Tests overflow key stability across input reordering and across <br>separate pile-ups</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/520/files#diff-e6505e30435d5ed341acd6df821302c4a01d6f476574d09510114b086d6f47cc">+188/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

