### PR TITLE
fix(calendar): show the connection toast after a successful OAuth return

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,6 +4,12 @@ Productivity OS that turns meeting transcripts into projects, actions, and decis
 
 ## Language
 
+### Deployment and sovereignty
+
+**Sovereign installation**:
+An Exponential installation that operates without an Exponential-controlled account or control plane. Its operator controls compute, primary data, object storage, credentials and encryption keys, identity, backups and exports, and update timing; it may use external processors explicitly configured by the operator.
+_Avoid_: Self-hosted, BYOC, customer cloud, or air-gapped as synonyms — those terms do not by themselves describe this control boundary.
+
 ### Meetings
 
 **Meeting**:

--- a/src/app/_components/calendar/CalendarPageContent.tsx
+++ b/src/app/_components/calendar/CalendarPageContent.tsx
@@ -6,6 +6,7 @@ import { notifications } from "@mantine/notifications";
 import { useState } from "react";
 import { api } from "~/trpc/react";
 import { useCalendarNavigation } from "./useCalendarNavigation";
+import { useCalendarConnectionToast } from "./useCalendarConnectionToast";
 import { CalendarHeader } from "./CalendarHeader";
 import { CalendarSidebar } from "./CalendarSidebar";
 import { CalendarDayTimeGrid } from "./CalendarDayTimeGrid";
@@ -38,6 +39,15 @@ export function CalendarPageContent() {
     goNext,
     goPrevious,
   } = useCalendarNavigation();
+
+  // Show toast for calendar_connected / calendar_error search params.
+  // Must live here (not in GoogleCalendarConnect/MicrosoftCalendarConnect)
+  // because after OAuth the calendar IS connected and those components
+  // only render in the disconnected empty state. Passing the connection
+  // state hands the disconnected case back to them, so a failed OAuth
+  // round-trip — which lands here still disconnected, with calendar_error
+  // set, and with both components mounted — shows one toast, not two.
+  useCalendarConnectionToast(calendarConnected);
 
   // Fetch calendar events from all selected calendars
   const { data: events, isLoading: eventsLoading } =

--- a/src/app/_components/calendar/useCalendarConnectionToast.ts
+++ b/src/app/_components/calendar/useCalendarConnectionToast.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { notifications } from "@mantine/notifications";
+import { useEffect, useRef } from "react";
+
+/**
+ * Shows toast notifications for calendar connection/error search params.
+ *
+ * This hook must run in a component that mounts on the calendar page
+ * regardless of connection status — after OAuth the calendar IS connected,
+ * so the GoogleCalendarConnect / MicrosoftCalendarConnect components
+ * (which only render in the disconnected empty state) never mount, and
+ * their identical useEffect never fires.
+ *
+ * `enabled` is the other half of that: when the calendar is *not* connected
+ * those components do mount and do fire, so running here as well would show
+ * every toast twice — which is exactly what a failed OAuth round-trip hits,
+ * since it returns to this page still disconnected and with `calendar_error`
+ * set. Pass the connection state and the two paths stay mutually exclusive.
+ */
+export function useCalendarConnectionToast(enabled = true) {
+  const searchParams = useSearchParams();
+  // The params survive in the URL after the toast, and `enabled` flips once
+  // the connection query resolves — so without this the same success toast
+  // fires again on the next render that changes either dependency.
+  const alreadyShown = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || alreadyShown.current) return;
+
+    const googleConnected = searchParams.get("calendar_connected");
+    const microsoftConnected = searchParams.get(
+      "microsoft_calendar_connected",
+    );
+    const calendarError = searchParams.get("calendar_error");
+
+    if (googleConnected === "true") {
+      notifications.show({
+        title: "Calendar Connected!",
+        message:
+          "Your Google Calendar is now connected and ready to use.",
+        color: "green",
+      });
+    }
+
+    if (microsoftConnected === "true") {
+      notifications.show({
+        title: "Calendar Connected!",
+        message:
+          "Your Outlook Calendar is now connected and ready to use.",
+        color: "green",
+      });
+    }
+
+    if (calendarError) {
+      let errorMessage = "Failed to connect calendar.";
+      switch (calendarError) {
+        case "access_denied":
+          errorMessage =
+            "Calendar access was denied. Please try again and grant permissions.";
+          break;
+        case "invalid_request":
+          errorMessage =
+            "Invalid request. Please try connecting again.";
+          break;
+        case "no_google_account":
+          errorMessage =
+            "Please sign in with Google first, then connect your calendar.";
+          break;
+        case "no_refresh_token":
+          errorMessage =
+            "Failed to get long-term access. Please try connecting again.";
+          break;
+        case "token_exchange_failed":
+          errorMessage =
+            "Failed to connect calendar. Please try again.";
+          break;
+      }
+      notifications.show({
+        title: "Connection Failed",
+        message: errorMessage,
+        color: "red",
+      });
+    }
+
+    // Latch only once something was actually shown: a first render with no
+    // params must not suppress a toast that arrives on a later client-side
+    // navigation.
+    if (googleConnected === "true" || microsoftConnected === "true" || calendarError) {
+      alreadyShown.current = true;
+    }
+  }, [searchParams, enabled]);
+}

--- a/src/app/_components/calendar/useCalendarConnectionToast.ts
+++ b/src/app/_components/calendar/useCalendarConnectionToast.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { notifications } from "@mantine/notifications";
 import { useEffect, useRef } from "react";
 
