### PR TITLE
feat(tickets): add prev/next ticket navigation arrows and hotkeys

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
@@ -289,6 +289,14 @@ export default function TicketDetailPage() {
     }
   }, [ticket]);
 
+  // A draft comment belongs to the ticket it was typed against. The nav arrows
+  // swap tickets without unmounting this page, so without this the draft would
+  // follow you and could be posted against the wrong one. Keyed on the id, not
+  // the ticket object, so an ordinary refetch doesn't discard what you typed.
+  useEffect(() => {
+    setComment("");
+  }, [ticket?.id]);
+
   // Canonicalise the address bar to the clean number form (`/tickets/29`) when
   // the ticket was reached via CUID or a Linear-style id. Legacy tickets with
   // no number (0) keep their CUID URL.

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
@@ -55,6 +55,7 @@ import {
 import { generateLinearId } from "~/lib/fun-ids";
 import { PriorityIcon } from "~/app/_components/product/PriorityIcon";
 import { NotionSyncBadge } from "~/app/_components/product/NotionSyncBadge";
+import { TicketNavArrows } from "~/app/_components/product/TicketNavArrows";
 import { TicketDependenciesSection } from "~/app/_components/product/TicketDependenciesSection";
 import { LinkedActionsSection } from "~/app/_components/product/LinkedActionsSection";
 import { LabelsCombobox } from "~/app/_components/product/LabelsCombobox";
@@ -409,6 +410,14 @@ export default function TicketDetailPage() {
                 </Text>
               )}
               <NotionSyncBadge syncs={ticket.syncs} />
+              {workspace && (
+                <TicketNavArrows
+                  productId={ticket.product.id}
+                  number={ticket.number}
+                  workspaceSlug={workspace.slug}
+                  productSlug={productSlug}
+                />
+              )}
             </Group>
 
             <Group justify="space-between" align="flex-start">

--- a/src/app/_components/product/TicketNavArrows.tsx
+++ b/src/app/_components/product/TicketNavArrows.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ActionIcon, Tooltip } from "@mantine/core";
-import { useHotkeys } from "@mantine/hooks";
 import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
 import { api } from "~/trpc/react";
