### PR TITLE
fix(goals): partial updateGoal, workspace-scoped okr.getAll, mount setParent

### DIFF
--- a/src/app/_components/CreateGoalModal.tsx
+++ b/src/app/_components/CreateGoalModal.tsx
@@ -4,6 +4,7 @@ import { Modal, Button, Group, TextInput, Select, Text, Textarea, MultiSelect, N
 import { IconPlus, IconTrash, IconX } from '@tabler/icons-react';
 import { useDisclosure } from '@mantine/hooks';
 import { useState, useEffect, useMemo } from "react";
+import { buildGoalUpdatePayload } from "./goalUpdatePayload";
 import { api } from "~/trpc/react";
 import { UnifiedDatePicker } from './UnifiedDatePicker';
 import { CreateProjectModal } from './CreateProjectModal';
@@ -425,6 +426,10 @@ export function CreateGoalModal({ children, goal, trigger, projectId, defaultWor
       setSelectedOutcomeIds(goal.outcomes?.map(o => o.id) ?? []);
       setSelectedWorkspaceId(goal.workspaceId ?? null);
       setDriUserId(goal.driUserId ?? null);
+      // These two were missing, so a `goal` that arrived after mount left them
+      // holding the initial render's values — and both are posted on save.
+      setStatus(goal.status ?? "active");
+      setParentGoalId(goal.parentGoalId != null ? String(goal.parentGoalId) : null);
     }
   }, [goal]);
 
