### PR TITLE
fix(ticketSync): identify pages by back-link, not by title

### DIFF
--- a/src/plugins/product/server/routers/ticketSync.ts
+++ b/src/plugins/product/server/routers/ticketSync.ts
@@ -12,7 +12,6 @@ import { createNotionTicketSyncAdapter } from "~/server/services/ticketSync/noti
 import {
   enqueueBackfill,
   planBackfill,
-  TITLE_WARNING_PROBE_LIMIT,
 } from "~/server/services/ticketSync/pushRunner";
 import { rerenderCreatedPageBodies } from "~/server/services/ticketSync/bodyRepair";
 
@@ -241,10 +240,12 @@ export const ticketSyncRouter = createTRPCRouter({
       return {
         count: items.length,
         sample: items.slice(0, 20),
-        /** How many rows the advisory title check covered. */
-        titleChecked: adapterResult.ok
-          ? Math.min(items.length, TITLE_WARNING_PROBE_LIMIT)
-          : 0,
+        /**
+         * How many rows the advisory title check actually completed — counted
+         * from the probe's own results, not assumed from the plan size, so a
+         * mid-run Notion failure can't be read as a clean check.
+         */
+        titleChecked: items.filter((i) => i.titleChecked).length,
       };
     }),
 

--- a/src/plugins/product/server/routers/ticketSync.ts
+++ b/src/plugins/product/server/routers/ticketSync.ts
@@ -12,6 +12,7 @@ import { createNotionTicketSyncAdapter } from "~/server/services/ticketSync/noti
 import {
   enqueueBackfill,
   planBackfill,
+  TITLE_WARNING_PROBE_LIMIT,
 } from "~/server/services/ticketSync/pushRunner";
 import { rerenderCreatedPageBodies } from "~/server/services/ticketSync/bodyRepair";
 
@@ -212,7 +213,7 @@ export const ticketSyncRouter = createTRPCRouter({
         where: {
           productId_provider: { productId: input.productId, provider: "notion" },
         },
-        select: { id: true, integrationId: true },
+        select: { id: true, integrationId: true, propertyNames: true },
       });
       if (!config) {
         throw new TRPCError({
@@ -226,8 +227,25 @@ export const ticketSyncRouter = createTRPCRouter({
           message: "Notion sync is disconnected for this product",
         });
       }
-      const items = await planBackfill(ctx.db, { configId: config.id });
-      return { count: items.length, sample: items.slice(0, 20) };
+      // Best-effort title check for the preview. It costs one Notion query per
+      // shown row and is advisory only, so a credential problem downgrades the
+      // preview rather than failing it.
+      const adapterResult = await createNotionTicketSyncAdapter(ctx.db, {
+        integrationId: config.integrationId,
+        propertyNames: config.propertyNames,
+      });
+      const items = await planBackfill(ctx.db, {
+        configId: config.id,
+        probe: adapterResult.ok ? adapterResult.adapter : undefined,
+      });
+      return {
+        count: items.length,
+        sample: items.slice(0, 20),
+        /** How many rows the advisory title check covered. */
+        titleChecked: adapterResult.ok
+          ? Math.min(items.length, TITLE_WARNING_PROBE_LIMIT)
+          : 0,
+      };
     }),
 
   /**

--- a/src/server/services/ticketSync/__tests__/harness/fakeNotion.ts
+++ b/src/server/services/ticketSync/__tests__/harness/fakeNotion.ts
@@ -110,6 +110,10 @@ export const DEFAULT_FAKE_SCHEMA: NotionDbSchema = {
   Label: { type: "multi_select", options: [] },
   Cycles: { type: "relation" },
   Assignee: { type: "people" },
+  // The creation markers a real backlog database carries. The back-link is
+  // what the outbound orphan probe reads, so the fake must model it.
+  Source: { type: "select", options: ["Exponential"] },
+  "Exponential URL": { type: "url" },
 };
 
 /** Property-name → page-column roles, mirroring the default config names. */
