### PR TITLE
feat(notion-sync): explain what Dry run and Sync now actually do

### DIFF
--- a/src/app/_components/products/NotionSyncSettings.tsx
+++ b/src/app/_components/products/NotionSyncSettings.tsx
@@ -269,12 +269,15 @@ export function NotionSyncSettings({ productId }: { productId: string }) {
     return (
       <div className="space-y-4">
         <div className="rounded-lg border border-border-primary bg-surface-secondary px-5 py-4">
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-3 min-w-0">
-              <IconBrandNotion size={22} className="text-text-secondary shrink-0" />
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex min-w-0 items-start gap-3">
+              <IconBrandNotion
+                size={22}
+                className="text-text-secondary mt-0.5 shrink-0"
+              />
               <div className="min-w-0">
-                <div className="flex items-center gap-2">
-                  <Text size="sm" fw={600} className="text-text-primary truncate">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Text size="sm" fw={600} className="text-text-primary">
                     {config.databaseName ?? "Notion database"}
                   </Text>
                   <Badge
@@ -286,52 +289,110 @@ export function NotionSyncSettings({ productId }: { productId: string }) {
                       ? "Connected"
                       : "Connection issue"}
                   </Badge>
+                  {!config.enabled && (
+                    <Badge size="xs" variant="light" color="yellow">
+                      Paused
+                    </Badge>
+                  )}
                 </div>
-                <Text size="xs" className="text-text-muted truncate">
+                {/* One fact per line: the old single truncated line hid the
+                    "last pulled" timestamp, which is the first thing you need
+                    when a ticket looks out of date. */}
+                <Text size="xs" className="text-text-muted mt-1">
                   via {config.integrationName}
                   {config.linkedTicketCount > 0 &&
                     ` · ${config.linkedTicketCount} linked ticket${config.linkedTicketCount === 1 ? "" : "s"}`}
+                </Text>
+                <Text size="xs" className="text-text-muted">
                   {config.lastPulledAt
-                    ? ` · last pulled ${new Date(config.lastPulledAt).toLocaleString()}`
-                    : " · never pulled"}
+                    ? `Last pulled ${new Date(config.lastPulledAt).toLocaleString()}`
+                    : "Never pulled"}
                 </Text>
               </div>
             </div>
-            <div className="flex items-center gap-2 shrink-0">
-              <Button
-                size="xs"
-                variant="light"
-                leftSection={<IconEyeSearch size={14} />}
-                onClick={() => syncNow.mutate({ productId, dryRun: true })}
-                loading={syncNow.isPending && syncNow.variables?.dryRun === true}
-                disabled={syncNow.isPending}
-              >
+            <Button
+              size="xs"
+              variant="subtle"
+              color="red"
+              className="shrink-0"
+              leftSection={<IconUnlink size={14} />}
+              onClick={onDisconnect}
+              loading={disconnect.isPending}
+            >
+              Disconnect
+            </Button>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border-primary bg-surface-secondary px-5 py-1">
+          <div className="flex items-start justify-between gap-4 border-b border-border-primary py-3.5">
+            <div className="min-w-0">
+              <Text size="sm" fw={600} className="text-text-primary">
                 Dry run
-              </Button>
-              <Button
-                size="xs"
-                variant="light"
-                leftSection={<IconRefresh size={14} />}
-                onClick={() => onSyncNow(!config.lastPulledAt)}
-                loading={
-                  gateDryRun.isPending ||
-                  (syncNow.isPending && syncNow.variables?.dryRun !== true)
-                }
-                disabled={syncNow.isPending || gateDryRun.isPending || !config.enabled}
-              >
-                Sync now
-              </Button>
-              <Button
-                size="xs"
-                variant="subtle"
-                color="red"
-                leftSection={<IconUnlink size={14} />}
-                onClick={onDisconnect}
-                loading={disconnect.isPending}
-              >
-                Disconnect
-              </Button>
+              </Text>
+              <Text size="xs" className="text-text-muted mt-0.5 max-w-prose">
+                Shows what a sync would change, ticket by ticket and with the
+                reason for each — without writing anything. Safe to run at any
+                time, including while sync is paused.
+              </Text>
             </div>
+            <Button
+              size="xs"
+              variant="light"
+              className="shrink-0"
+              leftSection={<IconEyeSearch size={14} />}
+              onClick={() => syncNow.mutate({ productId, dryRun: true })}
+              loading={syncNow.isPending && syncNow.variables?.dryRun === true}
+              disabled={syncNow.isPending}
+            >
+              Dry run
+            </Button>
+          </div>
+          <div className="flex items-start justify-between gap-4 py-3.5">
+            <div className="min-w-0">
+              <Text size="sm" fw={600} className="text-text-primary">
+                Sync now
+              </Text>
+              <Text size="xs" className="text-text-muted mt-0.5 max-w-prose">
+                Pulls from Notion into Exponential immediately, instead of
+                waiting for the next scheduled run. New rows become tickets, and
+                changes to title, status, priority, type, effort, cycle and
+                assignee land on their linked tickets.
+              </Text>
+              <Text size="xs" className="text-text-muted mt-1.5 max-w-prose">
+                This direction only — it never writes to Notion. That&apos;s
+                &quot;Push changes to Notion&quot; below.
+              </Text>
+              <Text size="xs" className="text-text-muted mt-1.5 max-w-prose">
+                It only checks rows Notion reports as edited since the last pull
+                {config.lastPulledAt
+                  ? ` (${new Date(config.lastPulledAt).toLocaleString()})`
+                  : ""}
+                . An edit Notion didn&apos;t re-timestamp won&apos;t be seen, so
+                if a ticket looks stale, run Dry run first to check whether
+                it&apos;s in the window at all.
+              </Text>
+              {!config.enabled && (
+                <Text size="xs" c="yellow" className="mt-1.5">
+                  Sync is paused — turn on &quot;Sync enabled&quot; below to run
+                  it.
+                </Text>
+              )}
+            </div>
+            <Button
+              size="xs"
+              variant="light"
+              className="shrink-0"
+              leftSection={<IconRefresh size={14} />}
+              onClick={() => onSyncNow(!config.lastPulledAt)}
+              loading={
+                gateDryRun.isPending ||
+                (syncNow.isPending && syncNow.variables?.dryRun !== true)
+              }
+              disabled={syncNow.isPending || gateDryRun.isPending || !config.enabled}
+            >
+              Sync now
+            </Button>
           </div>
         </div>
 


### PR DESCRIPTION
### **User description**
## What

The Notion sync settings card packed the database identity, three buttons and all the metadata into a single row. Two consequences:

- The buttons carried no explanation. "Sync now" gave no hint that it's **inbound-only**, or that it only looks at rows Notion re-timestamped since the last pull.
- The meta line was one `truncate`d string, so **"last pulled …" was the first thing to get cut off** — the one fact you need when a ticket looks stale.

Split into two cards: the connection card keeps identity and Disconnect, and the two actions move into their own card using the label/description/control row pattern that Sync enabled, Push changes to Notion and Backfill already use.

Also adds a `Paused` badge when sync is off, so the disabled Sync now button has a visible reason.

## Why now

Came out of investigating a CLEAR ticket whose cycle was stale — Notion said Cycle 13, Exponential said Cycle 12 — where the reasonable assumption was that "Sync now" would fix it. It does run a real inbound pull, but the incremental-window caveat wasn't discoverable anywhere in the UI. The copy now states it, and points at Dry run as the diagnostic.

The underlying sync defect that investigation turned up is filed separately as `ashen.marsh` (484) and is **not** addressed here — this PR is UI copy and layout only.

## Screenshot

Rendered against the `dev-fixture` workspace with a seeded Notion sync config (the seeding was throwaway; no fixture changes are in this PR).

Verified by rendering the page (see Testing below) — connection identity, the two explained action rows, then the existing toggles.

## Testing

- `eslint` clean on the changed file
- `tsc --noEmit` clean
- Pre-commit hook ran the full unit suite: 230 files, 2321 tests passed, plus the Prisma migration and hardcoded-colour checks
- Verified visually via Playwright against the dev-fixture workspace

No migrations. UI-only, single file.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Split Notion sync card into connection and actions cards

- Add explanatory copy for `Dry run` and `Sync now`

- Surface `Paused` badge and paused hint when sync disabled

- Stop truncating meta; show "last pulled" on its own line


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["Single card: identity + 3 buttons + truncated meta"]
  conn["Connection card: name, status, Paused badge, Disconnect"]
  actions["Actions card: labeled rows with descriptions"]
  dry["Dry run: preview, no writes"]
  sync["Sync now: inbound-only, incremental window caveat"]
  old --> conn
  old --> actions
  actions --> dry
  actions --> sync
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NotionSyncSettings.tsx</strong><dd><code>Restructure Notion sync settings into explained action rows</code></dd></summary>
<hr>

src/app/_components/products/NotionSyncSettings.tsx

<ul><li>Split the connected-state UI into two cards: connection <br>identity/<code>Disconnect</code>, and a separate actions card<br> <li> Moved <code>Dry run</code> and <code>Sync now</code> into label/description/control rows with <br>explanatory copy (inbound-only, incremental window, dry-run diagnostic <br>hint)<br> <li> Added a <code>Paused</code> badge and an inline paused message when <code>config.enabled</code> <br>is false<br> <li> Replaced the single truncated meta line with separate lines, giving <br>"Last pulled"/"Never pulled" its own row</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/538/files#diff-b770e43cfa4e1263d83ed5a8602ab1dd1f50b9cb84070cd382c81eb5d89ba756">+101/-40</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

