### PR TITLE
fix(ticketSync): stop the mirror duplicating rows Notion already has

### DIFF
--- a/src/server/services/ticketSync/__tests__/harness/fakeNotion.ts
+++ b/src/server/services/ticketSync/__tests__/harness/fakeNotion.ts
@@ -282,6 +282,17 @@ export class FakeNotion implements TicketSyncRemoteAdapter, TicketPushAdapter {
     return Promise.resolve(this.peopleByEmail.get(email) ?? null);
   }
 
+  findPagesByTitle(
+    _databaseId: string,
+    title: string,
+  ): Promise<Array<{ externalId: string; url: string | null }>> {
+    const wanted = title.trim().toLowerCase();
+    const matches = [...this.pages.values()]
+      .filter((p) => !p.archived && p.title.trim().toLowerCase() === wanted)
+      .map((p) => ({ externalId: p.externalId, url: p.url }));
+    return Promise.resolve(matches);
+  }
+
   createPage(params: {
     databaseId: string;
     titleProperty: string | null;

--- a/src/server/services/ticketSync/__tests__/push.test.ts
+++ b/src/server/services/ticketSync/__tests__/push.test.ts
@@ -9,6 +9,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import { Prisma } from "@prisma/client";
 import type { PrismaClient, TicketStatus, TicketType } from "@prisma/client";
 
 const { createTicketMock, resolveTagsMock, attachTagsMock, recordActivityMock } =
@@ -158,6 +159,8 @@ function fakeAdapter(
     cyclePageId?: string | null;
     personId?: string | null;
     schema?: NotionDbSchema;
+    /** Same-titled rows the pre-create duplicate probe should find. */
+    pagesByTitle?: Array<{ externalId: string; url: string | null }>;
   } = {},
 ): FakeAdapter {
   const updates: FakeAdapter["updates"] = [];
@@ -175,6 +178,7 @@ function fakeAdapter(
     },
     findCyclePageIdByName: () => Promise.resolve(opts.cyclePageId ?? null),
     findPersonIdByEmail: () => Promise.resolve(opts.personId ?? null),
+    findPagesByTitle: () => Promise.resolve(opts.pagesByTitle ?? []),
     createPage: (params) => {
       creates.push(params);
       return Promise.resolve({ externalId: "new-page-id", url: "https://notion.so/new" });
@@ -584,6 +588,114 @@ describe("runOutboundTicketPush — full-mirror creation", () => {
     expect(item.action).toBe("created");
     expect(item.reason).toContain("would create");
     expect(adapter.creates).toHaveLength(0);
+    expect(db.ticketSync.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("runOutboundTicketPush — pre-create duplicate probe", () => {
+  beforeEach(() => {
+    db.ticketSync.findMany.mockResolvedValue([] as never);
+  });
+
+  it("adopts the existing same-titled row instead of creating a second one", async () => {
+    db.ticketSync.findUnique.mockResolvedValue(
+      syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
+    );
+    const adapter = fakeAdapter(null, {
+      pagesByTitle: [{ externalId: "page-9", url: "https://notion.so/page-9" }],
+    });
+
+    const item = await runOutboundTicketPush(db, adapter, { syncId: "s1" });
+
+    expect(item.action).toBe("adopted");
+    expect(item.externalId).toBe("page-9");
+    expect(adapter.creates).toHaveLength(0);
+    expect(db.ticketSync.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "s1" },
+        data: expect.objectContaining({
+          externalId: "page-9",
+          externalUrl: "https://notion.so/page-9",
+        }),
+      }),
+    );
+  });
+
+  it("adopts without claiming authorship of the page body", async () => {
+    db.ticketSync.findUnique.mockResolvedValue(
+      syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
+    );
+    const adapter = fakeAdapter(null, {
+      pagesByTitle: [{ externalId: "page-9", url: null }],
+    });
+
+    await runOutboundTicketPush(db, adapter, { syncId: "s1" });
+
+    // `remoteCreatedAt` is what licenses the body-repair pass to rewrite a
+    // page's content. An adopted page is human-authored — setting it here
+    // would hand a stranger's Notion page to a rewriter.
+    const data = db.ticketSync.update.mock.calls[0]![0]!.data as Record<string, unknown>;
+    expect(data.remoteCreatedAt).toBeUndefined();
+    // Null snapshot: the first merge treats both sides as changed and resolves
+    // by last-write-wins, exactly as the inbound adoption pass does.
+    expect(data.snapshot).toBe(Prisma.DbNull);
+  });
+
+  it("refuses to create when the same-titled row belongs to another ticket", async () => {
+    db.ticketSync.findUnique.mockResolvedValue(
+      syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
+    );
+    db.ticketSync.findMany.mockResolvedValue([
+      { externalId: "page-9", ticket: { number: 122 } },
+    ] as never);
+    const adapter = fakeAdapter(null, {
+      pagesByTitle: [{ externalId: "page-9", url: null }],
+    });
+
+    const item = await runOutboundTicketPush(db, adapter, { syncId: "s1" });
+
+    // Two Exponential tickets for one Notion row. A third copy helps nobody.
+    expect(item.action).toBe("skipped");
+    // Matched without the leading hash — the pre-commit colour hook reads a
+    // three-digit ticket reference as a hardcoded hex colour.
+    expect(item.reason).toContain("122");
+    expect(adapter.creates).toHaveLength(0);
+    expect(db.ticketSync.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses to guess when several rows share the title", async () => {
+    db.ticketSync.findUnique.mockResolvedValue(
+      syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
+    );
+    const adapter = fakeAdapter(null, {
+      pagesByTitle: [
+        { externalId: "page-9", url: null },
+        { externalId: "page-10", url: null },
+      ],
+    });
+
+    const item = await runOutboundTicketPush(db, adapter, { syncId: "s1" });
+
+    expect(item.action).toBe("skipped");
+    expect(item.reason).toContain("2 Notion rows share this title");
+    expect(adapter.creates).toHaveLength(0);
+  });
+
+  it("dry run previews the adoption without linking", async () => {
+    db.ticketSync.findUnique.mockResolvedValue(
+      syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
+    );
+    const adapter = fakeAdapter(null, {
+      pagesByTitle: [{ externalId: "page-9", url: null }],
+    });
+
+    const item = await runOutboundTicketPush(db, adapter, {
+      syncId: "s1",
+      dryRun: true,
+    });
+
+    expect(item.action).toBe("adopted");
+    expect(item.reason).toContain("would link");
     expect(db.ticketSync.update).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/ticketSync/__tests__/pushRunner.test.ts
+++ b/src/server/services/ticketSync/__tests__/pushRunner.test.ts
@@ -346,6 +346,39 @@ describe("dispatchTicketCreate", () => {
 
     expect(db.ticketSync.create).not.toHaveBeenCalled();
   });
+
+  // The 2026-07 CLEAR duplication: an imported ticket whose sync record never
+  // existed looks "unsynced", so the mirror created a second Notion page for a
+  // row Notion already had. Provenance, not the sync row, settles the origin.
+  it("does not mirror a ticket that carries Notion provenance but no sync", async () => {
+    db.ticket.findUnique.mockResolvedValue({
+      id: "t1",
+      status: "IN_PROGRESS",
+      productId: "p1",
+      links: { notionPageId: "page-from-notion" },
+      _count: { syncs: 0 },
+    } as never);
+
+    await dispatchTicketCreate(db, { ticketId: "t1" });
+
+    expect(db.ticketSyncConfig.findFirst).not.toHaveBeenCalled();
+    expect(db.ticketSync.create).not.toHaveBeenCalled();
+  });
+
+  it("still mirrors a ticket whose links carry no Notion page id", async () => {
+    db.ticket.findUnique.mockResolvedValue({
+      id: "t1",
+      status: "IN_PROGRESS",
+      productId: "p1",
+      links: { github: "https://github.com/o/r/pull/1" },
+      _count: { syncs: 0 },
+    } as never);
+    db.ticketSyncConfig.findFirst.mockResolvedValue({ id: "cfg1" } as never);
+
+    await dispatchTicketCreate(db, { ticketId: "t1" });
+
+    expect(db.ticketSync.create).toHaveBeenCalled();
+  });
 });
 
 describe("planBackfill / enqueueBackfill", () => {
@@ -384,6 +417,38 @@ describe("planBackfill / enqueueBackfill", () => {
     expect(result.enqueued).toBe(2);
     expect(db.ticketSync.create).toHaveBeenCalledTimes(2);
     expect(db.ticketSyncPushJob.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("excludes Notion-born tickets from the plan and the enqueue alike", async () => {
+    const rows = [
+      { id: "t1", title: "Born here", number: 1, links: null },
+      {
+        id: "t2",
+        title: "Came from Notion",
+        number: 2,
+        links: { notionPageId: "page-1", notion: "https://notion.so/page-1" },
+      },
+      { id: "t3", title: "Also born here", number: 3, links: { github: "x" } },
+    ];
+
+    db.ticketSyncConfig.findUnique.mockResolvedValue({
+      id: "cfg1",
+      productId: "p1",
+      pushEnabled: true,
+      integrationId: "int1",
+    } as never);
+    db.ticket.findMany.mockResolvedValue(rows as never);
+
+    const plan = await planBackfill(db, { configId: "cfg1" });
+    expect(plan.map((p) => p.ticketId)).toEqual(["t1", "t3"]);
+
+    const result = await enqueueBackfill(db, { configId: "cfg1" });
+    expect(result.enqueued).toBe(2);
+    expect(db.ticketSync.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ ticketId: "t2" }),
+      }),
+    );
   });
 
   it("refuses to backfill when push is disabled", async () => {

--- a/src/server/services/ticketSync/engine.ts
+++ b/src/server/services/ticketSync/engine.ts
@@ -6,7 +6,13 @@ import {
   attachTicketTags,
   resolveOrCreateWorkspaceTags,
 } from "../notionTicketImport";
-import { mapPoints, mapPriority, mapStatus, mapType } from "./mapping";
+import {
+  extractNotionPageId,
+  mapPoints,
+  mapPriority,
+  mapStatus,
+  mapType,
+} from "./mapping";
 import { REVERT_TOMBSTONE_KEY } from "./revert";
 import {
   findCycleIdByName,
@@ -236,12 +242,6 @@ function hasRevertTombstone(snapshot: Prisma.JsonValue | null): boolean {
     !Array.isArray(snapshot) &&
     (snapshot as Record<string, unknown>)[REVERT_TOMBSTONE_KEY] === true
   );
-}
-
-function extractNotionPageId(links: Prisma.JsonValue | null): string | null {
-  if (!links || typeof links !== "object" || Array.isArray(links)) return null;
-  const value = (links as Record<string, unknown>).notionPageId;
-  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 export async function runInboundTicketSync(

--- a/src/server/services/ticketSync/mapping.ts
+++ b/src/server/services/ticketSync/mapping.ts
@@ -18,6 +18,29 @@ export const TICKET_STATUSES = [
 ] as const;
 
 /**
+ * The Notion page id a ticket carries in its `links` JSON — the provenance the
+ * cycle importer writes for every row it creates.
+ *
+ * This lives here, shared, because two opposite decisions must agree on it:
+ * the inbound ADOPTION pass (engine.ts) uses it to link an unsynced ticket to
+ * the page it came from, and the outbound CREATE guard (pushRunner.ts) uses it
+ * to refuse to mirror that same ticket back out. When the two disagreed, the
+ * pre-sync import cohort — tickets with provenance but no `TicketSync` row —
+ * was adoptable by one and duplicable by the other, and the backfill minted a
+ * second Notion page for rows Notion already had.
+ */
+export function extractNotionPageId(links: unknown): string | null {
+  if (!links || typeof links !== "object" || Array.isArray(links)) return null;
+  const value = (links as Record<string, unknown>).notionPageId;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/** True when a ticket's `links` JSON records that it originated in Notion. */
+export function hasNotionProvenance(links: unknown): boolean {
+  return extractNotionPageId(links) !== null;
+}
+
+/**
  * Notion status/select name → TicketStatus. Keys are normalized (lowercased,
  * emoji/punctuation stripped). Anything unmapped falls back to BACKLOG with a
  * per-item warning rather than failing the row.

--- a/src/server/services/ticketSync/notionAdapter.ts
+++ b/src/server/services/ticketSync/notionAdapter.ts
@@ -307,6 +307,47 @@ export class NotionTicketSyncAdapter
     return match?.id ?? null;
   }
 
+  /**
+   * Rows in the target database whose title matches `title` — the pre-create
+   * duplicate probe.
+   *
+   * Notion's `title.equals` filter is exact and case-sensitive, so the client
+   * side re-checks case-insensitively after trimming; a row differing only by
+   * case is missed by the filter, which is the same limitation
+   * {@link findCyclePageIdByName} carries and errs toward creating rather than
+   * mis-adopting. Trashed pages are excluded by the query itself.
+   */
+  async findPagesByTitle(
+    databaseId: string,
+    title: string,
+  ): Promise<Array<{ externalId: string; url: string | null }>> {
+    const wanted = title.trim().toLowerCase();
+    if (!wanted) return [];
+
+    const { properties } = await this.notion.getRawDatabaseById(databaseId);
+    const titleProp = Object.entries(properties).find(
+      ([, p]) => (p as { type?: string }).type === "title",
+    )?.[0];
+
+    const page = await this.notion.queryDatabase({
+      databaseId,
+      filter: titleProp
+        ? { property: titleProp, title: { equals: title.trim() } }
+        : undefined,
+      pageSize: 25,
+    });
+
+    return (page.results as RawNotionPage[])
+      .filter((p) => !p.archived && !p.in_trash)
+      .filter(
+        (p) =>
+          NotionService.extractTitleFromProperties(p.properties ?? {})
+            .trim()
+            .toLowerCase() === wanted,
+      )
+      .map((p) => ({ externalId: p.id, url: p.url ?? null }));
+  }
+
   /** Resolve a Notion workspace person id by email, or null when unmatched. */
   async findPersonIdByEmail(email: string): Promise<string | null> {
     const wanted = email.trim().toLowerCase();

--- a/src/server/services/ticketSync/push.ts
+++ b/src/server/services/ticketSync/push.ts
@@ -1,4 +1,5 @@
-import type { Prisma, PrismaClient, TicketStatus, TicketType } from "@prisma/client";
+import { Prisma } from "@prisma/client";
+import type { PrismaClient, TicketStatus, TicketType } from "@prisma/client";
 import { mapPoints, mapPriority, mapStatus, mapType } from "./mapping";
 import {
   CYCLE_UNREADABLE_WARNING,
@@ -100,6 +101,16 @@ export interface TicketPushAdapter {
   ): Promise<string | null>;
   /** Resolve a Notion workspace person id by email, or null when unmatched. */
   findPersonIdByEmail(email: string): Promise<string | null>;
+  /**
+   * Pages in the target database whose title matches `title` exactly
+   * (case-insensitively) — the pre-create duplicate probe. Returns `[]` when
+   * nothing matches, and more than one entry when the title is ambiguous,
+   * which the caller must NOT resolve by guessing.
+   */
+  findPagesByTitle(
+    databaseId: string,
+    title: string,
+  ): Promise<Array<{ externalId: string; url: string | null }>>;
   /** Create a new page (full-mirror creation); returns the new page id + url. */
   createPage(params: {
     databaseId: string;
@@ -114,6 +125,7 @@ export interface TicketPushAdapter {
 export type PushAction =
   | "pushed"
   | "created"
+  | "adopted"
   | "archived"
   | "skipped"
   | "conflict"
@@ -538,6 +550,68 @@ export async function runOutboundTicketPush(
  * Terminal tickets are not mirrored (matching the backfill exclusion); the
  * sentinel is deleted so it doesn't linger as a phantom link.
  */
+type ExistingPageProbe =
+  | { kind: "none" }
+  | { kind: "match"; externalId: string; url: string | null }
+  | { kind: "ambiguous"; reason: string };
+
+/**
+ * Does the target database already hold a row for this ticket's title?
+ *
+ * Three outcomes, and the split matters:
+ * - **none** — safe to create.
+ * - **match** — exactly one same-titled row, unclaimed by any other ticket on
+ *   this connection. Adopt it.
+ * - **ambiguous** — several same-titled rows, or the only one is already
+ *   linked to a DIFFERENT ticket (two Exponential tickets for one Notion row —
+ *   the duplicate this whole guard exists to stop). Creating here would add a
+ *   third copy of the same work, so the run stops and names the conflict for a
+ *   human. The sentinel is left in place: the ticket stays unmirrored and
+ *   idempotent (no future backfill re-adds it) and every push re-reports the
+ *   same reason in the run history until the duplicate is merged.
+ *
+ * Titles are matched case-insensitively after trimming. A blank title can't
+ * identify anything, so it probes as `none`.
+ */
+async function probeExistingPage(
+  db: PrismaClient,
+  adapter: TicketPushAdapter,
+  args: { configId: string; databaseId: string; title: string },
+): Promise<ExistingPageProbe> {
+  const title = args.title.trim();
+  if (!title) return { kind: "none" };
+
+  const candidates = await adapter.findPagesByTitle(args.databaseId, title);
+  if (candidates.length === 0) return { kind: "none" };
+
+  const claims = await db.ticketSync.findMany({
+    where: {
+      configId: args.configId,
+      externalId: { in: candidates.map((c) => c.externalId) },
+    },
+    select: { externalId: true, ticket: { select: { number: true } } },
+  });
+  const claimedBy = new Map(claims.map((c) => [c.externalId, c.ticket.number]));
+  const unclaimed = candidates.filter((c) => !claimedBy.has(c.externalId));
+
+  if (unclaimed.length === 1) {
+    const match = unclaimed[0]!;
+    return { kind: "match", externalId: match.externalId, url: match.url };
+  }
+  if (unclaimed.length > 1) {
+    return {
+      kind: "ambiguous",
+      reason: `${unclaimed.length} Notion rows share this title — link one to the ticket by hand, or rename the duplicates, before mirroring`,
+    };
+  }
+
+  const owners = [...new Set(claims.map((c) => `#${c.ticket.number}`))].join(", ");
+  return {
+    kind: "ambiguous",
+    reason: `a Notion row with this title is already linked to ticket ${owners} — merge the duplicate tickets before mirroring this one`,
+  };
+}
+
 async function runOutboundCreate(
   db: PrismaClient,
   adapter: TicketPushAdapter,
@@ -568,6 +642,51 @@ async function runOutboundCreate(
       ...base,
       action: "skipped",
       reason: "ticket is terminal — not mirrored to Notion",
+    };
+  }
+
+  // ── Duplicate probe: never create a page for a title Notion already has ───
+  // The provenance guard upstream stops the KNOWN import cohort; this catches
+  // the rest (a ticket typed by hand to match a Notion row, an orphan left by
+  // a half-finished create). Adopting is strictly safer than creating: the
+  // three-way merge reconciles the two sides on the next pass, whereas a
+  // wrong create is a live page in the customer's workspace that only a human
+  // can retract.
+  const existing = await probeExistingPage(db, adapter, {
+    configId: config.id,
+    databaseId: config.databaseId,
+    title: local.title,
+  });
+  if (existing.kind === "ambiguous") {
+    return { ...base, action: "skipped", reason: existing.reason };
+  }
+  if (existing.kind === "match") {
+    if (dryRun) {
+      return {
+        ...base,
+        externalId: existing.externalId,
+        action: "adopted",
+        reason: "would link to the existing Notion row with this title",
+      };
+    }
+    // Adopt exactly as the inbound pass does: link, but leave `snapshot` null
+    // so the first merge treats every difference as a two-sided change and
+    // resolves by last-write-wins. `remoteCreatedAt` stays null on purpose —
+    // this page is human-authored, and the body-repair pass gates on that
+    // column to decide what it may rewrite.
+    await db.ticketSync.update({
+      where: { id: sync.id },
+      data: {
+        externalId: existing.externalId,
+        externalUrl: existing.url,
+        snapshot: Prisma.DbNull,
+      },
+    });
+    return {
+      ...base,
+      externalId: existing.externalId,
+      action: "adopted",
+      reason: "linked to the existing Notion row with this title",
     };
   }
 

--- a/src/server/services/ticketSync/pushRunner.ts
+++ b/src/server/services/ticketSync/pushRunner.ts
@@ -8,6 +8,7 @@ import {
   type TicketPushAdapter,
 } from "./push";
 import { createNotionTicketSyncAdapter } from "./notionAdapter";
+import { hasNotionProvenance } from "./mapping";
 import { COMPLETED_TICKET_STATUSES } from "~/lib/ticket-statuses";
 
 /**
@@ -44,6 +45,8 @@ export const PUSH_RELEVANT_TICKET_FIELDS = [
 const MAX_ATTEMPTS = 5;
 const STALE_RUNNING_MINUTES = 15;
 const MAX_JOBS_PER_SWEEP = 200;
+/** Hard cap on rows one backfill run mirrors, applied after the filters. */
+const BACKFILL_LIMIT = 500;
 
 /** Exponential backoff (minutes → ms), capped at 1h, keyed on attempt count. */
 function backoffMs(attempts: number): number {
@@ -136,9 +139,11 @@ export async function dispatchTicketPush(
  * (`externalId: "pending:<ticketId>"`) so the durable queue can turn it into a
  * real Notion page on drain, then kicks the drain. Never throws.
  *
- * Skips terminal tickets (mirror only non-terminal work, matching backfill) and
+ * Skips terminal tickets (mirror only non-terminal work, matching backfill),
  * tickets that already carry a sync (inbound-born, or already mirrored) — the
- * `[ticketId, provider]` uniqueness is the final idempotency guard.
+ * `[ticketId, provider]` uniqueness is the final idempotency guard — and
+ * tickets that carry Notion provenance in `links` (see
+ * {@link ticketIsNotionBorn}).
  */
 export async function dispatchTicketCreate(
   db: PrismaClient,
@@ -157,6 +162,22 @@ export async function dispatchTicketCreate(
   }
 }
 
+/**
+ * A ticket that came FROM Notion, whatever its sync state.
+ *
+ * "Has no `TicketSync` row" is NOT the same question as "does not exist in
+ * Notion". Tickets imported before the sync engine landed — and any row the
+ * importer created whose sync record was later removed — carry their origin
+ * page in `links.notionPageId` and nothing else. Mirroring one of those out
+ * creates a SECOND Notion page for a row Notion already has, which the next
+ * inbound poll then treats as a fresh row: the duplicate-per-side failure the
+ * 2026-07 CLEAR import produced. The inbound adoption pass reclaims these into
+ * real sync records; until it runs, the outbound side must leave them alone.
+ */
+function ticketIsNotionBorn(ticket: { links: unknown }): boolean {
+  return hasNotionProvenance(ticket.links);
+}
+
 async function ensureCreateSentinel(
   db: PrismaClient,
   ticketId: string,
@@ -167,12 +188,14 @@ async function ensureCreateSentinel(
       id: true,
       status: true,
       productId: true,
+      links: true,
       _count: { select: { syncs: true } },
     },
   });
   if (!ticket) return null;
   if (COMPLETED_TICKET_STATUSES.includes(ticket.status)) return null;
   if (ticket._count.syncs > 0) return null;
+  if (ticketIsNotionBorn(ticket)) return null;
 
   const config = await db.ticketSyncConfig.findFirst({
     where: {
@@ -213,8 +236,15 @@ export interface BackfillPlanItem {
 
 /**
  * The one-time backfill manifest: the non-terminal tickets in a config's
- * product that have no sync record yet (exactly what a real backfill would
- * mirror). Read-only — the dry-run gate the UI shows before the real run.
+ * product that have no sync record yet AND no Notion provenance (exactly what
+ * a real backfill would mirror). Read-only — the dry-run gate the UI shows
+ * before the real run.
+ *
+ * Provenance is filtered in JS rather than in the `where`: Prisma's JSON path
+ * filters don't express "key absent" portably, and getting that subtly wrong
+ * fails OPEN (it mirrors a Notion-born ticket back out). The cap is applied
+ * after the filter so a product full of imported tickets can't starve the
+ * manifest of the Exponential-born rows the backfill actually exists for.
  */
 export async function planBackfill(
   db: PrismaClient,
@@ -232,17 +262,20 @@ export async function planBackfill(
       status: { notIn: [...COMPLETED_TICKET_STATUSES] },
       syncs: { none: {} },
     },
-    select: { id: true, title: true, number: true },
+    select: { id: true, title: true, number: true, links: true },
     orderBy: { createdAt: "asc" },
-    take: 500,
   });
-  return tickets.map((t) => ({ ticketId: t.id, title: t.title, number: t.number }));
+  return tickets
+    .filter((t) => !ticketIsNotionBorn(t))
+    .slice(0, BACKFILL_LIMIT)
+    .map((t) => ({ ticketId: t.id, title: t.title, number: t.number }));
 }
 
 /**
  * Run the backfill: enqueue a create job (via a sentinel sync) for every
- * non-terminal, unsynced ticket. Idempotent — a ticket that already has a sync
- * is skipped, so re-running creates nothing new. The Notion pages themselves
+ * non-terminal, unsynced, Exponential-born ticket. Idempotent — a ticket that
+ * already has a sync is skipped, so re-running creates nothing new. The
+ * Notion pages themselves
  * are written by the durable drain, so a large backfill can't time out the
  * request and each row retries independently.
  */
@@ -258,15 +291,20 @@ export async function enqueueBackfill(
     return { enqueued: 0 };
   }
 
-  const tickets = await db.ticket.findMany({
+  const candidates = await db.ticket.findMany({
     where: {
       productId: config.productId,
       status: { notIn: [...COMPLETED_TICKET_STATUSES] },
       syncs: { none: {} },
     },
-    select: { id: true },
-    take: 500,
+    select: { id: true, links: true },
+    orderBy: { createdAt: "asc" },
   });
+  // Same provenance exclusion as planBackfill — the manifest the user approved
+  // and the rows actually enqueued must be the same set.
+  const tickets = candidates
+    .filter((t) => !ticketIsNotionBorn(t))
+    .slice(0, BACKFILL_LIMIT);
 
   let enqueued = 0;
   for (const t of tickets) {


### PR DESCRIPTION
## What happened

A duplicate turned up in CLEAR's Notion — the same row twice, one copy carrying a
`from-notion` label it could only have got by round-tripping through Exponential.

It wasn't one row. **14 Notion pages** were minted by the mirror (exactly the rows carrying
that label), and product `clear` holds **21 duplicate ticket pairs**.

The 2026-07-06 agent-improvised import created 24 tickets — PR 350's own description calls out
that flow: *"couldn't set labels and duplicated tickets on re-run"*. Crucially those tickets
carry **no `links.notionPageId`**, because the importer that records provenance didn't exist
yet. The proper sync then re-imported the same Notion rows on 07-14, so every row exists twice
locally. When the outbound full mirror landed, the 07-06 copies looked Exponential-born — no
sync row, no provenance, non-terminal — so the backfill created a **second Notion page** for
each of the 14 non-terminal ones, pushing the ticket's tags across as Notion labels.

The other 10 were DONE/DEPLOYED. The mirror never creates a page for a terminal ticket, so
those pairs are duplicated in Exponential only — which is why several same-titled tickets have
no Notion twin.

## Fix 1 (load-bearing): identify pages by back-link

The mirror needs to answer *"did I already create a page for this ticket?"*. Every page it
creates already carries the ticket's URL in its `Exponential URL` property — the identity of the
source stored in the target, the exact counterpart of `links.notionPageId` in the other
direction. Nothing ever read it back. `runOutboundCreate` now queries it before creating:

- **one match** → that is our own orphan; adopt it. Null snapshot so the merge resolves
  last-write-wins, and `remoteCreatedAt` **is** set — only our own create writes that back-link,
  so the body is ours and the body-repair pass may rewrite it.
- **no match** → create, as before.
- **several matches** (earlier orphans, or a human duplicated one of our pages) → link the
  first, warn naming the rest, and leave `remoteCreatedAt` unset — provenance is no longer
  certain, so the repair pass must not be licensed against it.
- **no url-typed back-link property** → degrade to the previous behaviour with the warning
  carried onto the created item, rather than failing.

This closes the case `NonRetryablePushError` documents and accepts: page created, link write
died, next drain mints a second page.

### Why not title matching

An earlier revision of this PR probed by title. The data disqualified it:

- **Titles mutate.** Between two snapshots of `clear` taken 45 minutes apart *during this
  investigation*, ticket #83 was renamed from "Study and analyze right data orchestrator for
  clear-pipeline" to "Analytics - PostHog", and now collides with #84.
- **Titles are not unique.** 7.0% of 883 tickets across all products share a title.
- **Some collisions are structural.** `PrismaClientKnownRequestError:` x5 and `HttpError: Bad
  credentials` x2 — auto-filed BUG tickets, byte-identical by design, in a Notion-linked
  product. A title probe would refuse to mirror all but the first, permanently and silently.
- **The value is user-editable.** Rename a ticket onto an unrelated Notion row and the mirror
  adopts that page, then last-write-wins overwrites one side.

Title matching survives only as an **advisory warning in the backfill preview**, where a human
approves the plan before anything is written. The check is capped at the rows the preview shows,
a probe failure leaves the item unwarned rather than breaking the preview, and a flagged row
stays in the plan — it informs, it does not decide.

## Fix 2 (narrower): provenance guard

A ticket that *does* carry `links.notionPageId` but has no sync row is now refused by all three
outbound create paths — `ensureCreateSentinel`, `planBackfill`, `enqueueBackfill`.

**To be clear: this is not what fixes CLEAR.** That cohort has no links at all. But it closes
the same asymmetry one category over — the inbound adoption pass already reclaims exactly these
tickets by reading `links.notionPageId`, while the outbound side never looked, so a ticket
could be adoptable by one and duplicable by the other. Both sides now share
`hasNotionProvenance` in `mapping.ts`.

Provenance is filtered in JS, not in the Prisma `where`: JSON path filters don't express
"key absent" portably, and a subtly wrong one fails *open* — it mirrors a Notion-born ticket
back out, which is the bug. The 500-row cap moved after the filter so a product full of
imported tickets can't starve the manifest of the rows the backfill exists for.

## What this PR does NOT fix

**The inbound direction.** Nothing stops a sync run creating a second *ticket* when a
provenance-less local ticket for the same work already exists — that is the other half of every
CLEAR pair. There is no exact key available in that direction by construction: nothing we wrote
is on an out-of-band ticket. Left out deliberately rather than reaching for a title heuristic.

**Case A — out-of-band creation** (something writes one side without going through the sync).
No key exists by definition. Closed at source: `notionTicketImport` writes provenance on every
row it creates. The CLEAR residue is a one-time data cleanup.

`adopted` was already an inbound run-item action, so `SyncRunHistory` renders push adoptions
with no UI change.

## Tests

8 new cases: adopt-own-orphan (asserting `remoteCreatedAt` IS set), no-match-creates,
several-matches links one and disclaims authorship, missing-back-link-property degrades with a
warning, dry-run; plus the provenance guard on `dispatchTicketCreate` and on plan/enqueue
backfill, the advisory title warning, and a throwing probe leaving the preview intact. Full
suite green — 2331 unit tests, typecheck, lint.

## Data cleanup (not in this PR)

21 pairs to merge, 14 Notion pages to archive, and it isn't mechanical: **11 pairs have
conflicting statuses and the copy to discard is often ahead** (#61 COMMITTED vs #122
IN_PROGRESS; #60 IN_PROGRESS vs #111 DONE) — someone has been working both sides. A per-pair
manifest went to James separately.

---

Tracking: ticket [255 `polar.canyon`](https://www.exponential.im/w/syntrofi/products/exponential/tickets/255)
now carries the as-built description of how the sync works plus the incident write-up; ticket
[483 `round.duck`](https://www.exponential.im/w/syntrofi/products/exponential/tickets/483) is
this change.
