### PR TITLE
ci: park the GLM/OpenRouter PR reviewer until its key is funded

### DIFF
--- a/.github/workflows/pr_agent_glm.yml
+++ b/.github/workflows/pr_agent_glm.yml
@@ -14,17 +14,23 @@ name: PR Agent (GLM)
 #     pull_request:
 #       types: [opened, reopened, ready_for_review, synchronize]
 #
-# Nothing else needs changing — the job body is intact and was working apart
-# from the credit balance. Note this check is NOT in main's required set, so
-# parking it does not block any merge.
+# The job body below is untouched, so that is the only edit needed to bring it
+# back. Do not assume the rest is proven, though: this reviewer never completed
+# a successful run, so the credit balance is the only fault we have actually
+# observed. Anything downstream of the first model call — the GLM model id, the
+# 200k token ceiling, the non-persistent comment settings — is written but
+# unverified. Watch the first run after reactivating.
+#
+# Note this check is NOT in main's required set, so parking it does not block
+# any merge.
 #
 # WHAT IT WAS: a second automated reviewer — the same qodo-ai/pr-agent action as
 # pr_agent.yml, pointed at GLM via OpenRouter instead of Anthropic. Two
 # independent readers applying the same house rules from .pr_agent.toml.
 # pr_agent.yml (Anthropic) is unaffected and remains the active reviewer.
-#
-# No `issue_comment` trigger here (unlike pr_agent.yml) — manual `/review`
-# commands should reach one reviewer, not both.
+# It deliberately carried no `issue_comment` trigger (unlike pr_agent.yml), so
+# that manual `/review` commands reached one reviewer rather than both — keep
+# that in mind when restoring the trigger block.
 on:
   # Placeholder trigger: a workflow needs one, and this keeps the file valid and
   # visible in the Actions tab while it is parked. Dispatching it by hand does

--- a/.github/workflows/pr_agent_glm.yml
+++ b/.github/workflows/pr_agent_glm.yml
@@ -1,13 +1,35 @@
 name: PR Agent (GLM)
-# Second automated reviewer: the same qodo-ai/pr-agent action as pr_agent.yml,
-# pointed at GLM via OpenRouter instead of Anthropic. Two independent readers
-# applying the same house rules from .pr_agent.toml.
+#
+# ⏸️  DEACTIVATED 2026-08-07 — this reviewer does not run on PRs.
+#
+# The OPENROUTER_API_KEY secret has no credits ("This account never purchased
+# credits"), so every run reviewed nothing and — since PR 532 made a green tick
+# mean a review actually happened — reported that honestly as a red check on
+# every PR. A permanently red check that no one can act on is noise, so the
+# reviewer is parked until the key is funded rather than left failing.
+#
+# TO REACTIVATE: buy OpenRouter credits, then restore the trigger below to
+#
+#   on:
+#     pull_request:
+#       types: [opened, reopened, ready_for_review, synchronize]
+#
+# Nothing else needs changing — the job body is intact and was working apart
+# from the credit balance. Note this check is NOT in main's required set, so
+# parking it does not block any merge.
+#
+# WHAT IT WAS: a second automated reviewer — the same qodo-ai/pr-agent action as
+# pr_agent.yml, pointed at GLM via OpenRouter instead of Anthropic. Two
+# independent readers applying the same house rules from .pr_agent.toml.
+# pr_agent.yml (Anthropic) is unaffected and remains the active reviewer.
 #
 # No `issue_comment` trigger here (unlike pr_agent.yml) — manual `/review`
 # commands should reach one reviewer, not both.
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+  # Placeholder trigger: a workflow needs one, and this keeps the file valid and
+  # visible in the Actions tab while it is parked. Dispatching it by hand does
+  # NOT produce a review — the action needs a pull_request event for context.
+  workflow_dispatch:
 jobs:
   pr_agent_glm_job:
     # Skip bot-triggered events so the two reviewers can't set each other off.

--- a/.github/workflows/pr_agent_glm.yml
+++ b/.github/workflows/pr_agent_glm.yml
@@ -14,8 +14,10 @@ name: PR Agent (GLM)
 #     pull_request:
 #       types: [opened, reopened, ready_for_review, synchronize]
 #
