### PR TITLE
fix(activity): hide Notion ticket-sync runs from the feed

### DIFF
--- a/src/server/services/activity/__tests__/feed.test.ts
+++ b/src/server/services/activity/__tests__/feed.test.ts
@@ -74,7 +74,7 @@ describe("getActivityFeed — channel summaries + source filter", () => {
     );
   });
 
-  it("excludes channel summaries when source is internal", async () => {
+  it("excludes channel summaries and hidden types when source is internal", async () => {
     db.workspaceActivityEvent.findMany.mockResolvedValue([] as never);
 
     await getActivityFeed(db, { workspaceId: WORKSPACE_ID, source: "internal" });
@@ -83,19 +83,21 @@ describe("getActivityFeed — channel summaries + source filter", () => {
       expect.objectContaining({
         where: expect.objectContaining({
           workspaceId: WORKSPACE_ID,
-          entityType: { not: "channel_summary" },
+          entityType: { notIn: ["channel_summary", "ticket_sync_run"] },
         }),
       }),
     );
   });
 
-  it("applies no source constraint for 'all' (default)", async () => {
+  it("excludes only hidden types for 'all' (default)", async () => {
     db.workspaceActivityEvent.findMany.mockResolvedValue([] as never);
 
     await getActivityFeed(db, { workspaceId: WORKSPACE_ID, source: "all" });
 
     const call = db.workspaceActivityEvent.findMany.mock.calls[0]![0]!;
-    expect(call.where).not.toHaveProperty("entityType");
+    expect(call.where).toMatchObject({
+      entityType: { notIn: ["ticket_sync_run"] },
+    });
     expect(call.where).not.toHaveProperty("metadata");
   });
 });

--- a/src/server/services/activity/feed.ts
+++ b/src/server/services/activity/feed.ts
@@ -114,7 +114,7 @@ function readMetaString(metadata: unknown, key: string): string | null {
  * Notion ticket-sync runs are operational noise at feed altitude — the synced
  * tickets themselves already surface as regular ticket events.
  */
-const HIDDEN_ENTITY_TYPES = ["ticket_sync_run"];
+const HIDDEN_ENTITY_TYPES = ["ticket_sync_run"] as const;
 
 /**
  * Translate a `source` filter into a Prisma `where` fragment. `undefined`/`all`
@@ -126,7 +126,7 @@ function sourceWhere(
   source?: string,
 ): Prisma.WorkspaceActivityEventWhereInput {
   if (!source || source === "all") {
-    return { entityType: { notIn: HIDDEN_ENTITY_TYPES } };
+    return { entityType: { notIn: [...HIDDEN_ENTITY_TYPES] } };
   }
   if (source === "internal") {
     return {

--- a/src/server/services/activity/feed.ts
+++ b/src/server/services/activity/feed.ts
@@ -110,16 +110,28 @@ function readMetaString(metadata: unknown, key: string): string | null {
 }
 
 /**
+ * Entity types recorded for audit purposes but never shown on feed surfaces.
+ * Notion ticket-sync runs are operational noise at feed altitude — the synced
+ * tickets themselves already surface as regular ticket events.
+ */
+const HIDDEN_ENTITY_TYPES = ["ticket_sync_run"];
+
+/**
  * Translate a `source` filter into a Prisma `where` fragment. `undefined`/`all`
- * → no constraint; `internal` → everything except channel summaries; any other
- * value is treated as a provider → that provider's `channel_summary` rows.
+ * → only the hidden-type exclusion; `internal` → everything except channel
+ * summaries (and hidden types); any other value is treated as a provider →
+ * that provider's `channel_summary` rows.
  */
 function sourceWhere(
   source?: string,
 ): Prisma.WorkspaceActivityEventWhereInput {
-  if (!source || source === "all") return {};
+  if (!source || source === "all") {
+    return { entityType: { notIn: HIDDEN_ENTITY_TYPES } };
+  }
   if (source === "internal") {
-    return { entityType: { not: "channel_summary" } };
+    return {
+      entityType: { notIn: ["channel_summary", ...HIDDEN_ENTITY_TYPES] },
+    };
   }
   return {
     entityType: "channel_summary",


### PR DESCRIPTION
### **User description**
## What

- Exclude `ticket_sync_run` events (Notion ticket syncs) from the activity feed readers via a `HIDDEN_ENTITY_TYPES` exclusion in `sourceWhere`, covering the workspace `/w/[slug]/activity` page, the aggregated `/activity` page, and the home activity card.
- Update the feed unit tests to assert the new where-clauses.

## Why

Sync runs are operational noise at feed altitude — the synced tickets themselves already surface as regular ticket events. Verified in the browser against a seeded fixture workspace: a planted `ticket_sync_run` row is hidden on both pages while normal events still render.


___

### **PR Type**
Bug fix


___

### **Description**
- Exclude `ticket_sync_run` events from activity feeds

- Replace `not` filter with `notIn` in `sourceWhere`

- Apply hidden-type exclusion to all source filters

- Update feed unit tests for new where-clauses


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["source filter"] --> B["sourceWhere()"]
  B -- "all/undefined" --> C["notIn: [ticket_sync_run]"]
  B -- "internal" --> D["notIn: [channel_summary, ticket_sync_run]"]
  B -- "provider" --> E["channel_summary + provider match"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>feed.ts</strong><dd><code>Exclude hidden entity types in feed source filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/activity/feed.ts

<ul><li>Added <code>HIDDEN_ENTITY_TYPES</code> const (<code>ticket_sync_run</code>) with explanatory <br>comment.<br> <li> <code>sourceWhere</code> now returns a <code>notIn</code> exclusion for the default/<code>all</code> case <br>instead of an empty object.<br> <li> <code>internal</code> case switched from <code>entityType: { not: "channel_summary" }</code> to <br><code>notIn</code> including hidden types.<br> <li> Updated doc comment to describe the new filtering behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/553/files#diff-534acf3f64bafa21234f271ab348b5773103f28e109b14b2961ca9f579257d8b">+16/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>feed.test.ts</strong><dd><code>Update feed tests for hidden-type where clauses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/activity/__tests__/feed.test.ts

<ul><li>Updated <code>internal</code> source test to expect <code>notIn: ["channel_summary", </code><br><code>"ticket_sync_run"]</code>.<br> <li> Replaced the "no source constraint" assertion for <code>all</code> with a <br><code>toMatchObject</code> check for <code>notIn: ["ticket_sync_run"]</code>.<br> <li> Renamed both tests to reflect hidden-type exclusion.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/553/files#diff-100864579f854180f382628b1b13d60e808f368c94d0e2673a51490db629ee30">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

