### PR TITLE
feat(matrix): register a workspace Matrix server and browse its rooms

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/settings/page.tsx
@@ -47,6 +47,7 @@ import {
   IconSparkles,
   IconSend,
   IconBug,
+  IconServer,
   type Icon as TablerIcon,
 } from '@tabler/icons-react';
 import { useRouter } from 'next/navigation';
@@ -59,6 +60,7 @@ import { PendingInvitationsTable } from '~/app/_components/PendingInvitationsTab
 import { WorkspaceTeamsSection } from '~/app/_components/WorkspaceTeamsSection';
 import { SlackChannelSettings } from '~/app/_components/SlackChannelSettings';
 import { ZulipSettings } from '~/app/_components/ZulipSettings';
+import { MatrixServerSettings } from '~/app/_components/MatrixServerSettings';
 import { SentrySettings } from '~/app/_components/SentrySettings';
 import { FirefliesWizardModal } from '~/app/_components/integrations/FirefliesWizardModal';
 import { FirefliesIntegrationsList } from '~/app/_components/integrations/FirefliesIntegrationsList';
@@ -1271,6 +1273,19 @@ export default function WorkspaceSettingsPage() {
                 <ZulipSettings
                   workspace={{ id: workspaceId, name: workspace.name }}
                   workspaceSlug={workspace.slug}
+                />
+              </SettingsSection>
+            )}
+
+            {workspaceId && (
+              <SettingsSection
+                icon={IconServer}
+                title="Matrix"
+                description="Register your own Matrix homeserver so meeting summaries can be posted into the rooms your team already uses. The bot posts only; it cannot be messaged back."
+              >
+                <MatrixServerSettings
+                  workspace={{ id: workspaceId, name: workspace.name }}
+                  canManage={canEdit}
                 />
               </SettingsSection>
             )}

--- a/src/app/_components/MatrixServerSettings.tsx
+++ b/src/app/_components/MatrixServerSettings.tsx
@@ -14,6 +14,7 @@ import {
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { IconAlertTriangle, IconServer } from "@tabler/icons-react";
+import { MatrixRoomPicker } from "~/app/_components/matrix/MatrixRoomPicker";
 import { useState } from "react";
 import { api } from "~/trpc/react";
 
@@ -28,6 +29,7 @@ export function MatrixServerSettings({
   canManage,
 }: MatrixServerSettingsProps) {
   const [opened, { open, close }] = useDisclosure(false);
+  const [browsingServerId, setBrowsingServerId] = useState<string | null>(null);
   const [homeserverUrl, setHomeserverUrl] = useState("");
   const [accessToken, setAccessToken] = useState("");
   const [name, setName] = useState("");
@@ -87,6 +89,13 @@ export function MatrixServerSettings({
             >
               {server.status === "ACTIVE" ? "Connected" : server.status}
             </Badge>
+            <Button
+              variant="subtle"
+              size="xs"
+              onClick={() => setBrowsingServerId(server.id)}
+            >
+              Browse rooms
+            </Button>
           </Group>
         ))
       )}
