### PR TITLE
ci: unbreak the Exponential merge hooks and alarm when the token dies

### DIFF
--- a/.github/workflows/exponential-auth-canary.yml
+++ b/.github/workflows/exponential-auth-canary.yml
@@ -37,6 +37,12 @@ env:
   EXPO_PRODUCT: exponential
   EXPO_WORKSPACE: syntrofi
   ISSUE_TITLE: "EXPONENTIAL_TOKEN is not authenticating"
+  # This job deliberately runs no actions/checkout -- it needs no source. But
+  # that leaves `gh` with no git remote to infer the repository from, so every
+  # issue call below would die with "none of the git remotes configured for this
+  # repository point to a known GitHub host", breaking the alerting path at
+  # exactly the moment it is needed.
+  GH_REPO: ${{ github.repository }}
 
 jobs:
   canary:
@@ -87,7 +93,7 @@ jobs:
           # notification.
           EXISTING=$(gh issue list --state open --limit 50 \
             --json number,title \
-            --jq "map(select(.title == \"$ISSUE_TITLE\")) | .[0].number // empty")
+            --jq 'map(select(.title == env.ISSUE_TITLE)) | .[0].number // empty')
 
           BODY=$(cat <<EOF
           The daily canary could not authenticate to Exponential with the
@@ -133,7 +139,7 @@ jobs:
           set -euo pipefail
           EXISTING=$(gh issue list --state open --limit 50 \
             --json number,title \
-            --jq "map(select(.title == \"$ISSUE_TITLE\")) | .[0].number // empty")
+            --jq 'map(select(.title == env.ISSUE_TITLE)) | .[0].number // empty')
           if [ -n "$EXISTING" ]; then
             gh issue close "$EXISTING" --comment "Canary is green again -- the credential authenticates and can read tickets."
           fi

