### PR TITLE
feat(google): gate Calendar/Contacts/Gmail behind a tester allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,17 @@ AUTH_DISCORD_SECRET=""
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
 
+# Comma-separated allowlist of users who may use the Google features whose
+# scopes Google has not verified yet (Calendar, Contacts, Gmail). These must be
+# the same addresses registered as test users on the Google Cloud Console
+# project, or consent will still fail. Google *sign-in* is verified and is not
+# affected by this list.
+#
+# Empty or unset locks those features for everyone and shows a "premium
+# feature — contact support" message instead of a broken consent screen.
+# Example: GOOGLE_OAUTH_TESTER_EMAILS="a@example.com,b@example.com"
+GOOGLE_OAUTH_TESTER_EMAILS=""
+
 # Microsoft Entra ID (Azure AD)
 MICROSOFT_ENTRA_ID_CLIENT_ID=""
 MICROSOFT_ENTRA_ID_CLIENT_SECRET=""

--- a/src/app/(sidemenu)/daily-plan/_components/CalendarEventImporter.tsx
+++ b/src/app/(sidemenu)/daily-plan/_components/CalendarEventImporter.tsx
@@ -144,11 +144,14 @@ export function CalendarEventImporter({
           </div>
         )}
 
-        {!isLoading && !connectionStatus?.isConnected && connectionStatus?.gated && (
+        {/* Both branches require a defined status: on a query error we'd
+            otherwise show the connect prompt, which for a gated user leads
+            straight back to the premium page. */}
+        {!isLoading && connectionStatus && !connectionStatus.isConnected && connectionStatus.gated && (
           <GooglePremiumFeature feature="calendar" variant="alert" />
         )}
 
-        {!isLoading && !connectionStatus?.isConnected && !connectionStatus?.gated && (
+        {!isLoading && connectionStatus && !connectionStatus.isConnected && !connectionStatus.gated && (
           <Alert
             icon={<IconAlertCircle size={16} />}
             title="Calendar not connected"

--- a/src/app/(sidemenu)/daily-plan/_components/CalendarEventImporter.tsx
+++ b/src/app/(sidemenu)/daily-plan/_components/CalendarEventImporter.tsx
@@ -15,6 +15,7 @@ import {
 import { IconCalendar, IconAlertCircle } from "@tabler/icons-react";
 import { format, differenceInMinutes } from "date-fns";
 import { api } from "~/trpc/react";
+import { GooglePremiumFeature } from "~/app/_components/GooglePremiumFeature";
 
 interface CalendarEvent {
   id: string;
@@ -143,7 +144,11 @@ export function CalendarEventImporter({
           </div>
         )}
 
-        {!isLoading && !connectionStatus?.isConnected && (
+        {!isLoading && !connectionStatus?.isConnected && connectionStatus?.gated && (
+          <GooglePremiumFeature feature="calendar" variant="alert" />
+        )}
+
+        {!isLoading && !connectionStatus?.isConnected && !connectionStatus?.gated && (
           <Alert
             icon={<IconAlertCircle size={16} />}
             title="Calendar not connected"

--- a/src/app/(sidemenu)/google-access/page.tsx
+++ b/src/app/(sidemenu)/google-access/page.tsx
@@ -1,0 +1,28 @@
+import { Container, Stack } from "@mantine/core";
+import {
+  GooglePremiumFeature,
+  type GooglePremiumFeatureKind,
+} from "~/app/_components/GooglePremiumFeature";
+
+/**
+ * Landing page for users who tried to start a Google OAuth flow that needs a
+ * scope Google hasn't verified yet. `/api/auth/google-calendar` redirects here
+ * instead of handing them to Google's "unverified app" error screen.
+ */
+export default async function GoogleAccessPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ feature?: string }>;
+}) {
+  const { feature } = await searchParams;
+  const kind: GooglePremiumFeatureKind =
+    feature === "contacts" ? "contacts" : "calendar";
+
+  return (
+    <Container size="sm" py="xl">
+      <Stack gap="lg">
+        <GooglePremiumFeature feature={kind} variant="card" />
+      </Stack>
+    </Container>
+  );
+}

--- a/src/app/(sidemenu)/settings/integrations/page.tsx
+++ b/src/app/(sidemenu)/settings/integrations/page.tsx
@@ -22,6 +22,7 @@ import {
 import { notifications } from '@mantine/notifications';
 import { api } from '~/trpc/react';
 import { GoogleCalendarConnect } from '~/app/_components/GoogleCalendarConnect';
+import { GooglePremiumFeature } from '~/app/_components/GooglePremiumFeature';
 import { CalendarMultiSelect } from '~/app/_components/calendar/CalendarMultiSelect';
 import { FirefliesIntegrationsList } from '~/app/_components/integrations/FirefliesIntegrationsList';
 import { FirefliesWizardModal } from '~/app/_components/integrations/FirefliesWizardModal';
@@ -38,6 +39,9 @@ export default function IntegrationsSettingsPage() {
 
   // Calendar connection status
   const { data: calendarStatus } = api.calendar.getConnectionStatus.useQuery();
+  // True while our Google calendar scopes await verification and this user
+  // isn't an allowlisted tester — offer the premium message, not a connect button.
+  const calendarGated = calendarStatus?.gated ?? false;
 
   // Calendar disconnect mutation
   const disconnectCalendar = api.calendar.disconnect.useMutation({
@@ -132,7 +136,9 @@ export default function IntegrationsSettingsPage() {
                 <Text size="xs" c="dimmed">
                   {calendarStatus?.isConnected
                     ? 'Your calendar is connected'
-                    : 'Connect to see your events and schedule'}
+                    : calendarGated
+                      ? 'Available to select users during our verification process'
+                      : 'Connect to see your events and schedule'}
                 </Text>
               </div>
             </Group>
@@ -148,9 +154,15 @@ export default function IntegrationsSettingsPage() {
                 Disconnect
               </Button>
             ) : (
-              <GoogleCalendarConnect isConnected={false} />
+              <GoogleCalendarConnect isConnected={false} gated={calendarGated} />
             )}
           </Group>
+
+          {calendarGated && !calendarStatus?.isConnected && (
+            <div className="mt-4">
+              <GooglePremiumFeature feature="calendar" variant="alert" />
+            </div>
+          )}
 
           {calendarStatus?.isConnected && (
             <div className="mt-4 pt-4 border-t border-border-primary">

--- a/src/app/(sidemenu)/settings/integrations/page.tsx
+++ b/src/app/(sidemenu)/settings/integrations/page.tsx
@@ -42,6 +42,11 @@ export default function IntegrationsSettingsPage() {
   // True while our Google calendar scopes await verification and this user
   // isn't an allowlisted tester — offer the premium message, not a connect button.
   const calendarGated = calendarStatus?.gated ?? false;
+  // Gated, but tokens are still stored — the user connected before the gate
+  // (or fell off the allowlist). Keep Disconnect reachable: this is the only
+  // UI path to revoke an account we otherwise hide everywhere.
+  const hasGatedLeftoverConnection =
+    calendarGated && (calendarStatus?.hasStoredConnection ?? false);
 
   // Calendar disconnect mutation
   const disconnectCalendar = api.calendar.disconnect.useMutation({
@@ -136,13 +141,15 @@ export default function IntegrationsSettingsPage() {
                 <Text size="xs" c="dimmed">
                   {calendarStatus?.isConnected
                     ? 'Your calendar is connected'
-                    : calendarGated
-                      ? 'Available to select users during our verification process'
-                      : 'Connect to see your events and schedule'}
+                    : hasGatedLeftoverConnection
+                      ? 'Paused while we complete Google verification — you can still remove it'
+                      : calendarGated
+                        ? 'Available to select users during our verification process'
+                        : 'Connect to see your events and schedule'}
                 </Text>
               </div>
             </Group>
-            {calendarStatus?.isConnected ? (
+            {calendarStatus?.isConnected || hasGatedLeftoverConnection ? (
               <Button
                 variant="subtle"
                 color="red"

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/_components/ImportDialog.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/_components/ImportDialog.tsx
@@ -26,6 +26,7 @@ import {
 import { api } from "~/trpc/react";
 import { notifications } from "@mantine/notifications";
 import { subMonths, subYears } from "date-fns";
+import { GooglePremiumFeature } from "~/app/_components/GooglePremiumFeature";
 
 interface ImportDialogProps {
   opened: boolean;
@@ -96,7 +97,7 @@ export function ImportDialog({
   // Determine initial step based on connection
   useEffect(() => {
     if (!connectionLoading && opened) {
-      if (connection && connection.hasAllScopes && connection.hasRefreshToken) {
+      if (connection?.hasAllScopes && connection.hasRefreshToken) {
         setStep("options");  // Has Google with all scopes → Go to import options
       } else {
         setStep("connect");  // No Google or missing scopes/refresh token → Show connect step
@@ -151,10 +152,15 @@ export function ImportDialog({
       closeOnEscape={step !== "progress"}
     >
       <Stack gap="lg">
+        {/* Gated: contacts/Gmail scopes are still awaiting Google verification */}
+        {step === "connect" && connection?.gated && (
+          <GooglePremiumFeature feature="contacts" variant="alert" />
+        )}
+
         {/* Connect Step */}
-        {step === "connect" && (
+        {step === "connect" && !connection?.gated && (
           <>
-            {connection && (!connection.hasAllScopes || !connection.hasRefreshToken) ? (
+            {connection?.connected && (!connection.hasAllScopes || !connection.hasRefreshToken) ? (
               <Alert icon={<IconAlertCircle />} color="yellow" mb="md">
                 <Stack gap="xs">
                   <Text size="sm" fw={500}>
@@ -208,7 +214,9 @@ export function ImportDialog({
               onClick={handleConnectGoogle}
               loading={connectionLoading}
             >
-              {connection ? "Reconnect Google Account" : "Connect Google Account"}
+              {connection?.connected
+                ? "Reconnect Google Account"
+                : "Connect Google Account"}
             </Button>
           </>
         )}

--- a/src/app/_components/CreateMeetingModal.tsx
+++ b/src/app/_components/CreateMeetingModal.tsx
@@ -26,6 +26,7 @@ import {
   IconExternalLink,
 } from "@tabler/icons-react";
 import { GoogleCalendarConnect } from "./GoogleCalendarConnect";
+import { GooglePremiumFeature } from "./GooglePremiumFeature";
 
 interface CreateMeetingModalProps {
   projectId?: string;
@@ -167,6 +168,8 @@ export function CreateMeetingModal({
 
   const isValid = title.trim() && meetingDate && startTime;
   const isConnected = connectionStatus?.isConnected ?? false;
+  // Creating events needs the calendar scopes Google hasn't verified yet.
+  const isGated = connectionStatus?.gated ?? false;
 
   return (
     <>
@@ -196,6 +199,10 @@ export function CreateMeetingModal({
         {statusLoading ? (
           <Stack align="center" py="xl">
             <Text c="dimmed">Checking calendar connection...</Text>
+          </Stack>
+        ) : isGated ? (
+          <Stack gap="md" py="md">
+            <GooglePremiumFeature feature="calendar" variant="alert" />
           </Stack>
         ) : !isConnected ? (
           <Stack gap="md" py="md">

--- a/src/app/_components/GoogleCalendarConnect.tsx
+++ b/src/app/_components/GoogleCalendarConnect.tsx
@@ -1,16 +1,28 @@
 "use client";
 
-import { Button } from "@mantine/core";
-import { IconCalendar, IconCheck } from "@tabler/icons-react";
+import { Button, Tooltip } from "@mantine/core";
+import { IconCalendar, IconCheck, IconLock } from "@tabler/icons-react";
 import { useSearchParams } from "next/navigation";
+import Link from "next/link";
 import { notifications } from "@mantine/notifications";
 import { useEffect, useState } from "react";
 
 interface GoogleCalendarConnectProps {
   isConnected?: boolean;
+  /**
+   * True when Google Calendar is closed to this user because our calendar
+   * scopes are still awaiting Google verification. Callers read it from
+   * `calendar.getConnectionStatus().gated` or `user.isGoogleOAuthTester`.
+   * Passed in (rather than queried here) so this stays a presentational
+   * button; `/api/auth/google-calendar` re-checks server-side regardless.
+   */
+  gated?: boolean;
 }
 
-export function GoogleCalendarConnect({ isConnected = false }: GoogleCalendarConnectProps) {
+export function GoogleCalendarConnect({
+  isConnected = false,
+  gated = false,
+}: GoogleCalendarConnectProps) {
   const searchParams = useSearchParams();
   const [loading, setLoading] = useState(false);
 
@@ -57,6 +69,26 @@ export function GoogleCalendarConnect({ isConnected = false }: GoogleCalendarCon
     const returnUrl = encodeURIComponent(window.location.pathname + window.location.search);
     window.location.href = `/api/auth/google-calendar?returnUrl=${returnUrl}`;
   };
+
+  if (gated) {
+    return (
+      <Tooltip
+        multiline
+        w={260}
+        label="Google Calendar integration is currently available to select users during our verification process."
+      >
+        <Button
+          component={Link}
+          href="/google-access?feature=calendar"
+          variant="light"
+          color="gray"
+          leftSection={<IconLock size={16} />}
+        >
+          Premium Feature
+        </Button>
+      </Tooltip>
+    );
+  }
 
   if (isConnected) {
     return (

--- a/src/app/_components/GooglePremiumFeature.tsx
+++ b/src/app/_components/GooglePremiumFeature.tsx
@@ -2,12 +2,9 @@
 
 import { Alert, Button, Group, Paper, Stack, Text, Title } from "@mantine/core";
 import { IconLock, IconMail } from "@tabler/icons-react";
+import type { GooglePremiumFeatureKind } from "~/types/google";
 
-/**
- * Which gated Google feature the user just bumped into. Both depend on scopes
- * Google has not verified yet — see `isGoogleOAuthTester` in ~/lib/googleAuth.
- */
-export type GooglePremiumFeatureKind = "calendar" | "contacts";
+export type { GooglePremiumFeatureKind };
 
 const COPY: Record<
   GooglePremiumFeatureKind,

--- a/src/app/_components/GooglePremiumFeature.tsx
+++ b/src/app/_components/GooglePremiumFeature.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Alert, Button, Group, Paper, Stack, Text, Title } from "@mantine/core";
+import { IconLock, IconMail } from "@tabler/icons-react";
+
+/**
+ * Which gated Google feature the user just bumped into. Both depend on scopes
+ * Google has not verified yet — see `isGoogleOAuthTester` in ~/lib/googleAuth.
+ */
+export type GooglePremiumFeatureKind = "calendar" | "contacts";
+
+const COPY: Record<
+  GooglePremiumFeatureKind,
+  { title: string; body: string; mailto: string }
+> = {
+  calendar: {
+    title: "Google Calendar — Premium Feature",
+    body:
+      "Google Calendar integration is currently available to select users during " +
+      "our verification process. To request early access, contact our team.",
+    mailto:
+      "mailto:support@exponential.im?subject=Google%20Calendar%20Early%20Access",
+  },
+  contacts: {
+    title: "Contact Import — Premium Feature",
+    body:
+      "Importing contacts from Google is currently available to select users. " +
+      "To request early access, contact our team.",
+    mailto:
+      "mailto:support@exponential.im?subject=Contact%20Import%20Early%20Access",
+  },
+};
+
+interface GooglePremiumFeatureProps {
+  feature: GooglePremiumFeatureKind;
+  /**
+   * - `card`: full-bleed empty state (calendar page, dedicated page)
+   * - `alert`: inline notice inside an existing modal/drawer
+   * - `inline`: one-line hint, no call to action
+   */
+  variant?: "card" | "alert" | "inline";
+}
+
+function RequestAccessButton({ mailto }: { mailto: string }) {
+  return (
+    <Button
+      component="a"
+      href={mailto}
+      variant="light"
+      size="sm"
+      leftSection={<IconMail size={16} />}
+    >
+      Request Access
+    </Button>
+  );
+}
+
+/**
+ * The single place the "this Google feature isn't open yet" message is worded,
+ * so the calendar page, settings, onboarding and CRM import all say the same
+ * thing instead of drifting apart.
+ */
+export function GooglePremiumFeature({
+  feature,
+  variant = "card",
+}: GooglePremiumFeatureProps) {
+  const { title, body, mailto } = COPY[feature];
+
+  if (variant === "inline") {
+    return (
+      <div className="mt-2 rounded-md border border-border-primary bg-surface-secondary p-2">
+        <Group gap="xs" wrap="nowrap">
+          <IconLock size={14} className="text-text-muted" />
+          <Text size="xs" c="dimmed">
+            {title}
+          </Text>
+        </Group>
+      </div>
+    );
+  }
+
+  if (variant === "alert") {
+    return (
+      <Alert icon={<IconLock size={16} />} color="blue" title={title}>
+        <Stack gap="sm" align="flex-start">
+          <Text size="sm">{body}</Text>
+          <RequestAccessButton mailto={mailto} />
+        </Stack>
+      </Alert>
+    );
+  }
+
+  return (
+    <Paper
+      p="xl"
+      radius="md"
+      withBorder
+      className="border-border-primary bg-surface-secondary"
+    >
+      <Stack align="center" gap="lg">
+        <IconLock size={48} className="text-text-muted" />
+        <div className="text-center">
+          <Title order={3} className="mb-2 text-text-primary">
+            {title}
+          </Title>
+          <Text size="sm" c="dimmed" className="max-w-md">
+            {body}
+          </Text>
+        </div>
+        <RequestAccessButton mailto={mailto} />
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/app/_components/ProjectCalendarCard.tsx
+++ b/src/app/_components/ProjectCalendarCard.tsx
@@ -171,6 +171,7 @@ export function ProjectCalendarCard({ projectId, projectName, selectedDate: prop
   };
 
   const isConnected = connectionStatus?.isConnected ?? false;
+  const isGated = connectionStatus?.gated ?? false;
 
   const calendarScheduledActions: ScheduledAction[] =
     scheduledActions
@@ -239,13 +240,15 @@ export function ProjectCalendarCard({ projectId, projectName, selectedDate: prop
         </Stack>
       )}
 
-      {/* Not connected */}
+      {/* Not connected — or gated while Google verifies our calendar scopes */}
       {!statusLoading && !isConnected && (
         <Stack gap="sm" py="sm">
           <Text size="xs" c="dimmed" ta="center">
-            Connect your Google Calendar to see your schedule
+            {isGated
+              ? "Google Calendar is available to select users during our verification process"
+              : "Connect your Google Calendar to see your schedule"}
           </Text>
-          <GoogleCalendarConnect isConnected={false} />
+          <GoogleCalendarConnect isConnected={false} gated={isGated} />
         </Stack>
       )}
 

--- a/src/app/_components/SchedulingSuggestion.tsx
+++ b/src/app/_components/SchedulingSuggestion.tsx
@@ -2,6 +2,7 @@
 
 import { Badge, Button, Group, Text, Tooltip, Loader } from "@mantine/core";
 import { IconSparkles, IconCheck, IconX, IconCalendarEvent } from "@tabler/icons-react";
+import { api } from "~/trpc/react";
 
 export interface SchedulingSuggestionData {
   actionId: string;
@@ -155,6 +156,9 @@ export function SchedulingSuggestionsLoader({
   error,
   calendarConnected = true,
 }: SchedulingSuggestionsLoaderProps) {
+  const { data: connectionStatus } = api.calendar.getConnectionStatus.useQuery();
+  const googleCalendarGated = connectionStatus?.gated ?? false;
+
   if (error) {
     return (
       <div className="mt-2 p-2 rounded-md bg-surface-secondary border border-border-primary">
@@ -181,7 +185,9 @@ export function SchedulingSuggestionsLoader({
     );
   }
 
-  if (!calendarConnected) {
+  // Suppress the "connect your calendar" nudge while Google is verifying our
+  // calendar scopes — for non-testers it points at something they can't do.
+  if (!calendarConnected && !googleCalendarGated) {
     return (
       <div className="mt-2 p-2 rounded-md bg-surface-secondary border border-border-primary">
         <Group gap="xs">

--- a/src/app/_components/TodayContent.tsx
+++ b/src/app/_components/TodayContent.tsx
@@ -16,6 +16,7 @@ import { StartupRoutineForm } from "./StartupRoutineForm";
 import { api } from "~/trpc/react";
 import { format, parseISO } from "date-fns";
 import { CalendarDayView } from "./CalendarDayView";
+import { GooglePremiumFeature } from "./GooglePremiumFeature";
 import type { ScheduledAction } from "./calendar/types";
 import { CalendarWeekView } from "./CalendarWeekView";
 import { CalendarMonthView } from "./CalendarMonthView";
@@ -49,6 +50,9 @@ export function TodayContent({ calendarConnected, initialTab, focus, dateRange, 
   };
 
   const [activeTab, setActiveTab] = useState<TabValue>(getInitialTab);
+
+  const { data: calendarStatus } = api.calendar.getConnectionStatus.useQuery();
+  const googleCalendarGated = calendarStatus?.gated ?? false;
 
   // Memoize the viewName string to avoid recalculation
   const viewName = useMemo(
@@ -169,6 +173,12 @@ export function TodayContent({ calendarConnected, initialTab, focus, dateRange, 
 
   const renderCalendarContent = () => {
     if (!calendarConnected) {
+      // While Google verifies our calendar scopes, non-testers can't act on a
+      // "connect your calendar" prompt — explain the gate instead.
+      if (googleCalendarGated) {
+        return <GooglePremiumFeature feature="calendar" variant="card" />;
+      }
+
       return (
         <Paper
           p="xl"

--- a/src/app/_components/calendar/CalendarPageContent.tsx
+++ b/src/app/_components/calendar/CalendarPageContent.tsx
@@ -11,6 +11,7 @@ import { CalendarSidebar } from "./CalendarSidebar";
 import { CalendarDayTimeGrid } from "./CalendarDayTimeGrid";
 import { CalendarWeekTimeGrid } from "./CalendarWeekTimeGrid";
 import { GoogleCalendarConnect } from "~/app/_components/GoogleCalendarConnect";
+import { GooglePremiumFeature } from "~/app/_components/GooglePremiumFeature";
 import { MicrosoftCalendarConnect } from "~/app/_components/MicrosoftCalendarConnect";
 import { EditActionModal } from "~/app/_components/EditActionModal";
 import { TimeEntryModal } from "~/app/_components/TimeEntryModal";
@@ -24,6 +25,9 @@ export function CalendarPageContent() {
   const googleConnected = connectionStatuses?.google?.isConnected ?? false;
   const microsoftConnected = connectionStatuses?.microsoft?.isConnected ?? false;
   const calendarConnected = googleConnected || microsoftConnected;
+  // Google's calendar scopes are pending verification — non-testers get the
+  // premium message instead of a connect button that would dead-end.
+  const googleGated = connectionStatuses?.google?.gated ?? false;
   const {
     view,
     selectedDate,
@@ -343,6 +347,24 @@ export function CalendarPageContent() {
     }
 
     if (!calendarConnected) {
+      // With Google gated, Outlook is the only calendar we can actually
+      // connect — lead with the premium message rather than a broken option.
+      if (googleGated) {
+        return (
+          <div className="flex h-full items-center justify-center">
+            <Stack align="center" gap="lg" className="max-w-lg">
+              <GooglePremiumFeature feature="calendar" variant="card" />
+              <Stack align="center" gap="xs">
+                <Text size="sm" c="dimmed">
+                  Outlook calendars are available now.
+                </Text>
+                <MicrosoftCalendarConnect isConnected={false} />
+              </Stack>
+            </Stack>
+          </div>
+        );
+      }
+
       return (
         <Paper
           p="xl"

--- a/src/app/_components/calendar/CalendarSidebar.tsx
+++ b/src/app/_components/calendar/CalendarSidebar.tsx
@@ -36,6 +36,11 @@ export function CalendarSidebar({
   const { data, isLoading } = api.calendar.getCalendarAccounts.useQuery();
   const accounts = data?.accounts ?? [];
   const hasMicrosoft = accounts.some((a) => a.provider === "microsoft");
+  // Hide "Add Google account" while our calendar scopes await verification —
+  // the OAuth route would only bounce the user to the premium page.
+  const { data: connectionStatuses } =
+    api.calendar.getAllConnectionStatuses.useQuery();
+  const googleGated = connectionStatuses?.google?.gated ?? false;
 
   const startOAuth = (path: string) => {
     const returnUrl = encodeURIComponent(
@@ -254,13 +259,15 @@ export function CalendarSidebar({
             <div className="border-t border-border-primary my-1" />
 
             {/* Add accounts. Google can always stack additional accounts. */}
-            <UnstyledButton
-              onClick={() => startOAuth("/api/auth/google-calendar")}
-              className="flex items-center gap-2 text-text-secondary transition-colors hover:text-text-primary"
-            >
-              <IconPlus size={16} />
-              <Text size="sm">Add Google account</Text>
-            </UnstyledButton>
+            {!googleGated && (
+              <UnstyledButton
+                onClick={() => startOAuth("/api/auth/google-calendar")}
+                className="flex items-center gap-2 text-text-secondary transition-colors hover:text-text-primary"
+              >
+                <IconPlus size={16} />
+                <Text size="sm">Add Google account</Text>
+              </UnstyledButton>
+            )}
 
             {!hasMicrosoft && (
               <UnstyledButton

--- a/src/app/_components/home/TodaySnapshot/CalendarEventsToday.tsx
+++ b/src/app/_components/home/TodaySnapshot/CalendarEventsToday.tsx
@@ -69,6 +69,12 @@ export function CalendarEventsToday() {
     );
   }
 
+  // Nothing useful to say while Google verifies our calendar scopes: the user
+  // can't connect, so hide the section rather than nag about settings.
+  if (connectionStatus?.gated) {
+    return null;
+  }
+
   // Show connection prompt if not connected
   if (!connectionStatus?.isConnected) {
     return (

--- a/src/app/_components/tests/GoogleCalendarConnect.test.tsx
+++ b/src/app/_components/tests/GoogleCalendarConnect.test.tsx
@@ -83,6 +83,19 @@ describe('GoogleCalendarConnect', () => {
     });
   });
 
+  describe('when Google Calendar is gated', () => {
+    test('offers the premium explainer instead of a connect button', () => {
+      render(<GoogleCalendarConnect isConnected={false} gated />);
+
+      expect(
+        screen.queryByRole('button', { name: /connect google calendar/i }),
+      ).not.toBeInTheDocument();
+
+      const link = screen.getByRole('link', { name: /premium feature/i });
+      expect(link).toHaveAttribute('href', '/google-access?feature=calendar');
+    });
+  });
+
   describe('when calendar is connected', () => {
     test('renders connected state button', () => {
       render(<GoogleCalendarConnect isConnected={true} />);

--- a/src/app/_components/welcome/AskBlock.tsx
+++ b/src/app/_components/welcome/AskBlock.tsx
@@ -39,7 +39,9 @@ export function AskBlock({
   // Shares the cache entry with useWelcomeSetup's query, so this costs no
   // extra round trip and saves threading the flag through both parent views.
   const { data: setup } = api.welcome.getSetup.useQuery();
-  const googleCalendarGated = setup ? !setup.googleCalendarAvailable : false;
+  // Fail closed while loading, matching isGoogleOAuthTester: an enabled chip
+  // in that window would start an OAuth flow the user can't finish.
+  const googleCalendarGated = !setup?.googleCalendarAvailable;
 
   if (step === "plan") {
     return (

--- a/src/app/_components/welcome/AskBlock.tsx
+++ b/src/app/_components/welcome/AskBlock.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { IconArrowRight, IconCalendar } from "@tabler/icons-react";
+import { api } from "~/trpc/react";
 import {
   COPY,
   GOAL_SUGGESTIONS,
@@ -35,6 +36,10 @@ export function AskBlock({
 }: AskBlockProps) {
   const [text, setText] = useState("");
   const question = COPY.ask[step];
+  // Shares the cache entry with useWelcomeSetup's query, so this costs no
+  // extra round trip and saves threading the flag through both parent views.
+  const { data: setup } = api.welcome.getSetup.useQuery();
+  const googleCalendarGated = setup ? !setup.googleCalendarAvailable : false;
 
   if (step === "plan") {
     return (
@@ -70,9 +75,12 @@ export function AskBlock({
       <div>
         {!hideQuestion && <div className={styles.askQ}>{question}</div>}
         <div className={styles.chips}>
+          {/* Google's calendar scopes are awaiting verification, so for
+              non-testers the chip is shown as coming soon rather than leading
+              into an OAuth flow they can't complete. Outlook is unaffected. */}
           <button
             className={styles.chip}
-            disabled={disabled}
+            disabled={disabled || googleCalendarGated}
             onClick={() =>
               onAnswer({ value: "google", label: `Connect ${COPY.calChips.google}` })
             }
@@ -81,7 +89,9 @@ export function AskBlock({
               size={13}
               style={{ marginRight: 6, verticalAlign: -2 }}
             />
-            {COPY.calChips.google}
+            {googleCalendarGated
+              ? COPY.calChips.googleComingSoon
+              : COPY.calChips.google}
           </button>
           <button
             className={styles.chip}

--- a/src/app/_components/welcome/AskBlock.tsx
+++ b/src/app/_components/welcome/AskBlock.tsx
@@ -39,9 +39,13 @@ export function AskBlock({
   // Shares the cache entry with useWelcomeSetup's query, so this costs no
   // extra round trip and saves threading the flag through both parent views.
   const { data: setup } = api.welcome.getSetup.useQuery();
-  // Fail closed while loading, matching isGoogleOAuthTester: an enabled chip
-  // in that window would start an OAuth flow the user can't finish.
-  const googleCalendarGated = !setup?.googleCalendarAvailable;
+  // Two distinct things, because conflating them either lies or dead-ends:
+  // `googleCalendarGated` is only true once we KNOW the user is gated (so a
+  // tester never flashes "coming soon"), while the chip stays un-clickable
+  // until the answer arrives (so a gated user can't start an OAuth flow they
+  // can't finish in that window).
+  const googleCalendarGated = setup ? !setup.googleCalendarAvailable : false;
+  const googleCalendarUnknown = !setup;
 
   if (step === "plan") {
     return (
@@ -82,7 +86,7 @@ export function AskBlock({
               into an OAuth flow they can't complete. Outlook is unaffected. */}
           <button
             className={styles.chip}
-            disabled={disabled || googleCalendarGated}
+            disabled={disabled || googleCalendarGated || googleCalendarUnknown}
             onClick={() =>
               onAnswer({ value: "google", label: `Connect ${COPY.calChips.google}` })
             }

--- a/src/app/_components/welcome/useWelcomeSetup.ts
+++ b/src/app/_components/welcome/useWelcomeSetup.ts
@@ -61,6 +61,9 @@ export function useWelcomeSetup() {
   const { data, isLoading } = api.welcome.getSetup.useQuery();
   const state = data?.state ?? null;
   const calendarConnected = data?.calendarConnected ?? false;
+  // False while Google is verifying our calendar scopes and this user isn't an
+  // allowlisted tester — the Google half of the calendar step is unavailable.
+  const googleCalendarAvailable = data?.googleCalendarAvailable ?? false;
 
   const applyState = useCallback(
     (nextState: WelcomeSetupState) => {
@@ -171,6 +174,13 @@ export function useWelcomeSetup() {
             return;
           }
           const provider = answer.value === "outlook" ? "outlook" : "google";
+          // Belt and braces: AskBlock disables the Google chip while our
+          // calendar scopes await verification, so this only fires if the
+          // answer arrives another way. Explain rather than dead-end.
+          if (provider === "google" && !googleCalendarAvailable) {
+            router.push("/google-access?feature=calendar");
+            return;
+          }
           try {
             localStorage.setItem(CAL_PROVIDER_STASH, provider);
           } catch {
@@ -185,7 +195,7 @@ export function useWelcomeSetup() {
         }
       }
     },
-    [createGoal, createAction, planDay, setCalendar],
+    [createGoal, createAction, planDay, setCalendar, googleCalendarAvailable, router],
   );
 
   // Back from the calendar OAuth flow: the ConnectedAccount now exists, so
@@ -231,6 +241,7 @@ export function useWelcomeSetup() {
     firstName: data?.userName?.trim().split(/\s+/)[0] ?? null,
     state,
     calendarConnected,
+    googleCalendarAvailable,
     isStepDone,
     nextStep,
     doneCount,

--- a/src/app/_components/welcome/welcomeCopy.ts
+++ b/src/app/_components/welcome/welcomeCopy.ts
@@ -139,6 +139,8 @@ export const COPY = {
   },
   calChips: {
     google: "Google Calendar",
+    /** Shown while our Google calendar scopes are awaiting verification. */
+    googleComingSoon: "Google Calendar (coming soon)",
     outlook: "Outlook",
     skip: "Skip for now",
   },

--- a/src/app/api/auth/google-calendar/route.ts
+++ b/src/app/api/auth/google-calendar/route.ts
@@ -2,7 +2,11 @@ import { auth } from "~/server/auth";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
 import type { NextRequest } from "next/server";
-import { GOOGLE_SCOPE_SETS, type GoogleScopeType } from "~/lib/googleAuth";
+import {
+  GOOGLE_SCOPE_SETS,
+  isGoogleOAuthTester,
+  type GoogleScopeType,
+} from "~/lib/googleAuth";
 
 export async function GET(request: NextRequest) {
   const session = await auth();
@@ -21,6 +25,15 @@ export async function GET(request: NextRequest) {
     scopeTypeParam in GOOGLE_SCOPE_SETS
       ? (scopeTypeParam as GoogleScopeType)
       : "calendar";
+
+  // Every scope set here is still awaiting Google verification, so anyone who
+  // isn't a registered test user would land on Google's "unverified app"
+  // error. Send them to the explainer page instead of into that dead end.
+  // This is the last line of defence — the UI hides the entry points too.
+  if (!isGoogleOAuthTester(session.user.email)) {
+    const feature = scopeType === "calendar" ? "calendar" : "contacts";
+    redirect(`/google-access?feature=${feature}`);
+  }
 
   const scopes = GOOGLE_SCOPE_SETS[scopeType].join(" ");
 

--- a/src/app/api/auth/google-calendar/route.ts
+++ b/src/app/api/auth/google-calendar/route.ts
@@ -7,6 +7,22 @@ import {
   isGoogleOAuthTester,
   type GoogleScopeType,
 } from "~/lib/googleAuth";
+import type { GooglePremiumFeatureKind } from "~/app/_components/GooglePremiumFeature";
+
+/**
+ * Which explainer a gated user sees per scope set. Exhaustive over
+ * `GOOGLE_SCOPE_SETS`, so adding a scope set is a type error here rather than
+ * a silent fallback that shows the wrong copy. `crm` bundles contacts + Gmail
+ * and is only ever started from the contact-import flow.
+ */
+const GATED_FEATURE_BY_SCOPE_TYPE: Record<
+  GoogleScopeType,
+  GooglePremiumFeatureKind
+> = {
+  calendar: "calendar",
+  contacts: "contacts",
+  crm: "contacts",
+};
 
 export async function GET(request: NextRequest) {
   const session = await auth();
@@ -31,8 +47,7 @@ export async function GET(request: NextRequest) {
   // error. Send them to the explainer page instead of into that dead end.
   // This is the last line of defence — the UI hides the entry points too.
   if (!isGoogleOAuthTester(session.user.email)) {
-    const feature = scopeType === "calendar" ? "calendar" : "contacts";
-    redirect(`/google-access?feature=${feature}`);
+    redirect(`/google-access?feature=${GATED_FEATURE_BY_SCOPE_TYPE[scopeType]}`);
   }
 
   const scopes = GOOGLE_SCOPE_SETS[scopeType].join(" ");

--- a/src/app/api/auth/google-calendar/route.ts
+++ b/src/app/api/auth/google-calendar/route.ts
@@ -7,7 +7,7 @@ import {
   isGoogleOAuthTester,
   type GoogleScopeType,
 } from "~/lib/googleAuth";
-import type { GooglePremiumFeatureKind } from "~/app/_components/GooglePremiumFeature";
+import type { GooglePremiumFeatureKind } from "~/types/google";
 
 /**
  * Which explainer a gated user sees per scope set. Exhaustive over

--- a/src/lib/__tests__/googleAuth.test.ts
+++ b/src/lib/__tests__/googleAuth.test.ts
@@ -8,7 +8,7 @@
  * CLAUDE.md "Test database safety").
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.hoisted(() => {
   process.env.SKIP_ENV_VALIDATION ??= "true";
@@ -21,6 +21,7 @@ vi.mock("~/server/db", () => ({
 
 import {
   checkGoogleScopes,
+  isGoogleOAuthTester,
   GOOGLE_SCOPES,
 } from "~/lib/googleAuth";
 
@@ -75,5 +76,48 @@ describe("checkGoogleScopes (multi-account)", () => {
     const result = await checkGoogleScopes("u1", [GMAIL]);
     expect(result.hasScopes).toBe(false);
     expect(result.currentScopes).toEqual([CAL, CONTACTS]);
+  });
+});
+
+/**
+ * The tester allowlist gating the Google features whose scopes Google has not
+ * verified yet. Fails closed: an unset/empty list locks the features for
+ * everyone, because sending a non-tester to Google's consent screen is the
+ * exact failure this gate exists to prevent.
+ */
+describe("isGoogleOAuthTester", () => {
+  const original = process.env.GOOGLE_OAUTH_TESTER_EMAILS;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.GOOGLE_OAUTH_TESTER_EMAILS;
+    else process.env.GOOGLE_OAUTH_TESTER_EMAILS = original;
+  });
+
+  it("locks the features when the allowlist is unset or empty", () => {
+    delete process.env.GOOGLE_OAUTH_TESTER_EMAILS;
+    expect(isGoogleOAuthTester("a@example.com")).toBe(false);
+
+    process.env.GOOGLE_OAUTH_TESTER_EMAILS = "";
+    expect(isGoogleOAuthTester("a@example.com")).toBe(false);
+  });
+
+  it("matches allowlisted emails case-insensitively, ignoring whitespace", () => {
+    process.env.GOOGLE_OAUTH_TESTER_EMAILS = " A@Example.com , b@example.com ";
+    expect(isGoogleOAuthTester("a@example.com")).toBe(true);
+    expect(isGoogleOAuthTester("  B@EXAMPLE.COM ")).toBe(true);
+  });
+
+  it("rejects emails that are not on the list", () => {
+    process.env.GOOGLE_OAUTH_TESTER_EMAILS = "a@example.com";
+    expect(isGoogleOAuthTester("c@example.com")).toBe(false);
+  });
+
+  it("rejects a missing email rather than matching an empty entry", () => {
+    // A trailing comma leaves an empty entry; a user with no email must not
+    // slip through it.
+    process.env.GOOGLE_OAUTH_TESTER_EMAILS = "a@example.com,";
+    expect(isGoogleOAuthTester(null)).toBe(false);
+    expect(isGoogleOAuthTester(undefined)).toBe(false);
+    expect(isGoogleOAuthTester("")).toBe(false);
   });
 });

--- a/src/lib/googleAuth.ts
+++ b/src/lib/googleAuth.ts
@@ -60,6 +60,36 @@ export const GOOGLE_SCOPE_SETS = {
 export type GoogleScopeType = keyof typeof GOOGLE_SCOPE_SETS;
 
 /**
+ * Whether this user may use the Google features that depend on scopes Google
+ * has not verified yet (calendar, contacts, Gmail).
+ *
+ * Verification for those scopes is still pending, so only the accounts
+ * registered as test users on the Google Cloud Console project can actually
+ * complete the consent screen — everyone else hits an "unverified app" error.
+ * Rather than sending them into that dead end we gate the features behind
+ * `GOOGLE_OAUTH_TESTER_EMAILS`, a comma-separated allowlist, and show a
+ * "premium feature" message instead.
+ *
+ * Fails closed: an unset or empty allowlist locks the features for everyone,
+ * because a broken consent screen is worse than a missing button.
+ *
+ * Note that plain Google *sign-in* is verified and is deliberately NOT gated.
+ */
+export function isGoogleOAuthTester(email: string | null | undefined): boolean {
+  if (!email) return false;
+
+  const allowlist = process.env.GOOGLE_OAUTH_TESTER_EMAILS;
+  if (!allowlist) return false;
+
+  const normalized = email.trim().toLowerCase();
+  return allowlist
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0)
+    .includes(normalized);
+}
+
+/**
  * Individual Google OAuth scopes used in the application
  */
 export const GOOGLE_SCOPES = {

--- a/src/server/api/routers/briefing.ts
+++ b/src/server/api/routers/briefing.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { startOfDay, endOfDay, subDays } from "date-fns";
 import { buildProjectAccessWhere } from "~/server/services/access";
+import { isGoogleOAuthTester } from "~/lib/googleAuth";
 
 /**
  * Morning Briefing Router
@@ -98,7 +99,10 @@ export const briefingRouter = createTRPCRouter({
 
       // 1. Get calendar events for today across ALL connected Google accounts
       let calendarEvents: BriefingCalendarEvent[] = [];
-      if (input?.includeCalendar !== false) {
+      // Google's calendar scopes are unverified, so non-testers have no usable
+      // Google connection — skip the section rather than calling the API.
+      const calendarAvailable = isGoogleOAuthTester(ctx.session.user.email);
+      if (input?.includeCalendar !== false && calendarAvailable) {
         try {
           // Find every connected Google calendar that has calendar scope
           const googleAccounts = await ctx.db.connectedAccount.findMany({

--- a/src/server/api/routers/calendar.ts
+++ b/src/server/api/routers/calendar.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 import type { Prisma, PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { GoogleCalendarService } from "~/server/services/GoogleCalendarService";
 import { MicrosoftCalendarService } from "~/server/services/MicrosoftCalendarService";
 import type { CalendarInfo, CalendarProvider } from "~/server/services/CalendarProvider";
+import { isGoogleOAuthTester } from "~/lib/googleAuth";
 
 const providerSchema = z.enum(["google", "microsoft"]).default("google");
 
@@ -26,6 +28,22 @@ function getAccountProvider(provider: ProviderType): string {
 /** Maps a NextAuth account provider name back to our provider type */
 function toProviderType(accountProvider: string): ProviderType {
   return accountProvider === "microsoft-entra-id" ? "microsoft" : "google";
+}
+
+/**
+ * Whether Google calendar features are closed to this user.
+ *
+ * Google has not finished verifying our calendar scopes, so only allowlisted
+ * testers can complete the consent screen (see `isGoogleOAuthTester`). For
+ * everyone else we behave as though no Google calendar exists rather than
+ * calling the API and surfacing an OAuth error. Microsoft is a separate,
+ * approved OAuth app and is never gated.
+ */
+function isGoogleCalendarGated(
+  email: string | null | undefined,
+  provider: ProviderType,
+): boolean {
+  return provider === "google" && !isGoogleOAuthTester(email);
 }
 
 /** The OAuth scope that grants calendar access for each provider */
@@ -178,6 +196,16 @@ export const calendarRouter = createTRPCRouter({
       const provider = input?.provider ?? "google";
       const accountProvider = getAccountProvider(provider);
 
+      if (isGoogleCalendarGated(ctx.session.user.email, provider)) {
+        return {
+          isConnected: false,
+          hasCalendarScope: false,
+          tokenExpired: false,
+          canRefresh: false,
+          gated: true,
+        };
+      }
+
       // Aggregate across ALL of the user's connected accounts for this
       // provider — a user can connect several, so a single findFirst could
       // report the wrong one as (dis)connected.
@@ -208,11 +236,14 @@ export const calendarRouter = createTRPCRouter({
         hasCalendarScope,
         tokenExpired: hasCalendarScope && !anyTokenNotExpired,
         canRefresh,
+        gated: false,
       };
     }),
 
   // Returns connection status for all providers in one call
   getAllConnectionStatuses: protectedProcedure.query(async ({ ctx }) => {
+    const googleGated = isGoogleCalendarGated(ctx.session.user.email, "google");
+
     const accounts = await ctx.db.connectedAccount.findMany({
       where: {
         userId: ctx.session.user.id,
@@ -243,8 +274,10 @@ export const calendarRouter = createTRPCRouter({
     }
 
     return {
-      google: checkStatus("google"),
-      microsoft: checkStatus("microsoft-entra-id"),
+      google: googleGated
+        ? { isConnected: false, hasCalendarScope: false, connectedCount: 0, gated: true }
+        : { ...checkStatus("google"), gated: false },
+      microsoft: { ...checkStatus("microsoft-entra-id"), gated: false },
     };
   }),
 
@@ -272,7 +305,12 @@ export const calendarRouter = createTRPCRouter({
       orderBy: { id: "asc" },
     });
 
-    const connected = accounts.filter((a) => isCalendarConnected(a));
+    // Drop Google accounts entirely while the scopes are unverified — every
+    // entry here triggers a live listCalendars call.
+    const googleGated = isGoogleCalendarGated(ctx.session.user.email, "google");
+    const connected = accounts
+      .filter((a) => isCalendarConnected(a))
+      .filter((a) => !(googleGated && a.provider === "google"));
 
     const result = await Promise.all(
       connected.map(async (account) => {
@@ -309,7 +347,9 @@ export const calendarRouter = createTRPCRouter({
   getTodayEvents: protectedProcedure
     .input(z.object({ provider: providerSchema }).optional())
     .query(async ({ ctx, input }) => {
-      const service = getCalendarService(input?.provider ?? "google");
+      const provider = input?.provider ?? "google";
+      if (isGoogleCalendarGated(ctx.session.user.email, provider)) return [];
+      const service = getCalendarService(provider);
       return service.getTodayEvents(ctx.session.user.id);
     }),
 
@@ -319,7 +359,9 @@ export const calendarRouter = createTRPCRouter({
       provider: providerSchema,
     }).optional())
     .query(async ({ input, ctx }) => {
-      const service = getCalendarService(input?.provider ?? "google");
+      const provider = input?.provider ?? "google";
+      if (isGoogleCalendarGated(ctx.session.user.email, provider)) return [];
+      const service = getCalendarService(provider);
       return service.getUpcomingEvents(ctx.session.user.id, input?.days ?? 7);
     }),
 
@@ -333,6 +375,7 @@ export const calendarRouter = createTRPCRouter({
     }))
     .query(async ({ input, ctx }) => {
       const { provider, ...options } = input;
+      if (isGoogleCalendarGated(ctx.session.user.email, provider)) return [];
       const service = getCalendarService(provider);
       return service.getEvents(ctx.session.user.id, options);
     }),
@@ -347,6 +390,7 @@ export const calendarRouter = createTRPCRouter({
     }))
     .mutation(async ({ input, ctx }) => {
       const { provider, ...options } = input;
+      if (isGoogleCalendarGated(ctx.session.user.email, provider)) return [];
       const service = getCalendarService(provider);
       return service.refreshEvents(ctx.session.user.id, options);
     }),
@@ -426,6 +470,15 @@ export const calendarRouter = createTRPCRouter({
     }))
     .mutation(async ({ input, ctx }) => {
       const { provider, ...eventInput } = input;
+      if (isGoogleCalendarGated(ctx.session.user.email, provider)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Google Calendar is a premium feature that is currently available to " +
+            "select users during our verification process. Contact " +
+            "support@exponential.im to request early access.",
+        });
+      }
       const service = getCalendarService(provider);
       return service.createEvent(ctx.session.user.id, eventInput);
     }),
@@ -444,7 +497,9 @@ export const calendarRouter = createTRPCRouter({
       const userId = ctx.session.user.id;
       const account = await resolveAccount(ctx.db as DbClient, userId, input);
       if (!account) return [];
-      const service = getCalendarService(toProviderType(account.provider));
+      const provider = toProviderType(account.provider);
+      if (isGoogleCalendarGated(ctx.session.user.email, provider)) return [];
+      const service = getCalendarService(provider);
       return service.listCalendars(userId, account.id);
     }),
 
@@ -458,7 +513,10 @@ export const calendarRouter = createTRPCRouter({
       const userId = ctx.session.user.id;
       const account = await resolveAccount(ctx.db as DbClient, userId, input);
 
-      if (!account) {
+      if (
+        !account ||
+        isGoogleCalendarGated(ctx.session.user.email, toProviderType(account.provider))
+      ) {
         return { selectedCalendarIds: ["primary"], allCalendars: [], cacheUpdatedAt: null };
       }
 
@@ -521,9 +579,12 @@ export const calendarRouter = createTRPCRouter({
       const userId = ctx.session.user.id;
       const account = await resolveAccount(ctx.db as DbClient, userId, input);
       if (!account) {
-        return { success: true, calendars: [] };
+        return { success: true, calendars: [], gated: false };
       }
       const provider = toProviderType(account.provider);
+      if (isGoogleCalendarGated(ctx.session.user.email, provider)) {
+        return { success: true, calendars: [], gated: true };
+      }
       const service = getCalendarService(provider);
 
       const calendars = await service.listCalendars(userId, account.id);
@@ -547,6 +608,7 @@ export const calendarRouter = createTRPCRouter({
       return {
         success: true,
         calendars,
+        gated: false,
       };
     }),
 
@@ -579,7 +641,11 @@ export const calendarRouter = createTRPCRouter({
         },
       });
 
-      const connectedAccounts = accounts.filter((a) => isCalendarConnected(a));
+      // Non-testers contribute no Google events — see isGoogleCalendarGated.
+      const googleGated = isGoogleCalendarGated(ctx.session.user.email, "google");
+      const connectedAccounts = accounts
+        .filter((a) => isCalendarConnected(a))
+        .filter((a) => !(googleGated && a.provider === "google"));
 
       const allEvents: Array<{
         accountId: string;

--- a/src/server/api/routers/calendar.ts
+++ b/src/server/api/routers/calendar.ts
@@ -197,12 +197,20 @@ export const calendarRouter = createTRPCRouter({
       const accountProvider = getAccountProvider(provider);
 
       if (isGoogleCalendarGated(ctx.session.user.email, provider)) {
+        // A user gated *after* connecting still has stored tokens. Report that
+        // separately from `isConnected` so the UI can keep offering Disconnect
+        // — revoking access must never become unreachable just because the
+        // feature closed behind them.
+        const storedCount = await ctx.db.connectedAccount.count({
+          where: { userId: ctx.session.user.id, provider: accountProvider },
+        });
         return {
           isConnected: false,
           hasCalendarScope: false,
           tokenExpired: false,
           canRefresh: false,
           gated: true,
+          hasStoredConnection: storedCount > 0,
         };
       }
 
@@ -237,6 +245,7 @@ export const calendarRouter = createTRPCRouter({
         tokenExpired: hasCalendarScope && !anyTokenNotExpired,
         canRefresh,
         gated: false,
+        hasStoredConnection: accounts.length > 0,
       };
     }),
 

--- a/src/server/api/routers/crmContact.ts
+++ b/src/server/api/routers/crmContact.ts
@@ -12,6 +12,7 @@ import {
   enqueueContactEnrichment,
 } from "~/server/services/crm/enrichment/dispatchContactEnrichment";
 import { uploadToBlob, deleteFromBlob } from "~/lib/blob";
+import { isGoogleOAuthTester } from "~/lib/googleAuth";
 
 // Workspace roles allowed to spend enrichment budget (a paid web search + LLM
 // call per run). Viewers and project-only "guests" are excluded (ADR-0036).
@@ -1188,6 +1189,16 @@ export const crmContactRouter = createTRPCRouter({
         });
       }
 
+      if (!isGoogleOAuthTester(ctx.session.user.email)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Contact import is a premium feature that is currently available to " +
+            "select users during our verification process. Contact " +
+            "support@exponential.im to request early access.",
+        });
+      }
+
       // Check if user has Google OAuth connection
       const connection = await GoogleTokenManager.getConnection(
         ctx.session.user.id
@@ -1272,12 +1283,37 @@ export const crmContactRouter = createTRPCRouter({
         });
       }
 
+      // Contacts/Gmail scopes are still awaiting Google verification, so for
+      // non-testers report the integration as unavailable rather than probing
+      // for a connection they could never have completed.
+      if (!isGoogleOAuthTester(ctx.session.user.email)) {
+        return {
+          connected: false,
+          gated: true,
+          id: null,
+          provider: null,
+          scope: null,
+          expires_at: null,
+          hasAllScopes: false,
+          hasRefreshToken: false,
+        };
+      }
+
       const connection = await GoogleTokenManager.getConnection(
         ctx.session.user.id
       );
 
       if (!connection) {
-        return null;
+        return {
+          connected: false,
+          gated: false,
+          id: null,
+          provider: null,
+          scope: null,
+          expires_at: null,
+          hasAllScopes: false,
+          hasRefreshToken: false,
+        };
       }
 
       // Check if account has all required scopes
@@ -1294,6 +1330,8 @@ export const crmContactRouter = createTRPCRouter({
 
       // Return connection info without tokens
       return {
+        connected: true,
+        gated: false,
         id: connection.id,
         provider: connection.provider,
         scope: connection.scope,

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -2,8 +2,19 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
 import { uploadToBlob } from "~/lib/blob";
+import { isGoogleOAuthTester } from "~/lib/googleAuth";
 
 export const userRouter = createTRPCRouter({
+  /**
+   * Whether this user may use the Google features whose scopes Google has not
+   * verified yet (calendar, contacts, Gmail). The UI uses this to show the
+   * "premium feature" message instead of connect buttons that would dead-end
+   * on Google's unverified-app screen. Google *sign-in* is not affected.
+   */
+  isGoogleOAuthTester: protectedProcedure.query(({ ctx }) => {
+    return isGoogleOAuthTester(ctx.session.user.email);
+  }),
+
   getCurrentUser: protectedProcedure
     .query(async ({ ctx }) => {
       return {
@@ -130,17 +141,26 @@ export const userRouter = createTRPCRouter({
         }),
       ]);
 
+      // Google's calendar scopes are unverified, so a non-tester's Google
+      // connection can't be used — ignore it when scoring the calendar step.
+      // Microsoft is a separate, approved OAuth app and always counts.
+      const googleCalendarAvailable = isGoogleOAuthTester(ctx.session.user.email);
+      const usableCalendarAccounts = calendarAccounts.filter(
+        (account) => googleCalendarAvailable || account.provider !== 'google',
+      );
+
       return {
         userName: user?.name ?? null,
         welcomeCompletedAt: user?.welcomeCompletedAt ?? null,
         usageType: user?.usageType ?? null,
         userRole: user?.userRole ?? null,
+        googleCalendarAvailable,
         steps: {
           hasProject: projectCount > 0,
           hasGoal: goalCount > 0,
           hasOutcome: outcomeCount > 0,
           hasProjectActions: projectActionCount > 0,
-          hasCalendar: calendarAccounts.length > 0,
+          hasCalendar: usableCalendarAccounts.length > 0,
           hasDailyPlan: dailyPlanCount > 0,
           hasCompletedAction: completedActionCount > 0,
         },

--- a/src/server/api/routers/welcome.ts
+++ b/src/server/api/routers/welcome.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { Prisma, PrismaClient } from "@prisma/client";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { isGoogleOAuthTester } from "~/lib/googleAuth";
 
 /**
  * Per-user "Getting started" setup state, persisted on `User.welcomeSetupState`.
@@ -103,6 +104,10 @@ export const welcomeRouter = createTRPCRouter({
       userName: user?.name ?? null,
       welcomeCompletedAt: user?.welcomeCompletedAt ?? null,
       calendarConnected: calendarAccountCount > 0,
+      // Google's calendar scopes are still awaiting verification. For users who
+      // aren't allowlisted testers the step isn't "not connected", it's not
+      // available — the Google half of the step is hidden rather than offered.
+      googleCalendarAvailable: isGoogleOAuthTester(ctx.session.user.email),
       state: parseSetupState(user?.welcomeSetupState),
     };
   }),

--- a/src/types/google.ts
+++ b/src/types/google.ts
@@ -1,0 +1,8 @@
+/**
+ * Which gated Google feature a user has bumped into.
+ *
+ * Lives here rather than beside the `GooglePremiumFeature` component so the
+ * OAuth route handler can name it without a server module reaching into
+ * `app/_components` (and without the component reaching back into server code).
+ */
+export type GooglePremiumFeatureKind = "calendar" | "contacts";


### PR DESCRIPTION
### **User description**
## What

Gates every Google feature that depends on a scope Google hasn't verified yet (Calendar, Contacts, Gmail) behind `GOOGLE_OAUTH_TESTER_EMAILS` — a comma-separated allowlist of the accounts registered as test users on Cloud Console project `exponential-482719`.

- **`isGoogleOAuthTester()`** in `src/lib/googleAuth.ts`, plus a `user.isGoogleOAuthTester` tRPC query for the frontend. **Fails closed**: unset or empty locks the features for everyone.
- **Server-side gates** in the `calendar`, `crmContact`, `briefing`, `welcome` and `user` routers. Status queries report `gated: true`, event queries return empty, and `calendar.createEvent` / `crmContact.importContacts` throw `FORBIDDEN`.
- **OAuth entry point** — `/api/auth/google-calendar` redirects non-testers to a new `/google-access` explainer page instead of Google's consent screen. This is the last line of defence; the UI hides the entry points too.
- **UI** — one shared `GooglePremiumFeature` component (card / alert / inline) carries the copy across all 12 affected surfaces, replacing connect buttons with a "Premium Feature — Request Access" message.

## Why

Google OAuth *sign-in* is approved and working, but verification for the calendar/contacts/Gmail scopes is still pending. Users who aren't registered testers were being sent to Google's "unverified app" error screen. This turns that dead end into an honest "available to select users during our verification process" message.

## Not gated (deliberate)

Google sign-in, Microsoft calendar (separate approved OAuth app), manual CRM contact creation, and calendar disconnect.

## Verification

Ran the app against the `dev-fixture` user both ways:

| | non-tester | tester |
|---|---|---|
| `calendar.getConnectionStatus` | `gated: true` | `gated: false, isConnected: true` |
| `crmContact.getGoogleConnection` | `gated: true` | normal |
| `/api/auth/google-calendar` | → `/google-access?feature=calendar` | → 307 to Google, scopes unchanged |
| `?type=crm` | → `/google-access?feature=contacts` | → Google |
| Calendar page | premium card, Outlook still offered, no "Add Google account" in sidebar | normal |
| Settings | "Premium Feature" + explainer | "Your calendar is connected" / Disconnect |

`tsc --noEmit` clean, ESLint clean, 2379 unit tests pass (6 new: 5 for the allowlist semantics, 1 for the gated connect button).

## Deploy note

`GOOGLE_OAUTH_TESTER_EMAILS` must be set in Vercel for preview/production. Until it is, these features are locked for everyone there — which is the intended fail-closed behaviour, but worth setting deliberately rather than discovering.


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Add `GOOGLE_OAUTH_TESTER_EMAILS` fail-closed allowlist helper

- Gate Calendar/Contacts/Gmail in tRPC routers and OAuth route

- Add shared `GooglePremiumFeature` UI and `/google-access` page

- Keep Disconnect reachable for gated stored connections


___

### Diagram Walkthrough


```mermaid
flowchart LR
  env["GOOGLE_OAUTH_TESTER_EMAILS"] --> helper["isGoogleOAuthTester()"]
  helper --> routers["calendar / crmContact / briefing / welcome / user routers"]
  helper --> route["/api/auth/google-calendar"]
  routers -- "gated: true" --> ui["GooglePremiumFeature (card/alert/inline)"]
  route -- "redirect" --> page["/google-access explainer"]
  page --> ui
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>googleAuth.ts</strong><dd><code>Add fail-closed `isGoogleOAuthTester` allowlist helper</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-1b21472c8b0a6797182457f5d034a3675064b662dd50945c9ce76f67b66eb3e5">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>calendar.ts</strong><dd><code>Gate Google calendar queries, expose gated/hasStoredConnection</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-3ea28cfb0913635c7f71506ebea3ee31db3e51d9256c3985a50d6189f5f07702">+84/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>crmContact.ts</strong><dd><code>Block contact import and normalize gated connection payload</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-4365e036b2514a8aa3f9962c34aadb646c4e6e06b1223a39744976340d8b07a9">+39/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>user.ts</strong><dd><code>Add isGoogleOAuthTester query and calendar step scoring</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-0be33a0caef24060bbdb3f9704a54d9ab53e0e233001120194cf64f87026a3d6">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>welcome.ts</strong><dd><code>Return googleCalendarAvailable in welcome setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-0bb40f6dedc288631f49d9dbc59e64f1b23b047bf7865ca93bdd757675b5d777">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>briefing.ts</strong><dd><code>Skip calendar section for non-tester users</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-e95dfe1f857f644d7287513dc541a8b2f011265336ab6a2b1841e34f2814007f">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>route.ts</strong><dd><code>Redirect gated users to explainer per scope set</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-9ca351bcdbffc0df9d91ecf9583b01277a6ae5a087de7a7c88863180ca1cc0f1">+29/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GooglePremiumFeature.tsx</strong><dd><code>New shared premium-feature message component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-fbb2ad61ab17dcf3f44e8627186cf1ef2bf3e1f9a253b436b2e5dd1d3ad0f568">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>New landing page explaining gated Google access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-77c54b1fc42a50e63825bbcff37036a46b13a3c55adb8c4d859188b2f120ced3">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>google.ts</strong><dd><code>Add shared GooglePremiumFeatureKind type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-3494d732bab121d217a60164427fdf20a5b3c28945eb01fb704794235a0a64de">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GoogleCalendarConnect.tsx</strong><dd><code>Render Premium Feature link when gated</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-8572d0daee7f08c272a2a10145e802a4dcaf475d619655da236399d8b0379480">+35/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Show gated copy while keeping Disconnect reachable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-3f3878766b8dc99d77f9caef690325e3606afdc5244654f3af4df63dee45ad21">+22/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CalendarPageContent.tsx</strong><dd><code>Show premium card and Outlook fallback when gated</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-4dc94e639de63c1ae8f866804c60495505c1f8afbaacb6f643ea67471ab4d5b0">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CalendarSidebar.tsx</strong><dd><code>Hide "Add Google account" entry when gated</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-0af7a40e74957bfddbe3df0c9026fbc1c4f0a08428fce68b2ebb07e8f76a804a">+14/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useWelcomeSetup.ts</strong><dd><code>Redirect gated calendar choice to explainer page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-b7631ca8ccacb7ad5d1470959ce2c1fd41b68aac5042f10c586a26e33a323e45">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ImportDialog.tsx</strong><dd><code>Show gated alert and fix connection shape checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-ab150f93c8767a91160cad726a3e19ae7d9c5ff4572d97ebbce47e3d9b425ed8">+12/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CalendarEventImporter.tsx</strong><dd><code>Fail closed on unknown status, show gated alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-788b92289d3f23bddf9edce6fb34ee83a8899a57acf75ca34417087477a90aa6">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AskBlock.tsx</strong><dd><code>Disable Google chip while gated or unknown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-6f625b1870fdf67e8259047a8c29952b5a0b30092772f2d51402e2dd0c77c31a">+18/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>googleAuth.test.ts</strong><dd><code>Tests for allowlist parsing and fail-closed behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-916e1fe64232c0636876e3c3081f57c3ae4cded0da38d745fe2333ea8f3c78a2">+45/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>.env.example</strong><dd><code>Document GOOGLE_OAUTH_TESTER_EMAILS variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>CreateMeetingModal.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-eebaad2a0ee3ce6f57cd4f2e81cb96c315dd8ad4bd801e99eeef4d5014075832">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProjectCalendarCard.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-c374c95851a06dcd6f12a78433b5d54ad3cd9281aa5dbe2c9c6b4b37ef2f6224">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SchedulingSuggestion.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-9021615e18b2a2f252a12aed3042fb1c17391382e248717b0bc5019a66d7323d">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TodayContent.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-a7413874160e2024e7f00942fa1d11111cb5468d3452780eadd77913b604d0f4">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CalendarEventsToday.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-36a8b05b44c298ecfab90e7e85ae2f7882226b3ae41fe0351714e73c8f01328f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GoogleCalendarConnect.test.tsx</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-72df554e4f5a11468b548e591687f16bcd751f0264b804aa916a4bba996da091">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>welcomeCopy.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/539/files#diff-805062a8bffbedbe6868627b707996268993325dd3d56d7ecf0a48aa5228cd23">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