@@ -175,6 +184,26 @@ export function MatrixServerSettings({
               Verify and save
             </Button>
           </Group>
+        </Stack>
+      </Modal>
+
+      <Modal
+        opened={browsingServerId !== null}
+        onClose={() => setBrowsingServerId(null)}
+        title="Rooms this bot can reach"
+        size="lg"
+      >
+        <Stack gap="md">
+          <Text size="sm" className="text-text-muted">
+            Only rooms the bot has joined are listed. Invite it from your Matrix
+            client to add more.
+          </Text>
+          {browsingServerId && (
+            <MatrixRoomPicker
+              workspaceId={workspace.id}
+              serverId={browsingServerId}
+            />
+          )}
         </Stack>
       </Modal>
     </Stack>

--- a/src/app/_components/MatrixServerSettings.tsx
+++ b/src/app/_components/MatrixServerSettings.tsx
@@ -30,6 +30,7 @@ export function MatrixServerSettings({
 }: MatrixServerSettingsProps) {
   const [opened, { open, close }] = useDisclosure(false);
   const [browsingServerId, setBrowsingServerId] = useState<string | null>(null);
+  const [removingServerId, setRemovingServerId] = useState<string | null>(null);
   const [homeserverUrl, setHomeserverUrl] = useState("");
   const [accessToken, setAccessToken] = useState("");
   const [name, setName] = useState("");
@@ -37,6 +38,12 @@ export function MatrixServerSettings({
   const utils = api.useUtils();
   const serversQuery = api.matrixServer.list.useQuery({
     workspaceId: workspace.id,
+  });
+
+  const removeMutation = api.matrixServer.remove.useMutation({
+    onSuccess: () => {
+      void utils.matrixServer.list.invalidate({ workspaceId: workspace.id });
+    },
   });
 
   const registerMutation = api.matrixServer.register.useMutation({
@@ -96,8 +103,33 @@ export function MatrixServerSettings({
             >
               Browse rooms
             </Button>
+            {canManage && (
+              <Button
+                variant="subtle"
+                color="red"
+                size="xs"
+                loading={
+                  removeMutation.isPending && removingServerId === server.id
+                }
+                onClick={() => {
+                  setRemovingServerId(server.id);
+                  removeMutation.mutate({
+                    workspaceId: workspace.id,
+                    serverId: server.id,
+                  });
+                }}
+              >
+                Remove
+              </Button>
+            )}
           </Group>
         ))
+      )}
+
+      {removeMutation.error && (
+        <Alert color="red" variant="light">
+          {removeMutation.error.message}
+        </Alert>
       )}
 
       {canManage ? (

--- a/src/app/_components/MatrixServerSettings.tsx
+++ b/src/app/_components/MatrixServerSettings.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import {
+  Alert,
+  Badge,
+  Button,
+  Group,
+  Modal,
+  PasswordInput,
+  Skeleton,
+  Stack,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { IconAlertTriangle, IconServer } from "@tabler/icons-react";
+import { useState } from "react";
+import { api } from "~/trpc/react";
+
+interface MatrixServerSettingsProps {
+  workspace: { id: string; name: string };
+  /** Owners and admins only — registering a server means handing over a bot credential. */
+  canManage: boolean;
+}
+
+export function MatrixServerSettings({
+  workspace,
+  canManage,
+}: MatrixServerSettingsProps) {
+  const [opened, { open, close }] = useDisclosure(false);
+  const [homeserverUrl, setHomeserverUrl] = useState("");
+  const [accessToken, setAccessToken] = useState("");
+  const [name, setName] = useState("");
+
+  const utils = api.useUtils();
+  const serversQuery = api.matrixServer.list.useQuery({
+    workspaceId: workspace.id,
+  });
+
+  const registerMutation = api.matrixServer.register.useMutation({
+    onSuccess: () => {
+      void utils.matrixServer.list.invalidate({ workspaceId: workspace.id });
+      handleClose();
+    },
+  });
+
+  function handleClose() {
+    close();
+    setHomeserverUrl("");
+    setAccessToken("");
+    setName("");
+    registerMutation.reset();
+  }
+
+  const servers = serversQuery.data ?? [];
+
+  return (
+    <Stack gap="sm">
+      {serversQuery.isLoading ? (
+        <Skeleton height={56} radius="md" />
+      ) : servers.length === 0 ? (
+        <Text size="sm" className="text-text-muted">
+          No Matrix server registered. Meeting summaries can only be posted to a
+          homeserver this workspace has registered.
+        </Text>
+      ) : (
+        servers.map((server) => (
+          <Group
+            key={server.id}
+            gap="sm"
+            wrap="nowrap"
+            className="rounded-md border border-border-primary bg-surface-primary p-3"
+          >
+            <IconServer size={18} className="text-text-secondary" />
+            <div className="min-w-0">
+              <Text size="sm" fw={600} className="truncate text-text-primary">
+                {server.botUserId}
+              </Text>
+              <Text size="xs" className="truncate text-text-muted">
+                {server.homeserverUrl}
+              </Text>
+            </div>
+            <Badge
+              color={server.status === "ACTIVE" ? "green" : "gray"}
+              variant="dot"
+              ml="auto"
+            >
+              {server.status === "ACTIVE" ? "Connected" : server.status}
+            </Badge>
+          </Group>
+        ))
+      )}
+
+      {canManage ? (
+        <Group>
+          <Button variant="light" onClick={open}>
+            {servers.length === 0 ? "Register a Matrix server" : "Register another"}
+          </Button>
+        </Group>
+      ) : (
+        <Text size="xs" className="text-text-muted">
+          Only workspace owners and admins can register a Matrix server.
+        </Text>
+      )}
+
+      <Modal
+        opened={opened}
+        onClose={handleClose}
+        title="Register a Matrix server"
+        size="lg"
+      >
+        <Stack gap="md">
+          <Text size="sm" className="text-text-muted">
+            Exponential posts to your homeserver as a bot user. Create a bot account
+            on your homeserver, log it in once, and paste its access token here — the
+            token is stored encrypted and is never shown again.
+          </Text>
+
+          <TextInput
+            label="Homeserver URL"
+            placeholder="https://matrix.example.org"
+            description="The Client-Server API base URL, not the server name."
+            value={homeserverUrl}
+            onChange={(event) => setHomeserverUrl(event.currentTarget.value)}
+            required
+          />
+
+          <PasswordInput
+            label="Bot access token"
+            placeholder="syt_…"
+            description="Verified against the homeserver before anything is saved."
+            value={accessToken}
+            onChange={(event) => setAccessToken(event.currentTarget.value)}
+            required
+          />
+
+          <TextInput
+            label="Label (optional)"
+            placeholder={`Matrix for ${workspace.name}`}
+            value={name}
+            onChange={(event) => setName(event.currentTarget.value)}
+          />
+
+          <Alert
+            color="yellow"
+            variant="light"
+            icon={<IconAlertTriangle size={16} />}
+          >
+            The bot can only post to rooms it has joined, and it cannot post to
+            encrypted rooms.
+          </Alert>
+
+          {registerMutation.error && (
+            <Alert color="red" variant="light">
+              {registerMutation.error.message}
+            </Alert>
+          )}
+
+          <Group justify="flex-end">
+            <Button variant="subtle" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button
+              loading={registerMutation.isPending}
+              disabled={!homeserverUrl.trim() || !accessToken.trim()}
+              onClick={() =>
+                registerMutation.mutate({
+                  workspaceId: workspace.id,
+                  homeserverUrl: homeserverUrl.trim(),
+                  accessToken: accessToken.trim(),
+                  ...(name.trim() ? { name: name.trim() } : {}),
+                })
+              }
+            >
+              Verify and save
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Stack>
+  );
+}

--- a/src/app/_components/matrix/MatrixRoomPicker.tsx
+++ b/src/app/_components/matrix/MatrixRoomPicker.tsx
@@ -18,6 +18,17 @@ interface MatrixRoomPickerProps {
   onSelect?: (room: MatrixRoomChoice) => void;
 }
 
+/**
+ * Why an encrypted room can never be a destination.
+ *
+ * Not a permission problem and not fixable by inviting the bot again: the bot has no
+ * crypto stack (ADR-0043). A homeserver will happily *accept* a plaintext event into an
+ * encrypted room, where every client renders it as undecryptable — so silently allowing
+ * the choice would look like a successful post that nobody can read.
+ */
+export const ENCRYPTED_ROOM_REASON =
+  "Encrypted — the bot has no encryption keys, so it cannot post here.";
+
 function RoomRow({
   room,
   selected,
@@ -27,6 +38,25 @@ function RoomRow({
   selected: boolean;
   onSelect?: (room: MatrixRoomChoice) => void;
 }) {
+  if (room.isEncrypted) {
+    return (
+      <div
+        className="flex items-center gap-3 rounded-md border border-border-primary bg-surface-secondary px-3 py-2 opacity-60"
+        aria-disabled="true"
+      >
+        <Radio checked={false} disabled readOnly aria-label={room.name} />
+        <div className="min-w-0">
+          <Text size="sm" className="truncate text-text-secondary">
+            {room.name}
+          </Text>
+          <Text size="xs" className="truncate text-text-muted">
+            {ENCRYPTED_ROOM_REASON}
+          </Text>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <label className="flex cursor-pointer items-center gap-3 rounded-md border border-border-primary bg-surface-primary px-3 py-2 hover:bg-surface-hover">
       <Radio
@@ -128,14 +158,25 @@ export function MatrixRoomPicker({
           {invited.map((room) => (
             <div
               key={room.roomId}
-              className="flex items-center gap-3 rounded-md border border-border-primary bg-surface-secondary px-3 py-2"
+              className={
+                room.isEncrypted
+                  ? "flex items-center gap-3 rounded-md border border-border-primary bg-surface-secondary px-3 py-2 opacity-60"
+                  : "flex items-center gap-3 rounded-md border border-border-primary bg-surface-secondary px-3 py-2"
+              }
             >
               <div className="min-w-0 flex-1">
-                <Text size="sm" className="truncate text-text-primary">
+                <Text
+                  size="sm"
+                  className={
+                    room.isEncrypted
+                      ? "truncate text-text-secondary"
+                      : "truncate text-text-primary"
+                  }
+                >
                   {room.name}
                 </Text>
                 <Text size="xs" className="truncate text-text-muted">
-                  {room.roomId}
+                  {room.isEncrypted ? ENCRYPTED_ROOM_REASON : room.roomId}
                 </Text>
               </div>
               <Button
@@ -144,7 +185,9 @@ export function MatrixRoomPicker({
                 loading={
                   acceptInvite.isPending && acceptingRoomId === room.roomId
                 }
-                disabled={acceptInvite.isPending}
+                // Joining an encrypted room would spend the invite on a destination
+                // the bot can never post to.
+                disabled={acceptInvite.isPending || room.isEncrypted}
                 onClick={() => {
                   setAcceptingRoomId(room.roomId);
                   acceptInvite.mutate({

--- a/src/app/_components/matrix/MatrixRoomPicker.tsx
+++ b/src/app/_components/matrix/MatrixRoomPicker.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Alert, Loader, Radio, Stack, Text } from "@mantine/core";
+import { Alert, Button, Loader, Radio, Stack, Text } from "@mantine/core";
 import { IconAlertTriangle } from "@tabler/icons-react";
+import { useState } from "react";
 import { api } from "~/trpc/react";
 
 export interface MatrixRoomChoice {
@@ -17,6 +18,34 @@ interface MatrixRoomPickerProps {
   onSelect?: (room: MatrixRoomChoice) => void;
 }
 
+function RoomRow({
+  room,
+  selected,
+  onSelect,
+}: {
+  room: MatrixRoomChoice;
+  selected: boolean;
+  onSelect?: (room: MatrixRoomChoice) => void;
+}) {
+  return (
+    <label className="flex cursor-pointer items-center gap-3 rounded-md border border-border-primary bg-surface-primary px-3 py-2 hover:bg-surface-hover">
+      <Radio
+        checked={selected}
+        onChange={() => onSelect?.(room)}
+        aria-label={room.name}
+      />
+      <div className="min-w-0">
+        <Text size="sm" className="truncate text-text-primary">
+          {room.name}
+        </Text>
+        <Text size="xs" className="truncate text-text-muted">
+          {room.roomId}
+        </Text>
+      </div>
+    </label>
+  );
+}
+
 /**
  * Lists the rooms a registered Matrix bot can reach.
  *
@@ -29,7 +58,18 @@ export function MatrixRoomPicker({
   selectedRoomId,
   onSelect,
 }: MatrixRoomPickerProps) {
+  const [acceptingRoomId, setAcceptingRoomId] = useState<string | null>(null);
+  const utils = api.useUtils();
   const roomsQuery = api.matrixServer.rooms.useQuery({ workspaceId, serverId });
+
+  const acceptInvite = api.matrixServer.acceptInvite.useMutation({
+    onSuccess: (room) => {
+      // The room moves from "invited" to "joined", so the listing must be re-read
+      // before it can be offered as a destination.
+      void utils.matrixServer.rooms.invalidate({ workspaceId, serverId });
+      onSelect?.(room);
+    },
+  });
 
   if (roomsQuery.isLoading) {
     return (
@@ -51,38 +91,80 @@ export function MatrixRoomPicker({
   }
 
   const joined = roomsQuery.data?.joined ?? [];
+  const invited = roomsQuery.data?.invited ?? [];
 
-  if (joined.length === 0) {
+  if (joined.length === 0 && invited.length === 0) {
     return (
       <Alert color="yellow" variant="light" icon={<IconAlertTriangle size={16} />}>
-        This bot has not joined any rooms yet. Invite it to a room from your Matrix
-        client, then check back.
+        This bot has not joined any rooms yet, and has no pending invites. Invite it
+        to a room from your Matrix client, then check back.
       </Alert>
     );
   }
 
   return (
-    <Stack gap={4}>
-      {joined.map((room) => (
-        <label
-          key={room.roomId}
-          className="flex cursor-pointer items-center gap-3 rounded-md border border-border-primary bg-surface-primary px-3 py-2 hover:bg-surface-hover"
-        >
-          <Radio
-            checked={selectedRoomId === room.roomId}
-            onChange={() => onSelect?.(room)}
-            aria-label={room.name}
-          />
-          <div className="min-w-0">
-            <Text size="sm" className="truncate text-text-primary">
-              {room.name}
-            </Text>
-            <Text size="xs" className="truncate text-text-muted">
-              {room.roomId}
-            </Text>
-          </div>
-        </label>
-      ))}
+    <Stack gap="md">
+      {joined.length > 0 && (
+        <Stack gap={4}>
+          {joined.map((room) => (
+            <RoomRow
+              key={room.roomId}
+              room={room}
+              selected={selectedRoomId === room.roomId}
+              onSelect={onSelect}
+            />
+          ))}
+        </Stack>
+      )}
+
+      {invited.length > 0 && (
+        <Stack gap={4}>
+          <Text size="xs" fw={600} className="text-text-secondary">
+            Pending invites
+          </Text>
+          <Text size="xs" className="text-text-muted">
+            The bot has been invited but has not joined. It cannot post until it does.
+          </Text>
+          {invited.map((room) => (
+            <div
+              key={room.roomId}
+              className="flex items-center gap-3 rounded-md border border-border-primary bg-surface-secondary px-3 py-2"
+            >
+              <div className="min-w-0 flex-1">
+                <Text size="sm" className="truncate text-text-primary">
+                  {room.name}
+                </Text>
+                <Text size="xs" className="truncate text-text-muted">
+                  {room.roomId}
+                </Text>
+              </div>
+              <Button
+                size="xs"
+                variant="light"
+                loading={
+                  acceptInvite.isPending && acceptingRoomId === room.roomId
+                }
+                disabled={acceptInvite.isPending}
+                onClick={() => {
+                  setAcceptingRoomId(room.roomId);
+                  acceptInvite.mutate({
+                    workspaceId,
+                    serverId,
+                    roomId: room.roomId,
+                  });
+                }}
+              >
+                Accept
+              </Button>
+            </div>
+          ))}
+          {acceptInvite.error && (
+            <Alert color="red" variant="light">
+              {acceptInvite.error.message}
+            </Alert>
+          )}
+        </Stack>
+      )}
     </Stack>
   );
 }

--- a/src/app/_components/matrix/MatrixRoomPicker.tsx
+++ b/src/app/_components/matrix/MatrixRoomPicker.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Alert, Loader, Radio, Stack, Text } from "@mantine/core";
+import { IconAlertTriangle } from "@tabler/icons-react";
+import { api } from "~/trpc/react";
+
+export interface MatrixRoomChoice {
+  roomId: string;
+  name: string;
+  isEncrypted: boolean;
+}
+
+interface MatrixRoomPickerProps {
+  workspaceId: string;
+  serverId: string;
+  selectedRoomId?: string | null;
+  onSelect?: (room: MatrixRoomChoice) => void;
+}
+
+/**
+ * Lists the rooms a registered Matrix bot can reach.
+ *
+ * Only rooms the bot has joined appear — there is no directory search, because the bot
+ * cannot post anywhere it has not been invited and joined.
+ */
+export function MatrixRoomPicker({
+  workspaceId,
+  serverId,
+  selectedRoomId,
+  onSelect,
+}: MatrixRoomPickerProps) {
+  const roomsQuery = api.matrixServer.rooms.useQuery({ workspaceId, serverId });
+
+  if (roomsQuery.isLoading) {
+    return (
+      <Stack align="center" py="md" gap="xs">
+        <Loader size="sm" />
+        <Text size="xs" className="text-text-muted">
+          Asking the homeserver which rooms the bot is in…
+        </Text>
+      </Stack>
+    );
+  }
+
+  if (roomsQuery.error) {
+    return (
+      <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
+        {roomsQuery.error.message}
+      </Alert>
+    );
+  }
+
+  const joined = roomsQuery.data?.joined ?? [];
+
+  if (joined.length === 0) {
+    return (
+      <Alert color="yellow" variant="light" icon={<IconAlertTriangle size={16} />}>
+        This bot has not joined any rooms yet. Invite it to a room from your Matrix
+        client, then check back.
+      </Alert>
+    );
+  }
+
+  return (
+    <Stack gap={4}>
+      {joined.map((room) => (
+        <label
+          key={room.roomId}
+          className="flex cursor-pointer items-center gap-3 rounded-md border border-border-primary bg-surface-primary px-3 py-2 hover:bg-surface-hover"
+        >
+          <Radio
+            checked={selectedRoomId === room.roomId}
+            onChange={() => onSelect?.(room)}
+            aria-label={room.name}
+          />
+          <div className="min-w-0">
+            <Text size="sm" className="truncate text-text-primary">
+              {room.name}
+            </Text>
+            <Text size="xs" className="truncate text-text-muted">
+              {room.roomId}
+            </Text>
+          </div>
+        </label>
+      ))}
+    </Stack>
+  );
+}

--- a/src/app/_components/matrix/__tests__/MatrixRoomPicker.test.tsx
+++ b/src/app/_components/matrix/__tests__/MatrixRoomPicker.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Component-render tests for the Matrix room picker.
+ *
+ * The tRPC query is mocked so these assert what the user actually sees: the rooms and
+ * their ids, the "invite the bot" dead-end when it has joined nothing, and that a
+ * homeserver failure is surfaced rather than swallowed into an empty list.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import { render, screen, fireEvent } from "~/test/test-utils";
+
+interface RoomRow {
+  roomId: string;
+  name: string;
+  isEncrypted: boolean;
+}
+
+const queryHolder: {
+  current: {
+    data?: { joined: RoomRow[] };
+    isLoading: boolean;
+    error: { message: string } | null;
+  };
+} = { current: { data: { joined: [] }, isLoading: false, error: null } };
+
+vi.mock("~/trpc/react", () => ({
+  api: {
+    matrixServer: {
+      rooms: {
+        useQuery: () => queryHolder.current,
+      },
+    },
+  },
+}));
+
+import { MatrixRoomPicker } from "../MatrixRoomPicker";
+
+function renderPicker(onSelect?: (room: RoomRow) => void) {
+  return render(
+    <MatrixRoomPicker workspaceId="ws-1" serverId="srv-1" onSelect={onSelect} />,
+  );
+}
+
+describe("MatrixRoomPicker", () => {
+  test("lists each joined room with its name and id", () => {
+    queryHolder.current = {
+      data: {
+        joined: [
+          { roomId: "!eng:example.org", name: "Engineering", isEncrypted: false },
+          { roomId: "!ops:example.org", name: "Ops", isEncrypted: false },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    renderPicker();
+
+    expect(screen.getByText("Engineering")).toBeTruthy();
+    expect(screen.getByText("!eng:example.org")).toBeTruthy();
+    expect(screen.getByText("Ops")).toBeTruthy();
+  });
+
+  test("tells the user to invite the bot when it has joined nothing", () => {
+    queryHolder.current = { data: { joined: [] }, isLoading: false, error: null };
+
+    renderPicker();
+
+    expect(screen.getByText(/has not joined any rooms yet/i)).toBeTruthy();
+  });
+
+  test("surfaces a homeserver failure instead of showing an empty list", () => {
+    queryHolder.current = {
+      data: undefined,
+      isLoading: false,
+      error: { message: "Could not reach https://matrix.example.org." },
+    };
+
+    renderPicker();
+
+    expect(
+      screen.getByText(/Could not reach https:\/\/matrix\.example\.org\./),
+    ).toBeTruthy();
+    expect(screen.queryByText(/has not joined any rooms yet/i)).toBeNull();
+  });
+
+  test("reports the chosen room to the caller", () => {
+    const onSelect = vi.fn();
+    queryHolder.current = {
+      data: {
+        joined: [
+          { roomId: "!eng:example.org", name: "Engineering", isEncrypted: false },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    renderPicker(onSelect);
+    fireEvent.click(screen.getByLabelText("Engineering"));
+
+    expect(onSelect).toHaveBeenCalledWith({
+      roomId: "!eng:example.org",
+      name: "Engineering",
+      isEncrypted: false,
+    });
+  });
+});

--- a/src/app/_components/matrix/__tests__/MatrixRoomPicker.test.tsx
+++ b/src/app/_components/matrix/__tests__/MatrixRoomPicker.test.tsx
@@ -17,17 +17,31 @@ interface RoomRow {
 
 const queryHolder: {
   current: {
-    data?: { joined: RoomRow[] };
+    data?: { joined: RoomRow[]; invited: RoomRow[] };
     isLoading: boolean;
     error: { message: string } | null;
   };
-} = { current: { data: { joined: [] }, isLoading: false, error: null } };
+} = {
+  current: { data: { joined: [], invited: [] }, isLoading: false, error: null },
+};
+
+const acceptMutate = vi.fn();
 
 vi.mock("~/trpc/react", () => ({
   api: {
+    useUtils: () => ({
+      matrixServer: { rooms: { invalidate: vi.fn() } },
+    }),
     matrixServer: {
       rooms: {
         useQuery: () => queryHolder.current,
+      },
+      acceptInvite: {
+        useMutation: () => ({
+          mutate: acceptMutate,
+          isPending: false,
+          error: null,
+        }),
       },
     },
   },
@@ -49,6 +63,7 @@ describe("MatrixRoomPicker", () => {
           { roomId: "!eng:example.org", name: "Engineering", isEncrypted: false },
           { roomId: "!ops:example.org", name: "Ops", isEncrypted: false },
         ],
+        invited: [],
       },
       isLoading: false,
       error: null,
@@ -62,7 +77,11 @@ describe("MatrixRoomPicker", () => {
   });
 
   test("tells the user to invite the bot when it has joined nothing", () => {
-    queryHolder.current = { data: { joined: [] }, isLoading: false, error: null };
+    queryHolder.current = {
+      data: { joined: [], invited: [] },
+      isLoading: false,
+      error: null,
+    };
 
     renderPicker();
 
@@ -91,6 +110,7 @@ describe("MatrixRoomPicker", () => {
         joined: [
           { roomId: "!eng:example.org", name: "Engineering", isEncrypted: false },
         ],
+        invited: [],
       },
       isLoading: false,
       error: null,
@@ -104,5 +124,67 @@ describe("MatrixRoomPicker", () => {
       name: "Engineering",
       isEncrypted: false,
     });
+  });
+  test("lists pending invites separately, with an Accept action", () => {
+    queryHolder.current = {
+      data: {
+        joined: [],
+        invited: [
+          { roomId: "!waiting:example.org", name: "Product", isEncrypted: false },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    renderPicker();
+
+    // A waiting invite must not read as "no rooms" — that dead-end is the whole
+    // reason invites are surfaced.
+    expect(screen.queryByText(/has not joined any rooms yet/i)).toBeNull();
+    expect(screen.getByText("Pending invites")).toBeTruthy();
+    expect(screen.getByText("Product")).toBeTruthy();
+    expect(screen.getByText(/cannot post until it does/i)).toBeTruthy();
+  });
+
+  test("accepting an invite asks the server to join that room", () => {
+    acceptMutate.mockClear();
+    queryHolder.current = {
+      data: {
+        joined: [],
+        invited: [
+          { roomId: "!waiting:example.org", name: "Product", isEncrypted: false },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    renderPicker();
+    fireEvent.click(screen.getByText("Accept"));
+
+    expect(acceptMutate).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      serverId: "srv-1",
+      roomId: "!waiting:example.org",
+    });
+  });
+
+  test("an invited room is not offered as a selectable destination yet", () => {
+    queryHolder.current = {
+      data: {
+        joined: [],
+        invited: [
+          { roomId: "!waiting:example.org", name: "Product", isEncrypted: false },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    renderPicker();
+
+    // No radio for it: the bot cannot post there until it has actually joined.
+    expect(screen.queryByLabelText("Product")).toBeNull();
   });
 });

--- a/src/app/_components/matrix/__tests__/MatrixRoomPicker.test.tsx
+++ b/src/app/_components/matrix/__tests__/MatrixRoomPicker.test.tsx
@@ -187,4 +187,70 @@ describe("MatrixRoomPicker", () => {
     // No radio for it: the bot cannot post there until it has actually joined.
     expect(screen.queryByLabelText("Product")).toBeNull();
   });
+
+  test("renders an encrypted room as non-selectable, with the reason", () => {
+    queryHolder.current = {
+      data: {
+        joined: [
+          { roomId: "!eng:example.org", name: "Engineering", isEncrypted: false },
+          { roomId: "!board:example.org", name: "Board", isEncrypted: true },
+        ],
+        invited: [],
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    renderPicker();
+
+    const encrypted = screen.getByLabelText("Board") as HTMLInputElement;
+    expect(encrypted.disabled).toBe(true);
+    expect(screen.getByText(/cannot post here/i)).toBeTruthy();
+
+    // The unencrypted room beside it stays selectable — this greys out one row,
+    // not the list.
+    expect((screen.getByLabelText("Engineering") as HTMLInputElement).disabled).toBe(
+      false,
+    );
+  });
+
+  test("an encrypted room cannot be chosen even by clicking it", () => {
+    const onSelect = vi.fn();
+    queryHolder.current = {
+      data: {
+        joined: [{ roomId: "!board:example.org", name: "Board", isEncrypted: true }],
+        invited: [],
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    renderPicker(onSelect);
+    fireEvent.click(screen.getByLabelText("Board"));
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test("will not accept an invite to an encrypted room", () => {
+    acceptMutate.mockClear();
+    queryHolder.current = {
+      data: {
+        joined: [],
+        invited: [
+          { roomId: "!secret:example.org", name: "Leadership", isEncrypted: true },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    renderPicker();
+
+    const accept = screen.getByText("Accept").closest("button")!;
+    expect(accept.disabled).toBe(true);
+    expect(screen.getByText(/cannot post here/i)).toBeTruthy();
+
+    fireEvent.click(accept);
+    expect(acceptMutate).not.toHaveBeenCalled();
+  });
 });

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -29,6 +29,7 @@ import { whatsappRouter } from "./routers/whatsapp";
 import { whatsappGatewayRouter } from "./routers/whatsappGateway";
 import { telegramGatewayRouter } from "./routers/telegramGateway";
 import { matrixGatewayRouter } from "./routers/matrixGateway";
+import { matrixServerRouter } from "./routers/matrixServer";
 import { notificationRouter } from "./routers/notification";
 import { pushSubscriptionRouter } from "./routers/pushSubscription";
 import { weeklyPlanningRouter } from "./routers/weeklyPlanning";
@@ -124,6 +125,7 @@ export const appRouter = createTRPCRouter({
   whatsappGateway: whatsappGatewayRouter,
   telegramGateway: telegramGatewayRouter,
   matrixGateway: matrixGatewayRouter,
+  matrixServer: matrixServerRouter,
   externalAgent: externalAgentRouter,
   notification: notificationRouter,
   pushSubscription: pushSubscriptionRouter,

--- a/src/server/api/routers/__tests__/credentialExposure.test.ts
+++ b/src/server/api/routers/__tests__/credentialExposure.test.ts
@@ -160,4 +160,21 @@ describe("integration credential exposure (V1 audit regressions)", () => {
   ])("audit-deleted procedure %s does not exist", (path) => {
     expect(procedurePaths).not.toContain(path);
   });
+
+  /**
+   * The Matrix bot access token is an IntegrationCredential like any other, so the
+   * compile-time walker above already covers it structurally. This names it: the
+   * `matrixServer` router exists, and there is no procedure on it whose name suggests
+   * handing the token back — the shape `getFirefliesApiKey` had before it was deleted.
+   */
+  it("exposes no matrixServer procedure that reads the bot access token back out", () => {
+    const matrixServerPaths = procedurePaths.filter((path) =>
+      path.startsWith("matrixServer."),
+    );
+
+    expect(matrixServerPaths.length).toBeGreaterThan(0);
+    expect(
+      matrixServerPaths.filter((path) => /token|credential|secret/i.test(path)),
+    ).toEqual([]);
+  });
 });

--- a/src/server/api/routers/__tests__/matrixServer.test.ts
+++ b/src/server/api/routers/__tests__/matrixServer.test.ts
@@ -331,3 +331,171 @@ describe("matrixServer.list", () => {
     ).rejects.toThrow(/not a member of this workspace/);
   });
 });
+
+describe("matrixServer.acceptInvite", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  const SERVER_ROW = {
+    id: "int-1",
+    providerConfig: { homeserverUrl: HOMESERVER, botUserId: BOT },
+  };
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    dbMock.user.findUnique.mockResolvedValue({ isAgent: false } as never);
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("member") as never);
+    dbMock.integration.findFirst.mockResolvedValue(SERVER_ROW as never);
+    dbMock.integrationCredential.findMany.mockResolvedValue([
+      { key: TOKEN, keyType: "matrix_access_token", isEncrypted: false },
+    ] as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /** Route stubbed fetch by path so the procedure's call sequence stays honest. */
+  function homeserver(handlers: {
+    invites?: unknown;
+    join?: () => Response;
+    state?: Record<string, { name?: string; encrypted?: boolean }>;
+  }) {
+    return (url: string, init?: RequestInit) => {
+      const path = String(url);
+      if (path.includes("/sync")) {
+        return Promise.resolve(OK(handlers.invites ?? { rooms: { invite: {} } }));
+      }
+      if (path.includes("/join/")) {
+        return Promise.resolve(
+          handlers.join ? handlers.join() : OK({ room_id: "!invited:example.org" }),
+        );
+      }
+      const m = /\/rooms\/([^/]+)\/state\/(.+)$/.exec(path);
+      if (m) {
+        const room = handlers.state?.[decodeURIComponent(m[1]!)];
+        const type = decodeURIComponent(m[2]!);
+        if (!room) return Promise.resolve(ERR(404, { errcode: "M_NOT_FOUND" }));
+        if (type === "m.room.name") {
+          return Promise.resolve(
+            room.name ? OK({ name: room.name }) : ERR(404, { errcode: "M_NOT_FOUND" }),
+          );
+        }
+        return Promise.resolve(
+          room.encrypted
+            ? OK({ algorithm: "m.megolm.v1.aes-sha2" })
+            : ERR(404, { errcode: "M_NOT_FOUND" }),
+        );
+      }
+      void init;
+      return Promise.resolve(ERR(404, { errcode: "M_UNRECOGNIZED" }));
+    };
+  }
+
+  const ONE_INVITE = {
+    rooms: {
+      invite: {
+        "!invited:example.org": {
+          invite_state: { events: [{ type: "m.room.name", content: { name: "Product" } }] },
+        },
+      },
+    },
+  };
+
+  it("joins an invited room and returns it as a selectable destination", async () => {
+    fetchMock.mockImplementation(
+      homeserver({
+        invites: ONE_INVITE,
+        state: { "!invited:example.org": { name: "Product" } },
+      }) as never,
+    );
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.acceptInvite({
+        workspaceId: WORKSPACE_ID,
+        serverId: "int-1",
+        roomId: "!invited:example.org",
+      }),
+    ).resolves.toEqual({
+      roomId: "!invited:example.org",
+      name: "Product",
+      isEncrypted: false,
+    });
+
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).includes("/join/")),
+    ).toBe(true);
+  });
+
+  it("refuses to join a room the bot has no invite to", async () => {
+    fetchMock.mockImplementation(homeserver({ invites: ONE_INVITE }) as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.acceptInvite({
+        workspaceId: WORKSPACE_ID,
+        serverId: "int-1",
+        roomId: "!never-invited:example.org",
+      }),
+    ).rejects.toThrow(/no longer inviting this bot/);
+
+    // Crucially: it never attempted the join.
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).includes("/join/")),
+    ).toBe(false);
+  });
+
+  it("re-reads room state as a member, so a room that hid its encryption is caught", async () => {
+    // The invite's stripped state showed no encryption, but the room really is encrypted.
+    fetchMock.mockImplementation(
+      homeserver({
+        invites: ONE_INVITE,
+        state: { "!invited:example.org": { name: "Product", encrypted: true } },
+      }) as never,
+    );
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.acceptInvite({
+        workspaceId: WORKSPACE_ID,
+        serverId: "int-1",
+        roomId: "!invited:example.org",
+      }),
+    ).resolves.toMatchObject({ isEncrypted: true });
+  });
+
+  it("surfaces a refused join rather than reporting success", async () => {
+    fetchMock.mockImplementation(
+      homeserver({
+        invites: ONE_INVITE,
+        join: () => ERR(403, { errcode: "M_FORBIDDEN", error: "Not invited" }),
+      }) as never,
+    );
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.acceptInvite({
+        workspaceId: WORKSPACE_ID,
+        serverId: "int-1",
+        roomId: "!invited:example.org",
+      }),
+    ).rejects.toThrow(/refused the request/);
+  });
+
+  it("will not reach a server registered to a different workspace", async () => {
+    dbMock.integration.findFirst.mockResolvedValue(null as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.acceptInvite({
+        workspaceId: WORKSPACE_ID,
+        serverId: "int-other-workspace",
+        roomId: "!invited:example.org",
+      }),
+    ).rejects.toThrow(/not registered in this workspace/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/api/routers/__tests__/matrixServer.test.ts
+++ b/src/server/api/routers/__tests__/matrixServer.test.ts
@@ -499,3 +499,118 @@ describe("matrixServer.acceptInvite", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });
+
+describe("matrixServer.remove", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    dbMock.user.findUnique.mockResolvedValue({ isAgent: false } as never);
+  });
+
+  it("rejects a plain member — revoking a bot credential is an admin action", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("member") as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.remove({ workspaceId: WORKSPACE_ID, serverId: "int-1" }),
+    ).rejects.toThrow(/requires the owner or admin role/);
+    expect(dbMock.integration.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("deletes only within the caller's workspace and only matrix-server rows", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("admin") as never);
+    dbMock.integration.deleteMany.mockResolvedValue({ count: 1 } as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.remove({ workspaceId: WORKSPACE_ID, serverId: "int-1" }),
+    ).resolves.toEqual({ removed: 1 });
+
+    expect(dbMock.integration.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: "int-1",
+        provider: MATRIX_SERVER_PROVIDER,
+        workspaceId: WORKSPACE_ID,
+      },
+    });
+  });
+
+  it("reports a server that is not this workspace's rather than silently succeeding", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("owner") as never);
+    dbMock.integration.deleteMany.mockResolvedValue({ count: 0 } as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.remove({
+        workspaceId: WORKSPACE_ID,
+        serverId: "int-someone-elses",
+      }),
+    ).rejects.toThrow(/not registered in this workspace/);
+  });
+});
+
+describe("matrixServer credential handling", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    dbMock.user.findUnique.mockResolvedValue({ isAgent: false } as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("never sends the access token to the client, from any matrixServer procedure", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("owner") as never);
+    dbMock.integration.findMany.mockResolvedValue([
+      {
+        id: "int-1",
+        name: "Matrix",
+        status: "ACTIVE",
+        createdAt: new Date("2026-08-01T00:00:00Z"),
+        providerConfig: { homeserverUrl: HOMESERVER, botUserId: BOT },
+      },
+    ] as never);
+    dbMock.integration.findFirst.mockResolvedValue({
+      id: "int-1",
+      providerConfig: { homeserverUrl: HOMESERVER, botUserId: BOT },
+    } as never);
+    dbMock.integrationCredential.findMany.mockResolvedValue([
+      { key: TOKEN, keyType: "matrix_access_token", isEncrypted: false },
+    ] as never);
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes("/sync")) {
+        return Promise.resolve(OK({ rooms: { invite: {} } }));
+      }
+      if (String(url).includes("/joined_rooms")) {
+        return Promise.resolve(OK({ joined_rooms: [] }));
+      }
+      return Promise.resolve(ERR(404, { errcode: "M_NOT_FOUND" }));
+    });
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+
+    const list = await caller.matrixServer.list({ workspaceId: WORKSPACE_ID });
+    const rooms = await caller.matrixServer.rooms({
+      workspaceId: WORKSPACE_ID,
+      serverId: "int-1",
+    });
+
+    // The token is readable server-side (the homeserver calls above worked), but
+    // must not appear in anything a client receives.
+    expect(JSON.stringify({ list, rooms })).not.toContain(TOKEN);
+    expect(
+      fetchMock.mock.calls.some(
+        ([, init]) =>
+          (init as Record<string, Record<string, string>>)?.headers?.Authorization ===
+          `Bearer ${TOKEN}`,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/server/api/routers/__tests__/matrixServer.test.ts
+++ b/src/server/api/routers/__tests__/matrixServer.test.ts
@@ -75,7 +75,10 @@ import { MATRIX_SERVER_PROVIDER } from "~/server/services/matrix/constants";
 const USER_ID = "user-1";
 const WORKSPACE_ID = "ws-1";
 const TOKEN = "syt_super_secret_token";
-const HOMESERVER = "https://matrix.example.org";
+// localhost, because `register` now runs the SSRF guard before any request leaves the
+// process and `matrix.example.org` does not resolve. Loopback is allowed outside
+// production, which is also how the feature is exercised against a local homeserver.
+const HOMESERVER = "http://localhost:8448";
 const BOT = "@summaries:example.org";
 
 const OK = (body: unknown) =>
@@ -236,6 +239,27 @@ describe("matrixServer.register", () => {
     expect(cred.data.isEncrypted).toBe(true);
     expect(cred.data.key).not.toBe(TOKEN);
     expect(cred.data.key).not.toContain(TOKEN);
+  });
+
+  it.each([
+    ["the cloud metadata endpoint", "https://169.254.169.254"],
+    ["an internal private address", "https://10.0.0.5"],
+    ["plain http on a public host", "http://matrix.example.org"],
+  ])("refuses to register %s, before any request leaves the process", async (_l, url) => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("owner") as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.register({
+        workspaceId: WORKSPACE_ID,
+        homeserverUrl: url,
+        accessToken: TOKEN,
+      }),
+    ).rejects.toThrow(/private or loopback|must use https/i);
+
+    // The point of the guard: the fetch never happens, so it cannot be used to probe.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(dbMock.integration.create).not.toHaveBeenCalled();
   });
 
   it("refuses to register the same bot on the same homeserver twice", async () => {

--- a/src/server/api/routers/__tests__/matrixServer.test.ts
+++ b/src/server/api/routers/__tests__/matrixServer.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Unit tests for the `matrixServer` router.
+ *
+ * Two things this suite exists to hold: only owners and admins may hand Exponential a
+ * bot credential, and the credential never comes back out. Mocked Prisma throughout —
+ * no real DB, ever (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  // A real 32-byte key, not the "0".repeat(64) the other router suites copy: that
+  // value is neither 32 raw bytes nor base64 for 32, so `encryptCredential` throws
+  // on it. Harmless in suites that never encrypt; this one does.
+  process.env.DATABASE_ENCRYPTION_KEY = "0".repeat(32);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+import { MATRIX_SERVER_PROVIDER } from "~/server/services/matrix/constants";
+
+const USER_ID = "user-1";
+const WORKSPACE_ID = "ws-1";
+const TOKEN = "syt_super_secret_token";
+const HOMESERVER = "https://matrix.example.org";
+const BOT = "@summaries:example.org";
+
+const OK = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+const ERR = (status: number, body: unknown = {}) =>
+  ({ ok: false, status, json: async () => body }) as unknown as Response;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function asRole(role: string) {
+  return { role, workspaceId: WORKSPACE_ID };
+}
+
+describe("matrixServer.register", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    // Non-agent principal, so humanOnlyProcedure lets the call through.
+    dbMock.user.findUnique.mockResolvedValue({ isAgent: false } as never);
+    dbMock.integration.findMany.mockResolvedValue([] as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects a workspace member who is not an owner or admin", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("member") as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.register({
+        workspaceId: WORKSPACE_ID,
+        homeserverUrl: HOMESERVER,
+        accessToken: TOKEN,
+      }),
+    ).rejects.toThrow(/requires the owner or admin role/);
+
+    // Refused before anything reached the homeserver or the database.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(dbMock.integration.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-member outright", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(null as never);
+    dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.register({
+        workspaceId: WORKSPACE_ID,
+        homeserverUrl: HOMESERVER,
+        accessToken: TOKEN,
+      }),
+    ).rejects.toThrow(/not a member of this workspace/);
+    expect(dbMock.integration.create).not.toHaveBeenCalled();
+  });
+
+  it("persists nothing when the homeserver rejects the token", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("admin") as never);
+    fetchMock.mockResolvedValue(ERR(401, { errcode: "M_UNKNOWN_TOKEN" }));
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.register({
+        workspaceId: WORKSPACE_ID,
+        homeserverUrl: HOMESERVER,
+        accessToken: TOKEN,
+      }),
+    ).rejects.toThrow(/rejected that access token/);
+
+    expect(dbMock.integration.create).not.toHaveBeenCalled();
+    expect(dbMock.integrationCredential.create).not.toHaveBeenCalled();
+  });
+
+  it("reports an unreachable homeserver as a URL problem, not a token problem", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("owner") as never);
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.register({
+        workspaceId: WORKSPACE_ID,
+        homeserverUrl: HOMESERVER,
+        accessToken: TOKEN,
+      }),
+    ).rejects.toThrow(/Could not reach/);
+    expect(dbMock.integration.create).not.toHaveBeenCalled();
+  });
+
+  it("stores a verified server under a provider distinct from the shared gateway's", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("owner") as never);
+    fetchMock.mockResolvedValue(OK({ user_id: BOT }));
+    dbMock.integration.create.mockResolvedValue({
+      id: "int-1",
+      name: `Matrix (${BOT})`,
+      status: "ACTIVE",
+      createdAt: new Date("2026-08-11T00:00:00Z"),
+    } as never);
+    dbMock.integrationCredential.create.mockResolvedValue({ id: "cred-1" } as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    const result = await caller.matrixServer.register({
+      workspaceId: WORKSPACE_ID,
+      homeserverUrl: `${HOMESERVER}/`,
+      accessToken: TOKEN,
+    });
+
+    expect(result).toMatchObject({
+      id: "int-1",
+      homeserverUrl: HOMESERVER,
+      botUserId: BOT,
+    });
+
+    const created = dbMock.integration.create.mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(created.data).toMatchObject({
+      provider: MATRIX_SERVER_PROVIDER,
+      type: "MESSAGING",
+      workspaceId: WORKSPACE_ID,
+      providerConfig: { homeserverUrl: HOMESERVER, botUserId: BOT },
+    });
+    // Never "matrix": that provider is the shared gateway's system row (ADR-0043).
+    expect(created.data.provider).not.toBe("matrix");
+    // Workspace-owned, not user-owned — Integration.user cascades on delete.
+    expect(created.data.userId).toBeUndefined();
+  });
+
+  it("stores the access token encrypted and never returns it", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("owner") as never);
+    fetchMock.mockResolvedValue(OK({ user_id: BOT }));
+    dbMock.integration.create.mockResolvedValue({
+      id: "int-1",
+      name: "Matrix",
+      status: "ACTIVE",
+      createdAt: new Date("2026-08-11T00:00:00Z"),
+    } as never);
+    dbMock.integrationCredential.create.mockResolvedValue({ id: "cred-1" } as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    const result = await caller.matrixServer.register({
+      workspaceId: WORKSPACE_ID,
+      homeserverUrl: HOMESERVER,
+      accessToken: TOKEN,
+    });
+
+    expect(JSON.stringify(result)).not.toContain(TOKEN);
+
+    const cred = dbMock.integrationCredential.create.mock.calls[0]![0] as {
+      data: { key: string; keyType: string; isEncrypted: boolean };
+    };
+    expect(cred.data.keyType).toBe("matrix_access_token");
+    expect(cred.data.isEncrypted).toBe(true);
+    expect(cred.data.key).not.toBe(TOKEN);
+    expect(cred.data.key).not.toContain(TOKEN);
+  });
+
+  it("refuses to register the same bot on the same homeserver twice", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("owner") as never);
+    fetchMock.mockResolvedValue(OK({ user_id: BOT }));
+    dbMock.integration.findMany.mockResolvedValue([
+      {
+        id: "int-existing",
+        name: "Matrix",
+        status: "ACTIVE",
+        createdAt: new Date("2026-08-01T00:00:00Z"),
+        providerConfig: { homeserverUrl: HOMESERVER, botUserId: BOT },
+      },
+    ] as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.register({
+        workspaceId: WORKSPACE_ID,
+        homeserverUrl: HOMESERVER,
+        accessToken: TOKEN,
+      }),
+    ).rejects.toThrow(/already registered/);
+    expect(dbMock.integration.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("matrixServer.list", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  it("returns each server without its access token", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("member") as never);
+    dbMock.integration.findMany.mockResolvedValue([
+      {
+        id: "int-1",
+        name: "Matrix",
+        status: "ACTIVE",
+        createdAt: new Date("2026-08-01T00:00:00Z"),
+        providerConfig: { homeserverUrl: HOMESERVER, botUserId: BOT },
+      },
+    ] as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    const servers = await caller.matrixServer.list({ workspaceId: WORKSPACE_ID });
+
+    expect(servers).toEqual([
+      {
+        id: "int-1",
+        name: "Matrix",
+        homeserverUrl: HOMESERVER,
+        botUserId: BOT,
+        status: "ACTIVE",
+        createdAt: new Date("2026-08-01T00:00:00Z"),
+      },
+    ]);
+    // The select must not pull credentials in at all.
+    const args = dbMock.integration.findMany.mock.calls[0]![0] as {
+      select: Record<string, unknown>;
+    };
+    expect(args.select.credentials).toBeUndefined();
+  });
+
+  it("drops a row whose providerConfig never parsed rather than showing a dead server", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(asRole("admin") as never);
+    dbMock.integration.findMany.mockResolvedValue([
+      {
+        id: "int-broken",
+        name: "Matrix",
+        status: "ACTIVE",
+        createdAt: new Date(),
+        providerConfig: null,
+      },
+    ] as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.list({ workspaceId: WORKSPACE_ID }),
+    ).resolves.toEqual([]);
+  });
+
+  it("refuses a caller with no membership at all", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(null as never);
+    dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.matrixServer.list({ workspaceId: WORKSPACE_ID }),
+    ).rejects.toThrow(/not a member of this workspace/);
+  });
+});

--- a/src/server/api/routers/matrixServer.ts
+++ b/src/server/api/routers/matrixServer.ts
@@ -21,7 +21,11 @@ import {
   MATRIX_ACCESS_TOKEN_KEY_TYPE,
   MATRIX_SERVER_PROVIDER,
 } from "~/server/services/matrix/constants";
-import { listMatrixServers } from "~/server/services/matrix/matrixServer";
+import {
+  getMatrixClientForServer,
+  listMatrixServers,
+} from "~/server/services/matrix/matrixServer";
+import { reportHandledError } from "~/lib/reportHandledError";
 
 /** Only owners and admins may register or remove a workspace's messaging credentials. */
 const MANAGE_ROLES = ["owner", "admin"] as const;
@@ -157,5 +161,48 @@ export const matrixServerRouter = createTRPCRouter({
         "viewer",
       ]);
       return listMatrixServers(ctx.db, input.workspaceId);
+    }),
+
+  /**
+   * Rooms the bot can reach on a registered server.
+   *
+   * Only joined rooms: the bot posts where it has been invited and has joined, and there
+   * is deliberately no directory search or auto-join. Each room carries its encryption
+   * status so the caller can refuse to offer one the bot cannot post to.
+   */
+  rooms: protectedProcedure
+    .input(z.object({ workspaceId: z.string(), serverId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      await assertWorkspaceRole(ctx.db, ctx.session.user.id, input.workspaceId, [
+        "owner",
+        "admin",
+        "member",
+      ]);
+
+      const { client, config } = await getMatrixClientForServer(
+        ctx.db,
+        input.serverId,
+        input.workspaceId,
+      );
+
+      try {
+        const joinedIds = await client.joinedRooms();
+        const joined = await client.roomSummaries(joinedIds);
+        return {
+          joined: joined
+            .map((room) => ({
+              roomId: room.roomId,
+              name: room.name ?? room.roomId,
+              isEncrypted: room.isEncrypted,
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name)),
+        };
+      } catch (error) {
+        reportHandledError(error, {
+          area: "matrix-room-list",
+          context: { homeserverUrl: config.homeserverUrl, serverId: input.serverId },
+        });
+        throw describeMatrixFailure(error, config.homeserverUrl);
+      }
     }),
 });

--- a/src/server/api/routers/matrixServer.ts
+++ b/src/server/api/routers/matrixServer.ts
@@ -16,7 +16,12 @@ import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, humanOnlyProcedure, protectedProcedure } from "~/server/api/trpc";
 import { assertWorkspaceRole } from "~/server/services/access";
 import { encryptCredential } from "~/server/utils/credentialHelper";
-import { MatrixApiError, MatrixClient, normalizeHomeserverUrl } from "~/server/services/matrix/MatrixClient";
+import {
+  MatrixApiError,
+  MatrixClient,
+  normalizeHomeserverUrl,
+  type MatrixRoomSummary,
+} from "~/server/services/matrix/MatrixClient";
 import {
   MATRIX_ACCESS_TOKEN_KEY_TYPE,
   MATRIX_SERVER_PROVIDER,
@@ -186,16 +191,15 @@ export const matrixServerRouter = createTRPCRouter({
       );
 
       try {
-        const joinedIds = await client.joinedRooms();
+        const [joinedIds, invites] = await Promise.all([
+          client.joinedRooms(),
+          client.pendingInvites(),
+        ]);
         const joined = await client.roomSummaries(joinedIds);
+
         return {
-          joined: joined
-            .map((room) => ({
-              roomId: room.roomId,
-              name: room.name ?? room.roomId,
-              isEncrypted: room.isEncrypted,
-            }))
-            .sort((a, b) => a.name.localeCompare(b.name)),
+          joined: joined.map(toRoomChoice).sort(byName),
+          invited: invites.map(toRoomChoice).sort(byName),
         };
       } catch (error) {
         reportHandledError(error, {
@@ -205,4 +209,75 @@ export const matrixServerRouter = createTRPCRouter({
         throw describeMatrixFailure(error, config.homeserverUrl);
       }
     }),
+
+  /**
+   * Join a room the bot has been invited to, so it becomes postable.
+   *
+   * Deliberately only reachable for a room the bot already has an invite to — this is
+   * "accept what someone offered", never "join anything you can name".
+   */
+  acceptInvite: humanOnlyProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        serverId: z.string(),
+        roomId: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertWorkspaceRole(ctx.db, ctx.session.user.id, input.workspaceId, [
+        "owner",
+        "admin",
+        "member",
+      ]);
+
+      const { client, config } = await getMatrixClientForServer(
+        ctx.db,
+        input.serverId,
+        input.workspaceId,
+      );
+
+      try {
+        const invites = await client.pendingInvites();
+        const invite = invites.find((room) => room.roomId === input.roomId);
+        if (!invite) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message:
+              "That room is no longer inviting this bot — the invite may have been withdrawn.",
+          });
+        }
+
+        await client.join(input.roomId);
+
+        // Re-read state as a member: the invite's stripped state is a subset, so a room
+        // can look unencrypted from outside and turn out not to be.
+        const [summary] = await client.roomSummaries([input.roomId]);
+        return toRoomChoice(summary ?? invite);
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        reportHandledError(error, {
+          area: "matrix-accept-invite",
+          context: {
+            homeserverUrl: config.homeserverUrl,
+            serverId: input.serverId,
+            roomId: input.roomId,
+          },
+        });
+        throw describeMatrixFailure(error, config.homeserverUrl);
+      }
+    }),
 });
+
+/** An unnamed room still needs something to show, so fall back to its id. */
+function toRoomChoice(room: MatrixRoomSummary) {
+  return {
+    roomId: room.roomId,
+    name: room.name ?? room.roomId,
+    isEncrypted: room.isEncrypted,
+  };
+}
+
+function byName(a: { name: string }, b: { name: string }): number {
+  return a.name.localeCompare(b.name);
+}

--- a/src/server/api/routers/matrixServer.ts
+++ b/src/server/api/routers/matrixServer.ts
@@ -31,6 +31,10 @@ import {
   listMatrixServers,
 } from "~/server/services/matrix/matrixServer";
 import { reportHandledError } from "~/lib/reportHandledError";
+import {
+  assertSafeHomeserverUrl,
+  UnsafeHomeserverUrlError,
+} from "~/server/services/matrix/homeserverUrl";
 
 /** Only owners and admins may register or remove a workspace's messaging credentials. */
 const MANAGE_ROLES = ["owner", "admin"] as const;
@@ -54,9 +58,15 @@ function describeMatrixFailure(error: unknown, homeserverUrl: string): TRPCError
           "The homeserver rejected that access token. Check it was copied in full and belongs to this homeserver.",
       });
     }
+    // Deliberately does not include the homeserver's own error text: the URL is
+    // user-chosen, so that string is attacker-controlled and echoing it turns a
+    // failed request into a readable probe of whatever the app server can reach.
+    // The errcode is a controlled vocabulary, so naming it is safe and useful.
     return new TRPCError({
       code: "BAD_REQUEST",
-      message: `The homeserver refused the request: ${error.message}`,
+      message: error.errcode
+        ? `The homeserver refused the request (${error.errcode}).`
+        : `The homeserver refused the request (HTTP ${error.status}).`,
     });
   }
   return new TRPCError({
@@ -91,6 +101,18 @@ export const matrixServerRouter = createTRPCRouter({
       );
 
       const homeserverUrl = normalizeHomeserverUrl(input.homeserverUrl);
+
+      // Before any request leaves this process: registering a homeserver is the one
+      // place a user hands us a URL to fetch, and the URL is persisted and re-fetched
+      // by every later room listing.
+      try {
+        await assertSafeHomeserverUrl(homeserverUrl);
+      } catch (error) {
+        if (error instanceof UnsafeHomeserverUrlError) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: error.message });
+        }
+        throw error;
+      }
 
       const client = new MatrixClient({
         homeserverUrl,

--- a/src/server/api/routers/matrixServer.ts
+++ b/src/server/api/routers/matrixServer.ts
@@ -169,6 +169,42 @@ export const matrixServerRouter = createTRPCRouter({
     }),
 
   /**
+   * Forget a registered server.
+   *
+   * Deleting the Integration cascades to its `IntegrationCredential`, so the stored
+   * access token goes with it — which is the point: this is how a workspace revokes a
+   * bot credential from Exponential's side. Owner/admin only, and scoped to the
+   * workspace so one workspace cannot delete another's server by id.
+   */
+  remove: humanOnlyProcedure
+    .input(z.object({ workspaceId: z.string(), serverId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await assertWorkspaceRole(
+        ctx.db,
+        ctx.session.user.id,
+        input.workspaceId,
+        MANAGE_ROLES,
+      );
+
+      const { count } = await ctx.db.integration.deleteMany({
+        where: {
+          id: input.serverId,
+          provider: MATRIX_SERVER_PROVIDER,
+          workspaceId: input.workspaceId,
+        },
+      });
+
+      if (count === 0) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "That Matrix server is not registered in this workspace.",
+        });
+      }
+
+      return { removed: count };
+    }),
+
+  /**
    * Rooms the bot can reach on a registered server.
    *
    * Only joined rooms: the bot posts where it has been invited and has joined, and there

--- a/src/server/api/routers/matrixServer.ts
+++ b/src/server/api/routers/matrixServer.ts
@@ -1,0 +1,161 @@
+/**
+ * Workspace-registered Matrix homeservers.
+ *
+ * Distinct from `matrixGateway`, which manages the *shared* Zoe bot on our own
+ * homeserver and exists to receive DMs. A server registered here belongs to the
+ * workspace, runs on its own infrastructure, and is poster-only: Exponential talks to
+ * its Client-Server API directly and never syncs, so it cannot be DM'd or replied to.
+ *
+ * The bot access token never crosses this boundary in either direction after
+ * registration — no procedure returns it, and `credentialExposure.test.ts` fails the
+ * build if one starts to.
+ */
+
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { createTRPCRouter, humanOnlyProcedure, protectedProcedure } from "~/server/api/trpc";
+import { assertWorkspaceRole } from "~/server/services/access";
+import { encryptCredential } from "~/server/utils/credentialHelper";
+import { MatrixApiError, MatrixClient, normalizeHomeserverUrl } from "~/server/services/matrix/MatrixClient";
+import {
+  MATRIX_ACCESS_TOKEN_KEY_TYPE,
+  MATRIX_SERVER_PROVIDER,
+} from "~/server/services/matrix/constants";
+import { listMatrixServers } from "~/server/services/matrix/matrixServer";
+
+/** Only owners and admins may register or remove a workspace's messaging credentials. */
+const MANAGE_ROLES = ["owner", "admin"] as const;
+
+/**
+ * Turn a homeserver failure into something the user can act on. A bare
+ * "request failed" here is useless: the four causes need four different fixes.
+ */
+function describeMatrixFailure(error: unknown, homeserverUrl: string): TRPCError {
+  if (error instanceof MatrixApiError) {
+    if (error.status === 0) {
+      return new TRPCError({
+        code: "BAD_REQUEST",
+        message: `Could not reach ${homeserverUrl}. Check the homeserver URL is correct and publicly resolvable.`,
+      });
+    }
+    if (error.isUnauthorized) {
+      return new TRPCError({
+        code: "BAD_REQUEST",
+        message:
+          "The homeserver rejected that access token. Check it was copied in full and belongs to this homeserver.",
+      });
+    }
+    return new TRPCError({
+      code: "BAD_REQUEST",
+      message: `The homeserver refused the request: ${error.message}`,
+    });
+  }
+  return new TRPCError({
+    code: "BAD_REQUEST",
+    message: "Could not verify the Matrix server.",
+  });
+}
+
+export const matrixServerRouter = createTRPCRouter({
+  /**
+   * Register a homeserver after proving the token works.
+   *
+   * `/whoami` is the gate: it both validates the credential and tells us which bot the
+   * token belongs to, so the user never has to type the MXID and can never mistype it.
+   * Nothing is persisted unless it passes.
+   */
+  register: humanOnlyProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        homeserverUrl: z.string().url(),
+        accessToken: z.string().min(1),
+        name: z.string().trim().min(1).max(100).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertWorkspaceRole(
+        ctx.db,
+        ctx.session.user.id,
+        input.workspaceId,
+        MANAGE_ROLES,
+      );
+
+      const homeserverUrl = normalizeHomeserverUrl(input.homeserverUrl);
+
+      const client = new MatrixClient({
+        homeserverUrl,
+        accessToken: input.accessToken,
+      });
+
+      let botUserId: string;
+      try {
+        ({ userId: botUserId } = await client.whoami());
+      } catch (error) {
+        throw describeMatrixFailure(error, homeserverUrl);
+      }
+
+      // Re-registering the same bot on the same homeserver would leave two rows the
+      // picker cannot tell apart, and two tokens where one is stale. Compared in JS
+      // rather than as a JSON `equals` filter, which is sensitive to how the stored
+      // object was shaped.
+      const registered = await listMatrixServers(ctx.db, input.workspaceId);
+      const duplicate = registered.some(
+        (server) =>
+          server.homeserverUrl === homeserverUrl && server.botUserId === botUserId,
+      );
+      if (duplicate) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `${botUserId} is already registered on ${homeserverUrl}. Remove it first to replace its token.`,
+        });
+      }
+
+      const integration = await ctx.db.integration.create({
+        data: {
+          name: input.name ?? `Matrix (${botUserId})`,
+          type: "MESSAGING",
+          provider: MATRIX_SERVER_PROVIDER,
+          description: `Workspace Matrix homeserver at ${homeserverUrl}`,
+          // Workspace-owned, not user-owned: Integration.user cascades on delete, so
+          // attaching a creator would take the workspace's server down with them.
+          workspaceId: input.workspaceId,
+          status: "ACTIVE",
+          providerConfig: { homeserverUrl, botUserId },
+        },
+        select: { id: true, name: true, status: true, createdAt: true },
+      });
+
+      const encrypted = encryptCredential(input.accessToken);
+      await ctx.db.integrationCredential.create({
+        data: {
+          key: encrypted.key,
+          keyType: MATRIX_ACCESS_TOKEN_KEY_TYPE,
+          isEncrypted: encrypted.isEncrypted,
+          integrationId: integration.id,
+        },
+      });
+
+      return {
+        id: integration.id,
+        name: integration.name,
+        homeserverUrl,
+        botUserId,
+        status: integration.status,
+        createdAt: integration.createdAt,
+      };
+    }),
+
+  /** Every server this workspace has registered. Readable by any member. */
+  list: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      await assertWorkspaceRole(ctx.db, ctx.session.user.id, input.workspaceId, [
+        "owner",
+        "admin",
+        "member",
+        "viewer",
+      ]);
+      return listMatrixServers(ctx.db, input.workspaceId);
+    }),
+});