@@ -531,28 +536,26 @@ export function CreateGoalModal({ children, goal, trigger, projectId, defaultWor
             };
 
             if (goal?.id) {
-              // updateGoal only writes the keys it receives, so this full editor
-              // posts an explicit null for every field it owns and initialises
-              // from the goal — otherwise clearing an input wouldn't persist.
-              // `projectId` is the exception: the form seeds it from the caller's
-              // project prop, never from the goal, so an unset value means "don't
-              // touch the links" rather than "unlink everything".
-              updateGoal.mutate({
-                id: goal.id,
-                title,
-                description: description || null,
-                whyThisGoal: whyThisGoal || null,
-                notes: notes || null,
-                dueDate: dueDate ?? null,
-                period: period ?? null,
-                status: (status as "planned" | "active" | "completed" | "archived") ?? undefined,
-                lifeDomainId: lifeDomainId ?? null,
-                projectId: selectedProjectId,
-                outcomeIds: selectedOutcomeIds,
-                driUserId: driUserId ?? undefined,
-                workspaceId: selectedWorkspaceId ?? null,
-                parentGoalId: parentGoalId ? Number(parentGoalId) : null,
-              });
+              // Which keys this payload claims is the whole safety question —
+              // see buildGoalUpdatePayload. Extracted so it can be tested
+              // without mounting the modal.
+              updateGoal.mutate(
+                buildGoalUpdatePayload(goal, {
+                  title,
+                  description,
+                  whyThisGoal,
+                  notes,
+                  dueDate,
+                  period,
+                  status,
+                  lifeDomainId,
+                  selectedProjectId,
+                  driUserId,
+                  selectedOutcomeIds,
+                  selectedWorkspaceId,
+                  parentGoalId,
+                }),
+              );
             } else {
               createGoal.mutate(goalData);
             }

--- a/src/app/_components/CreateGoalModal.tsx
+++ b/src/app/_components/CreateGoalModal.tsx
@@ -186,6 +186,12 @@ export function CreateGoalModal({ children, goal, trigger, projectId, defaultWor
           projects: [],
           outcomes: [],
           childGoals: [],
+          keyResults: [],
+          workspace: null,
+          // A brand-new goal has no key results and no override, so its
+          // resolved progress is "no signal" until the refetch lands.
+          resolvedProgress: null,
+          isProgressManual: false,
           _count: { keyResults: 0 },
         };
         return old ? [...old, optimisticGoal] : [optimisticGoal];

--- a/src/app/_components/CreateGoalModal.tsx
+++ b/src/app/_components/CreateGoalModal.tsx
@@ -234,15 +234,20 @@ export function CreateGoalModal({ children, goal, trigger, projectId, defaultWor
 
       utils.goal.getAllMyGoals.setData(undefined, (old) => {
         if (!old) return old;
+        // updateGoal is a partial update: an omitted field keeps its current
+        // value, an explicit null clears it. The optimistic patch must mirror
+        // that, or the row flickers to null before the refetch corrects it.
+        const patch = <T,>(next: T | undefined, current: T) =>
+          next !== undefined ? next : current;
         return old.map(g => g.id === updatedGoal.id ? {
           ...g,
-          title: updatedGoal.title,
-          description: updatedGoal.description ?? null,
-          whyThisGoal: updatedGoal.whyThisGoal ?? null,
-          notes: updatedGoal.notes ?? null,
-          dueDate: updatedGoal.dueDate ?? null,
-          period: updatedGoal.period ?? null,
-          lifeDomainId: updatedGoal.lifeDomainId ?? null,
+          title: patch(updatedGoal.title, g.title),
+          description: patch(updatedGoal.description, g.description),
+          whyThisGoal: patch(updatedGoal.whyThisGoal, g.whyThisGoal),
+          notes: patch(updatedGoal.notes, g.notes),
+          dueDate: patch(updatedGoal.dueDate, g.dueDate),
+          period: patch(updatedGoal.period, g.period),
+          lifeDomainId: patch(updatedGoal.lifeDomainId, g.lifeDomainId),
         } : g);
       });
 
@@ -520,9 +525,27 @@ export function CreateGoalModal({ children, goal, trigger, projectId, defaultWor
             };
 
             if (goal?.id) {
+              // updateGoal only writes the keys it receives, so this full editor
+              // posts an explicit null for every field it owns and initialises
+              // from the goal — otherwise clearing an input wouldn't persist.
+              // `projectId` is the exception: the form seeds it from the caller's
+              // project prop, never from the goal, so an unset value means "don't
+              // touch the links" rather than "unlink everything".
               updateGoal.mutate({
                 id: goal.id,
-                ...goalData,
+                title,
+                description: description || null,
+                whyThisGoal: whyThisGoal || null,
+                notes: notes || null,
+                dueDate: dueDate ?? null,
+                period: period ?? null,
+                status: (status as "planned" | "active" | "completed" | "archived") ?? undefined,
+                lifeDomainId: lifeDomainId ?? null,
+                projectId: selectedProjectId,
+                outcomeIds: selectedOutcomeIds,
+                driUserId: driUserId ?? undefined,
+                workspaceId: selectedWorkspaceId ?? null,
+                parentGoalId: parentGoalId ? Number(parentGoalId) : null,
               });
             } else {
               createGoal.mutate(goalData);

--- a/src/app/_components/__tests__/goalUpdatePayload.test.ts
+++ b/src/app/_components/__tests__/goalUpdatePayload.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildGoalUpdatePayload,
+  type EditableGoal,
+  type GoalEditFormState,
+} from "../goalUpdatePayload";
+
+/**
+ * The incident these guard against: a `{id, title, status}` update wiped
+ * `period` and `workspaceId` and orphaned a goal out of its workspace. The
+ * server side is fixed — `updateGoal` is a partial update now — which moves the
+ * risk here: the edit form posts explicit nulls to make "clear this field"
+ * work, and a null for a field the form was never told about means the same
+ * orphaning by a different route.
+ */
+function form(overrides: Partial<GoalEditFormState> = {}): GoalEditFormState {
+  return {
+    title: "Ship OKR support",
+    description: "",
+    whyThisGoal: "",
+    notes: "",
+    dueDate: null,
+    period: "Q3-2026",
+    status: "active",
+    lifeDomainId: null,
+    selectedProjectId: undefined,
+    driUserId: null,
+    // What the form seeds to when the caller's goal object omitted these.
+    selectedOutcomeIds: [],
+    selectedWorkspaceId: null,
+    parentGoalId: null,
+    ...overrides,
+  };
+}
+
+describe("buildGoalUpdatePayload — never claims a field the caller withheld", () => {
+  // GoalsTable's shape: no workspaceId, no parentGoalId.
+  it("omits workspaceId and parentGoalId when the goal prop lacked them", () => {
+    const goal: EditableGoal = { id: 46, outcomes: [] };
+
+    const payload = buildGoalUpdatePayload(goal, form());
+
+    expect("workspaceId" in payload).toBe(false);
+    expect("parentGoalId" in payload).toBe(false);
+    expect(payload.title).toBe("Ship OKR support");
+  });
+
+  // GoalDetailContent's shape: no outcomes.
+  it("omits outcomeIds when the goal prop lacked outcomes", () => {
+    const goal: EditableGoal = {
+      id: 46,
+      workspaceId: "ws1",
+      parentGoalId: null,
+    };
+
+    const payload = buildGoalUpdatePayload(goal, form());
+
+    expect("outcomeIds" in payload).toBe(false);
+  });
+
+  it("sends a workspace the prop carried, including a real null", () => {
+    const withWorkspace = buildGoalUpdatePayload(
+      { id: 46, workspaceId: "ws1" },
+      form({ selectedWorkspaceId: "ws1" }),
+    );
+    expect(withWorkspace.workspaceId).toBe("ws1");
+
+    // A personal goal genuinely has workspaceId: null — present, so it sends.
+    const personal = buildGoalUpdatePayload(
+      { id: 46, workspaceId: null },
+      form({ selectedWorkspaceId: null }),
+    );
+    expect("workspaceId" in personal).toBe(true);
+    expect(personal.workspaceId).toBeNull();
+  });
+
+  it("lets the user actually clear a field the prop carried", () => {
+    const payload = buildGoalUpdatePayload(
+      { id: 46, workspaceId: "ws1", parentGoalId: 15, outcomes: [{ id: "o1" }] },
+      form({
+        selectedWorkspaceId: null,
+        parentGoalId: null,
+        selectedOutcomeIds: [],
+      }),
+    );
+
+    expect(payload.workspaceId).toBeNull();
+    expect(payload.parentGoalId).toBeNull();
+    expect(payload.outcomeIds).toEqual([]);
+  });
+
+  it("converts the parent picker's string to a number", () => {
+    const payload = buildGoalUpdatePayload(
+      { id: 47, parentGoalId: 15 },
+      form({ parentGoalId: "15" }),
+    );
+
+    expect(payload.parentGoalId).toBe(15);
+  });
+
+  it("normalises empty text inputs to null so they clear", () => {
+    const payload = buildGoalUpdatePayload(
+      { id: 46 },
+      form({ description: "", whyThisGoal: "", notes: "" }),
+    );
+
+    expect(payload.description).toBeNull();
+    expect(payload.whyThisGoal).toBeNull();
+    expect(payload.notes).toBeNull();
+  });
+
+  // projectId is seeded from the caller's project prop rather than the goal, so
+  // an unset value must not read as "unlink every project".
+  it("leaves projectId undefined when the form has no project selected", () => {
+    const payload = buildGoalUpdatePayload({ id: 46 }, form());
+
+    expect(payload.projectId).toBeUndefined();
+  });
+
+  // The specific regression: GoalsTable renaming a workspace goal.
+  it("a rename from a prop without workspaceId cannot orphan the goal", () => {
+    const goal: EditableGoal = { id: 46, outcomes: [{ id: "o1" }] };
+
+    const payload = buildGoalUpdatePayload(
+      goal,
+      form({ title: "Renamed", selectedWorkspaceId: null }),
+    );
+
+    expect(payload.title).toBe("Renamed");
+    expect("workspaceId" in payload).toBe(false);
+    expect("parentGoalId" in payload).toBe(false);
+  });
+});

--- a/src/app/_components/goalUpdatePayload.ts
+++ b/src/app/_components/goalUpdatePayload.ts
@@ -1,0 +1,92 @@
+/**
+ * Builds the `goal.updateGoal` payload for the edit form.
+ *
+ * `updateGoal` is a partial update: a key it receives is written, a key it
+ * doesn't is left alone, and an explicit `null` clears. That makes "which keys
+ * do we send?" the whole safety question, so it lives here rather than inline in
+ * the modal — it is the logic behind an incident, and it deserves a test.
+ *
+ * The rule: a field is only claimed when the caller's `goal` object actually
+ * carried it. Callers hand-build that object and most omit something, so an
+ * absent field means the form never learned its value — its state seeded to
+ * `null`/`[]`, and sending that would read as "clear it". That is precisely how
+ * a goal gets pushed out of its workspace by someone who only renamed it.
+ * A `null` that IS present in the prop is a real value and still sends.
+ */
+
+/** The subset of the goal the edit form is given. Optional keys may be absent. */
+export interface EditableGoal {
+  id: number;
+  status?: string;
+  parentGoalId?: number | null;
+  outcomes?: { id: string }[];
+  workspaceId?: string | null;
+  driUserId?: string | null;
+}
+
+/** Current form state, already normalised by the modal's inputs. */
+export interface GoalEditFormState {
+  title: string;
+  description: string;
+  whyThisGoal: string;
+  notes: string;
+  dueDate: Date | null;
+  period: string | null;
+  status: string | null;
+  lifeDomainId: number | null;
+  selectedProjectId: string | undefined;
+  driUserId: string | null;
+  selectedOutcomeIds: string[];
+  selectedWorkspaceId: string | null;
+  /** The parent picker holds a string; the API wants a number. */
+  parentGoalId: string | null;
+}
+
+export interface GoalUpdatePayload {
+  id: number;
+  title: string;
+  description: string | null;
+  whyThisGoal: string | null;
+  notes: string | null;
+  dueDate: Date | null;
+  period: string | null;
+  status?: "planned" | "active" | "completed" | "archived";
+  lifeDomainId: number | null;
+  projectId?: string;
+  driUserId?: string;
+  outcomeIds?: string[];
+  workspaceId?: string | null;
+  parentGoalId?: number | null;
+}
+
+export function buildGoalUpdatePayload(
+  goal: EditableGoal,
+  form: GoalEditFormState,
+): GoalUpdatePayload {
+  return {
+    id: goal.id,
+    title: form.title,
+    description: form.description || null,
+    whyThisGoal: form.whyThisGoal || null,
+    notes: form.notes || null,
+    dueDate: form.dueDate ?? null,
+    period: form.period ?? null,
+    status:
+      (form.status as "planned" | "active" | "completed" | "archived") ??
+      undefined,
+    lifeDomainId: form.lifeDomainId ?? null,
+    // Seeded from the caller's project prop, never from the goal, so an unset
+    // value means "leave the links alone" rather than "unlink everything".
+    projectId: form.selectedProjectId,
+    driUserId: form.driUserId ?? undefined,
+    ...(goal.outcomes !== undefined
+      ? { outcomeIds: form.selectedOutcomeIds }
+      : {}),
+    ...(goal.workspaceId !== undefined
+      ? { workspaceId: form.selectedWorkspaceId ?? null }
+      : {}),
+    ...(goal.parentGoalId !== undefined
+      ? { parentGoalId: form.parentGoalId ? Number(form.parentGoalId) : null }
+      : {}),
+  };
+}

--- a/src/plugins/okr/server/routers/__tests__/keyResultAccess.integration.test.ts
+++ b/src/plugins/okr/server/routers/__tests__/keyResultAccess.integration.test.ts
@@ -408,3 +408,74 @@ describe("okr.getById honours team-derived workspace access", () => {
     ).rejects.toThrow(/not found/i);
   });
 });
+
+// A key result follows its objective's workspace. Retargeting it across a
+// workspace boundary without moving it leaves the row readable and writable by
+// the original workspace's members while it belongs to another workspace's
+// objective — the divergence `create` already refuses.
+describe("moving a key result between objectives moves its workspace", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("re-homes the key result when the target objective is in another workspace", async () => {
+    const { owner, ws, keyResult } = await seedWorkspaceKeyResult(db);
+    const otherWs = await createWorkspace(db, { ownerId: owner.id });
+    const targetGoal = await createGoal(db, {
+      userId: owner.id,
+      workspaceId: otherWs.id,
+      title: "Objective over there",
+    });
+
+    await createTestCaller(owner.id).okr.update({
+      id: keyResult.id,
+      goalId: targetGoal.id,
+    });
+
+    const after = await db.keyResult.findUniqueOrThrow({
+      where: { id: keyResult.id },
+    });
+    expect(after.goalId).toBe(targetGoal.id);
+    expect(after.workspaceId).toBe(otherWs.id);
+    expect(after.workspaceId).not.toBe(ws.id);
+  });
+
+  it("leaves the workspace alone on an ordinary field update", async () => {
+    const { owner, ws, keyResult } = await seedWorkspaceKeyResult(db);
+
+    await createTestCaller(owner.id).okr.update({
+      id: keyResult.id,
+      title: "Just a rename",
+    });
+
+    const after = await db.keyResult.findUniqueOrThrow({
+      where: { id: keyResult.id },
+    });
+    expect(after.workspaceId).toBe(ws.id);
+  });
+
+  it("no longer leaves the old workspace's members able to write it", async () => {
+    const { owner, ws, keyResult } = await seedWorkspaceKeyResult(db);
+    const oldMember = await createUser(db);
+    await addWorkspaceMember(db, ws.id, oldMember.id);
+    const otherWs = await createWorkspace(db, { ownerId: owner.id });
+    const targetGoal = await createGoal(db, {
+      userId: owner.id,
+      workspaceId: otherWs.id,
+    });
+
+    await createTestCaller(owner.id).okr.update({
+      id: keyResult.id,
+      goalId: targetGoal.id,
+    });
+
+    await expect(
+      createTestCaller(oldMember.id).okr.checkIn({
+        keyResultId: keyResult.id,
+        newValue: 999,
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+});

--- a/src/plugins/okr/server/routers/__tests__/keyResultAccess.integration.test.ts
+++ b/src/plugins/okr/server/routers/__tests__/keyResultAccess.integration.test.ts
@@ -235,3 +235,136 @@ describe("okr key result mutations authorize owner OR workspace member", () => {
     ).rejects.toThrow(/not found/i);
   });
 });
+
+/**
+ * Membership is not edit rights. `viewer` is read-only and `guest` is
+ * synthesized for project-only access, so authorizing a write on
+ * `getWorkspaceMembership` alone hands both of them the ability to move a key
+ * result's value, retarget it onto another objective, or delete it — things
+ * they could previously only read. `canEditWorkspaceContent` is the repo's
+ * answer to that, and its docstring says as much.
+ */
+describe("okr writes require edit rights, not bare membership", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  async function seedWithViewer() {
+    const seeded = await seedWorkspaceKeyResult(db);
+    const viewer = await createUser(db);
+    await addWorkspaceMember(db, seeded.ws.id, viewer.id, "viewer");
+    return { ...seeded, viewer };
+  }
+
+  it("refuses a viewer's check-in", async () => {
+    const { viewer, keyResult } = await seedWithViewer();
+
+    await expect(
+      createTestCaller(viewer.id).okr.checkIn({
+        keyResultId: keyResult.id,
+        newValue: 999,
+      }),
+    ).rejects.toThrow(/not found/i);
+
+    const after = await db.keyResult.findUniqueOrThrow({
+      where: { id: keyResult.id },
+    });
+    expect(after.currentValue).toBe(40);
+  });
+
+  it("refuses a viewer's update and delete", async () => {
+    const { viewer, keyResult } = await seedWithViewer();
+    const caller = createTestCaller(viewer.id);
+
+    await expect(
+      caller.okr.update({ id: keyResult.id, targetValue: 1 }),
+    ).rejects.toThrow(/not found/i);
+    await expect(caller.okr.delete({ id: keyResult.id })).rejects.toThrow(
+      /not found/i,
+    );
+    expect(
+      await db.keyResult.findUnique({ where: { id: keyResult.id } }),
+    ).not.toBeNull();
+  });
+
+  it("refuses a viewer creating a key result on the objective", async () => {
+    const { viewer, goal } = await seedWithViewer();
+
+    await expect(
+      createTestCaller(viewer.id).okr.create({
+        goalId: goal.id,
+        title: "Nope",
+        targetValue: 1,
+        startValue: 0,
+        currentValue: 0,
+        unit: "count",
+        period: "Q3-2026",
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it("but a viewer can still read", async () => {
+    const { viewer, ws, keyResult } = await seedWithViewer();
+
+    const list = await createTestCaller(viewer.id).okr.getAll({
+      workspaceId: ws.id,
+    });
+
+    expect(list.map((kr) => kr.id)).toEqual([keyResult.id]);
+  });
+
+  it("still lets an ordinary member write", async () => {
+    const { member, keyResult } = await seedWithViewer();
+
+    await createTestCaller(member.id).okr.checkIn({
+      keyResultId: keyResult.id,
+      newValue: 100,
+    });
+
+    const after = await db.keyResult.findUniqueOrThrow({
+      where: { id: keyResult.id },
+    });
+    expect(after.currentValue).toBe(100);
+  });
+});
+
+describe("a key result belongs to its objective's workspace", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("inherits the objective's workspace rather than a caller-supplied one", async () => {
+    const { owner, ws, goal } = await seedWorkspaceKeyResult(db);
+    const other = await createWorkspace(db, { ownerId: owner.id });
+
+    await expect(
+      createTestCaller(owner.id).okr.create({
+        goalId: goal.id,
+        title: "Smuggled",
+        targetValue: 1,
+        startValue: 0,
+        currentValue: 0,
+        unit: "count",
+        period: "Q3-2026",
+        workspaceId: other.id,
+      }),
+    ).rejects.toThrow(/objective's workspace/i);
+
+    expect(await db.keyResult.count({ where: { workspaceId: other.id } })).toBe(0);
+
+    const created = await createTestCaller(owner.id).okr.create({
+      goalId: goal.id,
+      title: "Inherited",
+      targetValue: 1,
+      startValue: 0,
+      currentValue: 0,
+      unit: "count",
+      period: "Q3-2026",
+    });
+    expect(created.workspaceId).toBe(ws.id);
+  });
+});

--- a/src/plugins/okr/server/routers/__tests__/keyResultAccess.integration.test.ts
+++ b/src/plugins/okr/server/routers/__tests__/keyResultAccess.integration.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestDb } from "~/test/test-db";
+import { createTestCaller } from "~/test/trpc-helpers";
+import {
+  createUser,
+  createWorkspace,
+  addWorkspaceMember,
+  createGoal,
+} from "~/test/factories";
+
+/**
+ * `okr` is the KEY RESULT router (objectives live on `goal`). These tests pin
+ * down two fixes:
+ *
+ *   - `getAll` accepted a `workspaceId` but still filtered by `userId`, so a
+ *     member got `[]` for a colleague's key results. It now mirrors
+ *     `getByObjective`: validate membership, then return the workspace's KRs.
+ *   - `create`/`update`/`checkIn`/`delete` were owner-only while `linkProject`
+ *     and `linkFeature` already allowed owner OR workspace member. A teammate
+ *     could attach work to a KR but never move its value, which blocks
+ *     agent-driven check-ins entirely.
+ */
+async function seedWorkspaceKeyResult(db: ReturnType<typeof getTestDb>) {
+  const owner = await createUser(db);
+  const member = await createUser(db);
+  const stranger = await createUser(db);
+  const ws = await createWorkspace(db, { ownerId: owner.id });
+  await addWorkspaceMember(db, ws.id, member.id);
+  const goal = await createGoal(db, {
+    userId: owner.id,
+    workspaceId: ws.id,
+    title: "Grow activation",
+  });
+  const keyResult = await db.keyResult.create({
+    data: {
+      goalId: goal.id,
+      userId: owner.id,
+      workspaceId: ws.id,
+      title: "Weekly active teams 40 → 120",
+      startValue: 40,
+      currentValue: 40,
+      targetValue: 120,
+      unit: "count",
+      period: "Q3-2026",
+    },
+  });
+  return { owner, member, stranger, ws, goal, keyResult };
+}
+
+describe("okr.getAll workspace scoping", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("returns a colleague's key results to a workspace member", async () => {
+    const { member, ws, keyResult } = await seedWorkspaceKeyResult(db);
+
+    const results = await createTestCaller(member.id).okr.getAll({
+      workspaceId: ws.id,
+    });
+
+    expect(results.map((kr) => kr.id)).toEqual([keyResult.id]);
+  });
+
+  it("narrows back to the caller's own key results with onlyMine", async () => {
+    const { member, ws } = await seedWorkspaceKeyResult(db);
+
+    const results = await createTestCaller(member.id).okr.getAll({
+      workspaceId: ws.id,
+      onlyMine: true,
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  it("rejects a non-member", async () => {
+    const { stranger, ws } = await seedWorkspaceKeyResult(db);
+
+    await expect(
+      createTestCaller(stranger.id).okr.getAll({ workspaceId: ws.id }),
+    ).rejects.toThrow(/access/i);
+  });
+
+  it("still returns only the caller's own key results with no workspaceId", async () => {
+    const { member } = await seedWorkspaceKeyResult(db);
+
+    const results = await createTestCaller(member.id).okr.getAll();
+
+    expect(results).toEqual([]);
+  });
+
+  it("filters by goal, period and status", async () => {
+    const { owner, ws, goal, keyResult } = await seedWorkspaceKeyResult(db);
+    await db.keyResult.create({
+      data: {
+        goalId: goal.id,
+        userId: owner.id,
+        workspaceId: ws.id,
+        title: "Different period",
+        targetValue: 10,
+        period: "Q2-2026",
+      },
+    });
+
+    const caller = createTestCaller(owner.id);
+    const byPeriod = await caller.okr.getAll({
+      workspaceId: ws.id,
+      period: "Q3-2026",
+    });
+    expect(byPeriod.map((kr) => kr.id)).toEqual([keyResult.id]);
+
+    const byGoal = await caller.okr.getAll({ workspaceId: ws.id, goalId: goal.id });
+    expect(byGoal).toHaveLength(2);
+
+    const byStatus = await caller.okr.getAll({
+      workspaceId: ws.id,
+      status: "achieved",
+    });
+    expect(byStatus).toEqual([]);
+  });
+});
+
+describe("okr key result mutations authorize owner OR workspace member", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("lets a member check in against a colleague's key result", async () => {
+    const { member, keyResult } = await seedWorkspaceKeyResult(db);
+
+    await createTestCaller(member.id).okr.checkIn({
+      keyResultId: keyResult.id,
+      newValue: 100,
+      notes: "agent check-in",
+    });
+
+    const after = await db.keyResult.findUniqueOrThrow({
+      where: { id: keyResult.id },
+    });
+    expect(after.currentValue).toBe(100);
+    expect(after.status).toBe("on-track");
+  });
+
+  it("lets a member update a colleague's key result", async () => {
+    const { member, keyResult } = await seedWorkspaceKeyResult(db);
+
+    await createTestCaller(member.id).okr.update({
+      id: keyResult.id,
+      title: "Weekly active teams 40 → 150",
+      targetValue: 150,
+    });
+
+    const after = await db.keyResult.findUniqueOrThrow({
+      where: { id: keyResult.id },
+    });
+    expect(after.targetValue).toBe(150);
+  });
+
+  it("lets a member add a key result to a colleague's objective, inheriting the workspace", async () => {
+    const { member, ws, goal } = await seedWorkspaceKeyResult(db);
+
+    const created = await createTestCaller(member.id).okr.create({
+      goalId: goal.id,
+      title: "NPS 30 → 45",
+      targetValue: 45,
+      startValue: 30,
+      currentValue: 30,
+      unit: "count",
+      period: "Q3-2026",
+    });
+
+    expect(created.workspaceId).toBe(ws.id);
+  });
+
+  it("lets a member read a colleague's key result by id", async () => {
+    const { member, keyResult } = await seedWorkspaceKeyResult(db);
+
+    const fetched = await createTestCaller(member.id).okr.getById({
+      id: keyResult.id,
+    });
+
+    expect(fetched.id).toBe(keyResult.id);
+  });
+
+  it("lets a member delete a colleague's key result", async () => {
+    const { member, keyResult } = await seedWorkspaceKeyResult(db);
+
+    await createTestCaller(member.id).okr.delete({ id: keyResult.id });
+
+    expect(
+      await db.keyResult.findUnique({ where: { id: keyResult.id } }),
+    ).toBeNull();
+  });
+
+  it("still refuses a non-member on every mutation", async () => {
+    const { stranger, goal, keyResult } = await seedWorkspaceKeyResult(db);
+    const caller = createTestCaller(stranger.id);
+
+    await expect(
+      caller.okr.update({ id: keyResult.id, targetValue: 1 }),
+    ).rejects.toThrow(/not found/i);
+    await expect(
+      caller.okr.checkIn({ keyResultId: keyResult.id, newValue: 1 }),
+    ).rejects.toThrow(/not found/i);
+    await expect(caller.okr.delete({ id: keyResult.id })).rejects.toThrow(
+      /not found/i,
+    );
+    await expect(
+      caller.okr.create({
+        goalId: goal.id,
+        title: "Nope",
+        targetValue: 1,
+        startValue: 0,
+        currentValue: 0,
+        unit: "count",
+        period: "Q3-2026",
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it("refuses to move a key result onto an objective the caller cannot access", async () => {
+    const { member, keyResult } = await seedWorkspaceKeyResult(db);
+    const outsider = await createUser(db);
+    const foreignGoal = await createGoal(db, { userId: outsider.id });
+
+    await expect(
+      createTestCaller(member.id).okr.update({
+        id: keyResult.id,
+        goalId: foreignGoal.id,
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+});

--- a/src/plugins/okr/server/routers/__tests__/keyResultAccess.integration.test.ts
+++ b/src/plugins/okr/server/routers/__tests__/keyResultAccess.integration.test.ts
@@ -6,6 +6,7 @@ import {
   createWorkspace,
   addWorkspaceMember,
   createGoal,
+  createTeam,
 } from "~/test/factories";
 
 /**
@@ -366,5 +367,44 @@ describe("a key result belongs to its objective's workspace", () => {
       period: "Q3-2026",
     });
     expect(created.workspaceId).toBe(ws.id);
+  });
+});
+
+// An inline `workspace.members.some` filter sees only direct WorkspaceUser
+// rows, so a user whose access comes via a team would 404 on the very key
+// result getAll/getByObjective just handed them. linkProject records having
+// been bitten by this; getById goes through the resolver for the same reason.
+describe("okr.getById honours team-derived workspace access", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("lets a team-derived member read a key result they have no direct membership for", async () => {
+    const { ws, keyResult } = await seedWorkspaceKeyResult(db);
+    const teamUser = await createUser(db);
+    const team = await createTeam(db, { workspaceId: ws.id });
+    await db.teamUser.create({ data: { teamId: team.id, userId: teamUser.id } });
+
+    // No WorkspaceUser row — access exists only through the team.
+    expect(
+      await db.workspaceUser.findFirst({
+        where: { userId: teamUser.id, workspaceId: ws.id },
+      }),
+    ).toBeNull();
+
+    const fetched = await createTestCaller(teamUser.id).okr.getById({
+      id: keyResult.id,
+    });
+    expect(fetched.id).toBe(keyResult.id);
+  });
+
+  it("still refuses someone with no access at all", async () => {
+    const { stranger, keyResult } = await seedWorkspaceKeyResult(db);
+
+    await expect(
+      createTestCaller(stranger.id).okr.getById({ id: keyResult.id }),
+    ).rejects.toThrow(/not found/i);
   });
 });

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -479,14 +479,13 @@ export const keyResultRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       // Owner OR workspace member. `getAll`/`getByObjective` are workspace-wide,
       // so an owner-only detail read would 404 on rows those lists just returned.
+      // The membership test runs after the fetch, through the centralized
+      // resolver, so team-derived workspace access is honored — an inline
+      // `members.some` sees only direct WorkspaceUser rows and would 404 a team
+      // member on the very key result the list handed them. linkProject records
+      // having been bitten by exactly that.
       const keyResult = await ctx.db.keyResult.findFirst({
-        where: {
-          id: input.id,
-          OR: [
-            { userId: ctx.session.user.id },
-            { workspace: { members: { some: { userId: ctx.session.user.id } } } },
-          ],
-        },
+        where: { id: input.id },
         include: {
           goal: {
             include: {
@@ -540,7 +539,18 @@ export const keyResultRouter = createTRPCRouter({
         },
       });
 
-      if (!keyResult) {
+      if (
+        !keyResult ||
+        !(
+          keyResult.userId === ctx.session.user.id ||
+          (keyResult.workspaceId &&
+            (await getWorkspaceMembership(
+              ctx.db,
+              ctx.session.user.id,
+              keyResult.workspaceId,
+            )))
+        )
+      ) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Key result not found",

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -672,6 +672,7 @@ export const keyResultRouter = createTRPCRouter({
       }
 
       // Reassigning to a different objective requires access to the target too.
+      let movedWorkspaceId: string | null | undefined;
       if (updateData.goalId != null && updateData.goalId !== existing!.goalId) {
         const targetGoal = await ctx.db.goal.findUnique({
           where: { id: updateData.goalId },
@@ -684,11 +685,22 @@ export const keyResultRouter = createTRPCRouter({
             message: "Objective not found",
           });
         }
+
+        // A key result follows its objective's workspace — the same invariant
+        // `create` enforces. Retargeting without moving it would leave the row
+        // readable and writable by the ORIGINAL workspace's members while it
+        // hangs off another workspace's objective.
+        movedWorkspaceId = targetGoal!.workspaceId;
       }
 
       return ctx.db.keyResult.update({
         where: { id },
-        data: updateData,
+        data: {
+          ...updateData,
+          ...(movedWorkspaceId !== undefined
+            ? { workspaceId: movedWorkspaceId }
+            : {}),
+        },
         include: {
           goal: true,
         },

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -2,7 +2,10 @@ import { z } from "zod";
 import type { PrismaClient } from "@prisma/client";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
-import { getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
+import {
+  getWorkspaceMembership,
+  canEditWorkspaceContent,
+} from "~/server/services/access/resolvers/workspaceResolver";
 import {
   getProjectAccess,
   canEditProject,
@@ -57,14 +60,21 @@ async function getTicketProgressByFeature(
 }
 
 /**
- * Owner-OR-workspace-member authorization for a key result, the same model
- * `linkProject`/`linkFeature` use. `create`/`update`/`checkIn`/`delete` used to
- * require ownership, which meant a teammate (or a service account driving an
- * agent) could link work to a key result but not move its value — the exact
- * shape that blocks agent-driven check-ins. Pass the already-fetched row so
- * callers that need the full record don't query twice.
+ * May this user WRITE this key result?
+ *
+ * `create`/`update`/`checkIn`/`delete` used to require ownership, which meant a
+ * teammate (or a service account driving an agent) could link work to a key
+ * result but never move its value — the exact shape that blocks agent-driven
+ * check-ins. So membership counts, but only membership that carries edit
+ * rights: `viewer` is read-only and `guest` is synthesized for project-only
+ * access, and `getWorkspaceMembership` alone would let both write. That is what
+ * `canEditWorkspaceContent` exists to decide (see its docstring).
+ *
+ * The row's own owner always qualifies, regardless of workspace role.
+ * Pass the already-fetched record so callers needing the full row don't query
+ * twice.
  */
-async function canAccessKeyResult(
+async function canWriteKeyResult(
   db: PrismaClient,
   userId: string,
   keyResult: { userId: string; workspaceId: string | null } | null,
@@ -72,15 +82,16 @@ async function canAccessKeyResult(
   if (!keyResult) return false;
   if (keyResult.userId === userId) return true;
   if (!keyResult.workspaceId) return false;
-  return !!(await getWorkspaceMembership(db, userId, keyResult.workspaceId));
+  const membership = await getWorkspaceMembership(db, userId, keyResult.workspaceId);
+  return canEditWorkspaceContent(membership?.role ?? null);
 }
 
 /**
- * Owner-, DRI- or workspace-member access to an objective. Mirrors
- * `goalService.verifyGoalAccess` — used here to decide whether a key result may
- * hang off this goal, so KR authz matches the goal router's own read/write rule.
+ * May this user attach or move key results on this objective? Same rule as
+ * above: owner or DRI outright — both are explicit designations on the row —
+ * otherwise a workspace role that carries edit rights, never bare membership.
  */
-async function canAccessGoal(
+async function canWriteGoalKeyResults(
   db: PrismaClient,
   userId: string,
   goal: { userId: string; driUserId: string | null; workspaceId: string | null } | null,
@@ -88,7 +99,8 @@ async function canAccessGoal(
   if (!goal) return false;
   if (goal.userId === userId || goal.driUserId === userId) return true;
   if (!goal.workspaceId) return false;
-  return !!(await getWorkspaceMembership(db, userId, goal.workspaceId));
+  const membership = await getWorkspaceMembership(db, userId, goal.workspaceId);
+  return canEditWorkspaceContent(membership?.role ?? null);
 }
 
 // Input validation schemas
@@ -599,19 +611,31 @@ export const keyResultRouter = createTRPCRouter({
         select: { id: true, userId: true, driUserId: true, workspaceId: true },
       });
 
-      if (!(await canAccessGoal(ctx.db, ctx.session.user.id, goal))) {
+      if (!(await canWriteGoalKeyResults(ctx.db, ctx.session.user.id, goal))) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Goal not found or access denied",
         });
       }
 
+      // A key result's workspace is not the caller's to choose: it decides who
+      // can see and write the row, and letting it diverge from the objective's
+      // would strand the two behind different access checks. It is inherited,
+      // and an explicit value that disagrees is refused rather than ignored.
+      if (
+        input.workspaceId !== undefined &&
+        input.workspaceId !== goal!.workspaceId
+      ) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "A key result must belong to its objective's workspace",
+        });
+      }
+
       return ctx.db.keyResult.create({
         data: {
           ...input,
-          // A KR created against a workspace goal belongs to that workspace, so
-          // the owner-OR-member checks above resolve for every other member too.
-          workspaceId: input.workspaceId ?? goal!.workspaceId,
+          workspaceId: goal!.workspaceId,
           driUserId: input.driUserId ?? ctx.session.user.id,
           userId: ctx.session.user.id,
         },
@@ -630,7 +654,7 @@ export const keyResultRouter = createTRPCRouter({
       // Owner OR workspace member (mirrors linkProject).
       const existing = await ctx.db.keyResult.findFirst({ where: { id } });
 
-      if (!(await canAccessKeyResult(ctx.db, ctx.session.user.id, existing))) {
+      if (!(await canWriteKeyResult(ctx.db, ctx.session.user.id, existing))) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Key result not found",
@@ -644,7 +668,7 @@ export const keyResultRouter = createTRPCRouter({
           select: { id: true, userId: true, driUserId: true, workspaceId: true },
         });
 
-        if (!(await canAccessGoal(ctx.db, ctx.session.user.id, targetGoal))) {
+        if (!(await canWriteGoalKeyResults(ctx.db, ctx.session.user.id, targetGoal))) {
           throw new TRPCError({
             code: "NOT_FOUND",
             message: "Objective not found",
@@ -673,7 +697,7 @@ export const keyResultRouter = createTRPCRouter({
 
       if (
         !keyResult ||
-        !(await canAccessKeyResult(ctx.db, ctx.session.user.id, keyResult))
+        !(await canWriteKeyResult(ctx.db, ctx.session.user.id, keyResult))
       ) {
         throw new TRPCError({
           code: "NOT_FOUND",
@@ -736,7 +760,7 @@ export const keyResultRouter = createTRPCRouter({
         where: { id: input.id },
       });
 
-      if (!(await canAccessKeyResult(ctx.db, ctx.session.user.id, existing))) {
+      if (!(await canWriteKeyResult(ctx.db, ctx.session.user.id, existing))) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Key result not found",

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -197,12 +197,14 @@ export const keyResultRouter = createTRPCRouter({
       // membership, then return every member's KRs. Scoping by userId as well
       // would hand a member an empty list for a colleague's key results.
       // Without a workspaceId this stays the caller's personal list.
-      const isWorkspaceScoped = !!input?.workspaceId;
-      if (isWorkspaceScoped) {
+      // Bind it once: the local narrows on its own, which keeps the where
+      // clause free of non-null assertions on an optional input.
+      const workspaceId = input?.workspaceId;
+      if (workspaceId) {
         const membership = await getWorkspaceMembership(
           ctx.db,
           ctx.session.user.id,
-          input!.workspaceId!,
+          workspaceId,
         );
         if (!membership) {
           throw new TRPCError({
@@ -214,9 +216,9 @@ export const keyResultRouter = createTRPCRouter({
 
       return ctx.db.keyResult.findMany({
         where: {
-          ...(isWorkspaceScoped
+          ...(workspaceId
             ? {
-                workspaceId: input!.workspaceId,
+                workspaceId,
                 ...(input?.onlyMine ? { userId: ctx.session.user.id } : {}),
               }
             : { userId: ctx.session.user.id }),

--- a/src/plugins/okr/server/routers/keyResult.ts
+++ b/src/plugins/okr/server/routers/keyResult.ts
@@ -56,6 +56,41 @@ async function getTicketProgressByFeature(
   return progress;
 }
 
+/**
+ * Owner-OR-workspace-member authorization for a key result, the same model
+ * `linkProject`/`linkFeature` use. `create`/`update`/`checkIn`/`delete` used to
+ * require ownership, which meant a teammate (or a service account driving an
+ * agent) could link work to a key result but not move its value — the exact
+ * shape that blocks agent-driven check-ins. Pass the already-fetched row so
+ * callers that need the full record don't query twice.
+ */
+async function canAccessKeyResult(
+  db: PrismaClient,
+  userId: string,
+  keyResult: { userId: string; workspaceId: string | null } | null,
+): Promise<boolean> {
+  if (!keyResult) return false;
+  if (keyResult.userId === userId) return true;
+  if (!keyResult.workspaceId) return false;
+  return !!(await getWorkspaceMembership(db, userId, keyResult.workspaceId));
+}
+
+/**
+ * Owner-, DRI- or workspace-member access to an objective. Mirrors
+ * `goalService.verifyGoalAccess` — used here to decide whether a key result may
+ * hang off this goal, so KR authz matches the goal router's own read/write rule.
+ */
+async function canAccessGoal(
+  db: PrismaClient,
+  userId: string,
+  goal: { userId: string; driUserId: string | null; workspaceId: string | null } | null,
+): Promise<boolean> {
+  if (!goal) return false;
+  if (goal.userId === userId || goal.driUserId === userId) return true;
+  if (!goal.workspaceId) return false;
+  return !!(await getWorkspaceMembership(db, userId, goal.workspaceId));
+}
+
 // Input validation schemas
 const createKeyResultInput = z.object({
   goalId: z.number(),
@@ -152,14 +187,39 @@ export const keyResultRouter = createTRPCRouter({
           status: z
             .enum(["not-started", "on-track", "at-risk", "off-track", "achieved"])
             .optional(),
+          /** Narrow a workspace-scoped list back to the caller's own KRs. */
+          onlyMine: z.boolean().optional(),
         })
         .optional()
     )
     .query(async ({ ctx, input }) => {
+      // Workspace-scoped means workspace-wide, mirroring getByObjective: validate
+      // membership, then return every member's KRs. Scoping by userId as well
+      // would hand a member an empty list for a colleague's key results.
+      // Without a workspaceId this stays the caller's personal list.
+      const isWorkspaceScoped = !!input?.workspaceId;
+      if (isWorkspaceScoped) {
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          ctx.session.user.id,
+          input!.workspaceId!,
+        );
+        if (!membership) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "You don't have access to this workspace",
+          });
+        }
+      }
+
       return ctx.db.keyResult.findMany({
         where: {
-          userId: ctx.session.user.id,
-          ...(input?.workspaceId ? { workspaceId: input.workspaceId } : {}),
+          ...(isWorkspaceScoped
+            ? {
+                workspaceId: input!.workspaceId,
+                ...(input?.onlyMine ? { userId: ctx.session.user.id } : {}),
+              }
+            : { userId: ctx.session.user.id }),
           ...(input?.goalId ? { goalId: input.goalId } : {}),
           ...(input?.period ? { period: input.period } : {}),
           ...(input?.status ? { status: input.status } : {}),
@@ -403,10 +463,15 @@ export const keyResultRouter = createTRPCRouter({
   getById: protectedProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
+      // Owner OR workspace member. `getAll`/`getByObjective` are workspace-wide,
+      // so an owner-only detail read would 404 on rows those lists just returned.
       const keyResult = await ctx.db.keyResult.findFirst({
         where: {
           id: input.id,
-          userId: ctx.session.user.id,
+          OR: [
+            { userId: ctx.session.user.id },
+            { workspace: { members: { some: { userId: ctx.session.user.id } } } },
+          ],
         },
         include: {
           goal: {
@@ -526,15 +591,13 @@ export const keyResultRouter = createTRPCRouter({
   create: protectedProcedure
     .input(createKeyResultInput)
     .mutation(async ({ ctx, input }) => {
-      // Verify goal belongs to user
-      const goal = await ctx.db.goal.findFirst({
-        where: {
-          id: input.goalId,
-          userId: ctx.session.user.id,
-        },
+      // Owner, DRI or workspace member may add a key result to an objective.
+      const goal = await ctx.db.goal.findUnique({
+        where: { id: input.goalId },
+        select: { id: true, userId: true, driUserId: true, workspaceId: true },
       });
 
-      if (!goal) {
+      if (!(await canAccessGoal(ctx.db, ctx.session.user.id, goal))) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Goal not found or access denied",
@@ -544,6 +607,9 @@ export const keyResultRouter = createTRPCRouter({
       return ctx.db.keyResult.create({
         data: {
           ...input,
+          // A KR created against a workspace goal belongs to that workspace, so
+          // the owner-OR-member checks above resolve for every other member too.
+          workspaceId: input.workspaceId ?? goal!.workspaceId,
           driUserId: input.driUserId ?? ctx.session.user.id,
           userId: ctx.session.user.id,
         },
@@ -559,25 +625,24 @@ export const keyResultRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { id, ...updateData } = input;
 
-      // Verify ownership
-      const existing = await ctx.db.keyResult.findFirst({
-        where: { id, userId: ctx.session.user.id },
-      });
+      // Owner OR workspace member (mirrors linkProject).
+      const existing = await ctx.db.keyResult.findFirst({ where: { id } });
 
-      if (!existing) {
+      if (!(await canAccessKeyResult(ctx.db, ctx.session.user.id, existing))) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Key result not found",
         });
       }
 
-      // If reassigning to a different objective, verify the user owns the target goal
-      if (updateData.goalId != null && updateData.goalId !== existing.goalId) {
-        const targetGoal = await ctx.db.goal.findFirst({
-          where: { id: updateData.goalId, userId: ctx.session.user.id },
+      // Reassigning to a different objective requires access to the target too.
+      if (updateData.goalId != null && updateData.goalId !== existing!.goalId) {
+        const targetGoal = await ctx.db.goal.findUnique({
+          where: { id: updateData.goalId },
+          select: { id: true, userId: true, driUserId: true, workspaceId: true },
         });
 
-        if (!targetGoal) {
+        if (!(await canAccessGoal(ctx.db, ctx.session.user.id, targetGoal))) {
           throw new TRPCError({
             code: "NOT_FOUND",
             message: "Objective not found",
@@ -598,14 +663,16 @@ export const keyResultRouter = createTRPCRouter({
   checkIn: protectedProcedure
     .input(checkInInput)
     .mutation(async ({ ctx, input }) => {
+      // Owner OR workspace member (mirrors linkProject) — a check-in is the
+      // routine team/agent write on a KR, so it must not be owner-only.
       const keyResult = await ctx.db.keyResult.findFirst({
-        where: {
-          id: input.keyResultId,
-          userId: ctx.session.user.id,
-        },
+        where: { id: input.keyResultId },
       });
 
-      if (!keyResult) {
+      if (
+        !keyResult ||
+        !(await canAccessKeyResult(ctx.db, ctx.session.user.id, keyResult))
+      ) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Key result not found",
@@ -662,11 +729,12 @@ export const keyResultRouter = createTRPCRouter({
   delete: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
+      // Owner OR workspace member (mirrors linkProject).
       const existing = await ctx.db.keyResult.findFirst({
-        where: { id: input.id, userId: ctx.session.user.id },
+        where: { id: input.id },
       });
 
-      if (!existing) {
+      if (!(await canAccessKeyResult(ctx.db, ctx.session.user.id, existing))) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Key result not found",

--- a/src/server/api/routers/__tests__/goalPartialUpdate.integration.test.ts
+++ b/src/server/api/routers/__tests__/goalPartialUpdate.integration.test.ts
@@ -249,6 +249,38 @@ describe("goal workspace placement is an access change", () => {
     expect(after.workspaceId).toBe(ws.id);
   });
 
+  it("refuses a viewer placing a goal into the workspace they can only read", async () => {
+    const owner = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: owner.id });
+    const viewer = await createUser(db);
+    await addWorkspaceMember(db, ws.id, viewer.id, "viewer");
+
+    await expect(
+      createTestCaller(viewer.id).goal.createGoal({
+        title: "Read-only should not file this",
+        workspaceId: ws.id,
+      }),
+    ).rejects.toThrow(/not a member/i);
+  });
+
+  it("refuses a viewer moving a goal into that workspace", async () => {
+    const owner = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: owner.id });
+    const viewer = await createUser(db);
+    await addWorkspaceMember(db, ws.id, viewer.id, "viewer");
+    const personal = await createGoal(db, { userId: viewer.id });
+
+    await expect(
+      createTestCaller(viewer.id).goal.updateGoal({
+        id: personal.id,
+        workspaceId: ws.id,
+      }),
+    ).rejects.toThrow(/not a member/i);
+
+    const after = await db.goal.findUniqueOrThrow({ where: { id: personal.id } });
+    expect(after.workspaceId).toBeNull();
+  });
+
   it("refuses to create a goal in a workspace the caller is not in", async () => {
     const user = await createUser(db);
     const outsider = await createUser(db);

--- a/src/server/api/routers/__tests__/goalPartialUpdate.integration.test.ts
+++ b/src/server/api/routers/__tests__/goalPartialUpdate.integration.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getTestDb } from "~/test/test-db";
+import { createTestCaller } from "~/test/trpc-helpers";
+import {
+  createUser,
+  createWorkspace,
+  addWorkspaceMember,
+  createGoal,
+  createProject,
+} from "~/test/factories";
+
+/**
+ * Regression suite for the destructive `goal.updateGoal` overwrite.
+ *
+ * The incident: an agent archived a workspace goal with `{id, title, status}`.
+ * Because every field was coerced with `?? null`, the same call wiped `period`
+ * and `workspaceId` — orphaning the goal out of its workspace, which then made
+ * the access check fall through to owner-only and locked the agent out of its
+ * own change. The rule these tests pin down: an omitted key is never written,
+ * and only an explicit `null` clears a column.
+ */
+describe("goal.updateGoal — partial update semantics", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  async function seedGoal() {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const lifeDomain = await db.lifeDomain.create({
+      data: { title: `Domain ${Math.random()}` },
+    });
+    const project = await createProject(db, {
+      createdById: user.id,
+      workspaceId: ws.id,
+    });
+    const goal = await db.goal.create({
+      data: {
+        title: "Ship OKR support",
+        userId: user.id,
+        workspaceId: ws.id,
+        period: "Q3-2026",
+        status: "active",
+        lifeDomainId: lifeDomain.id,
+        description: "original description",
+        projects: { connect: [{ id: project.id }] },
+      },
+    });
+    return { user, ws, lifeDomain, project, goal, caller: createTestCaller(user.id) };
+  }
+
+  it("a {id, title, status} update leaves period, workspace, life domain and project links intact", async () => {
+    const { caller, goal, ws, lifeDomain, project } = await seedGoal();
+
+    await caller.goal.updateGoal({
+      id: goal.id,
+      title: "Ship OKR support (archived)",
+      status: "archived",
+    });
+
+    const after = await db.goal.findUniqueOrThrow({
+      where: { id: goal.id },
+      include: { projects: true },
+    });
+    expect(after.title).toBe("Ship OKR support (archived)");
+    expect(after.status).toBe("archived");
+    expect(after.period).toBe("Q3-2026");
+    expect(after.workspaceId).toBe(ws.id);
+    expect(after.lifeDomainId).toBe(lifeDomain.id);
+    expect(after.description).toBe("original description");
+    expect(after.projects.map((p) => p.id)).toEqual([project.id]);
+  });
+
+  it("an id-only update writes nothing at all", async () => {
+    const { caller, goal, ws, project } = await seedGoal();
+
+    await caller.goal.updateGoal({ id: goal.id });
+
+    const after = await db.goal.findUniqueOrThrow({
+      where: { id: goal.id },
+      include: { projects: true },
+    });
+    expect(after.title).toBe("Ship OKR support");
+    expect(after.period).toBe("Q3-2026");
+    expect(after.workspaceId).toBe(ws.id);
+    expect(after.projects.map((p) => p.id)).toEqual([project.id]);
+  });
+
+  it("an explicit null clears the field", async () => {
+    const { caller, goal } = await seedGoal();
+
+    await caller.goal.updateGoal({
+      id: goal.id,
+      period: null,
+      description: null,
+      lifeDomainId: null,
+    });
+
+    const after = await db.goal.findUniqueOrThrow({ where: { id: goal.id } });
+    expect(after.period).toBeNull();
+    expect(after.description).toBeNull();
+    expect(after.lifeDomainId).toBeNull();
+  });
+
+  it("clears project links only when projectId is explicitly null", async () => {
+    const { caller, goal } = await seedGoal();
+
+    await caller.goal.updateGoal({ id: goal.id, projectId: null });
+
+    const after = await db.goal.findUniqueOrThrow({
+      where: { id: goal.id },
+      include: { projects: true },
+    });
+    expect(after.projects).toEqual([]);
+  });
+
+  it("replaces project links when projectId names a different project", async () => {
+    const { caller, goal, user, ws } = await seedGoal();
+    const other = await createProject(db, {
+      createdById: user.id,
+      workspaceId: ws.id,
+    });
+
+    await caller.goal.updateGoal({ id: goal.id, projectId: other.id });
+
+    const after = await db.goal.findUniqueOrThrow({
+      where: { id: goal.id },
+      include: { projects: true },
+    });
+    expect(after.projects.map((p) => p.id)).toEqual([other.id]);
+  });
+
+  it("replaces project links wholesale from projectIds", async () => {
+    const { caller, goal, user, ws, project } = await seedGoal();
+    const second = await createProject(db, {
+      createdById: user.id,
+      workspaceId: ws.id,
+    });
+
+    await caller.goal.updateGoal({
+      id: goal.id,
+      projectIds: [project.id, second.id],
+    });
+
+    const after = await db.goal.findUniqueOrThrow({
+      where: { id: goal.id },
+      include: { projects: true },
+    });
+    expect(after.projects.map((p) => p.id).sort()).toEqual(
+      [project.id, second.id].sort(),
+    );
+  });
+
+  it("lets a workspace member who does not own the goal update it without orphaning it", async () => {
+    const { goal, ws, project } = await seedGoal();
+    const member = await createUser(db);
+    await addWorkspaceMember(db, ws.id, member.id);
+
+    await createTestCaller(member.id).goal.updateGoal({
+      id: goal.id,
+      title: "Renamed by a teammate",
+    });
+
+    const after = await db.goal.findUniqueOrThrow({
+      where: { id: goal.id },
+      include: { projects: true },
+    });
+    expect(after.title).toBe("Renamed by a teammate");
+    expect(after.workspaceId).toBe(ws.id);
+    expect(after.projects.map((p) => p.id)).toEqual([project.id]);
+  });
+});
+
+describe("goal.updateGoalStatus", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("writes only the status column", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const goal = await createGoal(db, {
+      userId: user.id,
+      workspaceId: ws.id,
+      period: "Q3-2026",
+      status: "active",
+    });
+
+    await createTestCaller(user.id).goal.updateGoalStatus({
+      id: goal.id,
+      status: "completed",
+    });
+
+    const after = await db.goal.findUniqueOrThrow({ where: { id: goal.id } });
+    expect(after.status).toBe("completed");
+    expect(after.period).toBe("Q3-2026");
+    expect(after.workspaceId).toBe(ws.id);
+  });
+
+  it("accepts on-hold, which updateGoal's enum does not", async () => {
+    const user = await createUser(db);
+    const goal = await createGoal(db, { userId: user.id });
+
+    await createTestCaller(user.id).goal.updateGoalStatus({
+      id: goal.id,
+      status: "on-hold",
+    });
+
+    const after = await db.goal.findUniqueOrThrow({ where: { id: goal.id } });
+    expect(after.status).toBe("on-hold");
+  });
+});
+
+describe("goal.setParent", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("re-parents without touching any other field", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const project = await createProject(db, {
+      createdById: user.id,
+      workspaceId: ws.id,
+    });
+    const annual = await createGoal(db, {
+      userId: user.id,
+      workspaceId: ws.id,
+      title: "Annual",
+      period: "Annual-2026",
+    });
+    const quarterly = await db.goal.create({
+      data: {
+        title: "Q3",
+        userId: user.id,
+        workspaceId: ws.id,
+        period: "Q3-2026",
+        projects: { connect: [{ id: project.id }] },
+      },
+    });
+
+    await createTestCaller(user.id).goal.setParent({
+      id: quarterly.id,
+      parentGoalId: annual.id,
+    });
+
+    const after = await db.goal.findUniqueOrThrow({
+      where: { id: quarterly.id },
+      include: { projects: true },
+    });
+    expect(after.parentGoalId).toBe(annual.id);
+    expect(after.period).toBe("Q3-2026");
+    expect(after.workspaceId).toBe(ws.id);
+    expect(after.projects.map((p) => p.id)).toEqual([project.id]);
+  });
+
+  it("detaches when parentGoalId is null", async () => {
+    const user = await createUser(db);
+    const parent = await createGoal(db, { userId: user.id, title: "Parent" });
+    const child = await createGoal(db, {
+      userId: user.id,
+      title: "Child",
+      parentGoalId: parent.id,
+    });
+
+    await createTestCaller(user.id).goal.setParent({
+      id: child.id,
+      parentGoalId: null,
+    });
+
+    const after = await db.goal.findUniqueOrThrow({ where: { id: child.id } });
+    expect(after.parentGoalId).toBeNull();
+  });
+
+  it("rejects a goal being its own parent", async () => {
+    const user = await createUser(db);
+    const goal = await createGoal(db, { userId: user.id });
+
+    await expect(
+      createTestCaller(user.id).goal.setParent({
+        id: goal.id,
+        parentGoalId: goal.id,
+      }),
+    ).rejects.toThrow(/own parent/i);
+  });
+
+  it("rejects a cycle", async () => {
+    const user = await createUser(db);
+    const parent = await createGoal(db, { userId: user.id, title: "Parent" });
+    const child = await createGoal(db, {
+      userId: user.id,
+      title: "Child",
+      parentGoalId: parent.id,
+    });
+
+    await expect(
+      createTestCaller(user.id).goal.setParent({
+        id: parent.id,
+        parentGoalId: child.id,
+      }),
+    ).rejects.toThrow(/cycle/i);
+  });
+});
+
+describe("goal.getAllMyGoals filters", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("filters a workspace list by period and status", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    await createGoal(db, {
+      userId: user.id,
+      workspaceId: ws.id,
+      title: "Current",
+      period: "Q3-2026",
+      status: "active",
+    });
+    await createGoal(db, {
+      userId: user.id,
+      workspaceId: ws.id,
+      title: "Last quarter",
+      period: "Q2-2026",
+      status: "completed",
+    });
+
+    const caller = createTestCaller(user.id);
+    const byPeriod = await caller.goal.getAllMyGoals({
+      workspaceId: ws.id,
+      period: "Q3-2026",
+    });
+    expect(byPeriod.map((g) => g.title)).toEqual(["Current"]);
+
+    const byStatus = await caller.goal.getAllMyGoals({
+      workspaceId: ws.id,
+      status: "completed",
+    });
+    expect(byStatus.map((g) => g.title)).toEqual(["Last quarter"]);
+  });
+});

--- a/src/server/api/routers/__tests__/goalPartialUpdate.integration.test.ts
+++ b/src/server/api/routers/__tests__/goalPartialUpdate.integration.test.ts
@@ -346,4 +346,110 @@ describe("goal.getAllMyGoals filters", () => {
     });
     expect(byStatus.map((g) => g.title)).toEqual(["Last quarter"]);
   });
+
+  // A goal list with no progress number can't answer "which goal is starving",
+  // which is the whole point of reading goals outside the app.
+  it("resolves progress from the goal's key results", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const goal = await createGoal(db, { userId: user.id, workspaceId: ws.id });
+    await db.keyResult.create({
+      data: {
+        goalId: goal.id,
+        userId: user.id,
+        workspaceId: ws.id,
+        title: "Half done",
+        startValue: 0,
+        currentValue: 50,
+        targetValue: 100,
+        period: "Q3-2026",
+      },
+    });
+
+    const [found] = await createTestCaller(user.id).goal.getAllMyGoals({
+      workspaceId: ws.id,
+    });
+
+    expect(found!.resolvedProgress).toBe(50);
+    expect(found!.isProgressManual).toBe(false);
+    expect(found!.keyResults).toHaveLength(1);
+  });
+
+  it("a manual override wins over the key-result mean", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const goal = await createGoal(db, { userId: user.id, workspaceId: ws.id });
+    await db.keyResult.create({
+      data: {
+        goalId: goal.id,
+        userId: user.id,
+        workspaceId: ws.id,
+        title: "Half done",
+        startValue: 0,
+        currentValue: 50,
+        targetValue: 100,
+        period: "Q3-2026",
+      },
+    });
+    await db.goal.update({
+      where: { id: goal.id },
+      data: { progressOverride: 90 },
+    });
+
+    const [found] = await createTestCaller(user.id).goal.getAllMyGoals({
+      workspaceId: ws.id,
+    });
+
+    expect(found!.resolvedProgress).toBe(90);
+    expect(found!.isProgressManual).toBe(true);
+  });
+
+  it("reports null progress for a goal with no key results and no override", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    await createGoal(db, { userId: user.id, workspaceId: ws.id });
+
+    const [found] = await createTestCaller(user.id).goal.getAllMyGoals({
+      workspaceId: ws.id,
+    });
+
+    expect(found!.resolvedProgress).toBeNull();
+  });
+
+  it("includes the workspace so a cross-workspace list can label each row", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id, slug: "labelled-ws" });
+    await createGoal(db, { userId: user.id, workspaceId: ws.id });
+
+    const [found] = await createTestCaller(user.id).goal.getAllMyGoals({
+      workspaceId: ws.id,
+    });
+
+    expect(found!.workspace).toMatchObject({ id: ws.id, slug: "labelled-ws" });
+  });
+
+  it("includes each goal's projects — the join that maps actions to goals", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const project = await createProject(db, {
+      createdById: user.id,
+      workspaceId: ws.id,
+    });
+    await db.goal.create({
+      data: {
+        title: "Joined",
+        userId: user.id,
+        workspaceId: ws.id,
+        projects: { connect: [{ id: project.id }] },
+      },
+    });
+
+    const [found] = await createTestCaller(user.id).goal.getAllMyGoals({
+      workspaceId: ws.id,
+    });
+
+    expect(found!.projects.map((p) => ({ id: p.id, slug: p.slug }))).toEqual([
+      { id: project.id, slug: project.slug },
+    ]);
+  });
 });

--- a/src/server/api/routers/__tests__/goalPartialUpdate.integration.test.ts
+++ b/src/server/api/routers/__tests__/goalPartialUpdate.integration.test.ts
@@ -173,6 +173,98 @@ describe("goal.updateGoal — partial update semantics", () => {
   });
 });
 
+describe("goal workspace placement is an access change", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  // A goal's workspace decides who can see and edit it. Letting anyone who can
+  // edit a goal set an arbitrary workspaceId means they can push it somewhere
+  // they cannot see — orphaning it exactly like the overwrite bug — or somewhere
+  // they can, exposing it to that workspace's members.
+  it("refuses to move a goal into a workspace the caller is not in", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const goal = await createGoal(db, { userId: user.id, workspaceId: ws.id });
+    const outsider = await createUser(db);
+    const foreignWs = await createWorkspace(db, { ownerId: outsider.id });
+
+    await expect(
+      createTestCaller(user.id).goal.updateGoal({
+        id: goal.id,
+        workspaceId: foreignWs.id,
+      }),
+    ).rejects.toThrow(/not a member/i);
+
+    const after = await db.goal.findUniqueOrThrow({ where: { id: goal.id } });
+    expect(after.workspaceId).toBe(ws.id);
+  });
+
+  it("allows a move into a workspace the caller belongs to", async () => {
+    const user = await createUser(db);
+    const from = await createWorkspace(db, { ownerId: user.id });
+    const to = await createWorkspace(db, { ownerId: user.id });
+    const goal = await createGoal(db, { userId: user.id, workspaceId: from.id });
+
+    await createTestCaller(user.id).goal.updateGoal({
+      id: goal.id,
+      workspaceId: to.id,
+    });
+
+    const after = await db.goal.findUniqueOrThrow({ where: { id: goal.id } });
+    expect(after.workspaceId).toBe(to.id);
+  });
+
+  it("still allows clearing the workspace, which needs no membership", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const goal = await createGoal(db, { userId: user.id, workspaceId: ws.id });
+
+    await createTestCaller(user.id).goal.updateGoal({
+      id: goal.id,
+      workspaceId: null,
+    });
+
+    const after = await db.goal.findUniqueOrThrow({ where: { id: goal.id } });
+    expect(after.workspaceId).toBeNull();
+  });
+
+  it("re-sending the goal's own workspace is not treated as a move", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const goal = await createGoal(db, { userId: user.id, workspaceId: ws.id });
+    const member = await createUser(db);
+    await addWorkspaceMember(db, ws.id, member.id);
+
+    await createTestCaller(member.id).goal.updateGoal({
+      id: goal.id,
+      title: "Renamed",
+      workspaceId: ws.id,
+    });
+
+    const after = await db.goal.findUniqueOrThrow({ where: { id: goal.id } });
+    expect(after.title).toBe("Renamed");
+    expect(after.workspaceId).toBe(ws.id);
+  });
+
+  it("refuses to create a goal in a workspace the caller is not in", async () => {
+    const user = await createUser(db);
+    const outsider = await createUser(db);
+    const foreignWs = await createWorkspace(db, { ownerId: outsider.id });
+
+    await expect(
+      createTestCaller(user.id).goal.createGoal({
+        title: "Smuggled",
+        workspaceId: foreignWs.id,
+      }),
+    ).rejects.toThrow(/not a member/i);
+
+    expect(await db.goal.count({ where: { workspaceId: foreignWs.id } })).toBe(0);
+  });
+});
+
 describe("goal.updateGoalStatus", () => {
   let db: ReturnType<typeof getTestDb>;
 

--- a/src/server/api/routers/goal.ts
+++ b/src/server/api/routers/goal.ts
@@ -125,6 +125,23 @@ export const goalRouter = createTRPCRouter({
       iconColor: z.string().nullable().optional(),
     }))
     .mutation(async ({ ctx, input }) => {
+      // A goal's workspace decides who can see and edit it, so filing one into a
+      // workspace the caller doesn't belong to is an access change rather than a
+      // field edit. Mirrors the move guard in goalService.updateGoal.
+      if (input.workspaceId) {
+        const membership = await getWorkspaceMembership(
+          ctx.db,
+          ctx.session.user.id,
+          input.workspaceId,
+        );
+        if (!membership) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "You are not a member of the target workspace",
+          });
+        }
+      }
+
       // Enforce max nesting depth of 5 levels for sub-goals
       if (input.parentGoalId) {
         let depth = 1;

--- a/src/server/api/routers/goal.ts
+++ b/src/server/api/routers/goal.ts
@@ -4,7 +4,10 @@ import {
   protectedProcedure,
   publicProcedure,
 } from "~/server/api/trpc";
-import { getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
+import {
+  getWorkspaceMembership,
+  canEditWorkspaceContent,
+} from "~/server/services/access/resolvers/workspaceResolver";
 import { getProjectAccess, hasProjectAccess } from "~/server/services/access";
 import { TRPCError } from "@trpc/server";
 import { recordActivity } from "~/server/services/activity/recordActivity";
@@ -134,7 +137,9 @@ export const goalRouter = createTRPCRouter({
           ctx.session.user.id,
           input.workspaceId,
         );
-        if (!membership) {
+        // Bare membership isn't the test — viewer is read-only and guest is
+        // project-only, and neither files goals into a workspace.
+        if (!canEditWorkspaceContent(membership?.role ?? null)) {
           throw new TRPCError({
             code: "FORBIDDEN",
             message: "You are not a member of the target workspace",

--- a/src/server/api/routers/goal.ts
+++ b/src/server/api/routers/goal.ts
@@ -8,6 +8,7 @@ import { getWorkspaceMembership } from "~/server/services/access/resolvers/works
 import { getProjectAccess, hasProjectAccess } from "~/server/services/access";
 import { TRPCError } from "@trpc/server";
 import { recordActivity } from "~/server/services/activity/recordActivity";
+import { resolveGoalProgress, isManualProgress } from "~/server/services/goalProgress";
 
 import {
   getMyPublicGoals,
@@ -64,7 +65,7 @@ export const goalRouter = createTRPCRouter({
         }
       }
 
-      return await ctx.db.goal.findMany({
+      const goals = await ctx.db.goal.findMany({
         where: {
           ...(workspaceId
             ? { workspaceId }
@@ -77,10 +78,32 @@ export const goalRouter = createTRPCRouter({
           projects: true,
           outcomes: true,
           childGoals: { select: { id: true, title: true, status: true, health: true } },
+          // Key result VALUES (not just the count) so progress can be resolved
+          // below without a second round trip — a list of goals with no progress
+          // number can't answer "which goal is starving". Lean select: these
+          // payloads transit agent tool calls and CLI output.
+          keyResults: {
+            select: {
+              id: true,
+              status: true,
+              startValue: true,
+              currentValue: true,
+              targetValue: true,
+            },
+          },
+          workspace: { select: { id: true, name: true, slug: true } },
           _count: { select: { keyResults: true } },
         },
         orderBy: { displayOrder: "asc" },
       });
+
+      // Same resolved-progress contract getGoalById exposes, so every consumer
+      // reads one number instead of recomputing the override-vs-KR-mean rule.
+      return goals.map((goal) => ({
+        ...goal,
+        resolvedProgress: resolveGoalProgress(goal),
+        isProgressManual: isManualProgress(goal),
+      }));
     }),
 
   createGoal: protectedProcedure

--- a/src/server/api/routers/goal.ts
+++ b/src/server/api/routers/goal.ts
@@ -19,6 +19,7 @@ import {
   computeGoalHealth,
   updateGoalIcon,
   verifyGoalAccess,
+  setGoalParent,
 } from "~/server/services/goalService";
 
 export const goalRouter = createTRPCRouter({
@@ -47,6 +48,9 @@ export const goalRouter = createTRPCRouter({
   getAllMyGoals: protectedProcedure
     .input(z.object({
       workspaceId: z.string().optional(),
+      // OKR period, a free-form string ("Q3-2026", "Annual-2026") — not an enum.
+      period: z.string().optional(),
+      status: z.enum(["planned", "active", "completed", "archived", "on-hold"]).optional(),
     }).optional())
     .query(async ({ ctx, input }) => {
       // When workspace-scoped, validate membership and show all workspace goals
@@ -65,6 +69,8 @@ export const goalRouter = createTRPCRouter({
           ...(workspaceId
             ? { workspaceId }
             : { userId: ctx.session.user.id }),
+          ...(input?.period ? { period: input.period } : {}),
+          ...(input?.status ? { status: input.status } : {}),
         },
         include: {
           lifeDomain: true,
@@ -146,27 +152,44 @@ export const goalRouter = createTRPCRouter({
       return goal;
     }),
 
+  // Partial update: omit a field to leave it untouched, pass an explicit null to
+  // clear it. Every nullable column is `.nullable().optional()` for that reason.
+  // For a status-only change prefer `updateGoalStatus`, and to re-parent prefer
+  // `setParent` — both write a single column.
   updateGoal: protectedProcedure
     .input(z.object({
       id: z.number(),
-      title: z.string(),
-      description: z.string().optional(),
-      whyThisGoal: z.string().optional(),
-      notes: z.string().optional(),
-      dueDate: z.date().optional(),
-      period: z.string().optional(),
+      title: z.string().min(1).optional(),
+      description: z.string().nullable().optional(),
+      whyThisGoal: z.string().nullable().optional(),
+      notes: z.string().nullable().optional(),
+      dueDate: z.date().nullable().optional(),
+      period: z.string().nullable().optional(),
       status: z.enum(["planned", "active", "completed", "archived"]).optional(),
-      lifeDomainId: z.number().optional(),
-      projectId: z.string().optional(),
+      lifeDomainId: z.number().nullable().optional(),
+      projectId: z.string().nullable().optional(),
+      projectIds: z.array(z.string()).optional(),
       outcomeIds: z.array(z.string()).optional(),
-      driUserId: z.string().optional(),
-      workspaceId: z.string().optional(),
+      driUserId: z.string().nullable().optional(),
+      workspaceId: z.string().nullable().optional(),
       parentGoalId: z.number().nullable().optional(),
       displayOrder: z.number().optional(),
       icon: z.string().nullable().optional(),
       iconColor: z.string().nullable().optional(),
     }))
     .mutation(updateGoal),
+
+  // Re-parent an objective (or detach it with parentGoalId: null) WITHOUT
+  // touching any other field. The safe alternative to updateGoal for cascade
+  // edits — validates access to both goals plus the no-self/no-cycle/depth rules.
+  setParent: protectedProcedure
+    .input(z.object({
+      id: z.number(),
+      parentGoalId: z.number().nullable(),
+    }))
+    .mutation(async ({ ctx, input }) =>
+      setGoalParent({ ctx, goalId: input.id, parentGoalId: input.parentGoalId }),
+    ),
 
   getProjectGoals: protectedProcedure
     .input(z.object({ projectId: z.string() }))
@@ -185,7 +208,7 @@ export const goalRouter = createTRPCRouter({
   getGoalTree: protectedProcedure
     .input(z.object({
       workspaceId: z.string().optional(),
-      status: z.enum(["planned", "active", "completed", "archived"]).optional(),
+      status: z.enum(["planned", "active", "completed", "archived", "on-hold"]).optional(),
     }).optional())
     .query(async ({ ctx, input }) => {
       if (input?.workspaceId) {

--- a/src/server/services/goalService.ts
+++ b/src/server/services/goalService.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from "@prisma/client";
 import { type Context } from "~/server/auth/types";
 import { getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
 import { resolveGoalProgress, isManualProgress } from "~/server/services/goalProgress";
@@ -254,9 +255,41 @@ async function validateParentAssignment({
   }
 }
 
-interface UpdateGoalInput extends GoalInput {
+/**
+ * A **partial** goal update. Every field is optional and follows one rule:
+ *
+ *   - key absent / `undefined` → leave the column exactly as it is
+ *   - key present with a value → write that value
+ *   - key present as `null`    → clear the column (nullable fields only)
+ *
+ * This matters because the goal form in the web UI posts every field, while API
+ * and CLI consumers send only what changed. The old full-overwrite shape wiped
+ * `period`, `workspaceId`, `lifeDomainId` and every project link on any caller
+ * that omitted them — orphaning workspace goals out of their workspace, which in
+ * turn locked the caller out of their own goal (the access check falls through
+ * to owner-only once `workspaceId` is null).
+ */
+interface UpdateGoalInput {
   id: number;
+  title?: string;
+  description?: string | null;
+  whyThisGoal?: string | null;
+  notes?: string | null;
+  dueDate?: Date | null;
+  period?: string | null;
+  status?: string;
+  lifeDomainId?: number | null;
+  /** Replace the goal's project links with this one project; `null` clears them. */
+  projectId?: string | null;
+  /** Replace the goal's project links wholesale; `[]` clears them. */
+  projectIds?: string[];
+  outcomeIds?: string[];
+  driUserId?: string | null;
+  workspaceId?: string | null;
+  parentGoalId?: number | null;
   displayOrder?: number;
+  icon?: string | null;
+  iconColor?: string | null;
 }
 
 export async function updateGoal({ ctx, input }: { ctx: Context, input: UpdateGoalInput }) {
@@ -279,35 +312,50 @@ export async function updateGoal({ ctx, input }: { ctx: Context, input: UpdateGo
     await validateParentAssignment({ ctx, goalId: input.id, parentGoalId: input.parentGoalId });
   }
 
+  const data: Prisma.GoalUncheckedUpdateInput = {};
+  // Only keys the caller actually supplied are written — see UpdateGoalInput.
+  const assign = <K extends keyof Prisma.GoalUncheckedUpdateInput>(
+    key: K,
+    value: Prisma.GoalUncheckedUpdateInput[K] | undefined,
+  ) => {
+    if (value !== undefined) data[key] = value;
+  };
+
+  assign("title", input.title);
+  assign("description", input.description);
+  assign("whyThisGoal", input.whyThisGoal);
+  assign("notes", input.notes);
+  assign("dueDate", input.dueDate);
+  assign("period", input.period);
+  assign("status", input.status);
+  assign("lifeDomainId", input.lifeDomainId);
+  assign("driUserId", input.driUserId);
+  assign("workspaceId", input.workspaceId);
+  assign("parentGoalId", input.parentGoalId);
+  assign("displayOrder", input.displayOrder);
+  assign("icon", input.icon);
+  assign("iconColor", input.iconColor);
+
+  // Project links are replaced only when the caller names them. `projectIds`
+  // wins over the legacy single-project `projectId` when both are sent.
+  if (input.projectIds !== undefined) {
+    data.projects = { set: input.projectIds.map((id) => ({ id })) };
+  } else if (input.projectId !== undefined) {
+    data.projects =
+      input.projectId === null
+        ? { set: [] }
+        : { set: [], connect: [{ id: input.projectId }] };
+  }
+
+  if (input.outcomeIds !== undefined) {
+    data.outcomes = { set: input.outcomeIds.map((id) => ({ id })) };
+  }
+
   return await ctx.db.goal.update({
     where: {
       id: input.id,
     },
-    data: {
-      title: input.title,
-      description: input.description,
-      whyThisGoal: input.whyThisGoal,
-      notes: input.notes,
-      dueDate: input.dueDate,
-      period: input.period ?? null,
-      status: input.status ?? existingGoal.status,
-      lifeDomainId: input.lifeDomainId ?? null,
-      driUserId: input.driUserId ?? existingGoal.driUserId ?? ctx.session.user.id,
-      workspaceId: input.workspaceId ?? null,
-      parentGoalId: input.parentGoalId !== undefined ? (input.parentGoalId ?? null) : existingGoal.parentGoalId,
-      displayOrder: input.displayOrder ?? existingGoal.displayOrder,
-      icon: input.icon !== undefined ? (input.icon ?? null) : existingGoal.icon,
-      iconColor: input.iconColor !== undefined ? (input.iconColor ?? null) : existingGoal.iconColor,
-      projects: input.projectId ? {
-        set: [], // Clear existing connections
-        connect: [{ id: input.projectId }]
-      } : {
-        set: [] // Clear project connection if no projectId provided
-      },
-      outcomes: input.outcomeIds !== undefined ? {
-        set: input.outcomeIds.map(id => ({ id }))
-      } : undefined,
-    },
+    data,
     include: {
       lifeDomain: true,
       projects: true,

--- a/src/server/services/goalService.ts
+++ b/src/server/services/goalService.ts
@@ -1,6 +1,9 @@
 import type { Prisma } from "@prisma/client";
 import { type Context } from "~/server/auth/types";
-import { getWorkspaceMembership } from "~/server/services/access/resolvers/workspaceResolver";
+import {
+  getWorkspaceMembership,
+  canEditWorkspaceContent,
+} from "~/server/services/access/resolvers/workspaceResolver";
 import { resolveGoalProgress, isManualProgress } from "~/server/services/goalProgress";
 
 /**
@@ -190,7 +193,7 @@ export async function createGoal({ ctx, input }: { ctx: Context, input: GoalInpu
   // Same rule as the move path in updateGoal: you may only file a goal into a
   // workspace you belong to.
   if (input.workspaceId) {
-    await assertWorkspaceMembership({ ctx, workspaceId: input.workspaceId });
+    await assertCanPlaceGoalInWorkspace({ ctx, workspaceId: input.workspaceId });
   }
 
   return await ctx.db.goal.create({
@@ -225,12 +228,15 @@ export async function createGoal({ ctx, input }: { ctx: Context, input: GoalInpu
 }
 
 /**
- * Assert the caller belongs to a workspace they are placing a goal into.
+ * Assert the caller may place a goal into this workspace.
+ *
  * Guards the create and move paths — a goal's workspace decides who can see and
- * edit it, so writing one the caller isn't in is an access change, not a field
- * edit.
+ * edit it, so writing one is an access change, not a field edit. Bare
+ * membership is not the test: `viewer` is read-only and `guest` is synthesized
+ * for project-only access, and neither should be filing goals into a workspace.
+ * `canEditWorkspaceContent` is the repo's answer (see its docstring).
  */
-async function assertWorkspaceMembership({
+async function assertCanPlaceGoalInWorkspace({
   ctx,
   workspaceId,
 }: {
@@ -240,7 +246,7 @@ async function assertWorkspaceMembership({
   const userId = ctx.session?.user?.id;
   if (!userId) throw new Error("User not authenticated");
   const membership = await getWorkspaceMembership(ctx.db, userId, workspaceId);
-  if (!membership) {
+  if (!canEditWorkspaceContent(membership?.role ?? null)) {
     throw new Error("You are not a member of the target workspace");
   }
 }
@@ -349,7 +355,7 @@ export async function updateGoal({ ctx, input }: { ctx: Context, input: UpdateGo
     input.workspaceId !== null &&
     input.workspaceId !== existingGoal.workspaceId
   ) {
-    await assertWorkspaceMembership({ ctx, workspaceId: input.workspaceId });
+    await assertCanPlaceGoalInWorkspace({ ctx, workspaceId: input.workspaceId });
   }
 
   const data: Prisma.GoalUncheckedUpdateInput = {};

--- a/src/server/services/goalService.ts
+++ b/src/server/services/goalService.ts
@@ -187,6 +187,12 @@ export async function createGoal({ ctx, input }: { ctx: Context, input: GoalInpu
     await validateParentAssignment({ ctx, parentGoalId: input.parentGoalId });
   }
 
+  // Same rule as the move path in updateGoal: you may only file a goal into a
+  // workspace you belong to.
+  if (input.workspaceId) {
+    await assertWorkspaceMembership({ ctx, workspaceId: input.workspaceId });
+  }
+
   return await ctx.db.goal.create({
     data: {
       title: input.title,
@@ -216,6 +222,27 @@ export async function createGoal({ ctx, input }: { ctx: Context, input: GoalInpu
       outcomes: true,
     },
   });
+}
+
+/**
+ * Assert the caller belongs to a workspace they are placing a goal into.
+ * Guards the create and move paths — a goal's workspace decides who can see and
+ * edit it, so writing one the caller isn't in is an access change, not a field
+ * edit.
+ */
+async function assertWorkspaceMembership({
+  ctx,
+  workspaceId,
+}: {
+  ctx: Context;
+  workspaceId: string;
+}) {
+  const userId = ctx.session?.user?.id;
+  if (!userId) throw new Error("User not authenticated");
+  const membership = await getWorkspaceMembership(ctx.db, userId, workspaceId);
+  if (!membership) {
+    throw new Error("You are not a member of the target workspace");
+  }
 }
 
 /**
@@ -310,6 +337,19 @@ export async function updateGoal({ ctx, input }: { ctx: Context, input: UpdateGo
     input.parentGoalId
   ) {
     await validateParentAssignment({ ctx, goalId: input.id, parentGoalId: input.parentGoalId });
+  }
+
+  // Moving a goal between workspaces is an access change, so the caller must
+  // belong to where it lands. Without this, anyone who can edit a goal can push
+  // it into a workspace they cannot see — orphaning it exactly like the
+  // overwrite bug above — or into one they can, exposing it to that workspace's
+  // members. Clearing to null (making it personal) needs no membership.
+  if (
+    input.workspaceId !== undefined &&
+    input.workspaceId !== null &&
+    input.workspaceId !== existingGoal.workspaceId
+  ) {
+    await assertWorkspaceMembership({ ctx, workspaceId: input.workspaceId });
   }
 
   const data: Prisma.GoalUncheckedUpdateInput = {};


### PR DESCRIPTION
### **User description**
## What

Three genuine bugs in the Goal/OKR server surface, plus the read the CLI and MCP need.

## Bug 1 (critical) — `goal.updateGoal` was a destructive full overwrite

`period`, `workspaceId` and `lifeDomainId` were coerced with `?? null` whether or not the caller supplied them, and project links were cleared whenever `projectId` was absent. A `{id, title, status}` update therefore wiped the goal's period and pushed it out of its workspace — after which the access check falls through to owner-only and locks the caller out of their own change. This is what happened to goal 46.

The repo already knew: `setGoalParent`'s docstring calls `updateGoal` "a full overwrite that clears projects, period, workspace, etc." The web UI never hit it because its form posts every field; any API or CLI consumer doing a partial update lost data silently.

It is now a true partial update — an omitted key is never written, an explicit `null` clears. `CreateGoalModal` posts explicit nulls for the fields it owns so clearing an input still persists; `projectId` is deliberately exempt there, because the modal seeds it from the caller's project prop and never from the goal, so an unset value must mean "don't touch the links".

## Bug 2 — `okr.getAll` ignored workspace scoping

It accepted a `workspaceId` while the `where` clause still hardcoded `userId`, so a workspace member got `[]` for a colleague's key results. Now mirrors `getByObjective`: validate membership, return the workspace's key results, with `onlyMine` to opt back into the personal list.

## Bug 3 — `setGoalParent` was implemented but never mounted

A safe single-field re-parent with cycle and depth validation, documented as the alternative to `updateGoal`, reachable from nothing. Exposed as `goal.setParent`.

## Also

- **KR mutation authz.** `okr.create`/`update`/`checkIn`/`delete`/`getById` required ownership, while `linkProject`/`linkFeature` already allowed owner OR workspace member. A teammate could attach work to a key result but not move its value — which blocks agent-driven check-ins entirely. Aligned on the `linkProject` model. `checkIn` and `getById` are included beyond the original list: `checkIn` is the routine team write, and an owner-only detail read would 404 on rows the workspace-wide lists had just returned.
- **`getAllMyGoals` carries resolved progress and its workspace.** It returned only `_count.keyResults`, so progress was uncomputable from it — `resolveGoalProgress` needs the key-result values, and only `getGoalById` attached them. A goal list with no progress number can't answer "which goal is starving", which is the main reason to read goals from outside the app.
- Optional `period`/`status` filters on `getAllMyGoals`.

## Tests

39 integration tests pass, including explicit regressions that a `{id, title, status}` update leaves `period`, `workspaceId`, `lifeDomainId` and project links intact. Full unit suite (2275) green.

## Why this matters now

`exponential-cli` 1.11.0 and `exponential-mcp` 0.5.0 are published and depend on this. Until it deploys: `goals reparent` hard-errors, `goals kr list --workspace` returns empty, and `progress` reads `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Make `goal.updateGoal` a true partial update

- Scope `okr.getAll` by workspace, add `onlyMine`

- Allow owner-or-editor writes on key results

- Mount `goal.setParent`; enrich `getAllMyGoals`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["updateGoal full overwrite"] -- "assign() only supplied keys" --> B["partial update + workspace move guard"]
  C["okr.getAll filtered by userId"] -- "membership check" --> D["workspace-wide + onlyMine"]
  E["KR mutations owner-only"] -- "canEditWorkspaceContent" --> F["owner OR editing member"]
  G["setGoalParent unmounted"] -- "expose" --> H["goal.setParent"]
  I["getAllMyGoals counts only"] -- "include keyResults/workspace" --> J["resolvedProgress + filters"]
  K["CreateGoalModal inline payload"] -- "extract" --> L["buildGoalUpdatePayload + tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>goalService.ts</strong><dd><code>Partial update semantics and workspace placement guard</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/533/files#diff-c62b1b040c51cc7b80a8fa51ccfdaf5cac8556fe6adf3948134616d37c002c43">+121/-27</a></td>

</tr>

<tr>
  <td><strong>keyResult.ts</strong><dd><code>Workspace-scoped getAll and owner-or-editor KR authz</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/533/files#diff-bc84848f5eb855384754b26268587f4d82ba0a0d871410753ab5c0435dcfab3d">+149/-33</a></td>

</tr>

<tr>
  <td><strong>CreateGoalModal.tsx</strong><dd><code>Use payload builder, fix state sync and optimistic patch</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/533/files#diff-04d3453bb612a7fd7cd225b1c97a8455d5bd9073547a7de2b1541b18b4df147d">+43/-11</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>goal.ts</strong><dd><code>Nullable optional inputs, setParent route, richer goal list</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/533/files#diff-4e4d94164aebf651ae2650b8ae8f2fe5bde74bc5942f1d6bad615a3761c9d174">+81/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>goalUpdatePayload.ts</strong><dd><code>New helper building safe partial goal update payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/533/files#diff-66217f7e66b64d9106221f3063c0e96f596c67e27ae72f7b2dc8b2fb55bb71c8">+92/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>goalPartialUpdate.integration.test.ts</strong><dd><code>Integration tests for partial update, setParent, filters</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/533/files#diff-70cbd23f8df05031429da5720c14702ec82fb63998abb710f60eed3673679751">+579/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>keyResultAccess.integration.test.ts</strong><dd><code>Integration tests for key result access and scoping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/533/files#diff-31f0fe64b46975ffba417023a3c82261ea7c219c6639a3fcece733ecb5abdcb0">+481/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>goalUpdatePayload.test.ts</strong><dd><code>Unit tests for goal update payload construction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/533/files#diff-8211804804369fa389332b02e4dfd4b87d6dbb120b4610266b7b8256391b7b78">+133/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