@@ -280,6 +284,22 @@ export class FakeNotion implements TicketSyncRemoteAdapter, TicketPushAdapter {
 
   findPersonIdByEmail(email: string): Promise<string | null> {
     return Promise.resolve(this.peopleByEmail.get(email) ?? null);
+  }
+
+  /** Pages whose recorded back-link equals `ticketUrl`; null = no such property. */
+  findPagesByBacklink(
+    _databaseId: string,
+    backlinkProperty: string,
+    ticketUrl: string,
+  ): Promise<Array<{ externalId: string; url: string | null }> | null> {
+    if (this.schema[backlinkProperty]?.type !== "url") return Promise.resolve(null);
+    const matches = [...this.pages.values()]
+      .filter((p) => {
+        const raw = p.extra[backlinkProperty] as { url?: string } | undefined;
+        return !p.archived && raw?.url === ticketUrl;
+      })
+      .map((p) => ({ externalId: p.externalId, url: p.url }));
+    return Promise.resolve(matches);
   }
 
   findPagesByTitle(

--- a/src/server/services/ticketSync/__tests__/push.test.ts
+++ b/src/server/services/ticketSync/__tests__/push.test.ts
@@ -599,6 +599,11 @@ describe("runOutboundTicketPush — full-mirror creation", () => {
 });
 
 describe("runOutboundTicketPush — orphan probe (back-link)", () => {
+  beforeEach(() => {
+    // Default: the matched page is not linked to any other ticket.
+    db.ticketSync.findFirst.mockResolvedValue(null as never);
+  });
+
   it("adopts the page a previous attempt already created for this ticket", async () => {
     db.ticketSync.findUnique.mockResolvedValue(
       syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
@@ -621,6 +626,26 @@ describe("runOutboundTicketPush — orphan probe (back-link)", () => {
     // Only our own create writes this back-link, so the body is ours and the
     // body-repair pass may rewrite it.
     expect(data.remoteCreatedAt).toBeInstanceOf(Date);
+  });
+
+  it("refuses to adopt a page already linked to another ticket", async () => {
+    db.ticketSync.findUnique.mockResolvedValue(
+      syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
+    );
+    // The inbound pass linked this page to a different ticket after our sync
+    // record was lost. Adopting would breach @@unique([configId, externalId])
+    // and kill the run with a constraint error.
+    db.ticketSync.findFirst.mockResolvedValue({ ticket: { number: 122 } } as never);
+    const adapter = fakeAdapter(null, {
+      pagesByBacklink: [{ externalId: "page-9", url: null }],
+    });
+
+    const item = await runOutboundTicketPush(db, adapter, { syncId: "s1" });
+
+    expect(item.action).toBe("skipped");
+    expect(item.reason).toContain("122");
+    expect(adapter.creates).toHaveLength(0);
+    expect(db.ticketSync.update).not.toHaveBeenCalled();
   });
 
   it("creates when no page carries this ticket's back-link", async () => {

--- a/src/server/services/ticketSync/__tests__/push.test.ts
+++ b/src/server/services/ticketSync/__tests__/push.test.ts
@@ -159,8 +159,11 @@ function fakeAdapter(
     cyclePageId?: string | null;
     personId?: string | null;
     schema?: NotionDbSchema;
-    /** Same-titled rows the pre-create duplicate probe should find. */
-    pagesByTitle?: Array<{ externalId: string; url: string | null }>;
+    /**
+     * Pages the orphan probe finds carrying this ticket's back-link.
+     * `null` models a database with no url-typed back-link property.
+     */
+    pagesByBacklink?: Array<{ externalId: string; url: string | null }> | null;
   } = {},
 ): FakeAdapter {
   const updates: FakeAdapter["updates"] = [];
@@ -178,7 +181,10 @@ function fakeAdapter(
     },
     findCyclePageIdByName: () => Promise.resolve(opts.cyclePageId ?? null),
     findPersonIdByEmail: () => Promise.resolve(opts.personId ?? null),
-    findPagesByTitle: () => Promise.resolve(opts.pagesByTitle ?? []),
+    findPagesByBacklink: () =>
+      Promise.resolve(
+        opts.pagesByBacklink === undefined ? [] : opts.pagesByBacklink,
+      ),
     createPage: (params) => {
       creates.push(params);
       return Promise.resolve({ externalId: "new-page-id", url: "https://notion.so/new" });
@@ -592,17 +598,13 @@ describe("runOutboundTicketPush — full-mirror creation", () => {
   });
 });
 
-describe("runOutboundTicketPush — pre-create duplicate probe", () => {
-  beforeEach(() => {
-    db.ticketSync.findMany.mockResolvedValue([] as never);
-  });
-
-  it("adopts the existing same-titled row instead of creating a second one", async () => {
+describe("runOutboundTicketPush — orphan probe (back-link)", () => {
+  it("adopts the page a previous attempt already created for this ticket", async () => {
     db.ticketSync.findUnique.mockResolvedValue(
       syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
     );
     const adapter = fakeAdapter(null, {
-      pagesByTitle: [{ externalId: "page-9", url: "https://notion.so/page-9" }],
+      pagesByBacklink: [{ externalId: "page-9", url: "https://notion.so/page-9" }],
     });
 
     const item = await runOutboundTicketPush(db, adapter, { syncId: "s1" });
@@ -610,65 +612,35 @@ describe("runOutboundTicketPush — pre-create duplicate probe", () => {
     expect(item.action).toBe("adopted");
     expect(item.externalId).toBe("page-9");
     expect(adapter.creates).toHaveLength(0);
-    expect(db.ticketSync.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "s1" },
-        data: expect.objectContaining({
-          externalId: "page-9",
-          externalUrl: "https://notion.so/page-9",
-        }),
-      }),
-    );
-  });
-
-  it("adopts without claiming authorship of the page body", async () => {
-    db.ticketSync.findUnique.mockResolvedValue(
-      syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
-    );
-    const adapter = fakeAdapter(null, {
-      pagesByTitle: [{ externalId: "page-9", url: null }],
-    });
-
-    await runOutboundTicketPush(db, adapter, { syncId: "s1" });
-
-    // `remoteCreatedAt` is what licenses the body-repair pass to rewrite a
-    // page's content. An adopted page is human-authored — setting it here
-    // would hand a stranger's Notion page to a rewriter.
     const data = db.ticketSync.update.mock.calls[0]![0]!.data as Record<string, unknown>;
-    expect(data.remoteCreatedAt).toBeUndefined();
+    expect(data.externalId).toBe("page-9");
+    expect(data.externalUrl).toBe("https://notion.so/page-9");
     // Null snapshot: the first merge treats both sides as changed and resolves
     // by last-write-wins, exactly as the inbound adoption pass does.
     expect(data.snapshot).toBe(Prisma.DbNull);
+    // Only our own create writes this back-link, so the body is ours and the
+    // body-repair pass may rewrite it.
+    expect(data.remoteCreatedAt).toBeInstanceOf(Date);
   });
 
-  it("refuses to create when the same-titled row belongs to another ticket", async () => {
+  it("creates when no page carries this ticket's back-link", async () => {
     db.ticketSync.findUnique.mockResolvedValue(
       syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
     );
-    db.ticketSync.findMany.mockResolvedValue([
-      { externalId: "page-9", ticket: { number: 122 } },
-    ] as never);
-    const adapter = fakeAdapter(null, {
-      pagesByTitle: [{ externalId: "page-9", url: null }],
-    });
+    const adapter = fakeAdapter(null, { pagesByBacklink: [] });
 
     const item = await runOutboundTicketPush(db, adapter, { syncId: "s1" });
 
-    // Two Exponential tickets for one Notion row. A third copy helps nobody.
-    expect(item.action).toBe("skipped");
-    // Matched without the leading hash — the pre-commit colour hook reads a
-    // three-digit ticket reference as a hardcoded hex colour.
-    expect(item.reason).toContain("122");
-    expect(adapter.creates).toHaveLength(0);
-    expect(db.ticketSync.update).not.toHaveBeenCalled();
+    expect(item.action).toBe("created");
+    expect(adapter.creates).toHaveLength(1);
   });
 
-  it("refuses to guess when several rows share the title", async () => {
+  it("links one page but disclaims authorship when several carry the back-link", async () => {
     db.ticketSync.findUnique.mockResolvedValue(
       syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
     );
     const adapter = fakeAdapter(null, {
-      pagesByTitle: [
+      pagesByBacklink: [
         { externalId: "page-9", url: null },
         { externalId: "page-10", url: null },
       ],
@@ -676,9 +648,28 @@ describe("runOutboundTicketPush — pre-create duplicate probe", () => {
 
     const item = await runOutboundTicketPush(db, adapter, { syncId: "s1" });
 
-    expect(item.action).toBe("skipped");
-    expect(item.reason).toContain("2 Notion rows share this title");
+    expect(item.action).toBe("adopted");
+    expect(item.externalId).toBe("page-9");
+    expect(item.reason).toContain("page-10");
     expect(adapter.creates).toHaveLength(0);
+    // Provenance is no longer certain (a human may have duplicated our page),
+    // so the body-repair pass must not be licensed against it.
+    const data = db.ticketSync.update.mock.calls[0]![0]!.data as Record<string, unknown>;
+    expect(data.remoteCreatedAt).toBeUndefined();
+  });
+
+  it("creates with a warning when the database has no back-link property", async () => {
+    db.ticketSync.findUnique.mockResolvedValue(
+      syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
+    );
+    // null = the probe could not run at all, which must degrade rather than fail.
+    const adapter = fakeAdapter(null, { pagesByBacklink: null });
+
+    const item = await runOutboundTicketPush(db, adapter, { syncId: "s1" });
+
+    expect(item.action).toBe("created");
+    expect(item.reason).toContain("cannot tell whether a page was already created");
+    expect(adapter.creates).toHaveLength(1);
   });
 
   it("dry run previews the adoption without linking", async () => {
@@ -686,7 +677,7 @@ describe("runOutboundTicketPush — pre-create duplicate probe", () => {
       syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
     );
     const adapter = fakeAdapter(null, {
-      pagesByTitle: [{ externalId: "page-9", url: null }],
+      pagesByBacklink: [{ externalId: "page-9", url: null }],
     });
 
     const item = await runOutboundTicketPush(db, adapter, {

--- a/src/server/services/ticketSync/__tests__/push.test.ts
+++ b/src/server/services/ticketSync/__tests__/push.test.ts
@@ -600,8 +600,8 @@ describe("runOutboundTicketPush — full-mirror creation", () => {
 
 describe("runOutboundTicketPush — orphan probe (back-link)", () => {
   beforeEach(() => {
-    // Default: the matched page is not linked to any other ticket.
-    db.ticketSync.findFirst.mockResolvedValue(null as never);
+    // Default: no candidate page is linked to any other ticket.
+    db.ticketSync.findMany.mockResolvedValue([] as never);
   });
 
   it("adopts the page a previous attempt already created for this ticket", async () => {
@@ -637,7 +637,9 @@ describe("runOutboundTicketPush — orphan probe (back-link)", () => {
     // The inbound pass linked this page to a different ticket after our sync
     // record was lost. Adopting would breach @@unique([configId, externalId])
     // and kill the run with a constraint error.
-    db.ticketSync.findFirst.mockResolvedValue({ ticket: { number: 122 } } as never);
+    db.ticketSync.findMany.mockResolvedValue([
+      { externalId: "page-9", ticket: { number: 122 } },
+    ] as never);
     const adapter = fakeAdapter(null, {
       pagesByBacklink: [{ externalId: "page-9", url: null }],
     });
@@ -648,6 +650,31 @@ describe("runOutboundTicketPush — orphan probe (back-link)", () => {
     expect(item.reason).toContain("122");
     expect(adapter.creates).toHaveLength(0);
     expect(db.ticketSync.update).not.toHaveBeenCalled();
+  });
+
+  it("skips the claimed page and adopts the usable one behind it", async () => {
+    db.ticketSync.findUnique.mockResolvedValue(
+      syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
+    );
+    // page-9 belongs to another ticket; page-10 is free. Checking only the
+    // head would skip the whole push despite a perfectly usable page.
+    db.ticketSync.findMany.mockResolvedValue([
+      { externalId: "page-9", ticket: { number: 122 } },
+    ] as never);
+    const adapter = fakeAdapter(null, {
+      pagesByBacklink: [
+        { externalId: "page-9", url: null },
+        { externalId: "page-10", url: null },
+      ],
+    });
+
+    const item = await runOutboundTicketPush(db, adapter, { syncId: "s1" });
+
+    expect(item.action).toBe("adopted");
+    expect(item.externalId).toBe("page-10");
+    // The reconciliation message must say which pages are already spoken for.
+    expect(item.reason).toContain("linked to ticket 122");
+    expect(adapter.creates).toHaveLength(0);
   });
 
   it("creates when no page carries this ticket's back-link", async () => {

--- a/src/server/services/ticketSync/__tests__/push.test.ts
+++ b/src/server/services/ticketSync/__tests__/push.test.ts
@@ -623,9 +623,11 @@ describe("runOutboundTicketPush — orphan probe (back-link)", () => {
     // Null snapshot: the first merge treats both sides as changed and resolves
     // by last-write-wins, exactly as the inbound adoption pass does.
     expect(data.snapshot).toBe(Prisma.DbNull);
-    // Only our own create writes this back-link, so the body is ours and the
-    // body-repair pass may rewrite it.
-    expect(data.remoteCreatedAt).toBeInstanceOf(Date);
+    // `remoteCreatedAt` must NOT be set: it licenses the body-repair pass to
+    // rewrite the page, and `Exponential URL` is a user-writable Notion
+    // property — a person pasting a ticket URL onto their own page produces
+    // exactly this single match. Adopting is fine; overwriting is not.
+    expect(data.remoteCreatedAt).toBeUndefined();
   });
 
   it("refuses to adopt a page already linked to another ticket", async () => {
@@ -660,7 +662,7 @@ describe("runOutboundTicketPush — orphan probe (back-link)", () => {
     expect(adapter.creates).toHaveLength(1);
   });
 
-  it("links one page but disclaims authorship when several carry the back-link", async () => {
+  it("links one page and names the rest when several carry the back-link", async () => {
     db.ticketSync.findUnique.mockResolvedValue(
       syncRecord({ snapshot: null, externalId: "pending:t1" }) as never,
     );
@@ -677,8 +679,6 @@ describe("runOutboundTicketPush — orphan probe (back-link)", () => {
     expect(item.externalId).toBe("page-9");
     expect(item.reason).toContain("page-10");
     expect(adapter.creates).toHaveLength(0);
-    // Provenance is no longer certain (a human may have duplicated our page),
-    // so the body-repair pass must not be licensed against it.
     const data = db.ticketSync.update.mock.calls[0]![0]!.data as Record<string, unknown>;
     expect(data.remoteCreatedAt).toBeUndefined();
   });

--- a/src/server/services/ticketSync/__tests__/pushRunner.test.ts
+++ b/src/server/services/ticketSync/__tests__/pushRunner.test.ts
@@ -483,6 +483,7 @@ describe("planBackfill / enqueueBackfill", () => {
     // the row from the plan. Title is not a key — acting on it is the bug.
     expect(plan).toHaveLength(2);
     expect(plan[0]!.warning).toBeUndefined();
+    expect(plan[0]!.titleChecked).toBe(true);
     expect(plan[1]!.warning).toContain("2 rows with this title");
   });
 
@@ -505,6 +506,8 @@ describe("planBackfill / enqueueBackfill", () => {
 
     expect(plan).toHaveLength(1);
     expect(plan[0]!.warning).toBeUndefined();
+    // The distinction that matters: unchecked, NOT checked-and-clean.
+    expect(plan[0]!.titleChecked).toBeFalsy();
   });
 
   it("refuses to backfill when push is disabled", async () => {

--- a/src/server/services/ticketSync/__tests__/pushRunner.test.ts
+++ b/src/server/services/ticketSync/__tests__/pushRunner.test.ts
@@ -451,6 +451,62 @@ describe("planBackfill / enqueueBackfill", () => {
     );
   });
 
+  it("flags same-titled Notion rows as an advisory warning, without acting on them", async () => {
+    db.ticketSyncConfig.findUnique.mockResolvedValue({
+      id: "cfg1",
+      productId: "p1",
+      databaseId: "db1",
+      pushEnabled: true,
+      integrationId: "int1",
+    } as never);
+    db.ticket.findMany.mockResolvedValue([
+      { id: "t1", title: "Unique thing", number: 1, links: null },
+      { id: "t2", title: "Untitled", number: 2, links: null },
+    ] as never);
+
+    const plan = await planBackfill(db, {
+      configId: "cfg1",
+      probe: {
+        findPagesByTitle: (_db, title) =>
+          Promise.resolve(
+            title === "Untitled"
+              ? [
+                  { externalId: "p-1", url: null },
+                  { externalId: "p-2", url: null },
+                ]
+              : [],
+          ),
+      },
+    });
+
+    // The warning informs the human approving the backfill; it does not remove
+    // the row from the plan. Title is not a key — acting on it is the bug.
+    expect(plan).toHaveLength(2);
+    expect(plan[0]!.warning).toBeUndefined();
+    expect(plan[1]!.warning).toContain("2 rows with this title");
+  });
+
+  it("survives a probe that throws — the preview still renders", async () => {
+    db.ticketSyncConfig.findUnique.mockResolvedValue({
+      id: "cfg1",
+      productId: "p1",
+      databaseId: "db1",
+      pushEnabled: true,
+      integrationId: "int1",
+    } as never);
+    db.ticket.findMany.mockResolvedValue([
+      { id: "t1", title: "A", number: 1, links: null },
+    ] as never);
+
+    const plan = await planBackfill(db, {
+      configId: "cfg1",
+      probe: { findPagesByTitle: () => Promise.reject(new Error("notion down")) },
+    });
+
+    expect(plan).toHaveLength(1);
+    expect(plan[0]!.warning).toBeUndefined();
+  });
+
   it("refuses to backfill when push is disabled", async () => {
     db.ticketSyncConfig.findUnique.mockResolvedValue({
       id: "cfg1",

--- a/src/server/services/ticketSync/notionAdapter.ts
+++ b/src/server/services/ticketSync/notionAdapter.ts
@@ -308,14 +308,45 @@ export class NotionTicketSyncAdapter
   }
 
   /**
-   * Rows in the target database whose title matches `title` — the pre-create
-   * duplicate probe.
+   * Rows in the target database whose back-link property equals `ticketUrl` —
+   * the pre-create probe for a page we already created for this ticket.
    *
-   * Notion's `title.equals` filter is exact and case-sensitive, so the client
-   * side re-checks case-insensitively after trimming; a row differing only by
-   * case is missed by the filter, which is the same limitation
-   * {@link findCyclePageIdByName} carries and errs toward creating rather than
-   * mis-adopting. Trashed pages are excluded by the query itself.
+   * Returns null when the database has no url-typed property under that name,
+   * so the caller can tell "cannot check" from "checked, found nothing". Only
+   * this adapter's create path ever writes that property with that URL, which
+   * is what makes the match exact rather than a guess. Trashed pages are
+   * excluded by the query itself; archived ones are filtered here.
+   */
+  async findPagesByBacklink(
+    databaseId: string,
+    backlinkProperty: string,
+    ticketUrl: string,
+  ): Promise<Array<{ externalId: string; url: string | null }> | null> {
+    const { properties } = await this.notion.getRawDatabaseById(databaseId);
+    const prop = (properties as Record<string, unknown>)[backlinkProperty] as
+      | { type?: string }
+      | undefined;
+    if (prop?.type !== "url") return null;
+
+    const page = await this.notion.queryDatabase({
+      databaseId,
+      filter: { property: backlinkProperty, url: { equals: ticketUrl } },
+      pageSize: 25,
+    });
+
+    return (page.results as RawNotionPage[])
+      .filter((p) => !p.archived && !p.in_trash)
+      .map((p) => ({ externalId: p.id, url: p.url ?? null }));
+  }
+
+  /**
+   * Rows whose title matches `title` — used ONLY to warn a human in the
+   * backfill preview, never to drive an automatic create/adopt decision.
+   * Titles are user-editable, mutate in place, and are not unique, so they
+   * are a hint for a person and nothing more.
+   *
+   * Notion's `title.equals` filter is exact and case-sensitive; the client
+   * side re-checks case-insensitively after trimming.
    */
   async findPagesByTitle(
     databaseId: string,

--- a/src/server/services/ticketSync/notionAdapter.ts
+++ b/src/server/services/ticketSync/notionAdapter.ts
@@ -80,15 +80,52 @@ function firstPersonEmail(
   return prop.people?.[0]?.person?.email ?? null;
 }
 
+/**
+ * Safety stop for the back-link probe's pagination. 100 rows per page, so this
+ * covers 500 pages carrying one ticket's back-link — pathological by any
+ * measure, and the bound keeps a mis-scoped filter from paging a whole
+ * database.
+ */
+const BACKLINK_PROBE_MAX_PAGES = 5;
+
 export class NotionTicketSyncAdapter
   implements TicketSyncRemoteAdapter, TicketPushAdapter
 {
+  /**
+   * Per-instance memo of `getRawDatabaseById`. A backfill drain builds one
+   * adapter per run and then asks for the same database's schema once per
+   * ticket — through getWriteSchema, the back-link probe, and the cycle
+   * lookup. Without this, mirroring N tickets costs ~3N schema fetches
+   * against a ~3 req/s API. An adapter is scoped to a single run, so the
+   * schema cannot go stale in any way that matters.
+   */
+  private readonly rawDatabaseCache = new Map<
+    string,
+    Promise<{ properties: Record<string, unknown> }>
+  >();
+
   constructor(
     private readonly notion: NotionService,
     private readonly propertyNames: PropertyNames,
     /** Our integration's bot user id, for echo suppression. */
     private readonly botId: string | null,
   ) {}
+
+  private getRawDatabase(
+    databaseId: string,
+  ): Promise<{ properties: Record<string, unknown> }> {
+    const cached = this.rawDatabaseCache.get(databaseId);
+    if (cached) return cached;
+    // Cache the PROMISE, not the result: concurrent callers within one run
+    // then share a single in-flight request instead of racing three of them.
+    const pending = this.notion.getRawDatabaseById(databaseId).catch((err) => {
+      // A failed fetch must not be memoised — the next call should retry.
+      this.rawDatabaseCache.delete(databaseId);
+      throw err;
+    }) as Promise<{ properties: Record<string, unknown> }>;
+    this.rawDatabaseCache.set(databaseId, pending);
+    return pending;
+  }
 
   async queryRows(params: {
     databaseId: string;
@@ -241,7 +278,7 @@ export class NotionTicketSyncAdapter
 
   /** The target database's property schema: type + option names per property. */
   async getWriteSchema(databaseId: string): Promise<NotionDbSchema> {
-    const { properties } = await this.notion.getRawDatabaseById(databaseId);
+    const { properties } = await this.getRawDatabase(databaseId);
     const schema: NotionDbSchema = {};
     for (const [name, raw] of Object.entries(properties)) {
       const prop = raw as {
@@ -278,14 +315,14 @@ export class NotionTicketSyncAdapter
     cycleProperty: string,
     name: string,
   ): Promise<string | null> {
-    const { properties } = await this.notion.getRawDatabaseById(databaseId);
-    const relation = (properties as Record<string, unknown>)[cycleProperty] as
+    const { properties } = await this.getRawDatabase(databaseId);
+    const relation = properties[cycleProperty] as
       | { type?: string; relation?: { database_id?: string } }
       | undefined;
     const targetDbId = relation?.relation?.database_id;
     if (relation?.type !== "relation" || !targetDbId) return null;
 
-    const target = await this.notion.getRawDatabaseById(targetDbId);
+    const target = await this.getRawDatabase(targetDbId);
     const titleProp = Object.entries(target.properties).find(
       ([, p]) => (p as { type?: string }).type === "title",
     )?.[0];
@@ -322,21 +359,34 @@ export class NotionTicketSyncAdapter
     backlinkProperty: string,
     ticketUrl: string,
   ): Promise<Array<{ externalId: string; url: string | null }> | null> {
-    const { properties } = await this.notion.getRawDatabaseById(databaseId);
-    const prop = (properties as Record<string, unknown>)[backlinkProperty] as
+    const { properties } = await this.getRawDatabase(databaseId);
+    const prop = properties[backlinkProperty] as
       | { type?: string }
       | undefined;
     if (prop?.type !== "url") return null;
 
-    const page = await this.notion.queryDatabase({
-      databaseId,
-      filter: { property: backlinkProperty, url: { equals: ticketUrl } },
-      pageSize: 25,
-    });
-
-    return (page.results as RawNotionPage[])
-      .filter((p) => !p.archived && !p.in_trash)
-      .map((p) => ({ externalId: p.id, url: p.url ?? null }));
+    // Page the whole result set. A single page of 25 would both truncate the
+    // "reconcile the others" list and — because archived rows are filtered
+    // client-side, AFTER the cap — let a page of trashed rows hide the live
+    // match and cause a duplicate create.
+    const live: Array<{ externalId: string; url: string | null }> = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < BACKLINK_PROBE_MAX_PAGES; page++) {
+      const res = await this.notion.queryDatabase({
+        databaseId,
+        filter: { property: backlinkProperty, url: { equals: ticketUrl } },
+        pageSize: 100,
+        startCursor: cursor,
+      });
+      for (const p of res.results as RawNotionPage[]) {
+        if (!p.archived && !p.in_trash) {
+          live.push({ externalId: p.id, url: p.url ?? null });
+        }
+      }
+      if (!res.hasMore || !res.nextCursor) break;
+      cursor = res.nextCursor;
+    }
+    return live;
   }
 
   /**
@@ -355,7 +405,7 @@ export class NotionTicketSyncAdapter
     const wanted = title.trim().toLowerCase();
     if (!wanted) return [];
 
-    const { properties } = await this.notion.getRawDatabaseById(databaseId);
+    const { properties } = await this.getRawDatabase(databaseId);
     const titleProp = Object.entries(properties).find(
       ([, p]) => (p as { type?: string }).type === "title",
     )?.[0];

--- a/src/server/services/ticketSync/push.ts
+++ b/src/server/services/ticketSync/push.ts
@@ -611,42 +611,51 @@ async function probeOwnOrphan(
   }
   if (found.length === 0) return { ...none, warnings: [] };
 
-  const [first, ...rest] = found;
-
-  // Is this page already linked to another ticket on this connection? A
-  // ticket URL is unique per ticket, so the back-link can't point at someone
+  // Which candidates are already linked to another ticket on this connection?
+  // A ticket URL is unique per ticket, so the back-link can't point at someone
   // else's page — but the LINK can already exist, e.g. the inbound pass
   // adopted this page onto a different ticket after our sync record was lost.
-  // `@@unique([configId, externalId])` would turn that into a constraint error
-  // that kills the run, so name the conflict instead.
-  const claim = await db.ticketSync.findFirst({
+  // `@@unique([configId, externalId])` would turn adopting one of those into a
+  // constraint error that kills the run.
+  //
+  // Resolve claims across ALL candidates in one query, not just the first:
+  // checking only the head both skips unnecessarily (a usable page sits behind
+  // a claimed one) and lets the reconciliation message name pages that already
+  // belong to another ticket without saying so.
+  const claims = await db.ticketSync.findMany({
     where: {
       configId: args.configId,
-      externalId: first!.externalId,
+      externalId: { in: found.map((f) => f.externalId) },
       id: { not: args.syncId },
     },
-    select: { ticket: { select: { number: true } } },
+    select: { externalId: true, ticket: { select: { number: true } } },
   });
-  if (claim) {
-    return {
-      ...none,
-      claimedBy: `ticket ${claim.ticket.number}`,
-      warnings: [],
-    };
+  const claimedBy = new Map(claims.map((c) => [c.externalId, c.ticket.number]));
+  const usable = found.filter((f) => !claimedBy.has(f.externalId));
+
+  if (usable.length === 0) {
+    const owners = [...new Set(claims.map((c) => `ticket ${c.ticket.number}`))];
+    return { ...none, claimedBy: owners.join(", "), warnings: [] };
   }
 
-  if (rest.length === 0) return { match: first!, claimedBy: null, warnings: [] };
+  const [match, ...rest] = usable;
+  if (rest.length === 0 && claimedBy.size === 0) {
+    return { match: match!, claimedBy: null, warnings: [] };
+  }
 
-  // Several pages carry this ticket's back-link: earlier orphans, or a human
-  // pasting the ticket URL onto more than one page. Linking one is still
-  // better than minting another, but the operator has to reconcile the rest.
+  // Several pages carry this ticket's back-link: earlier orphans, or a ticket
+  // URL pasted onto more than one page. Linking one is still better than
+  // minting another, but the operator has to reconcile the rest — and needs to
+  // know which of them are already spoken for.
+  const others = [
+    ...rest.map((r) => r.externalId),
+    ...claims.map((c) => `${c.externalId} (linked to ticket ${c.ticket.number})`),
+  ];
   return {
-    match: first!,
+    match: match!,
     claimedBy: null,
     warnings: [
-      `${found.length} Notion pages carry this ticket's back-link — linked ${first!.externalId}; reconcile the others: ${rest
-        .map((r) => r.externalId)
-        .join(", ")}`,
+      `${found.length} Notion pages carry this ticket's back-link — linked ${match!.externalId}; reconcile the others: ${others.join(", ")}`,
     ],
   };
 }

--- a/src/server/services/ticketSync/push.ts
+++ b/src/server/services/ticketSync/push.ts
@@ -553,14 +553,8 @@ export async function runOutboundTicketPush(
  * sentinel is deleted so it doesn't linger as a phantom link.
  */
 interface OrphanProbe {
-  /** A page we previously created for this ticket, if one exists. */
+  /** A page carrying this ticket's back-link, if one exists. */
   match: { externalId: string; url: string | null } | null;
-  /**
-   * True when we can be sure the matched page's body is ours to rewrite.
-   * False for a page whose provenance we can't pin down (e.g. a human
-   * duplicated one of our pages, so several carry the same back-link).
-   */
-  authored: boolean;
   /**
    * Set when the matched page is already linked to a DIFFERENT ticket on this
    * connection. Adopting would breach `@@unique([configId, externalId])` and
@@ -600,7 +594,7 @@ async function probeOwnOrphan(
     ticketUrl: string;
   },
 ): Promise<OrphanProbe> {
-  const none = { match: null, authored: false, claimedBy: null };
+  const none = { match: null, claimedBy: null };
   const found = await adapter.findPagesByBacklink(
     args.databaseId,
     args.backlinkProperty,
@@ -641,19 +635,13 @@ async function probeOwnOrphan(
     };
   }
 
-  if (rest.length === 0) {
-    // Only our own create writes this property with this exact URL, so the
-    // page — and its body — is ours.
-    return { match: first!, authored: true, claimedBy: null, warnings: [] };
-  }
+  if (rest.length === 0) return { match: first!, claimedBy: null, warnings: [] };
 
   // Several pages carry this ticket's back-link: earlier orphans, or a human
-  // duplicating one of our pages in Notion. Linking one is still better than
-  // minting another, but we can no longer claim authorship of the body — so
-  // `authored` stays false and the body-repair pass leaves it alone.
+  // pasting the ticket URL onto more than one page. Linking one is still
+  // better than minting another, but the operator has to reconcile the rest.
   return {
     match: first!,
-    authored: false,
     claimedBy: null,
     warnings: [
       `${found.length} Notion pages carry this ticket's back-link — linked ${first!.externalId}; reconcile the others: ${rest
@@ -726,17 +714,22 @@ async function runOutboundCreate(
       };
     }
     // Link, with a null snapshot so the first merge treats every difference as
-    // a two-sided change and resolves by last-write-wins. `remoteCreatedAt` is
-    // set ONLY when the back-link identified a single page: it licenses the
-    // body-repair pass to rewrite the content, which is right for a page we
-    // authored and wrong for anything else.
+    // a two-sided change and resolves by last-write-wins.
+    //
+    // `remoteCreatedAt` is deliberately NOT set. It licenses the body-repair
+    // pass to rewrite a page's content, and the back-link cannot prove we
+    // authored one: `Exponential URL` is an ordinary user-writable Notion
+    // property, so a person cross-referencing a ticket by pasting its URL
+    // produces a single match on a page we never touched. Adopting that page
+    // is reasonable — it is what the paste asked for — but rewriting its body
+    // is not, and that overwrite is irreversible. An orphan we really did
+    // create simply goes un-repaired, which costs nothing anyone will miss.
     await db.ticketSync.update({
       where: { id: sync.id },
       data: {
         externalId: orphan.match.externalId,
         externalUrl: orphan.match.url,
         snapshot: Prisma.DbNull,
-        ...(orphan.authored ? { remoteCreatedAt: new Date() } : {}),
       },
     });
     return {

--- a/src/server/services/ticketSync/push.ts
+++ b/src/server/services/ticketSync/push.ts
@@ -561,6 +561,13 @@ interface OrphanProbe {
    * duplicated one of our pages, so several carry the same back-link).
    */
   authored: boolean;
+  /**
+   * Set when the matched page is already linked to a DIFFERENT ticket on this
+   * connection. Adopting would breach `@@unique([configId, externalId])` and
+   * fail the run with a constraint error; the caller skips with this reason
+   * instead.
+   */
+  claimedBy: string | null;
   warnings: string[];
 }
 
@@ -583,9 +590,17 @@ interface OrphanProbe {
  * back-link is optional in the create payload too.
  */
 async function probeOwnOrphan(
+  db: PrismaClient,
   adapter: TicketPushAdapter,
-  args: { databaseId: string; backlinkProperty: string; ticketUrl: string },
+  args: {
+    configId: string;
+    syncId: string;
+    databaseId: string;
+    backlinkProperty: string;
+    ticketUrl: string;
+  },
 ): Promise<OrphanProbe> {
+  const none = { match: null, authored: false, claimedBy: null };
   const found = await adapter.findPagesByBacklink(
     args.databaseId,
     args.backlinkProperty,
@@ -594,20 +609,42 @@ async function probeOwnOrphan(
 
   if (found === null) {
     return {
-      match: null,
-      authored: false,
+      ...none,
       warnings: [
         `no url-typed "${args.backlinkProperty}" property in Notion — cannot tell whether a page was already created for this ticket`,
       ],
     };
   }
-  if (found.length === 0) return { match: null, authored: false, warnings: [] };
+  if (found.length === 0) return { ...none, warnings: [] };
 
   const [first, ...rest] = found;
+
+  // Is this page already linked to another ticket on this connection? A
+  // ticket URL is unique per ticket, so the back-link can't point at someone
+  // else's page — but the LINK can already exist, e.g. the inbound pass
+  // adopted this page onto a different ticket after our sync record was lost.
+  // `@@unique([configId, externalId])` would turn that into a constraint error
+  // that kills the run, so name the conflict instead.
+  const claim = await db.ticketSync.findFirst({
+    where: {
+      configId: args.configId,
+      externalId: first!.externalId,
+      id: { not: args.syncId },
+    },
+    select: { ticket: { select: { number: true } } },
+  });
+  if (claim) {
+    return {
+      ...none,
+      claimedBy: `ticket ${claim.ticket.number}`,
+      warnings: [],
+    };
+  }
+
   if (rest.length === 0) {
     // Only our own create writes this property with this exact URL, so the
     // page — and its body — is ours.
-    return { match: first!, authored: true, warnings: [] };
+    return { match: first!, authored: true, claimedBy: null, warnings: [] };
   }
 
   // Several pages carry this ticket's back-link: earlier orphans, or a human
@@ -617,6 +654,7 @@ async function probeOwnOrphan(
   return {
     match: first!,
     authored: false,
+    claimedBy: null,
     warnings: [
       `${found.length} Notion pages carry this ticket's back-link — linked ${first!.externalId}; reconcile the others: ${rest
         .map((r) => r.externalId)
@@ -662,11 +700,22 @@ async function runOutboundCreate(
   const backlinkUrl = ticketUrl(config, sync.ticket.number);
 
   // ── Orphan probe: did an earlier attempt already create this page? ────────
-  const orphan = await probeOwnOrphan(adapter, {
+  const orphan = await probeOwnOrphan(db, adapter, {
+    configId: config.id,
+    syncId: sync.id,
     databaseId: config.databaseId,
     backlinkProperty: markerNames.backlink,
     ticketUrl: backlinkUrl,
   });
+  if (orphan.claimedBy) {
+    // Creating here would mint a duplicate page for work Notion already has;
+    // adopting would breach the link uniqueness. Neither is safe to guess at.
+    return {
+      ...base,
+      action: "skipped",
+      reason: `the Notion page created for this ticket is already linked to ${orphan.claimedBy} — resolve the duplicate link before mirroring`,
+    };
+  }
   if (orphan.match) {
     if (dryRun) {
       return {

--- a/src/server/services/ticketSync/push.ts
+++ b/src/server/services/ticketSync/push.ts
@@ -102,15 +102,17 @@ export interface TicketPushAdapter {
   /** Resolve a Notion workspace person id by email, or null when unmatched. */
   findPersonIdByEmail(email: string): Promise<string | null>;
   /**
-   * Pages in the target database whose title matches `title` exactly
-   * (case-insensitively) — the pre-create duplicate probe. Returns `[]` when
-   * nothing matches, and more than one entry when the title is ambiguous,
-   * which the caller must NOT resolve by guessing.
+   * Pages in the target database whose back-link property equals `ticketUrl` —
+   * the pre-create probe for a page we already created for this ticket.
+   *
+   * Returns `null` when the database has no url-typed back-link property, so
+   * the caller can distinguish "cannot check" from "checked, found nothing".
    */
-  findPagesByTitle(
+  findPagesByBacklink(
     databaseId: string,
-    title: string,
-  ): Promise<Array<{ externalId: string; url: string | null }>>;
+    backlinkProperty: string,
+    ticketUrl: string,
+  ): Promise<Array<{ externalId: string; url: string | null }> | null>;
   /** Create a new page (full-mirror creation); returns the new page id + url. */
   createPage(params: {
     databaseId: string;
@@ -550,65 +552,76 @@ export async function runOutboundTicketPush(
  * Terminal tickets are not mirrored (matching the backfill exclusion); the
  * sentinel is deleted so it doesn't linger as a phantom link.
  */
-type ExistingPageProbe =
-  | { kind: "none" }
-  | { kind: "match"; externalId: string; url: string | null }
-  | { kind: "ambiguous"; reason: string };
+interface OrphanProbe {
+  /** A page we previously created for this ticket, if one exists. */
+  match: { externalId: string; url: string | null } | null;
+  /**
+   * True when we can be sure the matched page's body is ours to rewrite.
+   * False for a page whose provenance we can't pin down (e.g. a human
+   * duplicated one of our pages, so several carry the same back-link).
+   */
+  authored: boolean;
+  warnings: string[];
+}
 
 /**
- * Does the target database already hold a row for this ticket's title?
+ * Did we already create a Notion page for this ticket?
  *
- * Three outcomes, and the split matters:
- * - **none** — safe to create.
- * - **match** — exactly one same-titled row, unclaimed by any other ticket on
- *   this connection. Adopt it.
- * - **ambiguous** — several same-titled rows, or the only one is already
- *   linked to a DIFFERENT ticket (two Exponential tickets for one Notion row —
- *   the duplicate this whole guard exists to stop). Creating here would add a
- *   third copy of the same work, so the run stops and names the conflict for a
- *   human. The sentinel is left in place: the ticket stays unmirrored and
- *   idempotent (no future backfill re-adds it) and every push re-reports the
- *   same reason in the run history until the duplicate is merged.
+ * The back-link property every mirror-created page carries IS the identity of
+ * the source, stored in the target — the exact counterpart of
+ * `links.notionPageId` in the other direction. Reading it back answers the
+ * question outright, where a title match only guesses at it: titles are
+ * user-editable, mutate in place, and are not unique (7% of tickets across
+ * this workspace share one; auto-filed bug tickets are identical by design).
  *
- * Titles are matched case-insensitively after trimming. A blank title can't
- * identify anything, so it probes as `none`.
+ * What this catches is the orphan `NonRetryablePushError` documents: the page
+ * was created, then the write that turns the sentinel into a real link died.
+ * Without this probe the next drain creates a second page.
+ *
+ * A database with no url-typed back-link property can't be probed. That
+ * degrades to the old behaviour with a warning rather than failing — the
+ * back-link is optional in the create payload too.
  */
-async function probeExistingPage(
-  db: PrismaClient,
+async function probeOwnOrphan(
   adapter: TicketPushAdapter,
-  args: { configId: string; databaseId: string; title: string },
-): Promise<ExistingPageProbe> {
-  const title = args.title.trim();
-  if (!title) return { kind: "none" };
+  args: { databaseId: string; backlinkProperty: string; ticketUrl: string },
+): Promise<OrphanProbe> {
+  const found = await adapter.findPagesByBacklink(
+    args.databaseId,
+    args.backlinkProperty,
+    args.ticketUrl,
+  );
 
-  const candidates = await adapter.findPagesByTitle(args.databaseId, title);
-  if (candidates.length === 0) return { kind: "none" };
-
-  const claims = await db.ticketSync.findMany({
-    where: {
-      configId: args.configId,
-      externalId: { in: candidates.map((c) => c.externalId) },
-    },
-    select: { externalId: true, ticket: { select: { number: true } } },
-  });
-  const claimedBy = new Map(claims.map((c) => [c.externalId, c.ticket.number]));
-  const unclaimed = candidates.filter((c) => !claimedBy.has(c.externalId));
-
-  if (unclaimed.length === 1) {
-    const match = unclaimed[0]!;
-    return { kind: "match", externalId: match.externalId, url: match.url };
-  }
-  if (unclaimed.length > 1) {
+  if (found === null) {
     return {
-      kind: "ambiguous",
-      reason: `${unclaimed.length} Notion rows share this title — link one to the ticket by hand, or rename the duplicates, before mirroring`,
+      match: null,
+      authored: false,
+      warnings: [
+        `no url-typed "${args.backlinkProperty}" property in Notion — cannot tell whether a page was already created for this ticket`,
+      ],
     };
   }
+  if (found.length === 0) return { match: null, authored: false, warnings: [] };
 
-  const owners = [...new Set(claims.map((c) => `#${c.ticket.number}`))].join(", ");
+  const [first, ...rest] = found;
+  if (rest.length === 0) {
+    // Only our own create writes this property with this exact URL, so the
+    // page — and its body — is ours.
+    return { match: first!, authored: true, warnings: [] };
+  }
+
+  // Several pages carry this ticket's back-link: earlier orphans, or a human
+  // duplicating one of our pages in Notion. Linking one is still better than
+  // minting another, but we can no longer claim authorship of the body — so
+  // `authored` stays false and the body-repair pass leaves it alone.
   return {
-    kind: "ambiguous",
-    reason: `a Notion row with this title is already linked to ticket ${owners} — merge the duplicate tickets before mirroring this one`,
+    match: first!,
+    authored: false,
+    warnings: [
+      `${found.length} Notion pages carry this ticket's back-link — linked ${first!.externalId}; reconcile the others: ${rest
+        .map((r) => r.externalId)
+        .join(", ")}`,
+    ],
   };
 }
 
@@ -645,48 +658,43 @@ async function runOutboundCreate(
     };
   }
 
-  // ── Duplicate probe: never create a page for a title Notion already has ───
-  // The provenance guard upstream stops the KNOWN import cohort; this catches
-  // the rest (a ticket typed by hand to match a Notion row, an orphan left by
-  // a half-finished create). Adopting is strictly safer than creating: the
-  // three-way merge reconciles the two sides on the next pass, whereas a
-  // wrong create is a live page in the customer's workspace that only a human
-  // can retract.
-  const existing = await probeExistingPage(db, adapter, {
-    configId: config.id,
+  const markerNames = resolveMarkerNames(config.propertyNames);
+  const backlinkUrl = ticketUrl(config, sync.ticket.number);
+
+  // ── Orphan probe: did an earlier attempt already create this page? ────────
+  const orphan = await probeOwnOrphan(adapter, {
     databaseId: config.databaseId,
-    title: local.title,
+    backlinkProperty: markerNames.backlink,
+    ticketUrl: backlinkUrl,
   });
-  if (existing.kind === "ambiguous") {
-    return { ...base, action: "skipped", reason: existing.reason };
-  }
-  if (existing.kind === "match") {
+  if (orphan.match) {
     if (dryRun) {
       return {
         ...base,
-        externalId: existing.externalId,
+        externalId: orphan.match.externalId,
         action: "adopted",
-        reason: "would link to the existing Notion row with this title",
+        reason: ["would link the page already created for this ticket", ...orphan.warnings].join("; "),
       };
     }
-    // Adopt exactly as the inbound pass does: link, but leave `snapshot` null
-    // so the first merge treats every difference as a two-sided change and
-    // resolves by last-write-wins. `remoteCreatedAt` stays null on purpose —
-    // this page is human-authored, and the body-repair pass gates on that
-    // column to decide what it may rewrite.
+    // Link, with a null snapshot so the first merge treats every difference as
+    // a two-sided change and resolves by last-write-wins. `remoteCreatedAt` is
+    // set ONLY when the back-link identified a single page: it licenses the
+    // body-repair pass to rewrite the content, which is right for a page we
+    // authored and wrong for anything else.
     await db.ticketSync.update({
       where: { id: sync.id },
       data: {
-        externalId: existing.externalId,
-        externalUrl: existing.url,
+        externalId: orphan.match.externalId,
+        externalUrl: orphan.match.url,
         snapshot: Prisma.DbNull,
+        ...(orphan.authored ? { remoteCreatedAt: new Date() } : {}),
       },
     });
     return {
       ...base,
-      externalId: existing.externalId,
+      externalId: orphan.match.externalId,
       action: "adopted",
-      reason: "linked to the existing Notion row with this title",
+      reason: ["linked the page already created for this ticket", ...orphan.warnings].join("; "),
     };
   }
 
@@ -703,7 +711,10 @@ async function runOutboundCreate(
     currentRemoteStatusRaw: null,
   });
   const properties: Record<string, unknown> = { ...scalar.properties };
-  const warnings = [...scalar.warnings];
+  // Carry the probe's warnings onto the create: "couldn't check for an
+  // existing page" is exactly the context someone needs when a duplicate
+  // turns up later.
+  const warnings = [...orphan.warnings, ...scalar.warnings];
 
   if (local.cycleName) {
     const pageId = await adapter.findCyclePageIdByName(
@@ -723,12 +734,10 @@ async function runOutboundCreate(
       );
   }
 
-  const markerNames = resolveMarkerNames(config.propertyNames);
   const source = buildSourceProperty(schema, markerNames.source);
   if (source.property) Object.assign(properties, source.property);
   if (source.warning) warnings.push(source.warning);
 
-  const backlinkUrl = ticketUrl(config, sync.ticket.number);
   const backlink = buildBacklinkProperty(schema, markerNames.backlink, backlinkUrl);
   if (backlink) Object.assign(properties, backlink);
 

--- a/src/server/services/ticketSync/pushRunner.ts
+++ b/src/server/services/ticketSync/pushRunner.ts
@@ -232,7 +232,29 @@ export interface BackfillPlanItem {
   ticketId: string;
   title: string;
   number: number;
+  /**
+   * Set when Notion already holds a row with this title. Advisory ONLY — a
+   * title is user-editable, mutates in place, and is not unique (auto-filed
+   * bug tickets are identical by design), so it is a hint for the person
+   * approving the backfill and must never drive an automatic decision.
+   */
+  warning?: string;
 }
+
+/** Adapter surface the preview needs; a subset of the real Notion adapter. */
+export interface BackfillTitleProbe {
+  findPagesByTitle(
+    databaseId: string,
+    title: string,
+  ): Promise<Array<{ externalId: string; url: string | null }>>;
+}
+
+/**
+ * How many planned rows the title check covers. One Notion query per title, so
+ * this is capped at the number the preview UI actually shows; the router
+ * reports the cap rather than implying the whole plan was checked.
+ */
+export const TITLE_WARNING_PROBE_LIMIT = 20;
 
 /**
  * The one-time backfill manifest: the non-terminal tickets in a config's
@@ -248,11 +270,11 @@ export interface BackfillPlanItem {
  */
 export async function planBackfill(
   db: PrismaClient,
-  params: { configId: string },
+  params: { configId: string; probe?: BackfillTitleProbe },
 ): Promise<BackfillPlanItem[]> {
   const config = await db.ticketSyncConfig.findUnique({
     where: { id: params.configId },
-    select: { productId: true },
+    select: { productId: true, databaseId: true },
   });
   if (!config) return [];
 
@@ -265,10 +287,30 @@ export async function planBackfill(
     select: { id: true, title: true, number: true, links: true },
     orderBy: { createdAt: "asc" },
   });
-  return tickets
+  const items: BackfillPlanItem[] = tickets
     .filter((t) => !ticketIsNotionBorn(t))
     .slice(0, BACKFILL_LIMIT)
     .map((t) => ({ ticketId: t.id, title: t.title, number: t.number }));
+
+  if (!params.probe) return items;
+
+  // Advisory title check on the rows the preview shows. A failure here must
+  // never break the preview — a missing warning is a smaller problem than a
+  // backfill nobody can approve.
+  for (const item of items.slice(0, TITLE_WARNING_PROBE_LIMIT)) {
+    try {
+      const matches = await params.probe.findPagesByTitle(
+        config.databaseId,
+        item.title,
+      );
+      if (matches.length > 0) {
+        item.warning = `Notion already has ${matches.length === 1 ? "a row" : `${matches.length} rows`} with this title — check this isn't the same work before mirroring`;
+      }
+    } catch {
+      // Leave the item unwarned; the create path's own probe is the real guard.
+    }
+  }
+  return items;
 }
 
 /**

--- a/src/server/services/ticketSync/pushRunner.ts
+++ b/src/server/services/ticketSync/pushRunner.ts
@@ -239,6 +239,12 @@ export interface BackfillPlanItem {
    * approving the backfill and must never drive an automatic decision.
    */
   warning?: string;
+  /**
+   * True when the title check actually completed for this row. Absent warning
+   * + absent flag means "not checked", NOT "checked and clean" — the probe
+   * swallows per-row failures, so the two must stay distinguishable.
+   */
+  titleChecked?: boolean;
 }
 
 /** Adapter surface the preview needs; a subset of the real Notion adapter. */
@@ -296,18 +302,21 @@ export async function planBackfill(
 
   // Advisory title check on the rows the preview shows. A failure here must
   // never break the preview — a missing warning is a smaller problem than a
-  // backfill nobody can approve.
+  // backfill nobody can approve. Each item records whether its own check
+  // actually ran, so "no warning" is never read as "checked and clean" when
+  // Notion rate-limited us halfway through.
   for (const item of items.slice(0, TITLE_WARNING_PROBE_LIMIT)) {
     try {
       const matches = await params.probe.findPagesByTitle(
         config.databaseId,
         item.title,
       );
+      item.titleChecked = true;
       if (matches.length > 0) {
         item.warning = `Notion already has ${matches.length === 1 ? "a row" : `${matches.length} rows`} with this title — check this isn't the same work before mirroring`;
       }
     } catch {
-      // Leave the item unwarned; the create path's own probe is the real guard.
+      // Leave titleChecked false; the create path's own probe is the real guard.
     }
   }
   return items;


### PR DESCRIPTION
### **User description**
## What

Replaces the title-matching probe that landed in PR 534 with the exact key the sync already writes.

PR 534 merged the interim version, so `main` currently identifies pages **by title**. This
supersedes that half of it. The provenance guard from 534 is untouched.

## Why title matching had to go

534's probe asked *"does a Notion row share this title?"* to answer *"did I already create a page
for this ticket?"*. Different questions, and the data says title answers wrongly:

- **Titles mutate.** Between two snapshots of the `clear` product taken 45 minutes apart, ticket
  #83 was renamed from "Study and analyze right data orchestrator for clear-pipeline" to
  "Analytics - PostHog" — and now collides with #84. A key that changes under you is not a key.
- **Titles are not unique.** 7.0% of 883 tickets across all products share a title with another.
- **Some collisions are structural.** `PrismaClientKnownRequestError:` x5 and `HttpError: Bad
  credentials` x2 — auto-filed BUG tickets, byte-identical by design, sitting in a Notion-linked
  product. The merged probe would refuse to mirror all but the first, permanently, reporting only
  into run history.
- **The value is user-editable.** Rename a ticket onto an unrelated Notion row and the mirror
  adopts that page, then last-write-wins overwrites one side. Silent data loss from an ordinary
  rename.

## The key we already write and never read

Every page the mirror creates carries the ticket's URL in its `Exponential URL` property — the
identity of the source stored in the target, the exact counterpart of `links.notionPageId` in the
other direction. `runOutboundCreate` now queries it before creating:

- **one match** → adopt it. Null snapshot so the merge resolves last-write-wins.
- **no match** → create, as before.
- **several matches** (earlier orphans, or a ticket URL pasted onto more than one page) → link
  the first and warn naming the rest.
- **already linked to another ticket** → skip, naming it. `@@unique([configId, externalId])`
  would otherwise turn adoption into a constraint error that kills the run.
- **no url-typed back-link property** → degrade to the previous behaviour, with the warning
  carried onto the created item rather than failing.

`remoteCreatedAt` is **never** set on adoption. It licenses the body-repair pass to rewrite a
page body, and the back-link cannot prove we authored one: `Exponential URL` is an ordinary
user-writable Notion property, so a person cross-referencing a ticket by pasting its URL
produces exactly one match on a page we never touched. Adopting it is reasonable — the paste is
a plausible way to ask for a link — but rewriting its body would be an irreversible overwrite of
someone else's content. An orphan we really did create simply goes un-repaired.

This closes the case `NonRetryablePushError` documents and accepts: page created, link write
died, next drain mints a second page.

## Title matching, demoted

It survives only as an **advisory warning in the backfill preview**, where a human approves the
plan before anything is written. Capped at the rows the preview shows, a probe failure leaves the
item unwarned rather than breaking the preview, and a flagged row stays in the plan — it informs,
it does not decide.

## Scope

Unchanged: the **inbound** direction still creates a second ticket when a provenance-less local
ticket for the same work exists. No exact key is available there by construction — nothing we
wrote is on an out-of-band ticket — so I've deliberately not reached for a heuristic.

## Tests

9 cases on the probe: adopt (asserting `remoteCreatedAt` is NOT set), no-match-creates,
several-matches links one and names the rest, already-claimed skips, missing-back-link-property
degrades with a warning, dry-run; plus the advisory title warning, its honest "checked" flag, and
a throwing probe leaving the preview intact.
The fake Notion harness now models both creation markers, so the round-trip suite exercises the
real probe path. Full suite green — 2355 unit tests, typecheck, lint.

---

## Review

PR-Agent ran twice. Round one caught a dropped claim check — adopting a page already linked to
another ticket would have breached `@@unique([configId, externalId])` and killed the run with an
opaque error (`88bf3daf`). Round two caught the `remoteCreatedAt` data-loss path above, plus a
truncated/unpaginated probe result set, a `titleChecked` count computed from plan size rather
than completed probes, and repeated schema fetches during a drain — all fixed in `824c1c00`.

The one finding not acted on: preview latency from the advisory title check. The backfill
preview is a rare, deliberate gate in front of a bulk write to a live workspace, sequential
probing is the rate-limit-gentle choice, and the per-adapter schema cache added in `824c1c00`
removes most of the cost. Coverage is now reported honestly rather than assumed.

Tracking: ticket [483 `round.duck`](https://www.exponential.im/w/syntrofi/products/exponential/tickets/483).
Background and the as-built description of the sync live on ticket
[255 `polar.canyon`](https://www.exponential.im/w/syntrofi/products/exponential/tickets/255).


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Identify existing Notion pages by back-link URL, not title

- Adopt/skip logic handles claimed and multi-match pages

- Title matching demoted to advisory backfill-preview warning

- Memoize raw Notion database fetches per adapter instance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["runOutboundCreate"] -- "old" --> B["findPagesByTitle probe"]
  A -- "new" --> C["findPagesByBacklink(Exponential URL)"]
  C -- "null" --> D["create + warning"]
  C -- "no match" --> E["create page"]
  C -- "one usable match" --> F["adopt (null snapshot, no remoteCreatedAt)"]
  C -- "all claimed" --> G["skip with owner ticket"]
  C -- "several matches" --> H["adopt first + reconcile warning"]
  B -- "reused as" --> I["planBackfill advisory titleChecked/warning"]
  I --> J["backfillPreview returns titleChecked count"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>push.ts</strong><dd><code>Replace title duplicate probe with back-link orphan probe</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/537/files#diff-0504c91c3575b6a06d16df56910f78c731ff2ea60dda0fd1cb9363d23690afaa">+132/-72</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>notionAdapter.ts</strong><dd><code>Add paginated findPagesByBacklink and raw database caching</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/537/files#diff-01ccbdc7c270905dc6d098bdec52026e3fadd76ea2f3d33c301bece929bc8e5d">+93/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pushRunner.ts</strong><dd><code>Advisory title warnings and titleChecked in backfill plan</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/537/files#diff-f5164fbd46b930900b6f67bdbcde0f4ebdb4eafe1b1c3c53b48811191dab6aa6">+54/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ticketSync.ts</strong><dd><code>Backfill preview runs advisory title probe, reports count</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/537/files#diff-585d5c60345724f010f2656d948c90004a42c63e4c7d1d85ec8901cadf4bd1c9">+22/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>push.test.ts</strong><dd><code>Rewrite probe tests around back-link adoption cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/537/files#diff-5a8e270b8e45e16f0ee895e07876de657ce70698fffc22cb529906dd82ddfe9b">+82/-39</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pushRunner.test.ts</strong><dd><code>Cover advisory title warnings and probe failure tolerance</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/537/files#diff-ba7cd961950c31c30eb37eeb1a532ce04b44f5df8903078924c41ec28b1d552e">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fakeNotion.ts</strong><dd><code>Model Source/Exponential URL properties and back-link lookup</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/537/files#diff-ba2ee470ae82b0459adeef15836eb7fcdc170645e4f786d721308dde159c25cf">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