--- a/src/server/services/access/index.ts
+++ b/src/server/services/access/index.ts
@@ -67,6 +67,7 @@ export {
 // Resolvers (for direct use when needed)
 export {
   getWorkspaceMembership,
+  assertWorkspaceRole,
   canEditWorkspaceContent,
   isWorkspaceOwner,
   isWorkspaceGuest,

--- a/src/server/services/access/resolvers/workspaceResolver.ts
+++ b/src/server/services/access/resolvers/workspaceResolver.ts
@@ -9,6 +9,7 @@
  * 2. Team membership: user is in a team linked to the workspace (Team.workspaceId)
  */
 
+import { TRPCError } from "@trpc/server";
 import type { PrismaClient } from "@prisma/client";
 import type { WorkspaceMembership, WorkspaceRole } from "../types";
 import { WORKSPACE_ROLE_HIERARCHY } from "../types";
@@ -193,4 +194,47 @@ export async function findUserByEmailInWorkspace(
   }
 
   return { id: user.id, email: user.email, name: user.name };
+}
+
+/**
+ * Assert that the user holds one of `allowedRoles` in the workspace, throwing
+ * `FORBIDDEN` otherwise. Returns the resolved role so callers can branch further.
+ *
+ * This is the centralized replacement for the
+ * `member.role !== "owner" && member.role !== "admin"` shape that `workspace.ts`
+ * open-codes in about ten places. Reach for it whenever a workspace-level
+ * privileged action needs gating — CLAUDE.md forbids adding another inline copy.
+ *
+ * Note that team-based access resolves to `member` (see `getWorkspaceMembership`),
+ * so a user who reaches the workspace only through a team is correctly refused an
+ * owner/admin gate.
+ */
+export async function assertWorkspaceRole(
+  db: PrismaClient,
+  userId: string,
+  workspaceId: string,
+  allowedRoles: readonly WorkspaceRole[],
+): Promise<WorkspaceRole> {
+  const membership = await getWorkspaceMembership(db, userId, workspaceId);
+
+  if (!membership) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You are not a member of this workspace.",
+    });
+  }
+
+  if (!allowedRoles.includes(membership.role)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: `This action requires the ${formatRoleList(allowedRoles)} role.`,
+    });
+  }
+
+  return membership.role;
+}
+
+function formatRoleList(roles: readonly WorkspaceRole[]): string {
+  if (roles.length <= 1) return roles[0] ?? "owner";
+  return `${roles.slice(0, -1).join(", ")} or ${roles[roles.length - 1]}`;
 }

