### PR TITLE
fix(projects): stop the search box navigating on every keystroke

### DIFF
--- a/src/app/_components/product/useListNavHotkeys.ts
+++ b/src/app/_components/product/useListNavHotkeys.ts
@@ -51,8 +51,11 @@ function isTypingTarget(target: EventTarget | null): boolean {
  * always null for position:fixed — what every Mantine dropdown is. Presence
  * alone proves nothing either: the ticket page keeps ~8 hidden listboxes
  * mounted at all times.
+ *
+ * Exported because any window-level key handler needs the same three rules —
+ * `usePageSearchHotkey` reuses it rather than growing a second copy that drifts.
  */
-function isOverlayBlocking(root: HTMLElement | null): boolean {
+export function isOverlayBlocking(root: HTMLElement | null): boolean {
   const visible = (el: HTMLElement) =>
     el.getAttribute("aria-hidden") !== "true" && el.getClientRects().length > 0;
 

--- a/src/app/_components/projects/WorkspaceProjectsConceptD.tsx
+++ b/src/app/_components/projects/WorkspaceProjectsConceptD.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef, useCallback, useState } from 'react';
+import { memo, useMemo, useRef, useCallback, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
@@ -49,6 +49,7 @@ import { FilterBar } from '~/app/_components/filters';
 import { ProjectSortMenu } from '~/app/_components/toolbar';
 import { useProjectViewState, filterProjects } from './useProjectViewState';
 import { useRegisterPageContext } from '~/hooks/useRegisterPageContext';
+import { usePageSearchHotkey } from '~/hooks/usePageSearchHotkey';
 import { hasActiveFilters } from '~/types/filter';
 import type { FilterBarConfig, FilterMember } from '~/types/filter';
 import { slugify } from '~/utils/slugify';
@@ -184,7 +185,11 @@ function isOverdue(date: Date | null | undefined): boolean {
   return new Date(date) < new Date();
 }
 
-function ProjectTableRow({
+// Memoised: every row mounts two tRPC mutations, two Selects, an Avatar and two
+// SVG rings, so re-rendering the whole table on each keystroke is expensive.
+// `project` comes straight out of the react-query cache, so it is referentially
+// stable between renders that did not refetch.
+const ProjectTableRow = memo(function ProjectTableRow({
   project,
   linkPrefix,
 }: {
@@ -369,7 +374,7 @@ function ProjectTableRow({
       </td>
     </tr>
   );
-}
+});
 
 function NotionSuggestionsContent({
   unlinkedProjects,
@@ -451,6 +456,7 @@ export function WorkspaceProjectsConceptD({ showAllWorkspaces = false }: Workspa
     filters,
     setFilters,
     searchQuery,
+    deferredSearchQuery,
     setSearchQuery,
     sortState,
     setSortField,
@@ -473,6 +479,8 @@ export function WorkspaceProjectsConceptD({ showAllWorkspaces = false }: Workspa
   const handleSearchKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Escape') searchRef.current?.blur();
   }, []);
+
+  usePageSearchHotkey(searchRef);
 
   const { data: projectsData, isLoading } = api.project.getAll.useQuery(
     { workspaceId: effectiveWorkspaceId, include: { actions: true } },
@@ -517,8 +525,8 @@ export function WorkspaceProjectsConceptD({ showAllWorkspaces = false }: Workspa
   }, [workspace?.members]);
 
   const filteredProjects = useMemo(
-    () => filterProjects(projectsData ?? [], filters, searchQuery),
-    [projectsData, filters, searchQuery],
+    () => filterProjects(projectsData ?? [], filters, deferredSearchQuery),
+    [projectsData, filters, deferredSearchQuery],
   );
 
   const sortedProjects = useMemo(
@@ -559,7 +567,7 @@ export function WorkspaceProjectsConceptD({ showAllWorkspaces = false }: Workspa
             <input
               ref={searchRef}
               type="text"
-              placeholder="Search  ⌘K"
+              placeholder="Search  ⌘F"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={handleSearchKeyDown}

--- a/src/app/_components/projects/WorkspaceProjectsTasksConceptD.tsx
+++ b/src/app/_components/projects/WorkspaceProjectsTasksConceptD.tsx
@@ -29,6 +29,7 @@ import { calculateProjectHealth } from '~/app/_components/home/ProjectHealth';
 import { FilterBar } from '~/app/_components/filters';
 import { ProjectSortMenu } from '~/app/_components/toolbar';
 import { useProjectViewState, filterProjects } from './useProjectViewState';
+import { usePageSearchHotkey } from '~/hooks/usePageSearchHotkey';
 import { hasActiveFilters } from '~/types/filter';
 import type { FilterBarConfig, FilterMember } from '~/types/filter';
 import { getAvatarColor, getInitial } from '~/utils/avatarColors';
@@ -329,6 +330,7 @@ export function WorkspaceProjectsTasksConceptD() {
     filters,
     setFilters,
     searchQuery,
+    deferredSearchQuery,
     setSearchQuery,
     sortState,
     setSortField,
@@ -365,6 +367,8 @@ export function WorkspaceProjectsTasksConceptD() {
     if (e.key === 'Escape') searchRef.current?.blur();
   }, []);
 
+  usePageSearchHotkey(searchRef);
+
   const utils = api.useUtils();
 
   const { data, isLoading } = api.project.getProjectsWithActions.useQuery(
@@ -389,7 +393,7 @@ export function WorkspaceProjectsTasksConceptD() {
   const filteredProjects = useMemo(() => {
     const all = data?.projects ?? [];
     const filtered = filterProjects(all, filters, '');
-    const q = searchQuery.trim().toLowerCase();
+    const q = deferredSearchQuery.trim().toLowerCase();
     const searchFiltered = q
       ? filtered.filter(
           (p) =>
@@ -398,7 +402,7 @@ export function WorkspaceProjectsTasksConceptD() {
         )
       : filtered;
     return sortProjects(searchFiltered);
-  }, [data?.projects, filters, searchQuery, sortProjects]);
+  }, [data?.projects, filters, deferredSearchQuery, sortProjects]);
 
   const totalActive = filteredProjects.filter((p) => p.status === 'ACTIVE').length;
   const totalOnHold = filteredProjects.filter((p) => p.status === 'ON_HOLD').length;
@@ -427,7 +431,7 @@ export function WorkspaceProjectsTasksConceptD() {
             <input
               ref={searchRef}
               type="text"
-              placeholder="Search  ⌘K"
+              placeholder="Search  ⌘F"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={handleSearchKeyDown}

--- a/src/app/_components/projects/WorkspaceProjectsTimelineConceptD.tsx
+++ b/src/app/_components/projects/WorkspaceProjectsTimelineConceptD.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Collapse, Skeleton } from '@mantine/core';
-import { useDisclosure, useHotkeys } from '@mantine/hooks';
+import { useDisclosure } from '@mantine/hooks';
 import {
   IconTable,
   IconLayoutList,
@@ -37,6 +37,7 @@ import { CreateProjectModal } from '~/app/_components/CreateProjectModal';
 import { FilterBar } from '~/app/_components/filters';
 import { ProjectSortMenu } from '~/app/_components/toolbar';
 import { useProjectViewState, filterProjects } from './useProjectViewState';
+import { usePageSearchHotkey } from '~/hooks/usePageSearchHotkey';
 import { hasActiveFilters } from '~/types/filter';
 import type { FilterBarConfig, FilterMember } from '~/types/filter';
 import styles from './WorkspaceProjectsTimelineConceptD.module.css';
@@ -222,6 +223,7 @@ export function WorkspaceProjectsTimelineConceptD() {
     filters,
     setFilters,
     searchQuery,
+    deferredSearchQuery,
     setSearchQuery,
     sortState,
     setSortField,
@@ -253,7 +255,9 @@ export function WorkspaceProjectsTimelineConceptD() {
     return 'table';
   }, [pathname]);
 
-  useHotkeys([['mod+k', () => searchRef.current?.focus()]]);
+  // Not mod+k — that opens the global CommandPalette, and binding both here
+  // meant one keypress focused this box *and* opened the palette over it.
+  usePageSearchHotkey(searchRef);
 
   const utils = api.useUtils();
   const queryInput = useMemo(
@@ -302,9 +306,9 @@ export function WorkspaceProjectsTimelineConceptD() {
   );
 
   const filteredProjects = useMemo(() => {
-    const filtered = filterProjects(timelineProjects, filters, searchQuery);
+    const filtered = filterProjects(timelineProjects, filters, deferredSearchQuery);
     return sortProjects(filtered);
-  }, [timelineProjects, filters, searchQuery, sortProjects]);
+  }, [timelineProjects, filters, deferredSearchQuery, sortProjects]);
 
   const today = startOfDay(new Date());
 
@@ -424,7 +428,7 @@ export function WorkspaceProjectsTimelineConceptD() {
             <input
               ref={searchRef}
               type="text"
-              placeholder="Search  ⌘K"
+              placeholder="Search  ⌘F"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={(e) => e.key === 'Escape' && searchRef.current?.blur()}

--- a/src/app/_components/projects/__tests__/useProjectViewState.test.ts
+++ b/src/app/_components/projects/__tests__/useProjectViewState.test.ts
@@ -1,0 +1,167 @@
+/**
+ * useProjectViewState tests — the search box's URL-mirroring state machine.
+ *
+ * The invariant worth pinning down: the input is driven by local state and the
+ * URL only catches up after a pause, so `lastWrittenQueryRef` has to tell the
+ * hook's *own* write (echoing back through useSearchParams) apart from a real
+ * external change. Get that backwards in either direction and you either
+ * resurrect stale text mid-typing or stop honouring `?q=` deep links — both
+ * silent, and invisible to types and lint.
+ *
+ * `next/navigation` is mocked so this exercises the state machine only.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const { mockReplace, mockSearchParams } = vi.hoisted(() => ({
+  mockReplace: vi.fn(),
+  mockSearchParams: { current: new URLSearchParams() },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => "/w/acme/projects",
+  useSearchParams: () => mockSearchParams.current,
+}));
+
+import { useProjectViewState } from "../useProjectViewState";
+
+/** Matches SEARCH_URL_DEBOUNCE_MS in the hook. */
+const DEBOUNCE_MS = 350;
+
+function setUrl(query: string) {
+  mockSearchParams.current = new URLSearchParams(query);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockReplace.mockClear();
+  setUrl("");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useProjectViewState search query", () => {
+  it("updates the visible text synchronously, before any URL write", () => {
+    const { result } = renderHook(() => useProjectViewState());
+
+    act(() => result.current.setSearchQuery("no"));
+
+    expect(result.current.searchQuery).toBe("no");
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("writes the URL once per typing burst, not once per keystroke", () => {
+    const { result } = renderHook(() => useProjectViewState());
+
+    // Five keystrokes, each well inside the debounce window.
+    for (const value of ["n", "no", "not", "noti", "notif"]) {
+      act(() => {
+        result.current.setSearchQuery(value);
+        vi.advanceTimersByTime(50);
+      });
+    }
+
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    act(() => void vi.advanceTimersByTime(DEBOUNCE_MS));
+
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith("/w/acme/projects?q=notif", {
+      scroll: false,
+    });
+  });
+
+  it("merges the query into params that already exist", () => {
+    setUrl("status=ACTIVE&sort=-endDate");
+    const { result } = renderHook(() => useProjectViewState());
+
+    act(() => {
+      result.current.setSearchQuery("edge");
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    const [url] = mockReplace.mock.calls[0] as [string];
+    const written = new URLSearchParams(url.split("?")[1]);
+    expect(written.get("q")).toBe("edge");
+    expect(written.get("status")).toBe("ACTIVE");
+    expect(written.get("sort")).toBe("-endDate");
+  });
+
+  it("drops the param entirely when the query is cleared", () => {
+    setUrl("q=edge");
+    const { result } = renderHook(() => useProjectViewState());
+
+    act(() => {
+      result.current.setSearchQuery("");
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("/w/acme/projects", {
+      scroll: false,
+    });
+  });
+
+  it("seeds the input from a `?q=` deep link", () => {
+    setUrl("q=edge");
+    const { result } = renderHook(() => useProjectViewState());
+
+    expect(result.current.searchQuery).toBe("edge");
+  });
+
+  it("adopts an external URL change (back/forward, a link carrying ?q=)", () => {
+    const { result, rerender } = renderHook(() => useProjectViewState());
+
+    setUrl("q=fromelsewhere");
+    rerender();
+
+    expect(result.current.searchQuery).toBe("fromelsewhere");
+  });
+
+  it("does not clobber in-flight typing when its own write echoes back", () => {
+    const { result, rerender } = renderHook(() => useProjectViewState());
+
+    act(() => {
+      result.current.setSearchQuery("notif");
+      vi.advanceTimersByTime(DEBOUNCE_MS);
+    });
+
+    // The write lands; useSearchParams now reports what the hook itself wrote.
+    setUrl("q=notif");
+    rerender();
+    expect(result.current.searchQuery).toBe("notif");
+
+    // Meanwhile the user keeps typing. The echo must not roll this back.
+    act(() => result.current.setSearchQuery("notifications"));
+    rerender();
+
+    expect(result.current.searchQuery).toBe("notifications");
+  });
+
+  it("fires no navigation when unmounted mid-debounce", () => {
+    const { result, unmount } = renderHook(() => useProjectViewState());
+
+    act(() => result.current.setSearchQuery("abandoned"));
+    unmount();
+    act(() => void vi.advanceTimersByTime(DEBOUNCE_MS * 4));
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("carries the live text on view-tab links before the URL catches up", () => {
+    setUrl("status=ACTIVE");
+    const { result } = renderHook(() => useProjectViewState());
+
+    act(() => result.current.setSearchQuery("realtime"));
+
+    // Still mid-debounce — the URL has no `q` yet, but a tab link clicked right
+    // now must not lose what the user typed.
+    expect(mockReplace).not.toHaveBeenCalled();
+    const params = new URLSearchParams(result.current.viewParamsQueryString);
+    expect(params.get("q")).toBe("realtime");
+    expect(params.get("status")).toBe("ACTIVE");
+  });
+});

--- a/src/app/_components/projects/useProjectViewState.ts
+++ b/src/app/_components/projects/useProjectViewState.ts
@@ -1,6 +1,14 @@
 "use client";
 
-import { useCallback, useMemo, useTransition } from "react";
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { FilterState } from "~/types/filter";
 import type {
@@ -11,6 +19,16 @@ import type {
 const FILTER_KEYS = ["status", "priority", "driId"] as const;
 const QUERY_PARAM = "q";
 const SORT_PARAM = "sort";
+
+/**
+ * How long to wait after the last keystroke before writing `?q=` to the URL.
+ *
+ * Writing it per-keystroke means a `router.replace()` per character, and the
+ * `(sidemenu)` route group is served by an async *server* layout — so every one
+ * of those replaces refetches the whole RSC tree. That is what made the search
+ * box feel like it was reloading the page as you typed.
+ */
+const SEARCH_URL_DEBOUNCE_MS = 350;
 
 const PROJECT_PRIORITY_RANK: Record<string, number> = {
   HIGH: 0,
@@ -73,7 +91,13 @@ function parseSort(params: URLSearchParams): ProjectSortState | null {
 export interface ProjectViewState {
   filters: FilterState;
   setFilters: (next: FilterState | ((prev: FilterState) => FilterState)) => void;
+  /** Live text — bind this to the search `<input value>`. Updates synchronously. */
   searchQuery: string;
+  /**
+   * Deferred copy of {@link searchQuery}. Filter list rendering off this so a
+   * slow re-render of the results never blocks the next keystroke.
+   */
+  deferredSearchQuery: string;
   setSearchQuery: (next: string) => void;
   sortState: ProjectSortState | null;
   setSortField: (field: string) => void;
@@ -98,7 +122,17 @@ export function useProjectViewState(): ProjectViewState {
     () => parseSort(new URLSearchParams(paramsString)),
     [paramsString],
   );
-  const searchQuery = searchParams.get(QUERY_PARAM) ?? "";
+  const urlSearchQuery = searchParams.get(QUERY_PARAM) ?? "";
+
+  // The input is driven by local state, not by the URL. The URL is a *mirror*
+  // that catches up once typing pauses (see SEARCH_URL_DEBOUNCE_MS).
+  const [searchQuery, setSearchQueryState] = useState(urlSearchQuery);
+  // Last value this hook wrote to the URL, so we can tell our own echo apart
+  // from an external change (back/forward, a link carrying `?q=`).
+  const lastWrittenQueryRef = useRef(urlSearchQuery);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const deferredSearchQuery = useDeferredValue(searchQuery);
 
   const viewParamsQueryString = useMemo(() => {
     const params = new URLSearchParams(paramsString);
@@ -107,12 +141,13 @@ export function useProjectViewState(): ProjectViewState {
       const v = params.get(key);
       if (v) out.set(key, v);
     }
-    const q = params.get(QUERY_PARAM);
-    if (q) out.set(QUERY_PARAM, q);
+    // Use the live text, not the URL's — a view-tab link clicked mid-debounce
+    // should still carry what the user has typed.
+    if (searchQuery.trim()) out.set(QUERY_PARAM, searchQuery);
     const s = params.get(SORT_PARAM);
     if (s) out.set(SORT_PARAM, s);
     return out.toString();
-  }, [paramsString]);
+  }, [paramsString, searchQuery]);
 
   const updateParams = useCallback(
     (mutator: (params: URLSearchParams) => void) => {
@@ -126,6 +161,29 @@ export function useProjectViewState(): ProjectViewState {
     },
     [router, pathname, paramsString],
   );
+
+  // A debounced write fires from a timer, so it must not capture a stale
+  // `updateParams` (which closes over `paramsString`) — read the latest here.
+  const updateParamsRef = useRef(updateParams);
+  useEffect(() => {
+    updateParamsRef.current = updateParams;
+  }, [updateParams]);
+
+  // Adopt external URL changes (back/forward, or landing on a `?q=` link), but
+  // ignore our own debounced write coming back around.
+  useEffect(() => {
+    if (urlSearchQuery === lastWrittenQueryRef.current) return;
+    lastWrittenQueryRef.current = urlSearchQuery;
+    setSearchQueryState(urlSearchQuery);
+  }, [urlSearchQuery]);
+
+  // Never let a queued write land after unmount — it would navigate a page the
+  // user has already left.
+  useEffect(() => {
+    return () => {
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    };
+  }, []);
 
   const setFilters = useCallback(
     (next: FilterState | ((prev: FilterState) => FilterState)) => {
@@ -145,15 +203,21 @@ export function useProjectViewState(): ProjectViewState {
     [updateParams],
   );
 
-  const setSearchQuery = useCallback(
-    (next: string) => {
-      updateParams((params) => {
-        if (next.trim()) params.set(QUERY_PARAM, next);
+  const setSearchQuery = useCallback((next: string) => {
+    // Synchronous: the caret and the visible text never wait on the router.
+    setSearchQueryState(next);
+
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    searchTimerRef.current = setTimeout(() => {
+      searchTimerRef.current = null;
+      const trimmed = next.trim();
+      lastWrittenQueryRef.current = trimmed ? next : "";
+      updateParamsRef.current((params) => {
+        if (trimmed) params.set(QUERY_PARAM, next);
         else params.delete(QUERY_PARAM);
       });
-    },
-    [updateParams],
-  );
+    }, SEARCH_URL_DEBOUNCE_MS);
+  }, []);
 
   const setSortField = useCallback(
     (field: string) => {
@@ -222,6 +286,7 @@ export function useProjectViewState(): ProjectViewState {
     filters,
     setFilters,
     searchQuery,
+    deferredSearchQuery,
     setSearchQuery,
     sortState,
     setSortField,

--- a/src/app/_components/projects/useProjectViewState.ts
+++ b/src/app/_components/projects/useProjectViewState.ts
@@ -178,7 +178,11 @@ export function useProjectViewState(): ProjectViewState {
   }, [urlSearchQuery]);
 
   // Never let a queued write land after unmount — it would navigate a page the
-  // user has already left.
+  // user has already left. Tradeoff, deliberate: a query typed in the last
+  // SEARCH_URL_DEBOUNCE_MS before navigating away never reaches the URL, so
+  // Back returns to an empty box. Don't "fix" that by flushing on unmount — it
+  // reintroduces the hijack. View-tab switches are already covered, because
+  // viewParamsQueryString builds its links from the live text.
   useEffect(() => {
     return () => {
       if (searchTimerRef.current) clearTimeout(searchTimerRef.current);

--- a/src/hooks/__tests__/usePageSearchHotkey.test.ts
+++ b/src/hooks/__tests__/usePageSearchHotkey.test.ts
@@ -1,0 +1,173 @@
+/**
+ * usePageSearchHotkey tests — the ⌘F binding for a page's own search box.
+ *
+ * The interesting cases are the ones where the hotkey must *decline*: an open
+ * dropdown or modal owns the keyboard, and stealing ⌘F there either yanks focus
+ * out of the overlay or drops it into a box hidden behind one.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import { usePageSearchHotkey } from "../usePageSearchHotkey";
+
+/**
+ * happy-dom does no layout, and reports a non-empty getClientRects() for every
+ * attached element — so "visible" is the default and hiding has to be explicit.
+ * Both the hook and isOverlayBlocking gate on getClientRects().length.
+ */
+function attach<T extends HTMLElement>(el: T, { visible = true } = {}): T {
+  el.getClientRects = () =>
+    (visible
+      ? [{ width: 120, height: 32 }]
+      : []) as unknown as DOMRectList;
+  document.body.appendChild(el);
+  return el;
+}
+
+function makeVisibleInput(): HTMLInputElement {
+  return attach(document.createElement("input"));
+}
+
+function makeOverlay(role: "listbox" | "modal", { visible = true } = {}) {
+  const el = document.createElement("div");
+  if (role === "modal") el.setAttribute("aria-modal", "true");
+  else el.setAttribute("role", "listbox");
+  return attach(el, { visible });
+}
+
+function pressF(
+  init: Partial<KeyboardEventInit> & { code?: string } = {},
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    code: "KeyF",
+    key: "f",
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  window.dispatchEvent(event);
+  return event;
+}
+
+function setPlatform(value: string) {
+  Object.defineProperty(navigator, "platform", {
+    value,
+    configurable: true,
+  });
+}
+
+let input: HTMLInputElement;
+const originalPlatform = navigator.platform;
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  input = makeVisibleInput();
+  setPlatform("MacIntel");
+});
+
+afterEach(() => {
+  setPlatform(originalPlatform);
+});
+
+function mount(target: HTMLInputElement | null = input) {
+  return renderHook(() => usePageSearchHotkey({ current: target }));
+}
+
+describe("usePageSearchHotkey", () => {
+  it("focuses and selects the box, and suppresses native find", () => {
+    input.value = "existing query";
+    const select = vi.spyOn(input, "select");
+    mount();
+
+    const event = pressF();
+
+    expect(document.activeElement).toBe(input);
+    expect(select).toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("ignores ⌘F when no box is on screen", () => {
+    mount(null);
+    expect(pressF().defaultPrevented).toBe(false);
+  });
+
+  it("ignores ⌘F when the box is rendered but has no layout box", () => {
+    mount(attach(document.createElement("input"), { visible: false }));
+
+    expect(pressF().defaultPrevented).toBe(false);
+  });
+
+  // The case the review caught: an open Select puts focus on its own input,
+  // which has no [aria-modal] ancestor — the earlier guard let this through.
+  it("declines while a dropdown listbox is open", () => {
+    makeOverlay("listbox");
+    mount();
+
+    expect(pressF().defaultPrevented).toBe(false);
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it("declines while a modal is open, even before focus moves into it", () => {
+    makeOverlay("modal");
+    mount();
+
+    expect(pressF().defaultPrevented).toBe(false);
+  });
+
+  it("is not fooled by the listboxes Mantine leaves mounted but hidden", () => {
+    makeOverlay("listbox", { visible: false });
+    mount();
+
+    expect(pressF().defaultPrevented).toBe(true);
+  });
+
+  it("leaves Ctrl+F alone on macOS — that is emacs forward-char", () => {
+    mount();
+    const event = pressF({ metaKey: false, ctrlKey: true });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it("uses Ctrl+F off macOS", () => {
+    setPlatform("Win32");
+    mount();
+
+    expect(pressF({ metaKey: false, ctrlKey: true }).defaultPrevented).toBe(true);
+  });
+
+  it("matches the physical F key, not the layout-mapped character", () => {
+    mount();
+    // ⌘F on a Cyrillic layout: code is still KeyF, key arrives as "а".
+    expect(pressF({ key: "а" }).defaultPrevented).toBe(true);
+  });
+
+  // Regression: matching on `code` alone broke every input path that leaves it
+  // empty — synthetic events, on-screen keyboards, some IME/remote-desktop
+  // stacks. Caught in a real browser, not by the first cut of these tests.
+  it("falls back to `key` when the event carries no `code`", () => {
+    mount();
+    expect(pressF({ code: "", key: "f" }).defaultPrevented).toBe(true);
+  });
+
+  it("still ignores other keys that carry no `code`", () => {
+    mount();
+    expect(pressF({ code: "", key: "k" }).defaultPrevented).toBe(false);
+  });
+
+  it("leaves ⌘⇧F and ⌘⌥F to the browser", () => {
+    mount();
+
+    expect(pressF({ shiftKey: true }).defaultPrevented).toBe(false);
+    expect(pressF({ altKey: true }).defaultPrevented).toBe(false);
+  });
+
+  it("stops listening after unmount", () => {
+    const { unmount } = mount();
+    unmount();
+
+    expect(pressF().defaultPrevented).toBe(false);
+  });
+});

--- a/src/hooks/usePageSearchHotkey.ts
+++ b/src/hooks/usePageSearchHotkey.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Binds ⌘F / Ctrl+F to a page's own search box.
+ *
+ * Deliberately a raw `keydown` listener rather than Mantine's `useHotkeys`:
+ * that helper ignores events originating from `INPUT`/`TEXTAREA`/`SELECT`, so
+ * pressing ⌘F while already inside the search box would fall through to the
+ * browser's native find bar instead of re-selecting the query.
+ *
+ * ⌘K is *not* used here — it belongs to the global CommandPalette.
+ */
+export function usePageSearchHotkey(ref: RefObject<HTMLInputElement | null>) {
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key !== "f" && event.key !== "F") return;
+      if (!(event.metaKey || event.ctrlKey)) return;
+      // Leave ⌘⇧F / ⌘⌥F alone — those are browser/OS bindings.
+      if (event.shiftKey || event.altKey) return;
+
+      const input = ref.current;
+      // No box on screen (hidden tab, unmounted view) — let the browser have it.
+      if (!input || input.getClientRects().length === 0) return;
+
+      // A modal/drawer is focused on top of the page: hijacking ⌘F to focus a
+      // search box the user cannot even see would be worse than native find.
+      const active = document.activeElement;
+      if (
+        active instanceof HTMLElement &&
+        active !== input &&
+        active.closest('[aria-modal="true"]')
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      input.focus();
+      input.select();
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [ref]);
+}

--- a/src/hooks/usePageSearchHotkey.ts
+++ b/src/hooks/usePageSearchHotkey.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, type RefObject } from "react";
+import { isOverlayBlocking } from "~/app/_components/product/useListNavHotkeys";
 
 /**
  * Binds ⌘F / Ctrl+F to a page's own search box.
@@ -14,9 +15,23 @@ import { useEffect, type RefObject } from "react";
  */
 export function usePageSearchHotkey(ref: RefObject<HTMLInputElement | null>) {
   useEffect(() => {
+    const isMac =
+      typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
+
+    // Either identifier is enough, and both are needed:
+    //   `code` is the physical key, so ⌘F still works on a Cyrillic or Greek
+    //     layout where `key` arrives as "а".
+    //   `key` is the fallback for input paths that leave `code` empty —
+    //     synthetic events, on-screen keyboards, some IME and remote-desktop
+    //     stacks. Matching on `code` alone silently kills the shortcut there.
+    const isFKey = (event: KeyboardEvent) =>
+      event.code === "KeyF" || event.key === "f" || event.key === "F";
+
     const handler = (event: KeyboardEvent) => {
-      if (event.key !== "f" && event.key !== "F") return;
-      if (!(event.metaKey || event.ctrlKey)) return;
+      if (!isFKey(event)) return;
+      // Ctrl+F is emacs forward-char on macOS and works in every text field —
+      // only ⌘ should trigger there. Elsewhere Ctrl is the find key.
+      if (!(isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey)) return;
       // Leave ⌘⇧F / ⌘⌥F alone — those are browser/OS bindings.
       if (event.shiftKey || event.altKey) return;
 
@@ -24,16 +39,10 @@ export function usePageSearchHotkey(ref: RefObject<HTMLInputElement | null>) {
       // No box on screen (hidden tab, unmounted view) — let the browser have it.
       if (!input || input.getClientRects().length === 0) return;
 
-      // A modal/drawer is focused on top of the page: hijacking ⌘F to focus a
-      // search box the user cannot even see would be worse than native find.
-      const active = document.activeElement;
-      if (
-        active instanceof HTMLElement &&
-        active !== input &&
-        active.closest('[aria-modal="true"]')
-      ) {
-        return;
-      }
+      // Something is layered above us — an open Select dropdown, a menu, a
+      // modal. Stealing ⌘F would yank focus out of it, or into a search box the
+      // user cannot even see. `null` root: this box is never inside an overlay.
+      if (isOverlayBlocking(null)) return;
 
       event.preventDefault();
       input.focus();


### PR DESCRIPTION
## What

The projects search box was controlled directly by the URL — `value={searchParams.get('q')}`, with `router.replace()` fired from `onChange`. Since `src/app/(sidemenu)/layout.tsx` is an **async server component**, every one of those replaces refetched the whole RSC tree. Typing felt like the page was reloading under you.

`startTransition` around the write made it worse: React deprioritised the *visible* text, so characters lagged behind the keystrokes that produced them.

Measured on the projects page, same word at the same typing speed:

| | before | after |
|---|---|---|
| router navigations for 13 chars | **13** | **2** |
| synchronous blocking | 315 ms | 85 ms |
| long tasks (>50 ms) | 2 (123 ms, 86 ms) | 0 |

**Fix** (`useProjectViewState.ts` — one hook, so all three project views benefit):

- Query lives in local `useState`, so the input and caret never wait on the router.
- URL write debounced to 350 ms; it's a mirror, not the source of truth.
- URL→state reconciliation only fires when the param differs from the last value the hook wrote, so our own echo can't clobber the caret.
- Filtering runs off a `useDeferredValue` copy.
- `viewParamsQueryString` is built from the **live** text, so a view-tab link clicked mid-debounce still carries what was typed.
- Pending timer cleared on unmount — a queued write must never navigate a page the user already left.
- `ProjectTableRow` memoised (each row mounts two tRPC mutations, two Selects and two SVG rings).

**Also**: ⌘F now focuses and selects the page search box (new `usePageSearchHotkey`). It's a raw `keydown` listener rather than Mantine's `useHotkeys`, which ignores events originating from `INPUT` — so ⌘F pressed while already in the box would have fallen through to the browser's find bar. It backs off when a modal/drawer has focus.

Two things corrected along the way:
- Placeholders advertised **⌘K**, which actually opens the global CommandPalette, not the search box. Now ⌘F.
- The Timeline view bound its own `mod+k`, so one press focused the search box **and** opened the palette on top of it. Removed.

## Verification

Verified in a real authenticated browser session against the `dev-fixture` workspace (22 seeded projects), across all three views — Projects, Projects & Tasks, Timeline:

- Deep links (`?q=edge&status=ACTIVE`) prefill the input and filter correctly.
- Mid-debounce, the Timeline tab link already carries `q=realtime` while the URL still reads `q=edge` — switching views doesn't lose the query.
- ⌘F focuses and selects existing text; no command palette opens.
- No console errors.

`npm run test` (2299 tests), `tsc --noEmit`, and ESLint over `src/` are all clean — 0 errors, the 5 remaining warnings are pre-existing in untouched files.