+import {
+  LIST_NAV_HINT,
+  useListNavHotkeys,
+} from "~/app/_components/product/useListNavHotkeys";
 
 /**
  * Prev/next arrows for the ticket detail page. Left goes to the closest
@@ -15,17 +18,8 @@ import { api } from "~/trpc/react";
  * on that side renders disabled rather than disappearing, so the pair doesn't
  * shift position between tickets.
  *
- * Two keyboard routes to the same navigation:
- *
- *   ⌃⌘← / ⌃⌘→  works everywhere, including mid-sentence in the title or body.
- *   ← / →        works only when focus is outside a text field.
- *
- * The chord is Control+Command because every simpler arrow combination is
- * already spoken for on macOS: ⌘arrow is browser Back/Forward (and line
- * start/end while typing), ⌥arrow moves by word, ⌘⌥arrow switches browser tabs,
- * ⌃arrow switches Spaces, and fn⌃arrow tiles windows. ⌃⌘arrow is bound by none
- * of them. Mantine's useHotkeys matches modifiers exactly, so the plain ⌘arrow
- * Back/Forward the browser owns still reaches the browser untouched.
+ * Keys come from useListNavHotkeys, the same bindings the peek drawers use:
+ * j/k, plus ⌃⌘←/→ which also work while typing.
  */
 export function TicketNavArrows({
   productId,
@@ -39,6 +33,7 @@ export function TicketNavArrows({
   productSlug: string;
 }) {
   const router = useRouter();
+  const rootRef = useRef<HTMLDivElement>(null);
   const { data } = api.product.ticket.getAdjacent.useQuery(
     { productId, number },
     { enabled: !!productId && number > 0 },
@@ -49,52 +44,23 @@ export function TicketNavArrows({
     [workspaceSlug, productSlug],
   );
 
-  const go = useCallback(
-    (target: { number: number } | null | undefined) => {
-      if (!target) return;
-      // An open modal, menu or dropdown owns the keyboard — the ⋯ menu and the
-      // property selects both move between items with the arrow keys, and their
-      // items are buttons, so useHotkeys' tag filter doesn't cover them.
-      // This page keeps ~8 of these mounted-but-hidden, so presence alone
-      // proves nothing. getClientRects() is the test that works here:
-      // offsetParent is null for position:fixed, which every Mantine dropdown
-      // is, so it would report even an open one as closed.
-      //
-      // Matching on aria-modal rather than role="dialog" deliberately: the Zoe
-      // assistant rail is a permanently laid-out role="dialog" (aria-hidden
-      // while closed), so keying off the role alone would block every press.
-      const overlays = document.querySelectorAll<HTMLElement>(
-        '[aria-modal="true"], [role="menu"], [role="listbox"]',
-      );
-      for (const overlay of overlays) {
-        if (
-          overlay.getAttribute("aria-hidden") !== "true" &&
-          overlay.getClientRects().length > 0
-        ) {
-          return;
-        }
-      }
-      router.push(href(target.number));
-    },
-    [router, href],
+  const prev = data?.prev;
+  const next = data?.next;
+
+  const goPrev = useCallback(
+    () => prev && router.push(href(prev.number)),
+    [prev, router, href],
+  );
+  const goNext = useCallback(
+    () => next && router.push(href(next.number)),
+    [next, router, href],
   );
 
-  // Fires everywhere, including inside the title field and the body editor.
-  useHotkeys(
-    [
-      ["ctrl+meta+ArrowLeft", () => go(data?.prev)],
-      ["ctrl+meta+ArrowRight", () => go(data?.next)],
-    ],
-    [],
-    true,
-  );
-
-  // Bare arrows are a convenience for reading, so they keep the default guard
-  // that ignores inputs, textareas, selects and contenteditable.
-  useHotkeys([
-    ["ArrowLeft", () => go(data?.prev)],
-    ["ArrowRight", () => go(data?.next)],
-  ]);
+  useListNavHotkeys({
+    onPrev: prev ? goPrev : undefined,
+    onNext: next ? goNext : undefined,
+    root: rootRef,
+  });
 
   // Legacy tickets with no number have no neighbours to walk to.
   if (number <= 0) return null;
@@ -104,9 +70,8 @@ export function TicketNavArrows({
     target: { number: number; title: string } | null | undefined,
   ) => {
     const Icon = dir === "prev" ? IconChevronLeft : IconChevronRight;
-    const key = dir === "prev" ? "⌃⌘←" : "⌃⌘→";
     const label = target
-      ? `${key}  #${target.number} · ${target.title}`
+      ? `#${target.number} · ${target.title}  (${LIST_NAV_HINT[dir]})`
       : dir === "prev"
         ? "No earlier ticket"
         : "No later ticket";
@@ -121,18 +86,17 @@ export function TicketNavArrows({
             variant="subtle"
             size="sm"
             className="shrink-0 text-text-secondary"
-            aria-label={
-              dir === "prev" ? "Previous ticket" : "Next ticket"
-            }
+            aria-label={dir === "prev" ? "Previous ticket" : "Next ticket"}
           >
             <Icon size={16} />
           </ActionIcon>
         ) : (
           <span
             className="shrink-0 inline-flex items-center px-1 opacity-40"
-            role="button"
-            aria-disabled="true"
-            aria-label={dir === "prev" ? "Previous ticket" : "Next ticket"}
+            role="img"
+            aria-label={
+              dir === "prev" ? "No earlier ticket" : "No later ticket"
+            }
           >
             <Icon size={16} className="text-text-muted" />
           </span>
@@ -142,9 +106,9 @@ export function TicketNavArrows({
   };
 
   return (
-    <div className="flex items-center gap-0.5">
-      {arrow("prev", data?.prev)}
-      {arrow("next", data?.next)}
+    <div ref={rootRef} className="flex items-center gap-0.5">
+      {arrow("prev", prev)}
+      {arrow("next", next)}
     </div>
   );
 }

--- a/src/app/_components/product/TicketNavArrows.tsx
+++ b/src/app/_components/product/TicketNavArrows.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ActionIcon, Tooltip } from "@mantine/core";
+import { useHotkeys } from "@mantine/hooks";
+import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+import { api } from "~/trpc/react";
+
+/**
+ * Prev/next arrows for the ticket detail page. Left goes to the closest
+ * lower-numbered ticket in the same product, right to the closest higher one —
+ * gaps from deleted tickets are stepped over server-side. An arrow with nothing
+ * on that side renders disabled rather than disappearing, so the pair doesn't
+ * shift position between tickets.
+ *
+ * Two keyboard routes to the same navigation:
+ *
+ *   ⌃⌘← / ⌃⌘→  works everywhere, including mid-sentence in the title or body.
+ *   ← / →        works only when focus is outside a text field.
+ *
+ * The chord is Control+Command because every simpler arrow combination is
+ * already spoken for on macOS: ⌘arrow is browser Back/Forward (and line
+ * start/end while typing), ⌥arrow moves by word, ⌘⌥arrow switches browser tabs,
+ * ⌃arrow switches Spaces, and fn⌃arrow tiles windows. ⌃⌘arrow is bound by none
+ * of them. Mantine's useHotkeys matches modifiers exactly, so the plain ⌘arrow
+ * Back/Forward the browser owns still reaches the browser untouched.
+ */
+export function TicketNavArrows({
+  productId,
+  number,
+  workspaceSlug,
+  productSlug,
+}: {
+  productId: string;
+  number: number;
+  workspaceSlug: string;
+  productSlug: string;
+}) {
+  const router = useRouter();
+  const { data } = api.product.ticket.getAdjacent.useQuery(
+    { productId, number },
+    { enabled: !!productId && number > 0 },
+  );
+
+  const href = useCallback(
+    (n: number) => `/w/${workspaceSlug}/products/${productSlug}/tickets/${n}`,
+    [workspaceSlug, productSlug],
+  );
+
+  const go = useCallback(
+    (target: { number: number } | null | undefined) => {
+      if (!target) return;
+      // An open modal, menu or dropdown owns the keyboard — the ⋯ menu and the
+      // property selects both move between items with the arrow keys, and their
+      // items are buttons, so useHotkeys' tag filter doesn't cover them.
+      // This page keeps ~8 of these mounted-but-hidden, so presence alone
+      // proves nothing. getClientRects() is the test that works here:
+      // offsetParent is null for position:fixed, which every Mantine dropdown
+      // is, so it would report even an open one as closed.
+      //
+      // Matching on aria-modal rather than role="dialog" deliberately: the Zoe
+      // assistant rail is a permanently laid-out role="dialog" (aria-hidden
+      // while closed), so keying off the role alone would block every press.
+      const overlays = document.querySelectorAll<HTMLElement>(
+        '[aria-modal="true"], [role="menu"], [role="listbox"]',
+      );
+      for (const overlay of overlays) {
+        if (
+          overlay.getAttribute("aria-hidden") !== "true" &&
+          overlay.getClientRects().length > 0
+        ) {
+          return;
+        }
+      }
+      router.push(href(target.number));
+    },
+    [router, href],
+  );
+
+  // Fires everywhere, including inside the title field and the body editor.
+  useHotkeys(
+    [
+      ["ctrl+meta+ArrowLeft", () => go(data?.prev)],
+      ["ctrl+meta+ArrowRight", () => go(data?.next)],
+    ],
+    [],
+    true,
+  );
+
+  // Bare arrows are a convenience for reading, so they keep the default guard
+  // that ignores inputs, textareas, selects and contenteditable.
+  useHotkeys([
+    ["ArrowLeft", () => go(data?.prev)],
+    ["ArrowRight", () => go(data?.next)],
+  ]);
+
+  // Legacy tickets with no number have no neighbours to walk to.
+  if (number <= 0) return null;
+
+  const arrow = (
+    dir: "prev" | "next",
+    target: { number: number; title: string } | null | undefined,
+  ) => {
+    const Icon = dir === "prev" ? IconChevronLeft : IconChevronRight;
+    const key = dir === "prev" ? "⌃⌘←" : "⌃⌘→";
+    const label = target
+      ? `${key}  #${target.number} · ${target.title}`
+      : dir === "prev"
+        ? "No earlier ticket"
+        : "No later ticket";
+
+    return (
+      <Tooltip label={label} withArrow>
+        {/* Tooltip needs a real DOM child, so the disabled state stays a span. */}
+        {target ? (
+          <ActionIcon
+            component={Link}
+            href={href(target.number)}
+            variant="subtle"
+            size="sm"
+            className="shrink-0 text-text-secondary"
+            aria-label={
+              dir === "prev" ? "Previous ticket" : "Next ticket"
+            }
+          >
+            <Icon size={16} />
+          </ActionIcon>
+        ) : (
+          <span
+            className="shrink-0 inline-flex items-center px-1 opacity-40"
+            role="button"
+            aria-disabled="true"
+            aria-label={dir === "prev" ? "Previous ticket" : "Next ticket"}
+          >
+            <Icon size={16} className="text-text-muted" />
+          </span>
+        )}
+      </Tooltip>
+    );
+  };
+
+  return (
+    <div className="flex items-center gap-0.5">
+      {arrow("prev", data?.prev)}
+      {arrow("next", data?.next)}
+    </div>
+  );
+}

--- a/src/app/_components/product/peek/PeekDrawer.tsx
+++ b/src/app/_components/product/peek/PeekDrawer.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ActionIcon, Drawer, Group, Tooltip } from "@mantine/core";
+import {
+  LIST_NAV_HINT,
+  useListNavHotkeys,
+} from "~/app/_components/product/useListNavHotkeys";
 import {
   IconArrowsDiagonal,
   IconArrowsDiagonalMinimize2,
@@ -28,6 +32,8 @@ const WIDE_PREF_KEY = "peek-drawer-wide";
  * EditContactDrawer convention scaled up), prev/next to flip through the
  * list without closing (j/k also work), and an escape hatch to the full
  * detail page. Esc closes (Mantine default). Content is entity-specific.
+ * Navigation keys come from useListNavHotkeys, shared with the ticket detail
+ * page: j/k, plus ⌃⌘←/→ which also work while typing.
  */
 export function PeekDrawer({
   opened,
@@ -62,34 +68,12 @@ export function PeekDrawer({
       return !w;
     });
 
-  // j/k flip through the list (Linear convention) - never while typing.
-  useEffect(() => {
-    if (!opened) return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.metaKey || e.ctrlKey || e.altKey) return;
-      const target = e.target as HTMLElement | null;
-      if (
-        target &&
-        (target.tagName === "INPUT" ||
-          target.tagName === "TEXTAREA" ||
-          target.tagName === "SELECT" ||
-          target.isContentEditable)
-      )
-        return;
-      // Never flip entities under an open dropdown - the menu would suddenly
-      // refer to a different item.
-      if (
-        document.querySelector(
-          ".mantine-Menu-dropdown, .mantine-Popover-dropdown, .mantine-Select-dropdown, .mantine-Combobox-dropdown",
-        )
-      )
-        return;
-      if (e.key === "j" && onNext) onNext();
-      if (e.key === "k" && onPrev) onPrev();
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [opened, onPrev, onNext]);
+  // j/k flip through the list, ⌃⌘←/→ do the same while typing. Shared with the
+  // ticket detail page so the keys mean one thing app-wide. `bodyRef` tells the
+  // hook which modal is ours: this drawer is itself aria-modal, and without it
+  // the overlay guard would block the navigation it exists to provide.
+  const bodyRef = useRef<HTMLDivElement>(null);
+  useListNavHotkeys({ onPrev, onNext, enabled: opened, root: bodyRef });
 
   const hasNav = onPrev !== undefined || onNext !== undefined;
 
@@ -112,7 +96,10 @@ export function PeekDrawer({
           <span className="sr-only">{label}</span>
           {hasNav && (
             <>
-              <Tooltip label="Previous in list (k)" position="bottom">
+              <Tooltip
+                label={`Previous in list (${LIST_NAV_HINT.prev})`}
+                position="bottom"
+              >
                 <ActionIcon
                   variant="subtle"
                   size="sm"
@@ -124,7 +111,10 @@ export function PeekDrawer({
                   <IconChevronUp size={15} />
                 </ActionIcon>
               </Tooltip>
-              <Tooltip label="Next in list (j)" position="bottom">
+              <Tooltip
+                label={`Next in list (${LIST_NAV_HINT.next})`}
+                position="bottom"
+              >
                 <ActionIcon
                   variant="subtle"
                   size="sm"
@@ -177,7 +167,7 @@ export function PeekDrawer({
     >
       {/* Initial focus lands here (not on the title input), so j/k work
           immediately and opening the peek never starts an accidental edit. */}
-      <div data-autofocus tabIndex={-1} style={{ outline: "none" }}>
+      <div ref={bodyRef} data-autofocus tabIndex={-1} style={{ outline: "none" }}>
         {children}
       </div>
     </Drawer>

--- a/src/app/_components/product/useListNavHotkeys.ts
+++ b/src/app/_components/product/useListNavHotkeys.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Keyboard bindings for stepping through a list of entities — the peek drawers
+ * (tickets, features) and the ticket detail page all share this so the same
+ * keys mean the same thing wherever you are.
+ *
+ *   j / k       previous / next. Ignored while typing.
+ *   ⌃⌘← / ⌃⌘→   same, but works everywhere including mid-sentence.
+ *
+ * The chord is Control+Command because every simpler arrow combination is
+ * already spoken for on macOS: ⌘arrow is browser Back/Forward (and line
+ * start/end while typing), ⌥arrow moves by word, ⌘⌥arrow switches browser tabs,
+ * ⌃arrow switches Spaces, and fn⌃arrow tiles windows. Modifiers are matched
+ * exactly, so plain ⌘arrow still reaches the browser as Back/Forward.
+ */
+export const LIST_NAV_KEYS = { prev: "j", next: "k" } as const;
+
+/** Tooltip suffix, so the hint and the binding can't drift apart. */
+export const LIST_NAV_HINT = {
+  prev: `${LIST_NAV_KEYS.prev} or ⌃⌘←`,
+  next: `${LIST_NAV_KEYS.next} or ⌃⌘→`,
+} as const;
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.tagName === "SELECT" ||
+    target.isContentEditable
+  );
+}
+
+/**
+ * True when something above us owns the keyboard.
+ *
+ * Two separate rules, because the failure modes differ:
+ *
+ * - An open menu or listbox always wins — it uses the arrow keys for its own
+ *   items, and j/k for typeahead. Its items are buttons, so a tag-name filter
+ *   would not catch them.
+ * - A modal only wins if it isn't *ours*. The peek drawer is itself an
+ *   aria-modal container, so a naive check would block the very navigation it
+ *   is trying to provide; `root` lets a caller say "this overlay is the one I
+ *   live inside".
+ *
+ * Visibility is tested with getClientRects() rather than offsetParent, which is
+ * always null for position:fixed — what every Mantine dropdown is. Presence
+ * alone proves nothing either: the ticket page keeps ~8 hidden listboxes
+ * mounted at all times.
+ */
+function isOverlayBlocking(root: HTMLElement | null): boolean {
+  const visible = (el: HTMLElement) =>
+    el.getAttribute("aria-hidden") !== "true" && el.getClientRects().length > 0;
+
+  for (const el of document.querySelectorAll<HTMLElement>(
+    '[role="menu"], [role="listbox"]',
+  )) {
+    if (visible(el)) return true;
+  }
+
+  for (const el of document.querySelectorAll<HTMLElement>(
+    '[aria-modal="true"]',
+  )) {
+    if (!visible(el)) continue;
+    if (root && el.contains(root)) continue; // the container we live in
+    return true;
+  }
+
+  return false;
+}
+
+export function useListNavHotkeys({
+  onPrev,
+  onNext,
+  enabled = true,
+  root,
+}: {
+  /** Omit to render the boundary as a no-op (e.g. first item in the list). */
+  onPrev?: () => void;
+  onNext?: () => void;
+  enabled?: boolean;
+  /** The modal/drawer this consumer lives inside, if any. See isOverlayBlocking. */
+  root?: RefObject<HTMLElement | null>;
+}) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      const chord = e.ctrlKey && e.metaKey && !e.altKey && !e.shiftKey;
+      const bare =
+        !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey;
+
+      let dir: "prev" | "next" | null = null;
+      if (chord && e.key === "ArrowLeft") dir = "prev";
+      else if (chord && e.key === "ArrowRight") dir = "next";
+      else if (bare && e.key === LIST_NAV_KEYS.prev) dir = "prev";
+      else if (bare && e.key === LIST_NAV_KEYS.next) dir = "next";
+      if (!dir) return;
+
+      // The chord is the one that deliberately works while typing.
+      if (bare && isTypingTarget(e.target)) return;
+      if (isOverlayBlocking(root?.current ?? null)) return;
+
+      const handler = dir === "prev" ? onPrev : onNext;
+      if (!handler) return;
+
+      e.preventDefault();
+      // Commit field-level onBlur handlers (the ticket title saves that way)
+      // before the entity swaps underneath the open editor.
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+      handler();
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [enabled, onPrev, onNext, root]);
+}

--- a/src/plugins/product/server/routers/__tests__/ticket.test.ts
+++ b/src/plugins/product/server/routers/__tests__/ticket.test.ts
@@ -426,3 +426,87 @@ describe("ticket router — assignee containment guard (mocked)", () => {
     expect(dbMock.ticket.updateMany).not.toHaveBeenCalled();
   });
 });
+
+describe("ticket router — getAdjacent (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  /** The where/orderBy of the prev (0) and next (1) findFirst calls. */
+  function adjacentCalls(m: DeepMockProxy<PrismaClient>) {
+    return [
+      m.ticket.findFirst.mock.calls[0]?.[0],
+      m.ticket.findFirst.mock.calls[1]?.[0],
+    ] as const;
+  }
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    stubProductLookup(dbMock);
+    stubMembership(dbMock, true);
+  });
+
+  it("walks to the nearest neighbour on each side rather than assuming +/-1", async () => {
+    // Numbering has gaps (2, 6, 9) — deleting a ticket must not strand its
+    // neighbours behind a 404.
+    dbMock.ticket.findFirst
+      .mockResolvedValueOnce({ number: 2, title: "two" } as never)
+      .mockResolvedValueOnce({ number: 9, title: "nine" } as never);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const result = await caller.product.ticket.getAdjacent({
+      productId,
+      number: 6,
+    });
+
+    expect(result).toEqual({
+      prev: { number: 2, title: "two" },
+      next: { number: 9, title: "nine" },
+    });
+
+    const [prevCall, nextCall] = adjacentCalls(dbMock);
+    // Closest-first ordering is what makes it the *nearest* neighbour.
+    expect(prevCall).toMatchObject({
+      where: { productId, number: { lt: 6 } },
+      orderBy: { number: "desc" },
+    });
+    expect(nextCall).toMatchObject({
+      where: { productId, number: { gt: 6 } },
+      orderBy: { number: "asc" },
+    });
+  });
+
+  it("excludes legacy number=0 tickets from the prev side", async () => {
+    // number 0 is the legacy sentinel; those rows have no clean URL to reach.
+    dbMock.ticket.findFirst.mockResolvedValue(null as never);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await caller.product.ticket.getAdjacent({ productId, number: 1 });
+
+    const [prevCall] = adjacentCalls(dbMock);
+    expect(prevCall).toMatchObject({
+      where: { productId, number: { lt: 1, gt: 0 } },
+    });
+  });
+
+  it("returns null at each boundary of the list", async () => {
+    dbMock.ticket.findFirst.mockResolvedValue(null as never);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    const result = await caller.product.ticket.getAdjacent({
+      productId,
+      number: 1,
+    });
+
+    expect(result).toEqual({ prev: null, next: null });
+  });
+
+  it("refuses a product the caller is not a member of", async () => {
+    stubMembership(dbMock, false);
+
+    const caller = createMockCaller({ userId: callerId, db: dbMock });
+    await expect(
+      caller.product.ticket.getAdjacent({ productId, number: 3 }),
+    ).rejects.toThrow();
+    expect(dbMock.ticket.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -271,7 +271,11 @@ export const ticketRouter = createTRPCRouter({
    * clean URL to navigate to.
    */
   getAdjacent: protectedProcedure
-    .input(z.object({ productId: z.string(), number: z.number().int() }))
+    .input(
+      // Positive: the `next` branch has no lower bound of its own, so a
+      // non-positive input would let it match a legacy number=0 ticket.
+      z.object({ productId: z.string(), number: z.number().int().positive() }),
+    )
     .query(async ({ ctx, input }) => {
       await loadProductWithAccess(ctx.db, ctx.session.user.id, input.productId);
 

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -264,6 +264,38 @@ export const ticketRouter = createTRPCRouter({
     }),
 
   /**
+   * The nearest existing ticket either side of `number` within a product,
+   * powering the prev/next arrows on the detail page. Numbers have gaps (tickets
+   * get deleted), so this walks to the closest lower/higher number rather than
+   * assuming ±1. Legacy tickets with `number = 0` are skipped — they have no
+   * clean URL to navigate to.
+   */
+  getAdjacent: protectedProcedure
+    .input(z.object({ productId: z.string(), number: z.number().int() }))
+    .query(async ({ ctx, input }) => {
+      await loadProductWithAccess(ctx.db, ctx.session.user.id, input.productId);
+
+      const select = { number: true, title: true } as const;
+      const [prev, next] = await Promise.all([
+        ctx.db.ticket.findFirst({
+          where: {
+            productId: input.productId,
+            number: { lt: input.number, gt: 0 },
+          },
+          orderBy: { number: "desc" },
+          select,
+        }),
+        ctx.db.ticket.findFirst({
+          where: { productId: input.productId, number: { gt: input.number } },
+          orderBy: { number: "asc" },
+          select,
+        }),
+      ]);
+
+      return { prev, next };
+    }),
+
+  /**
    * Resolve a ticket URL segment to its canonical CUID, scoped to a product.
    * Accepts the user-friendly sequential number (`29`), a Linear-style id
    * (`PLAT-29`), a CUID, or a fun shortId. Powers `/tickets/29` URLs: the


### PR DESCRIPTION
## What

Navigation between tickets — on the detail page, and harmonized with the peek drawers.

- **Ticket detail page**: a pair of chevrons beside the Notion sync badge. Left goes to the closest lower-numbered ticket in the product, right to the closest higher one. `getAdjacent` resolves each side with one lightweight query, access-checked through the same `loadProductWithAccess` as `list`.
- **Shared keys**: `k` = next, `j` = previous, plus `Ctrl+Cmd+→` / `Ctrl+Cmd+←` which also work while typing. One hook (`useListNavHotkeys`) now drives the ticket peek, the feature peek and the ticket detail page.

## Why

Paging through tickets one at a time meant a round trip via the backlog each time. The peek drawers already had `j`/`k`, so the detail page adopting different keys would have been a third dialect.

## Key changes

**`j`/`k` swapped.** They previously followed vim (`j` down/next, `k` up/previous). Per product direction they are now `k` = next, `j` = previous, and both peek tooltips were updated to match. The hint strings are derived from the same constant that drives key matching, so the label and the binding can't drift apart.

**Why `Ctrl+Cmd`+arrow.** Every simpler arrow combination is already taken on macOS:

| Chord | Owner |
|---|---|
| `Cmd`+arrow | Browser Back/Forward; line start/end while typing |
| `Opt`+arrow | Move by word |
| `Cmd+Opt`+arrow | Chrome previous/next tab |
| `Ctrl`+arrow | Mission Control Spaces |
| `fn+Ctrl`+arrow | macOS Sequoia window tiling |
| `Ctrl+Cmd`+arrow | Unbound |

Modifiers are matched exactly, so plain `Cmd`+arrow still reaches the browser as Back/Forward.

**Gaps are stepped over, not assumed.** Deleted tickets leave holes in the numbering, so a literal `±1` would land on a 404. On ticket 400 with 401 deleted, next goes to 402.

## Two bugs fixed along the way

Both come from the detail page staying mounted while the ticket underneath it changes — a transition that didn't exist before this PR, since the back link went to the backlog (a different route).

1. **Unsaved title edits were silently discarded.** The title only persists via `onBlur`, and hotkey navigation never blurred it; the `[ticket]` effect then overwrote it. The hook now blurs the active element before navigating, so `onBlur` commits first.
2. **A comment draft followed you to the next ticket**, one click from being posted against the wrong one. Now cleared when the ticket id changes — keyed on the id rather than the ticket object, so an ordinary refetch doesn't discard what you typed.

## Overlay guard

Suppressing navigation while a menu or modal owns the keyboard needed care:

- `offsetParent !== null` is wrong — always null for `position: fixed`, which every Mantine dropdown is.
- Presence alone is wrong — the ticket page keeps ~8 hidden `role="listbox"` nodes mounted.
- `role="dialog"` is wrong — the Zoe assistant rail is a permanently laid-out one.
- Blocking on any `aria-modal` is wrong — the peek drawer is itself aria-modal, so it would block the navigation it exists to provide.

Final rule: an open menu/listbox always blocks; a modal blocks only when it isn't the container the caller lives in. Visibility via `getClientRects().length`.

## Tests

Four unit tests for `getAdjacent` (mocked Prisma, no DB): gap-skipping, both list boundaries, the legacy `number = 0` exclusion, and the membership guard. Full suite 2299 passing.

## Verification

Exercised against a seeded local fixture.

| Surface | Case | Result |
|---|---|---|
| Ticket peek | `k` / `j` | down to the next row, back up |
| Ticket peek | `⌃⌘→` | down |
| Ticket peek | up-chevron tooltip | "Previous in list (j or ⌃⌘←)" |
| Feature peek | `k` / `⌃⌘←` | down, back up |
| Ticket detail | `k` / `j` | 3 → 4 → 3 |
| Ticket detail | numbering gap (7, 8 absent) | 6 → 9 |
| Ticket detail | first / last ticket | arrow dimmed, key is a no-op |
| Ticket detail | plain `Cmd+←` | ignored, left to the browser |
| Title edit + `⌃⌘→` | | edit **saved** before navigating (confirmed in DB) |
| Comment draft + `⌃⌘→` | | box empty on the next ticket |

Typecheck, lint, unit tests and `next build` all pass.

## Known limitation

`Ctrl+Cmd`+arrow is a macOS-clean choice. On Windows `metaKey` is the Windows key, where `Win+Ctrl+←` switches virtual desktops — that would need a platform branch if Windows users matter.

## Out of scope

The features list page logs a pre-existing hydration error (a Badge `<div>` inside a Text `<p>` in the group header). Untouched here; tracked separately.
