### PR TITLE
feat(activity): render feature events with real names in the feed

### DIFF
--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -231,6 +231,7 @@ export async function loadFeatureWithAccess(
     where: { id: featureId },
     select: {
       id: true,
+      name: true,
       productId: true,
       product: { select: { workspaceId: true } },
     },
@@ -254,7 +255,11 @@ async function loadScopeWithAccess(
       featureId: true,
       status: true,
       feature: {
-        select: { productId: true, product: { select: { workspaceId: true } } },
+        select: {
+          name: true,
+          productId: true,
+          product: { select: { workspaceId: true } },
+        },
       },
     },
   });
@@ -549,6 +554,7 @@ export const featureRouter = createTRPCRouter({
         entityType: "feature",
         entityId: created.id,
         action: "created",
+        metadata: { name: created.name },
       });
       return created;
     }),
@@ -690,7 +696,11 @@ export const featureRouter = createTRPCRouter({
             entityType: "feature",
             entityId: id,
             action: "status_changed",
-            metadata: { from: prev?.status ?? "", to: rest.status! },
+            metadata: {
+              from: prev?.status ?? "",
+              to: rest.status!,
+              name: rest.name ?? feature.name,
+            },
           });
           return;
         }
@@ -705,7 +715,7 @@ export const featureRouter = createTRPCRouter({
             entityType: "feature",
             entityId: id,
             action: "updated",
-            metadata: { fieldsChanged },
+            metadata: { fieldsChanged, name: rest.name ?? feature.name },
           });
         }
       };
@@ -811,6 +821,7 @@ export const featureRouter = createTRPCRouter({
         where: { id: { in: uniqueIds } },
         select: {
           id: true,
+          name: true,
           status: true,
           productId: true,
           product: { select: { workspaceId: true } },
@@ -896,7 +907,12 @@ export const featureRouter = createTRPCRouter({
                 entityType: "feature",
                 entityId: f.id,
                 action: "status_changed",
-                metadata: { from: f.status, to: input.status!, bulk: true },
+                metadata: {
+                  from: f.status,
+                  to: input.status!,
+                  bulk: true,
+                  name: f.name,
+                },
               });
             }
             if (fieldsChanged.length === 0) return Promise.resolve(true);
@@ -906,7 +922,7 @@ export const featureRouter = createTRPCRouter({
               entityType: "feature",
               entityId: f.id,
               action: "updated",
-              metadata: { fieldsChanged, bulk: true },
+              metadata: { fieldsChanged, bulk: true, name: f.name },
             });
           }),
       );
@@ -1233,7 +1249,11 @@ export const featureRouter = createTRPCRouter({
         entityType: "feature_scope",
         entityId: scope.id,
         action: "created",
-        metadata: { featureId: input.featureId, version: input.version },
+        metadata: {
+          featureId: input.featureId,
+          version: input.version,
+          name: parentFeature.name,
+        },
       });
       return scope;
     }),
@@ -1276,7 +1296,11 @@ export const featureRouter = createTRPCRouter({
           entityType: "feature_scope",
           entityId: scope.id,
           action: "status_changed",
-          metadata: { from: scope.status, to: input.status! },
+          metadata: {
+            from: scope.status,
+            to: input.status!,
+            name: scope.feature.name,
+          },
         });
       } else {
         // displayOrder is drag-reorder noise, not timeline material.
@@ -1290,7 +1314,7 @@ export const featureRouter = createTRPCRouter({
             entityType: "feature_scope",
             entityId: scope.id,
             action: "updated",
-            metadata: { fieldsChanged },
+            metadata: { fieldsChanged, name: scope.feature.name },
           });
         }
       }

--- a/src/plugins/product/server/routers/feature.ts
+++ b/src/plugins/product/server/routers/feature.ts
@@ -1299,6 +1299,7 @@ export const featureRouter = createTRPCRouter({
           metadata: {
             from: scope.status,
             to: input.status!,
+            featureId: scope.featureId,
             name: scope.feature.name,
           },
         });
