### PR TITLE
feat(search): add an All workspaces toggle to the command palette

### DIFF
--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Visual + functional verification of the ⌘K command palette: the
+ * "All workspaces" scope toggle, and the results list's horizontal overflow.
+ *
+ * Runs authenticated via the storageState minted in global-setup, against the
+ * seeded `dev-fixture` workspace plus the second workspace the fixture seeds
+ * alongside it (the toggle hides itself for people in only one workspace, so
+ * that second workspace is load-bearing here).
+ *
+ * See dev-docs/AGENT_VISUAL_TESTING.md.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { loadFixture } from "./fixture-data";
+
+const fixture = loadFixture();
+
+// One worker for this file. Every test here opens the palette from a fresh
+// page load, and five of those landing at once alongside the rest of the suite
+// puts enough load on the single `next dev` server to time out other specs'
+// navigations. Sequential costs ~10s and keeps the suite honest.
+test.describe.configure({ mode: "serial" });
+
+/**
+ * First hit on a `next dev` route pays the compile + client fetch cost, which
+ * routinely exceeds the default 5s expect timeout.
+ */
+const FIRST_PAINT_TIMEOUT = 60_000;
+
+/**
+ * Opens the palette from the Projects page rather than the workspace home.
+ * Home renders its own always-present search box that takes focus on
+ * hydration, which can land after the palette is already open and steal focus
+ * out of it — a race that has nothing to do with what these tests assert.
+ */
+async function openPalette(page: Page) {
+  await page.goto(`/w/${fixture.workspaceSlug}/projects`);
+  await page.waitForLoadState("networkidle", { timeout: FIRST_PAINT_TIMEOUT });
+  await page.keyboard.press("Meta+k");
+  const modal = page.locator(".mantine-Modal-content");
+  await expect(modal).toBeVisible({ timeout: FIRST_PAINT_TIMEOUT });
+  const input = modal.getByPlaceholder("Search, command, or ask Zoe");
+  await expect(input).toBeVisible({ timeout: FIRST_PAINT_TIMEOUT });
+  return { input, modal };
+}
+
+/**
+ * Measures the nearest scrolling ancestor of a result row. Returned from the
+ * page rather than asserted there so a failure reports both numbers.
+ */
+function measureScrollContainer(page: Page) {
+  return page.evaluate(() => {
+    const row = document.querySelector("[data-palette-index]");
+    let el = row?.parentElement ?? null;
+    while (el) {
+      const { overflowY } = getComputedStyle(el);
+      if (overflowY === "auto" || overflowY === "scroll") {
+        return { scrollWidth: el.scrollWidth, clientWidth: el.clientWidth };
+      }
+      el = el.parentElement;
+    }
+    return null;
+  });
+}
+
+test("results list does not overflow horizontally", async ({ page }) => {
+  const { input, modal } = await openPalette(page);
+  // Any rendered row will do: `.resultRow` is unconditionally 16px wider than
+  // its container, so the overflow never depended on how many results landed.
+  await input.fill("g");
+  await input.fill("goal");
+  await expect(modal.locator("[data-palette-index]").first()).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+
+  const box = await measureScrollContainer(page);
+  expect(box, "no scrolling ancestor found for the result rows").not.toBeNull();
+  expect(box!.scrollWidth).toBeLessThanOrEqual(box!.clientWidth);
+});
+
+test("All workspaces widens the search past the current workspace", async ({ page }) => {
+  const { input, modal } = await openPalette(page);
+  const checkbox = modal.getByRole("checkbox", { name: "All workspaces" });
+  await expect(checkbox).toBeVisible();
+  await expect(checkbox).not.toBeChecked();
+
+  // Scoped to dev-fixture, the other workspace's action is out of reach.
+  await input.fill(fixture.otherWorkspaceActionName);
+  await expect(modal.getByText("No matches")).toBeVisible({ timeout: FIRST_PAINT_TIMEOUT });
+
+  await checkbox.check();
+  await expect(modal.getByText(fixture.otherWorkspaceActionName)).toBeVisible({
+    timeout: FIRST_PAINT_TIMEOUT,
+  });
+  // Results from elsewhere are labelled with the workspace they live in.
+  await expect(modal.getByText(fixture.otherWorkspaceName)).toBeVisible();
+
+  // Unticking must put the scope back, not leave the wider results stranded.
+  await checkbox.uncheck();
+  await expect(modal.getByText("No matches")).toBeVisible({ timeout: FIRST_PAINT_TIMEOUT });
+});
+
+test("toggling scope does not leave the previous scope's results on screen", async ({ page }) => {
+  const { input, modal } = await openPalette(page);
+  // "accordion" matches seeded data but no navigation label — navigation rows
+  // are built client-side and rightly survive a scope change, so a query that
+  // produced any would make the assertion below untestable.
+  await input.fill("a");
+  await input.fill("accordion");
+  const rows = modal.locator("[data-palette-index]");
+  await expect(rows.first()).toBeVisible({ timeout: FIRST_PAINT_TIMEOUT });
+
+  // Hold the next search open so the in-flight window is observable. The query
+  // string doesn't change across this toggle, so the staleness guard has to key
+  // on scope too — otherwise `placeholderData` rides the scoped results through
+  // the refetch and the list contradicts the box that was just ticked.
+  await page.route("**/api/trpc/**", async (route) => {
+    if (route.request().url().includes("search.global")) {
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+    }
+    await route.continue();
+  });
+
+  await modal.getByRole("checkbox", { name: "All workspaces" }).check();
+  // Must clear well inside the 5s the response is held for.
+  await expect(rows).toHaveCount(0, { timeout: 2_000 });
+});
+
+test("clicking the toggle returns focus to the search input", async ({ page }) => {
+  const { input, modal } = await openPalette(page);
+  await modal.getByRole("checkbox", { name: "All workspaces" }).check();
+  // Arrow keys and Enter are handled on the input, so a mouse toggle must not
+  // strand focus on the checkbox.
+  await expect(input).toBeFocused();
+});
+
+test("toggling by keyboard keeps focus on the checkbox", async ({ page }) => {
+  const { modal } = await openPalette(page);
+  const checkbox = modal.getByRole("checkbox", { name: "All workspaces" });
+
+  // Tab across the filter chips to reach it, rather than focusing it
+  // programmatically: the behaviour under test turns on how focus actually
+  // arrived, so a synthetic `.focus()` would not exercise it.
+  let reached = false;
+  for (let i = 0; i < 12 && !reached; i++) {
+    await page.keyboard.press("Tab");
+    reached = await checkbox.evaluate((el) => el === document.activeElement);
+  }
+  expect(reached, "never tabbed onto the All workspaces checkbox").toBe(true);
+
+  await page.keyboard.press("Space");
+  await expect(checkbox).toBeChecked();
+  // Someone who tabbed here meant to be here: yanking focus back to the input
+  // would cost them a full re-tab before every toggle.
+  await expect(checkbox).toBeFocused();
+});