@@ -19,11 +19,13 @@ import { useEffect, useRef } from "react";
  * since it returns to this page still disconnected and with `calendar_error`
  * set. Pass the connection state and the two paths stay mutually exclusive.
  */
-export function useCalendarConnectionToast(enabled = true) {
+export function useCalendarConnectionToast(enabled: boolean) {
   const searchParams = useSearchParams();
-  // The params survive in the URL after the toast, and `enabled` flips once
-  // the connection query resolves — so without this the same success toast
-  // fires again on the next render that changes either dependency.
+  const router = useRouter();
+  const pathname = usePathname();
+  // Guards the window between showing a toast and the URL rewrite below
+  // committing, during which this effect can re-run with the params still
+  // present.
   const alreadyShown = useRef(false);
 
   useEffect(() => {
@@ -89,6 +91,18 @@ export function useCalendarConnectionToast(enabled = true) {
     // navigation.
     if (googleConnected === "true" || microsoftConnected === "true" || calendarError) {
       alreadyShown.current = true;
+
+      // Strip the params so the toast is a one-off. They are consumed here
+      // and nowhere else, and leaving them in place replays the toast on
+      // every reload or remount — a ref only lives as long as the mount.
+      const remaining = new URLSearchParams(searchParams);
+      remaining.delete("calendar_connected");
+      remaining.delete("microsoft_calendar_connected");
+      remaining.delete("calendar_error");
+      const query = remaining.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname, {
+        scroll: false,
+      });
     }
-  }, [searchParams, enabled]);
+  }, [searchParams, enabled, router, pathname]);
 }


### PR DESCRIPTION
### **User description**
## What

- New `useCalendarConnectionToast(enabled)` hook, called from `CalendarPageContent`, showing the success/error toast for `calendar_connected`, `microsoft_calendar_connected` and `calendar_error`.
- Unrelated but riding along in its own commit: a `CONTEXT.md` glossary entry defining **Sovereign installation**.

## Why

The toast logic lived inside `GoogleCalendarConnect` / `MicrosoftCalendarConnect`, which only render in the **disconnected empty state**. After OAuth succeeded the calendar was connected, so those components never mounted and their `useEffect` never fired — the success toast was unreachable.

## The duplicate it would have introduced

Hoisting the effect alone isn't enough: those components still carry their own copy, and `CalendarPageContent` renders both in the disconnected state. A *failed* OAuth round-trip returns to this page still disconnected, with `calendar_error` set and both components mounted — so the error would have fired twice.

`enabled` makes the two paths mutually exclusive: connected → the hook (components absent); disconnected → the components (hook suppressed). That avoids touching the four other call sites (`settings/integrations`, `CreateMeetingModal`, `ProjectCalendarCard`, the calendar empty state), which still rely on the components' own effect after an OAuth `returnUrl` bounce.

A `useRef` latch stops a re-fire, since the params persist in the URL and `enabled` flips when the connection query resolves.

## Testing

- 2398 unit tests pass; typecheck and lint clean.
- The existing `GoogleCalendarConnect.test.tsx` (8 tests) passes unchanged — that component is untouched.

Not manually exercised through a live OAuth round-trip; the reasoning above is from the render paths.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Add `useCalendarConnectionToast` hook for OAuth return toasts

- Call it from `CalendarPageContent`, gated on connection state

- Strip connection params from URL after showing toast

- Add `Sovereign installation` glossary entry to `CONTEXT.md`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oauth["OAuth return with search params"] -- "connected" --> hook["useCalendarConnectionToast(enabled)"]
  oauth -- "disconnected" --> components["Google/MicrosoftCalendarConnect effects"]
  hook -- "show toast once (ref latch)" --> strip["router.replace strips params"]
  page["CalendarPageContent"] -- "always mounted" --> hook
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useCalendarConnectionToast.ts</strong><dd><code>New hook for calendar connection toasts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/calendar/useCalendarConnectionToast.ts

<ul><li>New client hook showing success/error toasts for <code>calendar_connected</code>, <br><code>microsoft_calendar_connected</code> and <code>calendar_error</code> params.<br> <li> Maps error codes (<code>access_denied</code>, <code>no_refresh_token</code>, etc.) to <br>user-facing messages.<br> <li> Uses a <code>useRef</code> latch, set only when a toast actually fires, to prevent <br>re-firing.<br> <li> Removes the consumed params via <code>router.replace</code> so reloads/remounts <br>don't replay the toast.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/547/files#diff-7003b11d3c345857501aa94eff6e512f2d59d6996692ba096c8028fe5ea59597">+108/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CalendarPageContent.tsx</strong><dd><code>Invoke connection toast hook from calendar page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/calendar/CalendarPageContent.tsx

<ul><li>Imports and calls <code>useCalendarConnectionToast(calendarConnected)</code>.<br> <li> Comment explains why the toast must live here and why it is gated on <br>connection state to avoid duplicate toasts.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/547/files#diff-4dc94e639de63c1ae8f866804c60495505c1f8afbaacb6f643ea67471ab4d5b0">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONTEXT.md</strong><dd><code>Add Sovereign installation glossary entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CONTEXT.md

<ul><li>Adds a <code>Deployment and sovereignty</code> section to the glossary.<br> <li> Defines <code>Sovereign installation</code> and its operator control boundary.<br> <li> Lists terms to avoid as synonyms (self-hosted, BYOC, customer cloud, <br>air-gapped).</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/547/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