@@ -1314,7 +1315,11 @@ export const featureRouter = createTRPCRouter({
             entityType: "feature_scope",
             entityId: scope.id,
             action: "updated",
-            metadata: { fieldsChanged, name: scope.feature.name },
+            metadata: {
+              fieldsChanged,
+              featureId: scope.featureId,
+              name: scope.feature.name,
+            },
           });
         }
       }

--- a/src/server/services/activity/__tests__/feedRenderHints.test.ts
+++ b/src/server/services/activity/__tests__/feedRenderHints.test.ts
@@ -95,7 +95,9 @@ describe("resolveFeedHint", () => {
     // Scopes have no name of their own (only a version), so the write sites
     // put the parent feature's name in metadata and the templates say so.
     const created = resolveFeedHint("feature_scope", "created");
-    expect(created.template).toBe("{actor} added a scope to feature {entityRef}");
+    expect(created.template).toBe(
+      "{actor} added a scope to feature {entityRef}",
+    );
     expect(created.iconKind).toBe("created");
 
     const updated = resolveFeedHint("feature_scope", "updated");

--- a/src/server/services/activity/__tests__/feedRenderHints.test.ts
+++ b/src/server/services/activity/__tests__/feedRenderHints.test.ts
@@ -75,6 +75,42 @@ describe("resolveFeedHint", () => {
     expect(hint.template).toContain("{entityRef}");
   });
 
+  it("renders feature events as readable sentences, not the fallback", () => {
+    const created = resolveFeedHint("feature", "created");
+    expect(created.template).toBe("{actor} created feature {entityRef}");
+    expect(created.iconKind).toBe("created");
+
+    const updated = resolveFeedHint("feature", "updated");
+    expect(updated.template).toBe("{actor} updated feature {entityRef}");
+    expect(updated.iconKind).toBe("updated");
+
+    const statusChanged = resolveFeedHint("feature", "status_changed");
+    expect(statusChanged.template).toBe(
+      "{actor} changed status on feature {entityRef}",
+    );
+    expect(statusChanged.iconKind).toBe("status_changed");
+  });
+
+  it("renders feature scope events against the parent feature's name", () => {
+    // Scopes have no name of their own (only a version), so the write sites
+    // put the parent feature's name in metadata and the templates say so.
+    const created = resolveFeedHint("feature_scope", "created");
+    expect(created.template).toBe("{actor} added a scope to feature {entityRef}");
+    expect(created.iconKind).toBe("created");
+
+    const updated = resolveFeedHint("feature_scope", "updated");
+    expect(updated.template).toBe(
+      "{actor} updated a scope on feature {entityRef}",
+    );
+    expect(updated.iconKind).toBe("updated");
+
+    const statusChanged = resolveFeedHint("feature_scope", "status_changed");
+    expect(statusChanged.template).toBe(
+      "{actor} changed a scope status on feature {entityRef}",
+    );
+    expect(statusChanged.iconKind).toBe("status_changed");
+  });
+
   it("falls back to a neutral hint for unknown pairs", () => {
     const hint = resolveFeedHint("nonsense", "nonsense");
     expect(hint.iconKind).toBe("fallback");

--- a/src/server/services/activity/feedRenderHints.ts
+++ b/src/server/services/activity/feedRenderHints.ts
@@ -85,6 +85,37 @@ const HINTS: Record<string, FeedRenderHint> = {
     iconKind: "commented",
   },
 
+  // Features (product plugin). Every feature event carries the feature name in
+  // metadata so {entityRef} renders the name, not a CUID slice.
+  [key("feature", "created")]: {
+    template: "{actor} created feature {entityRef}",
+    iconKind: "created",
+  },
+  [key("feature", "updated")]: {
+    template: "{actor} updated feature {entityRef}",
+    iconKind: "updated",
+  },
+  [key("feature", "status_changed")]: {
+    template: "{actor} changed status on feature {entityRef}",
+    iconKind: "status_changed",
+  },
+
+  // Feature scopes. A scope has no name of its own (only a version like "V1"),
+  // so scope events carry the PARENT feature's name in metadata and the
+  // templates read "…scope on/to feature {entityRef}".
+  [key("feature_scope", "created")]: {
+    template: "{actor} added a scope to feature {entityRef}",
+    iconKind: "created",
+  },
+  [key("feature_scope", "updated")]: {
+    template: "{actor} updated a scope on feature {entityRef}",
+    iconKind: "updated",
+  },
+  [key("feature_scope", "status_changed")]: {
+    template: "{actor} changed a scope status on feature {entityRef}",
+    iconKind: "status_changed",
+  },
+
   // Projects — completing a project is a milestone, so it gets the emphasized
   // "milestone" icon kind (trophy + filled chip) to stand out from task churn.
   [key("project", "created")]: {


### PR DESCRIPTION
### **User description**
## What

- Add render-hint templates for `feature` (created / updated / status_changed) and `feature_scope` (created / updated / status_changed) events to the workspace activity feed registry.
- Pass the feature name in event metadata from every feature and feature-scope `recordActivity` call site, so `{entityRef}` renders the feature's name instead of a truncated CUID. Scope events carry the parent feature's name (a scope only has a version, not a name).
- Pin the new hint pairs in the `feedRenderHints` unit tests.

## Why

Feature/ticket backlog work is instrumented into `WorkspaceActivityEvent`, but feature rows rendered as the neutral fallback sentence "James touched a1b2c3d4" on the workspace home feed. Tickets already rendered properly; this brings features to parity.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add feed render hints for `feature` and `feature_scope` events

- Pass feature `name` in activity metadata at all call sites

- Carry `featureId` in scope update/status metadata for links

- Select `name` in feature/scope access-loading queries

- Cover new hint pairs with unit tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["feature / feature_scope<br/>recordActivity calls"] -- "metadata: name, featureId" --> B["WorkspaceActivityEvent"]
  B --> C["feedRenderHints registry"]
  C -- "new feature templates" --> D["Readable feed sentence"]
  C -- "previously missing" --> E["Fallback: actor touched CUID"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>feedRenderHints.ts</strong><dd><code>Register feature and feature scope feed templates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/activity/feedRenderHints.ts

<ul><li>Added render-hint templates for <code>feature</code> created/updated/status_changed<br> <li> Added templates for <code>feature_scope</code> created/updated/status_changed <br>referencing the parent feature<br> <li> Documented why scope events use the parent feature name</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/549/files#diff-0ac3c61aee5e71e9b01643e40ecb972e63ef7f3dac140e646e5fd790b8034991">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>feature.ts</strong><dd><code>Pass feature name and featureId in activity metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/routers/feature.ts

<ul><li>Select <code>name</code> in <code>loadFeatureWithAccess</code>, <code>loadScopeWithAccess</code> and bulk <br>update query<br> <li> Include <code>name</code> in metadata for feature create/update/status_changed <br>activities (single and bulk)<br> <li> Include parent feature <code>name</code> in feature_scope <br>create/update/status_changed metadata<br> <li> Add <code>featureId</code> to scope update/status_changed metadata for link <br>resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/549/files#diff-bff1a29f77efa7f846d655a0106c96302d007305d09f09ecb53ab204ef97d03d">+37/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>feedRenderHints.test.ts</strong><dd><code>Test new feature and scope render hints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/activity/__tests__/feedRenderHints.test.ts

<ul><li>Added test asserting feature event templates and icon kinds<br> <li> Added test asserting feature_scope templates resolve against parent <br>feature</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/549/files#diff-81f59b62a1bf74560fa967a2c6003206fed7cabff4083f086e411e38916b48e2">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