--- a/.github/workflows/exponential-auth-canary.yml
+++ b/.github/workflows/exponential-auth-canary.yml
@@ -1,0 +1,139 @@
+# Daily liveness check on EXPONENTIAL_TOKEN.
+#
+# Four workflows (exponential-promote, exponential-requirements, ai-bug-fixer,
+# notion-sync-smoke) authenticate with this one secret. When it stopped working
+# on 2026-08-10 they all went red -- and nobody noticed for a day, because none
+# of them is a required check. Every PR merged green while its Ticket sat
+# unpromoted in QA.
+#
+# This job exists to turn that silence into a notification. It does NOT protect
+# merges: promotion is tracker bookkeeping and must never block shipping. It
+# opens a GitHub issue instead, which reaches watchers by email and mobile.
+#
+# It checks two things deliberately, not one:
+#   auth login  -- the credential is accepted at all (expiry, revocation, rotation)
+#   tickets list -- the principal can still READ THROUGH a product
+# The second matters because the token may become an external agent key, whose
+# workspace grants can be revoked independently of the key. An agent key that
+# authenticates but has lost its grant would otherwise fail late, inside a real
+# promote run, which is a worse failure than the one this replaces.
+name: Exponential Auth Canary
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # daily 07:00 UTC, ahead of the working day
+  workflow_dispatch:
+
+concurrency:
+  group: exponential-auth-canary
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  EXPO_API_URL: https://www.exponential.im
+  EXPO_PRODUCT: exponential
+  EXPO_WORKSPACE: syntrofi
+  ISSUE_TITLE: "EXPONENTIAL_TOKEN is not authenticating"
+
+jobs:
+  canary:
+    name: Check EXPONENTIAL_TOKEN
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - run: npm i -g exponential-cli
+
+      # continue-on-error so the alarm step below always gets to run. The final
+      # step re-raises, so a broken token still shows red in the Actions tab.
+      - name: Check credential
+        id: check
+        continue-on-error: true
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPONENTIAL_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${EXPO_TOKEN:-}" ]; then
+            echo "::error::EXPONENTIAL_TOKEN secret is unset"; exit 1
+          fi
+          exponential auth login --token "$EXPO_TOKEN" --api-url "$EXPO_API_URL"
+          exponential auth whoami
+          # Read through the product the promote/requirements hooks actually use.
+          exponential tickets list \
+            --product "$EXPO_PRODUCT" --workspace "$EXPO_WORKSPACE" \
+            --status QA --json > /tmp/canary.json
+          # Assert the SHAPE, not the count. `.tickets | length` would be 0 for
+          # an error payload like {"error":{"code":"UNAUTHORIZED"}} too, and
+          # `jq -e` exits 0 on a 0, so that check would pass on a failure. An
+          # empty QA list is the normal healthy case, so the count proves nothing.
+          jq -e '.tickets | type == "array"' /tmp/canary.json > /dev/null
+          echo "OK -- read $(jq '.tickets | length' /tmp/canary.json) QA ticket(s) through product $EXPO_PRODUCT"
+
+      - name: Raise the alarm
+        if: steps.check.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # One issue, reused. A new issue every morning would train everyone to
+          # ignore them; a comment on the open one keeps the thread and the
+          # notification.
+          EXISTING=$(gh issue list --state open --limit 50 \
+            --json number,title \
+            --jq "map(select(.title == \"$ISSUE_TITLE\")) | .[0].number // empty")
+
+          BODY=$(cat <<EOF
+          The daily canary could not authenticate to Exponential with the
+          \`EXPONENTIAL_TOKEN\` repo secret.
+
+          **What is broken while this is red:** \`exponential-promote\` (Tickets
+          stay stranded in QA when their PR merges), \`exponential-requirements\`,
+          \`ai-bug-fixer\`, and \`notion-sync-smoke\`. None of them is a required
+          check, so PRs will keep merging green.
+
+          **Fix:** re-set the secret from a valid login, without the value ever
+          touching your shell history --
+
+          \`\`\`bash
+          gh secret set EXPONENTIAL_TOKEN < <(exponential auth show --token)
+          \`\`\`
+
+          Then re-run the most recent failed \`exponential-promote\` run and
+          sweep any Tickets left in QA whose PR is already merged.
+
+          [Canary run log]($RUN_URL)
+          EOF
+          )
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+            echo "Commented on existing issue $EXISTING"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$BODY"
+          fi
+
+      - name: Re-raise the failure
+        if: steps.check.outcome != 'success'
+        run: exit 1
+
+      # Close the alarm once the credential works again, so the open issue is a
+      # truthful signal rather than something to be manually tidied.
+      - name: Stand down
+        if: steps.check.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          EXISTING=$(gh issue list --state open --limit 50 \
+            --json number,title \
+            --jq "map(select(.title == \"$ISSUE_TITLE\")) | .[0].number // empty")
+          if [ -n "$EXISTING" ]; then
+            gh issue close "$EXISTING" --comment "Canary is green again -- the credential authenticates and can read tickets."
+          fi

--- a/.github/workflows/exponential-promote.yml
+++ b/.github/workflows/exponential-promote.yml
@@ -38,11 +38,25 @@ jobs:
           # This PR, plus any child feature PRs referenced from a Rollup PR's
           # commit log (a Rollup PR promotes already-merged work along the chain,
           # so its own URL is on no Ticket -- its children's URLs are).
+          #
+          # The head commit is NOT guaranteed to be in the checkout on a closed
+          # PR: GitHub tears down refs/pull/N/merge at merge, and a squash merge
+          # leaves the head unreachable from main, so `git log BASE..HEAD` can
+          # die with "Invalid revision range". Under `set -o pipefail` that
+          # failed the whole hook and stranded the Ticket in QA. Skip the scan
+          # instead: an ordinary feature PR needs nothing from this log, and a
+          # Rollup PR merges with a merge commit, whose range does resolve.
           {
             echo "$PR_URL"
-            git log "$BASE_SHA..$HEAD_SHA" --format=%B \
-              | { grep -oE '#[0-9]+' || true; } | tr -d '#' | sort -u \
-              | sed "s@^@${REPO_URL}/pull/@"
+            if git rev-parse -q --verify "$BASE_SHA^{commit}" >/dev/null &&
+               git rev-parse -q --verify "$HEAD_SHA^{commit}" >/dev/null; then
+              git log "$BASE_SHA..$HEAD_SHA" --format=%B \
+                | { grep -oE '#[0-9]+' || true; } | tr -d '#' | sort -u \
+                | sed "s@^@${REPO_URL}/pull/@"
+            else
+              echo "Range $BASE_SHA..$HEAD_SHA is not in this checkout" \
+                   "-- skipping the Rollup child-PR scan." >&2
+            fi
           } | sort -u > /tmp/prs
           jq -R -s -c 'split("\n") | map(select(length > 0))' /tmp/prs > /tmp/prs.json
           exponential tickets list \

--- a/.github/workflows/exponential-requirements.yml
+++ b/.github/workflows/exponential-requirements.yml
@@ -47,11 +47,25 @@ jobs:
           # This PR, plus any child feature PRs referenced from a Rollup PR's
           # commit log (a Rollup PR promotes already-merged work along the chain,
           # so its own URL is on no Ticket -- its children's URLs are).
+          #
+          # The head commit is NOT guaranteed to be in the checkout on a closed
+          # PR: GitHub tears down refs/pull/N/merge at merge, and a squash merge
+          # leaves the head unreachable from main, so `git log BASE..HEAD` can
+          # die with "Invalid revision range". Under `set -o pipefail` that
+          # failed the whole hook and left the scope's requirements unticked.
+          # Skip the scan instead: an ordinary feature PR needs nothing from this
+          # log, and a Rollup PR merges with a merge commit, whose range resolves.
           {
             echo "$PR_URL"
-            git log "$BASE_SHA..$HEAD_SHA" --format=%B \
-              | { grep -oE '#[0-9]+' || true; } | tr -d '#' | sort -u \
-              | sed "s@^@${REPO_URL}/pull/@"
+            if git rev-parse -q --verify "$BASE_SHA^{commit}" >/dev/null &&
+               git rev-parse -q --verify "$HEAD_SHA^{commit}" >/dev/null; then
+              git log "$BASE_SHA..$HEAD_SHA" --format=%B \
+                | { grep -oE '#[0-9]+' || true; } | tr -d '#' | sort -u \
+                | sed "s@^@${REPO_URL}/pull/@"
+            else
+              echo "Range $BASE_SHA..$HEAD_SHA is not in this checkout" \
+                   "-- skipping the Rollup child-PR scan." >&2
+            fi
           } | sort -u > /tmp/prs
           jq -R -s -c 'split("\n") | map(select(length > 0))' /tmp/prs > /tmp/prs.json
           exponential tickets list \


### PR DESCRIPTION
### **User description**
The `EXPONENTIAL_TOKEN` repo secret expired around 2026-08-10 19:00Z. All four
workflows that use it went red, and nobody noticed for a day because none of
them is a required check — PRs kept merging green while their Tickets sat
unpromoted in QA. The secret has since been rotated; this PR fixes the two
things the outage exposed.

## 1. A missing head commit killed the hooks (`exponential-promote`, `exponential-requirements`)

Both hooks scan a Rollup PR's commit log for child PR numbers with
`git log BASE_SHA..HEAD_SHA`. On a **closed** PR the head commit is not
guaranteed to be in the checkout — GitHub tears down `refs/pull/N/merge` at
merge, and a squash merge leaves the head unreachable from `main` — so the range
can die with `fatal: Invalid revision range`. Under `set -o pipefail` that took
the whole job down at the resolve step, before a single Ticket was promoted or
requirement ticked.

This was latent and masked: Auth failed first, so it only surfaced once the token
was rotated. Earlier runs won a race — PR 540's hook ran 3s after merge and
resolved the range, PR 553's ran 21s after and did not.

Now both endpoints are verified before the scan, with a log line when they are
missing. Behaviour, tested against this repo:

| case | before | after |
| --- | --- | --- |
| head commit absent | **exit 128**, hook dies | exit 0, yields this PR's URL |
| Rollup range resolves | 5 child PR URLs | **byte-identical** 5 URLs |

An ordinary feature PR needs nothing from that log — its own URL is what the
Tickets carry. A Rollup PR merges with a merge commit, whose range still
resolves, so child detection is unchanged.

## 2. Nothing alarmed (`exponential-auth-canary`, new)

A daily 07:00 UTC liveness check on the secret. It opens **one** GitHub issue on
failure and comments on it thereafter rather than filing a new one each morning,
and closes it automatically once the credential works again.

It deliberately checks two things: that `auth login` is accepted at all, and that
the principal can still *read through* the product. The second matters if the
token is ever replaced with an external agent key, whose workspace grants can be
revoked independently of the key — that would otherwise fail late, inside a real
promote run. It asserts the response *shape* (`.tickets | type == "array"`), not
a count, because an error payload has length 0 too.

It does **not** gate merges. Promotion is tracker bookkeeping and must never
block shipping.

## Verification

- YAML parses and every `run:` block passes `bash -n` in all three workflows.
- The resolve block was extracted and run against this repo for both cases above.
- Pre-commit unit suite green.

## Follow-ups, not in this PR

- `notion-sync-smoke` is also red, for an unrelated reason: it authenticates fine
  and then dies on `Unexpected token 'A', "An error o"... is not valid JSON` —
  it is parsing an HTML/text error page as JSON.
- Consider moving the secret to a non-expiring `exp_agent_` external agent key;
  the api-keys UI caps JWT expiry at 90 days, so a JWT re-schedules this outage.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Guard `git log BASE..HEAD` scan behind commit existence checks

- Prevents merge hooks dying on closed/squash-merged PRs

- Add daily `EXPONENTIAL_TOKEN` liveness canary workflow

- Canary opens/comments/closes a single GitHub issue


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR closed event"] --> B["merge hooks: promote / requirements"]
  B -- "verify BASE & HEAD exist" --> C["scan commit log for child PRs"]
  B -- "commits missing" --> D["log & skip scan, still promote this PR"]
  E["daily cron 07:00 UTC"] --> F["auth canary: login + tickets list"]
  F -- "failure" --> G["open or comment GitHub issue, exit 1"]
  F -- "success" --> H["close existing alarm issue"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exponential-auth-canary.yml</strong><dd><code>Add daily EXPONENTIAL_TOKEN auth canary with issue alerting</code></dd></summary>
<hr>

.github/workflows/exponential-auth-canary.yml

<ul><li>New daily (07:00 UTC) plus manual workflow validating <br><code>EXPONENTIAL_TOKEN</code>.<br> <li> Checks credential acceptance via <code>auth login</code>/<code>whoami</code> and read access via <br><code>tickets list</code>, asserting JSON shape rather than count.<br> <li> On failure, creates or comments on a single tracking issue with <br>remediation steps, then re-raises to mark the run red.<br> <li> On success, closes any open alarm issue ("stand down").</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/560/files#diff-8f55df1c168dd54054f268b9e6f6003b85f6662cad9976e1e65cc214d9506179">+139/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exponential-promote.yml</strong><dd><code>Guard child-PR commit scan against missing commits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/exponential-promote.yml

<ul><li>Verify both <code>BASE_SHA</code> and <code>HEAD_SHA</code> resolve with <code>git rev-parse</code> before <br>running the child-PR scan.<br> <li> Skip the scan and log to stderr when the range is unavailable, <br>avoiding <code>pipefail</code> job failure that stranded Tickets in QA.<br> <li> Added explanatory comments about closed/squash-merged PR checkouts.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/560/files#diff-0581d2c5686027e1b22a2ba6bbadb773740ed3f38b6ae602b15c3ae389bd8144">+17/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>exponential-requirements.yml</strong><dd><code>Guard child-PR commit scan against missing commits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/exponential-requirements.yml

<ul><li>Same guard as the promote hook: validate base and head commits exist <br>before <code>git log</code> range scan.<br> <li> Log and skip the Rollup child-PR scan when the range is not in the <br>checkout, so requirements still get ticked.<br> <li> Added clarifying comments on the failure mode.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/560/files#diff-5de434c4737cd8ac2f831f78e81b18c105dc1d64650ff8ce7356c11247e1f54f">+17/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