-# The job body below is untouched, so that is the only edit needed to bring it
-# back. Do not assume the rest is proven, though: this reviewer never completed
+# That is the only edit needed — the job's steps are untouched, and its `if:`
+# guard was written to stay correct either way.
+#
+# Do not assume the rest is proven, though: this reviewer never completed
 # a successful run, so the credit balance is the only fault we have actually
 # observed. Anything downstream of the first model call — the GLM model id, the
 # 200k token ceiling, the non-persistent comment settings — is written but
@@ -34,12 +36,20 @@ name: PR Agent (GLM)
 on:
   # Placeholder trigger: a workflow needs one, and this keeps the file valid and
   # visible in the Actions tab while it is parked. Dispatching it by hand does
-  # NOT produce a review — the action needs a pull_request event for context.
+  # NOT produce a review — the action needs a pull_request event for context —
+  # so the job guard below skips dispatches outright rather than letting them
+  # fail against the unfunded key and leave a red run behind.
   workflow_dispatch:
 jobs:
   pr_agent_glm_job:
-    # Skip bot-triggered events so the two reviewers can't set each other off.
-    if: ${{ github.event.sender.type != 'Bot' }}
+    # First clause is the parking brake: a hand-dispatched run exits clean
+    # instead of failing. It stays correct once the pull_request trigger is
+    # restored (those events aren't workflow_dispatch), so reactivating is
+    # still just the trigger block — but dropping this clause at that point
+    # does no harm either.
+    # Second clause skips bot-triggered events so the two reviewers can't set
+    # each other off.
+    if: ${{ github.event_name != 'workflow_dispatch' && github.event.sender.type != 'Bot' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
### **User description**
## What

Park the GLM/OpenRouter PR reviewer (`.github/workflows/pr_agent_glm.yml`) by removing its `pull_request` trigger. `workflow_dispatch` stays as a placeholder so the file remains valid YAML and visible in the Actions tab.

## Why

The `OPENROUTER_API_KEY` secret has no credits — "This account never purchased credits" — so this reviewer has never once produced a review. PR 532 made a green PR-Agent tick mean a review *actually happened*, which correctly surfaced that as a red check on every PR. Accurate, but unactionable: nobody can fix it without funding the key, and a permanently red check makes PRs read as unmergeable.

Two things worth being precise about, since "blocking merges" was the concern:

- This check is **not** in `main`'s required status checks (`Migrations apply cleanly`, `Lint & Typecheck`, `Unit Tests`, `Integration Tests`, `Build`). It never gated merge at the policy level.
- It *did* trip `gh pr checks --watch --fail-fast`, which the `/ship-*` skills wait on — so it blocked automated shipping even while branch protection was indifferent. Removing the trigger clears that too.

## Scope

- `pr_agent.yml` (Anthropic reviewer) is **unaffected** and remains the active reviewer.
- The `ai-bug-fixer` workflow also uses OpenRouter, via a *different* secret (`AI_BUILDER_API_KEY`). Not touched.
- The job body is untouched. Reactivating is restoring the four-line trigger block once the key has credit — the file documents exactly how.


___

### **PR Type**
Other, Documentation


___

### **Description**
- Removes `pull_request` trigger from GLM reviewer workflow

- Leaves `workflow_dispatch` as inert placeholder trigger

- Guards job to skip hand-dispatched runs

- Documents deactivation reason and reactivation steps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PR["pull_request event"] -- "trigger removed" --> Parked["GLM reviewer parked"]
  Dispatch["workflow_dispatch"] -- "if: event_name guard" --> Skip["job skipped cleanly"]
  Anthropic["pr_agent.yml (Anthropic)"] -- "unaffected" --> Active["remains active reviewer"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_agent_glm.yml</strong><dd><code>Deactivate GLM reviewer and document reactivation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr_agent_glm.yml

<ul><li>Removed the <code>pull_request</code> trigger so the GLM reviewer no longer runs on <br>PRs.<br> <li> Added <code>workflow_dispatch</code> as a placeholder trigger to keep the file <br>valid/visible.<br> <li> Extended the job <code>if:</code> condition with <code>github.event_name != </code><br><code>'workflow_dispatch'</code> so manual dispatches exit without failing.<br> <li> Rewrote header comments explaining the unfunded <code>OPENROUTER_API_KEY</code>, <br>unverified config, and exact reactivation steps.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/535/files#diff-bb0b232f5e7f558ea33c510e85e574a370c3844e624c3a259f3123928710c06b">+47/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