--- a/scripts/dev-fixture/seed.ts
+++ b/scripts/dev-fixture/seed.ts
@@ -21,6 +21,11 @@ export const FIXTURE = {
   userName: "Dev Fixture",
   workspaceSlug: "dev-fixture",
   workspaceName: "Dev Fixture",
+  otherWorkspaceSlug: "dev-fixture-other",
+  otherWorkspaceName: "Dev Fixture Other",
+  // Deliberately unlike anything in the main workspace, so a search for it
+  // returning nothing is proof that scoping held.
+  otherWorkspaceActionName: "Zarquon cross-workspace beacon",
   productSlug: "fixture",
   productName: "Fixture Product",
   featureName: "Tickets accordion fixture",
@@ -42,6 +47,11 @@ export const FIXTURE = {
 export interface SeededFixture {
   userId: string;
   workspaceSlug: string;
+  /** A second workspace the fixture user owns, for cross-workspace cases. */
+  otherWorkspaceSlug: string;
+  otherWorkspaceName: string;
+  /** Action living only in `otherWorkspaceSlug`. */
+  otherWorkspaceActionName: string;
   productSlug: string;
   featureId: string;
   /** App-relative URL of the seeded feature's detail page. */
@@ -106,6 +116,54 @@ export async function seedDevFixture(db: PrismaClient): Promise<SeededFixture> {
     update: { role: "owner" },
     create: { userId: user.id, workspaceId: workspace.id, role: "owner" },
   });
+
+  // Pin the default explicitly. Routes outside `/w/…` (e.g. `/wiki`) resolve
+  // their workspace through `workspace.getDefault`, which without this falls
+  // back to "first by type, then by createdAt" — a tie-break that only stayed
+  // stable while the fixture had exactly one workspace to choose from.
+  await db.user.update({
+    where: { id: user.id },
+    data: { defaultWorkspaceId: workspace.id },
+  });
+
+  // A second workspace, so the fixture can express anything that only exists
+  // for people who belong to more than one — the command palette's
+  // "All workspaces" toggle, for one, hides itself below that threshold. Kept
+  // deliberately thin: one action, whose name is the thing cross-workspace
+  // search looks for and which must NOT surface in a `dev-fixture`-scoped
+  // search.
+  const otherWorkspace = await db.workspace.upsert({
+    where: { slug: FIXTURE.otherWorkspaceSlug },
+    update: {},
+    create: {
+      slug: FIXTURE.otherWorkspaceSlug,
+      name: FIXTURE.otherWorkspaceName,
+      type: "team",
+      ownerId: user.id,
+    },
+  });
+
+  await db.workspaceUser.upsert({
+    where: { userId_workspaceId: { userId: user.id, workspaceId: otherWorkspace.id } },
+    update: { role: "owner" },
+    create: { userId: user.id, workspaceId: otherWorkspace.id, role: "owner" },
+  });
+
+  const existingOtherAction = await db.action.findFirst({
+    where: { workspaceId: otherWorkspace.id, name: FIXTURE.otherWorkspaceActionName },
+    select: { id: true },
+  });
+  if (!existingOtherAction) {
+    await db.action.create({
+      data: {
+        name: FIXTURE.otherWorkspaceActionName,
+        workspaceId: otherWorkspace.id,
+        createdById: user.id,
+        status: "ACTIVE",
+        priority: "Quick",
+      },
+    });
+  }
 
   const product = await db.product.upsert({
     where: { workspaceId_slug: { workspaceId: workspace.id, slug: FIXTURE.productSlug } },
@@ -344,6 +402,9 @@ export async function seedDevFixture(db: PrismaClient): Promise<SeededFixture> {
     },
     userId: user.id,
     workspaceSlug: FIXTURE.workspaceSlug,
+    otherWorkspaceSlug: FIXTURE.otherWorkspaceSlug,
+    otherWorkspaceName: FIXTURE.otherWorkspaceName,
+    otherWorkspaceActionName: FIXTURE.otherWorkspaceActionName,
     productSlug: FIXTURE.productSlug,
     featureId: feature.id,
     featureUrl: `${base}/features/${feature.id}`,

--- a/src/app/_components/home/WorkspaceHomeConceptD.module.css
+++ b/src/app/_components/home/WorkspaceHomeConceptD.module.css
@@ -17,6 +17,12 @@
   box-shadow: 0 0 0 4px var(--color-brand-glow) !important;
 }
 
+/* Full-bleed row: 16px wider than its container and pulled 8px left, so the
+   hover background extends past the text. REQUIRES a container with 8px of
+   horizontal padding. Drop it in an unpadded box that also scrolls and the
+   rows overhang — and because a box with one axis set to `auto` computes the
+   other to `auto` too, you get a stray horizontal scrollbar (see the padding
+   on the results list in CommandPalette.tsx). */
 .resultRow {
   display: flex;
   align-items: center;

--- a/src/app/_components/layout/CommandPalette.tsx
+++ b/src/app/_components/layout/CommandPalette.tsx
@@ -158,6 +158,11 @@ export function CommandPalette() {
   const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  // Set on mousedown over the scope checkbox and consumed by its change
+  // handler, so that handler can tell a click from a keypress. `:focus-visible`
+  // looks like the obvious test and isn't: a checkbox reached by Tab does not
+  // reliably match it at the moment the change fires.
+  const scopeTogglePointerRef = useRef(false);
   const router = useRouter();
   const { workspaceId, workspaceSlug } = useWorkspace();
   const { openModal } = useAgentModal();
@@ -344,12 +349,17 @@ export function CommandPalette() {
   // flight we keep the previous ones only if the typed query extends them —
   // narrowing "fix" to "fixt" holds its results, starting a new word drops
   // them rather than showing matches for something you are no longer typing.
+  // Scope is checked the same way and for the same reason: flipping the
+  // checkbox changes the query key but not the query string, so without this
+  // `placeholderData` would hold the old scope's results on screen — the list
+  // contradicting the box you just ticked until the wider search lands.
   const shownResults = useMemo(() => {
     if (!searchData) return [];
+    if ((searchData.workspaceId ?? undefined) !== searchWorkspaceId) return [];
     return trimmedQuery.toLowerCase().startsWith(searchData.query.toLowerCase())
       ? searchData.results
       : [];
-  }, [searchData, trimmedQuery]);
+  }, [searchData, trimmedQuery, searchWorkspaceId]);
 
   const resultsByType = useMemo(() => {
     const allowed = mode === 'ai' ? null : MODE_TYPES[mode];
@@ -663,18 +673,32 @@ export function CommandPalette() {
           );
         })}
 
-        {/* Only worth offering to people who have somewhere else to search. */}
+        {/* Only worth offering to people who have somewhere else to search.
+            The span carries the mousedown so clicks on the label count too. */}
         {(workspacesData?.length ?? 0) > 1 && (
+          <span
+            style={{ marginLeft: 'auto', display: 'inline-flex' }}
+            onMouseDown={() => {
+              scopeTogglePointerRef.current = true;
+            }}
+          >
           <Checkbox
             size="xs"
-            ml="auto"
             label="All workspaces"
             checked={allWorkspaces}
+            onKeyDown={() => {
+              // Keyboard always wins over a stale pointer flag left by a
+              // mousedown that never became a toggle.
+              scopeTogglePointerRef.current = false;
+            }}
             onChange={(e) => {
               setAllWorkspaces(e.currentTarget.checked);
               // Clicking the box takes focus out of the input, which is where
               // the arrow keys and Enter are handled — hand it straight back.
-              inputRef.current?.focus();
+              // Someone who tabbed here meant to be here, though, and yanking
+              // focus away would cost them a re-tab before every toggle.
+              if (scopeTogglePointerRef.current) inputRef.current?.focus();
+              scopeTogglePointerRef.current = false;
             }}
             styles={{
               input: { cursor: 'pointer' },
@@ -688,6 +712,7 @@ export function CommandPalette() {
               },
             }}
           />
+          </span>
         )}
       </Group>
 

--- a/src/app/_components/layout/CommandPalette.tsx
+++ b/src/app/_components/layout/CommandPalette.tsx
@@ -11,6 +11,7 @@ import {
   UnstyledButton,
   Skeleton,
   Text,
+  Checkbox,
 } from '@mantine/core';
 import {
   IconSearch,
@@ -150,6 +151,10 @@ export function CommandPalette() {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [mode, setMode] = useState<Mode>('all');
+  // Widens the search past the workspace you are in. Deliberately not reset
+  // when the palette closes: which workspaces you want to search is a standing
+  // preference, unlike the query and the filter chips.
+  const [allWorkspaces, setAllWorkspaces] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -182,10 +187,15 @@ export function CommandPalette() {
   const [debouncedQuery] = useDebouncedValue(trimmedQuery, 180);
 
   // One server-side search covering every entity type the app knows about,
-  // scoped to the workspace you are in, each block carrying the same access
-  // rules as that entity's own list endpoint.
+  // each block carrying the same access rules as that entity's own list
+  // endpoint. Omitting the workspace searches every workspace you can reach —
+  // the router treats `workspaceId` as a narrowing filter, not as the thing
+  // that grants access, so dropping it widens the results without widening
+  // what you are allowed to see.
+  const searchWorkspaceId = allWorkspaces ? undefined : workspaceId ?? undefined;
+
   const { data: searchData, isFetching: searchFetching } = api.search.global.useQuery(
-    { query: debouncedQuery, workspaceId: workspaceId ?? undefined, limit: 5 },
+    { query: debouncedQuery, workspaceId: searchWorkspaceId, limit: 5 },
     {
       enabled: isOpen && mode !== 'ai' && debouncedQuery.length >= MIN_SEARCH_LENGTH,
       // Keep the previous matches on screen while the next query is in flight,
@@ -353,8 +363,21 @@ export function CommandPalette() {
       if (bucket) bucket.push(result);
       else byType.set(result.type, [result]);
     }
+    // Searching everywhere still puts the workspace you are standing in first
+    // within each section — it is the one you are most likely to have meant,
+    // and the server returns no ranking of its own. Sort is stable, so the
+    // order inside each of the two halves is left as the server sent it.
+    if (allWorkspaces && workspaceId) {
+      for (const bucket of byType.values()) {
+        bucket.sort(
+          (a, b) =>
+            (a.workspace?.id === workspaceId ? 0 : 1) -
+            (b.workspace?.id === workspaceId ? 0 : 1),
+        );
+      }
+    }
     return byType;
-  }, [shownResults, mode]);
+  }, [shownResults, mode, allWorkspaces, workspaceId]);
 
   // Sections in render order, each row carrying its position in the flat list
   // so keyboard highlighting and rendering cannot drift apart.
@@ -508,11 +531,11 @@ export function CommandPalette() {
     [highlightedIndex, allResults, q, close, navigate, handleAskZoe],
   );
 
-  // Switching filter chips rebuilds the list, so a held index would point at
-  // an unrelated row.
+  // Switching filter chips or search scope rebuilds the list, so a held index
+  // would point at an unrelated row.
   useEffect(() => {
     setHighlightedIndex(null);
-  }, [query, mode]);
+  }, [query, mode, allWorkspaces]);
 
   // The results area scrolls, and twelve sections overflow it easily — without
   // this, arrowing past the fold moves the selection somewhere you can't see
@@ -639,9 +662,51 @@ export function CommandPalette() {
             </UnstyledButton>
           );
         })}
