### PR TITLE
fix(goals): render Markdown in goal updates, comments and OKR drawer

### DIFF
--- a/src/app/_components/initiatives/GoalDetailContent.tsx
+++ b/src/app/_components/initiatives/GoalDetailContent.tsx
@@ -459,9 +459,12 @@ export function GoalDetailContent({ goalId, workspaceSlug }: GoalDetailContentPr
                 </Group>
 
                 {latestComment && (
-                  <Text size="sm" className="text-text-primary mb-3">
-                    {latestComment.content}
-                  </Text>
+                  <div className="mb-3">
+                    <MarkdownRenderer
+                      content={latestComment.content}
+                      variant="compact"
+                    />
+                  </div>
                 )}
 
                 <Group gap="sm" mt="xs">

--- a/src/plugins/okr/client/components/OkrDetailDrawer.tsx
+++ b/src/plugins/okr/client/components/OkrDetailDrawer.tsx
@@ -26,6 +26,7 @@ import { formatDistanceToNow, format } from "date-fns";
 import { api, type RouterOutputs } from "~/trpc/react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { useFavorite } from "~/app/_components/shared/useFavorite";
+import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
 import {
   clamp01,
   effectiveConfidence,
@@ -855,9 +856,7 @@ function LatestUpdateCard({
             <div className="flex-1" />
             <span className="text-[11px] text-text-muted">{latest.whenLabel}</span>
           </div>
-          <div className="text-sm leading-relaxed text-text-secondary">
-            {latest.body}
-          </div>
+          <MarkdownRenderer content={latest.body} variant="compact" />
         </>
       ) : (
         <div className="flex items-center gap-2 text-sm text-text-muted">
@@ -875,9 +874,7 @@ function DescriptionCard({ text }: { text?: string | null }) {
       <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wider text-text-muted">
         Description
       </div>
-      <div className="whitespace-pre-wrap text-sm leading-relaxed text-text-secondary">
-        {text}
-      </div>
+      <MarkdownRenderer content={text} variant="compact" />
     </div>
   );
 }
@@ -1140,8 +1137,8 @@ function ActivityFeed({
               </span>
             </div>
             {it.kind === "comment" ? (
-              <div className="mt-2 whitespace-pre-wrap rounded-lg border border-border-secondary bg-surface-primary p-3 text-sm leading-relaxed text-text-secondary">
-                {it.body}
+              <div className="mt-2 rounded-lg border border-border-secondary bg-surface-primary p-3">
+                <MarkdownRenderer content={it.body} variant="compact" />
               </div>
             ) : (
               <div className="mt-2 inline-flex items-baseline gap-2 rounded-lg border border-border-secondary bg-surface-primary px-3 py-2 tabular-nums">
@@ -1298,8 +1295,8 @@ function ObjectiveActivityFeed({
                       />
                     </div>
                   )}
-                  <div className="mt-2 whitespace-pre-wrap rounded-lg border border-border-secondary bg-surface-primary p-3 text-sm leading-relaxed text-text-secondary">
-                    {it.content}
+                  <div className="mt-2 rounded-lg border border-border-secondary bg-surface-primary p-3">
+                    <MarkdownRenderer content={it.content} variant="compact" />
                   </div>
                 </>
               )}


### PR DESCRIPTION
### **User description**
## What

- Replace plain-text render sites for authored prose with the canonical `MarkdownRenderer` (compact variant), per ADR-0017:
  - Goal detail page: **Latest update** card
  - OKR objective drawer: `LatestUpdateCard`, both activity feeds (comments + updates), and `DescriptionCard`

## Why

Comments/updates written via the Exponential CLI are Markdown, but the goal detail page (`/w/<ws>/goals/<id>`) and the OKR objective drawer (`?tab=okrs&drawer=objective:<id>`) rendered them as raw text — asterisks, backticks and list markers showed literally.

Verified in the dev-fixture workspace: bold/italic, inline code, ordered/unordered lists and links all render in every touched surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Render Markdown in goal detail latest update

- Render Markdown in OKR drawer cards/feeds

- Use canonical `MarkdownRenderer` compact variant per ADR-0017


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI-authored Markdown content"] -- "before" --> B["Plain text render (raw asterisks/backticks)"]
  A -- "after" --> C["MarkdownRenderer (variant=compact)"]
  C --> D["Goal detail latest update"]
  C --> E["OKR LatestUpdateCard"]
  C --> F["OKR DescriptionCard"]
  C --> G["Activity feeds (comments + updates)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GoalDetailContent.tsx</strong><dd><code>Render latest goal update as Markdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/initiatives/GoalDetailContent.tsx

<ul><li>Replaced plain <code>Text</code> rendering of the latest comment with <br><code>MarkdownRenderer</code> (compact variant)<br> <li> Wrapped renderer in a <code>div</code> retaining the <code>mb-3</code> spacing</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/548/files#diff-3d8ec56096ef9ab467a8904e66e2b1d19670aff1eb580ee0ac52008a3e70dee0">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OkrDetailDrawer.tsx</strong><dd><code>Markdown rendering across OKR drawer surfaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/okr/client/components/OkrDetailDrawer.tsx

<ul><li>Imported <code>MarkdownRenderer</code> from shared components<br> <li> <code>LatestUpdateCard</code> and <code>DescriptionCard</code> now render body/description as <br>Markdown<br> <li> Both <code>ActivityFeed</code> and <code>ObjectiveActivityFeed</code> comment bodies render <br>Markdown<br> <li> Removed <code>whitespace-pre-wrap</code> and inline text styling in favor of <br>renderer styles</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/548/files#diff-997f0c66c35e5d98639f2be6dcda60d6df6df9d5a6590a4197af8acdcbf8656c">+7/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

