### PR TITLE
fix(auth): give the iOS/Mac app its own native-auth redirect scheme

### DIFF
--- a/src/app/api/auth/native/start/route.ts
+++ b/src/app/api/auth/native/start/route.ts
@@ -22,8 +22,9 @@ import {
  *     signed, httpOnly cookie set before we bounced the user to `/signin`.
  *
  * If authenticated → mint a 60s auth code bound to the userId + PKCE challenge
- * and 302 back to the caller's own allow-listed scheme (`exponential://` for iOS
- * and the Electron shell, `exponential-beta://` for the Tauri shell). If not → stash the
+ * and 302 back to the caller's own allow-listed scheme (`exponential-voice://` for
+ * the iOS/Mac app, `exponential-beta://` for the Tauri shell, `exponential://` for
+ * the Electron shell and older iOS/Mac builds). If not → stash the
  * request in a signed cookie and redirect to `/signin`, which returns here.
  *
  * This handler is its own post-login callback — there is intentionally no

--- a/src/server/utils/__tests__/native-auth.test.ts
+++ b/src/server/utils/__tests__/native-auth.test.ts
@@ -6,6 +6,7 @@ import {
   ALLOWED_REDIRECT_URIS,
   NATIVE_REDIRECT_URI,
   TAURI_REDIRECT_URI,
+  VOICE_REDIRECT_URI,
   isAllowedRedirectUri,
   isValidCodeChallenge,
   isValidState,
@@ -36,31 +37,38 @@ describe("input validation", () => {
     expect(isValidCodeChallenge(null)).toBe(false);
   });
 
-  it("allow-lists both shell schemes and nothing else", () => {
+  it("allow-lists all three shell schemes and nothing else", () => {
     expect(isAllowedRedirectUri(NATIVE_REDIRECT_URI)).toBe(true);
     expect(isAllowedRedirectUri(TAURI_REDIRECT_URI)).toBe(true);
+    expect(isAllowedRedirectUri(VOICE_REDIRECT_URI)).toBe(true);
     expect(isAllowedRedirectUri("https://evil.example/callback")).toBe(false);
     expect(isAllowedRedirectUri("exponential://auth/other")).toBe(false);
     expect(isAllowedRedirectUri("exponential-beta://auth/other")).toBe(false);
-    // Near-misses on the new scheme: no prefix/suffix slack in the match.
+    expect(isAllowedRedirectUri("exponential-voice://auth/other")).toBe(false);
+    // Near-misses on the new schemes: no prefix/suffix slack in the match.
     expect(isAllowedRedirectUri("exponential-beta://auth/callback/")).toBe(false);
     expect(isAllowedRedirectUri("exponential-beta-evil://auth/callback")).toBe(false);
+    expect(isAllowedRedirectUri("exponential-voice://auth/callback/")).toBe(false);
+    expect(isAllowedRedirectUri("exponential-voice-evil://auth/callback")).toBe(false);
     expect(isAllowedRedirectUri(null)).toBe(false);
     expect(isAllowedRedirectUri(undefined)).toBe(false);
   });
 
-  it("pins the two schemes so a rename can't silently break a shipped shell", () => {
-    // iOS/Electron read these from the ADR-0005 contract; the values are frozen.
+  it("pins the three schemes so a rename can't silently break a shipped shell", () => {
+    // iOS/Mac/Electron read these from the ADR-0005 contract; the values are frozen.
     expect(NATIVE_REDIRECT_URI).toBe("exponential://auth/callback");
     expect(TAURI_REDIRECT_URI).toBe("exponential-beta://auth/callback");
-    expect(ALLOWED_REDIRECT_URIS).toEqual([NATIVE_REDIRECT_URI, TAURI_REDIRECT_URI]);
+    expect(VOICE_REDIRECT_URI).toBe("exponential-voice://auth/callback");
+    expect(ALLOWED_REDIRECT_URIS).toEqual([
+      NATIVE_REDIRECT_URI,
+      TAURI_REDIRECT_URI,
+      VOICE_REDIRECT_URI,
+    ]);
   });
 
-  it("keeps the two schemes distinct so macOS can route each shell's callback", () => {
-    expect(NATIVE_REDIRECT_URI).not.toBe(TAURI_REDIRECT_URI);
-    expect(new URL(NATIVE_REDIRECT_URI).protocol).not.toBe(
-      new URL(TAURI_REDIRECT_URI).protocol,
-    );
+  it("keeps every scheme distinct so macOS can route each shell's callback", () => {
+    const protocols = ALLOWED_REDIRECT_URIS.map((uri) => new URL(uri).protocol);
+    expect(new Set(protocols).size).toBe(ALLOWED_REDIRECT_URIS.length);
   });
 
   it("bounds state", () => {

--- a/src/server/utils/native-auth.ts
+++ b/src/server/utils/native-auth.ts
@@ -24,8 +24,10 @@ import jwt from "jsonwebtoken";
  */
 
 /**
- * The iOS app's and Electron shell's scheme (the locked CFBundleURLTypes value).
- * Recorded in the ADR-0005 contract in `exponential-ios` — never change it.
+ * The Electron shell's scheme, and the one older installed builds of the iOS/Mac
+ * app still send. Recorded in the ADR-0005 contract in `exponential-ios` — never
+ * change it. Current iOS/Mac builds use `VOICE_REDIRECT_URI` below; this value
+ * stays allow-listed so those older builds keep signing in.
  */
 export const NATIVE_REDIRECT_URI = "exponential://auth/callback";
 
@@ -38,6 +40,18 @@ export const NATIVE_REDIRECT_URI = "exponential://auth/callback";
 export const TAURI_REDIRECT_URI = "exponential-beta://auth/callback";
 
 /**
+ * The native iOS/Mac app's own scheme (`im.exponential.voice`). Split off
+ * `exponential://` for exactly the reason the Tauri shell was: macOS resolves a
+ * scheme to a single handler app, and with the Electron shell installed the OS
+ * was handing `exponential://auth/callback` to *it* rather than to
+ * ExponentialVoice — so native sign-in failed on any Mac that had both.
+ *
+ * `NATIVE_REDIRECT_URI` stays in the allow-list: the Electron shell still uses
+ * it, and older installed builds of the iOS/Mac app do too.
+ */
+export const VOICE_REDIRECT_URI = "exponential-voice://auth/callback";
+
+/**
  * Every redirect target we will ever emit. Deliberately a closed set of exact
  * strings: `mintAuthCode` binds the chosen URI into the signed code and the
  * redeem path re-validates it, so this predicate is the only thing standing
@@ -46,6 +60,7 @@ export const TAURI_REDIRECT_URI = "exponential-beta://auth/callback";
 export const ALLOWED_REDIRECT_URIS: readonly string[] = [
   NATIVE_REDIRECT_URI,
   TAURI_REDIRECT_URI,
+  VOICE_REDIRECT_URI,
 ];
 
 /** Signed, httpOnly cookie carrying the PKCE request across the NextAuth login bounce. */


### PR DESCRIPTION
### **User description**
## Why

macOS resolves a custom URL scheme to a **single handler app**. Both the Electron shell and the ExponentialVoice app claimed `exponential://`, so on a Mac with both installed the OS handed `exponential://auth/callback` to whichever it picked. Observed on a dogfooding machine:

```
NSWorkspace.urlForApplication(toOpen: "exponential://auth/callback")
  -> /Applications/Exponential.app
```

Native sign-in from the Mac app was therefore broken — the callback never reached it.

ADR 0005's `2026-08-03` amendment already ran into this hazard and solved it for the Tauri shell by giving it `exponential-beta://`, while stating "iOS/Mac are unaffected — same `exponential://` value." That was wrong, for exactly the reason the amendment itself gives. This gives the iOS/Mac app (`im.exponential.voice`) its own scheme too.

## What

`ALLOWED_REDIRECT_URIS` gains a third entry:

| `redirect_uri` | Client |
| --- | --- |
| `exponential-voice://auth/callback` | iOS and Mac (`im.exponential.voice`) — **new** |
| `exponential-beta://auth/callback` | Tauri desktop shell |
| `exponential://auth/callback` | Electron shell, and older installed iOS/Mac builds |

`exponential://` is **kept**, not reassigned — the Electron shell still uses it, and an already-installed older iOS/Mac build must keep signing in until it updates.

No behaviour changes beyond widening the allow-list. `mintAuthCode` already binds `redirect_uri` into the signed code and the redeem path already re-validates it, and `/start` already echoes the request's own validated value into the 302.

## ⚠️ Deploy ordering

**This must deploy before the matching client build ships.** The allow-list is a closed exact-match set, so a client sending the new value against an un-deployed server fails closed:

```
GET /api/auth/native/start?...&redirect_uri=exponential-voice://auth/callback
-> 400 "Bad request."
```

## Testing

`native-auth.test.ts` — 22 passing. The two pinning tests now cover all three schemes, and the distinctness test derives from `ALLOWED_REDIRECT_URIS` rather than hardcoding a pair, so a fourth scheme is checked automatically. The `it.each(ALLOWED_REDIRECT_URIS)` code-binding and redeem-validation cases pick up the new scheme for free.

Client side (`AuthCoordinator`, `CFBundleURLTypes`) and the ADR amendment land in `exponential-ios`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `exponential-voice://auth/callback` redirect URI

- Keep `exponential://` allow-listed for Electron/older builds

- Update `/start` route doc for scheme routing

- Extend tests to cover all three schemes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  voice["iOS/Mac app"] -- "exponential-voice://auth/callback (new)" --> allow["ALLOWED_REDIRECT_URIS"]
  tauri["Tauri shell"] -- "exponential-beta://auth/callback" --> allow
  electron["Electron shell + older iOS/Mac builds"] -- "exponential://auth/callback" --> allow
  allow -- "302 back to caller's scheme" --> start["/api/auth/native/start"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>native-auth.ts</strong><dd><code>Add dedicated iOS/Mac redirect URI to allow-list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/utils/native-auth.ts

<ul><li>Adds new exported <code>VOICE_REDIRECT_URI</code> constant <br>(<code>exponential-voice://auth/callback</code>) for the <code>im.exponential.voice</code> app.<br> <li> Appends it to the closed <code>ALLOWED_REDIRECT_URIS</code> allow-list.<br> <li> Rewrites <code>NATIVE_REDIRECT_URI</code> doc comment to state it now serves the <br>Electron shell and older iOS/Mac builds.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/542/files#diff-7707e3da0584c892deb468ef14a9f20021e1ce16295fe70c83b70d84ad60b3bf">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>native-auth.test.ts</strong><dd><code>Cover third redirect scheme in allow-list tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/utils/__tests__/native-auth.test.ts

<ul><li>Imports <code>VOICE_REDIRECT_URI</code> and asserts it is allow-listed.<br> <li> Adds near-miss negative cases (<code>exponential-voice://auth/other</code>, <br>trailing slash, <code>exponential-voice-evil://</code>).<br> <li> Pins the three frozen scheme values and the exact <br><code>ALLOWED_REDIRECT_URIS</code> array order.<br> <li> Generalizes the distinctness test to assert all allow-listed protocols <br>are unique.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/542/files#diff-437ac27a14fc4b0b2f6e757f338560bf00690a949033cc1986315f007226c680">+18/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Update route docs for new redirect scheme mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/auth/native/start/route.ts

<ul><li>Updates the handler's doc comment to describe which scheme belongs to <br>which client (voice, beta, legacy).<br> <li> No behavioral code change.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/542/files#diff-59d4e7042f0c389f21f504bc7ac48a11cf5edf50592ca1949deadcac290fb692">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