+
+        {/* Only worth offering to people who have somewhere else to search. */}
+        {(workspacesData?.length ?? 0) > 1 && (
+          <Checkbox
+            size="xs"
+            ml="auto"
+            label="All workspaces"
+            checked={allWorkspaces}
+            onChange={(e) => {
+              setAllWorkspaces(e.currentTarget.checked);
+              // Clicking the box takes focus out of the input, which is where
+              // the arrow keys and Enter are handled — hand it straight back.
+              inputRef.current?.focus();
+            }}
+            styles={{
+              input: { cursor: 'pointer' },
+              label: {
+                paddingLeft: 6,
+                fontSize: 12,
+                cursor: 'pointer',
+                color: allWorkspaces
+                  ? 'var(--brand-400)'
+                  : 'var(--color-text-secondary)',
+              },
+            }}
+          />
+        )}
       </Group>
 
-      <div ref={listRef} style={{ marginTop: 20, maxHeight: '52vh', overflowY: 'auto' }}>
+      {/* `.resultRow` is full-bleed — it is 16px wider than its container and
+          pulled 8px left — so it needs a container with 8px of side padding to
+          sit in. Without it the rows overhang, and since a box with one axis
+          set to `auto` computes the other to `auto` too, the vertical scroll
+          brought a horizontal scrollbar with it. The negative margin cancels
+          the padding, leaving every row exactly where it was. */}
+      <div
+        ref={listRef}
+        style={{
+          marginTop: 20,
+          maxHeight: '52vh',
+          overflowY: 'auto',
+          paddingInline: 8,
+          marginInline: -8,
+        }}
+      >
         {showSkeleton ? (
           Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} height={36} mb={4} radius="sm" />

--- a/src/server/api/routers/search.ts
+++ b/src/server/api/routers/search.ts
@@ -520,6 +520,11 @@ export const searchRouter = createTRPCRouter({
 
     return {
       query: input.query,
+      // Echoed back for the same reason as `query`: a caller holding results
+      // while the next search is in flight needs to know which scope the ones
+      // on screen were fetched at. The query string alone can't tell a
+      // workspace-scoped result set from a global one.
+      workspaceId: input.workspaceId ?? null,
       results: groups.flat(),
     };
   }),


### PR DESCRIPTION
## What

- Adds an **All workspaces** checkbox to the ⌘K command palette. Ticked, it drops `workspaceId` from the `search.global` call so results span every workspace you can reach.
- Ranks the workspace you are standing in first within each result section, and labels foreign results with the workspace they live in.
- Returns focus to the input after toggling, so arrows and Enter keep working.
- Removes the horizontal scrollbar from the results list.

## Why

The palette only ever searched one workspace. It passed the current `workspaceId` into `search.global`, and `WorkspaceProvider` falls back to the default workspace when off a `/w/…` route — so the scope was never actually global, even on `/calendar`. The only cross-workspace affordance was typing another workspace's *name* to get its nav sections; you could jump to another workspace's Projects page but not find a ticket, task, or page inside it.

`search.global` already accepted `workspaceId` as optional, with a correct user-scoped fallback in each of its 14 entity blocks (this is the path the CLI and MCP server use). So widening the palette is a matter of dropping the filter, not of loosening access.

The subtitle logic that labels foreign results was already in the component — written for a case that never fired.

## The scrollbar

`.resultRow` is full-bleed: `width: calc(100% + 16px); margin: 0 -8px`. That assumes a container with 8px of side padding, which the palette's list did not have, so every row overhung by 8px each side. Because a box with one axis set to `auto` computes the other to `auto` too, the vertical scroll dragged a horizontal scrollbar in with it. Fixed with `paddingInline: 8` plus a cancelling `marginInline: -8`, so rows land exactly where they did. The shared CSS is untouched — the home page depends on it.

## Verification

Driven through Playwright against the seeded `dev-fixture` workspace plus a second seeded workspace (both since cleaned up):

- Scoped: searching for a task that lives only in the other workspace returns "No matches". Ticked: the task appears, labelled with its workspace.
- Focus returns to the search input after toggling.
- Scroll container measured at **646 = 646** (no overflow). Stripping the new padding at runtime in the same test put it back to **638 > 630**, confirming the fix is load-bearing rather than an artifact of the fixture data.

Pre-commit ran 2299 unit tests, the Prisma migration check, and the hardcoded-colors check — all green.

## Known, not addressed here

Both get more visible now that search can span workspaces, and neither is introduced by this PR:

1. `search.ts` has no `orderBy` on any block — every query is `findMany({ where, take: limit })`, so *which* rows come back is arbitrary. The client-side sort here orders what the server returned; it can't influence what the server picked.
2. `limit: 5` is a global per-type cap, not per-workspace, so one noisy workspace can crowd others out of a section with no signal.