### PR TITLE
fix(activity): derive sparkline isToday from the week's local calendar

### DIFF
--- a/src/server/services/activity/__tests__/workspaceHomeStats.integration.test.ts
+++ b/src/server/services/activity/__tests__/workspaceHomeStats.integration.test.ts
@@ -37,7 +37,11 @@ async function seedEvent(
 describe("getWorkspaceHomeStats — T6 weekly fields (integration)", () => {
   let db: ReturnType<typeof getTestDb>;
   // Anchor "now" to a fixed Wednesday so ISO weeks are deterministic.
-  const now = new Date("2026-05-13T12:00:00Z"); // Wed
+  // Built from local components, not a Z-instant: a single UTC instant is a
+  // different weekday either side of the date line (12:00Z on 2026-05-13 is
+  // already Thursday at UTC+12 and beyond), which would make the "today" bar
+  // depend on the runner's timezone.
+  const now = new Date(2026, 4, 13, 12, 0, 0); // Wed 2026-05-13, local noon
   const thisMon = startOfISOWeek(now);
 
   beforeEach(() => {

--- a/src/server/services/activity/workspaceHomeStats.ts
+++ b/src/server/services/activity/workspaceHomeStats.ts
@@ -1,5 +1,10 @@
 import type { PrismaClient } from "@prisma/client";
-import { addWeeks, endOfISOWeek, startOfISOWeek } from "date-fns";
+import {
+  addWeeks,
+  differenceInCalendarDays,
+  endOfISOWeek,
+  startOfISOWeek,
+} from "date-fns";
 
 /**
  * One bar of the Week-in-Review sparkline. `day` is the ISO weekday label
@@ -55,14 +60,6 @@ export interface WorkspaceHomeStats {
 }
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
-function isSameDay(a: Date, b: Date): boolean {
-  return (
-    a.getUTCFullYear() === b.getUTCFullYear() &&
-    a.getUTCMonth() === b.getUTCMonth() &&
-    a.getUTCDate() === b.getUTCDate()
-  );
-}
 
 export async function getWorkspaceHomeStats(
   db: PrismaClient,
@@ -137,6 +134,13 @@ export async function getWorkspaceHomeStats(
   }
 
   // ── This-week sparkline (Mon → Sun) ────────────────────────────────
+  // Which bar is "today", as an offset from the start of the week. Derived
+  // from the injected `now` using the same local calendar `thisWeekStart`
+  // came from — comparing UTC components instead would shift the flag by a
+  // day for any caller running in a UTC+ timezone. Falls outside 0..6 (so
+  // every bar is false) when `now` isn't in the current ISO week.
+  const todayIndex = differenceInCalendarDays(now, thisWeekStart);
+
   const sparkline: WeeklySparklineBar[] = [];
   for (let i = 0; i < 7; i++) {
     const day = new Date(thisWeekStart.getTime() + i * MS_PER_DAY);
@@ -144,7 +148,7 @@ export async function getWorkspaceHomeStats(
     sparkline.push({
       day: DAY_LABELS[i] ?? "?",
       count: countsByDay.get(key) ?? 0,
-      isToday: isSameDay(day, now),
+      isToday: i === todayIndex,
     });
   }
 

--- a/src/server/services/activity/workspaceHomeStats.ts
+++ b/src/server/services/activity/workspaceHomeStats.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 import {
+  addDays,
   addWeeks,
   differenceInCalendarDays,
   endOfISOWeek,
@@ -58,8 +59,6 @@ export interface WorkspaceHomeStats {
   /** Highest single-ISO-week event total in the trailing 12 ISO weeks. */
   bestWeekTotal: number;
 }
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export async function getWorkspaceHomeStats(
   db: PrismaClient,
@@ -143,7 +142,7 @@ export async function getWorkspaceHomeStats(
 
   const sparkline: WeeklySparklineBar[] = [];
   for (let i = 0; i < 7; i++) {
-    const day = new Date(thisWeekStart.getTime() + i * MS_PER_DAY);
+    const day = addDays(thisWeekStart, i);
     const key = day.toISOString().slice(0, 10);
     sparkline.push({
       day: DAY_LABELS[i] ?? "?",
@@ -160,7 +159,7 @@ export async function getWorkspaceHomeStats(
     const weekStart = startOfISOWeek(addWeeks(now, -w));
     let total = 0;
     for (let d = 0; d < 7; d++) {
-      const day = new Date(weekStart.getTime() + d * MS_PER_DAY);
+      const day = addDays(weekStart, d);
       total += countsByDay.get(day.toISOString().slice(0, 10)) ?? 0;
     }
     weekTotals.push(total);

--- a/src/server/services/activity/workspaceHomeStats.ts
+++ b/src/server/services/activity/workspaceHomeStats.ts
@@ -133,11 +133,16 @@ export async function getWorkspaceHomeStats(
   }
 
   // ── This-week sparkline (Mon → Sun) ────────────────────────────────
-  // Which bar is "today", as an offset from the start of the week. Derived
-  // from the injected `now` using the same local calendar `thisWeekStart`
-  // came from — comparing UTC components instead would shift the flag by a
-  // day for any caller running in a UTC+ timezone. Falls outside 0..6 (so
-  // every bar is false) when `now` isn't in the current ISO week.
+  // Which bar is "today", as an offset from the start of the week — always
+  // 0..6, since `thisWeekStart` is derived from this same `now`.
+  //
+  // Deliberately the local calendar, so the flag agrees with the day labels.
+  // The `count` key below is a UTC date, matching the SQL's `date_trunc`, so
+  // flag and count line up only when the runtime is UTC — which is what
+  // production runs. On a non-UTC runtime the flagged bar can carry the
+  // adjacent UTC day's count; reconciling the two calendars means changing
+  // the SQL bucketing and the week window together, so it is left to its own
+  // change rather than half-done here.
   const todayIndex = differenceInCalendarDays(now, thisWeekStart);
 
   const sparkline: WeeklySparklineBar[] = [];


### PR DESCRIPTION
## Problem

`workspaceHomeStats.integration.test.ts` fails on any machine in a UTC+ timezone.

The reported symptom was "fails on any day that isn't Wednesday", but `isToday` never read the real clock — it already used the injected `now`. The actual cause is a **UTC/local calendar mismatch**:

- `startOfISOWeek(now)` returns a **local** midnight — in Europe/Berlin that's `2026-05-10T22:00Z`
- the sparkline bars are laid out from that instant
- `isSameDay` then compared **UTC** components, so each bar's UTC date sat a day behind its local one

Running the test unmodified reports `[false, false, false, true, …]` — the flag on **Thu**, not Wed, and not all-false.

So the failure is **timezone-dependent, not weekday-dependent**: it fails on every run in a UTC+ timezone and passes in UTC or UTC− on any day. The `day` and `count` assertions were unaffected because both sides of the count lookup derive their key the same way.

## Fix

Derive the flag from the same local calendar the buckets are built on:

```ts
const todayIndex = differenceInCalendarDays(now, thisWeekStart);
// …
isToday: i === todayIndex,
```

Local and UTC coincide on UTC servers, so **production output is unchanged**.

The test's anchor also moved to local components. `12:00Z` is already Thursday at UTC+12 and beyond, so no single instant is Wednesday everywhere on Earth — Pacific/Kiritimati still failed (correctly) after the source fix alone.

## The trade-off this makes

Worth being explicit, since it's the one thing a reviewer should push back on if they disagree.

Each bar has three parts: its **label** (`Mon`…`Sun`, positional), its **count** (looked up by a UTC date key, matching the SQL's `date_trunc`), and its **isToday** flag. On a non-UTC runtime the local and UTC calendars disagree, and the flag can only match one of the other two:

| | flag matches label | flag matches count |
|---|---|---|
| **before** (UTC comparison) | ✗ | ✓ |
| **after** (local calendar) | ✓ | ✗ |

Neither is correct — the underlying defect is that labels and count keys already come from different calendars, which predates this PR. This change moves which half is aligned; it doesn't introduce or remove the mismatch. **On a UTC runtime — production — all three agree and nothing changes.**

Fixing it properly means bucketing the SQL and the week window in one chosen zone, which changes what "this week" means for `WeekInReview` and `weeklyNarrativeService`. That's a design decision deserving its own change, so it's documented at the call site rather than half-done here.

## Verification

- `npx vitest run src/server/services/activity/__tests__/workspaceHomeStats.integration.test.ts` — 5/5 pass
- Green across UTC, Europe/Berlin, America/New_York, Asia/Kolkata, Pacific/Kiritimati, Pacific/Midway, Pacific/Auckland, America/Anchorage
- Confirmed red before the change (`AssertionError: expected [false, false, false, true, …]`)
- Typecheck clean; lint clean (pre-existing warnings only)
- Full suite: 2742 passed, 2 failed — both in `tag.integration.test.ts`, which fail identically on `c4c4f824` without these changes (pre-existing, unrelated)

## Review notes

Two PR-Agent findings were applied: `addDays` for the day loops, and a corrected `todayIndex` comment (it had documented a `0..6` fallback that can never fire).

The `addDays` swap is a **no-op consistency refactor, not a DST fix**. The reviewer's stated failure mode isn't reachable — DST transitions land on Sunday *after* local midnight, and Sunday is the last ISO-week day, so no bar's midnight crosses one. Sweeping 212 ISO weeks × 6 DST-varied zones, both forms produce identical date keys; they differ by one hour only on the Sunday bar in America/Santiago (which transitions at Sat 24:00), where the key still matches. Taken because it states the intent and costs nothing.