### PR TITLE
fix(comments): show mentions as @Name in composers instead of raw markup

### DIFF
--- a/src/app/_components/ActionDetailContent.tsx
+++ b/src/app/_components/ActionDetailContent.tsx
@@ -447,6 +447,7 @@ export function ActionDetailContent({
             onEditComment={activity.editComment}
             onDeleteImage={activity.deleteImage}
             mentionNames={activity.mentionNames}
+            mentionCandidates={activity.mentionCandidates}
             emptyMessage="No comments yet. Start the discussion!"
           />
 

--- a/src/app/_components/prd/PrdCommentsPanel.tsx
+++ b/src/app/_components/prd/PrdCommentsPanel.tsx
@@ -153,6 +153,7 @@ export function PrdCommentsPanel({
           comments={toThreadComments(rootRows)}
           currentUserId={currentUserId}
           mentionNames={mentionNames}
+          mentionCandidates={mentionCandidates}
           variant="inline"
           emptyMessage={null}
         />
@@ -163,6 +164,7 @@ export function PrdCommentsPanel({
               comments={toThreadComments(replyRows)}
               currentUserId={currentUserId}
               mentionNames={mentionNames}
+              mentionCandidates={mentionCandidates}
               variant="inline"
               emptyMessage={null}
             />

--- a/src/app/_components/prd/PrdThreadPopover.tsx
+++ b/src/app/_components/prd/PrdThreadPopover.tsx
@@ -21,6 +21,7 @@ import {
 } from "~/utils/avatarColors";
 import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
 import { CommentInput } from "~/app/_components/shared/CommentInput";
+import { collapseMentions, expandMentions } from "~/lib/content/mentionText";
 import type { FeatureCommentRow } from "~/app/_components/prd/PrdCommentsPanel";
 import type { ThreadStatus } from "~/lib/prd/thread-reconciliation";
 import type { MentionCandidate } from "~/hooks/useMentionAutocomplete";
@@ -122,14 +123,19 @@ export function PrdThreadPopover({
 
   const startEdit = (c: FeatureCommentRow) => {
     setEditingId(c.id);
-    setEditValue(c.body);
+    setEditValue(
+      mentionCandidates ? collapseMentions(c.body, mentionCandidates) : c.body,
+    );
   };
 
   const saveEdit = async () => {
     if (!editingId || !editValue.trim()) return;
     setSavingEdit(true);
     try {
-      await onEdit(editingId, editValue.trim());
+      const body = mentionCandidates
+        ? expandMentions(editValue.trim(), mentionCandidates)
+        : editValue.trim();
+      await onEdit(editingId, body);
       setEditingId(null);
     } finally {
       setSavingEdit(false);

--- a/src/app/_components/shared/ActivityFeed.tsx
+++ b/src/app/_components/shared/ActivityFeed.tsx
@@ -35,6 +35,7 @@ import type {
   ActivityFilter,
   StatusOption,
 } from "./activityTypes";
+import type { MentionCandidate } from "~/hooks/useMentionAutocomplete";
 
 const QUICK_EMOJIS = ["👍", "👎", "❤️", "🎉", "🚀", "👀", "💯", "🙌"];
 
@@ -62,6 +63,8 @@ interface ActivityFeedProps {
 
   statusOptions?: StatusOption[];
   mentionNames?: string[];
+  /** Enables display-text mentions in inline edit and reply composers. */
+  mentionCandidates?: MentionCandidate[];
   emptyMessage?: string;
 }
 
@@ -78,6 +81,7 @@ export function ActivityFeed({
   onEditReply,
   statusOptions,
   mentionNames,
+  mentionCandidates,
   emptyMessage = "No activity yet. Post an update or leave a comment to get started.",
 }: ActivityFeedProps) {
   const visible =
@@ -111,6 +115,7 @@ export function ActivityFeed({
             onEditReply={onEditReply}
             statusOptions={statusOptions}
             mentionNames={mentionNames}
+            mentionCandidates={mentionCandidates}
           />
         ) : (
           <Card
@@ -129,6 +134,7 @@ export function ActivityFeed({
               onDeleteImage={onDeleteImage}
               currentUserId={currentUserId}
               mentionNames={mentionNames}
+              mentionCandidates={mentionCandidates}
             />
           </Card>
         ),
@@ -278,6 +284,7 @@ function UpdateThread({
   onEditReply,
   statusOptions,
   mentionNames,
+  mentionCandidates,
 }: {
   item: ActivityUpdate;
   currentUserId?: string;
@@ -287,6 +294,7 @@ function UpdateThread({
   onEditReply?: (id: string, content: string) => Promise<void>;
   statusOptions?: StatusOption[];
   mentionNames?: string[];
+  mentionCandidates?: MentionCandidate[];
 }) {
   const [showReply, setShowReply] = useState(false);
   const [isSubmittingReply, setIsSubmittingReply] = useState(false);
@@ -398,6 +406,7 @@ function UpdateThread({
             onEditComment={onEditReply}
             currentUserId={currentUserId}
             mentionNames={mentionNames}
+            mentionCandidates={mentionCandidates}
           />
         </div>
       )}
@@ -409,6 +418,7 @@ function UpdateThread({
             onSubmit={handleAddReply}
             isSubmitting={isSubmittingReply}
             placeholder="Leave a reply..."
+            mentionCandidates={mentionCandidates}
           />
         </div>
       )}

--- a/src/app/_components/shared/ActivityTimeline.tsx
+++ b/src/app/_components/shared/ActivityTimeline.tsx
@@ -43,6 +43,7 @@ export function ActivityTimeline({
         onDeleteComment={activity.deleteComment}
         onEditComment={activity.editComment}
         mentionNames={mentionNames}
+        mentionCandidates={mentionCandidates}
         emptyMessage="No comments yet. Start the discussion!"
       />
       <ActivityComposer

--- a/src/app/_components/shared/CommentInput.tsx
+++ b/src/app/_components/shared/CommentInput.tsx
@@ -11,6 +11,7 @@ import {
 import { MentionDropdown } from "~/app/_components/MentionDropdown";
 import { useImagePaste } from "~/hooks/useImagePaste";
 import { MarkdownInput } from "~/app/_components/shared/MarkdownInput";
+import { expandMentions } from "~/lib/content/mentionText";
 
 interface CommentInputProps {
   onSubmit: (content: string) => Promise<void>;
@@ -59,8 +60,14 @@ export function CommentInput({
     const trimmedContent = content.trim();
     if (!trimmedContent) return;
 
+    // The textarea shows display-text mentions (@Name); the stored comment
+    // carries the canonical @[Name](id) markup the server and renderer expect.
+    const outgoing = hasMentions
+      ? expandMentions(trimmedContent, mentionCandidates ?? [])
+      : trimmedContent;
+
     try {
-      await onSubmit(trimmedContent);
+      await onSubmit(outgoing);
       setContent("");
     } catch {
       notifications.show({
@@ -69,7 +76,7 @@ export function CommentInput({
         color: "red",
       });
     }
-  }, [content, onSubmit, setContent]);
+  }, [content, hasMentions, mentionCandidates, onSubmit, setContent]);
 
   const handleChange = useCallback(
     (value: string, cursorPos: number) => {
@@ -148,6 +155,9 @@ export function CommentInput({
         maxRows={6}
         disabled={isSubmitting || isUploading}
         mentionNames={mentionNames}
+        previewContent={
+          hasMentions ? expandMentions(content, mentionCandidates ?? []) : undefined
+        }
         textareaRef={(el) => (textareaRef.current = el)}
         rightSection={
           <ActionIcon

--- a/src/app/_components/shared/CommentThread.tsx
+++ b/src/app/_components/shared/CommentThread.tsx
@@ -11,6 +11,8 @@ import {
   getTextColor,
 } from "~/utils/avatarColors";
 import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
+import { collapseMentions, expandMentions } from "~/lib/content/mentionText";
+import type { MentionCandidate } from "~/hooks/useMentionAutocomplete";
 
 export interface CommentAuthor {
   id: string;
@@ -33,6 +35,12 @@ interface CommentThreadProps {
   onDeleteImage?: (commentId: string, imageUrl: string) => void;
   currentUserId?: string;
   mentionNames?: string[];
+  /**
+   * When set, inline editing shows mentions as display text (@Name) instead
+   * of the stored @[Name](id) markup, converting back on save. Without it,
+   * editing falls back to the raw stored body.
+   */
+  mentionCandidates?: MentionCandidate[];
   variant?: "card" | "inline";
   emptyMessage?: string | null;
 }
@@ -48,6 +56,7 @@ export function CommentThread({
   onDeleteImage,
   currentUserId,
   mentionNames = [],
+  mentionCandidates,
   variant = "card",
   emptyMessage = "No comments yet. Start the discussion!",
 }: CommentThreadProps) {
@@ -57,7 +66,11 @@ export function CommentThread({
 
   const startEditing = (comment: Comment) => {
     setEditingCommentId(comment.id);
-    setEditContent(comment.content);
+    setEditContent(
+      mentionCandidates
+        ? collapseMentions(comment.content, mentionCandidates)
+        : comment.content,
+    );
   };
 
   const cancelEditing = () => {
@@ -69,7 +82,10 @@ export function CommentThread({
     if (!editingCommentId || !editContent.trim() || !onEditComment) return;
     setIsSaving(true);
     try {
-      await onEditComment(editingCommentId, editContent.trim());
+      const body = mentionCandidates
+        ? expandMentions(editContent.trim(), mentionCandidates)
+        : editContent.trim();
+      await onEditComment(editingCommentId, body);
       setEditingCommentId(null);
       setEditContent("");
     } finally {

--- a/src/app/_components/shared/MarkdownInput.tsx
+++ b/src/app/_components/shared/MarkdownInput.tsx
@@ -20,6 +20,13 @@ interface MarkdownInputProps {
   maxRows?: number;
   /** Names rendered as mention badges in the preview. */
   mentionNames?: string[];
+  /**
+   * What the Preview tab renders instead of `value`, when they differ — e.g.
+   * a composer that shows display-text mentions (`@Name`) while writing but
+   * submits canonical markup passes the expanded form here, so the preview
+   * matches what the feed will show.
+   */
+  previewContent?: string;
   /** Receives the underlying textarea element (for cursor/mention handling). */
   textareaRef?: (el: HTMLTextAreaElement | null) => void;
   onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
@@ -53,6 +60,7 @@ export function MarkdownInput({
   minRows = 3,
   maxRows = 10,
   mentionNames,
+  previewContent,
   textareaRef,
   onKeyDown,
   onPaste,
@@ -193,7 +201,7 @@ export function MarkdownInput({
         <div className="min-h-[4rem] rounded-md border border-border-primary bg-surface-secondary px-3 py-2">
           {value.trim() ? (
             <MarkdownRenderer
-              content={value}
+              content={previewContent ?? value}
               variant="compact"
               mentionNames={mentionNames}
             />

--- a/src/hooks/useMentionAutocomplete.ts
+++ b/src/hooks/useMentionAutocomplete.ts
@@ -78,10 +78,18 @@ export function useMentionAutocomplete({
       setCursorPosition(cursorPos);
       setSelectedIndex(0);
 
+      // Only open when at least one candidate matches — otherwise text after
+      // a completed display-text mention ("@James Farrell thanks…") would keep
+      // the trigger alive and float an empty dropdown.
       const trigger = findMentionTrigger(value, cursorPos);
-      setShowDropdown(trigger !== null);
+      setShowDropdown(
+        trigger !== null &&
+          candidates.some((c) =>
+            c.name.toLowerCase().includes(trigger.searchTerm),
+          ),
+      );
     },
-    [],
+    [candidates],
   );
 
   const selectCandidate = useCallback(
@@ -91,7 +99,9 @@ export function useMentionAutocomplete({
       const { triggerIndex } = mentionTrigger;
       const beforeTrigger = text.substring(0, triggerIndex);
       const afterCursor = text.substring(cursorPosition);
-      const insertion = `@[${candidate.name}](${candidate.id}) `;
+      // Insert the display form; the composer expands it to the canonical
+      // `@[Name](id)` markup on submit (see ~/lib/content/mentionText).
+      const insertion = `@${candidate.name} `;
       const newText = beforeTrigger + insertion + afterCursor;
 
       setText(newText);

--- a/src/lib/content/__tests__/mentionText.test.ts
+++ b/src/lib/content/__tests__/mentionText.test.ts
@@ -30,6 +30,18 @@ describe("collapseMentions", () => {
     expect(collapseMentions("@[James](u2)", [])).toBe("@[James](u2)");
     expect(collapseMentions("", CANDIDATES)).toBe("");
   });
+
+  it("keeps markup when the stored id doesn't match the candidate", () => {
+    expect(collapseMentions("@[James](u99)", CANDIDATES)).toBe("@[James](u99)");
+  });
+
+  it("keeps markup when two candidates share the display name", () => {
+    const dupes = [
+      { id: "a1", name: "Sam" },
+      { id: "a2", name: "Sam" },
+    ];
+    expect(collapseMentions("@[Sam](a1)", dupes)).toBe("@[Sam](a1)");
+  });
 });
 
 describe("expandMentions", () => {
@@ -81,5 +93,10 @@ describe("expandMentions", () => {
 
   it("is a no-op with no candidates", () => {
     expect(expandMentions("hi @James", [])).toBe("hi @James");
+  });
+
+  it("ignores blank candidate names instead of matching every bare @", () => {
+    const blanks = [{ id: "b1", name: "  " }];
+    expect(expandMentions("email me @ home", blanks)).toBe("email me @ home");
   });
 });

--- a/src/lib/content/__tests__/mentionText.test.ts
+++ b/src/lib/content/__tests__/mentionText.test.ts
@@ -95,6 +95,15 @@ describe("expandMentions", () => {
     expect(expandMentions("hi @James", [])).toBe("hi @James");
   });
 
+  it("does not expand mentions inside URL paths or after backticks", () => {
+    expect(expandMentions("see https://x.com/@James for more", CANDIDATES)).toBe(
+      "see https://x.com/@James for more",
+    );
+    expect(expandMentions("code `@James` literal", CANDIDATES)).toBe(
+      "code `@James` literal",
+    );
+  });
+
   it("ignores blank candidate names instead of matching every bare @", () => {
     const blanks = [{ id: "b1", name: "  " }];
     expect(expandMentions("email me @ home", blanks)).toBe("email me @ home");

--- a/src/lib/content/__tests__/mentionText.test.ts
+++ b/src/lib/content/__tests__/mentionText.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { collapseMentions, expandMentions } from "../mentionText";
+
+const CANDIDATES = [
+  { id: "u1", name: "James Farrell" },
+  { id: "u2", name: "James" },
+  { id: "u3", name: "Andi Stanner" },
+];
+
+describe("collapseMentions", () => {
+  it("collapses known-name markup to display text", () => {
+    expect(
+      collapseMentions("hi @[James Farrell](u1), ping @[Andi Stanner](u3)", CANDIDATES),
+    ).toBe("hi @James Farrell, ping @Andi Stanner");
+  });
+
+  it("leaves unknown-name markup untouched so it survives an edit round-trip", () => {
+    expect(collapseMentions("cc @[Departed User](u9)", CANDIDATES)).toBe(
+      "cc @[Departed User](u9)",
+    );
+  });
+
+  it("matches names case-insensitively", () => {
+    expect(collapseMentions("@[james farrell](u1)", CANDIDATES)).toBe(
+      "@james farrell",
+    );
+  });
+
+  it("is a no-op with no candidates or empty text", () => {
+    expect(collapseMentions("@[James](u2)", [])).toBe("@[James](u2)");
+    expect(collapseMentions("", CANDIDATES)).toBe("");
+  });
+});
+
+describe("expandMentions", () => {
+  it("expands display text to markup", () => {
+    expect(expandMentions("hi @James Farrell thats it", CANDIDATES)).toBe(
+      "hi @[James Farrell](u1) thats it",
+    );
+  });
+
+  it("prefers the longest matching name", () => {
+    expect(expandMentions("@James Farrell and @James", CANDIDATES)).toBe(
+      "@[James Farrell](u1) and @[James](u2)",
+    );
+  });
+
+  it("matches case-insensitively but emits the canonical name", () => {
+    expect(expandMentions("hey @james farrell", CANDIDATES)).toBe(
+      "hey @[James Farrell](u1)",
+    );
+  });
+
+  it("expands at the start of the text and before punctuation", () => {
+    expect(expandMentions("@James: hello", CANDIDATES)).toBe(
+      "@[James](u2): hello",
+    );
+    expect(expandMentions("thanks @James!", CANDIDATES)).toBe(
+      "thanks @[James](u2)!",
+    );
+  });
+
+  it("does not expand partial-word matches or mid-word @", () => {
+    expect(expandMentions("@Jameson", CANDIDATES)).toBe("@Jameson");
+    expect(expandMentions("mail me at farrell@James.com", CANDIDATES)).toBe(
+      "mail me at farrell@James.com",
+    );
+  });
+
+  it("leaves existing markup untouched", () => {
+    expect(
+      expandMentions("@[James Farrell](u1) meet @Andi Stanner", CANDIDATES),
+    ).toBe("@[James Farrell](u1) meet @[Andi Stanner](u3)");
+  });
+
+  it("round-trips through collapse", () => {
+    const stored = "ping @[James Farrell](u1) about @[Andi Stanner](u3)";
+    const display = collapseMentions(stored, CANDIDATES);
+    expect(expandMentions(display, CANDIDATES)).toBe(stored);
+  });
+
+  it("is a no-op with no candidates", () => {
+    expect(expandMentions("hi @James", [])).toBe("hi @James");
+  });
+});

--- a/src/lib/content/mentionText.ts
+++ b/src/lib/content/mentionText.ts
@@ -75,7 +75,12 @@ export function expandMentions(
     .join("|");
   // A leading-position capture instead of a lookbehind (older Safari); the
   // trailing guard stops "@JamesX" from half-matching a "James" candidate.
-  const displayRe = new RegExp(`(^|[^\\w])@(${alternation})(?![\\w])`, "gi");
+  // "/" and backtick are excluded from the prefix so URL paths
+  // (x.com/@James) and inline code stay untouched.
+  const displayRe = new RegExp(
+    `(^|[^\\w/\`])@(${alternation})(?![\\w])`,
+    "gi",
+  );
 
   const expandSegment = (segment: string): string =>
     segment.replace(displayRe, (full, prefix: string, name: string) => {

--- a/src/lib/content/mentionText.ts
+++ b/src/lib/content/mentionText.ts
@@ -1,0 +1,79 @@
+/**
+ * Mention text transforms for comment composers.
+ *
+ * Stored comments carry the canonical mention markup `@[Name](userId)` — the
+ * server parses it for notification fan-out and remarkMentions renders it as a
+ * badge. Composers show the friendlier display form `@Name` instead: markup
+ * collapses to display text when a comment is loaded for editing
+ * (`collapseMentions`), and display text expands back to markup on submit
+ * (`expandMentions`). Only names on the current candidate list are transformed
+ * in either direction, so a mention of someone who has since left the
+ * workspace survives an edit round-trip untouched.
+ */
+
+export interface MentionRef {
+  id: string;
+  name: string;
+}
+
+const MENTION_MARKUP_RE = /@\[([^\]\n]+)\]\(([^()\s]+)\)/g;
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Rewrite `@[Name](id)` markup as plain `@Name` for known candidate names. */
+export function collapseMentions(
+  text: string,
+  candidates: MentionRef[],
+): string {
+  if (!text || candidates.length === 0) return text;
+  const known = new Set(candidates.map((c) => c.name.toLowerCase()));
+  return text.replace(MENTION_MARKUP_RE, (match, name: string) =>
+    known.has(name.toLowerCase()) ? `@${name}` : match,
+  );
+}
+
+/**
+ * Rewrite plain `@Name` as `@[Name](id)` markup for known candidate names.
+ * Longest name wins ("@James Farrell" beats a "James" candidate), matching is
+ * case-insensitive, and the markup gets the candidate's canonical name.
+ * Existing markup passes through untouched.
+ */
+export function expandMentions(
+  text: string,
+  candidates: MentionRef[],
+): string {
+  if (!text || candidates.length === 0) return text;
+
+  const byName = new Map<string, MentionRef>();
+  for (const c of candidates) {
+    const key = c.name.toLowerCase();
+    if (!byName.has(key)) byName.set(key, c);
+  }
+
+  const alternation = [...byName.values()]
+    .sort((a, b) => b.name.length - a.name.length)
+    .map((c) => escapeRegExp(c.name))
+    .join("|");
+  // A leading-position capture instead of a lookbehind (older Safari); the
+  // trailing guard stops "@JamesX" from half-matching a "James" candidate.
+  const displayRe = new RegExp(`(^|[^\\w])@(${alternation})(?![\\w])`, "gi");
+
+  const expandSegment = (segment: string): string =>
+    segment.replace(displayRe, (full, prefix: string, name: string) => {
+      const ref = byName.get(name.toLowerCase());
+      return ref ? `${prefix}@[${ref.name}](${ref.id})` : full;
+    });
+
+  // Expand only the stretches between existing markup, never inside it.
+  const parts: string[] = [];
+  let last = 0;
+  for (const m of text.matchAll(MENTION_MARKUP_RE)) {
+    parts.push(expandSegment(text.slice(last, m.index)));
+    parts.push(m[0]);
+    last = m.index + m[0].length;
+  }
+  parts.push(expandSegment(text.slice(last)));
+  return parts.join("");
+}

--- a/src/lib/content/mentionText.ts
+++ b/src/lib/content/mentionText.ts
@@ -22,16 +22,29 @@ function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-/** Rewrite `@[Name](id)` markup as plain `@Name` for known candidate names. */
+/**
+ * Rewrite `@[Name](id)` markup as plain `@Name` — but only when the name
+ * resolves unambiguously back to the same id, so an edit round-trip through
+ * `expandMentions` can never re-point the mention (and its notification) at a
+ * different user. Duplicate display names and stale ids stay as markup.
+ */
 export function collapseMentions(
   text: string,
   candidates: MentionRef[],
 ): string {
   if (!text || candidates.length === 0) return text;
-  const known = new Set(candidates.map((c) => c.name.toLowerCase()));
-  return text.replace(MENTION_MARKUP_RE, (match, name: string) =>
-    known.has(name.toLowerCase()) ? `@${name}` : match,
-  );
+  const idsByName = new Map<string, Set<string>>();
+  for (const c of candidates) {
+    const key = c.name.trim().toLowerCase();
+    if (!key) continue;
+    const ids = idsByName.get(key) ?? new Set<string>();
+    ids.add(c.id);
+    idsByName.set(key, ids);
+  }
+  return text.replace(MENTION_MARKUP_RE, (match, name: string, id: string) => {
+    const ids = idsByName.get(name.toLowerCase());
+    return ids && ids.size === 1 && ids.has(id) ? `@${name}` : match;
+  });
 }
 
 /**
@@ -48,9 +61,13 @@ export function expandMentions(
 
   const byName = new Map<string, MentionRef>();
   for (const c of candidates) {
-    const key = c.name.toLowerCase();
+    // A blank name would put an empty alternative in the regex alternation
+    // and rewrite every stray "@" into markup.
+    const key = c.name.trim().toLowerCase();
+    if (!key) continue;
     if (!byName.has(key)) byName.set(key, c);
   }
+  if (byName.size === 0) return text;
 
   const alternation = [...byName.values()]
     .sort((a, b) => b.name.length - a.name.length)

--- a/src/lib/content/remarkMentions.ts
+++ b/src/lib/content/remarkMentions.ts
@@ -3,8 +3,9 @@
  * spans, so the canonical Markdown renderer can show mentions as badges
  * (ADR-0017).
  *
- * The stored mention syntax (`@[Name](userId)`, written by
- * `useMentionAutocomplete`) collides with Markdown link syntax: Markdown parses
+ * The stored mention syntax (`@[Name](userId)`, produced from the composer's
+ * display text by `~/lib/content/mentionText`) collides with Markdown link
+ * syntax: Markdown parses
  * `[Name](userId)` as a link sitting right after a literal `@`. This plugin
  * detects that exact shape — a `link` node immediately preceded by text ending
  * in `@` — and rewrites it into a span the renderer styles as a badge. Known


### PR DESCRIPTION
### **User description**
## What

- Mention autocomplete now inserts display text (`@Name`) into comment composers instead of the stored `@[Name](id)` markup, and expands it back to canonical markup on submit (new `src/lib/content/mentionText.ts` helpers, unit-tested).
- Inline comment editing (shared CommentThread + PRD thread popover) collapses stored markup to `@Name` for editing and re-expands on save; mentions of people no longer on the candidate list pass through untouched so they survive the round-trip.
- The composer's Preview tab renders the expanded form, so the preview matches what the feed will show.
- Reply composers under activity updates gain mention support (candidates are now threaded through ActivityFeed).
- The mention dropdown only opens when at least one candidate matches, so completed mentions don't re-trigger an empty dropdown.

## Why

Tagging someone in a comment on Features/Pages showed raw `@[James Farrell](cmdfuz…)` markup in the composer instead of a readable @mention. Stored format is unchanged (`@[Name](id)`), so server-side notification fan-out and badge rendering keep working; verified end-to-end against the dev-fixture workspace (compose → badge render → edit → save).


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Composers insert/show `@Name` display text instead of raw `@[Name](id)` markup

- New `mentionText` helpers expand on submit, collapse on edit, with unit tests

- Preview tab renders expanded markup via new `previewContent` prop

- Mention dropdown only opens on candidate match; reply composers gain mentions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mention autocomplete"] -- "inserts @Name" --> B["composer textarea"]
  B -- "expandMentions on submit" --> C["stored @[Name](id)"]
  C -- "collapseMentions on edit" --> B
  C -- "remarkMentions" --> D["badge in feed"]
  B -- "previewContent" --> E["Preview tab"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>mentionText.ts</strong><dd><code>New collapse/expand mention text transform helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/556/files#diff-3f114d9204a0c07f7e3f8c586f2f292de1e5d6c770ef428d278b4ff86a28bdd4">+101/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MarkdownInput.tsx</strong><dd><code>Add optional `previewContent` prop for preview tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/556/files#diff-43f2cc9882ba148a5735ce60d8f3c581160400d9a08dac93aa926fcd71f9a635">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ActivityFeed.tsx</strong><dd><code>Thread mentionCandidates through feed and reply composer</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/556/files#diff-1fe038ff4240badb298d6fc289c5001f28010e5651a510ea3beeaa80bbae0cca">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PrdCommentsPanel.tsx</strong><dd><code>Pass mentionCandidates to comment threads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/556/files#diff-c5f330aa2b560a1652fd392b74e3cf01750875e9fafee9c675ac811701f7eb8a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ActivityTimeline.tsx</strong><dd><code>Forward mentionCandidates to ActivityFeed</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/556/files#diff-c1c5c103db21011b3c929fa783a0d9a9d438e8cc24ffccde7bbf9bcfd8b17542">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ActionDetailContent.tsx</strong><dd><code>Forward mentionCandidates to ActivityFeed</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/556/files#diff-25a332a1a59ad9784416db610b6ffc77eafbf6a2e72a134d9d4c5cf9f0422072">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mentionText.test.ts</strong><dd><code>Unit tests for mention collapse/expand edge cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/556/files#diff-42e16b0cc19b3eff11abf9e43fda67b1cd6f2354695a821e384cf75b8421d328">+111/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>useMentionAutocomplete.ts</strong><dd><code>Insert display text and gate dropdown on matches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/556/files#diff-3da26032f79a270ac41d9ace9fd5b488fa078dbfed1a511a16e6d8f2664ccde6">+13/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CommentInput.tsx</strong><dd><code>Expand mentions on submit and in preview</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/556/files#diff-012a51c8a6a0cff06ba38f89233fa311021753bfa8b54911f934de0b7fd110be">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CommentThread.tsx</strong><dd><code>Collapse/expand mentions during inline comment editing</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/556/files#diff-95d23fe268fc974c77d294e5daaa32e2082fbd8461c939cf6dbd270e041a057b">+18/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PrdThreadPopover.tsx</strong><dd><code>Collapse/expand mentions in thread popover editing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/556/files#diff-ef76a211d53e36cef5b22b92e875015a8c4af20744a5edbcf970479cb95d98ac">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>remarkMentions.ts</strong><dd><code>Update doc comment to reference mentionText helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/556/files#diff-86a65e1ed3bf6f7fc56646e711760627b91e2388ac2411c76ee29e6fc2e02877">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

