### PR TITLE
fix(ci): make a green PR-Agent check mean a review actually happened

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -16,6 +16,10 @@ jobs:
       contents: write
     name: PR Agent review
     steps:
+      - name: Record start time
+        id: started
+        run: echo "at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: PR Agent action step
         id: pragent
         uses: qodo-ai/pr-agent@main
@@ -34,3 +38,37 @@ jobs:
           github_action_config.auto_describe: "true"
           github_action_config.auto_improve: "true"
           github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'
+
+      - name: Confirm a review was actually produced
+        # PR-Agent swallows provider errors. It posts "Failed to generate code
+        # suggestions for PR" as a PR comment and still exits 0, so without this
+        # the job goes green having reviewed nothing — which is worse than no
+        # reviewer at all, because the tick reads as "a reviewer looked at this".
+        # Seen for real on PR 530: the Anthropic key was out of credit, the job
+        # was green, and four failure notices sat unread on the PR.
+        #
+        # This check is not in branch protection's required set, so a red tick
+        # here reports the outage without blocking anyone's merge.
+        if: always() && steps.pragent.conclusion != 'skipped'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          SINCE: ${{ steps.started.outputs.at }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "No PR number on this event; nothing to verify."
+            exit 0
+          fi
+          # Only comments from this run — otherwise one bad run would keep the
+          # check red on every later push to the same PR.
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq "[.[] | select(.created_at >= \"${SINCE}\") | .body] | .[]" \
+            > /tmp/pr_agent_comments.txt
+          if grep -qiE 'failed to (generate|review)' /tmp/pr_agent_comments.txt; then
+            echo "::error title=PR-Agent produced no review::The action ran but every model call failed, so this PR was NOT reviewed. Check the step log for the provider error — it is usually an exhausted API credit balance on the ANTHROPIC_KEY secret."
+            grep -iE 'failed to (generate|review)' /tmp/pr_agent_comments.txt | head -5
+            exit 1
+          fi
+          echo "PR-Agent posted no failure notice — the review ran."

--- a/.github/workflows/pr_agent_glm.yml
+++ b/.github/workflows/pr_agent_glm.yml
@@ -19,6 +19,10 @@ jobs:
       contents: write
     name: PR Agent review (GLM)
     steps:
+      - name: Record start time
+        id: started
+        run: echo "at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: PR Agent action step
         id: pragent_glm
         uses: qodo-ai/pr-agent@main
@@ -47,3 +51,30 @@ jobs:
           # instead of posting its own.
           pr_reviewer.persistent_comment: "false"
           pr_code_suggestions.persistent_comment: "false"
+
+      - name: Confirm a review was actually produced
+        # See the same step in pr_agent.yml for why this exists. This reviewer
+        # has its own failure mode: as of PR 530 the OpenRouter key reported
+        # "Insufficient credits. This account never purchased credits" — i.e.
+        # this second opinion had never once run, and nothing said so.
+        if: always() && steps.pragent_glm.conclusion != 'skipped'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SINCE: ${{ steps.started.outputs.at }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "No PR number on this event; nothing to verify."
+            exit 0
+          fi
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq "[.[] | select(.created_at >= \"${SINCE}\") | .body] | .[]" \
+            > /tmp/pr_agent_glm_comments.txt
+          if grep -qiE 'failed to (generate|review)' /tmp/pr_agent_glm_comments.txt; then
+            echo "::error title=PR-Agent (GLM) produced no review::The action ran but every model call failed, so this PR was NOT reviewed. Check the step log for the provider error — it is usually an exhausted credit balance on the OPENROUTER_API_KEY secret."
+            grep -iE 'failed to (generate|review)' /tmp/pr_agent_glm_comments.txt | head -5
+            exit 1
+          fi
+          echo "PR-Agent (GLM) posted no failure notice — the review ran."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,27 +173,46 @@ removed `?? process.env.DATABASE_URL` fallback path.
 
 This is the primary project board for tracking all development work. Use the `exponential` CLI to query tasks and project status.
 
+### 🚨 Agents: every `exponential` call needs the `HOME=` prefix
+
+```bash
+HOME=/Users/james/.config/agent-homes/claude exponential <command>
+```
+
+The CLI reads its credentials from `$HOME`. Without the prefix an agent authenticates
+as **James's personal account**, so every ticket, comment and status transition it
+writes is misattributed to a human who didn't do it — and `@mentions` notify the wrong
+person. A global hook blocks unprefixed calls, but it matches on the command text, so
+it also fires on greps that merely *contain* the string; reword those rather than
+dropping the prefix.
+
+Human, in your own terminal: use the bare `exponential ...` — the prefix is for agents.
+
 ### Proactive Behavior
-- **At session start**: Run `exponential actions list --project mvp_development-cmlf3zmw40005l804w0eg28p4 --json` to check current tasks and priorities
+- **At session start**: Run the "current tasks" command below to check current tasks and priorities
 - **When picking up new work**: Check the project board for the latest task assignments and statuses
 - **After completing work**: Update task status if applicable
 
 ### Key CLI Commands
 ```bash
 # Check current tasks for this project
-exponential actions list --project mvp_development-cmlf3zmw40005l804w0eg28p4 --json
+HOME=/Users/james/.config/agent-homes/claude exponential actions list --project mvp_development-cmlf3zmw40005l804w0eg28p4 --json
 
 # View kanban board
-exponential actions kanban --json
+HOME=/Users/james/.config/agent-homes/claude exponential actions kanban --json
 
 # List all projects in the workspace
-exponential projects list --workspace exponential --json
+HOME=/Users/james/.config/agent-homes/claude exponential projects list --workspace exponential --json
 
-# Check auth status
-exponential auth status
+# Check auth status — also the fastest way to confirm which identity you are
+HOME=/Users/james/.config/agent-homes/claude exponential auth status
 ```
 
 The CLI outputs JSON when piped or when `--json` is passed, making it easy to parse programmatically. In a terminal it uses colored pretty output.
+
+Two flag gotchas that cost a round-trip each: `--project` takes the **bare CUID**, not the
+slug-prefixed id from the URL; and `tickets show` takes neither `--product` nor `--workspace`,
+so filter `tickets list --json` instead of calling `show` with them.
 
 ## Architecture Overview
 

--- a/docs/agents/commenting.md
+++ b/docs/agents/commenting.md
@@ -2,6 +2,13 @@
 
 Every commentable entity in Exponential is reachable from the `exponential` CLI. Add `--json` (or pipe) for machine-readable output.
 
+> **Agents:** every command on this page must be prefixed with
+> `HOME=/Users/james/.config/agent-homes/claude`. The examples below omit it for
+> readability. This page matters more than most: without the prefix your comment
+> is posted *as James*, so a note meant to read as an agent's finding arrives as
+> his. See the CLI section of
+> [`CLAUDE.md`](../../CLAUDE.md#-agents-every-exponential-call-needs-the-home-prefix).
+
 | Entity | Command |
 | --- | --- |
 | Feature (PRD) | `exponential features comment {list,add,reply,update,rm,resolve,unresolve}` |

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -2,6 +2,12 @@
 
 Issues and PRDs for this repo live in [Exponential](https://www.exponential.im). Use the `exponential` CLI for all operations. Add `--json` to any command (or pipe it) to get machine-readable output.
 
+> **Agents:** every command on this page must be prefixed with
+> `HOME=/Users/james/.config/agent-homes/claude`. The examples below omit it for
+> readability. Without it you authenticate as James's personal account and
+> everything you write is attributed to him. See the CLI section of
+> [`CLAUDE.md`](../../CLAUDE.md#-agents-every-exponential-call-needs-the-home-prefix).
+
 ## This repo's coordinates
 
 - **Workspace**: `syntrofi` (CUID `cmk01wbrb000arzxzj8zy4czg`)


### PR DESCRIPTION
## What

Both automated reviewers have been reporting success while reviewing nothing.

PR-Agent swallows provider errors: it posts `Failed to generate code suggestions for PR` as a PR comment and **exits 0**. The job goes green. That's worse than having no reviewer, because the tick reads as "someone looked at this".

Caught on [PR 530](https://github.com/positonic/exponential/pull/530) — four failure notices sat unread on the PR beneath two green ticks:

| Reviewer | Provider error |
|---|---|
| PR Agent review | `AnthropicException — "Your credit balance is too low to access the Anthropic API."` |
| PR Agent review (GLM) | `OpenrouterException — "Insufficient credits. This account never purchased credits."` |

The Anthropic fallback model is on the same key, so it failed too. And the GLM reviewer's error means that second opinion has **never once run** since it was added — nothing ever surfaced that.

## How

Each workflow now stamps a start time before the action, then afterwards checks the PR for failure notices posted inside that window and fails the job if it finds any, with the likely cause in the annotation.

Scoping to the run's own window is load-bearing: matching all comments would leave the check red on every later push to the same PR, long after the cause was fixed.

## Verification

The detection script was run against PR 530's real comments:

- window covering the failed run → **exit 1**, prints the matched notices
- window after all comments → **exit 0**
- event with no PR number → **exit 0**, no-op

**This PR's own PR-Agent checks are expected to go red** — the credits are still exhausted. That's the fix working. Neither check is in branch protection's required set (`Migrations apply cleanly`, `Lint & Typecheck`, `Unit Tests`, `Integration Tests`, `Build`), so a red tick reports the outage without blocking merges.

## Also: agents were writing to Exponential as James

`CLAUDE.md` documented the `exponential` CLI as bare `exponential ...`. The CLI reads credentials from `$HOME`, so an agent following those examples authenticates as James's personal account — every ticket, comment and status transition it writes is attributed to a human who didn't do it, and `@mentions` notify the wrong person. A global hook blocks this, but the docs were teaching the form the hook rejects.

`CLAUDE.md` now leads with the `HOME=` prefix and uses it in every example; `docs/agents/issue-tracker.md` and `docs/agents/commenting.md` get a banner rather than 20+ inline prefixes.

## Not fixed

The credit balances. Those need topping up on the `ANTHROPIC_KEY` and `OPENROUTER_API_KEY` secrets — until then these two checks stay red, which is the point.