### PR TITLE
fix(ticketSync): gate content rewrites on Notion's own created_by

### DIFF
--- a/src/server/services/ticketSync/__tests__/bodyRepair.test.ts
+++ b/src/server/services/ticketSync/__tests__/bodyRepair.test.ts
@@ -53,6 +53,8 @@ interface FakeNotionOps {
   appendBlockChildren(blockId: string, children: unknown[]): Promise<void>;
   deleted: string[];
   appended: Array<{ page: string; children: unknown[] }>;
+  /** Page fetches per page id — the attribution guards must share one. */
+  pageFetches: Record<string, number>;
 }
 
 /** Pages default to the shape the LEGACY creation path wrote: callout only. */
@@ -62,20 +64,28 @@ function fakeNotion(
     failOn?: string;
     failAppend?: boolean;
     failDelete?: boolean;
+    createdBy?: Record<string, string>;
     lastEditedBy?: Record<string, string>;
   } = {},
 ): FakeNotionOps {
   const deleted: string[] = [];
   const appended: Array<{ page: string; children: unknown[] }> = [];
+  const pageFetches: Record<string, number> = {};
   return {
     deleted,
     appended,
-    getPage: (page) =>
-      Promise.resolve(
-        opts.lastEditedBy?.[page]
+    pageFetches,
+    getPage: (page) => {
+      pageFetches[page] = (pageFetches[page] ?? 0) + 1;
+      return Promise.resolve({
+        ...(opts.createdBy?.[page]
+          ? { created_by: { id: opts.createdBy[page] } }
+          : {}),
+        ...(opts.lastEditedBy?.[page]
           ? { last_edited_by: { id: opts.lastEditedBy[page] } }
-          : {},
-      ),
+          : {}),
+      });
+    },
     listBlockChildren: (page) => {
       if (opts.failOn === page) return Promise.reject(new Error("boom 403"));
       return Promise.resolve(
@@ -262,6 +272,85 @@ describe("rerenderCreatedPageBodies", () => {
     expect(ops.deleted).toEqual([]);
     expect(ops.appended).toEqual([]);
     expect(result.items[0]?.reason).toContain("would replace 2 block(s)");
+  });
+
+  it("skips a page Notion says a person created, however innocent it otherwise looks", async () => {
+    db.ticketSync.findMany.mockResolvedValue([syncRow("page-a", "body")] as never);
+    // The incident page in miniature: the run ledger said we created it, the
+    // blocks are the plain legacy shape, and the bot really was the last writer
+    // (an inbound sync touched it). Every other guard waves it through; only
+    // Notion's own record of the creator says a person wrote this page.
+    const ops = fakeNotion(
+      { "page-a": [calloutBlock("c1"), paragraphBlock("p1")] },
+      {
+        createdBy: { "page-a": "human-user-id" },
+        lastEditedBy: { "page-a": "bot-id" },
+      },
+    );
+
+    const result = await live({
+      configId: "cfg1",
+      deps: { notionFactory: factoryFor(ops, "bot-id") },
+    });
+
+    expect(result.repaired).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(ops.deleted).toEqual([]);
+    expect(ops.appended).toEqual([]);
+    expect(result.items[0]?.reason).toContain("created by a person");
+  });
+
+  it("still repairs a page the bot both created and last edited", async () => {
+    db.ticketSync.findMany.mockResolvedValue([syncRow("page-a", "body")] as never);
+    const ops = fakeNotion(
+      { "page-a": [calloutBlock("c1"), paragraphBlock("p1")] },
+      {
+        createdBy: { "page-a": "bot-id" },
+        lastEditedBy: { "page-a": "bot-id" },
+      },
+    );
+
+    const result = await live({
+      configId: "cfg1",
+      deps: { notionFactory: factoryFor(ops, "bot-id") },
+    });
+
+    expect(result.repaired).toBe(1);
+    expect(ops.appended).toHaveLength(1);
+  });
+
+  it("falls through the creator guard when the integration has no bot id", async () => {
+    db.ticketSync.findMany.mockResolvedValue([syncRow("page-a", "body")] as never);
+    // With no bot id there is nothing to compare a creator against. "Cannot
+    // tell" must not become a block that strands the whole sweep on older
+    // integrations — nor permission, which is why the shape guard still runs.
+    const ops = fakeNotion(
+      { "page-a": [calloutBlock("c1"), paragraphBlock("p1")] },
+      { createdBy: { "page-a": "human-user-id" } },
+    );
+
+    const result = await live({
+      configId: "cfg1",
+      deps: { notionFactory: factoryFor(ops, null) },
+    });
+
+    expect(result.repaired).toBe(1);
+    expect(result.skipped).toBe(0);
+  });
+
+  it("asks Notion for the page once per candidate", async () => {
+    db.ticketSync.findMany.mockResolvedValue([syncRow("page-a", "body")] as never);
+    // Both attribution guards read one fetch. A second call would double the
+    // API cost of a sweep that already runs ~10-30 calls per page and is
+    // batched around the serverless timeout.
+    const ops = fakeNotion({ "page-a": [calloutBlock("c1"), paragraphBlock("p1")] });
+
+    await live({
+      configId: "cfg1",
+      deps: { notionFactory: factoryFor(ops, "bot-id") },
+    });
+
+    expect(ops.pageFetches).toEqual({ "page-a": 1 });
   });
 
   it("skips a page Notion says a person edited last, whatever its blocks look like", async () => {

--- a/src/server/services/ticketSync/bodyRepair.ts
+++ b/src/server/services/ticketSync/bodyRepair.ts
@@ -11,7 +11,7 @@ import { getPublicBaseUrlFromEnv } from "~/lib/urls";
  * Markdown→blocks renderer landed carry their ticket body as literal Markdown
  * text. This maintenance pass rebuilds those pages' content in place.
  *
- * This deletes Notion content, so it is guarded five times over. An earlier
+ * This deletes Notion content, so it is guarded six times over. An earlier
  * version inferred provenance from the run ledger's `action: "created"` — a
  * token the INBOUND engine also writes, meaning "created a ticket from this
  * page". Every page ever imported from Notion was therefore classified as
@@ -22,14 +22,20 @@ import { getPublicBaseUrlFromEnv } from "~/lib/urls";
  *     at the moment it created the page). The ledger is never consulted.
  *  2. NON-EMPTY BODY — never replace page content with a bare callout. If the
  *     ticket has no body there is nothing to restore, so deleting is pure loss.
- *  3. LAST EDITOR — Notion's own answer to "has a person touched this?". A page
- *     whose `last_edited_by` is not our bot is skipped whatever its blocks look
- *     like, which catches the human edit that a shape check cannot see.
- *  4. SHAPE — the content must still match the LEGACY creation path (sync
+ *  3. CREATOR — Notion's own record of who created the page. Guards 1 and 2
+ *     read OUR bookkeeping and are only as right as it is; this reads Notion's
+ *     and would have stopped the incident with no database state at all.
+ *  4. LAST EDITOR — Notion's answer to "has a person touched this since?",
+ *     which catches the human edit that a shape check cannot see.
+ *  5. SHAPE — the content must still match the LEGACY creation path (sync
  *     callout + flat paragraphs), which is the population this sweep exists to
  *     repair. Anything else is either a human edit or a page the current
  *     renderer already wrote correctly.
- *  5. DRY RUN — the caller must opt in to writing; a bare call only reports.
+ *  6. DRY RUN — the caller must opt in to writing; a bare call only reports.
+ *
+ * Guards 3 and 4 share one page fetch, so the stronger signal is free.
+ * Both treat a null `botId` or a missing field as "cannot tell" and fall
+ * through to the next guard — never as permission to write.
  *
  * A page failing any guard is reported without being touched. Writes are
  * ordered append-then-delete, so an interrupted repair leaves duplicated
@@ -154,7 +160,7 @@ export async function rerenderCreatedPageBodies(
     params.deps?.notionFactory ??
     (resolveNotionServiceForIntegration as unknown as NotionFactory);
 
-  // Guard 5: writing is opt-in. A caller that forgets the flag gets a report.
+  // Guard 6: writing is opt-in. A caller that forgets the flag gets a report.
   const dryRun = params.dryRun !== false;
 
   const config = await db.ticketSyncConfig.findUniqueOrThrow({
@@ -255,13 +261,34 @@ export async function rerenderCreatedPageBodies(
     }
 
     try {
-      // Guard 3: ask Notion who touched this last. Mirrors the echo-suppression
+      // One fetch answers both attribution guards below.
+      const page = await notion.getPage(sync.externalId);
+      const attribution = page as {
+        created_by?: { id?: string };
+        last_edited_by?: { id?: string };
+      };
+
+      // Guard 3: Notion's own record of WHO CREATED the page — the strongest
+      // provenance available, and the one signal that needs no database state.
+      // `remoteCreatedAt` (guard 1) is derived from our own bookkeeping and can
+      // be wrong if that bookkeeping was; this cannot. A page whose creator is
+      // not our bot is human-authored, full stop.
+      const creator = attribution.created_by?.id;
+      if (botId && creator && creator !== botId) {
+        skipped++;
+        items.push({
+          ...itemBase,
+          outcome: "skipped",
+          reason: "page was created by a person, not the sync bot",
+        });
+        continue;
+      }
+
+      // Guard 4: ask Notion who touched it last. Mirrors the echo-suppression
       // comparison in notionAdapter. A page edited by a person is off limits
       // however innocent its blocks look — this is the one signal that catches
       // a human appending plain paragraphs to a page we created.
-      const page = await notion.getPage(sync.externalId);
-      const lastEditor = (page as { last_edited_by?: { id?: string } })
-        .last_edited_by?.id;
+      const lastEditor = attribution.last_edited_by?.id;
       if (botId && lastEditor && lastEditor !== botId) {
         skipped++;
         items.push({
@@ -274,7 +301,7 @@ export async function rerenderCreatedPageBodies(
 
       const existing = await notion.listBlockChildren(sync.externalId);
 
-      // Guard 4: the content must still be the legacy render. Two very
+      // Guard 5: the content must still be the legacy render. Two very
       // different situations land here, and an operator needs to tell them
       // apart — "someone edited this" is a claim about a customer's workspace
       // and must not be made about a page we ourselves rendered correctly.


### PR DESCRIPTION
Follow-up to PR 527, which hardened the body-repair pass after it deleted human-authored Notion content in production.

## What changed

`rerenderCreatedPageBodies` now has a creator guard (guard 3) ahead of the existing last-editor guard. It reads `created_by.id` off the page and skips any page whose creator is not the sync bot, with the reason "page was created by a person, not the sync bot".

## Why `created_by` is the stronger signal

The pass currently establishes provenance from `remoteCreatedAt`, the column `push.ts` stamps at the moment it creates a page. That is our own bookkeeping, and it is only as correct as we are — which is exactly how the original incident happened. The old code inferred provenance from the run ledger's `action: "created"`, a token the inbound engine also writes to mean "created a ticket from this page", so every page ever imported *from* Notion was classified as machine-authored and had its content wiped.

`created_by` is Notion's own record. It depends on no state of ours, and it would have stopped that incident with an empty database. A page whose creator is not our bot is human-authored, and no amount of wrong bookkeeping on our side changes that answer.

## It costs nothing

The last-editor guard already calls `getPage`. Both attribution guards now read that single fetch, so the stronger signal adds no API call to a sweep that already spends ~10-30 calls per page and is batched around the serverless timeout. A test asserts the single fetch so a future refactor cannot quietly double it.

Consistent with guard 4: a null bot id or a missing `created_by` means "cannot tell" and falls through to the remaining guards — never a hard block that would strand the sweep on older integrations, and never permission to write.

## Tests

`src/server/services/ticketSync/__tests__/bodyRepair.test.ts`, now 23 tests. The fake's `getPage` gained a configurable `createdBy` map and a per-page call counter. New cases:

- A page created by a person is skipped even though its blocks are the innocent legacy shape *and* its last editor is the bot — every other guard waves that page through, so this proves guard 3 fires independently of guards 4 and 5.
- A page the bot both created and last edited still repairs.
- `created_by` present but bot id null falls through and still repairs.
- Exactly one `getPage` call per candidate page.

Full unit suite green (2295 tests), typecheck and lint clean.
