### PR TITLE
feat(product): scope epics to a product and give them a detail page

### DIFF
--- a/prisma/migrations/20260810120000_epic_product_scope/migration.sql
+++ b/prisma/migrations/20260810120000_epic_product_scope/migration.sql
@@ -1,0 +1,20 @@
+-- Epics become product-scoped.
+--
+-- `productId` is nullable for the backfill window only. Rows predating this
+-- column have no product, and the router treats a null-product epic as
+-- linkable from any product in its workspace, so no existing ticket loses its
+-- epic link when this lands. Once every row is assigned (see
+-- `scripts/backfill-epic-product.ts`), a follow-up migration tightens the
+-- column to NOT NULL.
+--
+-- ON DELETE CASCADE matches Feature's product relation: deleting a product
+-- removes the things that describe it. Tickets and actions pointing at a
+-- deleted epic fall back to their existing ON DELETE SET NULL.
+
+ALTER TABLE "Epic" ADD COLUMN "productId" TEXT;
+
+CREATE INDEX "Epic_productId_idx" ON "Epic"("productId");
+
+ALTER TABLE "Epic" ADD CONSTRAINT "Epic_productId_fkey"
+  FOREIGN KEY ("productId") REFERENCES "Product"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2285,11 +2285,17 @@ model Epic {
 
   ownerId     String
   workspaceId String
+  // An epic belongs to one Product. Nullable only for the backfill window:
+  // rows predating this column have no product yet, and a null epic stays
+  // linkable from any product in its workspace so existing tickets keep
+  // their epic. Tighten to required once every row is assigned.
+  productId   String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
   owner     User      @relation("EpicOwner", fields: [ownerId], references: [id])
   workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  product   Product?  @relation(fields: [productId], references: [id], onDelete: Cascade)
   actions   Action[]
   tickets   Ticket[]  @relation("TicketEpic")
   tags      EpicTag[]
@@ -2297,6 +2303,7 @@ model Epic {
   @@index([workspaceId])
   @@index([ownerId])
   @@index([status])
+  @@index([productId])
 }
 
 enum ActionStatus {
@@ -4073,6 +4080,7 @@ model Product {
   projects          Project[]
   ticketSyncConfigs TicketSyncConfig[]
   featureDrafts     MeetingFeatureDraft[]
+  epics             Epic[]
 
   @@unique([workspaceId, slug])
   @@index([workspaceId])

--- a/scripts/backfill-epic-product.ts
+++ b/scripts/backfill-epic-product.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env ts-node
+
+/**
+ * Backfill Epic.productId
+ *
+ * Epics used to be workspace-scoped and are now per-product. This assigns each
+ * existing epic to a product by majority vote of its tickets:
+ *
+ *   - all tickets in one product      -> assign that product (clean)
+ *   - tickets across several products -> assign the majority product and
+ *                                        REPORT the minority tickets, which
+ *                                        will lose their epic link when the
+ *                                        product-containment guard tightens
+ *   - no tickets at all               -> left null, needs a human decision
+ *
+ * The minority case is why this is not a blind UPDATE: at time of writing
+ * "Closed-loop Ticket lifecycle" spans agent-skills (6 tickets) and
+ * exponential (2), and which side keeps the epic is a product call.
+ *
+ * Dry run (default, read-only):   bun scripts/backfill-epic-product.ts
+ * Apply:                          bun scripts/backfill-epic-product.ts --apply
+ */
+
+// Load environment variables
+import { loadEnvConfig } from '@next/env';
+loadEnvConfig(process.cwd());
+
+import { db } from '../src/server/db';
+
+const APPLY = process.argv.includes('--apply');
+
+interface Plan {
+  epicId: string;
+  epicName: string;
+  workspaceSlug: string;
+  chosenProductId: string | null;
+  chosenProductSlug: string | null;
+  distribution: Array<{ productSlug: string; count: number }>;
+  orphanedTicketCount: number;
+  note: string;
+}
+
+async function buildPlan(): Promise<Plan[]> {
+  const epics = await db.epic.findMany({
+    where: { productId: null },
+    select: {
+      id: true,
+      name: true,
+      workspace: { select: { slug: true } },
+      tickets: {
+        select: { product: { select: { id: true, slug: true } } },
+      },
+    },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  return epics.map((epic) => {
+    const counts = new Map<string, { slug: string; count: number }>();
+    for (const ticket of epic.tickets) {
+      const entry = counts.get(ticket.product.id) ?? {
+        slug: ticket.product.slug,
+        count: 0,
+      };
+      entry.count += 1;
+      counts.set(ticket.product.id, entry);
+    }
+
+    const ranked = [...counts.entries()].sort((a, b) => b[1].count - a[1].count);
+    const winner = ranked[0];
+    const total = epic.tickets.length;
+    const majority = winner?.[1].count ?? 0;
+
+    return {
+      epicId: epic.id,
+      epicName: epic.name,
+      workspaceSlug: epic.workspace.slug,
+      chosenProductId: winner?.[0] ?? null,
+      chosenProductSlug: winner?.[1].slug ?? null,
+      distribution: ranked.map(([, v]) => ({ productSlug: v.slug, count: v.count })),
+      orphanedTicketCount: total - majority,
+      note:
+        total === 0
+          ? 'NO TICKETS — assign by hand in the UI'
+          : ranked.length > 1
+            ? `SPLIT across ${ranked.length} products — ${total - majority} ticket(s) will lose this epic`
+            : 'clean',
+    };
+  });
+}
+
+async function main() {
+  const plan = await buildPlan();
+
+  if (plan.length === 0) {
+    console.log('No epics with a null productId. Nothing to do.');
+    return;
+  }
+
+  console.log(`${APPLY ? 'APPLYING' : 'DRY RUN'} — ${plan.length} epic(s) without a product\n`);
+
+  for (const row of plan) {
+    const dist = row.distribution
+      .map((d) => `${d.productSlug}:${d.count}`)
+      .join(', ');
+    console.log(`  [${row.workspaceSlug}] ${row.epicName}`);
+    console.log(`      tickets   : ${dist || '(none)'}`);
+    console.log(`      -> product: ${row.chosenProductSlug ?? '(unassigned)'}`);
+    console.log(`      note      : ${row.note}\n`);
+  }
+
+  const splits = plan.filter((p) => p.orphanedTicketCount > 0);
+  const unassigned = plan.filter((p) => p.chosenProductId === null);
+
+  console.log('Summary');
+  console.log(`  assignable      : ${plan.length - unassigned.length}`);
+  console.log(`  needs a human   : ${unassigned.length}`);
+  console.log(`  cross-product   : ${splits.length}`);
+  console.log(
+    `  tickets losing their epic if applied as-is: ${splits.reduce((n, p) => n + p.orphanedTicketCount, 0)}`,
+  );
+
+  if (!APPLY) {
+    console.log('\nRe-run with --apply to write these assignments.');
+    return;
+  }
+
+  let written = 0;
+  for (const row of plan) {
+    if (!row.chosenProductId) continue;
+    await db.epic.update({
+      where: { id: row.epicId },
+      data: { productId: row.chosenProductId },
+    });
+    written += 1;
+  }
+  console.log(`\nAssigned ${written} epic(s).`);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(() => {
+    void db.$disconnect();
+  });

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/epics/[epicId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/epics/[epicId]/page.tsx
@@ -83,6 +83,7 @@ export default function EpicDetailPage() {
   const params = useParams();
   const epicId = params.epicId as string;
   const productSlug = params.productSlug as string;
+  const workspaceSlug = params.workspaceSlug as string;
   const { workspace, workspaceId } = useWorkspace();
   const utils = api.useUtils();
 
@@ -126,23 +127,28 @@ export default function EpicDetailPage() {
     },
   });
 
-  // An epic has exactly one canonical URL — the one under its own product.
-  // `getById` gates on workspace membership, not on the product in the path,
-  // so without this an epic reached through a sibling product's URL would
-  // render under that product's breadcrumbs and tab bar. Canonicalise instead
-  // of 404ing: the reader is entitled to see it, just not there. A
-  // product-less epic (pre-backfill) has no canonical URL yet, so it stays
-  // wherever it was opened — that is how it gets assigned one.
-  const wrongProduct =
-    !!epic?.product && epic.product.slug !== productSlug;
+  // An epic has exactly one canonical URL: its own workspace *and* its own
+  // product. `getById` gates on membership of the epic's workspace, not on
+  // either slug in the address bar, so a user in two workspaces can reach a
+  // foreign epic through this route and have it render under the wrong
+  // breadcrumbs — and rebuilding the path from the URL's own workspace would
+  // point at a product that does not exist there. Both segments therefore come
+  // from the epic itself. Canonicalise rather than 404: the reader is entitled
+  // to see it, just not here. A product-less epic (pre-backfill) has no
+  // canonical URL yet, so it stays wherever it was opened — that is how it
+  // gets assigned one.
+  const canonicalPath =
+    epic?.product && epic.workspace
+      ? `/w/${epic.workspace.slug}/products/${epic.product.slug}/epics/${epicId}`
+      : null;
+  const misplaced =
+    canonicalPath !== null &&
+    (epic!.product!.slug !== productSlug ||
+      epic!.workspace.slug !== workspaceSlug);
 
   useEffect(() => {
-    if (wrongProduct && epic?.product && workspace?.slug) {
-      router.replace(
-        `/w/${workspace.slug}/products/${epic.product.slug}/epics/${epicId}`,
-      );
-    }
-  }, [wrongProduct, epic?.product, workspace?.slug, epicId, router]);
+    if (misplaced && canonicalPath) router.replace(canonicalPath);
+  }, [misplaced, canonicalPath, router]);
 
   if (isLoading) {
     return (
@@ -158,7 +164,7 @@ export default function EpicDetailPage() {
 
   // Redirecting to the canonical product URL — don't paint this product's
   // chrome around another product's epic in the meantime.
-  if (wrongProduct) return null;
+  if (misplaced) return null;
 
   // A pre-backfill epic can still hold tickets from more than one product.
   // Anything outside this epic's own product is called out rather than listed

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/epics/[epicId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/epics/[epicId]/page.tsx
@@ -1,0 +1,515 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  ActionIcon,
+  Badge,
+  Group,
+  Menu,
+  Select,
+  Skeleton,
+  Stack,
+  Text,
+  Tooltip,
+} from "@mantine/core";
+import { DateInput } from "@mantine/dates";
+import { modals } from "@mantine/modals";
+import {
+  IconAlertTriangle,
+  IconArrowLeft,
+  IconBox,
+  IconCalendar,
+  IconCircleDot,
+  IconCopy,
+  IconDots,
+  IconFlag,
+  IconListCheck,
+  IconTicket,
+  IconTrash,
+  IconUser,
+} from "@tabler/icons-react";
+import { api } from "~/trpc/react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import {
+  PropertiesSidebar,
+  PropertyRow,
+  PropertyDivider,
+} from "~/app/_components/PropertiesSidebar";
+import { PriorityIcon } from "~/app/_components/product/PriorityIcon";
+import { CollapsibleSection } from "~/app/_components/product/CollapsibleSection";
+import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
+import { TagSelector } from "~/app/_components/TagSelector";
+import { EPIC_PRIORITY_OPTIONS, EPIC_STATUS_OPTIONS } from "~/types/epic";
+import type { EpicPriority, EpicStatus } from "~/types/epic";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const EPIC_STATUS_COLORS: Record<string, string> = {
+  OPEN: "gray",
+  IN_PROGRESS: "blue",
+  DONE: "green",
+  CANCELLED: "dark",
+};
+
+const PRIORITY_TO_NUM: Record<string, number> = {
+  HIGH: 1,
+  MEDIUM: 2,
+  LOW: 3,
+  NONE: 4,
+};
+
+const TICKET_STATUS_COLORS: Record<string, string> = {
+  BACKLOG: "gray",
+  TODO: "gray",
+  IN_PROGRESS: "blue",
+  IN_REVIEW: "violet",
+  QA: "orange",
+  DONE: "green",
+  ARCHIVED: "dark",
+};
+
+const DONE_TICKET_STATUSES = new Set(["DONE", "ARCHIVED"]);
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function EpicDetailPage() {
+  const router = useRouter();
+  const params = useParams();
+  const epicId = params.epicId as string;
+  const productSlug = params.productSlug as string;
+  const { workspace, workspaceId } = useWorkspace();
+  const utils = api.useUtils();
+
+  const { data: epic, isLoading } = api.epic.getById.useQuery(
+    { id: epicId },
+    { enabled: !!epicId },
+  );
+
+  const { data: products } = api.product.product.list.useQuery(
+    { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId },
+  );
+
+  const { data: epicTags } = api.tag.listForEntity.useQuery(
+    { entityType: "epic", entityId: epicId },
+    { enabled: !!epicId },
+  );
+
+  const backPath = `/w/${workspace?.slug}/products/${productSlug}/tickets`;
+
+  const updateEpic = api.epic.update.useMutation({
+    onSuccess: async () => {
+      await utils.epic.getById.invalidate({ id: epicId });
+      await utils.epic.list.invalidate();
+    },
+  });
+
+  const setEntityTags = api.tag.setEntityTags.useMutation({
+    onSuccess: async () => {
+      await utils.tag.listForEntity.invalidate({
+        entityType: "epic",
+        entityId: epicId,
+      });
+    },
+  });
+
+  const deleteEpic = api.epic.delete.useMutation({
+    onSuccess: async () => {
+      await utils.epic.list.invalidate();
+      router.push(backPath);
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <Stack gap="md">
+        <Skeleton height={24} width={120} />
+        <Skeleton height={36} width={400} />
+        <Skeleton height={200} />
+      </Stack>
+    );
+  }
+
+  if (!epic) return <Text className="text-text-muted">Epic not found</Text>;
+
+  // A pre-backfill epic can still hold tickets from more than one product.
+  // Anything outside this epic's own product is called out rather than listed
+  // as if it belonged here.
+  const homeProductId = epic.product?.id ?? null;
+  const foreignTickets = epic.tickets.filter(
+    (t) => homeProductId != null && t.product.id !== homeProductId,
+  );
+  const doneCount = epic.tickets.filter((t) =>
+    DONE_TICKET_STATUSES.has(t.status),
+  ).length;
+
+  const ticketHref = (t: (typeof epic.tickets)[number]) =>
+    `/w/${workspace?.slug}/products/${t.product.slug}/tickets/${t.id}`;
+
+  const ticketLabel = (t: (typeof epic.tickets)[number]) =>
+    t.product.funTicketIds && t.shortId ? t.shortId : `#${t.number}`;
+
+  return (
+    <div className="flex min-h-0">
+      {/* Main content */}
+      <div className="flex-1 overflow-y-auto pr-6">
+        <Stack gap="lg">
+          {/* Back nav */}
+          <Link
+            href={backPath}
+            className="inline-flex items-center gap-1.5 text-xs text-text-muted hover:text-text-primary transition-colors"
+          >
+            <IconArrowLeft size={14} />
+            Epics
+          </Link>
+
+          {/* Title + badges + overflow menu */}
+          <div>
+            <Group gap="sm" mb={8}>
+              <Badge
+                size="xs"
+                variant="filled"
+                color={EPIC_STATUS_COLORS[epic.status] ?? "gray"}
+                styles={{ label: { color: "var(--mantine-color-dark-9)" } }}
+              >
+                {EPIC_STATUS_OPTIONS.find((s) => s.value === epic.status)?.label ??
+                  epic.status}
+              </Badge>
+              {epic.product ? (
+                <Badge
+                  size="xs"
+                  variant="outline"
+                  color="gray"
+                  leftSection={<IconBox size={10} />}
+                >
+                  {epic.product.name}
+                </Badge>
+              ) : (
+                <Tooltip label="Pick a product in the sidebar to finish setting this epic up">
+                  <Badge
+                    size="xs"
+                    variant="outline"
+                    color="orange"
+                    leftSection={<IconAlertTriangle size={10} />}
+                  >
+                    No product
+                  </Badge>
+                </Tooltip>
+              )}
+            </Group>
+
+            <Group justify="space-between" align="flex-start">
+              <Text size="xl" fw={700} className="text-text-primary flex-1">
+                {epic.name}
+              </Text>
+              <Menu position="bottom-end" withinPortal>
+                <Menu.Target>
+                  <ActionIcon variant="subtle" className="text-text-muted">
+                    <IconDots size={18} />
+                  </ActionIcon>
+                </Menu.Target>
+                <Menu.Dropdown>
+                  <Menu.Item
+                    leftSection={<IconCopy size={14} />}
+                    onClick={() => {
+                      void navigator.clipboard.writeText(window.location.href);
+                    }}
+                  >
+                    Copy link
+                  </Menu.Item>
+                  <Menu.Divider />
+                  <Menu.Item
+                    color="red"
+                    leftSection={<IconTrash size={14} />}
+                    onClick={() => {
+                      modals.openConfirmModal({
+                        title: "Delete epic",
+                        children: (
+                          <Text size="sm">
+                            This deletes the epic. Its {epic._count.tickets}{" "}
+                            ticket(s) and {epic._count.actions} action(s) are
+                            kept — they simply lose their epic.
+                          </Text>
+                        ),
+                        labels: { confirm: "Delete", cancel: "Cancel" },
+                        confirmProps: { color: "red" },
+                        onConfirm: () => deleteEpic.mutate({ id: epicId }),
+                      });
+                    }}
+                  >
+                    Delete epic
+                  </Menu.Item>
+                </Menu.Dropdown>
+              </Menu>
+            </Group>
+          </div>
+
+          {/* Description */}
+          {epic.description && (
+            <CollapsibleSection title="Description">
+              <MarkdownRenderer content={epic.description} variant="prose" />
+            </CollapsibleSection>
+          )}
+
+          {/* Tickets */}
+          <CollapsibleSection
+            title="Tickets"
+            meta={
+              epic.tickets.length > 0
+                ? `${doneCount}/${epic.tickets.length} done`
+                : undefined
+            }
+          >
+            {epic.tickets.length === 0 ? (
+              <Text size="sm" className="text-text-muted py-4">
+                No tickets in this epic yet.
+              </Text>
+            ) : (
+              <>
+                {foreignTickets.length > 0 && (
+                  <div className="mb-3 flex items-start gap-2 rounded-lg border border-border-primary px-3 py-2">
+                    <IconAlertTriangle
+                      size={14}
+                      className="mt-0.5 shrink-0 text-text-muted"
+                    />
+                    <Text size="xs" className="text-text-secondary">
+                      {foreignTickets.length} ticket(s) below belong to another
+                      product. Epics are per-product now, so these will lose
+                      their epic the next time they are edited — move them, or
+                      split them into their own epic.
+                    </Text>
+                  </div>
+                )}
+                <div className="border border-border-primary rounded-lg overflow-hidden">
+                  {epic.tickets.map((ticket, i) => (
+                    <Link
+                      key={ticket.id}
+                      href={ticketHref(ticket)}
+                      className={`flex items-center gap-3 px-3 py-2 hover:bg-surface-hover transition-colors ${
+                        i < epic.tickets.length - 1
+                          ? "border-b border-border-primary"
+                          : ""
+                      }`}
+                    >
+                      <Badge
+                        size="xs"
+                        variant="filled"
+                        color={TICKET_STATUS_COLORS[ticket.status] ?? "gray"}
+                        styles={{
+                          label: { color: "var(--mantine-color-dark-9)" },
+                        }}
+                        className="shrink-0"
+                      >
+                        {ticket.status.toLowerCase().replace("_", " ")}
+                      </Badge>
+                      <Text size="xs" className="text-text-muted shrink-0 w-16">
+                        {ticketLabel(ticket)}
+                      </Text>
+                      <Text
+                        size="sm"
+                        className="text-text-primary flex-1 min-w-0"
+                        lineClamp={1}
+                      >
+                        {ticket.title}
+                      </Text>
+                      {homeProductId != null &&
+                        ticket.product.id !== homeProductId && (
+                          <Badge
+                            size="xs"
+                            variant="outline"
+                            color="orange"
+                            className="shrink-0"
+                          >
+                            {ticket.product.name}
+                          </Badge>
+                        )}
+                      <PriorityIcon priority={ticket.priority ?? 4} size={14} />
+                    </Link>
+                  ))}
+                </div>
+              </>
+            )}
+          </CollapsibleSection>
+
+          {/* Actions — an epic can hold Actions, which have no product of their
+              own. Read-only here; the write path is the action's own modal. */}
+          {epic.actions.length > 0 && (
+            <CollapsibleSection
+              title="Actions"
+              meta={String(epic.actions.length)}
+            >
+              <div className="border border-border-primary rounded-lg overflow-hidden">
+                {epic.actions.map((action, i) => (
+                  <div
+                    key={action.id}
+                    className={`flex items-center gap-3 px-3 py-2 ${
+                      i < epic.actions.length - 1
+                        ? "border-b border-border-primary"
+                        : ""
+                    }`}
+                  >
+                    <Badge size="xs" variant="light" className="shrink-0">
+                      {action.status.toLowerCase()}
+                    </Badge>
+                    <Text
+                      size="sm"
+                      className="text-text-primary flex-1 min-w-0"
+                      lineClamp={1}
+                    >
+                      {action.name}
+                    </Text>
+                  </div>
+                ))}
+              </div>
+            </CollapsibleSection>
+          )}
+        </Stack>
+      </div>
+
+      {/* Properties sidebar */}
+      <PropertiesSidebar>
+        <PropertyRow icon={<IconCircleDot size={14} />} label="Status">
+          <Select
+            value={epic.status}
+            onChange={(val) =>
+              val && updateEpic.mutate({ id: epicId, status: val as EpicStatus })
+            }
+            data={EPIC_STATUS_OPTIONS}
+            size="xs"
+            variant="unstyled"
+            comboboxProps={{ withinPortal: true }}
+            classNames={{
+              input: "text-text-primary text-xs font-medium cursor-pointer",
+            }}
+            styles={{ input: { height: 24, minHeight: 24 } }}
+          />
+        </PropertyRow>
+
+        <PropertyRow icon={<IconBox size={14} />} label="Product">
+          <Select
+            value={epic.product?.id ?? null}
+            onChange={(val) =>
+              val && updateEpic.mutate({ id: epicId, productId: val })
+            }
+            data={(products ?? []).map((p) => ({ value: p.id, label: p.name }))}
+            placeholder="Select a product"
+            size="xs"
+            variant="unstyled"
+            searchable
+            nothingFoundMessage="No products in this workspace"
+            comboboxProps={{ withinPortal: true }}
+            classNames={{
+              input: "text-text-primary text-xs font-medium cursor-pointer",
+            }}
+            styles={{ input: { height: 24, minHeight: 24 } }}
+          />
+        </PropertyRow>
+
+        <PropertyRow icon={<IconFlag size={14} />} label="Priority">
+          <Select
+            value={epic.priority}
+            onChange={(val) =>
+              val &&
+              updateEpic.mutate({
+                id: epicId,
+                priority: val as EpicPriority,
+              })
+            }
+            data={EPIC_PRIORITY_OPTIONS}
+            size="xs"
+            variant="unstyled"
+            comboboxProps={{ withinPortal: true }}
+            renderOption={({ option }) => (
+              <div className="flex items-center gap-2">
+                <PriorityIcon
+                  priority={PRIORITY_TO_NUM[option.value] ?? 4}
+                  size={14}
+                />
+                <span>{option.label}</span>
+              </div>
+            )}
+            classNames={{
+              input: "text-text-primary text-xs font-medium cursor-pointer",
+            }}
+            styles={{ input: { height: 24, minHeight: 24 } }}
+          />
+        </PropertyRow>
+
+        <PropertyRow icon={<IconUser size={14} />} label="Owner">
+          <Text size="xs" className="text-text-primary">
+            {epic.owner.name ?? epic.owner.email ?? "—"}
+          </Text>
+        </PropertyRow>
+
+        <PropertyDivider />
+
+        <PropertyRow icon={<IconCalendar size={14} />} label="Start">
+          <DateInput
+            value={epic.startDate ? new Date(epic.startDate) : null}
+            onChange={(val) => updateEpic.mutate({ id: epicId, startDate: val })}
+            placeholder="None"
+            clearable
+            size="xs"
+            variant="unstyled"
+            popoverProps={{ withinPortal: true }}
+            classNames={{ input: "text-text-primary text-xs cursor-pointer" }}
+            styles={{ input: { height: 24, minHeight: 24 } }}
+          />
+        </PropertyRow>
+
+        <PropertyRow icon={<IconCalendar size={14} />} label="Target">
+          <DateInput
+            value={epic.targetDate ? new Date(epic.targetDate) : null}
+            onChange={(val) => updateEpic.mutate({ id: epicId, targetDate: val })}
+            placeholder="None"
+            clearable
+            size="xs"
+            variant="unstyled"
+            popoverProps={{ withinPortal: true }}
+            classNames={{ input: "text-text-primary text-xs cursor-pointer" }}
+            styles={{ input: { height: 24, minHeight: 24 } }}
+          />
+        </PropertyRow>
+
+        <PropertyDivider />
+
+        <PropertyRow icon={<IconTicket size={14} />} label="Tickets">
+          <Text size="xs" className="text-text-primary">
+            {epic._count.tickets}
+          </Text>
+        </PropertyRow>
+
+        <PropertyRow icon={<IconListCheck size={14} />} label="Actions">
+          <Text size="xs" className="text-text-primary">
+            {epic._count.actions}
+          </Text>
+        </PropertyRow>
+
+        <PropertyDivider />
+
+        <div className="py-1.5">
+          <Text size="xs" className="text-text-muted mb-1.5">
+            Labels
+          </Text>
+          <TagSelector
+            selectedTagIds={(epicTags ?? []).map((t) => t.id)}
+            onChange={(tagIds) =>
+              setEntityTags.mutate({
+                entityType: "epic",
+                entityId: epicId,
+                tagIds,
+              })
+            }
+            workspaceId={workspaceId ?? undefined}
+            categoryFilter={null}
+          />
+        </div>
+      </PropertiesSidebar>
+    </div>
+  );
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/epics/[epicId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/epics/[epicId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import {
@@ -125,6 +126,24 @@ export default function EpicDetailPage() {
     },
   });
 
+  // An epic has exactly one canonical URL — the one under its own product.
+  // `getById` gates on workspace membership, not on the product in the path,
+  // so without this an epic reached through a sibling product's URL would
+  // render under that product's breadcrumbs and tab bar. Canonicalise instead
+  // of 404ing: the reader is entitled to see it, just not there. A
+  // product-less epic (pre-backfill) has no canonical URL yet, so it stays
+  // wherever it was opened — that is how it gets assigned one.
+  const wrongProduct =
+    !!epic?.product && epic.product.slug !== productSlug;
+
+  useEffect(() => {
+    if (wrongProduct && epic?.product && workspace?.slug) {
+      router.replace(
+        `/w/${workspace.slug}/products/${epic.product.slug}/epics/${epicId}`,
+      );
+    }
+  }, [wrongProduct, epic?.product, workspace?.slug, epicId, router]);
+
   if (isLoading) {
     return (
       <Stack gap="md">
@@ -136,6 +155,10 @@ export default function EpicDetailPage() {
   }
 
   if (!epic) return <Text className="text-text-muted">Epic not found</Text>;
+
+  // Redirecting to the canonical product URL — don't paint this product's
+  // chrome around another product's epic in the meantime.
+  if (wrongProduct) return null;
 
   // A pre-backfill epic can still hold tickets from more than one product.
   // Anything outside this epic's own product is called out rather than listed

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/epics/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/epics/page.tsx
@@ -1,0 +1,15 @@
+import { redirect } from "next/navigation";
+
+/**
+ * Epics have detail pages but no index of their own — the list lives as the
+ * Epics entity on the tickets board. Trimming an epic URL back to `/epics` is
+ * an easy thing to do by hand, so send it somewhere real instead of 404ing.
+ */
+export default async function EpicsIndexPage({
+  params,
+}: {
+  params: Promise<{ workspaceSlug: string; productSlug: string }>;
+}) {
+  const { workspaceSlug, productSlug } = await params;
+  redirect(`/w/${workspaceSlug}/products/${productSlug}/tickets`);
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
@@ -173,14 +173,19 @@ export default function ProductLayout({
     return <div className="w-full">{children}</div>;
   }
 
-  // Determine active tab from pathname
+  // Determine active tab from pathname. Epics live at their own `/epics/:id`
+  // route but are reached from — and navigate back to — the Backlog tab's
+  // entity switcher, so they keep Backlog lit rather than falling through to
+  // the "overview" default.
   const pathnameTab =
-    tabs.find(
-      (t) =>
-        t.href !== "" &&
-        (pathname === `${basePath}${t.href}` ||
-          pathname.startsWith(`${basePath}${t.href}/`)),
-    )?.value ?? "overview";
+    pathname === `${basePath}/epics` || pathname.startsWith(`${basePath}/epics/`)
+      ? "backlog"
+      : (tabs.find(
+          (t) =>
+            t.href !== "" &&
+            (pathname === `${basePath}${t.href}` ||
+              pathname.startsWith(`${basePath}${t.href}/`)),
+        )?.value ?? "overview");
   // While a navigation is pending, show the just-clicked tab as active so the
   // tab bar responds instantly; fall back to the real route once it commits.
   const activeTab = isPending && optimisticTab ? optimisticTab : pathnameTab;

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
@@ -245,9 +245,11 @@ export default function TicketDetailPage() {
     { workspaceId: workspaceId ?? "" },
     { enabled: !!workspaceId },
   );
+  // Only this ticket's own product's epics are linkable — the router rejects
+  // another product's epic, so offering it would be a dead option.
   const { data: epics } = api.epic.list.useQuery(
-    { workspaceId: workspaceId ?? "" },
-    { enabled: !!workspaceId },
+    { workspaceId: workspaceId ?? "", productId: ticket?.product.id },
+    { enabled: !!workspaceId && !!ticket?.product.id },
   );
   const { data: features } = api.product.feature.list.useQuery(
     { productId: ticket?.product.id ?? "" },
@@ -703,7 +705,14 @@ export default function TicketDetailPage() {
             epics={epics ?? []}
             onChange={(val) => handleFieldUpdate("epicId", val)}
             onCreate={(name) => {
-              if (workspaceId) createEpic.mutate({ workspaceId, name });
+              // Inline creation lands the epic on this ticket's own product.
+              if (workspaceId && ticket.product.id) {
+                createEpic.mutate({
+                  workspaceId,
+                  productId: ticket.product.id,
+                  name,
+                });
+              }
             }}
           />
         </PropertyRow>

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
@@ -18,7 +18,6 @@ import {
   Stack,
   Table,
   Text,
-  Textarea,
   TextInput,
   Tooltip,
   UnstyledButton,
@@ -61,6 +60,7 @@ import { PriorityIcon, PRIORITY_LABELS as PRIORITY_LABEL_MAP } from "~/app/_comp
 import { NotionSyncBadge } from "~/app/_components/product/NotionSyncBadge";
 import { BlockedIndicator } from "~/app/_components/product/TicketDependenciesSection";
 import { EpicsList } from "~/app/_components/product/EpicsList";
+import { CreateEpicModal } from "~/app/_components/CreateEpicModal";
 import { TagBadge } from "~/app/_components/TagBadge";
 import {
   groupTickets,
@@ -151,61 +151,6 @@ function sortValue(t: Record<string, unknown>, field: SortField): string | numbe
 // ---------------------------------------------------------------------------
 // SortHeader
 // ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// Create Epic Modal
-// ---------------------------------------------------------------------------
-
-function CreateEpicModal({ opened, onClose, workspaceId }: { opened: boolean; onClose: () => void; workspaceId: string }) {
-  const utils = api.useUtils();
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-
-  const createEpic = api.epic.create.useMutation({
-    onSuccess: async () => {
-      await utils.epic.list.invalidate();
-      onClose();
-      setName("");
-      setDescription("");
-    },
-  });
-
-  return (
-    <Modal opened={opened} onClose={onClose} title="New epic" size="md">
-      <Stack gap="md">
-        <TextInput
-          label="Name"
-          placeholder="Epic name"
-          value={name}
-          onChange={(e) => setName(e.currentTarget.value)}
-          size="sm"
-          required
-          autoFocus
-        />
-        <Textarea
-          label="Description"
-          placeholder="What does this epic cover?"
-          value={description}
-          onChange={(e) => setDescription(e.currentTarget.value)}
-          autosize
-          minRows={2}
-          maxRows={5}
-          size="sm"
-        />
-        <Group justify="flex-end">
-          <Button variant="subtle" onClick={onClose}>Cancel</Button>
-          <Button
-            onClick={() => createEpic.mutate({ workspaceId, name: name.trim(), description: description.trim() || undefined })}
-            loading={createEpic.isPending}
-            disabled={!name.trim()}
-          >
-            Create
-          </Button>
-        </Group>
-      </Stack>
-    </Modal>
-  );
-}
 
 // ---------------------------------------------------------------------------
 
@@ -511,9 +456,11 @@ export default function TicketsBacklogPage() {
     { enabled: !!workspaceId },
   );
 
+  // Epics are per-product. `includeUnassigned` keeps pre-backfill epics (no
+  // product yet) visible here so they can be opened and given one.
   const { data: epics } = api.epic.list.useQuery(
-    { workspaceId: workspaceId ?? "" },
-    { enabled: !!workspaceId },
+    { workspaceId: workspaceId ?? "", productId: product?.id },
+    { enabled: !!workspaceId && !!product?.id },
   );
 
   const utils = api.useUtils();
@@ -848,6 +795,7 @@ export default function TicketsBacklogPage() {
 
   if (!workspace) return null;
   const basePath = `/w/${workspace.slug}/products/${productSlug}/tickets`;
+  const epicsBasePath = `/w/${workspace.slug}/products/${productSlug}/epics`;
 
   // Clear only the overview deep-link params; keep any other query params.
   const clearUrlFilters = () => {
@@ -1290,7 +1238,7 @@ export default function TicketsBacklogPage() {
             <Text size="sm" className="text-text-muted">Timeline view coming soon</Text>
           </div>
         ) : (
-          <EpicsList epics={epics ?? []} search={search} basePath={basePath} view={view === "list" ? "list" : "table"} />
+          <EpicsList epics={epics ?? []} search={search} basePath={epicsBasePath} view={view === "list" ? "list" : "table"} />
         )
       ) : (isLoading || sessionPending) ? (
         <Stack gap="xs">
@@ -1590,6 +1538,7 @@ export default function TicketsBacklogPage() {
         opened={epicModalOpened}
         onClose={() => setEpicModalOpened(false)}
         workspaceId={workspaceId ?? ""}
+        productId={product?.id}
       />
 
       {/* Peek drawer - detail over the list, list stays mounted */}

--- a/src/app/_components/CreateEpicModal.tsx
+++ b/src/app/_components/CreateEpicModal.tsx
@@ -11,15 +11,30 @@ interface CreateEpicModalProps {
   opened: boolean;
   onClose: () => void;
   workspaceId?: string;
+  /**
+   * The product this epic belongs to. Pass it from a product-scoped surface
+   * (the Epics tab, a ticket) to skip the picker. Omit it from surfaces with
+   * no product of their own — the action modals — and the user picks one,
+   * because every epic needs a product.
+   */
+  productId?: string;
   onCreated?: (epic: { id: string; name: string }) => void;
 }
 
-export function CreateEpicModal({ opened, onClose, workspaceId, onCreated }: CreateEpicModalProps) {
+export function CreateEpicModal({ opened, onClose, workspaceId, productId, onCreated }: CreateEpicModalProps) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [priority, setPriority] = useState('MEDIUM');
   const [startDate, setStartDate] = useState<Date | null>(null);
   const [targetDate, setTargetDate] = useState<Date | null>(null);
+  const [pickedProductId, setPickedProductId] = useState<string | null>(null);
+
+  const needsProductPicker = !productId;
+  const { data: products } = api.product.product.list.useQuery(
+    { workspaceId: workspaceId ?? '' },
+    { enabled: opened && needsProductPicker && !!workspaceId },
+  );
+  const effectiveProductId = productId ?? pickedProductId;
 
   const createEpic = api.epic.create.useMutation({
     onSuccess: (data) => {
@@ -49,13 +64,15 @@ export function CreateEpicModal({ opened, onClose, workspaceId, onCreated }: Cre
     setPriority('MEDIUM');
     setStartDate(null);
     setTargetDate(null);
+    setPickedProductId(null);
   };
 
   const handleSubmit = () => {
-    if (!name.trim() || !workspaceId) return;
+    if (!name.trim() || !workspaceId || !effectiveProductId) return;
 
     createEpic.mutate({
       workspaceId,
+      productId: effectiveProductId,
       name: name.trim(),
       description: description.trim() || undefined,
       priority: priority as "HIGH" | "MEDIUM" | "LOW" | "NONE",
@@ -112,6 +129,20 @@ export function CreateEpicModal({ opened, onClose, workspaceId, onCreated }: Cre
           styles={inputStyles}
         />
 
+        {needsProductPicker && (
+          <Select
+            label="Product"
+            placeholder={products ? 'Select a product' : 'Loading…'}
+            value={pickedProductId}
+            onChange={setPickedProductId}
+            data={(products ?? []).map((p) => ({ value: p.id, label: p.name }))}
+            required
+            searchable
+            nothingFoundMessage="No products in this workspace"
+            styles={inputStyles}
+          />
+        )}
+
         <Select
           label="Priority"
           value={priority}
@@ -150,7 +181,7 @@ export function CreateEpicModal({ opened, onClose, workspaceId, onCreated }: Cre
           <Button
             onClick={handleSubmit}
             loading={createEpic.isPending}
-            disabled={!name.trim() || !workspaceId}
+            disabled={!name.trim() || !workspaceId || !effectiveProductId}
           >
             Create Epic
           </Button>

--- a/src/app/_components/layout/CommandPalette.tsx
+++ b/src/app/_components/layout/CommandPalette.tsx
@@ -32,6 +32,7 @@ import {
   IconCalendarEvent,
   IconUsers,
   IconTicket,
+  IconBolt,
   IconBulb,
   IconTrophy,
   IconUser,
@@ -88,13 +89,16 @@ const WORKSPACE_SECTIONS: {
 ];
 
 // How each entity type from search.global is presented, in the order the
-// sections appear. Two of the router's types are deliberately absent:
+// sections appear. One of the router's types is deliberately absent:
 // `workspace`, because a matching workspace already surfaces below with all of
-// its sub-pages, and `epic`, which has no detail route to navigate to.
+// its sub-pages. Epics are listed but an epic still awaiting a product returns
+// a null url and is dropped by the filter below, same as any other routeless
+// row.
 const RESULT_SECTIONS: { type: SearchType; label: string; icon: React.ElementType }[] = [
   { type: 'project', label: 'Projects', icon: IconStack2 },
   { type: 'action', label: 'Tasks', icon: IconSquareRoundedCheck },
   { type: 'ticket', label: 'Tickets', icon: IconTicket },
+  { type: 'epic', label: 'Epics', icon: IconBolt },
   { type: 'goal', label: 'Goals', icon: IconTarget },
   { type: 'keyResult', label: 'Key results', icon: IconTrophy },
   { type: 'outcome', label: 'Outcomes', icon: IconFlag },
@@ -109,7 +113,7 @@ const RESULT_SECTIONS: { type: SearchType; label: string; icon: React.ElementTyp
 // Which entity types each filter chip keeps. `all` keeps everything.
 const MODE_TYPES: Record<Exclude<Mode, 'ai'>, SearchType[] | null> = {
   all: null,
-  tasks: ['action', 'ticket'],
+  tasks: ['action', 'ticket', 'epic'],
   projects: ['project', 'product'],
   goals: ['goal', 'keyResult', 'outcome'],
 };

--- a/src/app/_components/product/EpicsList.tsx
+++ b/src/app/_components/product/EpicsList.tsx
@@ -56,6 +56,12 @@ interface EpicRow {
   description: string | null;
   status: string;
   priority: string;
+  /**
+   * Null for epics created before epics became per-product. They surface on
+   * every product board until someone assigns them, so they are flagged
+   * rather than shown as if they belonged here.
+   */
+  product?: { id: string; name: string; slug: string } | null;
   _count?: { actions?: number; tickets?: number };
 }
 
@@ -160,6 +166,18 @@ export function EpicsList({
     );
   }
 
+  const renderUnassignedBadge = (epic: EpicRow) =>
+    epic.product ? null : (
+      <Tooltip
+        label="Not assigned to a product yet — open it to pick one"
+        position="top"
+      >
+        <Badge size="xs" variant="outline" color="orange" className="shrink-0">
+          Unassigned
+        </Badge>
+      </Tooltip>
+    );
+
   const renderEditMenu = (epicId: string) => (
     <Menu position="bottom-end" withinPortal>
       <Menu.Target>
@@ -213,6 +231,7 @@ export function EpicsList({
               <Text size="sm" className="text-text-primary flex-1 min-w-0" lineClamp={1}>
                 {epic.name}
               </Text>
+              {renderUnassignedBadge(epic)}
               <PriorityIcon priority={PRIORITY_TO_NUM[epic.priority] ?? 4} size={14} />
               <Text size="xs" className="text-text-muted shrink-0">
                 {epic._count?.tickets ?? 0} tickets
@@ -259,7 +278,10 @@ export function EpicsList({
                   </Badge>
                 </Table.Td>
                 <Table.Td>
-                  <Text size="sm" className="text-text-primary" lineClamp={1}>{epic.name}</Text>
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Text size="sm" className="text-text-primary min-w-0" lineClamp={1}>{epic.name}</Text>
+                    {renderUnassignedBadge(epic)}
+                  </div>
                 </Table.Td>
                 <Table.Td style={{ width: 40 }}>
                   <Tooltip label={epic.priority.toLowerCase()} position="top">

--- a/src/app/_components/product/peek/TicketPeek.tsx
+++ b/src/app/_components/product/peek/TicketPeek.tsx
@@ -71,9 +71,10 @@ export function TicketPeek({ ticketId, basePath }: { ticketId: string; basePath:
     { productId: ticket?.product.id ?? "" },
     { enabled: !!ticket?.product.id },
   );
+  // Product-scoped: the router rejects another product's epic on write.
   const { data: epics } = api.epic.list.useQuery(
-    { workspaceId: workspaceId ?? "" },
-    { enabled: !!workspaceId },
+    { workspaceId: workspaceId ?? "", productId: ticket?.product.id },
+    { enabled: !!workspaceId && !!ticket?.product.id },
   );
   const { data: cycles } = api.product.cycle.list.useQuery(
     { workspaceId: workspaceId ?? "" },

--- a/src/plugins/product/server/routers/__tests__/ticket.test.ts
+++ b/src/plugins/product/server/routers/__tests__/ticket.test.ts
@@ -268,9 +268,11 @@ describe("ticket router — cross-workspace link guard (mocked)", () => {
         });
       });
 
+    // `productId` rides along because epics are per-product: the guard checks
+    // product containment on top of the workspace containment above.
     expect(dbMock.epic.findUnique).toHaveBeenCalledWith({
       where: { id: "epic-1" },
-      select: { workspaceId: true },
+      select: { workspaceId: true, productId: true },
     });
   });
 });

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -652,10 +652,21 @@ export const ticketRouter = createTRPCRouter({
         tickets.map((t) => [t.productId, t.product.workspaceId]),
       );
       for (const productId of productIds) {
+        // Both collections come from the same `tickets` rows, so a miss is
+        // unreachable — but defaulting to `null` here would quietly *disable*
+        // workspace containment for that product rather than reject, so fail
+        // loudly instead.
+        const refWorkspaceId = workspaceByProduct.get(productId);
+        if (!refWorkspaceId) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Could not resolve the workspace for a selected ticket",
+          });
+        }
         await assertWorkspaceScopedRefs(
           ctx.db,
           ctx.session.user.id,
-          workspaceByProduct.get(productId) ?? null,
+          refWorkspaceId,
           { epicId: input.epicId, cycleId: input.cycleId },
           productId,
         );

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -387,12 +387,19 @@ export const ticketRouter = createTRPCRouter({
 
       // A linked epic/feature/cycle/scope must live in the product's own
       // workspace, or its fields leak back through this ticket's includes.
-      await assertWorkspaceScopedRefs(ctx.db, ctx.session.user.id, product.workspaceId, {
-        epicId: input.epicId,
-        featureId: input.featureId,
-        cycleId: input.cycleId,
-        scopeId: input.scopeId,
-      });
+      // The trailing product id additionally holds an epic to this product.
+      await assertWorkspaceScopedRefs(
+        ctx.db,
+        ctx.session.user.id,
+        product.workspaceId,
+        {
+          epicId: input.epicId,
+          featureId: input.featureId,
+          cycleId: input.cycleId,
+          scopeId: input.scopeId,
+        },
+        product.id,
+      );
 
       // Same reasoning for the assignee, whose name and email come back through
       // `getById`'s include: only someone who could already read this ticket
@@ -491,6 +498,7 @@ export const ticketRouter = createTRPCRouter({
           cycleId: input.cycleId,
           scopeId: input.scopeId,
         },
+        previousTicket.productId,
       );
 
       await assertAssignableUser(
@@ -618,6 +626,7 @@ export const ticketRouter = createTRPCRouter({
         select: {
           id: true,
           status: true,
+          productId: true,
           product: { select: { workspaceId: true } },
         },
       });
@@ -629,18 +638,27 @@ export const ticketRouter = createTRPCRouter({
       );
       for (const workspaceId of workspaceIds) {
         await assertWorkspaceMember(ctx.db, ctx.session.user.id, workspaceId);
+        await assertAssignableUser(ctx.db, workspaceId, input.assigneeId);
+      }
 
-        // The same link and assignee guards as `create`/`update` — this path
-        // writes the identical foreign keys and its tickets are read back
-        // through the identical includes. The patch applies uniformly, so a
-        // reference must be valid in *every* workspace the selection spans.
+      // The same link guard as `create`/`update` — this path writes the
+      // identical foreign keys and its tickets are read back through the
+      // identical includes. The patch applies uniformly, so a reference must be
+      // valid in *every* product the selection spans: bulk-assigning one
+      // product's epic across a mixed selection is rejected outright rather
+      // than half-applied.
+      const productIds = Array.from(new Set(tickets.map((t) => t.productId)));
+      const workspaceByProduct = new Map(
+        tickets.map((t) => [t.productId, t.product.workspaceId]),
+      );
+      for (const productId of productIds) {
         await assertWorkspaceScopedRefs(
           ctx.db,
           ctx.session.user.id,
-          workspaceId,
+          workspaceByProduct.get(productId) ?? null,
           { epicId: input.epicId, cycleId: input.cycleId },
+          productId,
         );
-        await assertAssignableUser(ctx.db, workspaceId, input.assigneeId);
       }
 
       const data: Record<string, unknown> = Object.fromEntries(fields);

--- a/src/server/api/routers/__tests__/epic.test.ts
+++ b/src/server/api/routers/__tests__/epic.test.ts
@@ -74,7 +74,13 @@ import { createMockCaller } from "~/test/trpc-helpers";
 
 const WORKSPACE_ID = "ws-1";
 const USER_ID = "user-1";
-const EPIC = { id: "epic-1", name: "Payments", workspaceId: WORKSPACE_ID };
+const PRODUCT_ID = "prod-1";
+const EPIC = {
+  id: "epic-1",
+  name: "Payments",
+  workspaceId: WORKSPACE_ID,
+  productId: PRODUCT_ID,
+};
 
 type MembershipKind = "direct" | "team" | "none";
 
@@ -151,6 +157,102 @@ describe("epic router access gating (mocked)", () => {
         caller.epic.list({ workspaceId: WORKSPACE_ID }),
       ).rejects.toBeInstanceOf(TRPCError);
       expect(dbMock.epic.findMany).not.toHaveBeenCalled();
+    });
+
+    it("scopes to one product, and keeps product-less epics visible", async () => {
+      mockMembership(dbMock, "direct");
+      dbMock.epic.findMany.mockResolvedValue([] as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await caller.epic.list({
+        workspaceId: WORKSPACE_ID,
+        productId: PRODUCT_ID,
+      });
+
+      // Pre-backfill epics (productId null) must stay in the list or they are
+      // invisible from every product board and can never be assigned one.
+      expect(dbMock.epic.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            workspaceId: WORKSPACE_ID,
+            OR: [{ productId: PRODUCT_ID }, { productId: null }],
+          }),
+        }),
+      );
+    });
+
+    it("drops product-less epics when includeUnassigned is off", async () => {
+      mockMembership(dbMock, "direct");
+      dbMock.epic.findMany.mockResolvedValue([] as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await caller.epic.list({
+        workspaceId: WORKSPACE_ID,
+        productId: PRODUCT_ID,
+        includeUnassigned: false,
+      });
+
+      expect(dbMock.epic.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ OR: [{ productId: PRODUCT_ID }] }),
+        }),
+      );
+    });
+  });
+
+  describe("create", () => {
+    it("rejects a product from another workspace", async () => {
+      mockMembership(dbMock, "direct");
+      dbMock.product.findUnique.mockResolvedValue({
+        workspaceId: "ws-other",
+      } as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.epic.create({
+          workspaceId: WORKSPACE_ID,
+          productId: PRODUCT_ID,
+          name: "Payments",
+        }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+      expect(dbMock.epic.create).not.toHaveBeenCalled();
+    });
+
+    it("stores the product when it belongs to the workspace", async () => {
+      mockMembership(dbMock, "direct");
+      dbMock.product.findUnique.mockResolvedValue({
+        workspaceId: WORKSPACE_ID,
+      } as never);
+      dbMock.epic.create.mockResolvedValue(EPIC as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await caller.epic.create({
+        workspaceId: WORKSPACE_ID,
+        productId: PRODUCT_ID,
+        name: "Payments",
+      });
+
+      expect(dbMock.epic.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ productId: PRODUCT_ID }),
+        }),
+      );
+    });
+  });
+
+  describe("update", () => {
+    it("rejects moving an epic to another workspace's product", async () => {
+      mockMembership(dbMock, "direct");
+      dbMock.epic.findUnique.mockResolvedValue(EPIC as never);
+      dbMock.product.findUnique.mockResolvedValue({
+        workspaceId: "ws-other",
+      } as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await expect(
+        caller.epic.update({ id: EPIC.id, productId: PRODUCT_ID }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+      expect(dbMock.epic.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/server/api/routers/epic.ts
+++ b/src/server/api/routers/epic.ts
@@ -113,6 +113,10 @@ export const epicRouter = createTRPCRouter({
             select: { id: true, name: true, email: true, image: true },
           },
           product: { select: { id: true, name: true, slug: true } },
+          // The detail page canonicalises its own URL, which needs the epic's
+          // workspace slug — membership is checked against the epic's
+          // workspace, not the one in the address bar, so the two can differ.
+          workspace: { select: { id: true, slug: true } },
           actions: {
             select: {
               id: true,

--- a/src/server/api/routers/epic.ts
+++ b/src/server/api/routers/epic.ts
@@ -27,6 +27,33 @@ async function assertWorkspaceMember(
   return membership;
 }
 
+/**
+ * An epic belongs to a product, and that product must live in the epic's own
+ * workspace — otherwise the product's name and slug leak back through the
+ * `product` include on `getById`, the same sideways read the 2026-08-04 epic
+ * audit closed for the epic itself.
+ *
+ * NOT_FOUND rather than FORBIDDEN so the error does not confirm the id exists
+ * in some other workspace.
+ */
+async function assertProductInWorkspace(
+  db: PrismaClient,
+  productId: string,
+  workspaceId: string,
+) {
+  const product = await db.product.findUnique({
+    where: { id: productId },
+    select: { workspaceId: true },
+  });
+
+  if (!product || product.workspaceId !== workspaceId) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Product not found in this workspace",
+    });
+  }
+}
+
 export const epicRouter = createTRPCRouter({
   // List all epics for a workspace
   list: protectedProcedure
@@ -34,6 +61,18 @@ export const epicRouter = createTRPCRouter({
       z.object({
         workspaceId: z.string(),
         status: epicStatusSchema.optional(),
+        /**
+         * Scope to one product. Omit for the workspace-wide list (the action
+         * side, which has no product context — an Action has no product).
+         */
+        productId: z.string().optional(),
+        /**
+         * Backfill window: epics created before `Epic.productId` existed have
+         * none, and would be invisible — and therefore unassignable — from
+         * every product board. Including them is what lets a user open one and
+         * give it a product. Drops to a no-op once the backfill is done.
+         */
+        includeUnassigned: z.boolean().default(true),
       })
     )
     .query(async ({ ctx, input }) => {
@@ -43,12 +82,21 @@ export const epicRouter = createTRPCRouter({
         where: {
           workspaceId: input.workspaceId,
           ...(input.status ? { status: input.status } : {}),
+          ...(input.productId
+            ? {
+                OR: [
+                  { productId: input.productId },
+                  ...(input.includeUnassigned ? [{ productId: null }] : []),
+                ],
+              }
+            : {}),
         },
         orderBy: [{ status: "asc" }, { name: "asc" }],
         include: {
           owner: {
             select: { id: true, name: true, email: true, image: true },
           },
+          product: { select: { id: true, name: true, slug: true } },
           _count: { select: { actions: true, tickets: true } },
         },
       });
@@ -64,6 +112,7 @@ export const epicRouter = createTRPCRouter({
           owner: {
             select: { id: true, name: true, email: true, image: true },
           },
+          product: { select: { id: true, name: true, slug: true } },
           actions: {
             select: {
               id: true,
@@ -81,7 +130,25 @@ export const epicRouter = createTRPCRouter({
               },
             },
           },
-          _count: { select: { actions: true } },
+          // The detail page's main column. `product` comes back per ticket
+          // because a pre-backfill epic can still hold tickets from more than
+          // one product, and the page has to be able to say so rather than
+          // render them as if they all belonged here.
+          tickets: {
+            select: {
+              id: true,
+              number: true,
+              shortId: true,
+              title: true,
+              status: true,
+              priority: true,
+              type: true,
+              product: { select: { id: true, slug: true, name: true, funTicketIds: true } },
+              assignee: { select: { id: true, name: true, image: true } },
+            },
+            orderBy: [{ status: "asc" }, { number: "asc" }],
+          },
+          _count: { select: { actions: true, tickets: true } },
         },
       });
 
@@ -102,6 +169,7 @@ export const epicRouter = createTRPCRouter({
     .input(
       z.object({
         workspaceId: z.string(),
+        productId: z.string(),
         name: boundedText("Name", TEXT_LIMITS.LABEL, { min: 1 }),
         description: boundedText("Description", TEXT_LIMITS.LARGE).optional(),
         priority: epicPrioritySchema.default("MEDIUM"),
@@ -111,6 +179,7 @@ export const epicRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       await assertWorkspaceMember(ctx.db, ctx.session.user.id, input.workspaceId);
+      await assertProductInWorkspace(ctx.db, input.productId, input.workspaceId);
 
       return ctx.db.epic.create({
         data: {
@@ -120,6 +189,7 @@ export const epicRouter = createTRPCRouter({
           startDate: input.startDate,
           targetDate: input.targetDate,
           workspaceId: input.workspaceId,
+          productId: input.productId,
           ownerId: ctx.session.user.id,
         },
       });
@@ -136,6 +206,12 @@ export const epicRouter = createTRPCRouter({
         priority: epicPrioritySchema.optional(),
         startDate: z.date().nullable().optional(),
         targetDate: z.date().nullable().optional(),
+        /**
+         * Moving an epic between products is allowed — it is how a pre-backfill
+         * epic gets its first product. Tickets are not moved with it; ones left
+         * in another product show up as foreign on the detail page.
+         */
+        productId: z.string().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -153,6 +229,14 @@ export const epicRouter = createTRPCRouter({
       }
 
       await assertWorkspaceMember(ctx.db, ctx.session.user.id, epic.workspaceId);
+
+      if (updateData.productId) {
+        await assertProductInWorkspace(
+          ctx.db,
+          updateData.productId,
+          epic.workspaceId,
+        );
+      }
 
       return ctx.db.epic.update({
         where: { id },

--- a/src/server/api/routers/search.ts
+++ b/src/server/api/routers/search.ts
@@ -343,6 +343,7 @@ async function searchEpics({ db, userId, q, workspaceId, limit }: SearchArgs): P
       name: true,
       status: true,
       workspace: { select: { id: true, slug: true, name: true } },
+      product: { select: { slug: true } },
     },
     take: limit,
   });
@@ -352,8 +353,11 @@ async function searchEpics({ db, userId, q, workspaceId, limit }: SearchArgs): P
     title: e.name,
     subtitle: e.status,
     workspace: e.workspace,
-    // Epics have no dedicated detail route; they surface inside kanban views.
-    url: null,
+    // The detail route is product-nested. An epic still awaiting its product
+    // (pre-backfill) has nowhere to point, so it stays unlinked.
+    url: e.product
+      ? `/w/${e.workspace.slug}/products/${e.product.slug}/epics/${e.id}`
+      : null,
   }));
 }
 

--- a/src/server/services/access/__tests__/workspaceRefs.test.ts
+++ b/src/server/services/access/__tests__/workspaceRefs.test.ts
@@ -173,4 +173,77 @@ describe("assertWorkspaceScopedRefs", () => {
       }),
     ).rejects.toMatchObject({ message: "Cycle not found in this workspace" });
   });
+
+  // Epics are per-product. Same workspace is no longer sufficient for a
+  // ticket → epic link; the epic has to belong to the ticket's own product.
+  describe("product containment for epics", () => {
+    const PRODUCT_ID = "prod-1";
+    const OTHER_PRODUCT_ID = "prod-2";
+
+    it("admits an epic in the pointing ticket's own product", async () => {
+      db.epic.findUnique.mockResolvedValue({
+        workspaceId: WORKSPACE_ID,
+        productId: PRODUCT_ID,
+      } as never);
+
+      await expect(
+        assertWorkspaceScopedRefs(
+          db,
+          USER_ID,
+          WORKSPACE_ID,
+          { epicId: "epic-1" },
+          PRODUCT_ID,
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects another product's epic even inside one workspace", async () => {
+      db.epic.findUnique.mockResolvedValue({
+        workspaceId: WORKSPACE_ID,
+        productId: OTHER_PRODUCT_ID,
+      } as never);
+
+      await expect(
+        assertWorkspaceScopedRefs(
+          db,
+          USER_ID,
+          WORKSPACE_ID,
+          { epicId: "epic-1" },
+          PRODUCT_ID,
+        ),
+      ).rejects.toMatchObject({ message: "Epic not found in this product" });
+    });
+
+    it("still admits a product-less epic during the backfill window", async () => {
+      db.epic.findUnique.mockResolvedValue({
+        workspaceId: WORKSPACE_ID,
+        productId: null,
+      } as never);
+
+      await expect(
+        assertWorkspaceScopedRefs(
+          db,
+          USER_ID,
+          WORKSPACE_ID,
+          { epicId: "epic-1" },
+          PRODUCT_ID,
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it("ignores product containment when the caller has no product (actions)", async () => {
+      db.epic.findUnique.mockResolvedValue({
+        workspaceId: WORKSPACE_ID,
+        productId: OTHER_PRODUCT_ID,
+      } as never);
+
+      // An Action has no product of its own, so workspace containment is the
+      // only rule that can apply to it.
+      await expect(
+        assertWorkspaceScopedRefs(db, USER_ID, WORKSPACE_ID, {
+          epicId: "epic-1",
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
 });

--- a/src/server/services/access/workspaceRefs.ts
+++ b/src/server/services/access/workspaceRefs.ts
@@ -52,6 +52,17 @@ export async function assertWorkspaceScopedRefs(
   userId: string,
   workspaceId: string | null,
   refs: WorkspaceScopedRefs,
+  /**
+   * The pointing row's product, when it has one (tickets always do; actions
+   * never do). Supplying it additionally requires that an epic belong to that
+   * same product — epics are per-product, so a ticket may not borrow another
+   * product's epic even inside one workspace.
+   *
+   * An epic with no product yet (pre-backfill) is exempt: it is still
+   * workspace-scoped in practice, and rejecting it would break every existing
+   * ticket→epic link the moment this ships.
+   */
+  productId?: string,
 ): Promise<void> {
   const lookups: Array<Promise<{ label: string; refWorkspaceId: string | null }>> =
     [];
@@ -61,12 +72,25 @@ export async function assertWorkspaceScopedRefs(
       db.epic
         .findUnique({
           where: { id: refs.epicId },
-          select: { workspaceId: true },
+          select: { workspaceId: true, productId: true },
         })
-        .then((row) => ({
-          label: "Epic",
-          refWorkspaceId: row?.workspaceId ?? null,
-        })),
+        .then((row) => {
+          if (
+            row &&
+            productId &&
+            row.productId &&
+            row.productId !== productId
+          ) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Epic not found in this product",
+            });
+          }
+          return {
+            label: "Epic",
+            refWorkspaceId: row?.workspaceId ?? null,
+          };
+        }),
     );
   }
 


### PR DESCRIPTION
### **User description**
## What

- `Epic.productId` (nullable for the backfill window) + `Product.epics`, indexed, `onDelete: Cascade` to match `Feature`.
- `epic.list` takes `productId` (+ `includeUnassigned`); `epic.create` requires one; `epic.update` can move an epic between products. Both validate the product lives in the epic's workspace.
- `epic.getById` returns `product`, `tickets` (each with its own product) and counts for both children — it previously returned actions only, which is why no detail page was possible.
- Product-containment guard: a ticket may not link another product's epic. Applied on ticket create, update, and the bulk path (reworked to loop per product, so a mixed selection is rejected outright rather than half-applied). Actions are exempt — an `Action` has no product.
- New route `/w/:ws/products/:slug/epics/:id`, modelled on the feature detail page: ticket list with a done/total meter, actions, description, and an inline-editable properties sidebar. Carries the **delete** affordance the router always had and the UI never exposed. `/epics` redirects to the board rather than 404ing.
- Search and the command palette can link epics; both were previously disabled *because* no detail route existed.
- Tickets page: dropped its private duplicate `CreateEpicModal` for the shared one, which gains a product picker for surfaces with no product of their own (the action modals).
- Backlog tab stays lit on `/epics/:id`, which otherwise fell through to the "overview" default.

## Why

Clicking any row in a product's Epics list navigated into the *ticket* route with an epic id and rendered "Ticket not found" — epics had no detail page at all. Epics were also workspace-scoped while only ever surfaced inside one product, so every product's Epics tab listed every epic in the workspace with cross-product ticket counts.

## Migration + backfill

`prisma/migrations/20260810120000_epic_product_scope` adds the column as nullable, and a null-product epic stays linkable from any product in its workspace, so no existing ticket loses its epic on deploy. `scripts/backfill-epic-product.ts` assigns each existing epic by majority vote of its tickets and reports what it can't decide (dry run by default, `--apply` to write). One production epic is genuinely cross-product — "Closed-loop Ticket lifecycle", 6 tickets in `agent-skills` and 2 in `exponential` — and needs a human call. Tighten the column to `NOT NULL` in a follow-up once every row is assigned.

## Follow-ups not in this PR

- `exponential epics create` will fail until the CLI and SDK send `productId` (separate repos).
- Epic status still doesn't roll up from tickets; the product settings "Epics → Lifecycle stages" row remains display-only.

## Testing

- 2393 unit tests pass; typecheck and lint clean.
- New coverage: product scoping and `includeUnassigned` on `epic.list`, cross-workspace product rejection on `create`/`update`, and four cases on the containment guard (own product admitted, foreign product rejected, null-product epic admitted during the backfill window, actions exempt).
- Verified in the browser against a seeded fixture workspace: created an epic and linked three tickets through the real tRPC API, then walked list → row click → detail page.


___

### **PR Type**
Enhancement, Tests, Bug fix


___

### **Description**
- Add `Epic.productId` (nullable) with migration and backfill script

- Scope epic list/create/update and pickers to a product

- New product-nested epic detail page with delete, canonical URL redirect

- Enforce product containment on ticket→epic links, plus tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  schema["Epic.productId + Product.epics"] -- "migration" --> backfill["backfill-epic-product.ts"]
  schema -- "router" --> epicRouter["epic.list/create/update/getById"]
  epicRouter -- "product-scoped pickers" --> ui["tickets page, peek, CreateEpicModal"]
  epicRouter -- "new route" --> detail["/products/:slug/epics/:id"]
  schema -- "guard" --> refs["assertWorkspaceScopedRefs(productId)"]
  refs --> ticketRouter["ticket create/update/bulk"]
  detail --> search["search + command palette links"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>schema.prisma</strong><dd><code>Add nullable `Epic.productId` relation and index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backfill-epic-product.ts</strong><dd><code>Dry-run/apply backfill assigning epics by ticket majority</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-df8c45249153fae8556579c61e2c0bb51eca05458f206385a1b8b710a55f60bf">+146/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>epic.ts</strong><dd><code>Product scoping for list/create/update, richer getById</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-737ea566df8468c7d11217c4cc278a1c8954e62773ed3f28048bcfdd22492fd5">+89/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>workspaceRefs.ts</strong><dd><code>Optional product containment check for epic refs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-1dde13ac84147ebc7b832c39ae20aa7b9970df02b0eeda8c926c1f28248c7ba1">+29/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ticket.ts</strong><dd><code>Pass productId to link guard; rework bulk per-product</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-2c667429b802690451b0f2771795cba4b39b00fb9a8b2cca853b1f95497032c5">+41/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>New epic detail page with tickets, sidebar, delete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-62f03f52dd99d89f23405a974b2b90dc6178812d615a58800f259e8fd02a4e79">+544/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Redirect bare `/epics` to the tickets board</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-994c3d7b9d8825b6bb7283c9b260c97069a3eb6fa4f9586a95af63d21d4e0929">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Use shared CreateEpicModal and product-scoped epic list</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-69941eb4af92853c12847ec637d5a3d8e18c01c445e6f9cea9242888c995d2d5">+8/-59</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Scope epic query and inline creation to ticket's product</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-706c264109ddf1898c5e70d30b0818c48fce7c90f203b6163df7a766806d5642">+12/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CreateEpicModal.tsx</strong><dd><code>Add optional product picker and required productId</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-ffc48c335fe34e0f7c564138bb65ab15a5210df70ecae6813baf9e90ab7b2941">+34/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EpicsList.tsx</strong><dd><code>Show "Unassigned" badge for product-less epics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-0c50622a1fd6edd9724c5166c72fd7425d2e9c7e909dd9e093447d54d5860af8">+23/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TicketPeek.tsx</strong><dd><code>Scope epic options to the ticket's product</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-71ee94155c37aef723aeccfef4d289d7b91bccb9611c36c0087d459e378947d0">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CommandPalette.tsx</strong><dd><code>Surface epics as linkable search results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-0013838800caad36867dc467a14704c56996820c63a945eca5fdc33a7d4dfb45">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>search.ts</strong><dd><code>Build product-nested epic URLs in global search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-8e2eb893e53f741f2d3019aa28559a3d29775df802c1921a49c131a2ac642dc8">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>migration.sql</strong><dd><code>Migration adding productId column, index, cascade FK</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-3dc1b52885fa54da4395b4d119faf02880b5a89943a5025969e415fb312a41c8">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>layout.tsx</strong><dd><code>Keep Backlog tab active on epic routes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-e4b549b8684af1c44327f01d54fdb07cb6227e22f9b734f7cf17e8f3526dbd8f">+12/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>epic.test.ts</strong><dd><code>Tests for product scoping in list/create/update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-c5cde11d8e655b5486e4a715f6e4d88ebc8117e7ca41855ccf21bc1850c99768">+103/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workspaceRefs.test.ts</strong><dd><code>Tests for epic product containment rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-55d126822bfc9904bc7c15dd55b8e04cbcca32320b6d694553eeb652031f0a82">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ticket.test.ts</strong><dd><code>Assert epic lookup now selects productId</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/541/files#diff-66527097b6bcfccf7a0834b7eb1748adc3c1d1c4757849b6b03fcd4a6da75849">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

