### PR TITLE
perf(actions): make reschedule instant on the project page

### DIFF
--- a/src/app/_components/Actions.tsx
+++ b/src/app/_components/Actions.tsx
@@ -14,7 +14,15 @@ import type { FilterBarConfig, FilterMember } from "~/types/filter";
 import { filtersToSearchParams, filtersFromSearchParams } from "~/lib/filters/url";
 import tasksStyles from "./ProjectTasks.module.css";
 import { useState, useEffect, useMemo, useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { getQueryKey } from "@trpc/react-query";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import {
+  cancelActionQueries,
+  patchActionCaches,
+  restoreActionCaches,
+  type ActionCacheSnapshot,
+} from "~/lib/actions/optimisticCache";
 import { CreateOutcomeModal } from "~/app/_components/CreateOutcomeModal";
 import { CreateGoalModal } from "~/app/_components/CreateGoalModal";
 import { notifications } from "@mantine/notifications";
@@ -26,6 +34,17 @@ import { useWorkspace } from "~/providers/WorkspaceProvider";
 type OutcomeType = 'daily' | 'weekly' | 'monthly' | 'quarterly' | 'annual' | 'life' | 'problem';
 
 import type { FilterState } from "~/types/filter";
+
+/**
+ * Every cached list an action can appear in. Path-only keys, so each one
+ * matches all input variants (every project id, every assignee filter).
+ * `getProjectActions` is the one the project page's Tasks tab reads.
+ */
+const ACTION_LIST_KEYS = [
+  getQueryKey(api.action.getAll),
+  getQueryKey(api.action.getToday),
+  getQueryKey(api.action.getProjectActions),
+];
 
 const ACTION_FILTER_CONFIG: FilterBarConfig = {
   fields: [
@@ -104,6 +123,7 @@ export function Actions({ viewName, defaultView = 'list', projectId, displayAlig
   const [internalSearch, setInternalSearch] = useState("");
   const [internalFilters, setInternalFilters] = useState<FilterState>({});
   const utils = api.useUtils();
+  const queryClient = useQueryClient();
   const { actionIdFromUrl, setActionId, clearActionId } = useActionDeepLink();
   const detailedEnabled = useDetailedActionsEnabled(projectId);
   const { workspace } = useWorkspace();
@@ -408,33 +428,20 @@ export function Actions({ viewName, defaultView = 'list', projectId, displayAlig
   };
 
   // Bulk update mutation for rescheduling
-  const bulkUpdateMutation = api.action.update.useMutation({
+  const bulkUpdateMutation = api.action.update.useMutation<ActionCacheSnapshot>({
     onMutate: async ({ id, dueDate }) => {
       // Cancel any outgoing refetches
-      await utils.action.getAll.cancel();
+      await cancelActionQueries(queryClient, ACTION_LIST_KEYS);
 
-      // Get current data
-      const previousData = utils.action.getAll.getData();
-
-      // Optimistically update the cache
-      if (previousData) {
-        utils.action.getAll.setData(undefined, (old) => {
-          if (!old) return [];
-          return old.map((action) =>
-            action.id === id
-              ? { ...action, dueDate: dueDate ?? null }
-              : action
-          );
-        });
-      }
-
-      return { previousData, actionId: id };
+      // Optimistically update every cached list this action appears in —
+      // including getProjectActions, which backs the project page.
+      return patchActionCaches(queryClient, ACTION_LIST_KEYS, (action) =>
+        action.id === id ? { ...action, dueDate: dueDate ?? null } : action,
+      );
     },
-    onError: (err, variables, context) => {
+    onError: (err, variables, snapshot) => {
       // Rollback on error
-      if (context?.previousData) {
-        utils.action.getAll.setData(undefined, context.previousData);
-      }
+      if (snapshot) restoreActionCaches(queryClient, snapshot);
 
       notifications.show({
         title: 'Update Failed',
@@ -452,33 +459,24 @@ export function Actions({ viewName, defaultView = 'list', projectId, displayAlig
   });
 
   // Bulk reschedule mutation - single API call for multiple actions
-  const bulkRescheduleMutation = api.action.bulkReschedule.useMutation({
+  const bulkRescheduleMutation = api.action.bulkReschedule.useMutation<ActionCacheSnapshot>({
     onMutate: async ({ actionIds, dueDate }) => {
-      await utils.action.getAll.cancel();
-      const previousData = utils.action.getAll.getData();
+      await cancelActionQueries(queryClient, ACTION_LIST_KEYS);
+      const targeted = new Set(actionIds);
 
       // Optimistically update ALL selected actions at once (scheduledStart + dueDate)
-      if (previousData) {
-        utils.action.getAll.setData(undefined, (old) => {
-          if (!old) return [];
-          return old.map((action) => {
-            if (!actionIds.includes(action.id)) return action;
-            const newScheduledStart = dueDate ?? null;
-            // Update dueDate only if it's before the new date or null
-            const newDueDate = dueDate
-              ? (!action.dueDate || action.dueDate < dueDate ? dueDate : action.dueDate)
-              : null;
-            return { ...action, scheduledStart: newScheduledStart, dueDate: newDueDate };
-          });
-        });
-      }
-
-      return { previousData };
+      return patchActionCaches(queryClient, ACTION_LIST_KEYS, (action) => {
+        if (!targeted.has(action.id)) return action;
+        const currentDue = action.dueDate;
+        // Update dueDate only if it's before the new date or null
+        const newDueDate = dueDate
+          ? (currentDue instanceof Date && currentDue >= dueDate ? currentDue : dueDate)
+          : null;
+        return { ...action, scheduledStart: dueDate ?? null, dueDate: newDueDate };
+      });
     },
-    onError: (_err, _variables, context) => {
-      if (context?.previousData) {
-        utils.action.getAll.setData(undefined, context.previousData);
-      }
+    onError: (_err, _variables, snapshot) => {
+      if (snapshot) restoreActionCaches(queryClient, snapshot);
     },
     onSettled: () => {
       void utils.action.getAll.invalidate();
@@ -495,28 +493,19 @@ export function Actions({ viewName, defaultView = 'list', projectId, displayAlig
   );
 
   // Bulk assign project mutation
-  const bulkAssignProjectMutation = api.action.bulkAssignProject.useMutation({
+  const bulkAssignProjectMutation = api.action.bulkAssignProject.useMutation<ActionCacheSnapshot>({
     onMutate: async ({ actionIds, projectId: newProjectId }) => {
-      await utils.action.getAll.cancel();
-      const previousData = utils.action.getAll.getData();
+      await cancelActionQueries(queryClient, ACTION_LIST_KEYS);
+      const targeted = new Set(actionIds);
 
-      if (previousData) {
-        utils.action.getAll.setData(undefined, (old) => {
-          if (!old) return [];
-          return old.map((action) =>
-            actionIds.includes(action.id)
-              ? { ...action, projectId: newProjectId }
-              : action
-          );
-        });
-      }
-
-      return { previousData };
+      return patchActionCaches(queryClient, ACTION_LIST_KEYS, (action) =>
+        targeted.has(action.id)
+          ? { ...action, projectId: newProjectId }
+          : action,
+      );
     },
-    onError: (_err, _variables, context) => {
-      if (context?.previousData) {
-        utils.action.getAll.setData(undefined, context.previousData);
-      }
+    onError: (_err, _variables, snapshot) => {
+      if (snapshot) restoreActionCaches(queryClient, snapshot);
     },
     onSettled: () => {
       void utils.action.getAll.invalidate();

--- a/src/app/_components/actions/hooks/__tests__/useActionMutations.test.ts
+++ b/src/app/_components/actions/hooks/__tests__/useActionMutations.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { getQueryKey } from "@trpc/react-query";
 
 // Capture every config passed to api.action.update.useMutation so tests can
 // invoke the lifecycle callbacks (onSettled) directly.
@@ -58,23 +61,38 @@ vi.mock("~/trpc/react", () => ({
           return { mutate: mockMutate, isPending: false };
         },
       },
+      // getQueryKey() only reads `_def().path`, so these stubs are enough to
+      // let the hook build real query keys against the mocked client.
+      getAll: { _def: () => ({ path: ["action", "getAll"] }) },
+      getToday: { _def: () => ({ path: ["action", "getToday"] }) },
+      getProjectActions: { _def: () => ({ path: ["action", "getProjectActions"] }) },
     },
   },
 }));
 
+import { api } from "~/trpc/react";
 import { useActionMutations } from "../useActionMutations";
+
+let queryClient: QueryClient;
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(QueryClientProvider, { client: queryClient }, children);
+
+const renderUseActionMutations = (viewName: string) =>
+  renderHook(() => useActionMutations({ viewName }), { wrapper });
 
 beforeEach(() => {
   Object.values(invalidates).forEach((m) => m.mockClear());
   mockMutate.mockClear();
   lastConfig.current = undefined;
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
 });
 
 describe("useActionMutations onSettled routing", () => {
   test("transcription-actions routes to getByTranscription", () => {
-    renderHook(() =>
-      useActionMutations({ viewName: "transcription-actions" }),
-    );
+    renderUseActionMutations("transcription-actions");
     lastConfig.current?.onSettled?.({ projectId: null });
     expect(invalidates.getByTranscription).toHaveBeenCalledTimes(1);
     expect(invalidates.getAll).not.toHaveBeenCalled();
@@ -82,21 +100,21 @@ describe("useActionMutations onSettled routing", () => {
   });
 
   test("today (lowercase) invalidates both getAll and getToday", () => {
-    renderHook(() => useActionMutations({ viewName: "today" }));
+    renderUseActionMutations("today");
     lastConfig.current?.onSettled?.({ projectId: null });
     expect(invalidates.getAll).toHaveBeenCalledTimes(1);
     expect(invalidates.getToday).toHaveBeenCalledTimes(1);
   });
 
   test("Today (mixed case) invalidates both via toLowerCase", () => {
-    renderHook(() => useActionMutations({ viewName: "Today" }));
+    renderUseActionMutations("Today");
     lastConfig.current?.onSettled?.({ projectId: null });
     expect(invalidates.getAll).toHaveBeenCalledTimes(1);
     expect(invalidates.getToday).toHaveBeenCalledTimes(1);
   });
 
   test("projectId in result routes to getProjectActions", () => {
-    renderHook(() => useActionMutations({ viewName: "actions" }));
+    renderUseActionMutations("actions");
     lastConfig.current?.onSettled?.({ projectId: "proj-123" });
     expect(invalidates.getProjectActions).toHaveBeenCalledWith({
       projectId: "proj-123",
@@ -105,15 +123,85 @@ describe("useActionMutations onSettled routing", () => {
   });
 
   test("default viewName falls back to getAll", () => {
-    renderHook(() => useActionMutations({ viewName: "actions" }));
+    renderUseActionMutations("actions");
     lastConfig.current?.onSettled?.({ projectId: null });
     expect(invalidates.getAll).toHaveBeenCalledTimes(1);
   });
 
   test("scoring queries always invalidate on settled", () => {
-    renderHook(() => useActionMutations({ viewName: "actions" }));
+    renderUseActionMutations("actions");
     lastConfig.current?.onSettled?.({ projectId: null });
     expect(invalidates.getTodayScore).toHaveBeenCalledTimes(1);
     expect(invalidates.getProductivityStats).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The project page's Tasks tab reads action.getProjectActions, not getAll.
+// While onMutate patched getAll only, a reschedule there showed nothing until
+// the mutation *and* the follow-up refetch had both landed — a ~3s stall.
+describe("useActionMutations optimistic patching", () => {
+  const projectActionsKey = (projectId: string) =>
+    getQueryKey(api.action.getProjectActions, { projectId }, "query");
+
+  const seedProject = (projectId: string) =>
+    queryClient.setQueryData(projectActionsKey(projectId), [
+      { id: "a1", name: "Overdue task", scheduledStart: new Date("2020-01-01"), dueDate: new Date("2020-01-01") },
+      { id: "a2", name: "Untouched", scheduledStart: null, dueDate: null },
+    ]);
+
+  test("patches the cached getProjectActions list for the targeted action", async () => {
+    seedProject("proj-1");
+    renderUseActionMutations("project-grow-socials");
+
+    const nextDate = new Date("2026-08-09T00:00:00");
+    await lastConfig.current?.onMutate?.({
+      id: "a1",
+      scheduledStart: nextDate,
+      dueDate: nextDate,
+    });
+
+    const patched = queryClient.getQueryData(projectActionsKey("proj-1"));
+    expect(patched).toEqual([
+      expect.objectContaining({ id: "a1", scheduledStart: nextDate, dueDate: nextDate }),
+      expect.objectContaining({ id: "a2", scheduledStart: null, dueDate: null }),
+    ]);
+  });
+
+  test("patches every cached project variant, not just one", async () => {
+    seedProject("proj-1");
+    seedProject("proj-2");
+    renderUseActionMutations("project-grow-socials");
+
+    await lastConfig.current?.onMutate?.({ id: "a1", status: "COMPLETED" });
+
+    for (const projectId of ["proj-1", "proj-2"]) {
+      const rows = queryClient.getQueryData<Array<{ id: string; status?: string }>>(
+        projectActionsKey(projectId),
+      );
+      expect(rows?.[0]).toMatchObject({ id: "a1", status: "COMPLETED" });
+    }
+  });
+
+  test("onError rolls the cached list back", async () => {
+    seedProject("proj-1");
+    renderUseActionMutations("project-grow-socials");
+
+    const before = queryClient.getQueryData(projectActionsKey("proj-1"));
+    const snapshot = await lastConfig.current?.onMutate?.({
+      id: "a1",
+      status: "COMPLETED",
+    });
+    lastConfig.current?.onError?.(new Error("boom"), { id: "a1" }, snapshot);
+
+    expect(queryClient.getQueryData(projectActionsKey("proj-1"))).toEqual(before);
+  });
+
+  test("does not fabricate cache entries for lists the user never opened", async () => {
+    renderUseActionMutations("project-grow-socials");
+
+    await lastConfig.current?.onMutate?.({ id: "a1", status: "COMPLETED" });
+
+    expect(queryClient.getQueryData(getQueryKey(api.action.getAll, undefined, "query")))
+      .toBeUndefined();
   });
 });

--- a/src/app/_components/actions/hooks/useActionMutations.ts
+++ b/src/app/_components/actions/hooks/useActionMutations.ts
@@ -1,5 +1,14 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { getQueryKey } from "@trpc/react-query";
 import { notifications } from "@mantine/notifications";
-import { api, type RouterInputs, type RouterOutputs } from "~/trpc/react";
+import { api, type RouterInputs } from "~/trpc/react";
+import {
+  cancelActionQueries,
+  patchActionCaches,
+  restoreActionCaches,
+  type ActionCacheSnapshot,
+  type CachedActionRow,
+} from "~/lib/actions/optimisticCache";
 
 export type ActionUpdateInput = RouterInputs["action"]["update"];
 
@@ -13,13 +22,16 @@ interface UseActionMutationsResult {
   isUpdating: boolean;
 }
 
-type GetAllActions = RouterOutputs["action"]["getAll"];
-type GetTodayActions = RouterOutputs["action"]["getToday"];
-
-interface OptimisticSnapshot {
-  getAll: GetAllActions | undefined;
-  getToday: GetTodayActions | undefined;
-}
+/**
+ * Every cached list an action can appear in. `getProjectActions` is the one the
+ * project page's Tasks tab reads — omitting it is what left that page with no
+ * optimistic path. Keys are path-only, so each matches all input variants.
+ */
+const ACTION_LIST_KEYS = [
+  getQueryKey(api.action.getAll),
+  getQueryKey(api.action.getToday),
+  getQueryKey(api.action.getProjectActions),
+];
 
 /**
  * Wraps `api.action.update.useMutation` with cache-routing,
@@ -31,46 +43,28 @@ export function useActionMutations(
   context: ActionMutationsContext,
 ): UseActionMutationsResult {
   const utils = api.useUtils();
+  const queryClient = useQueryClient();
 
-  const mutation = api.action.update.useMutation({
+  const mutation = api.action.update.useMutation<ActionCacheSnapshot>({
     onMutate: async (variables) => {
-      await Promise.all([
-        utils.action.getAll.cancel(),
-        utils.action.getToday.cancel(),
-      ]);
+      await cancelActionQueries(queryClient, ACTION_LIST_KEYS);
 
-      const snapshot: OptimisticSnapshot = {
-        getAll: utils.action.getAll.getData(),
-        getToday: utils.action.getToday.getData(),
-      };
-
-      const apply = <T extends { id: string }>(list: T[] | undefined): T[] => {
-        if (!list) return [];
-        return list.map((a) => {
-          if (a.id !== variables.id) return a;
-          const next: Record<string, unknown> = { ...a };
-          if (variables.status !== undefined) next.status = variables.status;
-          if (variables.scheduledStart !== undefined)
-            next.scheduledStart = variables.scheduledStart;
-          if (variables.dueDate !== undefined) next.dueDate = variables.dueDate;
-          if (variables.priority !== undefined)
-            next.priority = variables.priority;
-          if (variables.kanbanStatus !== undefined)
-            next.kanbanStatus = variables.kanbanStatus;
-          return next as T;
-        });
-      };
-
-      utils.action.getAll.setData(undefined, apply);
-      utils.action.getToday.setData(undefined, apply);
-
-      return snapshot;
+      return patchActionCaches(queryClient, ACTION_LIST_KEYS, (a) => {
+        if (a.id !== variables.id) return a;
+        const next: CachedActionRow = { ...a };
+        if (variables.status !== undefined) next.status = variables.status;
+        if (variables.scheduledStart !== undefined)
+          next.scheduledStart = variables.scheduledStart;
+        if (variables.dueDate !== undefined) next.dueDate = variables.dueDate;
+        if (variables.priority !== undefined) next.priority = variables.priority;
+        if (variables.kanbanStatus !== undefined)
+          next.kanbanStatus = variables.kanbanStatus;
+        return next;
+      });
     },
 
-    onError: (_err, _vars, ctx) => {
-      if (!ctx) return;
-      utils.action.getAll.setData(undefined, ctx.getAll);
-      utils.action.getToday.setData(undefined, ctx.getToday);
+    onError: (_err, _vars, snapshot) => {
+      if (snapshot) restoreActionCaches(queryClient, snapshot);
       notifications.show({
         title: "Update failed",
         message: "Could not update action.",

--- a/src/lib/actions/optimisticCache.ts
+++ b/src/lib/actions/optimisticCache.ts
@@ -1,0 +1,69 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+
+/**
+ * Optimistic patching across *every* cached list of actions.
+ *
+ * The UI reads actions from more than one procedure: `action.getAll` backs the
+ * standalone lists, `action.getToday` backs the Today widgets, and
+ * `action.getProjectActions` backs the project page's Tasks tab. Patching only
+ * `getAll` — which is what every mutation here used to do — leaves the project
+ * page with no optimistic path at all, so a reschedule there sits still until
+ * the mutation *and* the follow-up refetch both land. That is the ~3s stall.
+ *
+ * These helpers work off the raw query cache rather than `utils.<proc>.setData`
+ * so a single call covers every input variant of a procedure (each project id,
+ * each assignee filter) without the caller having to know which ones exist.
+ * They also only touch entries that are already cached, so — unlike a bare
+ * `setData(undefined, …)` — they never fabricate an empty list for a query the
+ * user has not opened yet.
+ */
+
+/** Cached entries captured before a patch, for rollback on error. */
+export type ActionCacheSnapshot = Array<[QueryKey, unknown]>;
+
+/** The shape we need to match a cached row against a mutation's target. */
+export type CachedActionRow = Record<string, unknown> & { id: string };
+
+export async function cancelActionQueries(
+  queryClient: QueryClient,
+  keys: readonly QueryKey[],
+): Promise<void> {
+  await Promise.all(
+    keys.map((queryKey) => queryClient.cancelQueries({ queryKey })),
+  );
+}
+
+/**
+ * Run `patch` over every action in every cached list under `keys`, returning a
+ * snapshot for `restoreActionCaches`. `patch` should return the row unchanged
+ * for rows it does not target.
+ */
+export function patchActionCaches(
+  queryClient: QueryClient,
+  keys: readonly QueryKey[],
+  patch: (action: CachedActionRow) => CachedActionRow,
+): ActionCacheSnapshot {
+  const snapshot: ActionCacheSnapshot = [];
+
+  for (const queryKey of keys) {
+    for (const [cachedKey, data] of queryClient.getQueriesData({ queryKey })) {
+      if (!Array.isArray(data)) continue;
+      snapshot.push([cachedKey, data]);
+      queryClient.setQueryData(
+        cachedKey,
+        (data as CachedActionRow[]).map(patch),
+      );
+    }
+  }
+
+  return snapshot;
+}
+
+export function restoreActionCaches(
+  queryClient: QueryClient,
+  snapshot: ActionCacheSnapshot,
+): void {
+  for (const [queryKey, data] of snapshot) {
+    queryClient.setQueryData(queryKey, data);
+  }
+}

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -667,41 +667,46 @@ export const actionRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { id, ...updateData } = input;
 
-      // Verify user has edit access to this action
-      const access = await getActionAccess(ctx.db, ctx.session.user.id, id);
+      // Check if action is being marked as completed
+      const isCompleting = updateData.status === "COMPLETED" || updateData.kanbanStatus === "DONE";
+      const isUncompleting = updateData.status === "ACTIVE" || (updateData.kanbanStatus && updateData.kanbanStatus !== "DONE");
+
+      // The access check and the pre-update snapshot are independent reads, so
+      // they go out together rather than stacking two round trips. Both are
+      // reads — nothing is written before the FORBIDDEN check below.
+      const [access, currentAction] = await Promise.all([
+        // Verify user has edit access to this action
+        getActionAccess(ctx.db, ctx.session.user.id, id),
+        // Get current action to check previous state
+        ctx.db.action.findUnique({
+          where: { id },
+          select: {
+            status: true,
+            kanbanStatus: true,
+            completedAt: true,
+            scheduledStart: true,
+            scheduledEnd: true,
+            projectId: true,
+            dueDate: true,
+            workspaceId: true,
+            name: true,
+            description: true,
+            priority: true,
+            epicId: true,
+            effortEstimate: true,
+            // T7: include workspaceId and any fields we diff against `updateData`
+            // so we can compute fieldsChanged without an extra query.
+            project: { select: { workspaceId: true } },
+          },
+        }),
+      ]);
+
       if (!access || !canEditAction(access)) {
         throw new TRPCError({
           code: "FORBIDDEN",
           message: "You do not have permission to edit this action",
         });
       }
-
-      // Check if action is being marked as completed
-      const isCompleting = updateData.status === "COMPLETED" || updateData.kanbanStatus === "DONE";
-      const isUncompleting = updateData.status === "ACTIVE" || (updateData.kanbanStatus && updateData.kanbanStatus !== "DONE");
-
-      // Get current action to check previous state
-      const currentAction = await ctx.db.action.findUnique({
-        where: { id },
-        select: {
-          status: true,
-          kanbanStatus: true,
-          completedAt: true,
-          scheduledStart: true,
-          scheduledEnd: true,
-          projectId: true,
-          dueDate: true,
-          workspaceId: true,
-          name: true,
-          description: true,
-          priority: true,
-          epicId: true,
-          effortEstimate: true,
-          // T7: include workspaceId and any fields we diff against `updateData`
-          // so we can compute fieldsChanged without an extra query.
-          project: { select: { workspaceId: true } },
-        },
-      });
 
       const wasCompleted = currentAction?.status === "COMPLETED" || currentAction?.kanbanStatus === "DONE";
 
@@ -921,25 +926,29 @@ export const actionRouter = createTRPCRouter({
           });
 
           if (remainingOverdue === 0) {
-            // All overdue tasks cleared - mark processedOverdue on today's daily plan
-            await ctx.db.dailyPlan.updateMany({
-              where: {
-                userId: ctx.session.user.id,
-                date: today,
-                processedOverdue: false,
-              },
-              data: { processedOverdue: true },
-            });
-
-            // Also mark on DailyScore directly (decoupled from daily plan)
-            await ctx.db.dailyScore.updateMany({
-              where: {
-                userId: ctx.session.user.id,
-                date: today,
-                processedOverdue: false,
-              },
-              data: { processedOverdue: true },
-            });
+            // All overdue tasks cleared. The two writes are independent, so
+            // they go out together — this block sits on the critical path of
+            // every reschedule of an already-overdue action.
+            await Promise.all([
+              // Mark processedOverdue on today's daily plan
+              ctx.db.dailyPlan.updateMany({
+                where: {
+                  userId: ctx.session.user.id,
+                  date: today,
+                  processedOverdue: false,
+                },
+                data: { processedOverdue: true },
+              }),
+              // Also mark on DailyScore directly (decoupled from daily plan)
+              ctx.db.dailyScore.updateMany({
+                where: {
+                  userId: ctx.session.user.id,
+                  date: today,
+                  processedOverdue: false,
+                },
+                data: { processedOverdue: true },
+              }),
+            ]);
           }
 
           // Fire and forget - recalculate today's score since overdue count changed

--- a/src/server/services/access/resolvers/projectResolver.ts
+++ b/src/server/services/access/resolvers/projectResolver.ts
@@ -56,42 +56,43 @@ export async function getProjectAccess(
   const isPublic = project.isPublic;
   const isRestricted = project.isRestricted;
 
-  // Check direct project membership
-  const projectMember = await db.projectMember.findFirst({
-    where: { projectId, userId },
-    select: { role: true },
-  });
+  // The three membership paths are independent of each other, so they go out
+  // together. Awaiting them in sequence put three DB round trips on the
+  // critical path of every action mutation *and* every project query — the
+  // dominant server-side cost of a reschedule on the project page.
+  const [projectMember, teamMembership, wsMembership] = await Promise.all([
+    // Direct project membership
+    db.projectMember.findFirst({
+      where: { projectId, userId },
+      select: { role: true },
+    }),
+    // Team membership (if project has a team)
+    project.teamId
+      ? db.teamUser.findUnique({
+          where: { userId_teamId: { userId, teamId: project.teamId } },
+          select: { role: true },
+        })
+      : null,
+    // Workspace membership (if project has a workspace). getWorkspaceMembership
+    // checks both direct WorkspaceUser and team-based access (user in a team
+    // linked to the workspace).
+    project.workspaceId
+      ? getWorkspaceMembership(db, userId, project.workspaceId)
+      : null,
+  ]);
+
   const isMember = !!projectMember;
   const memberRole = projectMember
     ? (projectMember.role as ProjectMemberRole)
     : undefined;
 
-  // Check team membership (if project has a team)
-  let isTeamMember = false;
-  let teamRole: TeamRole | undefined;
-  if (project.teamId) {
-    const teamMembership = await db.teamUser.findUnique({
-      where: { userId_teamId: { userId, teamId: project.teamId } },
-      select: { role: true },
-    });
-    if (teamMembership) {
-      isTeamMember = true;
-      teamRole = teamMembership.role as TeamRole;
-    }
-  }
+  const isTeamMember = !!teamMembership;
+  const teamRole = teamMembership
+    ? (teamMembership.role as TeamRole)
+    : undefined;
 
-  // Check workspace membership (if project has a workspace)
-  // Uses getWorkspaceMembership which checks both direct WorkspaceUser
-  // and team-based access (user in a team linked to the workspace)
-  let isWorkspaceMember = false;
-  let workspaceRole: WorkspaceRole | undefined;
-  if (project.workspaceId) {
-    const wsMembership = await getWorkspaceMembership(db, userId, project.workspaceId);
-    if (wsMembership) {
-      isWorkspaceMember = true;
-      workspaceRole = wsMembership.role;
-    }
-  }
+  const isWorkspaceMember = !!wsMembership;
+  const workspaceRole: WorkspaceRole | undefined = wsMembership?.role;
 
   return {
     isCreator,


### PR DESCRIPTION
### **User description**
## What

Rescheduling a task from the picker on a project page took ~3s before the row moved. Two causes, both fixed here.

**The project page had no optimistic update at all.** `useActionMutations`' `onMutate` patched `action.getAll` and `action.getToday`, but the project Tasks tab renders `action.getProjectActions`. The patch went into caches that page doesn't read, so the row couldn't move until the mutation returned *and* the follow-up invalidate refetched — two strictly serial round trips. The same blind spot was in all three optimistic mutations in `Actions.tsx`, so "Reschedule all → Today" had it too.

- New `src/lib/actions/optimisticCache.ts` patches every cached action list via the raw query cache, so one call covers `getAll`, `getToday`, and every input variant of `getProjectActions` without the caller needing to know which project ids are cached. It also only touches entries that already exist — the previous `setData(undefined, old => old ?? [])` pattern fabricated empty lists for queries the user had never opened.
- `useActionMutations` and the three optimistic mutations in `Actions.tsx` now route through it.

**Each round trip was a long sequential DB chain.**

- `getProjectAccess` awaited project → projectMember → teamUser → workspaceUser one at a time. The three membership probes are independent, so they now go out together. This shortens the mutation *and* every project query, including the refetch.
- `action.update` awaited the access check, then the pre-update snapshot. Both are reads, so they now run in parallel; the `FORBIDDEN` throw still happens before any write.
- Rescheduling an already-overdue task hit a count plus two sequential `updateMany`s. The two writes are independent and now run together.

Roughly **16 → 10** serialised DB round trips, and the row moves in the same frame as the click.

## Verification

- `tsc --noEmit` clean; ESLint clean on all changed files.
- Full unit suite: **2378 passed**, including 4 new tests pinning the fix — a cached `getProjectActions` list is patched, *all* project variants are patched, `onError` rolls back, and unopened queries aren't fabricated. The first fails against the old code.
- **Not verified in a browser.** Connecting to the local Postgres was blocked by a permission classifier, so the dev server wouldn't boot.

## Deliberately not changed

- `recordActivity` is still awaited in `action.update` (~1 round trip). Making it fire-and-forget risks silently dropping activity-feed events when Vercel freezes the lambda after the response.
- `getProjectActions` still refetches the whole project with five includes on every single-field change.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add shared optimistic action cache helpers

- Patch `getProjectActions` caches on mutations

- Parallelise project access membership probes

- Parallelise action.update reads and overdue writes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["optimisticCache.ts (new)"] -- "patch/restore/cancel" --> B["useActionMutations"]
  A -- "patch/restore/cancel" --> C["Actions.tsx bulk mutations"]
  A -- "covers all input variants" --> D["getAll / getToday / getProjectActions caches"]
  E["action.update"] -- "parallel reads + writes" --> F["fewer DB round trips"]
  G["getProjectAccess"] -- "parallel membership probes" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>optimisticCache.ts</strong><dd><code>New shared optimistic action cache utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/actions/optimisticCache.ts

<ul><li>New helpers <code>cancelActionQueries</code>, <code>patchActionCaches</code>, <br><code>restoreActionCaches</code><br> <li> Operate on the raw query cache to cover all input variants of a <br>procedure<br> <li> Only patch already-cached array entries, never fabricate empty lists<br> <li> Export <code>ActionCacheSnapshot</code> and <code>CachedActionRow</code> types for rollback</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/559/files#diff-a83bbcc6c9be117282b791ea0357f45bdad22d780b1d568c1141e7c55b212a91">+69/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useActionMutations.ts</strong><dd><code>Route update mutation through cache helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/actions/hooks/useActionMutations.ts

<ul><li>Replace per-procedure <code>setData</code>/<code>getData</code> snapshots with cache helpers<br> <li> Add <code>getProjectActions</code> to the patched key list<br> <li> Use <code>useQueryClient</code> and typed <code>ActionCacheSnapshot</code> context<br> <li> Rollback via <code>restoreActionCaches</code> on error</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/559/files#diff-3225063f1167beb861abffd2a624412854281e6778493c1711a3efd17849f4c6">+38/-44</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Actions.tsx</strong><dd><code>Optimistic updates now cover project action lists</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/Actions.tsx

<ul><li>Rewire <code>update</code>, <code>bulkReschedule</code> and <code>bulkAssignProject</code> optimistic paths<br> <li> Introduce <code>ACTION_LIST_KEYS</code> covering getAll/getToday/getProjectActions<br> <li> Use <code>Set</code> lookups for targeted action ids<br> <li> Adjust dueDate comparison to handle <code>Date</code> instances explicitly</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/559/files#diff-65e9996dcf9a13f0965bdf1c744e38745fb9cbd327c3b2d7a19c4e339f00cae0">+53/-64</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>action.ts</strong><dd><code>Parallelise reads and overdue bookkeeping writes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/action.ts

<ul><li>Run access check and current-action snapshot in parallel<br> <li> Keep FORBIDDEN check before any write<br> <li> Move completion/uncompletion flag computation earlier<br> <li> Run the two overdue <code>updateMany</code> calls concurrently</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/559/files#diff-5b198a3cc9e3495e32e4dcdf28771f225d15998a0c3ab9de63ef7f12941d1dbb">+57/-48</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>projectResolver.ts</strong><dd><code>Parallelise project membership lookups</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/access/resolvers/projectResolver.ts

<ul><li>Run project, team and workspace membership lookups in parallel<br> <li> Replace sequential mutable flags with derived booleans/roles</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/559/files#diff-17c0b8c351e8144da4502acb11e73ac3a1436dda4c6b1a842de5c8ebfd877ff8">+31/-30</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useActionMutations.test.ts</strong><dd><code>Tests for optimistic project cache patching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/actions/hooks/__tests__/useActionMutations.test.ts

<ul><li>Wrap hook renders in a real <code>QueryClientProvider</code><br> <li> Stub <code>_def()</code> paths for getAll/getToday/getProjectActions<br> <li> Add tests for patching project caches, multiple project variants, <br>rollback<br> <li> Assert no cache entries are fabricated for unopened queries</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/559/files#diff-09e51071ce4a8a15c84fed2fd54eb0df2629446e57412cafd2bfb20faa370ed6">+96/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

