### PR TITLE
fix: cursor-batch the body-repair mutation (serverless timeout)

### DIFF
--- a/src/plugins/product/server/routers/ticketSync.ts
+++ b/src/plugins/product/server/routers/ticketSync.ts
@@ -273,7 +273,15 @@ export const ticketSyncRouter = createTRPCRouter({
    * created pages are touched — imported/adopted pages are never rewritten.
    */
   rerenderCreatedBodies: protectedProcedure
-    .input(z.object({ productId: z.string() }))
+    .input(
+      z.object({
+        productId: z.string(),
+        // A page repair costs ~10-30 Notion calls; a whole product cannot fit
+        // in one serverless request. Callers loop on the returned nextCursor.
+        cursor: z.string().optional(),
+        limit: z.number().int().min(1).max(10).optional(),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       await loadProductWithAccess(ctx.db, ctx.session.user.id, input.productId);
       const config = await ctx.db.ticketSyncConfig.findUnique({
@@ -301,7 +309,11 @@ export const ticketSyncRouter = createTRPCRouter({
           message: "Enable push before re-rendering page bodies",
         });
       }
-      return rerenderCreatedPageBodies(ctx.db, { configId: config.id });
+      return rerenderCreatedPageBodies(ctx.db, {
+        configId: config.id,
+        cursor: input.cursor,
+        limit: input.limit,
+      });
     }),
 
   syncNow: protectedProcedure

--- a/src/server/services/ticketSync/__tests__/bodyRepair.test.ts
+++ b/src/server/services/ticketSync/__tests__/bodyRepair.test.ts
@@ -142,8 +142,56 @@ describe("rerenderCreatedPageBodies", () => {
       deps: { notionFactory: factoryFor(ops) },
     });
 
-    expect(result).toEqual({ ok: true, repaired: 0, failed: 0, items: [] });
+    expect(result).toEqual({
+      ok: true,
+      repaired: 0,
+      failed: 0,
+      items: [],
+      nextCursor: null,
+    });
     expect(db.ticketSync.findMany).not.toHaveBeenCalled();
+  });
+
+  it("paginates: returns a cursor when a full batch was processed, resumes after it", async () => {
+    db.ticketSyncRun.findMany.mockResolvedValue([
+      ledgerRun([
+        { action: "created", externalId: "page-1" },
+        { action: "created", externalId: "page-2" },
+        { action: "created", externalId: "page-3" },
+      ]),
+    ] as never);
+    db.ticketSync.findMany.mockResolvedValue([
+      syncRow("page-1", "b"),
+      syncRow("page-2", "b"),
+    ] as never);
+    const ops = fakeNotion();
+
+    const first = await rerenderCreatedPageBodies(db, {
+      configId: "cfg1",
+      limit: 2,
+      deps: { notionFactory: factoryFor(ops) },
+    });
+    // Full batch consumed -> a cursor pointing at the last processed sync.
+    expect(first.repaired).toBe(2);
+    expect(first.nextCursor).toBe("s-page-2");
+
+    db.ticketSync.findMany.mockResolvedValue([syncRow("page-3", "b")] as never);
+    const second = await rerenderCreatedPageBodies(db, {
+      configId: "cfg1",
+      cursor: first.nextCursor!,
+      limit: 2,
+      deps: { notionFactory: factoryFor(ops) },
+    });
+    expect(second.repaired).toBe(1);
+    // Short batch -> done.
+    expect(second.nextCursor).toBeNull();
+    // The resume cursor reached the query.
+    expect(db.ticketSync.findMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: { gt: "s-page-2" } }),
+        take: 2,
+      }),
+    );
   });
 
   it("refuses a disconnected config", async () => {

--- a/src/server/services/ticketSync/bodyRepair.ts
+++ b/src/server/services/ticketSync/bodyRepair.ts
@@ -37,10 +37,17 @@ export interface BodyRepairResult {
   repaired: number;
   failed: number;
   items: BodyRepairItem[];
+  /**
+   * Continuation cursor (last processed sync id) when more created pages
+   * remain; null when the sweep is complete. A page repair costs ~10-30
+   * Notion API calls, so a full product cannot fit in one serverless
+   * request — callers loop with the cursor.
+   */
+  nextCursor: string | null;
 }
 
-/** Hard cap per invocation — rerun for more (matches backfill's cap ethos). */
-const MAX_REPAIR_PAGES = 200;
+/** Pages per invocation — small enough to finish inside a function timeout. */
+const DEFAULT_BATCH_SIZE = 3;
 
 interface NotionBlockOps {
   listBlockChildrenIds(blockId: string): Promise<string[]>;
@@ -78,6 +85,10 @@ export async function rerenderCreatedPageBodies(
   db: PrismaClient,
   params: {
     configId: string;
+    /** Resume after this sync id (the previous call's nextCursor). */
+    cursor?: string;
+    /** Pages this invocation may repair (keep small: serverless timeout). */
+    limit?: number;
     deps?: { notionFactory?: NotionFactory };
   },
 ): Promise<BodyRepairResult> {
@@ -101,12 +112,22 @@ export async function rerenderCreatedPageBodies(
       repaired: 0,
       failed: 0,
       items: [],
+      nextCursor: null,
     };
   }
 
+  const limit = Math.max(1, Math.min(params.limit ?? DEFAULT_BATCH_SIZE, 10));
+
   const resolved = await notionFactory(db, config.integrationId);
   if (!resolved.ok) {
-    return { ok: false, error: resolved.error, repaired: 0, failed: 0, items: [] };
+    return {
+      ok: false,
+      error: resolved.error,
+      repaired: 0,
+      failed: 0,
+      items: [],
+      nextCursor: null,
+    };
   }
   const notion = resolved.notion;
 
@@ -118,7 +139,7 @@ export async function rerenderCreatedPageBodies(
   });
   const createdIds = createdExternalIdsFromLedger(runs);
   if (createdIds.size === 0) {
-    return { ok: true, repaired: 0, failed: 0, items: [] };
+    return { ok: true, repaired: 0, failed: 0, items: [], nextCursor: null };
   }
 
   const syncs = await db.ticketSync.findMany({
@@ -126,7 +147,9 @@ export async function rerenderCreatedPageBodies(
       configId: config.id,
       externalId: { in: [...createdIds] },
       tombstonedAt: null,
+      ...(params.cursor ? { id: { gt: params.cursor } } : {}),
     },
+    orderBy: { id: "asc" },
     select: {
       id: true,
       externalId: true,
@@ -134,7 +157,7 @@ export async function rerenderCreatedPageBodies(
         select: { id: true, title: true, body: true, number: true },
       },
     },
-    take: MAX_REPAIR_PAGES,
+    take: limit,
   });
 
   const base = getPublicBaseUrlFromEnv();
@@ -175,5 +198,7 @@ export async function rerenderCreatedPageBodies(
     }
   }
 
-  return { ok: true, repaired, failed, items };
+  const nextCursor =
+    syncs.length === limit ? (syncs[syncs.length - 1]?.id ?? null) : null;
+  return { ok: true, repaired, failed, items, nextCursor };
 }


### PR DESCRIPTION
## What

Follow-up to #521 (**ivory.pike**): the first live `rerenderCreatedBodies` run timed out at the platform level — a page repair costs ~10–30 Notion API calls, so 82 pages can't fit in one serverless request. Vercel killed the function mid-sweep (clients got its HTML error page), and a mid-page kill can even leave a page wiped-but-unwritten (a re-run heals it, since wipe+append is idempotent).

The mutation now takes `cursor`/`limit` (default 3, max 10 pages per call), processes syncs in stable id order, and returns `nextCursor` while more created pages remain — callers loop until `null`. Ledger provenance, per-page failure isolation, and all gates unchanged.

## Verification

New pagination test (full batch → cursor; resume passes `id > cursor` to the query; short batch → null). 259 ticket-sync tests green; `tsc --noEmit` clean.

---

Ships: ivory.pike (follow-up)

[View in Exponential](https://www.exponential.im/w/syntrofi/products/exponential/tickets/430)