### PR TITLE
fix(assistant): scope assistants to their owner (odd.iris)

### DIFF
--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -297,10 +297,14 @@ export async function POST(req: Request) {
       entries.push(["slackUserId", slackMapping.externalUserId]);
     }
 
-    // If an assistantId is provided, fetch the custom personality and inject it
+    // If an assistantId is provided, fetch the custom personality and inject it.
+    // `assistantId` is client-supplied, and the row's personality/instructions/
+    // userContext are injected verbatim into the system prompt below — so scope
+    // the lookup to the caller's own assistants. An id belonging to anyone else
+    // simply doesn't resolve, and the request falls through to the default agent.
     if (assistantId) {
-      const assistant = await db.assistant.findUnique({
-        where: { id: assistantId },
+      const assistant = await db.assistant.findFirst({
+        where: { id: assistantId, createdById: session.user.id },
       });
 
       if (assistant) {

--- a/src/server/api/routers/__tests__/assistant.test.ts
+++ b/src/server/api/routers/__tests__/assistant.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Unit tests for the `assistant` router.
+ *
+ * The Assistant row carries the user's chosen agent name plus their free-text
+ * persona (`personality`, `instructions`, `userContext`) — the persona is
+ * injected verbatim into the system prompt by /api/chat/stream, so read access
+ * to a row is read access to private content.
+ *
+ * These tests pin two properties:
+ *   1. Ownership — only the creator can read/rename/delete their assistant.
+ *      Every id-addressed procedure took an arbitrary CUID with no ownership
+ *      check, so any authenticated principal could rename or delete any
+ *      assistant in any workspace (cross-tenant IDOR).
+ *   2. Per-user scoping — `getDefault`/`list` are scoped by creator as well as
+ *      workspace, and setting a default only unsets the *caller's* other
+ *      defaults. Workspace-wide scoping meant co-members shared a single
+ *      "default assistant" and silently overwrote each other's agent name.
+ *
+ * Uses `mockDeep<PrismaClient>()` — no real DB, ever.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const OWNER_ID = "user-owner";
+const ATTACKER_ID = "user-attacker";
+const WORKSPACE_ID = "ws-1";
+const ASSISTANT_ID = "assistant-1";
+
+/** A row belonging to OWNER_ID, as the DB would return it. */
+const ownedAssistant = {
+  id: ASSISTANT_ID,
+  workspaceId: WORKSPACE_ID,
+  createdById: OWNER_ID,
+  name: "Aria",
+  emoji: "✨",
+  personality: "Warm, direct, allergic to filler.",
+  instructions: null,
+  userContext: null,
+  isDefault: true,
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+/**
+ * Make the ownership-scoped lookup behave like Postgres: return the row only
+ * when the query actually asks for this row's owner. A resolver that omits
+ * `createdById` from its `where` gets the row back — which is the bug.
+ */
+function stubOwnershipScopedLookup(dbMock: DeepMockProxy<PrismaClient>) {
+  const matches = (where: Record<string, unknown> | undefined) =>
+    where?.id === ASSISTANT_ID && where?.createdById === OWNER_ID;
+
+  dbMock.assistant.findFirst.mockImplementation((args) =>
+    Promise.resolve(
+      matches(args?.where as Record<string, unknown> | undefined) ? ownedAssistant : null,
+    ) as never,
+  );
+  dbMock.assistant.findUnique.mockImplementation((args) =>
+    Promise.resolve(
+      (args?.where as Record<string, unknown> | undefined)?.id === ASSISTANT_ID
+        ? ownedAssistant
+        : null,
+    ) as never,
+  );
+}
+
+describe("assistant router — ownership (cross-tenant IDOR)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    stubOwnershipScopedLookup(dbMock);
+    dbMock.assistant.update.mockResolvedValue(ownedAssistant as never);
+    dbMock.assistant.delete.mockResolvedValue(ownedAssistant as never);
+    dbMock.assistant.updateMany.mockResolvedValue({ count: 0 } as never);
+  });
+
+  it("refuses to rename an assistant the caller does not own", async () => {
+    const caller = createMockCaller({ userId: ATTACKER_ID, db: dbMock });
+
+    await expect(
+      caller.assistant.update({ id: ASSISTANT_ID, name: "pwned" }),
+    ).rejects.toThrow(TRPCError);
+
+    expect(dbMock.assistant.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses to delete an assistant the caller does not own", async () => {
+    const caller = createMockCaller({ userId: ATTACKER_ID, db: dbMock });
+
+    await expect(caller.assistant.delete({ id: ASSISTANT_ID })).rejects.toThrow(TRPCError);
+
+    expect(dbMock.assistant.delete).not.toHaveBeenCalled();
+  });
+
+  it("refuses to read another user's persona via getById", async () => {
+    const caller = createMockCaller({ userId: ATTACKER_ID, db: dbMock });
+
+    await expect(caller.assistant.getById({ id: ASSISTANT_ID })).rejects.toThrow(TRPCError);
+  });
+
+  it("refuses to flip another user's default via setDefault", async () => {
+    const caller = createMockCaller({ userId: ATTACKER_ID, db: dbMock });
+
+    await expect(caller.assistant.setDefault({ id: ASSISTANT_ID })).rejects.toThrow(TRPCError);
+
+    expect(dbMock.assistant.update).not.toHaveBeenCalled();
+    expect(dbMock.assistant.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("still lets the owner rename their own assistant", async () => {
+    const caller = createMockCaller({ userId: OWNER_ID, db: dbMock });
+
+    await expect(
+      caller.assistant.update({ id: ASSISTANT_ID, name: "Max" }),
+    ).resolves.toMatchObject({ id: ASSISTANT_ID });
+
+    expect(dbMock.assistant.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ name: "Max" }) }),
+    );
+  });
+});
+
+describe("assistant router — per-user default scoping", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    // Direct workspace membership, as `getWorkspaceMembership` reads it.
+    dbMock.workspaceUser.findUnique.mockResolvedValue({
+      role: "owner",
+      workspaceId: WORKSPACE_ID,
+    } as never);
+    dbMock.assistant.findFirst.mockResolvedValue(ownedAssistant as never);
+    dbMock.assistant.findMany.mockResolvedValue([ownedAssistant] as never);
+    dbMock.assistant.updateMany.mockResolvedValue({ count: 0 } as never);
+    dbMock.assistant.create.mockResolvedValue(ownedAssistant as never);
+    dbMock.assistant.update.mockResolvedValue(ownedAssistant as never);
+  });
+
+  it("scopes getDefault to the calling user, not just the workspace", async () => {
+    const caller = createMockCaller({ userId: OWNER_ID, db: dbMock });
+
+    await caller.assistant.getDefault({ workspaceId: WORKSPACE_ID });
+
+    expect(dbMock.assistant.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          workspaceId: WORKSPACE_ID,
+          createdById: OWNER_ID,
+        }),
+      }),
+    );
+  });
+
+  it("scopes list to the calling user, not just the workspace", async () => {
+    const caller = createMockCaller({ userId: OWNER_ID, db: dbMock });
+
+    await caller.assistant.list({ workspaceId: WORKSPACE_ID });
+
+    expect(dbMock.assistant.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          workspaceId: WORKSPACE_ID,
+          createdById: OWNER_ID,
+        }),
+      }),
+    );
+  });
+
+  it("refuses to list assistants in a workspace the caller does not belong to", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(null as never);
+    dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+
+    const caller = createMockCaller({ userId: ATTACKER_ID, db: dbMock });
+
+    await expect(caller.assistant.list({ workspaceId: WORKSPACE_ID })).rejects.toThrow(
+      TRPCError,
+    );
+    expect(dbMock.assistant.findMany).not.toHaveBeenCalled();
+  });
+
+  it("only unsets the caller's own defaults when creating a new default", async () => {
+    const caller = createMockCaller({ userId: OWNER_ID, db: dbMock });
+
+    await caller.assistant.create({
+      workspaceId: WORKSPACE_ID,
+      name: "Aria",
+      personality: "Warm, direct.",
+      isDefault: true,
+    });
+
+    expect(dbMock.assistant.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ createdById: OWNER_ID }),
+      }),
+    );
+  });
+});

