### PR TITLE
feat(matrix): bind a room to a project and post a meeting summary

### DIFF
--- a/prisma/migrations/20260812130515_matrix_channel_link_direction_and_post_log/migration.sql
+++ b/prisma/migrations/20260812130515_matrix_channel_link_direction_and_post_log/migration.sql
@@ -1,0 +1,53 @@
+-- AlterTable
+ALTER TABLE "ChannelLink" ADD COLUMN     "direction" TEXT NOT NULL DEFAULT 'inbound',
+ADD COLUMN     "serverIntegrationId" TEXT;
+
+-- CreateTable
+CREATE TABLE "MatrixPostLog" (
+    "id" TEXT NOT NULL,
+    "transcriptionSessionId" TEXT NOT NULL,
+    "channelLinkId" TEXT,
+    "roomId" TEXT NOT NULL,
+    "serverIntegrationId" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "postedById" TEXT NOT NULL,
+    "postedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MatrixPostLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MatrixPostLog_transcriptionSessionId_roomId_idx" ON "MatrixPostLog"("transcriptionSessionId", "roomId");
+
+-- CreateIndex
+CREATE INDEX "MatrixPostLog_serverIntegrationId_idx" ON "MatrixPostLog"("serverIntegrationId");
+
+-- CreateIndex
+CREATE INDEX "MatrixPostLog_channelLinkId_idx" ON "MatrixPostLog"("channelLinkId");
+
+-- CreateIndex
+CREATE INDEX "MatrixPostLog_postedById_idx" ON "MatrixPostLog"("postedById");
+
+-- CreateIndex
+CREATE INDEX "ChannelLink_projectId_direction_idx" ON "ChannelLink"("projectId", "direction");
+
+-- CreateIndex
+CREATE INDEX "ChannelLink_workspaceId_direction_idx" ON "ChannelLink"("workspaceId", "direction");
+
+-- CreateIndex
+CREATE INDEX "ChannelLink_serverIntegrationId_idx" ON "ChannelLink"("serverIntegrationId");
+
+-- AddForeignKey
+ALTER TABLE "ChannelLink" ADD CONSTRAINT "ChannelLink_serverIntegrationId_fkey" FOREIGN KEY ("serverIntegrationId") REFERENCES "Integration"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MatrixPostLog" ADD CONSTRAINT "MatrixPostLog_transcriptionSessionId_fkey" FOREIGN KEY ("transcriptionSessionId") REFERENCES "TranscriptionSession"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MatrixPostLog" ADD CONSTRAINT "MatrixPostLog_channelLinkId_fkey" FOREIGN KEY ("channelLinkId") REFERENCES "ChannelLink"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MatrixPostLog" ADD CONSTRAINT "MatrixPostLog_serverIntegrationId_fkey" FOREIGN KEY ("serverIntegrationId") REFERENCES "Integration"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MatrixPostLog" ADD CONSTRAINT "MatrixPostLog_postedById_fkey" FOREIGN KEY ("postedById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -210,6 +210,7 @@ model User {
   workspaceActivityEvents        WorkspaceActivityEvent[]
   // Inbound channel links created by this user
   channelLinksCreated            ChannelLink[]                   @relation("ChannelLinkCreatedBy")
+  matrixPostsPosted              MatrixPostLog[]                 @relation("MatrixPostLogPostedBy")
   // Per-user favourites (polymorphic pins)
   favorites                      Favorite[]
 
@@ -506,8 +507,8 @@ model WorkspaceActivityEvent {
 // Integration-FK-bound SlackChannelConfig - this is inbound and integration-free.
 model ChannelLink {
   id          String   @id @default(cuid())
-  provider    String // "whatsapp" | "slack" | "telegram" | …
-  externalId  String // provider conversation id (e.g. WhatsApp group JID)
+  provider    String // "whatsapp" | "slack" | "telegram" | "matrix" | …
+  externalId  String // provider conversation id (e.g. WhatsApp group JID, Matrix room id)
   displayName String?
   workspaceId String
   projectId   String?
@@ -516,14 +517,64 @@ model ChannelLink {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  project   Project?  @relation(fields: [projectId], references: [id], onDelete: SetNull)
-  createdBy User?     @relation("ChannelLinkCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+  // Which way this link routes. ADR-0023 defined ChannelLink as inbound-only
+  // ("which workspace/project owns this conversation?"); outbound rows answer the
+  // reverse ("where does this project's content go?"). Existing WhatsApp rows keep
+  // the default, so the ADR-0023 summarization path is untouched.
+  direction String @default("inbound") // "inbound" | "outbound"
 
+  // For outbound rows, the registered server to send through. Null for inbound rows,
+  // which are attributed by the gateway that received them rather than by credential.
+  serverIntegrationId String?
+  serverIntegration   Integration? @relation("ChannelLinkServer", fields: [serverIntegrationId], references: [id], onDelete: Cascade)
+
+  workspace   Workspace       @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  project     Project?        @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  createdBy   User?           @relation("ChannelLinkCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+  matrixPosts MatrixPostLog[]
+
+  // Kept as-is for V1. Consequence: a workspace default and a project override cannot
+  // name the same room. That is a recorded open decision on the feature, not an
+  // oversight — do not relax it without deciding it.
   @@unique([provider, externalId])
   @@index([workspaceId])
   @@index([projectId])
   @@index([createdById])
+  @@index([projectId, direction])
+  @@index([workspaceId, direction])
+  @@index([serverIntegrationId])
+}
+
+/// One row per successful post of a meeting summary into a Matrix room.
+///
+/// A table rather than a timestamp column on TranscriptionSession, because the
+/// destination is not singular: `slackNotificationAt` is the single-destination
+/// precedent and it breaks the moment a meeting is re-tagged to a project with a
+/// different room. Rows are written only after the homeserver accepts the event, so
+/// the log never claims a post that did not happen.
+model MatrixPostLog {
+  id                     String   @id @default(cuid())
+  transcriptionSessionId String
+  /// The binding used, when the destination came from one. Null for a one-off post to
+  /// an explicitly picked room, which deliberately persists no binding.
+  channelLinkId          String?
+  roomId                 String
+  serverIntegrationId    String
+  /// The homeserver's event id for the message that was sent.
+  eventId                String
+  postedById             String
+  postedAt               DateTime @default(now())
+
+  transcriptionSession TranscriptionSession @relation(fields: [transcriptionSessionId], references: [id], onDelete: Cascade)
+  channelLink          ChannelLink?         @relation(fields: [channelLinkId], references: [id], onDelete: SetNull)
+  serverIntegration    Integration          @relation("MatrixPostLogServer", fields: [serverIntegrationId], references: [id], onDelete: Cascade)
+  postedBy             User                 @relation("MatrixPostLogPostedBy", fields: [postedById], references: [id], onDelete: Cascade)
+
+  /// Answers "has this meeting already been posted here?" — the repost guard.
+  @@index([transcriptionSessionId, roomId])
+  @@index([serverIntegrationId])
+  @@index([channelLinkId])
+  @@index([postedById])
 }
 
 // Cached AI-generated Week-in-Review narrative. One row per (workspace, ISO week).
@@ -1344,6 +1395,7 @@ model TranscriptionSession {
   user              User?                             @relation(fields: [userId], references: [id])
   workspace         Workspace?                        @relation(fields: [workspaceId], references: [id])
   participants      TranscriptionSessionParticipant[]
+  matrixPosts       MatrixPostLog[]
 
   @@index([sessionId])
   @@index([workspaceId])
@@ -1413,6 +1465,10 @@ model Integration {
   // GitHub repo connection (ADR-0020): repos a workspace tracks via this installation
   workspaceRepositories   WorkspaceRepository[]
   syncConfigs             TicketSyncConfig[]
+  // Outbound routing (matrix-server rows): rooms bound through this server, and the
+  // log of what has been posted through it.
+  outboundChannelLinks    ChannelLink[]            @relation("ChannelLinkServer")
+  matrixPostLogs          MatrixPostLog[]          @relation("MatrixPostLogServer")
 
   @@index([userId])
   @@index([teamId])

--- a/src/app/_components/MatrixServerSettings.tsx
+++ b/src/app/_components/MatrixServerSettings.tsx
@@ -15,6 +15,7 @@ import {
 import { useDisclosure } from "@mantine/hooks";
 import { IconAlertTriangle, IconServer } from "@tabler/icons-react";
 import { MatrixRoomPicker } from "~/app/_components/matrix/MatrixRoomPicker";
+import { MatrixRoomBinding } from "~/app/_components/matrix/MatrixRoomBinding";
 import { useState } from "react";
 import { api } from "~/trpc/react";
 
@@ -124,6 +125,19 @@ export function MatrixServerSettings({
             )}
           </Group>
         ))
+      )}
+
+      {servers.length > 0 && (
+        <Stack gap={4} className="rounded-md border border-border-primary bg-surface-secondary p-3">
+          <Text size="sm" fw={600} className="text-text-primary">
+            Default room
+          </Text>
+          <Text size="xs" className="text-text-muted">
+            Used by projects set to Inherit. Ships unset, so nothing posts until
+            someone chooses a room.
+          </Text>
+          <MatrixRoomBinding workspaceId={workspace.id} projectId={null} />
+        </Stack>
       )}
 
       {removeMutation.error && (

--- a/src/app/_components/ProjectContent.tsx
+++ b/src/app/_components/ProjectContent.tsx
@@ -6,6 +6,7 @@ import { Actions } from "./Actions";
 import ProjectDetails from "./ProjectDetails";
 //import Chat from "./Chat";
 import { Team } from "./Team";
+import { MatrixRoomBinding } from "~/app/_components/matrix/MatrixRoomBinding";
 // import { Plan } from "./Plan";
 import { OutcomesTable } from "./OutcomesTable";
 import { OutcomeTimeline } from "./OutcomeTimeline";
@@ -1029,6 +1030,30 @@ export function ProjectContent({
                   fullWidth
                   disabled={updateBountiesMutation.isPending}
                 />
+              </Stack>
+            </Card>
+          </Stack>
+
+          {/* Matrix room binding */}
+          <Stack gap="xs">
+            <Group gap="xs" align="center">
+              <IconMessageCircle size={16} className="text-brand-primary" />
+              <Text size="sm" fw={600} className="text-brand-primary">
+                MATRIX ROOM
+              </Text>
+            </Group>
+            <Card withBorder p="md" radius="lg" className="bg-surface-secondary border-border-primary">
+              <Stack gap="sm">
+                <Text size="sm" className="text-text-secondary">
+                  Where this project&apos;s meeting summaries are posted. Posting is
+                  always a manual click — nothing is sent automatically.
+                </Text>
+                {workspaceId && resolvedProjectId && (
+                  <MatrixRoomBinding
+                    workspaceId={workspaceId}
+                    projectId={resolvedProjectId}
+                  />
+                )}
               </Stack>
             </Card>
           </Stack>

--- a/src/app/_components/matrix/MatrixRoomBinding.tsx
+++ b/src/app/_components/matrix/MatrixRoomBinding.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import {
+  Alert,
+  Button,
+  Modal,
+  SegmentedControl,
+  Skeleton,
+  Stack,
+  Text,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { IconAlertTriangle } from "@tabler/icons-react";
+import { useState } from "react";
+import { api } from "~/trpc/react";
+import { MatrixRoomPicker, type MatrixRoomChoice } from "./MatrixRoomPicker";
+
+interface MatrixRoomBindingProps {
+  workspaceId: string;
+  /** Null binds the workspace default; a project id binds that project. */
+  projectId?: string | null;
+}
+
+/**
+ * Where this project's (or workspace's) meeting summaries go.
+ *
+ * The project control is the tri-state used elsewhere in the drawer. `Off` is not
+ * cosmetic: it hard-blocks posting and does not fall through to the workspace default,
+ * which is what makes it usable as a confidential-project escape hatch.
+ *
+ * The workspace default has no `Off` — there is nothing above it to opt out of, and it
+ * ships unset so nothing posts until someone deliberately picks a room.
+ */
+export function MatrixRoomBinding({
+  workspaceId,
+  projectId = null,
+}: MatrixRoomBindingProps) {
+  const [pickerOpened, { open: openPicker, close: closePicker }] = useDisclosure(false);
+  const [chosen, setChosen] = useState<MatrixRoomChoice | null>(null);
+
+  const utils = api.useUtils();
+  const serversQuery = api.matrixServer.list.useQuery({ workspaceId });
+  const bindingQuery = api.matrixRoom.getBinding.useQuery({ workspaceId, projectId });
+
+  const servers = serversQuery.data ?? [];
+  const serverId = servers[0]?.id ?? null;
+
+  function refresh() {
+    void utils.matrixRoom.getBinding.invalidate({ workspaceId, projectId });
+  }
+
+  const bind = api.matrixRoom.bind.useMutation({
+    onSuccess: () => {
+      refresh();
+      closePicker();
+      setChosen(null);
+    },
+  });
+  const setOff = api.matrixRoom.setOff.useMutation({ onSuccess: refresh });
+  const unbind = api.matrixRoom.unbind.useMutation({ onSuccess: refresh });
+
+  if (serversQuery.isLoading || bindingQuery.isLoading) {
+    return <Skeleton height={40} radius="md" />;
+  }
+
+  if (servers.length === 0) {
+    return (
+      <Text size="sm" className="text-text-muted">
+        No Matrix server is registered for this workspace yet.
+      </Text>
+    );
+  }
+
+  const binding = bindingQuery.data;
+  const pending = bind.isPending || setOff.isPending || unbind.isPending;
+  const error = bind.error ?? setOff.error ?? unbind.error;
+
+  function handleModeChange(value: string) {
+    if (value === "inherit") {
+      unbind.mutate({ workspaceId, projectId });
+      return;
+    }
+    if (value === "off" && projectId) {
+      setOff.mutate({ workspaceId, projectId });
+      return;
+    }
+    // "room" needs a choice before it means anything.
+    openPicker();
+  }
+
+  const effective = binding?.effective;
+
+  return (
+    <Stack gap="xs">
+      {projectId ? (
+        <SegmentedControl
+          value={binding?.mode ?? "inherit"}
+          onChange={handleModeChange}
+          disabled={pending}
+          fullWidth
+          data={[
+            {
+              label:
+                effective?.kind === "room" && binding?.mode === "inherit"
+                  ? `Inherit (${effective.name})`
+                  : "Inherit (none)",
+              value: "inherit",
+            },
+            { label: "Room", value: "room" },
+            { label: "Off", value: "off" },
+          ]}
+        />
+      ) : (
+        <Button variant="light" size="xs" onClick={openPicker} disabled={pending}>
+          {binding?.room ? "Change default room" : "Set a default room"}
+        </Button>
+      )}
+
+      {binding?.mode === "room" && binding.room && (
+        <Text size="xs" className="text-text-secondary">
+          Posting to <span className="text-text-primary">{binding.room.name}</span>.{" "}
+          <Button
+            variant="subtle"
+            size="compact-xs"
+            onClick={openPicker}
+            disabled={pending}
+          >
+            Change
+          </Button>
+        </Text>
+      )}
+
+      {binding?.mode === "off" && (
+        <Text size="xs" className="text-text-muted">
+          Meeting summaries for this project stay in Exponential.
+        </Text>
+      )}
+
+      {binding?.mode === "inherit" && effective?.kind === "none" && (
+        <Text size="xs" className="text-text-muted">
+          Nothing is configured, so nothing posts until a room is chosen.
+        </Text>
+      )}
+
+      {error && (
+        <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
+          {error.message}
+        </Alert>
+      )}
+
+      <Modal
+        opened={pickerOpened}
+        onClose={closePicker}
+        title={projectId ? "Choose this project's room" : "Choose the default room"}
+        size="lg"
+      >
+        <Stack gap="md">
+          {serverId && (
+            <MatrixRoomPicker
+              workspaceId={workspaceId}
+              serverId={serverId}
+              selectedRoomId={chosen?.roomId ?? binding?.room?.roomId ?? null}
+              onSelect={setChosen}
+            />
+          )}
+
+          {bind.error && (
+            <Alert color="red" variant="light">
+              {bind.error.message}
+            </Alert>
+          )}
+
+          <Button
+            disabled={!chosen || !serverId}
+            loading={bind.isPending}
+            onClick={() => {
+              if (!chosen || !serverId) return;
+              bind.mutate({
+                workspaceId,
+                projectId,
+                serverId,
+                roomId: chosen.roomId,
+                roomName: chosen.name,
+              });
+            }}
+          >
+            Bind {chosen?.name ?? "the selected room"}
+          </Button>
+        </Stack>
+      </Modal>
+    </Stack>
+  );
+}

--- a/src/app/_components/matrix/PostToMatrixButton.tsx
+++ b/src/app/_components/matrix/PostToMatrixButton.tsx
@@ -33,12 +33,23 @@ export function PostToMatrixButton({
     | { kind: "idle" }
     | { kind: "posted"; roomId: string }
     | { kind: "blocked"; message: string }
-    | { kind: "confirm"; roomId: string; lastPostedAt: Date }
+    | {
+        kind: "confirm";
+        roomId: string;
+        lastPostedAt: Date;
+        /** The exact destination the warning refers to, captured when it was raised. */
+        retry: { roomId: string; serverId: string } | null;
+      }
   >({ kind: "idle" });
   const [chosen, setChosen] = useState<MatrixRoomChoice | null>(null);
   // Off by default: a one-off post is not a configuration change, and quietly
   // rebinding someone's project from a post dialog would be a surprise.
   const [saveAsProjectRoom, setSaveAsProjectRoom] = useState(false);
+  // What the in-flight post is aimed at, so a confirmation retries the same thing.
+  const [pendingDestination, setPendingDestination] = useState<{
+    roomId: string;
+    serverId: string;
+  } | null>(null);
 
   const utils = api.useUtils();
   const serversQuery = api.matrixServer.list.useQuery(
@@ -81,6 +92,8 @@ export function PostToMatrixButton({
             });
           }
           setStatus({ kind: "posted", roomId: result.roomId });
+          setChosen(null);
+          setPendingDestination(null);
           closePicker();
           return;
         case "needs-confirm":
@@ -88,6 +101,10 @@ export function PostToMatrixButton({
             kind: "confirm",
             roomId: result.roomId,
             lastPostedAt: new Date(result.lastPostedAt),
+            // Captured now. Reading `chosen` at click time would send the repost to
+            // whatever was picked last, which need not be the room the warning names —
+            // and Matrix has no un-send, so a wrong-room copy is permanent.
+            retry: pendingDestination,
           });
           return;
         case "no-destination":
@@ -118,17 +135,29 @@ export function PostToMatrixButton({
 
   function postToResolvedRoom(confirmRepost = false) {
     setStatus({ kind: "idle" });
+    setPendingDestination(null);
     post.mutate({ meetingId, ...(confirmRepost ? { confirmRepost } : {}) });
   }
 
   function postToChosenRoom(confirmRepost = false) {
     if (!chosen || !serverId) return;
     setStatus({ kind: "idle" });
+    setPendingDestination({ roomId: chosen.roomId, serverId });
     post.mutate({
       meetingId,
       roomId: chosen.roomId,
       serverId,
       ...(confirmRepost ? { confirmRepost } : {}),
+    });
+  }
+
+  /** Retry exactly what the confirmation warned about, not whatever state says now. */
+  function confirmRepostNow(retry: { roomId: string; serverId: string } | null) {
+    setStatus({ kind: "idle" });
+    post.mutate({
+      meetingId,
+      confirmRepost: true,
+      ...(retry ? { roomId: retry.roomId, serverId: retry.serverId } : {}),
     });
   }
 
@@ -175,7 +204,7 @@ export function PostToMatrixButton({
                   mt="xs"
                   color="yellow"
                   loading={post.isPending}
-                  onClick={() => (chosen ? postToChosenRoom(true) : postToResolvedRoom(true))}
+                  onClick={() => confirmRepostNow(status.retry)}
                 >
                   Post again
                 </Button>

--- a/src/app/_components/matrix/PostToMatrixButton.tsx
+++ b/src/app/_components/matrix/PostToMatrixButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Alert, Button, Modal, Popover, Stack, Text } from "@mantine/core";
+import { Alert, Button, Checkbox, Modal, Popover, Stack, Text } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { IconAlertTriangle, IconCheck, IconSend } from "@tabler/icons-react";
 import { useState } from "react";
@@ -26,6 +26,9 @@ export function PostToMatrixButton({
   projectId = null,
 }: PostToMatrixButtonProps) {
   const [pickerOpened, { open: openPicker, close: closePicker }] = useDisclosure(false);
+  // Mantine's Popover is controlled — without `opened` the target click does nothing.
+  const [popoverOpened, { toggle: togglePopover, close: closePopover }] =
+    useDisclosure(false);
   const [status, setStatus] = useState<
     | { kind: "idle" }
     | { kind: "posted"; roomId: string }
@@ -33,7 +36,11 @@ export function PostToMatrixButton({
     | { kind: "confirm"; roomId: string; lastPostedAt: Date }
   >({ kind: "idle" });
   const [chosen, setChosen] = useState<MatrixRoomChoice | null>(null);
+  // Off by default: a one-off post is not a configuration change, and quietly
+  // rebinding someone's project from a post dialog would be a surprise.
+  const [saveAsProjectRoom, setSaveAsProjectRoom] = useState(false);
 
+  const utils = api.useUtils();
   const serversQuery = api.matrixServer.list.useQuery(
     { workspaceId: workspaceId ?? "" },
     { enabled: !!workspaceId },
@@ -49,10 +56,30 @@ export function PostToMatrixButton({
   );
   const effective = bindingQuery.data?.effective;
 
+  const bindRoom = api.matrixRoom.bind.useMutation({
+    onSuccess: () => {
+      void utils.matrixRoom.getBinding.invalidate({
+        workspaceId: workspaceId ?? "",
+        projectId,
+      });
+    },
+  });
+
   const post = api.transcription.postToMatrix.useMutation({
     onSuccess: (result) => {
       switch (result.kind) {
         case "posted":
+          // Persist only now: binding a room to a project on the strength of a post
+          // that then failed would leave the project pointing somewhere unproven.
+          if (saveAsProjectRoom && chosen && serverId && projectId) {
+            bindRoom.mutate({
+              workspaceId: workspaceId ?? "",
+              projectId,
+              serverId,
+              roomId: chosen.roomId,
+              roomName: chosen.name,
+            });
+          }
           setStatus({ kind: "posted", roomId: result.roomId });
           closePicker();
           return;
@@ -107,9 +134,18 @@ export function PostToMatrixButton({
 
   return (
     <>
-      <Popover width={320} position="bottom-end" withArrow>
+      <Popover
+        width={320}
+        position="bottom-end"
+        withArrow
+        opened={popoverOpened}
+        onChange={(next) => (next ? togglePopover() : closePopover())}
+        // No transition: the dropdown is a decision surface, not an animation, and a
+        // deferred mount makes it untestable and slower to appear.
+        transitionProps={{ duration: 0 }}
+      >
         <Popover.Target>
-          <button className="mp-btn" type="button">
+          <button className="mp-btn" type="button" onClick={togglePopover}>
             <IconSend size={14} /> Post to Matrix
           </button>
         </Popover.Target>
@@ -174,7 +210,14 @@ export function PostToMatrixButton({
             >
               Post summary
             </Button>
-            <Button size="xs" variant="subtle" onClick={openPicker}>
+            <Button
+              size="xs"
+              variant="subtle"
+              onClick={() => {
+                closePopover();
+                openPicker();
+              }}
+            >
               Choose a room
             </Button>
           </Stack>
@@ -186,6 +229,7 @@ export function PostToMatrixButton({
         onClose={closePicker}
         title="Post this summary to a room"
         size="lg"
+        transitionProps={{ duration: 0 }}
       >
         <Stack gap="md">
           {serverId && (
@@ -194,6 +238,15 @@ export function PostToMatrixButton({
               serverId={serverId}
               selectedRoomId={chosen?.roomId ?? null}
               onSelect={setChosen}
+            />
+          )}
+
+          {projectId && (
+            <Checkbox
+              checked={saveAsProjectRoom}
+              onChange={(event) => setSaveAsProjectRoom(event.currentTarget.checked)}
+              label="Save as this project's room"
+              description="Future summaries for this project will go here by default."
             />
           )}
 

--- a/src/app/_components/matrix/PostToMatrixButton.tsx
+++ b/src/app/_components/matrix/PostToMatrixButton.tsx
@@ -3,7 +3,7 @@
 import { Alert, Button, Checkbox, Modal, Popover, Stack, Text } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { IconAlertTriangle, IconCheck, IconSend } from "@tabler/icons-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { api } from "~/trpc/react";
 import { MatrixRoomPicker, type MatrixRoomChoice } from "./MatrixRoomPicker";
 
@@ -45,11 +45,13 @@ export function PostToMatrixButton({
   // Off by default: a one-off post is not a configuration change, and quietly
   // rebinding someone's project from a post dialog would be a surprise.
   const [saveAsProjectRoom, setSaveAsProjectRoom] = useState(false);
-  // What the in-flight post is aimed at, so a confirmation retries the same thing.
-  const [pendingDestination, setPendingDestination] = useState<{
-    roomId: string;
-    serverId: string;
-  } | null>(null);
+  // What the in-flight post is aimed at, so a confirmation retries the same thing and a
+  // "save as this project's room" binds the room actually posted to.
+  //
+  // A ref, not state: the mutation callbacks read it, and a state update would not have
+  // flushed by the time a synchronous callback runs. This is control data, not something
+  // rendered, so there is nothing to re-render for either.
+  const pendingDestination = useRef<{ roomId: string; serverId: string } | null>(null);
 
   const utils = api.useUtils();
   const serversQuery = api.matrixServer.list.useQuery(
@@ -80,20 +82,27 @@ export function PostToMatrixButton({
     onSuccess: (result) => {
       switch (result.kind) {
         case "posted":
-          // Persist only now: binding a room to a project on the strength of a post
-          // that then failed would leave the project pointing somewhere unproven.
-          if (saveAsProjectRoom && chosen && serverId && projectId) {
+          // Bind the room that was actually posted to, not whatever is sitting in
+          // `chosen`. Persisted only now, because binding a project to a room on the
+          // strength of a post that then failed would leave it pointing somewhere
+          // unproven — and only when this post *was* the picked one, so posting the
+          // resolved destination cannot silently rebind the project to an abandoned pick.
+          if (
+            saveAsProjectRoom &&
+            projectId &&
+            serverId &&
+            pendingDestination.current?.roomId === result.roomId
+          ) {
             bindRoom.mutate({
               workspaceId: workspaceId ?? "",
               projectId,
               serverId,
-              roomId: chosen.roomId,
-              roomName: chosen.name,
+              roomId: result.roomId,
+              ...(chosen?.roomId === result.roomId ? { roomName: chosen.name } : {}),
             });
           }
           setStatus({ kind: "posted", roomId: result.roomId });
-          setChosen(null);
-          setPendingDestination(null);
+          resetPickerChoice();
           closePicker();
           return;
         case "needs-confirm":
@@ -104,7 +113,7 @@ export function PostToMatrixButton({
             // Captured now. Reading `chosen` at click time would send the repost to
             // whatever was picked last, which need not be the room the warning names —
             // and Matrix has no un-send, so a wrong-room copy is permanent.
-            retry: pendingDestination,
+            retry: pendingDestination.current,
           });
           return;
         case "no-destination":
@@ -133,16 +142,28 @@ export function PostToMatrixButton({
 
   if (!workspaceId || servers.length === 0) return null;
 
+  /** Abandoning or completing the picker clears what it armed. */
+  function resetPickerChoice() {
+    setChosen(null);
+    pendingDestination.current = null;
+    setSaveAsProjectRoom(false);
+  }
+
+  function closePickerAndReset() {
+    resetPickerChoice();
+    closePicker();
+  }
+
   function postToResolvedRoom(confirmRepost = false) {
     setStatus({ kind: "idle" });
-    setPendingDestination(null);
+    pendingDestination.current = null;
     post.mutate({ meetingId, ...(confirmRepost ? { confirmRepost } : {}) });
   }
 
   function postToChosenRoom(confirmRepost = false) {
     if (!chosen || !serverId) return;
     setStatus({ kind: "idle" });
-    setPendingDestination({ roomId: chosen.roomId, serverId });
+    pendingDestination.current = { roomId: chosen.roomId, serverId };
     post.mutate({
       meetingId,
       roomId: chosen.roomId,
@@ -255,7 +276,7 @@ export function PostToMatrixButton({
 
       <Modal
         opened={pickerOpened}
-        onClose={closePicker}
+        onClose={closePickerAndReset}
         title="Post this summary to a room"
         size="lg"
         transitionProps={{ duration: 0 }}

--- a/src/app/_components/matrix/PostToMatrixButton.tsx
+++ b/src/app/_components/matrix/PostToMatrixButton.tsx
@@ -10,6 +10,7 @@ import { MatrixRoomPicker, type MatrixRoomChoice } from "./MatrixRoomPicker";
 interface PostToMatrixButtonProps {
   meetingId: string;
   workspaceId: string | null;
+  projectId?: string | null;
 }
 
 /**
@@ -19,7 +20,11 @@ interface PostToMatrixButtonProps {
  * on project assignment, not on summarization. This button is the only way a summary
  * reaches a room.
  */
-export function PostToMatrixButton({ meetingId, workspaceId }: PostToMatrixButtonProps) {
+export function PostToMatrixButton({
+  meetingId,
+  workspaceId,
+  projectId = null,
+}: PostToMatrixButtonProps) {
   const [pickerOpened, { open: openPicker, close: closePicker }] = useDisclosure(false);
   const [status, setStatus] = useState<
     | { kind: "idle" }
@@ -35,6 +40,14 @@ export function PostToMatrixButton({ meetingId, workspaceId }: PostToMatrixButto
   );
   const servers = serversQuery.data ?? [];
   const serverId = servers[0]?.id ?? null;
+
+  // Show where this will actually go before it goes there — the destination is
+  // configured elsewhere, so the button must not be a leap of faith.
+  const bindingQuery = api.matrixRoom.getBinding.useQuery(
+    { workspaceId: workspaceId ?? "", projectId },
+    { enabled: !!workspaceId },
+  );
+  const effective = bindingQuery.data?.effective;
 
   const post = api.transcription.postToMatrix.useMutation({
     onSuccess: (result) => {
@@ -139,10 +152,20 @@ export function PostToMatrixButton({ meetingId, workspaceId }: PostToMatrixButto
               </Alert>
             )}
 
-            <Text size="xs" className="text-text-muted">
-              Sends this meeting&apos;s summary, action count and a link to the room
-              bound to its project.
-            </Text>
+            {effective?.kind === "room" ? (
+              <Text size="xs" className="text-text-muted">
+                Goes to <span className="text-text-primary">{effective.name}</span>
+                {effective.inherited ? " (workspace default)" : ""}.
+              </Text>
+            ) : effective?.kind === "off" ? (
+              <Text size="xs" className="text-text-muted">
+                This project&apos;s Matrix posting is switched off.
+              </Text>
+            ) : (
+              <Text size="xs" className="text-text-muted">
+                No room is bound yet — you&apos;ll be asked to pick one.
+              </Text>
+            )}
 
             <Button
               size="xs"

--- a/src/app/_components/matrix/PostToMatrixButton.tsx
+++ b/src/app/_components/matrix/PostToMatrixButton.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { Alert, Button, Modal, Popover, Stack, Text } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { IconAlertTriangle, IconCheck, IconSend } from "@tabler/icons-react";
+import { useState } from "react";
+import { api } from "~/trpc/react";
+import { MatrixRoomPicker, type MatrixRoomChoice } from "./MatrixRoomPicker";
+
+interface PostToMatrixButtonProps {
+  meetingId: string;
+  workspaceId: string | null;
+}
+
+/**
+ * Posting is always a click, never an event.
+ *
+ * Matrix has no un-send, so there is deliberately no automatic trigger anywhere — not
+ * on project assignment, not on summarization. This button is the only way a summary
+ * reaches a room.
+ */
+export function PostToMatrixButton({ meetingId, workspaceId }: PostToMatrixButtonProps) {
+  const [pickerOpened, { open: openPicker, close: closePicker }] = useDisclosure(false);
+  const [status, setStatus] = useState<
+    | { kind: "idle" }
+    | { kind: "posted"; roomId: string }
+    | { kind: "blocked"; message: string }
+    | { kind: "confirm"; roomId: string; lastPostedAt: Date }
+  >({ kind: "idle" });
+  const [chosen, setChosen] = useState<MatrixRoomChoice | null>(null);
+
+  const serversQuery = api.matrixServer.list.useQuery(
+    { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId },
+  );
+  const servers = serversQuery.data ?? [];
+  const serverId = servers[0]?.id ?? null;
+
+  const post = api.transcription.postToMatrix.useMutation({
+    onSuccess: (result) => {
+      switch (result.kind) {
+        case "posted":
+          setStatus({ kind: "posted", roomId: result.roomId });
+          closePicker();
+          return;
+        case "needs-confirm":
+          setStatus({
+            kind: "confirm",
+            roomId: result.roomId,
+            lastPostedAt: new Date(result.lastPostedAt),
+          });
+          return;
+        case "no-destination":
+          // Not a dead end: offer the picker so the post can still happen.
+          setStatus({ kind: "idle" });
+          openPicker();
+          return;
+        case "blocked-off":
+          setStatus({
+            kind: "blocked",
+            message:
+              "This project's Matrix posting is switched off, so its summaries stay in Exponential.",
+          });
+          return;
+        case "no-summary":
+          setStatus({
+            kind: "blocked",
+            message: "This meeting has no summary yet — generate one first.",
+          });
+          return;
+        default:
+          setStatus({ kind: "blocked", message: result.reason });
+      }
+    },
+  });
+
+  if (!workspaceId || servers.length === 0) return null;
+
+  function postToResolvedRoom(confirmRepost = false) {
+    setStatus({ kind: "idle" });
+    post.mutate({ meetingId, ...(confirmRepost ? { confirmRepost } : {}) });
+  }
+
+  function postToChosenRoom(confirmRepost = false) {
+    if (!chosen || !serverId) return;
+    setStatus({ kind: "idle" });
+    post.mutate({
+      meetingId,
+      roomId: chosen.roomId,
+      serverId,
+      ...(confirmRepost ? { confirmRepost } : {}),
+    });
+  }
+
+  return (
+    <>
+      <Popover width={320} position="bottom-end" withArrow>
+        <Popover.Target>
+          <button className="mp-btn" type="button">
+            <IconSend size={14} /> Post to Matrix
+          </button>
+        </Popover.Target>
+        <Popover.Dropdown>
+          <Stack gap="xs">
+            {status.kind === "posted" && (
+              <Alert color="green" variant="light" icon={<IconCheck size={16} />}>
+                Posted to {status.roomId}.
+              </Alert>
+            )}
+
+            {status.kind === "blocked" && (
+              <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
+                {status.message}
+              </Alert>
+            )}
+
+            {status.kind === "confirm" && (
+              <Alert color="yellow" variant="light" icon={<IconAlertTriangle size={16} />}>
+                <Text size="sm">
+                  Already posted to this room{" "}
+                  {status.lastPostedAt.toLocaleString()}. Matrix has no un-send, so a
+                  second copy is permanent.
+                </Text>
+                <Button
+                  size="xs"
+                  mt="xs"
+                  color="yellow"
+                  loading={post.isPending}
+                  onClick={() => (chosen ? postToChosenRoom(true) : postToResolvedRoom(true))}
+                >
+                  Post again
+                </Button>
+              </Alert>
+            )}
+
+            {post.error && (
+              <Alert color="red" variant="light">
+                {post.error.message}
+              </Alert>
+            )}
+
+            <Text size="xs" className="text-text-muted">
+              Sends this meeting&apos;s summary, action count and a link to the room
+              bound to its project.
+            </Text>
+
+            <Button
+              size="xs"
+              loading={post.isPending}
+              onClick={() => postToResolvedRoom()}
+            >
+              Post summary
+            </Button>
+            <Button size="xs" variant="subtle" onClick={openPicker}>
+              Choose a room
+            </Button>
+          </Stack>
+        </Popover.Dropdown>
+      </Popover>
+
+      <Modal
+        opened={pickerOpened}
+        onClose={closePicker}
+        title="Post this summary to a room"
+        size="lg"
+      >
+        <Stack gap="md">
+          {serverId && (
+            <MatrixRoomPicker
+              workspaceId={workspaceId}
+              serverId={serverId}
+              selectedRoomId={chosen?.roomId ?? null}
+              onSelect={setChosen}
+            />
+          )}
+
+          {status.kind === "blocked" && (
+            <Alert color="red" variant="light">
+              {status.message}
+            </Alert>
+          )}
+
+          <Button
+            disabled={!chosen}
+            loading={post.isPending}
+            onClick={() => postToChosenRoom()}
+          >
+            Post to {chosen?.name ?? "the selected room"}
+          </Button>
+        </Stack>
+      </Modal>
+    </>
+  );
+}

--- a/src/app/_components/matrix/__tests__/PostToMatrixButton.test.tsx
+++ b/src/app/_components/matrix/__tests__/PostToMatrixButton.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * The post button's own decisions: what it tells the user before posting, and whether
+ * choosing a room quietly reconfigures their project.
+ *
+ * The seam's behaviour is covered in postMeetingSummary.test.ts; these are the choices
+ * that only exist in the UI.
+ */
+
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "~/test/test-utils";
+
+interface Effective {
+  kind: "room" | "off" | "none";
+  name?: string;
+  inherited?: boolean;
+}
+
+const state: {
+  servers: { id: string }[];
+  effective: Effective;
+  rooms: { joined: { roomId: string; name: string; isEncrypted: boolean }[]; invited: [] };
+} = {
+  servers: [{ id: "srv-1" }],
+  effective: { kind: "none" },
+  rooms: { joined: [], invited: [] },
+};
+
+const postMutate = vi.fn();
+const bindMutate = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+  api: {
+    useUtils: () => ({ matrixRoom: { getBinding: { invalidate: vi.fn() } } }),
+    matrixServer: {
+      list: { useQuery: () => ({ data: state.servers, isLoading: false, error: null }) },
+      rooms: { useQuery: () => ({ data: state.rooms, isLoading: false, error: null }) },
+      acceptInvite: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false, error: null }),
+      },
+    },
+    matrixRoom: {
+      getBinding: {
+        useQuery: () => ({
+          data: { mode: "inherit", room: null, effective: state.effective },
+          isLoading: false,
+          error: null,
+        }),
+      },
+      bind: { useMutation: () => ({ mutate: bindMutate, isPending: false, error: null }) },
+    },
+    transcription: {
+      postToMatrix: {
+        useMutation: () => ({ mutate: postMutate, isPending: false, error: null }),
+      },
+    },
+  },
+}));
+
+import { PostToMatrixButton } from "../PostToMatrixButton";
+
+beforeEach(() => {
+  postMutate.mockClear();
+  bindMutate.mockClear();
+  state.servers = [{ id: "srv-1" }];
+  state.effective = { kind: "none" };
+  state.rooms = { joined: [], invited: [] };
+});
+
+describe("PostToMatrixButton", () => {
+  test("renders nothing when the workspace has no Matrix server", () => {
+    state.servers = [];
+    render(<PostToMatrixButton meetingId="m1" workspaceId="ws-1" projectId="p1" />);
+    expect(screen.queryByText("Post to Matrix")).toBeNull();
+  });
+
+  test("renders nothing for a meeting outside any workspace", () => {
+    render(<PostToMatrixButton meetingId="m1" workspaceId={null} projectId={null} />);
+    expect(screen.queryByText("Post to Matrix")).toBeNull();
+  });
+
+  test("names the resolved room before anything is sent", () => {
+    state.effective = { kind: "room", name: "Engineering", inherited: false };
+    render(<PostToMatrixButton meetingId="m1" workspaceId="ws-1" projectId="p1" />);
+
+    fireEvent.click(screen.getByText("Post to Matrix"));
+    expect(screen.getByText("Engineering")).toBeTruthy();
+  });
+
+  test("says when the room is inherited from the workspace", () => {
+    state.effective = { kind: "room", name: "General", inherited: true };
+    render(<PostToMatrixButton meetingId="m1" workspaceId="ws-1" projectId="p1" />);
+
+    fireEvent.click(screen.getByText("Post to Matrix"));
+    expect(screen.getByText(/workspace default/i)).toBeTruthy();
+  });
+
+  test("warns that posting is switched off for the project", () => {
+    state.effective = { kind: "off" };
+    render(<PostToMatrixButton meetingId="m1" workspaceId="ws-1" projectId="p1" />);
+
+    fireEvent.click(screen.getByText("Post to Matrix"));
+    expect(screen.getByText(/switched off/i)).toBeTruthy();
+  });
+
+  test("says a picker is coming when nothing is bound", () => {
+    render(<PostToMatrixButton meetingId="m1" workspaceId="ws-1" projectId="p1" />);
+
+    fireEvent.click(screen.getByText("Post to Matrix"));
+    expect(screen.getByText(/No room is bound yet/i)).toBeTruthy();
+  });
+
+  test("posting the resolved destination sends no room override", () => {
+    state.effective = { kind: "room", name: "Engineering", inherited: false };
+    render(<PostToMatrixButton meetingId="m1" workspaceId="ws-1" projectId="p1" />);
+
+    fireEvent.click(screen.getByText("Post to Matrix"));
+    fireEvent.click(screen.getByText("Post summary"));
+
+    expect(postMutate).toHaveBeenCalledWith({ meetingId: "m1" });
+  });
+
+  test("does not bind anything just from opening the picker", () => {
+    render(<PostToMatrixButton meetingId="m1" workspaceId="ws-1" projectId="p1" />);
+
+    fireEvent.click(screen.getByText("Post to Matrix"));
+    fireEvent.click(screen.getByText("Choose a room"));
+
+    // The checkbox exists but is off — a one-off post is not a configuration change.
+    const checkbox = screen.getByLabelText(
+      "Save as this project's room",
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    expect(bindMutate).not.toHaveBeenCalled();
+  });
+
+  test("offers no save checkbox for a meeting with no project", () => {
+    render(<PostToMatrixButton meetingId="m1" workspaceId="ws-1" projectId={null} />);
+
+    fireEvent.click(screen.getByText("Post to Matrix"));
+    fireEvent.click(screen.getByText("Choose a room"));
+
+    // There is no project to save it to.
+    expect(screen.queryByLabelText("Save as this project's room")).toBeNull();
+  });
+});

--- a/src/app/_components/matrix/__tests__/PostToMatrixButton.test.tsx
+++ b/src/app/_components/matrix/__tests__/PostToMatrixButton.test.tsx
@@ -27,6 +27,8 @@ const state: {
 
 const postMutate = vi.fn();
 const bindMutate = vi.fn();
+/** What the next postToMatrix call should resolve to, so onSuccess branches can run. */
+const mutationResult: { current: unknown } = { current: null };
 
 vi.mock("~/trpc/react", () => ({
   api: {
@@ -50,7 +52,15 @@ vi.mock("~/trpc/react", () => ({
     },
     transcription: {
       postToMatrix: {
-        useMutation: () => ({ mutate: postMutate, isPending: false, error: null }),
+        useMutation: (opts?: { onSuccess?: (r: unknown) => void }) => ({
+          mutate: (vars: unknown) => {
+            postMutate(vars);
+            const next = mutationResult.current;
+            if (next) opts?.onSuccess?.(next);
+          },
+          isPending: false,
+          error: null,
+        }),
       },
     },
   },
@@ -61,6 +71,7 @@ import { PostToMatrixButton } from "../PostToMatrixButton";
 beforeEach(() => {
   postMutate.mockClear();
   bindMutate.mockClear();
+  mutationResult.current = null;
   state.servers = [{ id: "srv-1" }];
   state.effective = { kind: "none" };
   state.rooms = { joined: [], invited: [] };
@@ -141,5 +152,40 @@ describe("PostToMatrixButton", () => {
 
     // There is no project to save it to.
     expect(screen.queryByLabelText("Save as this project's room")).toBeNull();
+  });
+
+  test("a confirmed repost goes to the room the warning named, not a stale pick", () => {
+    // The reviewer's scenario: pick a room in the picker but DON'T post it, then post
+    // the resolved destination and confirm the repost. Reading the picked room at click
+    // time would send the repost somewhere the warning never mentioned — and Matrix has
+    // no un-send, so that copy is permanent.
+    state.effective = { kind: "room", name: "Engineering", inherited: false };
+    state.rooms = {
+      joined: [{ roomId: "!other:example.org", name: "Other", isEncrypted: false }],
+      invited: [],
+    };
+    render(<PostToMatrixButton meetingId="m1" workspaceId="ws-1" projectId="p1" />);
+
+    // Select "Other" — this sets `chosen` — then abandon the picker without posting.
+    fireEvent.click(screen.getByText("Post to Matrix"));
+    fireEvent.click(screen.getByText("Choose a room"));
+    fireEvent.click(screen.getByLabelText("Other"));
+    fireEvent.click(document.querySelector(".mantine-Modal-close")!);
+
+    // Post the RESOLVED destination and get a repost warning naming it.
+    mutationResult.current = {
+      kind: "needs-confirm",
+      roomId: "!eng:example.org",
+      lastPostedAt: "2026-08-11T09:00:00Z",
+    };
+    fireEvent.click(screen.getByText("Post to Matrix"));
+    fireEvent.click(screen.getByText("Post summary"));
+
+    postMutate.mockClear();
+    mutationResult.current = { kind: "posted", roomId: "!eng:example.org" };
+    fireEvent.click(screen.getByText("Post again"));
+
+    // No room override — the resolved destination is what the warning was about.
+    expect(postMutate).toHaveBeenCalledWith({ meetingId: "m1", confirmRepost: true });
   });
 });

--- a/src/app/_components/matrix/__tests__/PostToMatrixButton.test.tsx
+++ b/src/app/_components/matrix/__tests__/PostToMatrixButton.test.tsx
@@ -188,4 +188,53 @@ describe("PostToMatrixButton", () => {
     // No room override — the resolved destination is what the warning was about.
     expect(postMutate).toHaveBeenCalledWith({ meetingId: "m1", confirmRepost: true });
   });
+
+  test("does not bind an abandoned pick when the resolved room is posted", () => {
+    // Tick the checkbox and pick "Other", then abandon the picker and post the
+    // RESOLVED room. The post goes to the resolved room, so the project must not be
+    // bound to "Other" — a binding is permanent configuration, not a side effect.
+    state.effective = { kind: "room", name: "Engineering", inherited: false };
+    state.rooms = {
+      joined: [{ roomId: "!other:example.org", name: "Other", isEncrypted: false }],
+      invited: [],
+    };
+    render(<PostToMatrixButton meetingId="m1" workspaceId="ws-1" projectId="p1" />);
+
+    fireEvent.click(screen.getByText("Post to Matrix"));
+    fireEvent.click(screen.getByText("Choose a room"));
+    fireEvent.click(screen.getByLabelText("Save as this project's room"));
+    fireEvent.click(screen.getByLabelText("Other"));
+    fireEvent.click(document.querySelector(".mantine-Modal-close")!);
+
+    mutationResult.current = { kind: "posted", roomId: "!eng:example.org" };
+    fireEvent.click(screen.getByText("Post to Matrix"));
+    fireEvent.click(screen.getByText("Post summary"));
+
+    expect(bindMutate).not.toHaveBeenCalled();
+  });
+
+  test("binds the picked room when that is the room actually posted to", () => {
+    state.effective = { kind: "none" };
+    state.rooms = {
+      joined: [{ roomId: "!other:example.org", name: "Other", isEncrypted: false }],
+      invited: [],
+    };
+    render(<PostToMatrixButton meetingId="m1" workspaceId="ws-1" projectId="p1" />);
+
+    fireEvent.click(screen.getByText("Post to Matrix"));
+    fireEvent.click(screen.getByText("Choose a room"));
+    fireEvent.click(screen.getByLabelText("Save as this project's room"));
+    fireEvent.click(screen.getByLabelText("Other"));
+
+    mutationResult.current = { kind: "posted", roomId: "!other:example.org" };
+    fireEvent.click(screen.getByText("Post to Other"));
+
+    expect(bindMutate).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      projectId: "p1",
+      serverId: "srv-1",
+      roomId: "!other:example.org",
+      roomName: "Other",
+    });
+  });
 });

--- a/src/app/_components/meeting/MeetingDetail.tsx
+++ b/src/app/_components/meeting/MeetingDetail.tsx
@@ -198,6 +198,7 @@ export function MeetingDetail({
             <PostToMatrixButton
               meetingId={session.id}
               workspaceId={session.workspaceId ?? null}
+              projectId={session.projectId ?? null}
             />
           }
         />

--- a/src/app/_components/meeting/MeetingDetail.tsx
+++ b/src/app/_components/meeting/MeetingDetail.tsx
@@ -5,6 +5,7 @@ import { notifications } from "@mantine/notifications";
 import { IconSparkles, IconFileText, IconPhoto } from "@tabler/icons-react";
 import "./meeting-detail.css";
 import { MeetingHeader } from "./MeetingHeader";
+import { PostToMatrixButton } from "~/app/_components/matrix/PostToMatrixButton";
 import { SummaryTab } from "./SummaryTab";
 import { TranscriptView } from "./TranscriptView";
 import { ScreenshotsTab } from "./ScreenshotsTab";
@@ -193,6 +194,12 @@ export function MeetingDetail({
           workspaceName={session.workspace?.name ?? null}
           backHref={backHref}
           onShare={handleShare}
+          extraActions={
+            <PostToMatrixButton
+              meetingId={session.id}
+              workspaceId={session.workspaceId ?? null}
+            />
+          }
         />
 
         <nav className="mp-tabs" role="tablist" aria-label="Meeting sections">

--- a/src/app/_components/meeting/MeetingHeader.tsx
+++ b/src/app/_components/meeting/MeetingHeader.tsx
@@ -20,6 +20,8 @@ interface MeetingHeaderProps {
   workspaceName: string | null;
   backHref: string;
   onShare: () => void;
+  /** Extra actions rendered beside Share, e.g. posting the summary to a chat room. */
+  extraActions?: React.ReactNode;
 }
 
 export function MeetingHeader({
@@ -33,6 +35,7 @@ export function MeetingHeader({
   workspaceName,
   backHref,
   onShare,
+  extraActions,
 }: MeetingHeaderProps) {
   return (
     <header className="mp-head">
@@ -99,6 +102,7 @@ export function MeetingHeader({
           <button className="mp-btn" onClick={onShare}>
             <IconShare size={14} /> Share
           </button>
+          {extraActions}
         </div>
       </div>
     </header>

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -30,6 +30,7 @@ import { whatsappGatewayRouter } from "./routers/whatsappGateway";
 import { telegramGatewayRouter } from "./routers/telegramGateway";
 import { matrixGatewayRouter } from "./routers/matrixGateway";
 import { matrixServerRouter } from "./routers/matrixServer";
+import { matrixRoomRouter } from "./routers/matrixRoom";
 import { notificationRouter } from "./routers/notification";
 import { pushSubscriptionRouter } from "./routers/pushSubscription";
 import { weeklyPlanningRouter } from "./routers/weeklyPlanning";
@@ -126,6 +127,7 @@ export const appRouter = createTRPCRouter({
   telegramGateway: telegramGatewayRouter,
   matrixGateway: matrixGatewayRouter,
   matrixServer: matrixServerRouter,
+  matrixRoom: matrixRoomRouter,
   externalAgent: externalAgentRouter,
   notification: notificationRouter,
   pushSubscription: pushSubscriptionRouter,

--- a/src/server/api/routers/__tests__/channelLink.test.ts
+++ b/src/server/api/routers/__tests__/channelLink.test.ts
@@ -69,6 +69,7 @@ vi.mock("~/server/db", () => {
 });
 
 import { createMockCaller } from "~/test/trpc-helpers";
+import { resolveChannelLink } from "~/server/services/channelLinkService";
 
 const WORKSPACE_ID = "ws-1";
 const USER_ID = "user-1";
@@ -218,6 +219,59 @@ describe("channelLink router (mocked)", () => {
       ).rejects.toMatchObject({ code: "FORBIDDEN" });
 
       expect(dbMock.channelLink.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * ChannelLink now carries outbound routing rows too (which room a project's meeting
+   * summaries go to). The inbound resolver must not see them: it answers the opposite
+   * question, and treating an outbound row as inbound would attribute an incoming
+   * message to a binding that was never about receiving.
+   */
+  describe("direction", () => {
+    it("resolves an existing WhatsApp row, which defaults to inbound", async () => {
+      dbMock.channelLink.findUnique.mockResolvedValue({
+        id: "cl-1",
+        provider: PROVIDER,
+        externalId: EXTERNAL_ID,
+        workspaceId: WORKSPACE_ID,
+        isActive: true,
+        direction: "inbound",
+      } as never);
+
+      await expect(
+        resolveChannelLink(dbMock, PROVIDER, EXTERNAL_ID),
+      ).resolves.toMatchObject({ id: "cl-1" });
+    });
+
+    it("is blind to an outbound row", async () => {
+      dbMock.channelLink.findUnique.mockResolvedValue({
+        id: "cl-outbound",
+        provider: "matrix",
+        externalId: "!room:example.org",
+        workspaceId: WORKSPACE_ID,
+        isActive: true,
+        direction: "outbound",
+      } as never);
+
+      await expect(
+        resolveChannelLink(dbMock, "matrix", "!room:example.org"),
+      ).resolves.toBeNull();
+    });
+
+    it("still drops an inactive inbound row", async () => {
+      dbMock.channelLink.findUnique.mockResolvedValue({
+        id: "cl-1",
+        provider: PROVIDER,
+        externalId: EXTERNAL_ID,
+        workspaceId: WORKSPACE_ID,
+        isActive: false,
+        direction: "inbound",
+      } as never);
+
+      await expect(
+        resolveChannelLink(dbMock, PROVIDER, EXTERNAL_ID),
+      ).resolves.toBeNull();
     });
   });
 });

--- a/src/server/api/routers/__tests__/matrixRoom.test.ts
+++ b/src/server/api/routers/__tests__/matrixRoom.test.ts
@@ -136,6 +136,32 @@ describe("matrixRoom.bind", () => {
     });
   });
 
+  it("refuses a project that belongs to a different workspace", async () => {
+    // Edit rights on a project in workspace A must not let someone write outbound
+    // ChannelLink rows scoped to workspace B. The rows are keyed on
+    // (workspaceId, projectId), so a mismatched pair is a cross-tenant write.
+    asWorkspaceRole("owner");
+    dbMock.project.findUnique.mockResolvedValue({
+      id: PROJECT,
+      createdById: USER,
+      workspaceId: "ws-somewhere-else",
+      isRestricted: false,
+      teamId: null,
+    } as never);
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.bind({
+        workspaceId: WORKSPACE,
+        projectId: PROJECT,
+        serverId: SERVER,
+        roomId: ROOM,
+      }),
+    ).rejects.toThrow(/not in this workspace/i);
+    expect(dbMock.channelLink.create).not.toHaveBeenCalled();
+    expect(dbMock.channelLink.update).not.toHaveBeenCalled();
+  });
+
   it("refuses a server registered to another workspace", async () => {
     asWorkspaceRole("owner");
     asProjectOwner();
@@ -254,6 +280,36 @@ describe("matrixRoom.unbind", () => {
         projectId: PROJECT,
       },
     });
+  });
+});
+
+describe("cross-workspace writes", () => {
+  beforeEach(() => {
+    asWorkspaceRole("owner");
+    dbMock.project.findUnique.mockResolvedValue({
+      id: PROJECT,
+      createdById: USER,
+      workspaceId: "ws-somewhere-else",
+      isRestricted: false,
+      teamId: null,
+    } as never);
+  });
+
+  it("will not delete another workspace's binding rows via unbind", async () => {
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.unbind({ workspaceId: WORKSPACE, projectId: PROJECT }),
+    ).rejects.toThrow(/not in this workspace/i);
+    expect(dbMock.channelLink.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("will not switch off a project in another workspace", async () => {
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.setOff({ workspaceId: WORKSPACE, projectId: PROJECT }),
+    ).rejects.toThrow(/not in this workspace/i);
+    expect(dbMock.channelLink.update).not.toHaveBeenCalled();
+    expect(dbMock.channelLink.create).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/api/routers/__tests__/matrixRoom.test.ts
+++ b/src/server/api/routers/__tests__/matrixRoom.test.ts
@@ -205,10 +205,14 @@ describe("matrixRoom.setOff", () => {
       caller.matrixRoom.setOff({ workspaceId: WORKSPACE, projectId: PROJECT }),
     ).resolves.toEqual({ off: true });
 
-    expect(dbMock.channelLink.update).toHaveBeenCalledWith({
-      where: { id: "link-1" },
-      data: { isActive: false },
-    });
+    const update = dbMock.channelLink.update.mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(update.data.isActive).toBe(false);
+    // The room id is released, or `@@unique([provider, externalId])` would keep that
+    // room reserved by a switched-off project and unbindable anywhere else.
+    expect(update.data.externalId).toBe(`off:${PROJECT}`);
+    expect(update.data.serverIntegrationId).toBeNull();
     expect(dbMock.channelLink.delete).not.toHaveBeenCalled();
   });
 

--- a/src/server/api/routers/__tests__/matrixRoom.test.ts
+++ b/src/server/api/routers/__tests__/matrixRoom.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Binding rooms to projects and workspaces.
+ *
+ * The three modes must stay distinguishable — Inherit is an absent row, Room is an
+ * active one, Off is an inactive one — because each leads to different behaviour when a
+ * post is attempted. Mocked Prisma; no DB.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(32);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const USER = "user-1";
+const WORKSPACE = "ws-1";
+const PROJECT = "proj-1";
+const SERVER = "int-1";
+const ROOM = "!eng:example.org";
+
+let dbMock: DeepMockProxy<PrismaClient>;
+
+function asWorkspaceRole(role: string) {
+  dbMock.workspaceUser.findUnique.mockResolvedValue({
+    role,
+    workspaceId: WORKSPACE,
+  } as never);
+  dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+}
+
+/** Project edit access via ownership, which is the simplest path through the resolver. */
+function asProjectOwner() {
+  dbMock.project.findUnique.mockResolvedValue({
+    id: PROJECT,
+    createdById: USER,
+    workspaceId: WORKSPACE,
+    isRestricted: false,
+    teamId: null,
+  } as never);
+  dbMock.projectMember.findFirst.mockResolvedValue(null as never);
+}
+
+beforeEach(() => {
+  dbMock = getDbMock();
+  mockReset(dbMock);
+  dbMock.user.findUnique.mockResolvedValue({ isAgent: false } as never);
+  dbMock.integration.findFirst.mockResolvedValue({ id: SERVER } as never);
+});
+
+describe("matrixRoom.bind", () => {
+  it("creates an active outbound row for a project", async () => {
+    asWorkspaceRole("member");
+    asProjectOwner();
+    dbMock.channelLink.findFirst.mockResolvedValue(null as never);
+    dbMock.channelLink.create.mockResolvedValue({
+      id: "link-1",
+      externalId: ROOM,
+    } as never);
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.bind({
+        workspaceId: WORKSPACE,
+        projectId: PROJECT,
+        serverId: SERVER,
+        roomId: ROOM,
+        roomName: "Engineering",
+      }),
+    ).resolves.toMatchObject({ roomId: ROOM });
+
+    const created = dbMock.channelLink.create.mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(created.data).toMatchObject({
+      provider: "matrix",
+      direction: "outbound",
+      externalId: ROOM,
+      workspaceId: WORKSPACE,
+      projectId: PROJECT,
+      isActive: true,
+      serverIntegrationId: SERVER,
+    });
+  });
+
+  it("refuses a server registered to another workspace", async () => {
+    asWorkspaceRole("owner");
+    asProjectOwner();
+    dbMock.integration.findFirst.mockResolvedValue(null as never);
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.bind({
+        workspaceId: WORKSPACE,
+        projectId: PROJECT,
+        serverId: "int-elsewhere",
+        roomId: ROOM,
+      }),
+    ).rejects.toThrow(/not registered in this workspace/);
+    expect(dbMock.channelLink.create).not.toHaveBeenCalled();
+  });
+
+  it("requires owner/admin for the workspace default, not mere membership", async () => {
+    asWorkspaceRole("member");
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.bind({
+        workspaceId: WORKSPACE,
+        projectId: null,
+        serverId: SERVER,
+        roomId: ROOM,
+      }),
+    ).rejects.toThrow(/requires the owner or admin role/);
+    expect(dbMock.channelLink.create).not.toHaveBeenCalled();
+  });
+
+  it("lets an admin set the workspace default", async () => {
+    asWorkspaceRole("admin");
+    dbMock.channelLink.findFirst.mockResolvedValue(null as never);
+    dbMock.channelLink.create.mockResolvedValue({
+      id: "link-ws",
+      externalId: ROOM,
+    } as never);
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.bind({
+        workspaceId: WORKSPACE,
+        projectId: null,
+        serverId: SERVER,
+        roomId: ROOM,
+      }),
+    ).resolves.toMatchObject({ roomId: ROOM });
+
+    const created = dbMock.channelLink.create.mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(created.data.projectId).toBeNull();
+  });
+});
+
+describe("matrixRoom.setOff", () => {
+  it("deactivates rather than deleting, so Off stays distinct from never-configured", async () => {
+    asWorkspaceRole("member");
+    asProjectOwner();
+    dbMock.channelLink.findFirst.mockResolvedValue({ id: "link-1" } as never);
+    dbMock.channelLink.update.mockResolvedValue({ id: "link-1" } as never);
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.setOff({ workspaceId: WORKSPACE, projectId: PROJECT }),
+    ).resolves.toEqual({ off: true });
+
+    expect(dbMock.channelLink.update).toHaveBeenCalledWith({
+      where: { id: "link-1" },
+      data: { isActive: false },
+    });
+    expect(dbMock.channelLink.delete).not.toHaveBeenCalled();
+  });
+
+  it("creates an inactive row when the project had no binding at all", async () => {
+    asWorkspaceRole("member");
+    asProjectOwner();
+    dbMock.channelLink.findFirst.mockResolvedValue(null as never);
+    dbMock.channelLink.create.mockResolvedValue({ id: "link-off" } as never);
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await caller.matrixRoom.setOff({ workspaceId: WORKSPACE, projectId: PROJECT });
+
+    const created = dbMock.channelLink.create.mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(created.data.isActive).toBe(false);
+    // Namespaced, not a real room id — an Off row must not consume a real room's one
+    // binding slot under the (provider, externalId) unique.
+    expect(created.data.externalId).toBe(`off:${PROJECT}`);
+  });
+});
+
+describe("matrixRoom.unbind", () => {
+  it("removes the row so resolution falls through to the workspace again", async () => {
+    asWorkspaceRole("member");
+    asProjectOwner();
+    dbMock.channelLink.deleteMany.mockResolvedValue({ count: 1 } as never);
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.unbind({ workspaceId: WORKSPACE, projectId: PROJECT }),
+    ).resolves.toEqual({ removed: 1 });
+
+    expect(dbMock.channelLink.deleteMany).toHaveBeenCalledWith({
+      where: {
+        provider: "matrix",
+        direction: "outbound",
+        workspaceId: WORKSPACE,
+        projectId: PROJECT,
+      },
+    });
+  });
+});
+
+describe("matrixRoom.getBinding", () => {
+  it("reports inherit plus the room actually inherited from the workspace", async () => {
+    asWorkspaceRole("member");
+    // No project row; the workspace default answers the resolution call.
+    dbMock.channelLink.findFirst
+      .mockResolvedValueOnce(null as never)
+      .mockResolvedValueOnce(null as never)
+      .mockResolvedValueOnce({
+        id: "link-ws",
+        externalId: ROOM,
+        displayName: "Engineering",
+        projectId: null,
+        isActive: true,
+      } as never);
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    const result = await caller.matrixRoom.getBinding({
+      workspaceId: WORKSPACE,
+      projectId: PROJECT,
+    });
+
+    expect(result.mode).toBe("inherit");
+    expect(result.effective).toMatchObject({
+      kind: "room",
+      name: "Engineering",
+      inherited: true,
+    });
+  });
+
+  it("reports off, and an effective destination of off", async () => {
+    asWorkspaceRole("member");
+    dbMock.channelLink.findFirst.mockResolvedValue({
+      id: "link-1",
+      externalId: `off:${PROJECT}`,
+      displayName: null,
+      projectId: PROJECT,
+      isActive: false,
+    } as never);
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    const result = await caller.matrixRoom.getBinding({
+      workspaceId: WORKSPACE,
+      projectId: PROJECT,
+    });
+
+    expect(result.mode).toBe("off");
+    expect(result.room).toBeNull();
+    expect(result.effective).toEqual({ kind: "off" });
+  });
+
+  it("refuses a non-member", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(null as never);
+    dbMock.teamUser.findFirst.mockResolvedValue(null as never);
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.getBinding({ workspaceId: WORKSPACE, projectId: PROJECT }),
+    ).rejects.toThrow(/not a member of this workspace/);
+  });
+});

--- a/src/server/api/routers/matrixRoom.ts
+++ b/src/server/api/routers/matrixRoom.ts
@@ -221,7 +221,16 @@ export const matrixRoomRouter = createTRPCRouter({
       if (existing) {
         await ctx.db.channelLink.update({
           where: { id: existing.id },
-          data: { isActive: false },
+          data: {
+            isActive: false,
+            // Release the room's binding slot. `@@unique([provider, externalId])` means
+            // one room maps to one destination, so leaving the real room id on a
+            // switched-off row would make that room unbindable anywhere else — the
+            // project turns Off and quietly takes the room out of circulation.
+            externalId: `off:${input.projectId}`,
+            displayName: null,
+            serverIntegrationId: null,
+          },
         });
         return { off: true };
       }

--- a/src/server/api/routers/matrixRoom.ts
+++ b/src/server/api/routers/matrixRoom.ts
@@ -1,0 +1,268 @@
+/**
+ * Binding a Matrix room to a project (or to a workspace as its default).
+ *
+ * Bindings are outbound `ChannelLink` rows — the same record ADR-0023 defines as the
+ * routing authority — rather than a Matrix-specific table, because an inbound room agent
+ * will later need to answer "which workspace and project is this room?", which is the
+ * same question read the other way.
+ *
+ * The tri-state a project sees is Inherit / Room / Off:
+ *   - Inherit → no project row at all; resolution falls through to the workspace.
+ *   - Room    → an active project row naming the room.
+ *   - Off     → an *inactive* project row, so "explicitly off" stays distinguishable
+ *               from "never configured". Off hard-blocks and does not fall through.
+ */
+
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { Prisma } from "@prisma/client";
+import { createTRPCRouter, humanOnlyProcedure, protectedProcedure } from "~/server/api/trpc";
+import {
+  assertWorkspaceRole,
+  canEditProject,
+  getProjectAccess,
+  getWorkspaceMembership,
+} from "~/server/services/access";
+import { OUTBOUND } from "~/server/services/channelLinkService";
+import { MATRIX_CHANNEL_PROVIDER } from "~/server/services/matrix/constants";
+import { resolveMatrixDestination } from "~/server/services/matrix/resolveMatrixDestination";
+
+/** A project lead configures their own project's room; only admins set the default. */
+async function assertCanBind(
+  db: Parameters<typeof getProjectAccess>[0],
+  userId: string,
+  workspaceId: string,
+  projectId: string | null,
+): Promise<void> {
+  if (!projectId) {
+    await assertWorkspaceRole(db, userId, workspaceId, ["owner", "admin"]);
+    return;
+  }
+
+  const access = await getProjectAccess(db, userId, projectId);
+  if (!canEditProject(access)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You do not have edit access to this project.",
+    });
+  }
+}
+
+export const matrixRoomRouter = createTRPCRouter({
+  /**
+   * What this project (or workspace) is bound to, and what would actually be used.
+   *
+   * `effective` is what the post button will do; `mode` is what the control shows. They
+   * differ under Inherit, which is the whole point of showing both.
+   */
+  getBinding: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        projectId: z.string().nullable().optional(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const membership = await getWorkspaceMembership(
+        ctx.db,
+        ctx.session.user.id,
+        input.workspaceId,
+      );
+      if (!membership) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You are not a member of this workspace.",
+        });
+      }
+
+      const projectId = input.projectId ?? null;
+
+      const own = await ctx.db.channelLink.findFirst({
+        where: {
+          provider: MATRIX_CHANNEL_PROVIDER,
+          direction: OUTBOUND,
+          workspaceId: input.workspaceId,
+          projectId,
+        },
+      });
+
+      const effective = await resolveMatrixDestination(ctx.db, {
+        projectId,
+        workspaceId: input.workspaceId,
+      });
+
+      const mode = !own ? "inherit" : own.isActive ? "room" : "off";
+
+      return {
+        mode,
+        room: own?.isActive
+          ? {
+              roomId: own.externalId,
+              name: own.displayName ?? own.externalId,
+              serverId: own.serverIntegrationId,
+            }
+          : null,
+        effective:
+          effective.kind === "room"
+            ? {
+                kind: "room" as const,
+                roomId: effective.link.externalId,
+                name: effective.link.displayName ?? effective.link.externalId,
+                inherited: effective.link.projectId !== projectId,
+              }
+            : { kind: effective.kind },
+      };
+    }),
+
+  /** Bind a room. Project-level for a lead, workspace-level for an admin. */
+  bind: humanOnlyProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        projectId: z.string().nullable().optional(),
+        serverId: z.string(),
+        roomId: z.string().min(1),
+        roomName: z.string().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const projectId = input.projectId ?? null;
+      await assertCanBind(ctx.db, ctx.session.user.id, input.workspaceId, projectId);
+
+      // The server must belong to this workspace, or a binding could point at another
+      // workspace's homeserver credentials.
+      const server = await ctx.db.integration.findFirst({
+        where: { id: input.serverId, workspaceId: input.workspaceId },
+        select: { id: true },
+      });
+      if (!server) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "That Matrix server is not registered in this workspace.",
+        });
+      }
+
+      const existing = await ctx.db.channelLink.findFirst({
+        where: {
+          provider: MATRIX_CHANNEL_PROVIDER,
+          direction: OUTBOUND,
+          workspaceId: input.workspaceId,
+          projectId,
+        },
+        select: { id: true },
+      });
+
+      const data = {
+        displayName: input.roomName ?? null,
+        externalId: input.roomId,
+        isActive: true,
+        serverIntegrationId: input.serverId,
+      };
+
+      try {
+        const link = existing
+          ? await ctx.db.channelLink.update({ where: { id: existing.id }, data })
+          : await ctx.db.channelLink.create({
+              data: {
+                ...data,
+                provider: MATRIX_CHANNEL_PROVIDER,
+                direction: OUTBOUND,
+                workspaceId: input.workspaceId,
+                projectId,
+                createdById: ctx.session.user.id,
+              },
+            });
+        return { id: link.id, roomId: link.externalId };
+      } catch (error) {
+        // `@@unique([provider, externalId])` means one room maps to exactly one
+        // destination. Correct for inbound routing, and a real constraint here: a
+        // workspace default and a project override cannot name the same room. Kept
+        // deliberately for V1 (a recorded open decision), so say so plainly rather
+        // than failing with a raw constraint error.
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === "P2002"
+        ) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "That room is already bound elsewhere. A room can only be bound to one project or workspace at a time.",
+          });
+        }
+        throw error;
+      }
+    }),
+
+  /**
+   * Switch a project's posting off. Project-level only: the confidential-project escape
+   * hatch is about one project opting out of a default, so there is nothing at workspace
+   * level for it to mean.
+   */
+  setOff: humanOnlyProcedure
+    .input(z.object({ workspaceId: z.string(), projectId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await assertCanBind(
+        ctx.db,
+        ctx.session.user.id,
+        input.workspaceId,
+        input.projectId,
+      );
+
+      const existing = await ctx.db.channelLink.findFirst({
+        where: {
+          provider: MATRIX_CHANNEL_PROVIDER,
+          direction: OUTBOUND,
+          workspaceId: input.workspaceId,
+          projectId: input.projectId,
+        },
+        select: { id: true },
+      });
+
+      if (existing) {
+        await ctx.db.channelLink.update({
+          where: { id: existing.id },
+          data: { isActive: false },
+        });
+        return { off: true };
+      }
+
+      // An "off" row still needs an externalId (the column is required and unique), so
+      // it is namespaced per project rather than naming a real room — there is no room
+      // to name, and a real room id here would consume that room's one binding slot.
+      await ctx.db.channelLink.create({
+        data: {
+          provider: MATRIX_CHANNEL_PROVIDER,
+          direction: OUTBOUND,
+          externalId: `off:${input.projectId}`,
+          workspaceId: input.workspaceId,
+          projectId: input.projectId,
+          isActive: false,
+          createdById: ctx.session.user.id,
+        },
+      });
+      return { off: true };
+    }),
+
+  /** Back to Inherit: remove the row entirely so resolution falls through again. */
+  unbind: humanOnlyProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        projectId: z.string().nullable().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const projectId = input.projectId ?? null;
+      await assertCanBind(ctx.db, ctx.session.user.id, input.workspaceId, projectId);
+
+      const { count } = await ctx.db.channelLink.deleteMany({
+        where: {
+          provider: MATRIX_CHANNEL_PROVIDER,
+          direction: OUTBOUND,
+          workspaceId: input.workspaceId,
+          projectId,
+        },
+      });
+      return { removed: count };
+    }),
+});

--- a/src/server/api/routers/matrixRoom.ts
+++ b/src/server/api/routers/matrixRoom.ts
@@ -39,6 +39,24 @@ async function assertCanBind(
     return;
   }
 
+  // The project must actually live in the workspace the caller named. Without this,
+  // edit rights on a project in workspace A would let someone write or delete outbound
+  // ChannelLink rows scoped to workspace B — the rows are keyed on
+  // (workspaceId, projectId), so a mismatched pair is a cross-tenant write.
+  const project = await db.project.findUnique({
+    where: { id: projectId },
+    select: { workspaceId: true },
+  });
+  if (!project || project.workspaceId !== workspaceId) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "That project is not in this workspace.",
+    });
+  }
+
+  // Project edit access, deliberately not workspace membership: a project lead
+  // configures their own project's room, and a lead may reach the project as a
+  // project-only member without being a workspace member.
   const access = await getProjectAccess(db, userId, projectId);
   if (!canEditProject(access)) {
     throw new TRPCError({

--- a/src/server/api/routers/transcription.ts
+++ b/src/server/api/routers/transcription.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { Prisma, PrismaClient } from "@prisma/client";
 import {
   createTRPCRouter,
+  humanOnlyProcedure,
   protectedProcedure,
 } from "~/server/api/trpc";
 import { TRPCError } from "@trpc/server";
@@ -15,6 +16,7 @@ import {
   normalizeFeatureName,
 } from "~/server/services/FeatureExtractionService";
 import { TICKET_TYPES } from "~/lib/ticket-types";
+import { postMeetingSummaryToMatrix } from "~/server/services/matrix/postMeetingSummary";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 import { loadProductWithAccess } from "~/plugins/product/server/routers/product";
 import { createTicketWithNumber } from "~/plugins/product/server/services/createTicket";
@@ -2742,5 +2744,47 @@ export const transcriptionRouter = createTRPCRouter({
         logs,
         nextCursor,
       };
+    }),
+
+  /**
+   * Post a meeting's summary into a Matrix room.
+   *
+   * Always an explicit human action — never wired to an event. Matrix has no un-send,
+   * and `bulkAssignProject` would otherwise turn one click into forty room messages.
+   *
+   * All the judgement lives in `postMeetingSummaryToMatrix`; this only translates the
+   * result into something the client can render. Expected outcomes (no destination,
+   * blocked off, needs confirmation) come back as data rather than errors, because the
+   * UI shows each of them differently.
+   */
+  postToMatrix: humanOnlyProcedure
+    .input(
+      z.object({
+        meetingId: z.string(),
+        roomId: z.string().optional(),
+        serverId: z.string().optional(),
+        confirmRepost: z.boolean().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const result = await postMeetingSummaryToMatrix(ctx.db, {
+        meetingId: input.meetingId,
+        ...(input.roomId ? { roomId: input.roomId } : {}),
+        ...(input.serverId ? { serverId: input.serverId } : {}),
+        ...(input.confirmRepost ? { confirmRepost: input.confirmRepost } : {}),
+        actorUserId: ctx.session.user.id,
+      });
+
+      if (result.kind === "not-found") {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meeting not found." });
+      }
+      if (result.kind === "no-access") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You do not have edit access to this meeting.",
+        });
+      }
+
+      return result;
     }),
 });

--- a/src/server/services/channelLinkService.ts
+++ b/src/server/services/channelLinkService.ts
@@ -29,9 +29,25 @@ export interface CreateChannelLinkInput {
 }
 
 /**
+ * `ChannelLink.direction` values.
+ *
+ * `inbound` is ADR-0023's original meaning and the column default, so every row that
+ * predates outbound routing keeps it: "which workspace/project owns this conversation?"
+ * `outbound` rows answer the reverse — "where does this project's content go?"
+ */
+export const INBOUND = "inbound";
+export const OUTBOUND = "outbound";
+
+/**
  * Resolve a watched conversation to its link. System path (ingest) — no access
  * check. Returns only an active link; an inactive or missing link resolves to
  * `null`, which the ingest path treats as "drop this summary".
+ *
+ * Inbound rows only. `ChannelLink` now also carries outbound routing rows (which room
+ * does this project's content go to), and those answer a different question — treating
+ * one as an inbound link would attribute an incoming message to a binding that was
+ * never about receiving. Existing rows default to `"inbound"`, so nothing that worked
+ * before changes.
  */
 export async function resolveChannelLink(
   db: PrismaClient,
@@ -42,6 +58,10 @@ export async function resolveChannelLink(
     where: { provider_externalId: { provider, externalId } },
   });
   if (!link || !link.isActive) return null;
+  // Only an *explicitly* outbound row is excluded. Anything else — the "inbound"
+  // default, or a row read through a mock that omits the column — is inbound, so this
+  // cannot start dropping links that worked before.
+  if (link.direction === OUTBOUND) return null;
   return link;
 }
 

--- a/src/server/services/matrix/MatrixClient.ts
+++ b/src/server/services/matrix/MatrixClient.ts
@@ -34,6 +34,20 @@ export class MatrixApiError extends Error {
   }
 }
 
+/**
+ * Refusal to post into an encrypted room. Its own type because it is not a homeserver
+ * failure at all — nothing was sent, and no retry or reconfiguration will help until
+ * ADR-0043's E2EE retrofit.
+ */
+export class MatrixEncryptedRoomError extends Error {
+  constructor(readonly roomId: string) {
+    super(
+      "That room is encrypted, and the bot has no encryption keys, so it cannot post there.",
+    );
+    this.name = "MatrixEncryptedRoomError";
+  }
+}
+
 interface MatrixErrorBody {
   errcode?: string;
   error?: string;
@@ -221,6 +235,44 @@ export class MatrixClient {
         isEncrypted: events.some((event) => event.type === "m.room.encryption"),
       };
     });
+  }
+
+  /**
+   * Send a formatted message into a room.
+   *
+   * Refuses encrypted rooms *before* the network call, even though the picker already
+   * filters them. Belt and braces on purpose: the homeserver would accept the plaintext
+   * event and every client would render it as undecryptable, so a post that "succeeded"
+   * would be invisible. A room can also become encrypted between listing and sending.
+   *
+   * `txnId` must be derived from the post's identity, not from a clock or a random
+   * value: Matrix deduplicates on it, so a retried request with the same txnId is the
+   * same message rather than a second copy. There is no un-send to clean up after.
+   */
+  async send(
+    roomId: string,
+    { html, text, txnId }: { html: string; text: string; txnId: string },
+  ): Promise<{ eventId: string }> {
+    const encryption = await this.roomState<{ algorithm?: string }>(
+      roomId,
+      "m.room.encryption",
+    );
+    if (encryption !== null) {
+      throw new MatrixEncryptedRoomError(roomId);
+    }
+
+    const body = await this.request<{ event_id?: string }>(
+      "PUT",
+      `/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${encodeURIComponent(txnId)}`,
+      {
+        msgtype: "m.text",
+        body: text,
+        format: "org.matrix.custom.html",
+        formatted_body: html,
+      },
+    );
+
+    return { eventId: body.event_id ?? "" };
   }
 
   /** Accept an invite (or join a public room) by id or alias. */

--- a/src/server/services/matrix/__tests__/postMeetingSummary.test.ts
+++ b/src/server/services/matrix/__tests__/postMeetingSummary.test.ts
@@ -433,6 +433,33 @@ describe("explicit room validation", () => {
   });
 });
 
+describe("cross-workspace protection", () => {
+  it("refuses a serverId belonging to another workspace", async () => {
+    // The seam takes serverId from the client, so the scoping has to be enforced when
+    // the client is built rather than trusted from the input. `getMatrixClientForServer`
+    // requires a workspaceId and filters on it; this pins that so a refactor cannot
+    // quietly drop the argument and let one workspace post through another's
+    // homeserver credentials.
+    db.integration.findFirst.mockResolvedValue(null as never);
+
+    await expect(
+      postMeetingSummaryToMatrix(db, {
+        meetingId: MEETING_ID,
+        actorUserId: ACTOR,
+        roomId: "!picked:example.org",
+        serverId: "int-another-workspace",
+        // No injected client, so the real credential lookup runs.
+      }),
+    ).rejects.toThrow(/not registered in this workspace/i);
+
+    const lookup = db.integration.findFirst.mock.calls[0]![0] as {
+      where: Record<string, unknown>;
+    };
+    expect(lookup.where.workspaceId).toBe("ws-1");
+    expect(db.matrixPostLog.create).not.toHaveBeenCalled();
+  });
+});
+
 describe("buildTransactionId", () => {
   it("is stable across retries of the same post, so Matrix deduplicates them", () => {
     const first = buildTransactionId(MEETING_ID, ROOM, 0);

--- a/src/server/services/matrix/__tests__/postMeetingSummary.test.ts
+++ b/src/server/services/matrix/__tests__/postMeetingSummary.test.ts
@@ -84,6 +84,7 @@ beforeEach(() => {
   db.transcriptionSessionParticipant.findFirst.mockResolvedValue(null as never);
   db.channelLink.findFirst.mockResolvedValue(outboundLink() as never);
   db.matrixPostLog.findFirst.mockResolvedValue(null as never);
+  db.matrixPostLog.count.mockResolvedValue(0 as never);
   db.matrixPostLog.create.mockResolvedValue({ id: "log-1" } as never);
 });
 
@@ -243,6 +244,43 @@ describe("postMeetingSummaryToMatrix", () => {
 
       expect(result).toMatchObject({ kind: "posted" });
       expect(client.send).toHaveBeenCalledTimes(1);
+    });
+
+    it("gives a confirmed repost a NEW transaction id, or Matrix would swallow it", async () => {
+      // Matrix deduplicates on txnId. Reusing the first post's id would make the
+      // homeserver silently discard the repost while we reported success — the user
+      // confirms, sees "posted", and nothing appears in the room.
+      db.matrixPostLog.findFirst.mockResolvedValue({
+        id: "log-old",
+        postedAt: new Date("2026-08-11T09:00:00Z"),
+      } as never);
+      db.matrixPostLog.count.mockResolvedValue(1 as never);
+      const client = stubClient();
+
+      await postMeetingSummaryToMatrix(db, {
+        meetingId: MEETING_ID,
+        actorUserId: ACTOR,
+        confirmRepost: true,
+        client,
+      });
+
+      const [, payload] = client.send.mock.calls[0]! as [string, SendArgs];
+      expect(payload.txnId).toBe(buildTransactionId(MEETING_ID, ROOM, 1));
+      expect(payload.txnId).not.toBe(buildTransactionId(MEETING_ID, ROOM, 0));
+    });
+
+    it("uses attempt 0 for the first post to a room", async () => {
+      db.matrixPostLog.count.mockResolvedValue(0 as never);
+      const client = stubClient();
+
+      await postMeetingSummaryToMatrix(db, {
+        meetingId: MEETING_ID,
+        actorUserId: ACTOR,
+        client,
+      });
+
+      const [, payload] = client.send.mock.calls[0]! as [string, SendArgs];
+      expect(payload.txnId).toBe(buildTransactionId(MEETING_ID, ROOM, 0));
     });
   });
 

--- a/src/server/services/matrix/__tests__/postMeetingSummary.test.ts
+++ b/src/server/services/matrix/__tests__/postMeetingSummary.test.ts
@@ -1,0 +1,362 @@
+/**
+ * The primary suite for this feature: everything that decides whether a summary reaches
+ * a room goes through `postMeetingSummaryToMatrix`.
+ *
+ * Assertions are about external behaviour — which room got the payload, what the caller
+ * is told, whether a log row exists — not about how the destination was queried. Mocked
+ * Prisma and an injected client; no DB, no network.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import {
+  buildTransactionId,
+  postMeetingSummaryToMatrix,
+} from "~/server/services/matrix/postMeetingSummary";
+import {
+  MatrixApiError,
+  MatrixEncryptedRoomError,
+} from "~/server/services/matrix/MatrixClient";
+
+const ACTOR = "user-1";
+const MEETING_ID = "meeting-1";
+const ROOM = "!eng:example.org";
+const SERVER = "int-server-1";
+
+type SendArgs = { html: string; text: string; txnId: string };
+
+/** A stand-in for MatrixClient with only the surface the seam uses. */
+function stubClient(
+  behaviour: { send?: (roomId: string, args: SendArgs) => Promise<{ eventId: string }> } = {},
+) {
+  const send = vi.fn(
+    behaviour.send ??
+      ((_roomId: string, _args: SendArgs) => Promise.resolve({ eventId: "$evt:example.org" })),
+  );
+  return { send } as unknown as Parameters<typeof postMeetingSummaryToMatrix>[1]["client"] & {
+    send: typeof send;
+  };
+}
+
+function meetingRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: MEETING_ID,
+    title: "Weekly sync",
+    summary: JSON.stringify({ overview: "We agreed to ship on Friday." }),
+    meetingDate: new Date("2026-08-10T10:00:00Z"),
+    createdAt: new Date("2026-08-10T10:00:00Z"),
+    userId: ACTOR,
+    projectId: "proj-1",
+    workspaceId: "ws-1",
+    project: { id: "proj-1", name: "Apollo" },
+    actions: [{ id: "a1" }, { id: "a2" }],
+    ...overrides,
+  };
+}
+
+function outboundLink(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "link-1",
+    provider: "matrix",
+    externalId: ROOM,
+    displayName: "Engineering",
+    workspaceId: "ws-1",
+    projectId: "proj-1",
+    isActive: true,
+    direction: "outbound",
+    serverIntegrationId: SERVER,
+    createdById: ACTOR,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+let db: DeepMockProxy<PrismaClient>;
+
+beforeEach(() => {
+  db = mockDeep<PrismaClient>();
+  mockReset(db);
+  db.transcriptionSession.findUnique.mockResolvedValue(meetingRow() as never);
+  // Owner of the meeting → edit access, without needing project/workspace lookups.
+  db.transcriptionSessionParticipant.findFirst.mockResolvedValue(null as never);
+  db.channelLink.findFirst.mockResolvedValue(outboundLink() as never);
+  db.matrixPostLog.findFirst.mockResolvedValue(null as never);
+  db.matrixPostLog.create.mockResolvedValue({ id: "log-1" } as never);
+});
+
+describe("postMeetingSummaryToMatrix", () => {
+  it("posts to the project's bound room and records the post", async () => {
+    const client = stubClient();
+
+    const result = await postMeetingSummaryToMatrix(db, {
+      meetingId: MEETING_ID,
+      actorUserId: ACTOR,
+      client,
+    });
+
+    expect(result).toMatchObject({ kind: "posted", roomId: ROOM });
+    expect(client.send).toHaveBeenCalledTimes(1);
+    expect(client.send.mock.calls[0]![0]).toBe(ROOM);
+
+    const logged = db.matrixPostLog.create.mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(logged.data).toMatchObject({
+      transcriptionSessionId: MEETING_ID,
+      roomId: ROOM,
+      serverIntegrationId: SERVER,
+      eventId: "$evt:example.org",
+      postedById: ACTOR,
+      channelLinkId: "link-1",
+    });
+  });
+
+  it("sends the title, date, summary, action count and an absolute link", async () => {
+    const client = stubClient();
+
+    await postMeetingSummaryToMatrix(db, {
+      meetingId: MEETING_ID,
+      actorUserId: ACTOR,
+      client,
+    });
+
+    const [, payload] = client.send.mock.calls[0]! as [string, SendArgs];
+    expect(payload.text).toContain("Weekly sync");
+    expect(payload.text).toContain("2026-08-10");
+    expect(payload.text).toContain("We agreed to ship on Friday.");
+    expect(payload.text).toContain("2 action items");
+    // Absolute, because most readers are in a Matrix client, not in the app.
+    expect(payload.text).toMatch(/https?:\/\/[^\s]+\/recording\/meeting-1/);
+    expect(payload.html).toContain("<a href=");
+  });
+
+  it("blocks and says so when the project's binding is Off", async () => {
+    db.channelLink.findFirst.mockResolvedValue(
+      outboundLink({ isActive: false }) as never,
+    );
+    const client = stubClient();
+
+    const result = await postMeetingSummaryToMatrix(db, {
+      meetingId: MEETING_ID,
+      actorUserId: ACTOR,
+      client,
+    });
+
+    expect(result).toEqual({ kind: "blocked-off" });
+    expect(client.send).not.toHaveBeenCalled();
+    expect(db.matrixPostLog.create).not.toHaveBeenCalled();
+  });
+
+  it("reports no destination rather than failing, so the caller can offer a picker", async () => {
+    db.channelLink.findFirst.mockResolvedValue(null as never);
+    const client = stubClient();
+
+    const result = await postMeetingSummaryToMatrix(db, {
+      meetingId: MEETING_ID,
+      actorUserId: ACTOR,
+      client,
+    });
+
+    expect(result).toEqual({ kind: "no-destination" });
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("refuses to post a meeting that has no summary", async () => {
+    db.transcriptionSession.findUnique.mockResolvedValue(
+      meetingRow({ summary: null }) as never,
+    );
+    const client = stubClient();
+
+    const result = await postMeetingSummaryToMatrix(db, {
+      meetingId: MEETING_ID,
+      actorUserId: ACTOR,
+      client,
+    });
+
+    expect(result).toEqual({ kind: "no-summary" });
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("refuses a user without edit access to the meeting", async () => {
+    db.transcriptionSession.findUnique.mockResolvedValue(
+      meetingRow({ userId: "someone-else", projectId: null, workspaceId: null }) as never,
+    );
+    const client = stubClient();
+
+    const result = await postMeetingSummaryToMatrix(db, {
+      meetingId: MEETING_ID,
+      actorUserId: ACTOR,
+      client,
+    });
+
+    expect(result).toEqual({ kind: "no-access" });
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing meeting", async () => {
+    db.transcriptionSession.findUnique.mockResolvedValue(null as never);
+
+    await expect(
+      postMeetingSummaryToMatrix(db, {
+        meetingId: MEETING_ID,
+        actorUserId: ACTOR,
+        client: stubClient(),
+      }),
+    ).resolves.toEqual({ kind: "not-found" });
+  });
+
+  describe("repost guard", () => {
+    it("refuses a second post to the same room without confirmation", async () => {
+      const lastPostedAt = new Date("2026-08-11T09:00:00Z");
+      db.matrixPostLog.findFirst.mockResolvedValue({
+        id: "log-old",
+        postedAt: lastPostedAt,
+      } as never);
+      const client = stubClient();
+
+      const result = await postMeetingSummaryToMatrix(db, {
+        meetingId: MEETING_ID,
+        actorUserId: ACTOR,
+        client,
+      });
+
+      expect(result).toEqual({ kind: "needs-confirm", roomId: ROOM, lastPostedAt });
+      expect(client.send).not.toHaveBeenCalled();
+    });
+
+    it("posts once confirmed", async () => {
+      db.matrixPostLog.findFirst.mockResolvedValue({
+        id: "log-old",
+        postedAt: new Date("2026-08-11T09:00:00Z"),
+      } as never);
+      const client = stubClient();
+
+      const result = await postMeetingSummaryToMatrix(db, {
+        meetingId: MEETING_ID,
+        actorUserId: ACTOR,
+        confirmRepost: true,
+        client,
+      });
+
+      expect(result).toMatchObject({ kind: "posted" });
+      expect(client.send).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("failures", () => {
+    it("writes no log row when the send fails", async () => {
+      const client = stubClient({
+        send: () => Promise.reject(new MatrixApiError("nope", 403, "M_FORBIDDEN")),
+      });
+
+      const result = await postMeetingSummaryToMatrix(db, {
+        meetingId: MEETING_ID,
+        actorUserId: ACTOR,
+        client,
+      });
+
+      expect(result).toMatchObject({ kind: "failed" });
+      expect((result as { reason: string }).reason).toMatch(/not in that room/i);
+      // The log is the record of what actually reached a room. A phantom row here
+      // would make the repost guard refuse a post that never happened.
+      expect(db.matrixPostLog.create).not.toHaveBeenCalled();
+    });
+
+    it("explains an encrypted room specifically", async () => {
+      const client = stubClient({
+        send: () => Promise.reject(new MatrixEncryptedRoomError(ROOM)),
+      });
+
+      const result = await postMeetingSummaryToMatrix(db, {
+        meetingId: MEETING_ID,
+        actorUserId: ACTOR,
+        client,
+      });
+
+      expect((result as { reason: string }).reason).toMatch(/encrypted/i);
+      expect(db.matrixPostLog.create).not.toHaveBeenCalled();
+    });
+
+    it("distinguishes an unreachable homeserver from a permission problem", async () => {
+      const client = stubClient({
+        send: () => Promise.reject(new MatrixApiError("down", 0)),
+      });
+
+      const result = await postMeetingSummaryToMatrix(db, {
+        meetingId: MEETING_ID,
+        actorUserId: ACTOR,
+        client,
+      });
+
+      expect((result as { reason: string }).reason).toMatch(/could not reach/i);
+    });
+  });
+
+  describe("explicit room override", () => {
+    it("posts to the picked room and persists no binding", async () => {
+      const client = stubClient();
+
+      const result = await postMeetingSummaryToMatrix(db, {
+        meetingId: MEETING_ID,
+        actorUserId: ACTOR,
+        roomId: "!picked:example.org",
+        serverId: SERVER,
+        client,
+      });
+
+      expect(result).toMatchObject({ kind: "posted", roomId: "!picked:example.org" });
+      expect(client.send.mock.calls[0]![0]).toBe("!picked:example.org");
+      // A one-off post is not a configuration change.
+      expect(db.channelLink.create).not.toHaveBeenCalled();
+      expect(db.channelLink.upsert).not.toHaveBeenCalled();
+
+      const logged = db.matrixPostLog.create.mock.calls[0]![0] as {
+        data: Record<string, unknown>;
+      };
+      expect(logged.data.channelLinkId).toBeNull();
+    });
+
+    it("cannot route around Off by picking a room in the picker", async () => {
+      // Off is the confidential-project escape hatch; a picked room must not defeat it.
+      db.channelLink.findFirst.mockResolvedValue(
+        outboundLink({ isActive: false }) as never,
+      );
+      const client = stubClient();
+
+      const result = await postMeetingSummaryToMatrix(db, {
+        meetingId: MEETING_ID,
+        actorUserId: ACTOR,
+        roomId: "!picked:example.org",
+        serverId: SERVER,
+        client,
+      });
+
+      expect(result).toEqual({ kind: "blocked-off" });
+      expect(client.send).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("buildTransactionId", () => {
+  it("is stable across retries of the same post, so Matrix deduplicates them", () => {
+    const first = buildTransactionId(MEETING_ID, ROOM, 0);
+    const second = buildTransactionId(MEETING_ID, ROOM, 0);
+    expect(first).toBe(second);
+  });
+
+  it("differs per room and per attempt", () => {
+    expect(buildTransactionId(MEETING_ID, ROOM, 0)).not.toBe(
+      buildTransactionId(MEETING_ID, "!other:example.org", 0),
+    );
+    expect(buildTransactionId(MEETING_ID, ROOM, 0)).not.toBe(
+      buildTransactionId(MEETING_ID, ROOM, 1),
+    );
+  });
+
+  it("contains no characters that need escaping in a URL path segment", () => {
+    expect(buildTransactionId(MEETING_ID, ROOM, 0)).toMatch(/^[A-Za-z0-9-]+$/);
+  });
+});

--- a/src/server/services/matrix/__tests__/postMeetingSummary.test.ts
+++ b/src/server/services/matrix/__tests__/postMeetingSummary.test.ts
@@ -29,15 +29,21 @@ type SendArgs = { html: string; text: string; txnId: string };
 
 /** A stand-in for MatrixClient with only the surface the seam uses. */
 function stubClient(
-  behaviour: { send?: (roomId: string, args: SendArgs) => Promise<{ eventId: string }> } = {},
+  behaviour: {
+    send?: (roomId: string, args: SendArgs) => Promise<{ eventId: string }>;
+    joinedRooms?: string[];
+  } = {},
 ) {
   const send = vi.fn(
     behaviour.send ??
       ((_roomId: string, _args: SendArgs) => Promise.resolve({ eventId: "$evt:example.org" })),
   );
-  return { send } as unknown as Parameters<typeof postMeetingSummaryToMatrix>[1]["client"] & {
-    send: typeof send;
-  };
+  const joinedRooms = vi.fn(() =>
+    Promise.resolve(behaviour.joinedRooms ?? [ROOM, "!picked:example.org"]),
+  );
+  return { send, joinedRooms } as unknown as Parameters<
+    typeof postMeetingSummaryToMatrix
+  >[1]["client"] & { send: typeof send; joinedRooms: typeof joinedRooms };
 }
 
 function meetingRow(overrides: Record<string, unknown> = {}) {
@@ -375,6 +381,55 @@ describe("postMeetingSummaryToMatrix", () => {
       expect(result).toEqual({ kind: "blocked-off" });
       expect(client.send).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("explicit room validation", () => {
+  it("refuses a room the bot has not joined, even with edit access", async () => {
+    // The picker only offers joined rooms, so an unjoined room means a hand-crafted
+    // request. Without this, a full summary could be pushed into any room the bot is
+    // in — including another workspace's, if the same bot were registered twice.
+    const client = stubClient({ joinedRooms: [ROOM] });
+
+    const result = await postMeetingSummaryToMatrix(db, {
+      meetingId: MEETING_ID,
+      actorUserId: ACTOR,
+      roomId: "!somewhere-else:example.org",
+      serverId: SERVER,
+      client,
+    });
+
+    expect(result).toMatchObject({ kind: "failed" });
+    expect((result as { reason: string }).reason).toMatch(/not in that room/i);
+    expect(client.send).not.toHaveBeenCalled();
+    expect(db.matrixPostLog.create).not.toHaveBeenCalled();
+  });
+
+  it("allows a picked room the bot has joined", async () => {
+    const client = stubClient({ joinedRooms: ["!picked:example.org"] });
+
+    await expect(
+      postMeetingSummaryToMatrix(db, {
+        meetingId: MEETING_ID,
+        actorUserId: ACTOR,
+        roomId: "!picked:example.org",
+        serverId: SERVER,
+        client,
+      }),
+    ).resolves.toMatchObject({ kind: "posted" });
+  });
+
+  it("does not spend a joined-rooms call on a resolved destination", async () => {
+    // A resolved room came from a binding that was already authorised.
+    const client = stubClient();
+
+    await postMeetingSummaryToMatrix(db, {
+      meetingId: MEETING_ID,
+      actorUserId: ACTOR,
+      client,
+    });
+
+    expect(client.joinedRooms).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/matrix/__tests__/resolveMatrixDestination.test.ts
+++ b/src/server/services/matrix/__tests__/resolveMatrixDestination.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Destination resolution: project → workspace, with Off as a distinct answer.
+ *
+ * The three outcomes lead to three different UIs — a room, a stated block, or a picker —
+ * so collapsing any two of them would be a user-visible bug.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import { resolveMatrixDestination } from "~/server/services/matrix/resolveMatrixDestination";
+
+const PROJECT = "proj-1";
+const WORKSPACE = "ws-1";
+
+function link(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "link-1",
+    provider: "matrix",
+    externalId: "!room:example.org",
+    displayName: null,
+    workspaceId: WORKSPACE,
+    projectId: PROJECT,
+    isActive: true,
+    direction: "outbound",
+    serverIntegrationId: "int-1",
+    createdById: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+let db: DeepMockProxy<PrismaClient>;
+
+beforeEach(() => {
+  db = mockDeep<PrismaClient>();
+  mockReset(db);
+});
+
+/**
+ * Answer findFirst from a small table, matching on the scalar keys of the where clause.
+ * Lets these tests exercise the real predicates rather than a canned return value.
+ */
+function tableOf(rows: Record<string, unknown>[]) {
+  return (args?: { where?: Record<string, unknown> }) => {
+    const where = args?.where ?? {};
+    const match = rows.find((row) =>
+      Object.entries(where).every(([key, value]) => row[key] === value),
+    );
+    return Promise.resolve(match ?? null);
+  };
+}
+
+describe("resolveMatrixDestination", () => {
+  it("uses the project's binding when it has one", async () => {
+    const projectRow = link({ externalId: "!project-room:example.org" });
+    const workspaceRow = link({
+      id: "link-ws",
+      projectId: null,
+      externalId: "!workspace-room:example.org",
+    });
+    db.channelLink.findFirst.mockImplementation(
+      tableOf([projectRow, workspaceRow]) as never,
+    );
+
+    const result = await resolveMatrixDestination(db, {
+      projectId: PROJECT,
+      workspaceId: WORKSPACE,
+    });
+
+    expect(result).toMatchObject({ kind: "room" });
+    expect((result as { link: { externalId: string } }).link.externalId).toBe(
+      "!project-room:example.org",
+    );
+  });
+
+  it("falls back to the workspace default when the project has no binding", async () => {
+    const workspaceRow = link({
+      id: "link-ws",
+      projectId: null,
+      externalId: "!workspace-room:example.org",
+    });
+    db.channelLink.findFirst.mockImplementation(tableOf([workspaceRow]) as never);
+
+    const result = await resolveMatrixDestination(db, {
+      projectId: PROJECT,
+      workspaceId: WORKSPACE,
+    });
+
+    expect((result as { link: { externalId: string } }).link.externalId).toBe(
+      "!workspace-room:example.org",
+    );
+  });
+
+  it("treats an inactive project row as Off, and does NOT fall through to the workspace", async () => {
+    // The whole point of Off: a confidential project must not inherit the default.
+    const offRow = link({ isActive: false });
+    const workspaceRow = link({
+      id: "link-ws",
+      projectId: null,
+      externalId: "!workspace-room:example.org",
+    });
+    db.channelLink.findFirst.mockImplementation(
+      tableOf([offRow, workspaceRow]) as never,
+    );
+
+    await expect(
+      resolveMatrixDestination(db, { projectId: PROJECT, workspaceId: WORKSPACE }),
+    ).resolves.toEqual({ kind: "off" });
+  });
+
+  it("reports none when nothing is configured anywhere", async () => {
+    db.channelLink.findFirst.mockImplementation(tableOf([]) as never);
+
+    await expect(
+      resolveMatrixDestination(db, { projectId: PROJECT, workspaceId: WORKSPACE }),
+    ).resolves.toEqual({ kind: "none" });
+  });
+
+  it("ships unset: a workspace with no default resolves to none, so nothing posts by accident", async () => {
+    db.channelLink.findFirst.mockImplementation(tableOf([]) as never);
+
+    await expect(
+      resolveMatrixDestination(db, { projectId: null, workspaceId: WORKSPACE }),
+    ).resolves.toEqual({ kind: "none" });
+  });
+
+  it("ignores inbound rows — those answer the opposite question", async () => {
+    const inboundRow = link({ direction: "inbound" });
+    db.channelLink.findFirst.mockImplementation(tableOf([inboundRow]) as never);
+
+    await expect(
+      resolveMatrixDestination(db, { projectId: PROJECT, workspaceId: WORKSPACE }),
+    ).resolves.toEqual({ kind: "none" });
+  });
+
+  it("ignores another provider's rows", async () => {
+    const whatsapp = link({ provider: "whatsapp" });
+    db.channelLink.findFirst.mockImplementation(tableOf([whatsapp]) as never);
+
+    await expect(
+      resolveMatrixDestination(db, { projectId: PROJECT, workspaceId: WORKSPACE }),
+    ).resolves.toEqual({ kind: "none" });
+  });
+
+  it("resolves to none for a meeting with neither project nor workspace", async () => {
+    await expect(
+      resolveMatrixDestination(db, { projectId: null, workspaceId: null }),
+    ).resolves.toEqual({ kind: "none" });
+    expect(db.channelLink.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("does not treat an inactive workspace default as Off", async () => {
+    // Off is a project-level concept. An inactive workspace row just means no default.
+    const inactiveWorkspaceRow = link({
+      id: "link-ws",
+      projectId: null,
+      isActive: false,
+    });
+    db.channelLink.findFirst.mockImplementation(
+      tableOf([inactiveWorkspaceRow]) as never,
+    );
+
+    await expect(
+      resolveMatrixDestination(db, { projectId: PROJECT, workspaceId: WORKSPACE }),
+    ).resolves.toEqual({ kind: "none" });
+  });
+});

--- a/src/server/services/matrix/__tests__/resolveMatrixDestination.test.ts
+++ b/src/server/services/matrix/__tests__/resolveMatrixDestination.test.ts
@@ -167,4 +167,14 @@ describe("resolveMatrixDestination", () => {
       resolveMatrixDestination(db, { projectId: PROJECT, workspaceId: WORKSPACE }),
     ).resolves.toEqual({ kind: "none" });
   });
+
+  it("ignores a project row belonging to another workspace", async () => {
+    // Resolution must agree with the write paths, which all scope by workspace.
+    const foreign = link({ workspaceId: "ws-other" });
+    db.channelLink.findFirst.mockImplementation(tableOf([foreign]) as never);
+
+    await expect(
+      resolveMatrixDestination(db, { projectId: PROJECT, workspaceId: WORKSPACE }),
+    ).resolves.toEqual({ kind: "none" });
+  });
 });

--- a/src/server/services/matrix/constants.ts
+++ b/src/server/services/matrix/constants.ts
@@ -26,3 +26,12 @@ export interface MatrixServerConfig {
   homeserverUrl: string;
   botUserId: string;
 }
+
+/**
+ * `ChannelLink.provider` for a Matrix room binding.
+ *
+ * Note this is `"matrix"`, not `MATRIX_SERVER_PROVIDER` — a ChannelLink names the
+ * *chat platform* the room is on, alongside `"whatsapp"` and `"slack"`, whereas an
+ * Integration's provider names the kind of credential. The two namespaces are separate.
+ */
+export const MATRIX_CHANNEL_PROVIDER = "matrix";

--- a/src/server/services/matrix/matrixServer.ts
+++ b/src/server/services/matrix/matrixServer.ts
@@ -75,6 +75,10 @@ export async function listMatrixServers(
  * Throws `NOT_FOUND` when the server does not belong to `workspaceId` — the workspace
  * check is here rather than at each call site so a server id from one workspace can
  * never be used to reach another's homeserver.
+ *
+ * `workspaceId` is required for exactly that reason: callers take `serverId` from client
+ * input, so the scoping has to be enforced where the credential is loaded rather than
+ * trusted from the request. Do not make it optional.
  */
 export async function getMatrixClientForServer(
   db: PrismaClient,

--- a/src/server/services/matrix/postMeetingSummary.ts
+++ b/src/server/services/matrix/postMeetingSummary.ts
@@ -174,6 +174,31 @@ export async function postMeetingSummaryToMatrix(
     client = (await getMatrixClientForServer(db, serverId, meeting.workspaceId)).client;
   }
 
+  // An explicit room came from the client, so it is a claim rather than a fact. The
+  // picker only ever offers joined rooms; checking that here stops a hand-crafted
+  // request from pushing a full meeting summary into any other room the bot happens to
+  // be in — which, if the same bot is registered by two workspaces, includes rooms
+  // belonging to someone else. A resolved room needs no check: it came from a binding
+  // that was already authorised.
+  if (input.roomId) {
+    let joined: string[];
+    try {
+      joined = await client.joinedRooms();
+    } catch (error) {
+      reportHandledError(error, {
+        area: "matrix-post-summary",
+        context: { meetingId, roomId, serverId },
+      });
+      return { kind: "failed", reason: describePostFailure(error) };
+    }
+    if (!joined.includes(roomId)) {
+      return {
+        kind: "failed",
+        reason: "The bot is not in that room, so it cannot post there.",
+      };
+    }
+  }
+
   let eventId: string;
   try {
     ({ eventId } = await client.send(roomId, {

--- a/src/server/services/matrix/postMeetingSummary.ts
+++ b/src/server/services/matrix/postMeetingSummary.ts
@@ -76,7 +76,7 @@ export async function postMeetingSummaryToMatrix(
   db: PrismaClient,
   input: PostMeetingSummaryInput,
 ): Promise<PostMeetingSummaryResult> {
-  const { meetingId, actorUserId, attempt = 0 } = input;
+  const { meetingId, actorUserId } = input;
 
   const meeting = await db.transcriptionSession.findUnique({
     where: { id: meetingId },
@@ -141,13 +141,25 @@ export async function postMeetingSummaryToMatrix(
   if (!meeting.summary?.trim()) return { kind: "no-summary" };
 
   // Already posted here? Matrix has no un-send, so a second copy is permanent.
-  const previous = await db.matrixPostLog.findFirst({
-    where: { transcriptionSessionId: meeting.id, roomId },
-    orderBy: { postedAt: "desc" },
-  });
+  const [previous, priorPostCount] = await Promise.all([
+    db.matrixPostLog.findFirst({
+      where: { transcriptionSessionId: meeting.id, roomId },
+      orderBy: { postedAt: "desc" },
+    }),
+    db.matrixPostLog.count({
+      where: { transcriptionSessionId: meeting.id, roomId },
+    }),
+  ]);
   if (previous && !input.confirmRepost) {
     return { kind: "needs-confirm", roomId, lastPostedAt: previous.postedAt };
   }
+
+  // The attempt number is what makes a *deliberate* repost a new message. Matrix
+  // deduplicates on the transaction id, so reusing it would make the homeserver
+  // silently discard the second post while we reported success. Derived from how many
+  // times this meeting has already reached this room, so it survives a restart —
+  // a counter in memory would not.
+  const attemptNumber = input.attempt ?? priorPostCount;
 
   const rendered = renderMeetingSummary(meeting as MeetingForSummary);
 
@@ -167,7 +179,7 @@ export async function postMeetingSummaryToMatrix(
     ({ eventId } = await client.send(roomId, {
       html: rendered.html,
       text: rendered.text,
-      txnId: buildTransactionId(meeting.id, roomId, attempt),
+      txnId: buildTransactionId(meeting.id, roomId, attemptNumber),
     }));
   } catch (error) {
     // A failure writes no log row: the log is the record of what actually reached a

--- a/src/server/services/matrix/postMeetingSummary.ts
+++ b/src/server/services/matrix/postMeetingSummary.ts
@@ -1,0 +1,214 @@
+/**
+ * The one seam through which a meeting summary reaches a Matrix room.
+ *
+ * Every caller — the tRPC procedure today, anything later — goes through here, so the
+ * access check, the Off block, the repost guard and the post log cannot be bypassed by
+ * adding a second entry point. Shaped after
+ * `TranscriptionProcessingService.sendSlackNotification`, which is the existing
+ * precedent for "post this meeting somewhere".
+ *
+ * **Never call this from an event handler.** Matrix has no un-send — only the bot can
+ * redact its own events — so every post is a human deciding, once. `bulkAssignProject`
+ * would otherwise turn one click into forty room messages, and assignment routinely
+ * happens before summarization, so they would be forty empty ones.
+ *
+ * Returns a discriminated result and does not throw for expected states: "no
+ * destination", "blocked off" and "needs confirmation" are answers the UI renders, not
+ * exceptions.
+ */
+
+import type { ChannelLink, PrismaClient } from "@prisma/client";
+import {
+  canEditTranscription,
+  getTranscriptionAccess,
+} from "~/server/services/access";
+import { reportHandledError } from "~/lib/reportHandledError";
+import {
+  MatrixApiError,
+  MatrixEncryptedRoomError,
+  type MatrixClient,
+} from "./MatrixClient";
+import { getMatrixClientForServer } from "./matrixServer";
+import { resolveMatrixDestination } from "./resolveMatrixDestination";
+import { renderMeetingSummary, type MeetingForSummary } from "./renderMeetingSummary";
+
+export type PostMeetingSummaryResult =
+  | { kind: "posted"; roomId: string; eventId: string; postLogId: string }
+  | { kind: "blocked-off" }
+  | { kind: "no-destination" }
+  | { kind: "no-summary" }
+  | { kind: "needs-confirm"; roomId: string; lastPostedAt: Date }
+  | { kind: "no-access" }
+  | { kind: "not-found" }
+  | { kind: "failed"; reason: string };
+
+export interface PostMeetingSummaryInput {
+  meetingId: string;
+  /** Explicit destination, chosen in the picker. Overrides resolution entirely. */
+  roomId?: string;
+  /** Which registered server to send through. Required alongside an explicit roomId. */
+  serverId?: string;
+  actorUserId: string;
+  confirmRepost?: boolean;
+  /** Injection point for tests; otherwise built from the resolved server's credentials. */
+  client?: MatrixClient;
+  /** Attempt number, folded into the transaction id so a retry cannot double-post. */
+  attempt?: number;
+}
+
+/**
+ * Matrix deduplicates on the transaction id, so deriving it from the post's identity
+ * (rather than a clock or random value) makes a retried request the *same* message
+ * instead of a second copy. Same meeting, same room, same attempt → same event.
+ */
+export function buildTransactionId(
+  meetingId: string,
+  roomId: string,
+  attempt: number,
+): string {
+  // Room ids contain characters that are awkward in a URL path segment even encoded;
+  // reducing to a stable slug keeps the id readable in homeserver logs.
+  const roomSlug = roomId.replace(/[^a-zA-Z0-9]/g, "");
+  return `expo-${meetingId}-${roomSlug}-${attempt}`;
+}
+
+export async function postMeetingSummaryToMatrix(
+  db: PrismaClient,
+  input: PostMeetingSummaryInput,
+): Promise<PostMeetingSummaryResult> {
+  const { meetingId, actorUserId, attempt = 0 } = input;
+
+  const meeting = await db.transcriptionSession.findUnique({
+    where: { id: meetingId },
+    include: {
+      project: { select: { id: true, name: true } },
+      actions: { select: { id: true } },
+    },
+  });
+
+  if (!meeting) return { kind: "not-found" };
+
+  // ADR-0014's canonical resolver, not a bespoke check: posting a full summary into a
+  // room is at least as sensitive as editing the meeting, so it takes edit access.
+  const access = await getTranscriptionAccess(db, actorUserId, {
+    id: meeting.id,
+    userId: meeting.userId,
+    projectId: meeting.projectId,
+    workspaceId: meeting.workspaceId,
+  });
+  if (!canEditTranscription(access)) return { kind: "no-access" };
+
+  // Resolution runs even when the caller picked a room explicitly, because `Off` has to
+  // be consulted either way. Off is the confidential-project escape hatch; if choosing a
+  // room in the picker could route around it, it would not be one.
+  const destination = await resolveMatrixDestination(db, {
+    projectId: meeting.projectId,
+    workspaceId: meeting.workspaceId,
+  });
+  if (destination.kind === "off") return { kind: "blocked-off" };
+
+  let roomId: string;
+  let serverId: string;
+  let link: ChannelLink | null = null;
+
+  if (input.roomId) {
+    if (!input.serverId) {
+      return { kind: "failed", reason: "No Matrix server was given for that room." };
+    }
+    roomId = input.roomId;
+    serverId = input.serverId;
+    // A one-off post to a picked room is not a configuration change, so it is only
+    // attributed to a binding when it happens to be that binding's room.
+    if (destination.kind === "room" && destination.link.externalId === roomId) {
+      link = destination.link;
+    }
+  } else {
+    if (destination.kind === "none") return { kind: "no-destination" };
+    if (!destination.link.serverIntegrationId) {
+      return {
+        kind: "failed",
+        reason: "That room's binding has no Matrix server attached — re-bind the room.",
+      };
+    }
+
+    link = destination.link;
+    roomId = destination.link.externalId;
+    serverId = destination.link.serverIntegrationId;
+  }
+
+  // A summary is the whole payload; posting without one would send a title and a link
+  // to people who cannot open it.
+  if (!meeting.summary?.trim()) return { kind: "no-summary" };
+
+  // Already posted here? Matrix has no un-send, so a second copy is permanent.
+  const previous = await db.matrixPostLog.findFirst({
+    where: { transcriptionSessionId: meeting.id, roomId },
+    orderBy: { postedAt: "desc" },
+  });
+  if (previous && !input.confirmRepost) {
+    return { kind: "needs-confirm", roomId, lastPostedAt: previous.postedAt };
+  }
+
+  const rendered = renderMeetingSummary(meeting as MeetingForSummary);
+
+  let client = input.client;
+  if (!client) {
+    if (!meeting.workspaceId) {
+      return {
+        kind: "failed",
+        reason: "This meeting is not in a workspace, so no Matrix server applies.",
+      };
+    }
+    client = (await getMatrixClientForServer(db, serverId, meeting.workspaceId)).client;
+  }
+
+  let eventId: string;
+  try {
+    ({ eventId } = await client.send(roomId, {
+      html: rendered.html,
+      text: rendered.text,
+      txnId: buildTransactionId(meeting.id, roomId, attempt),
+    }));
+  } catch (error) {
+    // A failure writes no log row: the log is the record of what actually reached a
+    // room, and a phantom entry would make the repost guard refuse a post that never
+    // happened. Reported rather than swallowed — a silent catch here is invisible.
+    reportHandledError(error, {
+      area: "matrix-post-summary",
+      context: { meetingId, roomId, serverId },
+    });
+    return { kind: "failed", reason: describePostFailure(error) };
+  }
+
+  const postLog = await db.matrixPostLog.create({
+    data: {
+      transcriptionSessionId: meeting.id,
+      channelLinkId: link?.id ?? null,
+      roomId,
+      serverIntegrationId: serverId,
+      eventId,
+      postedById: actorUserId,
+    },
+    select: { id: true },
+  });
+
+  return { kind: "posted", roomId, eventId, postLogId: postLog.id };
+}
+
+/** Each cause needs a different fix, so each gets its own sentence. */
+function describePostFailure(error: unknown): string {
+  if (error instanceof MatrixEncryptedRoomError) return error.message;
+  if (error instanceof MatrixApiError) {
+    if (error.status === 0) {
+      return "Could not reach the homeserver. It may be down or unreachable from here.";
+    }
+    if (error.isForbidden) {
+      return "The bot is not in that room, or is not allowed to post there. Invite it and try again.";
+    }
+    if (error.isUnauthorized) {
+      return "The homeserver rejected the bot's access token. Re-register the server with a fresh token.";
+    }
+    return `The homeserver refused the message (HTTP ${error.status}).`;
+  }
+  return "The message could not be sent.";
+}

--- a/src/server/services/matrix/renderMeetingSummary.ts
+++ b/src/server/services/matrix/renderMeetingSummary.ts
@@ -1,0 +1,142 @@
+/**
+ * Turning a meeting into the message that lands in a room.
+ *
+ * Matrix messages carry a plain-text `body` and an optional HTML `formatted_body`;
+ * clients that cannot render HTML fall back to the text, so both are built rather than
+ * one being derived from the other at display time.
+ *
+ * `TranscriptionSession.summary` is a JSON *string* and malformed values exist in the
+ * data — `TranscriptionProcessingService` already wraps its own `JSON.parse` in a
+ * try/catch for this reason. A summary that will not parse is treated as prose rather
+ * than discarded: the text is what the reader wants, and losing it to a parse error
+ * would be worse than showing it unstructured.
+ */
+
+import { getPublicBaseUrlFromEnv } from "~/lib/urls";
+
+export interface MeetingForSummary {
+  id: string;
+  title: string | null;
+  summary: string | null;
+  meetingDate: Date | null;
+  createdAt: Date;
+  workspaceId: string | null;
+  project: { id: string; name: string } | null;
+  actions: { id: string }[];
+}
+
+export interface RenderedSummary {
+  text: string;
+  html: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Pull readable prose out of whatever shape the summary is in.
+ *
+ * Fireflies-derived summaries are objects with named sections; older and hand-written
+ * ones are plain strings. Both reach this function.
+ */
+export function extractSummaryText(rawSummary: string): string {
+  const trimmed = rawSummary.trim();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    // Not JSON at all — it is already the prose we want.
+    return trimmed;
+  }
+
+  if (typeof parsed === "string") return parsed.trim();
+  if (parsed === null || typeof parsed !== "object") return trimmed;
+
+  const record = parsed as Record<string, unknown>;
+  const sections: string[] = [];
+
+  for (const [key, value] of Object.entries(record)) {
+    const rendered = renderSection(value);
+    if (!rendered) continue;
+    sections.push(`${humanizeKey(key)}\n${rendered}`);
+  }
+
+  // An object we could not get any prose out of is more useful shown raw than dropped.
+  return sections.length > 0 ? sections.join("\n\n") : trimmed;
+}
+
+function renderSection(value: unknown): string | null {
+  if (typeof value === "string") return value.trim() || null;
+  if (Array.isArray(value)) {
+    const items = value
+      .map((entry) => (typeof entry === "string" ? entry.trim() : null))
+      .filter((entry): entry is string => !!entry)
+      .map((entry) => `• ${entry}`);
+    return items.length > 0 ? items.join("\n") : null;
+  }
+  return null;
+}
+
+/** `action_items` / `actionItems` → `Action items`. */
+function humanizeKey(key: string): string {
+  const spaced = key
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
+/**
+ * The absolute link back. Relative paths are useless here: most readers are in a Matrix
+ * client, not in the app, and some of them are not Exponential users at all.
+ */
+export function meetingUrl(meeting: MeetingForSummary): string {
+  // Same resolution the Matrix DM channel and email use, so deep links point at one
+  // origin everywhere. Safe outside a request scope, which matters because posting can
+  // be driven from anywhere.
+  const origin = process.env.NEXTAUTH_URL ?? getPublicBaseUrlFromEnv();
+  // `/recording/{id}` is the meeting detail page — `/meetings` is the list, and has no
+  // per-meeting route, so linking there would land readers on someone else's inbox.
+  return `${origin.replace(/\/+$/, "")}/recording/${meeting.id}`;
+}
+
+function formatMeetingDate(meeting: MeetingForSummary): string {
+  const date = meeting.meetingDate ?? meeting.createdAt;
+  return date.toISOString().slice(0, 10);
+}
+
+export function renderMeetingSummary(meeting: MeetingForSummary): RenderedSummary {
+  const title = meeting.title?.trim() ?? "Untitled meeting";
+  const date = formatMeetingDate(meeting);
+  const body = meeting.summary ? extractSummaryText(meeting.summary) : "";
+  const actionCount = meeting.actions.length;
+  const actionLine = `${actionCount} action item${actionCount === 1 ? "" : "s"}`;
+  const url = meetingUrl(meeting);
+  const project = meeting.project?.name;
+
+  const textParts = [
+    `📋 ${title}`,
+    project ? `${date} · ${project}` : date,
+    "",
+    body,
+    "",
+    actionLine,
+    url,
+  ];
+
+  const htmlBody = escapeHtml(body).replace(/\n/g, "<br/>");
+  const html = [
+    `<h4>📋 ${escapeHtml(title)}</h4>`,
+    `<p><em>${escapeHtml(project ? `${date} · ${project}` : date)}</em></p>`,
+    `<p>${htmlBody}</p>`,
+    `<p>${escapeHtml(actionLine)} — <a href="${escapeHtml(url)}">open in Exponential</a></p>`,
+  ].join("");
+
+  return { text: textParts.join("\n").trim(), html };
+}

--- a/src/server/services/matrix/resolveMatrixDestination.ts
+++ b/src/server/services/matrix/resolveMatrixDestination.ts
@@ -1,0 +1,63 @@
+/**
+ * Where does this meeting's summary go?
+ *
+ * Deliberately **not** `resolveChannelLink()`. That one is keyed on the
+ * `(provider, externalId)` unique and answers the inbound question — "which workspace
+ * and project owns this conversation?" This walks the other way: given a project, which
+ * room does its content go to. Same table (ADR-0023's routing record), opposite
+ * direction, which is exactly why `ChannelLink.direction` exists.
+ *
+ * Resolution is project → workspace. There is no team tier.
+ */
+
+import type { ChannelLink, PrismaClient } from "@prisma/client";
+import { MATRIX_CHANNEL_PROVIDER } from "./constants";
+import { OUTBOUND } from "~/server/services/channelLinkService";
+
+export type MatrixDestination =
+  | { kind: "room"; link: ChannelLink }
+  /** The project is explicitly switched off — the confidential-project escape hatch. */
+  | { kind: "off" }
+  /** Nothing configured anywhere. The caller should offer a picker, not fail. */
+  | { kind: "none" };
+
+/**
+ * `Off` is stored as a project-level row with `isActive: false` rather than as an
+ * absent row, so "explicitly off" and "never configured" stay distinguishable — they
+ * lead to different UI (a stated block vs. a picker). A row with a null `projectId` is
+ * the workspace default.
+ */
+export async function resolveMatrixDestination(
+  db: PrismaClient,
+  { projectId, workspaceId }: { projectId: string | null; workspaceId: string | null },
+): Promise<MatrixDestination> {
+  if (projectId) {
+    const projectLink = await db.channelLink.findFirst({
+      where: {
+        projectId,
+        provider: MATRIX_CHANNEL_PROVIDER,
+        direction: OUTBOUND,
+      },
+    });
+
+    if (projectLink) {
+      // An inactive project row is the explicit "off", and it must not fall through to
+      // the workspace default — that would silently defeat the whole point of Off.
+      return projectLink.isActive ? { kind: "room", link: projectLink } : { kind: "off" };
+    }
+  }
+
+  if (!workspaceId) return { kind: "none" };
+
+  const workspaceLink = await db.channelLink.findFirst({
+    where: {
+      workspaceId,
+      projectId: null,
+      provider: MATRIX_CHANNEL_PROVIDER,
+      direction: OUTBOUND,
+      isActive: true,
+    },
+  });
+
+  return workspaceLink ? { kind: "room", link: workspaceLink } : { kind: "none" };
+}

--- a/src/server/services/matrix/resolveMatrixDestination.ts
+++ b/src/server/services/matrix/resolveMatrixDestination.ts
@@ -35,6 +35,10 @@ export async function resolveMatrixDestination(
     const projectLink = await db.channelLink.findFirst({
       where: {
         projectId,
+        // Scoped by workspace like every write path (bind/setOff/unbind/getBinding).
+        // Without it, resolution and configuration could disagree about the same
+        // project, and a row under another workspace would be honoured here.
+        ...(workspaceId ? { workspaceId } : {}),
         provider: MATRIX_CHANNEL_PROVIDER,
         direction: OUTBOUND,
       },


### PR DESCRIPTION
### **User description**
## What

The second half of V1: bind a Matrix room to a project and post a meeting summary into it from the recording page. Six vertical slices, one commit each.

**Migration** (run by James, not by me): `ChannelLink` gains `direction` (defaulting to `"inbound"`, so every existing WhatsApp row keeps working untouched) and `serverIntegrationId`; new `MatrixPostLog` table.

`MatrixPostLog` is a table rather than a timestamp column because the destination is not singular — `slackNotificationAt` is the single-destination precedent and it breaks the moment a meeting is re-tagged to a project with a different room.

The `(provider, externalId)` unique is deliberately left alone. Its consequence — a room can only be bound in one place — is a recorded open decision, so a collision reports "already bound elsewhere" rather than surfacing a raw constraint violation.

## Three defects found while building, all real

**1. `Off` could be routed around from the picker.** An explicitly picked room bypassed the Off check entirely, so the confidential-project escape hatch could be defeated by anyone choosing a room by hand. Resolution now runs even when a room is given explicitly, and Off blocks either way. Verified end-to-end.

**2. A confirmed repost reused its transaction id.** Found by exercising the real flow against a stub homeserver — the seam reported `posted` both times and the log had two rows, so from inside everything looked correct. The stub showed both sends carrying the same `txnId`, and Matrix deduplicates on it: a real homeserver would have accepted the first and silently discarded the second, telling the user it worked while nothing appeared in the room. The attempt number now derives from how many times this meeting has already reached this room, so it survives a restart.

**3. The Post to Matrix button was dead.** Mantine's `Popover` is controlled; mine had no `opened` prop, so clicking it did nothing in the app. Caught by writing the component test. Both the dropdown and the picker modal now use a zero-duration transition — the same root cause meant Mantine deferred mounting until a `requestAnimationFrame`-driven transition completed, which never happens in a hidden tab or JSDOM.

Also: the deep link pointed at `/meetings/{id}`, which does not exist — `/meetings` is a list with no per-meeting route. It is `/recording/{id}`, so every posted summary would have landed readers on their own inbox.

## Notable decisions

- **`resolveChannelLink` now ignores explicitly-outbound rows**, so an outbound binding cannot be mistaken for an inbound routing record. Only *explicitly* outbound — anything else counts as inbound, so it cannot start dropping links that worked before. Four WhatsApp ingest tests failing against a stricter check are what showed that mattered.
- **An `Off` row is namespaced `off:{projectId}`**, not a real room id, so it does not consume a real room's one binding slot under the unique.
- **Permissions split as the PRD asks**: a project lead binds their own project's room; only an owner or admin sets the workspace default, since the default affects every project inheriting it.
- **A failed post writes no log row** — the log records what actually reached a room, and a phantom entry would make the repost guard refuse a post that never happened.
- **Nothing is wired to an event.** No trigger on assignment, bulk assignment, or summarization.

## Verification

Exercised against a stub homeserver through the real HTTP stack, not only unit-mocked:

| Scenario | Result |
|---|---|
| Post with nothing bound | `no-destination` (offers picker) |
| Post to the project's bound room | `posted`, log row written |
| Immediate repost | `needs-confirm` with last-posted time |
| Confirmed repost | `posted`, **distinct** txn id |
| Project switched `Off` | `blocked-off` |
| `Off` + explicitly picked room | `blocked-off` |
| Encrypted room | `failed`, with the encryption reason, **no log row** |
| One-off post to a picked room | posted, **zero** bindings persisted |

The message that actually landed carried title, date, project, summary, action count and an absolute `/recording/{id}` link.

2565 unit tests green, typecheck clean, lint clean.

## Acceptance criteria

- [x] Resolve from the project's binding, falling back to the workspace on Inherit
- [x] `Off` blocks posting and states the reason
- [x] Post carries title, meeting date, full summary, action count, absolute link
- [x] Reject posts from users without edit access to the meeting
- [x] No destination → picker, post without persisting a binding
- [x] The save checkbox persists the binding
- [x] Each successful post recorded as meeting × room × timestamp × actor
- [x] Repost shows last-posted time and requires confirmation
- [x] A failed post surfaces to the user and writes no log row
- [x] Never posts in response to assignment, bulk assignment, or summary generation
- [x] Bindings stored as `ChannelLink` rows with a server reference and direction flag
- [x] Existing WhatsApp rows still resolve as inbound (`channelLink.test.ts` extended)
- [x] Unit tests only — mocked Prisma and an injected client
- [x] Migration created via `prisma migrate dev` (run by James)
- [x] No hardcoded colors; typecheck + lint pass

---

Ships: brisk.spruce


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Bind Matrix rooms to projects/workspaces via `ChannelLink` direction

- New `postMeetingSummaryToMatrix` seam with access, Off, repost guards

- `matrixRoom` router plus binding and post-to-Matrix UI

- Schema migration adding `direction` and `MatrixPostLog`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["PostToMatrixButton / MatrixRoomBinding"] -- "bind / setOff / unbind" --> Router["matrixRoom router"]
  UI -- "postToMatrix" --> TR["transcription.postToMatrix"]
  Router -- "outbound rows" --> CL["ChannelLink (direction, serverIntegrationId)"]
  TR -- "single seam" --> Seam["postMeetingSummaryToMatrix"]
  Seam -- "project → workspace" --> Resolve["resolveMatrixDestination"]
  Resolve -- "reads" --> CL
  Seam -- "render text/html" --> Render["renderMeetingSummary"]
  Seam -- "send with txnId" --> Client["MatrixClient.send"]
  Seam -- "record success" --> Log["MatrixPostLog"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>postMeetingSummary.ts</strong><dd><code>New seam posting meeting summaries to Matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-38b21496926a1f5f74c60c0bf2860583317acc12c25a81c97874d5771f6ddaf3">+251/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>matrixRoom.ts</strong><dd><code>Router for binding, off, unbind and getBinding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-89f7154caca8a20cdf4f6d48701aacd59398224e846be6ca66ab65460a195a65">+277/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>resolveMatrixDestination.ts</strong><dd><code>Project-to-workspace outbound destination resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-291ab233117acdead3c8816ce733855266f8c4891a59b9d8ef9895ccabaacddc">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>renderMeetingSummary.ts</strong><dd><code>Render summary as Matrix text and HTML</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-c68a9e4a56a83599ca53fd1e6f248966d964e09b00c156ce086d66a7b85d0eb7">+142/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MatrixClient.ts</strong><dd><code>Add send() and encrypted-room error type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-a6dacf3b6be98a42641f823d82686a2202407b609022fdbe263f9deffe682329">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transcription.ts</strong><dd><code>Add postToMatrix mutation delegating to seam</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-14d6aec7ca6f74348adfbedb772dd759262f6da276ab98b75041752d8d7ea06b">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>channelLinkService.ts</strong><dd><code>Add direction constants; inbound-only resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-3b24b8d4fac4854149feea06a062b003be653adff33ba2155fa9a3143171e41e">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PostToMatrixButton.tsx</strong><dd><code>New post button with picker and repost confirm</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-ee54011a189b1344dd5f65061f3eea0cbec40c5e941faefddbde32ab0f86f698">+299/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MatrixRoomBinding.tsx</strong><dd><code>Tri-state Inherit/Room/Off room binding control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-31341deada7813324aae19fa74d9afc9747f7e9b823617f91acc68d91b74944f">+193/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ProjectContent.tsx</strong><dd><code>Add Matrix room binding section to project</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-60023cc61d58a79d8bb99cd49422681b1f8e87fd3823d3f9e8bf6d68872c9002">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MatrixServerSettings.tsx</strong><dd><code>Add workspace default room binding section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-62e00acd5c2698405267f16d18ce96592668c7bc973309292dda0991f3c2ff25">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MeetingDetail.tsx</strong><dd><code>Render post-to-Matrix button in meeting header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-41107acc702a3dcd87864323be0e890f6db435de5d96596e83ae64af93022c21">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MeetingHeader.tsx</strong><dd><code>Support extraActions slot beside Share</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-534663d93570be32de794581b779c4146d73ab1516d4e223eb673fff0ce8c700">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>schema.prisma</strong><dd><code>ChannelLink direction/server plus MatrixPostLog model</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565c">+62/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>migration.sql</strong><dd><code>Migration for direction, server FK and post log</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-69acbff21e775099ec24309515ab169f202058af6427db9ea1fe35afaf09f588">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>postMeetingSummary.test.ts</strong><dd><code>Extensive tests for the posting seam</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-c07a17b5cc97aa0ed45c6382cbdaf4f3438d4bf5ebb5dd93ce73f24a4d86441f">+482/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>matrixRoom.test.ts</strong><dd><code>Tests for bind, setOff, unbind, getBinding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-0e30d09b30944ca1d75063e4c39d6f413c8d97a72ff6695e7e65b9d9afb2a4d0">+319/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>resolveMatrixDestination.test.ts</strong><dd><code>Tests for destination resolution and Off semantics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-007f7f6cebce401206c1d2186022d2c22f8bf9bac138d5bbaa07ee8be7428678">+180/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>PostToMatrixButton.test.tsx</strong><dd><code>Component tests for post button behaviour</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-4e30e3b57c0a00f91ff4a0e570009f8cca4425286c4f9654b9ba68763ebf83e1">+191/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>channelLink.test.ts</strong><dd><code>Tests that inbound resolution ignores outbound rows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-07ac3ba71cb748cf9290df47eea72e20a37858316d63085d99004ebee8e3e085">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>root.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-6a8cad7e52067d5afa93671900c038e0e0a9526f8f0e3bd10985cecf4295b4fc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>constants.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-e10dbc0293662110edafc32c70fd535909c921d15d9ebf77c74ecef68fe9ee8a">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>matrixServer.ts</strong></td>
  <td><a href="https://github.com/positonic/exponential/pull/557/files#diff-19d5f1d736808d8cd6354b8ddccf16a07b00d867c05696029c3d1395b517db46">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

