### PR TITLE
chore(matrix): guard the shared Matrix integration lookups against workspace-scoped rows

### DIFF
--- a/src/app/api/matrix-gateway/__tests__/mappings.test.ts
+++ b/src/app/api/matrix-gateway/__tests__/mappings.test.ts
@@ -8,6 +8,10 @@ vi.mock("~/server/db", () => ({ db: mockDeep<PrismaClient>() }));
 import { db } from "~/server/db";
 import { POST, GET, DELETE } from "../mappings/route";
 import { POST as refreshToken } from "../refresh-token/route";
+import {
+  fakeIntegrationFindFirst,
+  SYSTEM_MATRIX_INTEGRATION,
+} from "~/test/matrixIntegrationFixtures";
 
 const dbMock = db as unknown as DeepMockProxy<PrismaClient>;
 
@@ -147,6 +151,29 @@ describe("GET /api/matrix-gateway/mappings", () => {
     const res = await GET(makeRequest("GET", { secret: SECRET }));
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ mappings: [] });
+  });
+
+  it("reads the system row's mappings, not a workspace Matrix server's", async () => {
+    // A workspace-registered homeserver is an Integration with userId: null too,
+    // so a lookup that forgets workspaceId: null can return it and hand the
+    // gateway an empty (or foreign) mapping set.
+    dbMock.integration.findFirst.mockImplementation(
+      fakeIntegrationFindFirst() as never,
+    );
+    dbMock.integrationUserMapping.findMany.mockResolvedValue([
+      { externalUserId: "@james:syntro.fi", userId: "u1" },
+    ] as never);
+
+    const res = await GET(makeRequest("GET", { secret: SECRET }));
+
+    expect(await res.json()).toEqual({
+      mappings: [{ mxid: "@james:syntro.fi", userId: "u1" }],
+    });
+    expect(dbMock.integrationUserMapping.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { integrationId: SYSTEM_MATRIX_INTEGRATION.id },
+      }),
+    );
   });
 
   it("returns persisted mappings as { mxid, userId }", async () => {

--- a/src/app/api/matrix-gateway/mappings/route.ts
+++ b/src/app/api/matrix-gateway/mappings/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { db } from "~/server/db";
+import { SHARED_MATRIX_INTEGRATION_WHERE } from "~/server/utils/matrixGatewayIntegration";
 
 /**
  * /api/matrix-gateway/mappings
@@ -44,7 +45,7 @@ function checkGatewaySecret(request: NextRequest): NextResponse | null {
 
 async function getOrCreateMatrixIntegration() {
   const existing = await db.integration.findFirst({
-    where: { provider: "matrix", status: "ACTIVE", userId: null },
+    where: SHARED_MATRIX_INTEGRATION_WHERE,
   });
   if (existing) return existing;
   return db.integration.create({
@@ -53,6 +54,10 @@ async function getOrCreateMatrixIntegration() {
       type: "MESSAGING",
       provider: "matrix",
       status: "ACTIVE",
+      // Explicitly system-scoped: SHARED_MATRIX_INTEGRATION_WHERE only finds
+      // this row again while both userId and workspaceId stay null.
+      userId: null,
+      workspaceId: null,
       description:
         "System integration anchoring Matrix Gateway pairing mappings (ADR-0043)",
     },
@@ -124,7 +129,7 @@ export async function GET(request: NextRequest) {
     if (denied) return denied;
 
     const integration = await db.integration.findFirst({
-      where: { provider: "matrix", status: "ACTIVE", userId: null },
+      where: SHARED_MATRIX_INTEGRATION_WHERE,
     });
     if (!integration) {
       // Nothing has paired yet — the Integration row is created on first POST.
@@ -164,7 +169,7 @@ export async function DELETE(request: NextRequest) {
     }
 
     const integration = await db.integration.findFirst({
-      where: { provider: "matrix", status: "ACTIVE", userId: null },
+      where: SHARED_MATRIX_INTEGRATION_WHERE,
     });
     if (!integration) {
       return NextResponse.json({ deleted: 0 });

--- a/src/server/api/routers/__tests__/matrixGateway.test.ts
+++ b/src/server/api/routers/__tests__/matrixGateway.test.ts
@@ -69,6 +69,7 @@ vi.mock("~/server/db", () => {
 });
 
 import { createMockCaller } from "~/test/trpc-helpers";
+import { SHARED_MATRIX_INTEGRATION_WHERE } from "~/server/utils/matrixGatewayIntegration";
 
 const USER_ID = "user-1";
 const MXID = "@james:syntro.fi";
@@ -119,6 +120,29 @@ describe("matrixGateway router (mocked)", () => {
       await expect(caller.matrixGateway.getStatus()).resolves.toEqual({
         paired: true,
         mxid: MXID,
+      });
+    });
+
+    it("scopes the fallback lookup to the system row, not a workspace's Matrix server", async () => {
+      // A workspace-registered homeserver is also an Integration with userId: null,
+      // so the predicate must pin workspaceId: null or the mapping can be read
+      // against the wrong integration entirely.
+      fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+      dbMock.integrationUserMapping.findFirst.mockResolvedValue(null as never);
+
+      const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+      await caller.matrixGateway.getStatus();
+
+      expect(dbMock.integrationUserMapping.findFirst).toHaveBeenCalledWith({
+        where: {
+          userId: USER_ID,
+          integration: SHARED_MATRIX_INTEGRATION_WHERE,
+        },
+      });
+      expect(SHARED_MATRIX_INTEGRATION_WHERE).toMatchObject({
+        provider: "matrix",
+        userId: null,
+        workspaceId: null,
       });
     });
 
@@ -200,7 +224,7 @@ describe("matrixGateway router (mocked)", () => {
       expect(dbMock.integrationUserMapping.deleteMany).toHaveBeenCalledWith({
         where: {
           userId: USER_ID,
-          integration: { provider: "matrix", status: "ACTIVE", userId: null },
+          integration: SHARED_MATRIX_INTEGRATION_WHERE,
         },
       });
     });

--- a/src/server/api/routers/__tests__/notificationMatrixOptIn.test.ts
+++ b/src/server/api/routers/__tests__/notificationMatrixOptIn.test.ts
@@ -66,6 +66,10 @@ vi.mock("~/server/db", () => {
 });
 
 import { createMockCaller } from "~/test/trpc-helpers";
+import {
+  fakeIntegrationFindFirst,
+  SYSTEM_MATRIX_INTEGRATION,
+} from "~/test/matrixIntegrationFixtures";
 
 const USER_ID = "user-1";
 const MATRIX_INT = { id: "int-matrix", provider: "matrix", status: "ACTIVE" };
@@ -94,6 +98,26 @@ describe("notification.getMatrixOptIn", () => {
     await expect(caller.notification.getMatrixOptIn()).resolves.toEqual({
       available: false,
       integrationId: null,
+    });
+  });
+
+  it("resolves the system row, not a workspace-registered Matrix server", async () => {
+    // Both a workspace homeserver and the shared gateway row exist, and the
+    // workspace ones are userId: null too. Only the workspaceId: null constraint
+    // keeps them apart.
+    dbMock.integration.findFirst.mockImplementation(
+      fakeIntegrationFindFirst() as never,
+    );
+    dbMock.integrationUserMapping.findFirst.mockResolvedValue({
+      userId: USER_ID,
+      integrationId: SYSTEM_MATRIX_INTEGRATION.id,
+      externalUserId: "@james:syntro.fi",
+    } as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(caller.notification.getMatrixOptIn()).resolves.toEqual({
+      available: true,
+      integrationId: SYSTEM_MATRIX_INTEGRATION.id,
     });
   });
 

--- a/src/server/api/routers/matrixGateway.ts
+++ b/src/server/api/routers/matrixGateway.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { createTRPCRouter, humanOnlyProcedure } from "~/server/api/trpc";
 import { generateJWT } from "~/server/utils/jwt";
+import { SHARED_MATRIX_INTEGRATION_WHERE } from "~/server/utils/matrixGatewayIntegration";
 
 const MATRIX_GATEWAY_URL =
   process.env.MATRIX_GATEWAY_URL ?? "http://localhost:4114";
@@ -41,7 +42,7 @@ export const matrixGatewayRouter = createTRPCRouter({
     const mapping = await ctx.db.integrationUserMapping.findFirst({
       where: {
         userId: ctx.session.user.id,
-        integration: { provider: "matrix", status: "ACTIVE", userId: null },
+        integration: SHARED_MATRIX_INTEGRATION_WHERE,
       },
     });
 
@@ -147,7 +148,7 @@ export const matrixGatewayRouter = createTRPCRouter({
     await ctx.db.integrationUserMapping.deleteMany({
       where: {
         userId: ctx.session.user.id,
-        integration: { provider: "matrix", status: "ACTIVE", userId: null },
+        integration: SHARED_MATRIX_INTEGRATION_WHERE,
       },
     });
 

--- a/src/server/api/routers/notification.ts
+++ b/src/server/api/routers/notification.ts
@@ -8,6 +8,7 @@ import {
   CHANNEL_LIST,
   DEFAULT_MATRIX,
 } from "~/server/services/notifications/emit/constants";
+import { SHARED_MATRIX_INTEGRATION_WHERE } from "~/server/utils/matrixGatewayIntegration";
 
 /**
  * Which opt-in channels the user has actually connected — Push/Email are
@@ -16,7 +17,7 @@ import {
  */
 async function resolveChannelAvailability(db: PrismaClient, userId: string) {
   const matrixIntegration = await db.integration.findFirst({
-    where: { provider: "matrix", status: "ACTIVE", userId: null },
+    where: SHARED_MATRIX_INTEGRATION_WHERE,
     select: { id: true },
   });
   const [matrixMapping, zulipMapping, whatsappMapping] = await Promise.all([
@@ -82,7 +83,7 @@ export const notificationRouter = createTRPCRouter({
   // by itself; the user must choose Matrix here. (V2, ADR-0043)
   getMatrixOptIn: protectedProcedure.query(async ({ ctx }) => {
     const integration = await ctx.db.integration.findFirst({
-      where: { provider: "matrix", status: "ACTIVE", userId: null },
+      where: SHARED_MATRIX_INTEGRATION_WHERE,
     });
     if (!integration) return { available: false, integrationId: null };
 
@@ -99,7 +100,7 @@ export const notificationRouter = createTRPCRouter({
   // scheduler), so opt-in can be verified on the spot. Requires a Matrix mapping.
   sendMatrixTest: protectedProcedure.mutation(async ({ ctx }) => {
     const integration = await ctx.db.integration.findFirst({
-      where: { provider: "matrix", status: "ACTIVE", userId: null },
+      where: SHARED_MATRIX_INTEGRATION_WHERE,
     });
     const mapping = integration
       ? await ctx.db.integrationUserMapping.findFirst({

--- a/src/server/utils/matrixGatewayIntegration.ts
+++ b/src/server/utils/matrixGatewayIntegration.ts
@@ -1,0 +1,20 @@
+/**
+ * The shared Matrix gateway Integration (ADR-0043).
+ *
+ * It is a single *system* row: no user, no team, no workspace. Workspace-registered
+ * Matrix servers are Integration rows too, and they also have `userId: null` — so a
+ * lookup that constrains only on `userId` can return a workspace's homeserver instead
+ * of the system row, silently rehoming every paired user's DM mapping and breaking
+ * Matrix notifications for everyone.
+ *
+ * Every lookup of the shared gateway integration goes through this predicate, so the
+ * `workspaceId: null` half of the constraint cannot be forgotten at a new call site.
+ * It is the load-bearing half: it holds even if a workspace-scoped row is ever created
+ * with the `matrix` provider rather than `matrix-server`.
+ */
+export const SHARED_MATRIX_INTEGRATION_WHERE = {
+  provider: "matrix",
+  status: "ACTIVE",
+  userId: null,
+  workspaceId: null,
+} as const;

--- a/src/test/matrixIntegrationFixtures.ts
+++ b/src/test/matrixIntegrationFixtures.ts
@@ -1,0 +1,69 @@
+/**
+ * Fixtures for the "a workspace-scoped Matrix row must not shadow the shared
+ * gateway Integration" regression.
+ *
+ * The shared Matrix gateway (ADR-0043) is one system Integration row. Workspace-
+ * registered Matrix homeservers are Integration rows too and they are *also*
+ * `userId: null`, so any lookup that constrains only on `userId` can return a
+ * workspace's server instead of the system row — silently rehoming every paired
+ * user's DM mapping.
+ *
+ * `fakeIntegrationFindFirst` returns the first row matching every scalar key of the
+ * `where` clause, over a table whose workspace-scoped rows come *first*. A lookup
+ * that drops `workspaceId: null` therefore resolves the wrong row and the test fails.
+ */
+
+export const SYSTEM_MATRIX_INTEGRATION = {
+  id: "int-matrix",
+  name: "Matrix Gateway",
+  provider: "matrix",
+  status: "ACTIVE",
+  userId: null,
+  teamId: null,
+  workspaceId: null,
+};
+
+/** A workspace-registered homeserver, in its intended shape. */
+export const WORKSPACE_MATRIX_SERVER = {
+  id: "int-matrix-server-ws",
+  name: "CLEAR homeserver",
+  provider: "matrix-server",
+  status: "ACTIVE",
+  userId: null,
+  teamId: null,
+  workspaceId: "ws-1",
+};
+
+/**
+ * The pessimistic case: a workspace-scoped row that reuses the `matrix` provider.
+ * Only the `workspaceId: null` constraint keeps this one out of the results, which
+ * is why that constraint — not the distinct provider string — is the load-bearing half.
+ */
+export const WORKSPACE_MATRIX_SERVER_LEGACY_PROVIDER = {
+  id: "int-matrix-legacy-ws",
+  name: "Legacy workspace homeserver",
+  provider: "matrix",
+  status: "ACTIVE",
+  userId: null,
+  teamId: null,
+  workspaceId: "ws-2",
+};
+
+/** Workspace rows first, so an unconstrained lookup picks the wrong one. */
+export const MATRIX_INTEGRATION_TABLE = [
+  WORKSPACE_MATRIX_SERVER,
+  WORKSPACE_MATRIX_SERVER_LEGACY_PROVIDER,
+  SYSTEM_MATRIX_INTEGRATION,
+];
+
+type Row = Record<string, unknown>;
+
+export function fakeIntegrationFindFirst(rows: Row[] = MATRIX_INTEGRATION_TABLE) {
+  return (args?: { where?: Row }) => {
+    const where = args?.where ?? {};
+    const match = rows.find((row) =>
+      Object.entries(where).every(([key, value]) => row[key] === value),
+    );
+    return Promise.resolve(match ?? null);
+  };
+}


### PR DESCRIPTION
### **User description**
## What

Preventive hardening, landed before any workspace-scoped Matrix server row can exist.

Call sites resolving *the* shared Matrix gateway Integration used `findFirst({ where: { provider: "matrix", status: "ACTIVE", userId: null } })`. A per-workspace Matrix server Integration also has `userId: null`, so once the parent feature registers one, `findFirst` can return a workspace's server instead of the system row — silently rehoming every paired user's DM mapping and breaking Matrix notifications for everyone.

All of them now go through a single `SHARED_MATRIX_INTEGRATION_WHERE` predicate (`src/server/utils/matrixGatewayIntegration.ts`) that also pins `workspaceId: null`. A shared constant rather than N inline copies, so a future call site can't reintroduce the gap.

**The ticket named six sites; grepping found eight** — `src/app/api/matrix-gateway/mappings/route.ts` has three lookups, not one (get-or-create, GET, DELETE), plus three in `notification.ts` and two in `matrixGateway.ts`. The get-or-create's `create` now also sets `userId`/`workspaceId` explicitly, so the row it writes is findable by the same predicate.

The later tickets in this feature use a distinct provider string (`matrix-server`), but this constraint is the load-bearing half: it holds even if someone later reuses the `matrix` provider.

## Tests

Three regression tests resolve the lookup against a fake integration table (`src/test/matrixIntegrationFixtures.ts`) whose workspace-scoped rows come **first** — including one that deliberately reuses the `matrix` provider, so the test proves the `workspaceId` constraint specifically rather than the provider string.

Verified by mutation: dropping `workspaceId: null` from the predicate fails all three. Full unit suite green (2398 tests).

## Acceptance criteria

- [x] Requirement: "Every lookup of the shared Matrix gateway integration shall additionally constrain on workspaceId being null."
- [x] A grep for `provider: "matrix"` shows no remaining unconstrained `findFirst`
- [x] `matrixGateway.test.ts` and `notificationMatrixOptIn.test.ts` fixtures include a workspace-scoped sibling row, and pairing still resolves the system row
- [x] `npm run check` passes (typecheck clean; lint run with the documented worktree bypass — 0 errors)

---

Ships: sharp.pelican


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add shared `SHARED_MATRIX_INTEGRATION_WHERE` predicate pinning `workspaceId: null`

- Route all eight shared-gateway lookups through the predicate

- Set `userId`/`workspaceId` explicitly on gateway row creation

- Add fixtures and three regression tests for workspace-row shadowing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["8 lookups: provider matrix, status ACTIVE, userId null"] -- "replaced by" --> B["SHARED_MATRIX_INTEGRATION_WHERE (+ workspaceId: null)"]
  B --> C["mappings/route.ts (get-or-create, GET, DELETE)"]
  B --> D["notification.ts (3 lookups)"]
  B --> E["matrixGateway.ts (2 lookups)"]
  F["matrixIntegrationFixtures.ts"] -- "fake table, workspace rows first" --> G["3 regression tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>matrixGatewayIntegration.ts</strong><dd><code>New shared system-scoped Matrix integration predicate</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/543/files#diff-48444856b8e59cf4df006412a58f67ceb67380be3700b4ab5c69d5cae3c0d018">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>route.ts</strong><dd><code>Use shared predicate in three lookups; explicit null scoping on create</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/543/files#diff-ffa869caa0ca6c0202a4d3afea5387a9b325ca94fcbac52646a9db138ef2d44c">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notification.ts</strong><dd><code>Replace three inline Matrix lookups with shared predicate</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/543/files#diff-7a4d7ed5cb5604efb6f21f81571ba47677e6cd15dad28e7b7ae60d0a9df394b6">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>matrixGateway.ts</strong><dd><code>Scope status fallback and disconnect lookups to system row</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/543/files#diff-1a88de67850480195d09678a44ad34d6efa1fd3afd9e633343da03bf6bdd4991">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>matrixIntegrationFixtures.ts</strong><dd><code>Fake integration table with workspace rows ordered first</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/543/files#diff-b84724d326a9c79a56b5421077f69dfdb7a325115b69517d175fa8a1db04e2fa">+69/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mappings.test.ts</strong><dd><code>Test GET reads system row mappings, not workspace server</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/543/files#diff-d55d4ed5e97e6cd8f0bb91415c072f0a3ac3858c4a20fdd4f3a561514541e5bd">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>matrixGateway.test.ts</strong><dd><code>Assert fallback and disconnect use shared predicate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/543/files#diff-202655c3b86581e335a7cdd7df9cd37caa6659e1ce0e3eae58e21c46923e221b">+25/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notificationMatrixOptIn.test.ts</strong><dd><code>Test opt-in resolves system integration id</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/543/files#diff-cb19efe3f7e8ad0cffa0da24e165b9e06c16df6d74d95c7fa3108d7f97c3d6ac">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