--- a/src/server/api/routers/assistant.ts
+++ b/src/server/api/routers/assistant.ts
@@ -1,9 +1,42 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { requireWorkspaceMembership } from "~/server/services/access/middleware";
 import { TRPCError } from "@trpc/server";
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * Assistants are **per user, per workspace** — each member of a workspace gets
+ * their own agent with their own name and persona. Two consequences:
+ *
+ *  - Every id-addressed procedure loads the row scoped by `createdById`, so a
+ *    CUID belonging to someone else simply doesn't resolve. NOT_FOUND rather
+ *    than FORBIDDEN, so the API doesn't confirm that an id exists.
+ *  - Workspace-scoped queries (`list`, `getDefault`, `create`) additionally
+ *    filter by `createdById`, so co-members never see or clobber each other's
+ *    assistant. This matches how the Telegram and Matrix gateways resolve the
+ *    default assistant (`{ createdById, isDefault }`).
+ *
+ * `personality`, `instructions`, and `userContext` are free-text private
+ * content injected verbatim into the system prompt by /api/chat/stream, so
+ * read access is as sensitive as write access — `getById` and `list` are
+ * guarded on the same terms as the mutations.
+ */
+async function getOwnedAssistantOrThrow(
+  db: PrismaClient,
+  id: string,
+  userId: string,
+) {
+  const assistant = await db.assistant.findFirst({
+    where: { id, createdById: userId },
+  });
+  if (!assistant) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Assistant not found" });
+  }
+  return assistant;
+}
 
 export const assistantRouter = createTRPCRouter({
-  /** Create a new custom assistant for a workspace */
+  /** Create a new assistant owned by the calling user */
   create: protectedProcedure
     .input(
       z.object({
@@ -16,13 +49,15 @@ export const assistantRouter = createTRPCRouter({
         isDefault: z.boolean().optional().default(false),
       })
     )
+    .use(requireWorkspaceMembership("edit"))
     .mutation(async ({ input, ctx }) => {
       const { workspaceId, isDefault, ...data } = input;
+      const userId = ctx.session.user.id;
 
-      // If setting as default, unset any existing default first
+      // Unset only *this user's* existing default — never a co-member's.
       if (isDefault) {
         await ctx.db.assistant.updateMany({
-          where: { workspaceId, isDefault: true },
+          where: { workspaceId, createdById: userId, isDefault: true },
           data: { isDefault: false },
         });
       }
@@ -31,13 +66,13 @@ export const assistantRouter = createTRPCRouter({
         data: {
           ...data,
           workspaceId,
-          createdById: ctx.session.user.id,
+          createdById: userId,
           isDefault,
         },
       });
     }),
 
-  /** Update an existing assistant */
+  /** Update an assistant owned by the calling user */
   update: protectedProcedure
     .input(
       z.object({
@@ -52,16 +87,18 @@ export const assistantRouter = createTRPCRouter({
     )
     .mutation(async ({ input, ctx }) => {
       const { id, isDefault, ...data } = input;
+      const userId = ctx.session.user.id;
 
-      const existing = await ctx.db.assistant.findUnique({ where: { id } });
-      if (!existing) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Assistant not found" });
-      }
+      const existing = await getOwnedAssistantOrThrow(ctx.db, id, userId);
 
-      // If setting as default, unset any existing default first
       if (isDefault) {
         await ctx.db.assistant.updateMany({
-          where: { workspaceId: existing.workspaceId, isDefault: true, id: { not: id } },
+          where: {
+            workspaceId: existing.workspaceId,
+            createdById: userId,
+            isDefault: true,
+            id: { not: id },
+          },
           data: { isDefault: false },
         });
       }
@@ -75,63 +112,65 @@ export const assistantRouter = createTRPCRouter({
       });
     }),
 
-  /** Get a single assistant by ID */
+  /** Get a single assistant owned by the calling user */
   getById: protectedProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ input, ctx }) => {
-      const assistant = await ctx.db.assistant.findUnique({ where: { id: input.id } });
-      if (!assistant) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Assistant not found" });
-      }
-      return assistant;
+      return getOwnedAssistantOrThrow(ctx.db, input.id, ctx.session.user.id);
     }),
 
-  /** List all assistants for a workspace */
+  /** List the calling user's assistants in a workspace */
   list: protectedProcedure
     .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
     .query(async ({ input, ctx }) => {
       return ctx.db.assistant.findMany({
-        where: { workspaceId: input.workspaceId },
+        where: {
+          workspaceId: input.workspaceId,
+          createdById: ctx.session.user.id,
+        },
         orderBy: [{ isDefault: "desc" }, { createdAt: "desc" }],
       });
     }),
 
-  /** Get the default assistant for a workspace (or null) */
+  /** Get the calling user's default assistant for a workspace (or null) */
   getDefault: protectedProcedure
     .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
     .query(async ({ input, ctx }) => {
       return ctx.db.assistant.findFirst({
-        where: { workspaceId: input.workspaceId, isDefault: true },
+        where: {
+          workspaceId: input.workspaceId,
+          createdById: ctx.session.user.id,
+          isDefault: true,
+        },
       });
     }),
 
-  /** Delete an assistant */
+  /** Delete an assistant owned by the calling user */
   delete: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ input, ctx }) => {
-      const existing = await ctx.db.assistant.findUnique({ where: { id: input.id } });
-      if (!existing) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Assistant not found" });
-      }
+      await getOwnedAssistantOrThrow(ctx.db, input.id, ctx.session.user.id);
       return ctx.db.assistant.delete({ where: { id: input.id } });
     }),
 
