### PR TITLE
feat(product): read a feature's key result links from the feature side

### DIFF
--- a/src/plugins/product/server/routers/__tests__/featureKeyResultReadback.test.ts
+++ b/src/plugins/product/server/routers/__tests__/featureKeyResultReadback.test.ts
@@ -86,6 +86,24 @@ const MEMBER_ID = "user-member";
 const WORKSPACE_ID = "ws-1";
 const PRODUCT_ID = "prod-1";
 const FEATURE_ID = "feat-1";
+const KR_ID = "kr-1";
+
+/** A populated join row, so tests can assert on the response and not just the query. */
+const LINK_ROW = {
+  assignedAt: new Date("2026-08-01T00:00:00.000Z"),
+  keyResult: {
+    id: KR_ID,
+    title: "Ship 2 situational analysis modules",
+    period: "Q3-2026",
+    status: "on-track",
+    currentValue: 1,
+    targetValue: 2,
+    unit: "count",
+    unitLabel: null,
+    goalId: 75,
+    goal: { id: 75, title: "Field teams decide faster" },
+  },
+};
 
 /** The nested `keyResultLinks` select, however the router spelled it. */
 type LinkInclude = { select?: { keyResult?: { select?: Record<string, unknown> } } };
@@ -116,8 +134,24 @@ describe("Feature-side key result readback (ADR-0050)", () => {
       db.feature.findUnique.mockResolvedValue({
         id: FEATURE_ID,
         product: { id: PRODUCT_ID, workspaceId: WORKSPACE_ID },
-        keyResultLinks: [],
+        keyResultLinks: [LINK_ROW],
       } as never);
+    });
+
+    it("surfaces the links on the returned feature, under `keyResultLinks`", async () => {
+      const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+      const feature = await caller.product.feature.getById({ id: FEATURE_ID });
+
+      // Asserting the *response* field, not just the query args: a rename of
+      // the relation on the way out would slip past a shape-only assertion.
+      expect(feature.keyResultLinks).toHaveLength(1);
+      expect(feature.keyResultLinks[0]!.keyResult).toMatchObject({
+        id: KR_ID,
+        title: "Ship 2 situational analysis modules",
+        currentValue: 1,
+        targetValue: 2,
+      });
     });
 
     it("requests the linked key results with their progress values", async () => {
@@ -161,7 +195,19 @@ describe("Feature-side key result readback (ADR-0050)", () => {
 
   describe("list", () => {
     beforeEach(() => {
-      db.feature.findMany.mockResolvedValue([] as never);
+      db.feature.findMany.mockResolvedValue([
+        { id: FEATURE_ID, productId: PRODUCT_ID, keyResultLinks: [LINK_ROW] },
+      ] as never);
+    });
+
+    it("surfaces the links on each listed feature", async () => {
+      const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+      const features = await caller.product.feature.list({
+        productId: PRODUCT_ID,
+      });
+
+      expect(features[0]!.keyResultLinks[0]!.keyResult.id).toBe(KR_ID);
     });
 
     it("carries a lean key result shape so one call builds the column", async () => {

--- a/src/plugins/product/server/routers/__tests__/featureKeyResultReadback.test.ts
+++ b/src/plugins/product/server/routers/__tests__/featureKeyResultReadback.test.ts
@@ -1,0 +1,190 @@
+/**
+ * feature.list / feature.getById — the Feature side of the Feature↔Key result
+ * execution edge (ADR-0050).
+ *
+ * ADR-0050 made the edge writable and readable from the *key result* side
+ * (`okr.linkFeature`, `okr.getById`). The Feature side carried only `goal` —
+ * the coarser Objective alignment — so "which numbers does this Feature move?"
+ * had no answer without enumerating every key result in the workspace and
+ * inverting the mapping. These tests pin the readback.
+ *
+ * External behavior under test:
+ * - getById asks for `keyResultLinks` with the full KR shape (progress values
+ *   included) so a single Feature read can render its key results.
+ * - list asks for `keyResultLinks` with the *lean* shape, so a per-Feature key
+ *   result column costs one query rather than N.
+ * - `goal` is untouched on both. It answers a different question and the two
+ *   are allowed to disagree (ADR-0050 "Consequences").
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const MEMBER_ID = "user-member";
+const WORKSPACE_ID = "ws-1";
+const PRODUCT_ID = "prod-1";
+const FEATURE_ID = "feat-1";
+
+/** The nested `keyResultLinks` select, however the router spelled it. */
+type LinkInclude = { select?: { keyResult?: { select?: Record<string, unknown> } } };
+
+describe("Feature-side key result readback (ADR-0050)", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+    db.workspaceUser.findUnique.mockResolvedValue({
+      role: "member",
+      workspaceId: WORKSPACE_ID,
+    } as never);
+    db.teamUser.findFirst.mockResolvedValue(null as never);
+    db.product.findUnique.mockResolvedValue({
+      id: PRODUCT_ID,
+      workspaceId: WORKSPACE_ID,
+    } as never);
+    db.product.findFirst.mockResolvedValue({
+      id: PRODUCT_ID,
+      workspaceId: WORKSPACE_ID,
+    } as never);
+  });
+
+  describe("getById", () => {
+    beforeEach(() => {
+      db.feature.findUnique.mockResolvedValue({
+        id: FEATURE_ID,
+        product: { id: PRODUCT_ID, workspaceId: WORKSPACE_ID },
+        keyResultLinks: [],
+      } as never);
+    });
+
+    it("requests the linked key results with their progress values", async () => {
+      const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+      await caller.product.feature.getById({ id: FEATURE_ID });
+
+      expect(db.feature.findUnique).toHaveBeenCalledTimes(1);
+      const include = db.feature.findUnique.mock.calls[0]![0]!.include as {
+        goal?: unknown;
+        keyResultLinks?: LinkInclude;
+      };
+
+      const krSelect = include.keyResultLinks?.select?.keyResult?.select;
+      expect(krSelect).toBeDefined();
+      // Enough to render "which number, where is it now, where should it be".
+      for (const field of [
+        "id",
+        "title",
+        "period",
+        "status",
+        "currentValue",
+        "targetValue",
+        "goalId",
+      ]) {
+        expect(krSelect).toHaveProperty(field, true);
+      }
+    });
+
+    it("leaves the Objective alignment (`goal`) in place beside it", async () => {
+      const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+      await caller.product.feature.getById({ id: FEATURE_ID });
+
+      const include = db.feature.findUnique.mock.calls[0]![0]!.include as {
+        goal?: unknown;
+      };
+      expect(include.goal).toBeDefined();
+    });
+  });
+
+  describe("list", () => {
+    beforeEach(() => {
+      db.feature.findMany.mockResolvedValue([] as never);
+    });
+
+    it("carries a lean key result shape so one call builds the column", async () => {
+      const caller = createMockCaller({ userId: MEMBER_ID, db });
+
+      await caller.product.feature.list({ productId: PRODUCT_ID });
+
+      expect(db.feature.findMany).toHaveBeenCalledTimes(1);
+      const include = db.feature.findMany.mock.calls[0]![0]!.include as {
+        keyResultLinks?: LinkInclude;
+      };
+
+      const krSelect = include.keyResultLinks?.select?.keyResult?.select;
+      expect(krSelect).toBeDefined();
+      // Lean on purpose: the list is a board/table read. Progress values are
+      // getById's job — widening this select silently costs every product
+      // listing with hundreds of features.
+      expect(Object.keys(krSelect!).sort()).toEqual([
+        "goalId",
+        "id",
+        "period",
+        "title",
+      ]);
+    });
+  });
+});

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -444,6 +444,14 @@ export const featureRouter = createTRPCRouter({
           // answers a different question: which Objective this Feature serves,
           // versus which specific numbers it is meant to move. The two can
           // legitimately disagree, so neither substitutes for the other.
+          //
+          // No workspace filter on the join, matching `okr.getById`'s mirror
+          // include: a link row cannot cross workspaces in the first place.
+          // Both write paths - `okr.linkFeature` and `okr.updateLinkedFeatures`
+          // - reject a feature whose product is in a different workspace than
+          // the key result, and both rejections are covered by tests. Filtering
+          // here would duplicate that guard and mask, rather than surface, any
+          // future breach of the invariant.
           keyResultLinks: {
             orderBy: { assignedAt: "asc" },
             select: {

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -315,6 +315,18 @@ export const featureRouter = createTRPCRouter({
           goal: { select: { id: true, title: true, period: true } },
           area: { select: { id: true, name: true, displayOrder: true } },
           tags: { include: { tag: true } },
+          // Lean Key result edges (ADR-0050) so a per-Feature "which numbers
+          // does this move" column can be built from one list call instead of
+          // N `getById`s. Deliberately id+title+period only - the full KR with
+          // its progress values is {@link getById}'s job.
+          keyResultLinks: {
+            orderBy: { assignedAt: "asc" },
+            select: {
+              keyResult: {
+                select: { id: true, title: true, period: true, goalId: true },
+              },
+            },
+          },
           _count: {
             select: { scopes: true, requirements: true, tickets: true },
           },
@@ -427,6 +439,31 @@ export const featureRouter = createTRPCRouter({
             },
           },
           tags: { include: { tag: true } },
+          // The Feature→Key result execution edges (ADR-0050), readable from
+          // this side too. `goal` above is the coarser Objective alignment and
+          // answers a different question: which Objective this Feature serves,
+          // versus which specific numbers it is meant to move. The two can
+          // legitimately disagree, so neither substitutes for the other.
+          keyResultLinks: {
+            orderBy: { assignedAt: "asc" },
+            select: {
+              assignedAt: true,
+              keyResult: {
+                select: {
+                  id: true,
+                  title: true,
+                  period: true,
+                  status: true,
+                  currentValue: true,
+                  targetValue: true,
+                  unit: true,
+                  unitLabel: true,
+                  goalId: true,
+                  goal: { select: { id: true, title: true } },
+                },
+              },
+            },
+          },
           // `comments` is a count, not the list: the UI loads the thread lazily
           // via `featureComment.list`, and API callers need to know a discussion
           // exists before paying for it.


### PR DESCRIPTION
### **User description**
## What

- `feature.getById` now includes `keyResultLinks` — the linked key results with their progress values (`currentValue` / `targetValue` / `status` / `period`), so one Feature read can render the numbers it moves.
- `feature.list` includes a deliberately lean `id` / `title` / `period` / `goalId` shape, so a per-Feature key result column costs one query instead of N.
- New unit test pinning both select shapes, mirroring the existing `keyResultFeatureLinks.test.ts` on the key result side.

## Why

[ADR-0050](docs/adr/0050-key-results-accept-feature-execution-links.md) made the Feature↔Key result execution edge writable and readable from the **key result** side (`okr.linkFeature`, `okr.getById`, `goals kr link --feature` in the CLI). The **Feature** side carried only `goal` — the coarser Objective alignment — so "which numbers does this Feature move?" had no answer without enumerating every key result in the workspace and inverting the mapping.

This came out of building a Feature table with a KR column and finding the edge write-only from that direction.

`goal` is untouched on both procedures. It answers a different question — which Objective a Feature *serves* versus which specific numbers it is meant to *move* — and ADR-0050's Consequences section explicitly allows the two to disagree.

## Notes

The `list` select is lean on purpose: it backs board/table reads on products with hundreds of features, and the test asserts the exact key set so a future widening has to be deliberate.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `keyResultLinks` to `feature.getById` with full KR progress data

- Add lean `keyResultLinks` shape to `feature.list` for table columns

- Document why no workspace filter on the join

- New unit tests pinning both select shapes and responses


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["feature.getById"] -- "include" --> B["keyResultLinks (full KR: progress, unit, goal)"]
  C["feature.list"] -- "include" --> D["keyResultLinks (lean: id/title/period/goalId)"]
  E["featureKeyResultReadback.test.ts"] -- "asserts" --> B
  E -- "asserts" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>feature.ts</strong><dd><code>Expose key result links on feature read procedures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/routers/feature.ts

<ul><li><code>feature.list</code> now includes <code>keyResultLinks</code> with a lean <br><code>id</code>/<code>title</code>/<code>period</code>/<code>goalId</code> KR select, ordered by <code>assignedAt</code>.<br> <li> <code>feature.getById</code> now includes <code>keyResultLinks</code> with <code>assignedAt</code> and a full <br>KR select (status, <code>currentValue</code>, <code>targetValue</code>, unit, nested <code>goal</code>).<br> <li> Added comments explaining the distinction from <code>goal</code> (Objective <br>alignment) and why the join is not workspace-filtered (invariant <br>enforced at write paths).</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/540/files#diff-bff1a29f77efa7f846d655a0106c96302d007305d09f09ecb53ab204ef97d03d">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>featureKeyResultReadback.test.ts</strong><dd><code>Tests for feature-side key result readback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/routers/__tests__/featureKeyResultReadback.test.ts

<ul><li>New test suite using <code>mockDeep<PrismaClient>()</code> and a mock tRPC caller, with <br>env/auth/openai mocks.<br> <li> Asserts <code>getById</code> returns populated <code>keyResultLinks</code> and requests KR <br>progress fields while keeping <code>goal</code>.<br> <li> Asserts <code>list</code> surfaces links and pins the exact lean KR select key set.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/540/files#diff-69837b6c932baaec1717bc135243b87f0991338eb6bf2ea6e9638ddba9b0e16e">+236/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