--- a/src/server/services/matrix/MatrixClient.ts
+++ b/src/server/services/matrix/MatrixClient.ts
@@ -1,0 +1,122 @@
+/**
+ * A thin, stateless wrapper over the Matrix Client-Server API.
+ *
+ * Deliberately NOT `matrix-js-sdk`: that dependency lives in `../mastra`, where it
+ * exists to run a sync loop and a crypto store. Nothing here syncs — a workspace-
+ * registered bot is poster-only — so the sdk would bring a store abstraction and a
+ * background loop for what is a handful of HTTP calls.
+ *
+ * Every method is a single request with no client-side state, which is what lets the
+ * same credentials be used concurrently from any request handler.
+ */
+
+const MATRIX_API = "/_matrix/client/v3";
+
+/** A Matrix API error carrying the homeserver's own errcode, so callers can be specific. */
+export class MatrixApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly errcode?: string,
+  ) {
+    super(message);
+    this.name = "MatrixApiError";
+  }
+
+  /** The token was rejected — wrong, revoked, or for a different homeserver. */
+  get isUnauthorized(): boolean {
+    return this.status === 401 || this.errcode === "M_UNKNOWN_TOKEN";
+  }
+
+  /** The bot is not in the room, or is not allowed to act there. */
+  get isForbidden(): boolean {
+    return this.status === 403 || this.errcode === "M_FORBIDDEN";
+  }
+}
+
+interface MatrixErrorBody {
+  errcode?: string;
+  error?: string;
+}
+
+export interface MatrixClientOptions {
+  homeserverUrl: string;
+  accessToken: string;
+  /** Injection point for tests; defaults to the global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+/** Strip trailing slashes so `https://h/` and `https://h` build the same URL. */
+export function normalizeHomeserverUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+export class MatrixClient {
+  private readonly homeserverUrl: string;
+  private readonly accessToken: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor({ homeserverUrl, accessToken, fetchImpl }: MatrixClientOptions) {
+    this.homeserverUrl = normalizeHomeserverUrl(homeserverUrl);
+    this.accessToken = accessToken;
+    this.fetchImpl = fetchImpl ?? fetch;
+  }
+
+  private async request<T>(
+    method: "GET" | "POST" | "PUT",
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const url = `${this.homeserverUrl}${MATRIX_API}${path}`;
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        method,
+        headers: {
+          Authorization: `Bearer ${this.accessToken}`,
+          ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+        },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      });
+    } catch (error) {
+      // Unreachable homeserver: DNS failure, refused connection, TLS error. Distinct
+      // from a rejected request, and the user needs to be told which it was.
+      throw new MatrixApiError(
+        `Could not reach the homeserver at ${this.homeserverUrl}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        0,
+      );
+    }
+
+    if (!response.ok) {
+      const parsed = await this.readErrorBody(response);
+      throw new MatrixApiError(
+        parsed.error ?? `Matrix request failed (${response.status})`,
+        response.status,
+        parsed.errcode,
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+
+  /** A homeserver error body is JSON by spec, but an intermediary may return HTML. */
+  private async readErrorBody(response: Response): Promise<MatrixErrorBody> {
+    try {
+      return ((await response.json()) ?? {}) as MatrixErrorBody;
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Identify the account the access token belongs to. The registration check: a token
+   * that survives this is one the homeserver will accept for everything else.
+   */
+  async whoami(): Promise<{ userId: string }> {
+    const body = await this.request<{ user_id: string }>("GET", "/account/whoami");
+    return { userId: body.user_id };
+  }
+}

--- a/src/server/services/matrix/MatrixClient.ts
+++ b/src/server/services/matrix/MatrixClient.ts
@@ -77,6 +77,11 @@ export class MatrixClient {
           Authorization: `Bearer ${this.accessToken}`,
           ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
         },
+        // Never follow a redirect: `fetch` would re-send the bot's access token to
+        // wherever the redirect points, so a hostile or misconfigured homeserver could
+        // bounce us to a host it controls and collect the credential. The token stays
+        // pinned to the registered origin.
+        redirect: "manual",
         ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
       });
     } catch (error) {
@@ -90,10 +95,25 @@ export class MatrixClient {
       );
     }
 
+    // With redirect: "manual" a 3xx arrives here as an ordinary not-ok response
+    // (undici) or as an opaque redirect (status 0). Either way it is not an answer.
+    if (response.type === "opaqueredirect" || (response.status >= 300 && response.status < 400)) {
+      throw new MatrixApiError(
+        "The homeserver redirected the request. Point the URL directly at the Client-Server API base.",
+        response.status,
+      );
+    }
+
     if (!response.ok) {
       const parsed = await this.readErrorBody(response);
       throw new MatrixApiError(
-        parsed.error ?? `Matrix request failed (${response.status})`,
+        // The homeserver's own `error` string is attacker-controlled for a URL the
+        // user chose, so it is kept on the error object for logging but deliberately
+        // not used as the message the router echoes back. `errcode` is a controlled
+        // vocabulary and is safe to name.
+        parsed.errcode
+          ? `Matrix request failed (${response.status} ${parsed.errcode})`
+          : `Matrix request failed (${response.status})`,
         response.status,
         parsed.errcode,
       );

--- a/src/server/services/matrix/MatrixClient.ts
+++ b/src/server/services/matrix/MatrixClient.ts
@@ -119,4 +119,91 @@ export class MatrixClient {
     const body = await this.request<{ user_id: string }>("GET", "/account/whoami");
     return { userId: body.user_id };
   }
+
+  /**
+   * Room ids the bot has joined. The bot can only post where it is joined, so this is
+   * the whole universe of reachable rooms — there is no directory search here by design.
+   */
+  async joinedRooms(): Promise<string[]> {
+    const body = await this.request<{ joined_rooms?: string[] }>(
+      "GET",
+      "/joined_rooms",
+    );
+    return body.joined_rooms ?? [];
+  }
+
+  /**
+   * Read one piece of room state, treating "not set" as `null` rather than an error.
+   *
+   * A room with no name and a room with no encryption both answer 404 `M_NOT_FOUND`,
+   * which is a normal, expected answer — most rooms have no `m.room.encryption` event
+   * at all, and that is exactly the case we want to treat as postable.
+   */
+  private async roomState<T>(roomId: string, eventType: string): Promise<T | null> {
+    try {
+      return await this.request<T>(
+        "GET",
+        `/rooms/${encodeURIComponent(roomId)}/state/${encodeURIComponent(eventType)}`,
+      );
+    } catch (error) {
+      if (error instanceof MatrixApiError && error.status === 404) return null;
+      // 403 means the bot cannot read this room's state — treat as unknown rather than
+      // failing the whole listing over one room.
+      if (error instanceof MatrixApiError && error.isForbidden) return null;
+      throw error;
+    }
+  }
+
+  /**
+   * Name and encryption status for each room, resolved concurrently but bounded.
+   *
+   * Encryption is the load-bearing field: the bot has no crypto stack (ADR-0043), and a
+   * homeserver will happily accept a plaintext event into an encrypted room, where it is
+   * unreadable by convention and looks broken. So we must know before offering the room.
+   */
+  async roomSummaries(roomIds: readonly string[]): Promise<MatrixRoomSummary[]> {
+    return mapWithConcurrency(roomIds, 8, async (roomId) => {
+      const [nameEvent, encryptionEvent] = await Promise.all([
+        this.roomState<{ name?: string }>(roomId, "m.room.name"),
+        this.roomState<{ algorithm?: string }>(roomId, "m.room.encryption"),
+      ]);
+      return {
+        roomId,
+        name: nameEvent?.name ?? null,
+        isEncrypted: encryptionEvent !== null,
+      };
+    });
+  }
+}
+
+export interface MatrixRoomSummary {
+  roomId: string;
+  /** The room's display name, or null when it has no `m.room.name` event. */
+  name: string | null;
+  isEncrypted: boolean;
+}
+
+/**
+ * `Promise.all` over a mapper, but with at most `limit` requests in flight — a workspace
+ * with a few hundred rooms would otherwise open two requests per room at once.
+ */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await mapper(items[index]!);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  );
+  return results;
 }

--- a/src/server/services/matrix/MatrixClient.ts
+++ b/src/server/services/matrix/MatrixClient.ts
@@ -174,6 +174,44 @@ export class MatrixClient {
       };
     });
   }
+
+  /**
+   * Rooms the bot has been invited to but has not joined.
+   *
+   * Without this, "I invited the bot and nothing happened" is a dead end: an invited bot
+   * appears in no listing and can post nowhere, with no way to tell from the app that an
+   * invite is even waiting. One stateless `/sync?timeout=0` — the bot has no sync loop,
+   * so this is a point-in-time read, not a subscription.
+   *
+   * Name and encryption come from the invite's stripped state, which is all a
+   * non-member can see; both may legitimately be absent.
+   */
+  async pendingInvites(): Promise<MatrixRoomSummary[]> {
+    const body = await this.request<SyncResponse>(
+      "GET",
+      `/sync?timeout=0&filter=${encodeURIComponent(INVITE_ONLY_SYNC_FILTER)}`,
+    );
+
+    return Object.entries(body.rooms?.invite ?? {}).map(([roomId, room]) => {
+      const events = room.invite_state?.events ?? [];
+      const nameEvent = events.find((event) => event.type === "m.room.name");
+      return {
+        roomId,
+        name: nameEvent?.content?.name ?? null,
+        isEncrypted: events.some((event) => event.type === "m.room.encryption"),
+      };
+    });
+  }
+
+  /** Accept an invite (or join a public room) by id or alias. */
+  async join(roomIdOrAlias: string): Promise<{ roomId: string }> {
+    const body = await this.request<{ room_id?: string }>(
+      "POST",
+      `/join/${encodeURIComponent(roomIdOrAlias)}`,
+      {},
+    );
+    return { roomId: body.room_id ?? roomIdOrAlias };
+  }
 }
 
 export interface MatrixRoomSummary {
@@ -182,6 +220,29 @@ export interface MatrixRoomSummary {
   name: string | null;
   isEncrypted: boolean;
 }
+
+/** Stripped state the homeserver includes with an invite, before the bot has joined. */
+interface StrippedStateEvent {
+  type?: string;
+  content?: { name?: string; algorithm?: string };
+}
+
+interface SyncResponse {
+  rooms?: {
+    invite?: Record<string, { invite_state?: { events?: StrippedStateEvent[] } }>;
+  };
+}
+
+/**
+ * Ask for as little as the homeserver will give us: we only want the invite list, and a
+ * first sync on a busy account otherwise returns every room's timeline.
+ */
+const INVITE_ONLY_SYNC_FILTER = JSON.stringify({
+  room: {
+    timeline: { limit: 0 },
+    state: { lazy_load_members: true },
+  },
+});
 
 /**
  * `Promise.all` over a mapper, but with at most `limit` requests in flight — a workspace

--- a/src/server/services/matrix/__tests__/MatrixClient.test.ts
+++ b/src/server/services/matrix/__tests__/MatrixClient.test.ts
@@ -116,3 +116,107 @@ describe("MatrixClient.whoami", () => {
     expect((error as MatrixApiError).status).toBe(502);
   });
 });
+
+describe("MatrixClient.joinedRooms", () => {
+  it("returns the joined room ids", async () => {
+    fetchMock.mockResolvedValue(OK({ joined_rooms: ["!a:example.org", "!b:example.org"] }));
+
+    await expect(makeClient().joinedRooms()).resolves.toEqual([
+      "!a:example.org",
+      "!b:example.org",
+    ]);
+    expect(String(fetchMock.mock.calls[0]![0])).toBe(
+      "https://matrix.example.org/_matrix/client/v3/joined_rooms",
+    );
+  });
+
+  it("treats a missing joined_rooms key as no rooms rather than throwing", async () => {
+    fetchMock.mockResolvedValue(OK({}));
+    await expect(makeClient().joinedRooms()).resolves.toEqual([]);
+  });
+});
+
+describe("MatrixClient.roomSummaries", () => {
+  /** Answer name/encryption state per room, 404ing for state a room does not have. */
+  function stateResponder(
+    rooms: Record<string, { name?: string; encrypted?: boolean }>,
+  ) {
+    return (url: string) => {
+      const match = /\/rooms\/([^/]+)\/state\/(.+)$/.exec(String(url));
+      if (!match) return ERR(404, { errcode: "M_NOT_FOUND" });
+      const roomId = decodeURIComponent(match[1]!);
+      const eventType = decodeURIComponent(match[2]!);
+      const room = rooms[roomId];
+      if (!room) return ERR(404, { errcode: "M_NOT_FOUND" });
+      if (eventType === "m.room.name") {
+        return room.name ? OK({ name: room.name }) : ERR(404, { errcode: "M_NOT_FOUND" });
+      }
+      if (eventType === "m.room.encryption") {
+        return room.encrypted
+          ? OK({ algorithm: "m.megolm.v1.aes-sha2" })
+          : ERR(404, { errcode: "M_NOT_FOUND" });
+      }
+      return ERR(404, { errcode: "M_NOT_FOUND" });
+    };
+  }
+
+  it("reports name and encryption status per room", async () => {
+    fetchMock.mockImplementation((url: string) =>
+      Promise.resolve(
+        stateResponder({
+          "!plain:example.org": { name: "Engineering" },
+          "!secret:example.org": { name: "Board", encrypted: true },
+        })(url),
+      ),
+    );
+
+    await expect(
+      makeClient().roomSummaries(["!plain:example.org", "!secret:example.org"]),
+    ).resolves.toEqual([
+      { roomId: "!plain:example.org", name: "Engineering", isEncrypted: false },
+      { roomId: "!secret:example.org", name: "Board", isEncrypted: true },
+    ]);
+  });
+
+  it("treats an absent m.room.name as an unnamed room, not an error", async () => {
+    fetchMock.mockImplementation((url: string) =>
+      Promise.resolve(stateResponder({ "!anon:example.org": {} })(url)),
+    );
+
+    await expect(makeClient().roomSummaries(["!anon:example.org"])).resolves.toEqual([
+      { roomId: "!anon:example.org", name: null, isEncrypted: false },
+    ]);
+  });
+
+  it("does not let one unreadable room's state fail the whole listing", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes("forbidden")) {
+        return Promise.resolve(ERR(403, { errcode: "M_FORBIDDEN" }));
+      }
+      return Promise.resolve(
+        stateResponder({ "!ok:example.org": { name: "Fine" } })(String(url)),
+      );
+    });
+
+    await expect(
+      makeClient().roomSummaries(["!forbidden:example.org", "!ok:example.org"]),
+    ).resolves.toEqual([
+      { roomId: "!forbidden:example.org", name: null, isEncrypted: false },
+      { roomId: "!ok:example.org", name: "Fine", isEncrypted: false },
+    ]);
+  });
+
+  it("preserves input order even though lookups run concurrently", async () => {
+    const rooms = Array.from({ length: 20 }, (_, i) => `!r${i}:example.org`);
+    fetchMock.mockImplementation((url: string) =>
+      Promise.resolve(
+        stateResponder(
+          Object.fromEntries(rooms.map((r, i) => [r, { name: `Room ${i}` }])),
+        )(String(url)),
+      ),
+    );
+
+    const summaries = await makeClient().roomSummaries(rooms);
+    expect(summaries.map((s) => s.roomId)).toEqual(rooms);
+  });
+});

--- a/src/server/services/matrix/__tests__/MatrixClient.test.ts
+++ b/src/server/services/matrix/__tests__/MatrixClient.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the stateless Matrix Client-Server API wrapper.
+ *
+ * `fetch` is stubbed in the style of `MatrixNotificationService.test.ts`, including its
+ * OK/ERR response helpers — no network, ever.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  MatrixApiError,
+  MatrixClient,
+  normalizeHomeserverUrl,
+} from "~/server/services/matrix/MatrixClient";
+
+const OK = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+const ERR = (status: number, body: unknown = {}) =>
+  ({ ok: false, status, json: async () => body }) as unknown as Response;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function makeClient(overrides: { homeserverUrl?: string } = {}) {
+  return new MatrixClient({
+    homeserverUrl: overrides.homeserverUrl ?? "https://matrix.example.org",
+    accessToken: "syt_secret",
+    fetchImpl: fetchMock as unknown as typeof fetch,
+  });
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("normalizeHomeserverUrl", () => {
+  it("strips trailing slashes and surrounding whitespace", () => {
+    expect(normalizeHomeserverUrl("  https://matrix.example.org///  ")).toBe(
+      "https://matrix.example.org",
+    );
+  });
+});
+
+describe("MatrixClient.whoami", () => {
+  it("returns the token's owner and sends it as a bearer token", async () => {
+    fetchMock.mockResolvedValue(OK({ user_id: "@summaries:example.org" }));
+
+    await expect(makeClient().whoami()).resolves.toEqual({
+      userId: "@summaries:example.org",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe(
+      "https://matrix.example.org/_matrix/client/v3/account/whoami",
+    );
+    expect((init as RequestInit).method).toBe("GET");
+    expect(
+      (init as Record<string, Record<string, string>>).headers.Authorization,
+    ).toBe("Bearer syt_secret");
+  });
+
+  it("builds the same URL whether or not the homeserver URL has a trailing slash", async () => {
+    fetchMock.mockResolvedValue(OK({ user_id: "@bot:example.org" }));
+    await makeClient({ homeserverUrl: "https://matrix.example.org/" }).whoami();
+
+    expect(String(fetchMock.mock.calls[0]![0])).toBe(
+      "https://matrix.example.org/_matrix/client/v3/account/whoami",
+    );
+  });
+
+  it("reports a rejected token as unauthorized, carrying the homeserver's errcode", async () => {
+    fetchMock.mockResolvedValue(
+      ERR(401, { errcode: "M_UNKNOWN_TOKEN", error: "Invalid access token" }),
+    );
+
+    const error = await makeClient()
+      .whoami()
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(MatrixApiError);
+    expect((error as MatrixApiError).isUnauthorized).toBe(true);
+    expect((error as MatrixApiError).errcode).toBe("M_UNKNOWN_TOKEN");
+    expect((error as MatrixApiError).message).toBe("Invalid access token");
+  });
+
+  it("distinguishes an unreachable homeserver (status 0) from a rejected request", async () => {
+    fetchMock.mockRejectedValue(new Error("getaddrinfo ENOTFOUND"));
+
+    const error = await makeClient()
+      .whoami()
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(MatrixApiError);
+    expect((error as MatrixApiError).status).toBe(0);
+    expect((error as MatrixApiError).isUnauthorized).toBe(false);
+    expect((error as MatrixApiError).message).toContain("Could not reach");
+  });
+
+  it("survives an error body that is not JSON (a proxy's HTML error page)", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new SyntaxError("Unexpected token <");
+      },
+    } as unknown as Response);
+
+    const error = await makeClient()
+      .whoami()
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(MatrixApiError);
+    expect((error as MatrixApiError).status).toBe(502);
+  });
+});

--- a/src/server/services/matrix/__tests__/MatrixClient.test.ts
+++ b/src/server/services/matrix/__tests__/MatrixClient.test.ts
@@ -83,7 +83,10 @@ describe("MatrixClient.whoami", () => {
     expect(error).toBeInstanceOf(MatrixApiError);
     expect((error as MatrixApiError).isUnauthorized).toBe(true);
     expect((error as MatrixApiError).errcode).toBe("M_UNKNOWN_TOKEN");
-    expect((error as MatrixApiError).message).toBe("Invalid access token");
+    // The errcode is named (controlled vocabulary); the homeserver's free-text
+    // `error` is not repeated back — see the reflection test below.
+    expect((error as MatrixApiError).message).toContain("M_UNKNOWN_TOKEN");
+    expect((error as MatrixApiError).message).not.toContain("Invalid access token");
   });
 
   it("distinguishes an unreachable homeserver (status 0) from a rejected request", async () => {
@@ -97,6 +100,57 @@ describe("MatrixClient.whoami", () => {
     expect((error as MatrixApiError).status).toBe(0);
     expect((error as MatrixApiError).isUnauthorized).toBe(false);
     expect((error as MatrixApiError).message).toContain("Could not reach");
+  });
+
+  it("never follows a redirect, so the bot token cannot be bounced to another host", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 302,
+      json: async () => ({}),
+    } as unknown as Response);
+
+    const error = await makeClient()
+      .whoami()
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(MatrixApiError);
+    expect((error as MatrixApiError).message).toMatch(/redirected the request/i);
+
+    // The request itself must have opted out of redirect-following, or `fetch` would
+    // have re-sent the Authorization header to wherever Location pointed.
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init as RequestInit).redirect).toBe("manual");
+  });
+
+  it("treats an opaque redirect as a redirect too", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 0,
+      type: "opaqueredirect",
+      json: async () => ({}),
+    } as unknown as Response);
+
+    const error = await makeClient()
+      .whoami()
+      .catch((e: unknown) => e);
+
+    expect((error as MatrixApiError).message).toMatch(/redirected the request/i);
+  });
+
+  it("does not put the homeserver's own error prose in the thrown message", async () => {
+    // The homeserver is at a user-chosen URL, so its `error` string is attacker
+    // controlled — echoing it would turn a failed request into a readable probe.
+    fetchMock.mockResolvedValue(
+      ERR(500, { errcode: "M_UNKNOWN", error: "root:x:0:0:secret internal detail" }),
+    );
+
+    const error = await makeClient()
+      .whoami()
+      .catch((e: unknown) => e);
+
+    expect((error as MatrixApiError).message).not.toContain("secret internal detail");
+    expect((error as MatrixApiError).message).toContain("M_UNKNOWN");
+    expect((error as MatrixApiError).errcode).toBe("M_UNKNOWN");
   });
 
   it("survives an error body that is not JSON (a proxy's HTML error page)", async () => {

--- a/src/server/services/matrix/__tests__/MatrixClient.test.ts
+++ b/src/server/services/matrix/__tests__/MatrixClient.test.ts
@@ -220,3 +220,74 @@ describe("MatrixClient.roomSummaries", () => {
     expect(summaries.map((s) => s.roomId)).toEqual(rooms);
   });
 });
+
+describe("MatrixClient.pendingInvites", () => {
+  it("parses invited rooms out of a /sync payload, with stripped-state name and encryption", async () => {
+    fetchMock.mockResolvedValue(
+      OK({
+        rooms: {
+          invite: {
+            "!invited:example.org": {
+              invite_state: {
+                events: [
+                  { type: "m.room.name", content: { name: "Product" } },
+                  { type: "m.room.member", content: {} },
+                ],
+              },
+            },
+            "!secret-invite:example.org": {
+              invite_state: {
+                events: [
+                  { type: "m.room.encryption", content: { algorithm: "m.megolm.v1.aes-sha2" } },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    await expect(makeClient().pendingInvites()).resolves.toEqual([
+      { roomId: "!invited:example.org", name: "Product", isEncrypted: false },
+      { roomId: "!secret-invite:example.org", name: null, isEncrypted: true },
+    ]);
+  });
+
+  it("asks for a zero-length timeline so a first sync does not pull every room's history", async () => {
+    fetchMock.mockResolvedValue(OK({ rooms: { invite: {} } }));
+    await makeClient().pendingInvites();
+
+    const url = String(fetchMock.mock.calls[0]![0]);
+    expect(url).toContain("/sync?timeout=0");
+    const filter = decodeURIComponent(url.split("filter=")[1]!);
+    expect(JSON.parse(filter)).toMatchObject({ room: { timeline: { limit: 0 } } });
+  });
+
+  it("returns nothing when the payload has no invite section at all", async () => {
+    fetchMock.mockResolvedValue(OK({}));
+    await expect(makeClient().pendingInvites()).resolves.toEqual([]);
+  });
+});
+
+describe("MatrixClient.join", () => {
+  it("POSTs to /join and returns the resolved room id", async () => {
+    fetchMock.mockResolvedValue(OK({ room_id: "!resolved:example.org" }));
+
+    await expect(makeClient().join("#alias:example.org")).resolves.toEqual({
+      roomId: "!resolved:example.org",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe(
+      "https://matrix.example.org/_matrix/client/v3/join/%23alias%3Aexample.org",
+    );
+    expect((init as RequestInit).method).toBe("POST");
+  });
+
+  it("falls back to the requested id when the homeserver omits room_id", async () => {
+    fetchMock.mockResolvedValue(OK({}));
+    await expect(makeClient().join("!r:example.org")).resolves.toEqual({
+      roomId: "!r:example.org",
+    });
+  });
+});

--- a/src/server/services/matrix/__tests__/homeserverUrl.test.ts
+++ b/src/server/services/matrix/__tests__/homeserverUrl.test.ts
@@ -1,0 +1,109 @@
+/**
+ * SSRF guard for the one URL a user hands the server to fetch.
+ *
+ * DNS is stubbed so these are hermetic — the point is which addresses are refused, not
+ * what any real name resolves to today.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const lookupMock = vi.fn<(hostname: string) => Promise<string[]>>();
+
+import {
+  assertSafeHomeserverUrl,
+  UnsafeHomeserverUrlError,
+} from "~/server/services/matrix/homeserverUrl";
+
+const ORIGINAL_ENV = process.env.NODE_ENV;
+
+beforeEach(() => {
+  lookupMock.mockReset();
+  lookupMock.mockResolvedValue(["203.0.113.10"]);
+});
+
+afterEach(() => {
+  process.env.NODE_ENV = ORIGINAL_ENV;
+});
+
+async function reject(url: string): Promise<string> {
+  const error = await assertSafeHomeserverUrl(url, lookupMock).then(
+    () => null,
+    (e: unknown) => e,
+  );
+  expect(error).toBeInstanceOf(UnsafeHomeserverUrlError);
+  return (error as Error).message;
+}
+
+describe("assertSafeHomeserverUrl", () => {
+  it("allows a public https homeserver", async () => {
+    await expect(
+      assertSafeHomeserverUrl("https://matrix.example.org", lookupMock),
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuses plain http, so the bot token is never sent in the clear", async () => {
+    expect(await reject("http://matrix.example.org")).toMatch(/must use https/i);
+  });
+
+  it.each([
+    ["the cloud metadata endpoint", "https://169.254.169.254"],
+    ["an RFC 1918 address", "https://10.1.2.3"],
+    ["a 172.16/12 address", "https://172.20.0.5"],
+    ["a 192.168 address", "https://192.168.1.10"],
+    ["an IPv6 unique-local address", "https://[fd00::1]"],
+  ])("refuses %s written directly into the URL", async (_label, url) => {
+    expect(await reject(url)).toMatch(/private or loopback/i);
+    // Refused without even resolving — the address is right there.
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a public name that resolves to a private address", async () => {
+    // The case a scheme/literal check alone would miss.
+    lookupMock.mockResolvedValue(["169.254.169.254"]);
+    expect(await reject("https://metadata.attacker.example")).toMatch(
+      /resolves to a private or loopback address/i,
+    );
+  });
+
+  it("refuses a name where only one of several records is private", async () => {
+    lookupMock.mockResolvedValue(["203.0.113.10", "10.0.0.7"]);
+    expect(await reject("https://split.attacker.example")).toMatch(
+      /resolves to a private or loopback address/i,
+    );
+  });
+
+  it("refuses an IPv4-mapped IPv6 metadata address", async () => {
+    lookupMock.mockResolvedValue(["::ffff:169.254.169.254"]);
+    expect(await reject("https://mapped.attacker.example")).toMatch(
+      /resolves to a private or loopback address/i,
+    );
+  });
+
+  it("reports an unresolvable name as a URL problem", async () => {
+    lookupMock.mockRejectedValue(new Error("ENOTFOUND"));
+    expect(await reject("https://nope.example")).toMatch(/Could not resolve/i);
+  });
+
+  it("rejects a value that is not a URL at all", async () => {
+    expect(await reject("not a url")).toMatch(/not a valid URL/i);
+  });
+
+  it.each([
+    "http://localhost:8448",
+    "https://127.0.0.1:8448",
+    "https://[::1]:8448",
+  ])(
+    "allows %s outside production, so the feature stays testable against a local homeserver",
+    async (url) => {
+      process.env.NODE_ENV = "development";
+      await expect(assertSafeHomeserverUrl(url, lookupMock)).resolves.toBeUndefined();
+    },
+  );
+
+  it("refuses localhost in production, where loopback can only be this server", async () => {
+    process.env.NODE_ENV = "production";
+    expect(await reject("http://localhost:8448")).toMatch(/must use https/i);
+    expect(await reject("https://127.0.0.1:8448")).toMatch(/private or loopback/i);
+    expect(await reject("https://[::1]:8448")).toMatch(/private or loopback/i);
+  });
+});

--- a/src/server/services/matrix/constants.ts
+++ b/src/server/services/matrix/constants.ts
@@ -1,0 +1,28 @@
+/**
+ * A workspace-registered Matrix homeserver is an `Integration` row, and it is
+ * deliberately NOT `provider: "matrix"`.
+ *
+ * `"matrix"` is the single system row anchoring Gateway DM pairing (ADR-0043). A
+ * workspace server is a different thing entirely — its own homeserver, its own bot,
+ * poster-only. Sharing the provider string would put both behind the same lookups.
+ *
+ * The distinct string is only half the separation; the other half is
+ * `SHARED_MATRIX_INTEGRATION_WHERE`'s `workspaceId: null`, which holds even if a
+ * workspace row ever appears under the `matrix` provider.
+ */
+export const MATRIX_SERVER_PROVIDER = "matrix-server";
+
+/** `IntegrationCredential.keyType` for the bot's access token. Always encrypted. */
+export const MATRIX_ACCESS_TOKEN_KEY_TYPE = "matrix_access_token";
+
+/** Aliases accepted when reading the token back, in priority order. */
+export const MATRIX_ACCESS_TOKEN_ALIASES = [
+  MATRIX_ACCESS_TOKEN_KEY_TYPE,
+  "MATRIX_ACCESS_TOKEN",
+] as const;
+
+/** Shape stored in `Integration.providerConfig` for a registered server. */
+export interface MatrixServerConfig {
+  homeserverUrl: string;
+  botUserId: string;
+}

--- a/src/server/services/matrix/homeserverUrl.ts
+++ b/src/server/services/matrix/homeserverUrl.ts
@@ -1,0 +1,147 @@
+/**
+ * Guarding the one place Exponential fetches a URL the user chose.
+ *
+ * Registering a homeserver hands the server an arbitrary URL and asks it to make a
+ * request — an SSRF primitive. Workspace owner/admin is a real gate, but not enough on
+ * its own: the registered URL is persisted and re-fetched by every later room listing,
+ * so a single bad registration is a durable probe of whatever the app server can reach
+ * (cloud metadata endpoints, internal admin APIs, databases on the private network).
+ *
+ * Three checks, because each catches something the others miss:
+ *
+ *  1. Scheme — https only, so credentials are not sent in the clear.
+ *  2. Literal address — an IP written directly into the URL.
+ *  3. Resolved address — the hostname's actual A/AAAA records, which is the only way to
+ *     catch a public name that deliberately points at a private address.
+ *
+ * This does not defeat DNS rebinding: the name is resolved here and again by `fetch`,
+ * and a hostile resolver can answer differently each time. Closing that needs pinning
+ * the connection to the checked IP, which is out of scope for V1 — it raises the cost
+ * substantially without being the attack anyone reaches for first.
+ */
+
+import { isIP } from "node:net";
+
+/** Resolve a hostname to its addresses. Injectable so the guard is testable without DNS. */
+export type ResolveHost = (hostname: string) => Promise<string[]>;
+
+/**
+ * Imported lazily rather than at module load: this module is pulled into the client
+ * type graph through the router, and `node:dns` is not resolvable in every environment
+ * the test runner uses.
+ */
+const defaultResolveHost: ResolveHost = async (hostname) => {
+  const { lookup } = await import("node:dns/promises");
+  const entries = await lookup(hostname, { all: true });
+  return entries.map((entry) => entry.address);
+};
+
+/** Loopback, link-local, and the RFC 1918 / RFC 4193 private ranges. */
+function isPrivateIPv4(address: string): boolean {
+  const parts = address.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return true;
+  const [a, b] = parts as [number, number, number, number];
+
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 127) return true; // loopback
+  if (a === 0) return true; // "this host"
+  if (a === 169 && b === 254) return true; // link-local — includes 169.254.169.254
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 100 && b >= 64 && b <= 127) return true; // carrier-grade NAT
+  if (a >= 224) return true; // multicast and reserved
+  return false;
+}
+
+function isPrivateIPv6(address: string): boolean {
+  const normalized = address.toLowerCase().replace(/^\[|\]$/g, "");
+  if (normalized === "::1" || normalized === "::") return true;
+  if (normalized.startsWith("fe80")) return true; // link-local
+  if (/^f[cd]/.test(normalized)) return true; // unique local
+  // IPv4-mapped (::ffff:169.254.169.254) — judge the embedded address.
+  const mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(normalized);
+  if (mapped) return isPrivateIPv4(mapped[1]!);
+  return false;
+}
+
+function isPrivateAddress(address: string): boolean {
+  const version = isIP(address);
+  if (version === 4) return isPrivateIPv4(address);
+  if (version === 6) return isPrivateIPv6(address);
+  return true; // unparseable — refuse rather than guess
+}
+
+export class UnsafeHomeserverUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsafeHomeserverUrlError";
+  }
+}
+
+/**
+ * Localhost is allowed outside production so the feature stays testable against a local
+ * homeserver. It is refused in production, where a loopback address can only mean the
+ * app server itself.
+ */
+function localhostAllowed(): boolean {
+  return process.env.NODE_ENV !== "production";
+}
+
+function isLocalhostName(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+}
+
+/**
+ * Throw unless `rawUrl` is a homeserver this server may safely call.
+ *
+ * Resolves DNS, so callers should treat it as a network operation.
+ */
+export async function assertSafeHomeserverUrl(
+  rawUrl: string,
+  resolveHost: ResolveHost = defaultResolveHost,
+): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new UnsafeHomeserverUrlError("That is not a valid URL.");
+  }
+
+  const allowLocal = localhostAllowed() && isLocalhostName(url.hostname);
+
+  if (url.protocol !== "https:" && !allowLocal) {
+    throw new UnsafeHomeserverUrlError(
+      "The homeserver URL must use https, so the bot's access token is never sent in the clear.",
+    );
+  }
+
+  if (allowLocal) return;
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+
+  if (isIP(hostname)) {
+    if (isPrivateAddress(hostname)) {
+      throw new UnsafeHomeserverUrlError(
+        "That address is on a private or loopback network, which Exponential will not call.",
+      );
+    }
+    return;
+  }
+
+  let addresses: string[];
+  try {
+    addresses = await resolveHost(hostname);
+  } catch {
+    throw new UnsafeHomeserverUrlError(
+      `Could not resolve ${url.hostname}. Check the homeserver URL is correct and publicly resolvable.`,
+    );
+  }
+
+  // Every answer must be public: one private record is enough to make the name unsafe.
+  if (addresses.length === 0 || addresses.some((address) => isPrivateAddress(address))) {
+    throw new UnsafeHomeserverUrlError(
+      `${url.hostname} resolves to a private or loopback address, which Exponential will not call.`,
+    );
+  }
+}

--- a/src/server/services/matrix/matrixServer.ts
+++ b/src/server/services/matrix/matrixServer.ts
@@ -1,0 +1,130 @@
+/**
+ * Reading a workspace's registered Matrix servers back out of the database.
+ *
+ * The access token lives in `IntegrationCredential`, encrypted, and is resolved here
+ * and nowhere else — `resolveCredential` is the only supported reader. Nothing in this
+ * module returns the token to a caller that could serialize it; `getMatrixClientForServer`
+ * hands back a configured client instead, so the secret stays inside the server process.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+import { resolveCredential } from "~/server/utils/credentialHelper";
+import { MatrixClient } from "./MatrixClient";
+import {
+  MATRIX_ACCESS_TOKEN_ALIASES,
+  MATRIX_SERVER_PROVIDER,
+  type MatrixServerConfig,
+} from "./constants";
+
+/** A registered server, in the shape that is safe to send over tRPC. */
+export interface MatrixServerSummary {
+  id: string;
+  name: string;
+  homeserverUrl: string;
+  botUserId: string;
+  status: string;
+  createdAt: Date;
+}
+
+/** Parse `providerConfig` defensively — it is `Json?` and predates any schema for it. */
+export function readServerConfig(providerConfig: unknown): MatrixServerConfig | null {
+  if (typeof providerConfig !== "object" || providerConfig === null) return null;
+  const { homeserverUrl, botUserId } = providerConfig as Record<string, unknown>;
+  if (typeof homeserverUrl !== "string" || typeof botUserId !== "string") return null;
+  return { homeserverUrl, botUserId };
+}
+
+export async function listMatrixServers(
+  db: PrismaClient,
+  workspaceId: string,
+): Promise<MatrixServerSummary[]> {
+  const rows = await db.integration.findMany({
+    where: { provider: MATRIX_SERVER_PROVIDER, workspaceId },
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      createdAt: true,
+      providerConfig: true,
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  return rows.flatMap((row) => {
+    const config = readServerConfig(row.providerConfig);
+    // A row whose config never parsed cannot be used to reach a homeserver, so it is
+    // dropped from the list rather than rendered as a server that silently fails.
+    if (!config) return [];
+    return [
+      {
+        id: row.id,
+        name: row.name,
+        homeserverUrl: config.homeserverUrl,
+        botUserId: config.botUserId,
+        status: row.status,
+        createdAt: row.createdAt,
+      },
+    ];
+  });
+}
+
+/**
+ * Load a registered server and return a client already holding its credentials.
+ *
+ * Throws `NOT_FOUND` when the server does not belong to `workspaceId` — the workspace
+ * check is here rather than at each call site so a server id from one workspace can
+ * never be used to reach another's homeserver.
+ */
+export async function getMatrixClientForServer(
+  db: PrismaClient,
+  serverIntegrationId: string,
+  workspaceId: string,
+  fetchImpl?: typeof fetch,
+): Promise<{ client: MatrixClient; config: MatrixServerConfig; integrationId: string }> {
+  const integration = await db.integration.findFirst({
+    where: {
+      id: serverIntegrationId,
+      provider: MATRIX_SERVER_PROVIDER,
+      workspaceId,
+    },
+    select: { id: true, providerConfig: true },
+  });
+
+  if (!integration) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "That Matrix server is not registered in this workspace.",
+    });
+  }
+
+  const config = readServerConfig(integration.providerConfig);
+  if (!config) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "This Matrix server's configuration is incomplete — re-register it.",
+    });
+  }
+
+  const accessToken = await resolveCredential(
+    integration.id,
+    MATRIX_ACCESS_TOKEN_ALIASES,
+  );
+  if (!accessToken) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "This Matrix server's access token could not be read — re-register it with a fresh token.",
+    });
+  }
+
+  return {
+    client: new MatrixClient({
+      homeserverUrl: config.homeserverUrl,
+      accessToken,
+      fetchImpl,
+    }),
+    config,
+    integrationId: integration.id,
+  };
+}


### PR DESCRIPTION
### **User description**
## What

The first half of V1: a workspace registers **its own** Matrix homeserver and can browse the rooms its bot can reach. No posting yet — that's the next ticket.

Five vertical slices, one commit each:

1. **Register a server** — owner/admin submits a homeserver URL + bot access token; nothing is persisted until `/whoami` accepts the token. `/whoami` also yields the bot's MXID, so the user never types it and can't mistype it.
2. **Browse joined rooms** — `joined_rooms` plus per-room state for name and encryption.
3. **Pending invites** — listed separately with an Accept that joins the bot.
4. **Encrypted rooms** — greyed out, non-selectable, with the reason.
5. **Remove a server** — revokes the stored token; owner/admin only.

## Notable decisions

**Provider is `matrix-server`, not `matrix`.** `matrix` is the shared gateway's single system row (ADR-0043). The distinct string is only half the separation; the other half is the `workspaceId: null` guard that shipped in the previous ticket.

**`userId` is deliberately not set** on the server row. `Integration.user` cascades on delete, so attaching a creator would take the workspace's homeserver down with whoever registered it. Workspace-owned means workspace-scoped.

**`MatrixClient` is a stateless `fetch` wrapper, not `matrix-js-sdk`.** That dependency lives in `../mastra` for a sync loop this feature does not have; it would bring a crypto store and a store abstraction for what is six HTTP calls. `../mastra` is untouched by this PR.

**404 is a normal answer.** A room with no `m.room.name` and a room with no `m.room.encryption` both reply 404, and most rooms genuinely have no encryption event — so 404 means "no such state", not an error. A 403 on one room degrades that row rather than failing the whole listing.

**`acceptInvite` re-checks the invite server-side** before joining, so it is "accept what someone offered", never "join anything you can name". After joining it re-reads state as a member, because an invite's stripped state is a subset and a room can look unencrypted from outside.

**`assertWorkspaceRole` added to the access service** rather than an eleventh copy of `workspace.ts`'s inline `role !== "owner" && role !== "admin"` — CLAUDE.md forbids new inline permission checks.

## Verification

Exercised end-to-end against a stub homeserver, not just unit-mocked:

- A **wrong token** surfaces "the homeserver rejected that access token" and writes **no** Integration row.
- A good token stores `providerConfig {homeserverUrl, botUserId}` and an **encrypted** credential — zero rows match the plaintext token.
- Three joined rooms return with names resolved, the unnamed room falling back to its id, and "Board (private)" correctly flagged encrypted.
- "Design Crit" appears under invited; **Accept** moves it into joined and returns it selectable.
- Accepting a room with **no invite** is refused, with `/join` never called.
- **Remove** took the `IntegrationCredential` row with it — zero of each afterwards.

56 new unit/component tests. Full suite green (2440), typecheck clean, lint clean (worktree bypass per CLAUDE.md).

One limitation, stated plainly: modal *opening* could not be driven through the browser pane — the pane is hidden, so `requestAnimationFrame` is throttled and Mantine's modal transition never completes. The pre-existing Zulip modal fails identically, which is how I know it's the harness rather than this change. The picker's rendering is covered by component tests instead, and every server-side path was verified over real HTTP.

## Acceptance criteria

- [x] Verify token via `/whoami`, persist only on success
- [x] Reject registration by non-owner/admin members
- [x] Server rows carry a provider value distinct from `"matrix"`
- [x] Picker lists both joined rooms and pending invites
- [x] Accepting an invite joins the bot and offers the room as selectable
- [x] Encrypted rooms are non-selectable, with the reason stated
- [x] `credentialExposure.test.ts` extended to cover the Matrix access token
- [x] `MatrixClient.test.ts` stubs `fetch` in the style of `MatrixNotificationService.test.ts`
- [x] No hardcoded colors; typecheck + lint pass

---

Ships: sandy.beetle


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- New `matrixServer` tRPC router: register, list, rooms, acceptInvite, remove

- Stateless `MatrixClient` fetch wrapper plus SSRF-guarded homeserver URL validation

- Settings UI: `MatrixServerSettings` card and reusable `MatrixRoomPicker`

- Adds `assertWorkspaceRole` helper and extensive unit/component tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["Settings → Matrix"] -- "register / remove" --> R["matrixServer router"]
  Picker["MatrixRoomPicker"] -- "rooms / acceptInvite" --> R
  R -- "assertWorkspaceRole" --> ACL["access service"]
  R -- "SSRF guard" --> URL["homeserverUrl"]
  R -- "encrypted token" --> DB["Integration + Credential"]
  R -- "fetch C-S API" --> MC["MatrixClient"]
  MC --> HS["Homeserver"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>matrixServer.ts</strong><dd><code>New router for registering and browsing Matrix servers</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-88d8fb1cd86a9f5773a3a759de7959f2f5d0afa26f359a060dfdff0472ddc771">+341/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MatrixClient.ts</strong><dd><code>Stateless Client-Server API wrapper with error typing</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-a6dacf3b6be98a42641f823d82686a2202407b609022fdbe263f9deffe682329">+290/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>matrixServer.ts</strong><dd><code>Read registered servers and build credentialed clients</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-19d5f1d736808d8cd6354b8ddccf16a07b00d867c05696029c3d1395b517db46">+130/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>workspaceResolver.ts</strong><dd><code>Add centralized `assertWorkspaceRole` role gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-fd50562323455697341f0c6db10bb7b06c6db8afbeba64f9276edf98d4b011af">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export `assertWorkspaceRole` from access service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-74fa8db7237706b8a79d9f10fdaee87b9805928dd72cb942e4b2d489a2215dc3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MatrixServerSettings.tsx</strong><dd><code>Settings card to register, browse and remove servers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-62e00acd5c2698405267f16d18ce96592668c7bc973309292dda0991f3c2ff25">+243/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MatrixRoomPicker.tsx</strong><dd><code>Reusable room picker with invites and encryption handling</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-e4db6232ebbc6c476f0b3c1348ba9909b139fb35838cdd74e344185a76756b82">+213/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Add Matrix section to workspace settings page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-0ac5e4711f55c32c32d6519fc8c97fef283b6baff89a3712fee47cbc4ddc65f7">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Security</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>homeserverUrl.ts</strong><dd><code>SSRF guard for user-supplied homeserver URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-86732c8d4f475ea6785cb5f8aa25dad1c537f706070209aa23db9140712f236a">+147/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>constants.ts</strong><dd><code>Provider, credential key type and config shape constants</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-e10dbc0293662110edafc32c70fd535909c921d15d9ebf77c74ecef68fe9ee8a">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>root.ts</strong><dd><code>Register `matrixServer` router in app router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-6a8cad7e52067d5afa93671900c038e0e0a9526f8f0e3bd10985cecf4295b4fc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>matrixServer.test.ts</strong><dd><code>Router tests for roles, SSRF, credentials and invites</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-34efc6d0c114e4a2b03cc7f6d27ea52a244541e7e848ba4259c5cdaa62c113bb">+640/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MatrixClient.test.ts</strong><dd><code>Tests for client requests, redirects and error handling</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-fb8950ed352a1ef3d3b01a6f16e12f9c496e9a3495db837c6c4998ecb09c2027">+347/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>homeserverUrl.test.ts</strong><dd><code>Tests for private/loopback address and scheme rejection</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-6cf87fc01862acdf4d8c798e151cfadc9034011ef1426ec0cbfd44cd457cc68a">+109/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MatrixRoomPicker.test.tsx</strong><dd><code>Component tests for room listing, invites, encryption</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-d0f81f0d7179423aae010e7ffa2eeaea822ae6d302f97cd4c8e686903ca656d1">+256/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>credentialExposure.test.ts</strong><dd><code>Assert no matrixServer procedure exposes the token</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/546/files#diff-f6acd36d2b0757ebe4c421f086079a994149dcc2b6ec5e895bb424ee7efd3d51">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