-  /** Set an assistant as the workspace default */
+  /** Set one of the calling user's assistants as their workspace default */
   setDefault: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ input, ctx }) => {
-      const assistant = await ctx.db.assistant.findUnique({ where: { id: input.id } });
-      if (!assistant) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Assistant not found" });
-      }
+      const userId = ctx.session.user.id;
+      const assistant = await getOwnedAssistantOrThrow(ctx.db, input.id, userId);
 
-      // Unset existing default
       await ctx.db.assistant.updateMany({
-        where: { workspaceId: assistant.workspaceId, isDefault: true },
+        where: {
+          workspaceId: assistant.workspaceId,
+          createdById: userId,
+          isDefault: true,
+        },
         data: { isDefault: false },
       });
 
-      // Set new default
       return ctx.db.assistant.update({
         where: { id: input.id },
         data: { isDefault: true },


### PR DESCRIPTION
Fixes Exponential ticket **odd.iris** (`cmsj0tzpk0001l504qtcs4jyh`) — BUG, priority 0.

> Note: this is an *Exponential* ticket id, not a GitHub issue. It is deliberately not
> written as a bare number — GitHub auto-links that to an unrelated issue in this repo.

## What was wrong

Investigating a report that a user's **Telegram bot name kept changing on its own** turned up two defects in the same surface.

**1. `assistantRouter` had no object-level authorization.** Every procedure was a bare `protectedProcedure` that took a CUID and never checked who owned it:

```ts
const existing = await ctx.db.assistant.findUnique({ where: { id } });
if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
// ← no ownership check, no workspace-membership check
return ctx.db.assistant.update({ where: { id }, data });
```

So any authenticated principal could rename, delete, read, or re-default **any** assistant in **any** workspace, cross-tenant. It used `protectedProcedure` rather than `humanOnlyProcedure`, so external-agent API keys (`exp_agent_`) could reach it too.

`getById` and `list` return `personality` / `instructions` / `userContext` — free text the user wrote about themselves and their team. `/api/chat/stream` had the same hole (`assistantId` came from the client body and was loaded with a bare `findUnique`), and that content is injected verbatim into the system prompt, so another user's persona could be read straight back out of the model.

**2. `getDefault` and `list` were scoped by `workspaceId` alone.** A workspace had exactly one "default assistant" shared by every member. So: user B opens `/settings/assistant`, the form loads **A's** row, B types their own name and saves, and `update` mutates A's row by id. A's agent — including the name their Telegram bot introduces itself with — is now B's name. No attacker required, and this is the likelier explanation for the original report.

## The fix

Assistants are now **per user, per workspace**:

- Id-addressed procedures (`update`, `delete`, `getById`, `setDefault`) load via `{ id, createdById }`, so someone else's CUID doesn't resolve. `NOT_FOUND` rather than `FORBIDDEN`, so the API doesn't confirm that an id exists.
- `create` / `list` / `getDefault` gate on `requireWorkspaceMembership` (`edit` / `view` / `view`) and filter by `createdById`.
- Setting a default unsets only the **caller's own** other defaults, not the whole workspace's.
- `/api/chat/stream` scopes its lookup to the caller's own assistants.

This aligns the UI with the Telegram and Matrix gateways, which already resolved the default assistant as `{ createdById, isDefault }` — the two halves of the app disagreed, which is what made the symptom intermittent.

## Behaviour change worth a look

Making `getDefault` per-user means a co-member who previously saw **someone else's** assistant now sees none of their own. This degrades cleanly — every `getDefault` consumer null-guards (`customAssistant &&`, `?? "Zoe"`), and the settings page falls through to `create`, so they get an empty form and make their own. But it is a visible change for anyone in a shared workspace who had been using a co-member's assistant, and it's the intended semantics per "each user has their own version of one of the agents".

No migration: existing rows keep their `createdById`, so each assistant stays with whoever created it.

## Tests

New `src/server/api/routers/__tests__/assistant.test.ts` — 9 unit tests, mocked Prisma, no DB. Written red first: 7 of 8 failed against `7f1ec0eb`, with the IDOR cases failing as `promise resolved "{ id: 'assistant-1', …(10) }" instead of rejecting`.

- Full unit suite: 2308 passed (229 files)
- `tsc --noEmit`: clean
- `eslint` on changed files: clean

## Not covered

This fixes the assistant surface and the one bug class it belongs to; I swept the other routers for the same shape (id-addressed `findUnique` on a `protectedProcedure` with no owner filter) and the only other hits are `adminProcedure`-gated. It is **not** a full application security audit — that's a bigger piece of work than one PR.

## Forensics still worth running

There's no audit table for `Assistant`, so determining whether anyone actually exploited this needs prod data — the ticket carries the queries. In short: if `updatedAt ≈ createdAt` on the affected rows, nobody renamed anything and it was defect 2. If `updatedAt` jumped, check Vercel logs for `assistant.(update|create|setDefault|delete)` around that timestamp and whether the caller was an `isAgent` principal. Separately, if the Telegram **@handle** changed rather than just how the bot introduces itself, that's BotFather-level on the shared `TELEGRAM_BOT_TOKEN` and means the env token leaked — rotate it.
