### PR TITLE
feat(metrics): all-cycles roll-up and per-cycle trend chart

### DIFF
--- a/docs/adr/0047-metrics-page-live-computation.md
+++ b/docs/adr/0047-metrics-page-live-computation.md
@@ -20,6 +20,18 @@ goal below is temporarily unmet on the agent side; realigning the agent onto the
 (or confirming it should stay Action-based) is a tracked follow-up. Everything else below stands:
 still live-computed, still no `SprintMetrics` persistence, still merged-PR-turnaround-only.
 
+**Amended — 2026-08-07 (all-cycles roll-up).** The page's headline is now the **all-cycles**
+roll-up — every cycle's Ticket metrics summed, with a line chart tracking each metric across
+cycles — and the single-cycle view moved below it behind the cycle dropdown. This extends the v1
+scope line below ("single workspace-wide roll-up per cycle"); it does not change the decision.
+Still live-computed, still Ticket-based, still nothing persisted to `SprintMetrics`. The new
+`getAllCyclesMetrics` is **batched** — one query for the cycles, one for all their tickets, one
+pass over the workspace's merged PRs — rather than 3N queries, because "recomputing 5–10 cycles is
+cheap" stops being true if each cycle costs its own round trips. Cycles with no tickets are
+excluded from the series, and a PR falling inside two overlapping cycle windows is counted once in
+the roll-up. The bar-list "velocity trend" widget was removed: the chart is a strictly better
+version of it. `getVelocityTrend` remains on the router, now unused by the UI.
+
 ## Context
 
 The app already has a sprint-analytics backend built for the Mastra PM agent, reached

--- a/src/app/_components/metrics/CycleTrendChart.tsx
+++ b/src/app/_components/metrics/CycleTrendChart.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Group, Stack, Text, UnstyledButton } from '@mantine/core';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { RouterOutputs } from '~/trpc/react';
+
+type CyclePoint =
+  RouterOutputs['sprintAnalytics']['getAllCyclesMetrics']['cycles'][number];
+
+type SeriesKey =
+  | 'completedTickets'
+  | 'completedPoints'
+  | 'mergedPrCount'
+  | 'completionRate';
+
+interface Series {
+  key: SeriesKey;
+  label: string;
+  /** CSS variable — never a literal hex (see the styling architecture doc). */
+  color: string;
+  axis: 'left' | 'right';
+}
+
+/**
+ * Counts share the left axis; completion rate gets its own 0–100 right axis so
+ * a percentage can't dwarf a ticket count (or vice versa).
+ */
+const SERIES: Series[] = [
+  {
+    key: 'completedTickets',
+    label: 'Tickets completed',
+    color: 'var(--color-brand-primary)',
+    axis: 'left',
+  },
+  {
+    key: 'completedPoints',
+    label: 'Points delivered',
+    color: 'var(--accent-meetings)',
+    axis: 'left',
+  },
+  {
+    key: 'mergedPrCount',
+    label: 'PRs merged',
+    color: 'var(--accent-crm)',
+    axis: 'left',
+  },
+  {
+    key: 'completionRate',
+    label: 'Completion %',
+    color: 'var(--accent-okr)',
+    axis: 'right',
+  },
+];
+
+function shortName(name: string): string {
+  return name.length > 14 ? `${name.slice(0, 13)}…` : name;
+}
+
+function formatSeriesValue(key: SeriesKey, value: number): string {
+  return key === 'completionRate' ? `${Math.round(value)}%` : String(value);
+}
+
+/**
+ * Every metric plotted across every cycle, oldest → newest. Series are
+ * toggleable; any series that is flat-zero across all cycles (typically
+ * "PRs merged" in a workspace with no GitHub webhook data) starts hidden so it
+ * doesn't read as a real trend line at the axis floor.
+ */
+export function CycleTrendChart({ cycles }: { cycles: CyclePoint[] }) {
+  const chartData = useMemo(
+    () =>
+      cycles.map((c) => ({
+        name: c.cycleName,
+        completedTickets: c.completedTickets,
+        completedPoints: c.completedPoints,
+        mergedPrCount: c.mergedPrCount,
+        completionRate: Math.round(c.completionRate),
+        totalTickets: c.totalTickets,
+      })),
+    [cycles],
+  );
+
+  const defaultVisible = useMemo(() => {
+    const visible = new Set<SeriesKey>();
+    for (const series of SERIES) {
+      if (chartData.some((row) => row[series.key] > 0)) visible.add(series.key);
+    }
+    return visible;
+  }, [chartData]);
+
+  const [picked, setPicked] = useState<Set<SeriesKey> | null>(null);
+  const visible = picked ?? defaultVisible;
+
+  const toggle = (key: SeriesKey) => {
+    const next = new Set(visible);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    setPicked(next);
+  };
+
+  return (
+    <Stack gap="sm">
+      <Group gap="xs" wrap="wrap">
+        {SERIES.map((series) => {
+          const isOn = visible.has(series.key);
+          return (
+            <UnstyledButton
+              key={series.key}
+              onClick={() => toggle(series.key)}
+              aria-pressed={isOn}
+              className={`flex items-center gap-2 rounded-full border px-3 py-1 text-xs transition-colors ${
+                isOn
+                  ? 'border-border-primary bg-surface-hover text-text-primary'
+                  : 'border-border-secondary text-text-muted hover:text-text-secondary'
+              }`}
+            >
+              <span
+                className="h-2 w-2 rounded-full"
+                style={{
+                  backgroundColor: isOn ? series.color : 'var(--color-text-muted)',
+                }}
+              />
+              {series.label}
+            </UnstyledButton>
+          );
+        })}
+      </Group>
+
+      <ResponsiveContainer width="100%" height={320}>
+        <LineChart data={chartData} margin={{ top: 8, right: 8, bottom: 8, left: -8 }}>
+          <CartesianGrid
+            strokeDasharray="2 2"
+            stroke="var(--color-border-secondary)"
+          />
+          <XAxis
+            dataKey="name"
+            stroke="var(--color-text-muted)"
+            fontSize={11}
+            tickFormatter={shortName}
+            interval="preserveStartEnd"
+            minTickGap={8}
+          />
+          <YAxis
+            yAxisId="left"
+            stroke="var(--color-text-muted)"
+            fontSize={11}
+            allowDecimals={false}
+          />
+          <YAxis
+            yAxisId="right"
+            orientation="right"
+            domain={[0, 100]}
+            tickFormatter={(v: number) => `${v}%`}
+            stroke="var(--color-text-muted)"
+            fontSize={11}
+          />
+          <Tooltip
+            content={({
+              active,
+              payload,
+              label,
+            }: {
+              active?: boolean;
+              payload?: Array<{ payload: (typeof chartData)[number] }>;
+              label?: string | number;
+            }) => {
+              if (!active || !payload?.length) return null;
+              const row = payload[0]?.payload;
+              if (!row) return null;
+              return (
+                <div className="rounded-md border border-border-primary bg-surface-primary p-3 shadow-lg">
+                  <Text size="xs" fw={600} className="mb-1 text-text-primary">
+                    {String(label ?? row.name)}
+                  </Text>
+                  {SERIES.filter((s) => visible.has(s.key)).map((s) => (
+                    <Text key={s.key} size="xs" className="text-text-secondary">
+                      <span
+                        className="mr-2 inline-block h-2 w-2 rounded-full align-middle"
+                        style={{ backgroundColor: s.color }}
+                      />
+                      {s.label}: {formatSeriesValue(s.key, row[s.key])}
+                    </Text>
+                  ))}
+                  <Text size="xs" className="mt-1 text-text-muted">
+                    {row.totalTickets}{' '}
+                    {row.totalTickets === 1 ? 'ticket' : 'tickets'} in cycle
+                  </Text>
+                </div>
+              );
+            }}
+          />
+          {SERIES.filter((s) => visible.has(s.key)).map((s) => (
+            <Line
+              key={s.key}
+              yAxisId={s.axis}
+              type="monotone"
+              dataKey={s.key}
+              name={s.label}
+              stroke={s.color}
+              strokeWidth={2}
+              dot={{ r: 3 }}
+              activeDot={{ r: 5 }}
+              isAnimationActive={false}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </Stack>
+  );
+}

--- a/src/app/_components/metrics/MetricsDashboard.tsx
+++ b/src/app/_components/metrics/MetricsDashboard.tsx
@@ -9,6 +9,7 @@ import {
   Progress,
   Container,
   Select,
+  Divider,
 } from '@mantine/core';
 import {
   IconChartBar,
@@ -16,19 +17,25 @@ import {
   IconBolt,
   IconTrendingUp,
   IconGitPullRequest,
+  IconTargetArrow,
 } from '@tabler/icons-react';
 import { api, type RouterOutputs } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { CycleTrendChart } from './CycleTrendChart';
 
 /**
  * Metrics page dashboard.
  *
- * Renders the selected cycle (default: the workspace's ACTIVE cycle) — velocity
- * (completed-ticket **count** as the headline, summed points alongside),
- * completion, and merged-PR turnaround — plus a workspace-wide velocity trend.
- * A cycle selector lets the user view any cycle. All numbers are computed live
- * over the cycle's Tickets; nothing is read from the dormant `SprintMetrics`
- * table. See ADR-0047 (incl. the Ticket-based amendment).
+ * Two tiers, in the order they answer questions:
+ *  1. **All cycles** (headline) — every cycle's metrics summed into one
+ *     roll-up, with a line chart tracking each metric across cycles.
+ *  2. **Cycle breakdown** — the same metrics for one cycle, chosen from a
+ *     dropdown (defaults to the ACTIVE cycle).
+ *
+ * All numbers are computed live over the cycles' Tickets — velocity is a
+ * completed-ticket **count** with summed points alongside; nothing is read from
+ * the dormant `SprintMetrics` table. See ADR-0047 (incl. the Ticket-based
+ * amendment).
  */
 export function MetricsDashboard() {
   const { workspace, workspaceId } = useWorkspace();
@@ -58,146 +65,263 @@ export function MetricsDashboard() {
     () =>
       (cycles ?? []).map((c) => ({
         value: c.id,
-        label:
-          c.status === 'ACTIVE' ? `${c.name} (active)` : c.name,
+        label: c.status === 'ACTIVE' ? `${c.name} (active)` : c.name,
       })),
     [cycles],
   );
 
   return (
-    <Container size="lg" className="w-full py-6">
-      <Stack gap="lg">
-        <Group justify="space-between" align="flex-start" wrap="nowrap">
-          <Group gap="sm">
-            <IconChartBar size={24} className="text-text-secondary" />
-            <div>
-              <Text fw={600} size="xl" className="text-text-primary">
-                Metrics
-              </Text>
-              <Text size="sm" className="text-text-secondary">
-                {workspace?.name
-                  ? `Delivery metrics for ${workspace.name}`
-                  : 'Delivery metrics'}
-              </Text>
-            </div>
-          </Group>
-
-          {cycleOptions.length > 0 && (
-            <Select
-              aria-label="Select cycle"
-              data={cycleOptions}
-              value={selectedCycleId}
-              onChange={setPicked}
-              allowDeselect={false}
-              checkIconPosition="right"
-              w={220}
-              size="sm"
-            />
-          )}
+    <Container size="xl" className="w-full py-6">
+      <Stack gap="xl">
+        <Group gap="sm">
+          <IconChartBar size={24} className="text-text-secondary" />
+          <div>
+            <Text fw={600} size="xl" className="text-text-primary">
+              Metrics
+            </Text>
+            <Text size="sm" className="text-text-secondary">
+              {workspace?.name
+                ? `Delivery metrics for ${workspace.name}`
+                : 'Delivery metrics'}
+            </Text>
+          </div>
         </Group>
 
-        {isLoading || !workspaceId ? (
-          <LoadingState />
-        ) : !data ? (
-          <EmptyState />
-        ) : (
-          <ActiveCycleMetrics data={data} cycleId={selectedCycleId ?? undefined} />
-        )}
+        <AllCyclesSection workspaceId={workspaceId} />
 
-        <VelocityTrend workspaceId={workspaceId} />
+        <Divider className="border-border-primary" />
+
+        <Stack gap="md">
+          <Group justify="space-between" align="center" wrap="nowrap">
+            <div>
+              <Text fw={600} size="lg" className="text-text-primary">
+                Cycle breakdown
+              </Text>
+              <Text size="sm" className="text-text-secondary">
+                The same metrics for a single cycle.
+              </Text>
+            </div>
+
+            {cycleOptions.length > 0 && (
+              <Select
+                aria-label="Select cycle"
+                data={cycleOptions}
+                value={selectedCycleId}
+                onChange={setPicked}
+                allowDeselect={false}
+                checkIconPosition="right"
+                w={220}
+                size="sm"
+              />
+            )}
+          </Group>
+
+          {isLoading || !workspaceId ? (
+            <LoadingState />
+          ) : !data ? (
+            <EmptyState />
+          ) : (
+            <SelectedCycleMetrics
+              data={data}
+              cycleId={selectedCycleId ?? undefined}
+            />
+          )}
+        </Stack>
       </Stack>
     </Container>
   );
 }
 
-function VelocityTrend({ workspaceId }: { workspaceId: string | null }) {
-  const { data, isLoading } = api.sprintAnalytics.getVelocityTrend.useQuery(
-    { workspaceId: workspaceId ?? '', count: 8 },
+type AllCycles = RouterOutputs['sprintAnalytics']['getAllCyclesMetrics'];
+
+/**
+ * The headline block: every cycle summed into one set of numbers, plus the
+ * per-cycle trend chart behind them.
+ */
+function AllCyclesSection({ workspaceId }: { workspaceId: string | null }) {
+  const { data, isLoading } = api.sprintAnalytics.getAllCyclesMetrics.useQuery(
+    { workspaceId: workspaceId ?? '' },
     { enabled: !!workspaceId },
   );
 
   if (isLoading || !workspaceId) {
     return (
-      <Card
-        withBorder
-        radius="md"
-        className="border-border-primary bg-surface-secondary"
-      >
-        <div className="animate-pulse space-y-3">
-          <div className="h-4 w-1/4 rounded bg-surface-hover" />
-          <div className="h-24 rounded bg-surface-hover" />
-        </div>
-      </Card>
+      <Stack gap="md">
+        <LoadingState />
+        <Card
+          withBorder
+          radius="md"
+          className="border-border-primary bg-surface-secondary"
+        >
+          <div className="animate-pulse space-y-3">
+            <div className="h-4 w-1/4 rounded bg-surface-hover" />
+            <div className="h-64 rounded bg-surface-hover" />
+          </div>
+        </Card>
+      </Stack>
     );
   }
 
-  // Trend needs at least 2 completed cycles to be meaningful.
-  if (!data || data.length < 2) {
+  if (!data || data.cycleCount === 0) {
     return (
       <Card
         withBorder
         radius="md"
         className="border-border-primary bg-surface-secondary"
       >
-        <Group gap="xs" className="mb-2">
-          <IconTrendingUp size={16} className="text-text-muted" />
-          <Text size="sm" fw={500} className="text-text-secondary">
-            Velocity trend
+        <Stack gap="xs" align="center" className="py-10 text-center">
+          <IconChartBar size={32} className="text-text-muted" />
+          <Text fw={500} className="text-text-primary">
+            No cycle data yet
           </Text>
-        </Group>
-        <Text size="sm" className="text-text-muted">
-          Not enough completed cycles yet — the trend appears once at least two
-          cycles have completed.
-        </Text>
+          <Text size="sm" className="text-text-secondary">
+            Once cycles have tickets assigned, their totals and trend appear
+            here.
+          </Text>
+        </Stack>
       </Card>
     );
   }
 
-  // Service returns most-recent-first; show oldest → newest for a trend read.
-  const cycles = [...data].reverse();
-  const maxTickets = Math.max(...cycles.map((c) => c.completedTickets), 1);
+  return (
+    <Stack gap="md">
+      <Group justify="space-between" align="flex-end" wrap="nowrap">
+        <div>
+          <Text fw={600} size="lg" className="text-text-primary">
+            All cycles
+          </Text>
+          <Text size="sm" className="text-text-secondary">
+            Totals across {data.cycleCount}{' '}
+            {data.cycleCount === 1 ? 'cycle' : 'cycles'}
+          </Text>
+        </div>
+      </Group>
 
+      <AllCyclesTotals data={data} />
+
+      <Card
+        withBorder
+        radius="md"
+        className="border-border-primary bg-surface-secondary"
+      >
+        <Stack gap="md">
+          <Group gap="xs">
+            <IconTrendingUp size={16} className="text-text-muted" />
+            <Text size="sm" fw={500} className="text-text-secondary">
+              Metrics by cycle
+            </Text>
+            <Text size="xs" className="text-text-muted">
+              (oldest → newest)
+            </Text>
+          </Group>
+
+          {data.cycles.length < 2 ? (
+            <Text size="sm" className="text-text-muted">
+              Only one cycle has data so far — the trend appears once a second
+              cycle has tickets.
+            </Text>
+          ) : (
+            <CycleTrendChart cycles={data.cycles} />
+          )}
+        </Stack>
+      </Card>
+    </Stack>
+  );
+}
+
+function AllCyclesTotals({ data }: { data: AllCycles }) {
+  const completionRate = Math.round(data.completionRate);
+  const avg = data.avgPrHours != null ? formatHours(data.avgPrHours) : null;
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <StatCard
+        icon={<IconBolt size={16} className="text-text-muted" />}
+        label="Velocity"
+        value={String(data.completedTickets)}
+        valueSuffix={data.completedTickets === 1 ? 'ticket' : 'tickets'}
+        hint={`${data.completedPoints} of ${data.totalPoints} points delivered`}
+      />
+
+      <StatCard
+        icon={<IconTargetArrow size={16} className="text-text-muted" />}
+        label="Tickets tracked"
+        value={String(data.totalTickets)}
+        valueSuffix="total"
+        hint={`${data.totalTickets - data.completedTickets} not yet completed`}
+      />
+
+      <StatCard
+        icon={<IconCircleCheck size={16} className="text-text-muted" />}
+        label="Completion"
+        value={`${completionRate}%`}
+        valueSuffix={`${data.completedTickets}/${data.totalTickets} tickets`}
+      >
+        <Progress
+          value={completionRate}
+          size="sm"
+          radius="xl"
+          color={completionRate >= 100 ? 'green' : 'indigo'}
+        />
+      </StatCard>
+
+      <StatCard
+        icon={<IconGitPullRequest size={16} className="text-text-muted" />}
+        label="PRs merged"
+        value={String(data.mergedPrCount)}
+        valueSuffix={data.mergedPrCount === 1 ? 'PR' : 'PRs'}
+        hint={
+          avg
+            ? `${avg.value}${avg.unit} avg turnaround`
+            : 'Turnaround unavailable — needs GitHub PR webhook events'
+        }
+      />
+    </div>
+  );
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+  valueSuffix,
+  hint,
+  children,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  valueSuffix?: string;
+  hint?: string;
+  children?: React.ReactNode;
+}) {
   return (
     <Card
       withBorder
       radius="md"
       className="border-border-primary bg-surface-secondary"
     >
-      <Stack gap="md">
+      <Stack gap="xs">
         <Group gap="xs">
-          <IconTrendingUp size={16} className="text-text-muted" />
+          {icon}
           <Text size="sm" fw={500} className="text-text-secondary">
-            Velocity trend
-          </Text>
-          <Text size="xs" className="text-text-muted">
-            (last {cycles.length} completed cycles)
+            {label}
           </Text>
         </Group>
-
-        <Stack gap="sm">
-          {cycles.map((cycle) => (
-            <div key={cycle.cycleId}>
-              <Group justify="space-between" gap="xs" className="mb-1">
-                <Text size="xs" className="truncate text-text-secondary">
-                  {cycle.cycleName}
-                </Text>
-                <Text size="xs" className="text-text-muted">
-                  <span className="font-semibold text-text-primary">
-                    {cycle.completedTickets}
-                  </span>{' '}
-                  {cycle.completedTickets === 1 ? 'ticket' : 'tickets'} ·{' '}
-                  {cycle.completedPoints} pts
-                </Text>
-              </Group>
-              <Progress
-                value={(cycle.completedTickets / maxTickets) * 100}
-                size="lg"
-                radius="sm"
-                color="indigo"
-              />
-            </div>
-          ))}
-        </Stack>
+        <Group align="baseline" gap="xs">
+          <Text className="text-4xl font-bold text-accent-indigo">{value}</Text>
+          {valueSuffix && (
+            <Text size="sm" className="text-text-muted">
+              {valueSuffix}
+            </Text>
+          )}
+        </Group>
+        {hint && (
+          <Text size="xs" className="text-text-muted">
+            {hint}
+          </Text>
+        )}
+        {children}
       </Stack>
     </Card>
   );
@@ -207,7 +331,7 @@ type CycleMetrics = NonNullable<
   RouterOutputs['sprintAnalytics']['getActiveCycleMetrics']
 >;
 
-function ActiveCycleMetrics({
+function SelectedCycleMetrics({
   data,
   cycleId,
 }: {
@@ -219,8 +343,8 @@ function ActiveCycleMetrics({
   return (
     <Stack gap="md">
       <Text size="sm" className="text-text-muted">
-        Active cycle:{' '}
-        <span className="text-text-secondary font-medium">{data.cycleName}</span>
+        Cycle:{' '}
+        <span className="font-medium text-text-secondary">{data.cycleName}</span>
       </Text>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
@@ -290,7 +414,8 @@ function ActiveCycleMetrics({
 
 /** Format a duration in hours as a compact, sensible unit. */
 function formatHours(hours: number): { value: string; unit: string } {
-  if (hours < 1) return { value: String(Math.max(1, Math.round(hours * 60))), unit: 'min' };
+  if (hours < 1)
+    return { value: String(Math.max(1, Math.round(hours * 60))), unit: 'min' };
   if (hours < 48) return { value: String(Math.round(hours)), unit: 'h' };
   return { value: (hours / 24).toFixed(1), unit: 'd' };
 }

--- a/src/server/api/routers/sprintAnalytics.ts
+++ b/src/server/api/routers/sprintAnalytics.ts
@@ -6,6 +6,7 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { apiKeyMiddleware } from "~/server/api/middleware/apiKeyAuth";
 import {
   sprintAnalyticsService,
+  type AllCyclesMetricsResult,
   type CycleSummary,
   type CycleTicketMetricsResult,
   type CycleVelocityPoint,
@@ -87,6 +88,22 @@ export const sprintAnalyticsRouter = createTRPCRouter({
     .query(async ({ ctx, input }): Promise<CycleSummary[]> => {
       await assertWorkspaceMember(ctx.db, ctx.session.user.id, input.workspaceId);
       return sprintAnalyticsService.getWorkspaceCycles(input.workspaceId);
+    }),
+
+  /**
+   * Metrics page (UI): the workspace's all-cycles roll-up — summed velocity,
+   * overall completion and merged-PR turnaround across every cycle, plus the
+   * per-cycle series behind them for the trend chart.
+   *
+   * Enforces workspace membership. Computed live and batched (see
+   * `getAllCyclesMetrics`); nothing is read from the dormant `SprintMetrics`
+   * table. See ADR-0047.
+   */
+  getAllCyclesMetrics: protectedProcedure
+    .input(z.object({ workspaceId: z.string().min(1) }))
+    .query(async ({ ctx, input }): Promise<AllCyclesMetricsResult> => {
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, input.workspaceId);
+      return sprintAnalyticsService.getAllCyclesMetrics(input.workspaceId);
     }),
 
   /**

--- a/src/server/services/SprintAnalyticsService.ts
+++ b/src/server/services/SprintAnalyticsService.ts
@@ -769,7 +769,25 @@ export class SprintAnalyticsService {
       ticketsByCycle.set(ticket.cycleId, bucket);
     }
 
-    const allPrs = await this.getMergedPrDurations(workspaceId);
+    // Bound the PR scan to the union of every cycle window. A PR merged
+    // outside all of them is discarded below anyway, so this is equivalent to
+    // an unscoped fetch — but it keeps the query (and the `prNumber IN (…)`
+    // list it builds) proportional to the cycles' span rather than to the
+    // workspace's entire GitHubActivity history. No dated cycle → no window to
+    // fall in, so skip the two queries entirely.
+    const dated = cycles.filter((c) => c.startDate && c.endDate);
+    const unionWindow = dated.length
+      ? {
+          start: new Date(
+            Math.min(...dated.map((c) => c.startDate!.getTime())),
+          ),
+          end: new Date(Math.max(...dated.map((c) => c.endDate!.getTime()))),
+        }
+      : null;
+
+    const allPrs = unionWindow
+      ? await this.getMergedPrDurations(workspaceId, unionWindow)
+      : [];
 
     const points: CycleMetricsPoint[] = [];
     // PRs counted in at least one cycle window, so overlapping windows don't

--- a/src/server/services/SprintAnalyticsService.ts
+++ b/src/server/services/SprintAnalyticsService.ts
@@ -96,6 +96,57 @@ export interface PrTurnaroundResult {
   medianHours: number | null;
 }
 
+/**
+ * One cycle's roll-up in the all-cycles view: the same Ticket-based numbers as
+ * {@link CycleTicketMetricsResult}, plus that cycle's merged-PR turnaround, so
+ * a single request can plot every metric against every cycle.
+ */
+export interface CycleMetricsPoint {
+  cycleId: string;
+  cycleName: string;
+  status: string; // ListStatus (ACTIVE / COMPLETED / PLANNED / …)
+  startDate: Date | null;
+  endDate: Date | null;
+  totalTickets: number;
+  completedTickets: number;
+  completedPoints: number;
+  totalPoints: number;
+  completionRate: number;
+  mergedPrCount: number;
+  /** Avg opened→merged hours for PRs merged in this cycle's window. */
+  avgPrHours: number | null;
+}
+
+/**
+ * Workspace-wide metrics across **all** cycles: the summed/overall figures for
+ * the headline, plus the per-cycle series behind them.
+ */
+export interface AllCyclesMetricsResult {
+  /** Number of cycles in the series (i.e. cycles that hold at least one ticket). */
+  cycleCount: number;
+  totalTickets: number;
+  completedTickets: number;
+  completedPoints: number;
+  totalPoints: number;
+  /** Overall completedTickets / totalTickets, as a percentage. */
+  completionRate: number;
+  /** PRs merged inside any cycle window, deduped across overlapping windows. */
+  mergedPrCount: number;
+  avgPrHours: number | null;
+  medianPrHours: number | null;
+  /** Chronological, oldest → newest, for the trend chart. */
+  cycles: CycleMetricsPoint[];
+}
+
+/** A merged PR with its opened→merged duration, when measurable. */
+interface MergedPrDuration {
+  /** `${repoFullName}#${prNumber}` — the dedup key. */
+  key: string;
+  mergedAt: Date;
+  /** Null when no `opened` event was captured for the PR. */
+  hours: number | null;
+}
+
 export interface VelocityHistoryPoint {
   sprintId: string;
   sprintName: string;
@@ -116,6 +167,32 @@ const KANBAN_STATUSES: ActionStatus[] = [
   "DONE",
   "CANCELLED",
 ];
+
+/**
+ * Reduce a set of merged PRs to count + avg/median turnaround. PRs without a
+ * measurable duration still count toward `mergedPrCount`; avg/median stay null
+ * when none are measurable (no NaN from an empty average).
+ */
+function summarizePrDurations(prs: MergedPrDuration[]): PrTurnaroundResult {
+  const durations = prs
+    .map((pr) => pr.hours)
+    .filter((h): h is number => h != null);
+
+  if (durations.length === 0) {
+    return { mergedPrCount: prs.length, avgHours: null, medianHours: null };
+  }
+
+  const avgHours = durations.reduce((sum, h) => sum + h, 0) / durations.length;
+
+  const sorted = [...durations].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const medianHours =
+    sorted.length % 2 === 0
+      ? (sorted[mid - 1]! + sorted[mid]!) / 2
+      : sorted[mid]!;
+
+  return { mergedPrCount: prs.length, avgHours, medianHours };
+}
 
 export class SprintAnalyticsService {
   constructor(private prisma: PrismaClient) {}
@@ -533,13 +610,34 @@ export class SprintAnalyticsService {
 
     if (!list.startDate || !list.endDate || !list.workspaceId) return empty;
 
-    // PRs merged within the cycle window.
+    const prs = await this.getMergedPrDurations(list.workspaceId, {
+      start: list.startDate,
+      end: list.endDate,
+    });
+
+    return summarizePrDurations(prs);
+  }
+
+  /**
+   * Merged PRs for a workspace with their opened→merged duration, deduped by
+   * (repo, PR number). Optionally restricted to a merge-time window.
+   *
+   * Shared by the single-cycle {@link getPrTurnaround} (window-scoped, two
+   * queries) and the all-cycles roll-up (one unscoped pass, then bucketed per
+   * cycle in memory rather than 2N queries).
+   */
+  private async getMergedPrDurations(
+    workspaceId: string,
+    window?: { start: Date; end: Date },
+  ): Promise<MergedPrDuration[]> {
     const mergedRows = await this.prisma.gitHubActivity.findMany({
       where: {
-        workspaceId: list.workspaceId,
+        workspaceId,
         eventType: "pull_request",
         prNumber: { not: null },
-        prMergedAt: { gte: list.startDate, lte: list.endDate },
+        prMergedAt: window
+          ? { gte: window.start, lte: window.end }
+          : { not: null },
       },
       select: { prNumber: true, repoFullName: true, prMergedAt: true },
     });
@@ -562,7 +660,7 @@ export class SprintAnalyticsService {
       }
     }
 
-    if (mergedByPr.size === 0) return empty;
+    if (mergedByPr.size === 0) return [];
 
     const merged = [...mergedByPr.values()];
     const prNumbers = [...new Set(merged.map((m) => m.prNumber))];
@@ -571,7 +669,7 @@ export class SprintAnalyticsService {
     // Opened events for those PRs → earliest opened timestamp per PR.
     const openedRows = await this.prisma.gitHubActivity.findMany({
       where: {
-        workspaceId: list.workspaceId,
+        workspaceId,
         eventType: "pull_request",
         eventAction: "opened",
         prNumber: { in: prNumbers },
@@ -590,34 +688,155 @@ export class SprintAnalyticsService {
       }
     }
 
-    const durationsHours: number[] = [];
-    for (const [key, { mergedAt }] of mergedByPr) {
+    return [...mergedByPr.entries()].map(([key, { mergedAt }]) => {
       const openedAt = openedByPr.get(key);
-      if (!openedAt) continue; // no opened event captured → not measurable
-      const ms = mergedAt.getTime() - openedAt.getTime();
-      if (ms < 0) continue;
-      durationsHours.push(ms / (1000 * 60 * 60));
+      // No opened event captured (or a clock-skewed negative) → not measurable,
+      // but the PR still counts toward mergedPrCount.
+      const ms = openedAt ? mergedAt.getTime() - openedAt.getTime() : null;
+      return {
+        key,
+        mergedAt,
+        hours: ms != null && ms >= 0 ? ms / (1000 * 60 * 60) : null,
+      };
+    });
+  }
+
+  /**
+   * Every cycle's metrics for a workspace in one request, plus the summed
+   * all-cycles roll-up that heads the Metrics page.
+   *
+   * Same Ticket-based definitions as {@link getCycleTicketMetrics} (ADR-0047),
+   * but batched: one query for the cycles, one for all their tickets, and one
+   * pass over the workspace's merged PRs — not 3N queries. Cycles holding no
+   * tickets are dropped from the series so an auto-generated empty future cycle
+   * doesn't flatten the chart.
+   */
+  async getAllCyclesMetrics(
+    workspaceId: string,
+  ): Promise<AllCyclesMetricsResult> {
+    const empty: AllCyclesMetricsResult = {
+      cycleCount: 0,
+      totalTickets: 0,
+      completedTickets: 0,
+      completedPoints: 0,
+      totalPoints: 0,
+      completionRate: 0,
+      mergedPrCount: 0,
+      avgPrHours: null,
+      medianPrHours: null,
+      cycles: [],
+    };
+
+    const cycles = await this.prisma.list.findMany({
+      where: { workspaceId, listType: "SPRINT" },
+      // Chronological for the trend chart; undated cycles fall to the end.
+      orderBy: [{ startDate: "asc" }, { createdAt: "asc" }],
+      select: {
+        id: true,
+        name: true,
+        status: true,
+        startDate: true,
+        endDate: true,
+      },
+    });
+
+    if (cycles.length === 0) return empty;
+
+    const tickets = await this.prisma.ticket.findMany({
+      where: { cycleId: { in: cycles.map((c) => c.id) } },
+      select: { cycleId: true, status: true, points: true },
+    });
+
+    const ticketsByCycle = new Map<
+      string,
+      { total: number; completed: number; completedPoints: number; totalPoints: number }
+    >();
+    for (const ticket of tickets) {
+      if (!ticket.cycleId) continue;
+      const bucket = ticketsByCycle.get(ticket.cycleId) ?? {
+        total: 0,
+        completed: 0,
+        completedPoints: 0,
+        totalPoints: 0,
+      };
+      const points = ticket.points ?? 0;
+      bucket.total += 1;
+      bucket.totalPoints += points;
+      if (COMPLETED_TICKET_STATUSES.has(ticket.status)) {
+        bucket.completed += 1;
+        bucket.completedPoints += points;
+      }
+      ticketsByCycle.set(ticket.cycleId, bucket);
     }
 
-    if (durationsHours.length === 0) {
-      // PRs merged in-window, but none had a captured opened event to measure.
-      return { mergedPrCount: mergedByPr.size, avgHours: null, medianHours: null };
+    const allPrs = await this.getMergedPrDurations(workspaceId);
+
+    const points: CycleMetricsPoint[] = [];
+    // PRs counted in at least one cycle window, so overlapping windows don't
+    // double-count them in the roll-up.
+    const prsInAnyCycle = new Map<string, MergedPrDuration>();
+
+    for (const cycle of cycles) {
+      const bucket = ticketsByCycle.get(cycle.id);
+      if (!bucket) continue; // empty cycle — nothing to plot
+
+      const cyclePrs =
+        cycle.startDate && cycle.endDate
+          ? allPrs.filter(
+              (pr) =>
+                pr.mergedAt >= cycle.startDate! && pr.mergedAt <= cycle.endDate!,
+            )
+          : [];
+      for (const pr of cyclePrs) prsInAnyCycle.set(pr.key, pr);
+      const cyclePrSummary = summarizePrDurations(cyclePrs);
+
+      points.push({
+        cycleId: cycle.id,
+        cycleName: cycle.name,
+        status: cycle.status,
+        startDate: cycle.startDate,
+        endDate: cycle.endDate,
+        totalTickets: bucket.total,
+        completedTickets: bucket.completed,
+        completedPoints: bucket.completedPoints,
+        totalPoints: bucket.totalPoints,
+        completionRate:
+          bucket.total > 0 ? (bucket.completed / bucket.total) * 100 : 0,
+        mergedPrCount: cyclePrSummary.mergedPrCount,
+        avgPrHours: cyclePrSummary.avgHours,
+      });
     }
 
-    const avgHours =
-      durationsHours.reduce((sum, h) => sum + h, 0) / durationsHours.length;
+    if (points.length === 0) return empty;
 
-    const sorted = [...durationsHours].sort((a, b) => a - b);
-    const mid = Math.floor(sorted.length / 2);
-    const medianHours =
-      sorted.length % 2 === 0
-        ? (sorted[mid - 1]! + sorted[mid]!) / 2
-        : sorted[mid]!;
+    const totals = points.reduce(
+      (acc, p) => ({
+        totalTickets: acc.totalTickets + p.totalTickets,
+        completedTickets: acc.completedTickets + p.completedTickets,
+        completedPoints: acc.completedPoints + p.completedPoints,
+        totalPoints: acc.totalPoints + p.totalPoints,
+      }),
+      {
+        totalTickets: 0,
+        completedTickets: 0,
+        completedPoints: 0,
+        totalPoints: 0,
+      },
+    );
+
+    const prSummary = summarizePrDurations([...prsInAnyCycle.values()]);
 
     return {
-      mergedPrCount: mergedByPr.size,
-      avgHours,
-      medianHours,
+      cycleCount: points.length,
+      ...totals,
+      completionRate:
+        totals.totalTickets > 0
+          ? (totals.completedTickets / totals.totalTickets) * 100
+          : 0,
+      mergedPrCount: prSummary.mergedPrCount,
+      avgPrHours: prSummary.avgHours,
+      medianPrHours: prSummary.medianHours,
+      cycles: points,
     };
   }
 

--- a/src/server/services/__tests__/SprintAnalyticsService.allCycles.test.ts
+++ b/src/server/services/__tests__/SprintAnalyticsService.allCycles.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for the all-cycles roll-up behind the Metrics page headline.
+ *
+ * These pin the parts that are easy to get subtly wrong: summing across cycles
+ * without double-counting a PR that lands in two overlapping cycle windows,
+ * dropping empty cycles from the trend series, and never emitting NaN.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+import type { PrismaClient } from "@prisma/client";
+import { SprintAnalyticsService } from "../SprintAnalyticsService";
+
+interface CycleRow {
+  id: string;
+  name: string;
+  status: string;
+  startDate: Date | null;
+  endDate: Date | null;
+}
+
+interface TicketRow {
+  cycleId: string;
+  status: string;
+  points: number | null;
+}
+
+interface PrRow {
+  prNumber: number;
+  repoFullName: string;
+  /** When set, the PR is a merge event; otherwise it's an `opened` event. */
+  prMergedAt?: Date;
+  eventTimestamp?: Date;
+}
+
+/**
+ * Minimal Prisma stub for `getAllCyclesMetrics`: canned cycles, tickets and
+ * GitHubActivity rows. `gitHubActivity.findMany` branches on the query the
+ * service issues (merged rows vs `opened` rows).
+ */
+function makeService(opts: {
+  cycles: CycleRow[];
+  tickets: TicketRow[];
+  merged?: PrRow[];
+  opened?: PrRow[];
+}) {
+  const prisma = {
+    list: {
+      findMany: vi.fn().mockResolvedValue(opts.cycles),
+    },
+    ticket: {
+      findMany: vi.fn().mockResolvedValue(opts.tickets),
+    },
+    gitHubActivity: {
+      findMany: vi.fn().mockImplementation((args: { where: { eventAction?: string } }) =>
+        Promise.resolve(
+          args.where.eventAction === "opened"
+            ? (opts.opened ?? [])
+            : (opts.merged ?? []),
+        ),
+      ),
+    },
+  } as unknown as PrismaClient;
+
+  return new SprintAnalyticsService(prisma);
+}
+
+const HOUR = 60 * 60 * 1000;
+
+describe("SprintAnalyticsService.getAllCyclesMetrics", () => {
+  it("sums ticket metrics across cycles and returns them oldest → newest", async () => {
+    const service = makeService({
+      cycles: [
+        {
+          id: "c1",
+          name: "Cycle 1",
+          status: "COMPLETED",
+          startDate: new Date("2026-01-01"),
+          endDate: new Date("2026-01-14"),
+        },
+        {
+          id: "c2",
+          name: "Cycle 2",
+          status: "ACTIVE",
+          startDate: new Date("2026-01-15"),
+          endDate: new Date("2026-01-28"),
+        },
+      ],
+      tickets: [
+        { cycleId: "c1", status: "DONE", points: 3 },
+        { cycleId: "c1", status: "DEPLOYED", points: 2 },
+        { cycleId: "c1", status: "IN_PROGRESS", points: 5 },
+        { cycleId: "c2", status: "DONE", points: null },
+        { cycleId: "c2", status: "BACKLOG", points: 1 },
+      ],
+    });
+
+    const result = await service.getAllCyclesMetrics("ws-1");
+
+    expect(result.cycleCount).toBe(2);
+    expect(result.totalTickets).toBe(5);
+    expect(result.completedTickets).toBe(3); // 2 in c1 + 1 in c2
+    expect(result.completedPoints).toBe(5); // 3 + 2 + 0
+    expect(result.totalPoints).toBe(11);
+    expect(result.completionRate).toBeCloseTo(60); // 3/5
+
+    expect(result.cycles.map((c) => c.cycleName)).toEqual([
+      "Cycle 1",
+      "Cycle 2",
+    ]);
+    expect(result.cycles[0]).toMatchObject({
+      completedTickets: 2,
+      completedPoints: 5,
+      totalTickets: 3,
+    });
+    expect(result.cycles[0]?.completionRate).toBeCloseTo(66.67, 1);
+    expect(result.cycles[1]).toMatchObject({
+      completedTickets: 1,
+      completedPoints: 0,
+      totalTickets: 2,
+      completionRate: 50,
+    });
+  });
+
+  it("drops cycles with no tickets from the series", async () => {
+    const service = makeService({
+      cycles: [
+        {
+          id: "c1",
+          name: "Cycle 1",
+          status: "COMPLETED",
+          startDate: new Date("2026-01-01"),
+          endDate: new Date("2026-01-14"),
+        },
+        {
+          id: "c2",
+          name: "Empty future cycle",
+          status: "PLANNED",
+          startDate: new Date("2026-02-01"),
+          endDate: new Date("2026-02-14"),
+        },
+      ],
+      tickets: [{ cycleId: "c1", status: "DONE", points: 1 }],
+    });
+
+    const result = await service.getAllCyclesMetrics("ws-1");
+
+    expect(result.cycleCount).toBe(1);
+    expect(result.cycles.map((c) => c.cycleName)).toEqual(["Cycle 1"]);
+  });
+
+  it("counts a PR merged inside two overlapping cycle windows only once overall", async () => {
+    const mergedAt = new Date("2026-01-14T12:00:00Z");
+    const service = makeService({
+      cycles: [
+        {
+          id: "c1",
+          name: "Cycle 1",
+          status: "COMPLETED",
+          startDate: new Date("2026-01-01"),
+          endDate: new Date("2026-01-20"),
+        },
+        {
+          id: "c2",
+          name: "Cycle 2",
+          status: "COMPLETED",
+          // Overlaps c1's window — the PR falls in both.
+          startDate: new Date("2026-01-10"),
+          endDate: new Date("2026-01-31"),
+        },
+      ],
+      tickets: [
+        { cycleId: "c1", status: "DONE", points: 1 },
+        { cycleId: "c2", status: "DONE", points: 1 },
+      ],
+      merged: [{ prNumber: 7, repoFullName: "acme/app", prMergedAt: mergedAt }],
+      opened: [
+        {
+          prNumber: 7,
+          repoFullName: "acme/app",
+          eventTimestamp: new Date(mergedAt.getTime() - 4 * HOUR),
+        },
+      ],
+    });
+
+    const result = await service.getAllCyclesMetrics("ws-1");
+
+    // Both cycle windows contain it…
+    expect(result.cycles[0]?.mergedPrCount).toBe(1);
+    expect(result.cycles[1]?.mergedPrCount).toBe(1);
+    // …but the roll-up counts the PR once.
+    expect(result.mergedPrCount).toBe(1);
+    expect(result.avgPrHours).toBeCloseTo(4);
+    expect(result.medianPrHours).toBeCloseTo(4);
+  });
+
+  it("counts an unmeasurable PR (no opened event) without producing NaN", async () => {
+    const service = makeService({
+      cycles: [
+        {
+          id: "c1",
+          name: "Cycle 1",
+          status: "COMPLETED",
+          startDate: new Date("2026-01-01"),
+          endDate: new Date("2026-01-14"),
+        },
+      ],
+      tickets: [{ cycleId: "c1", status: "DONE", points: 1 }],
+      merged: [
+        {
+          prNumber: 9,
+          repoFullName: "acme/app",
+          prMergedAt: new Date("2026-01-05"),
+        },
+      ],
+      opened: [], // never captured
+    });
+
+    const result = await service.getAllCyclesMetrics("ws-1");
+
+    expect(result.mergedPrCount).toBe(1);
+    expect(result.avgPrHours).toBeNull();
+    expect(result.medianPrHours).toBeNull();
+    expect(result.cycles[0]?.avgPrHours).toBeNull();
+  });
+
+  it("ignores PRs merged outside every cycle window", async () => {
+    const service = makeService({
+      cycles: [
+        {
+          id: "c1",
+          name: "Cycle 1",
+          status: "COMPLETED",
+          startDate: new Date("2026-01-01"),
+          endDate: new Date("2026-01-14"),
+        },
+      ],
+      tickets: [{ cycleId: "c1", status: "DONE", points: 1 }],
+      merged: [
+        {
+          prNumber: 11,
+          repoFullName: "acme/app",
+          prMergedAt: new Date("2026-03-01"), // long after the cycle
+        },
+      ],
+      opened: [
+        {
+          prNumber: 11,
+          repoFullName: "acme/app",
+          eventTimestamp: new Date("2026-02-28"),
+        },
+      ],
+    });
+
+    const result = await service.getAllCyclesMetrics("ws-1");
+
+    expect(result.mergedPrCount).toBe(0);
+    expect(result.cycles[0]?.mergedPrCount).toBe(0);
+  });
+
+  it("returns a zeroed result (no NaN) for a workspace with no cycles", async () => {
+    const service = makeService({ cycles: [], tickets: [] });
+
+    const result = await service.getAllCyclesMetrics("ws-1");
+
+    expect(result).toMatchObject({
+      cycleCount: 0,
+      totalTickets: 0,
+      completedTickets: 0,
+      completionRate: 0,
+      mergedPrCount: 0,
+      avgPrHours: null,
+      cycles: [],
+    });
+    expect(Number.isNaN(result.completionRate)).toBe(false);
+  });
+});

--- a/src/server/services/__tests__/SprintAnalyticsService.allCycles.test.ts
+++ b/src/server/services/__tests__/SprintAnalyticsService.allCycles.test.ts
@@ -60,13 +60,31 @@ function makeService(opts: {
       findMany: vi.fn().mockResolvedValue(opts.tickets),
     },
     gitHubActivity: {
-      findMany: vi.fn().mockImplementation((args: { where: { eventAction?: string } }) =>
-        Promise.resolve(
-          args.where.eventAction === "opened"
-            ? (opts.opened ?? [])
-            : (opts.merged ?? []),
+      findMany: vi
+        .fn()
+        .mockImplementation(
+          (args: {
+            where: {
+              eventAction?: string;
+              prMergedAt?: { gte?: Date; lte?: Date };
+            };
+          }) => {
+            if (args.where.eventAction === "opened") {
+              return Promise.resolve(opts.opened ?? []);
+            }
+            // Honour the merge-time window the caller asked for, so tests
+            // actually exercise the bounded query rather than silently
+            // relying on the in-memory filter downstream.
+            const { gte, lte } = args.where.prMergedAt ?? {};
+            const rows = (opts.merged ?? []).filter((row) => {
+              if (!row.prMergedAt) return false;
+              if (gte && row.prMergedAt < gte) return false;
+              if (lte && row.prMergedAt > lte) return false;
+              return true;
+            });
+            return Promise.resolve(rows);
+          },
         ),
-      ),
     },
   } as unknown as PrismaClient;
 
@@ -264,6 +282,57 @@ describe("SprintAnalyticsService.getAllCyclesMetrics", () => {
 
     expect(result.mergedPrCount).toBe(0);
     expect(result.cycles[0]?.mergedPrCount).toBe(0);
+  });
+
+  /**
+   * The Metrics page reads the same cycle through two independent code paths:
+   * the batched roll-up below the chart, and `getCycleTicketMetrics` in the
+   * per-cycle breakdown. They sum tickets with separate loops, so a change to
+   * one could silently disagree with the other — exactly the drift ADR-0047
+   * set out to prevent. This pins them together.
+   */
+  it("agrees with getCycleTicketMetrics for the same cycle", async () => {
+    const tickets = [
+      { cycleId: "c1", status: "DONE", points: 3 },
+      { cycleId: "c1", status: "DEPLOYED", points: null },
+      { cycleId: "c1", status: "IN_PROGRESS", points: 5 },
+      { cycleId: "c1", status: "QA", points: 2 },
+    ];
+    const cycle = {
+      id: "c1",
+      name: "Cycle 1",
+      status: "COMPLETED",
+      startDate: new Date("2026-01-01"),
+      endDate: new Date("2026-01-14"),
+    };
+
+    const prisma = {
+      list: {
+        findMany: vi.fn().mockResolvedValue([cycle]),
+        findUniqueOrThrow: vi.fn().mockResolvedValue(cycle),
+      },
+      ticket: {
+        findMany: vi.fn().mockResolvedValue(tickets),
+      },
+      gitHubActivity: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+    } as unknown as PrismaClient;
+
+    const service = new SprintAnalyticsService(prisma);
+
+    const rollUp = await service.getAllCyclesMetrics("ws-1");
+    const single = await service.getCycleTicketMetrics("c1");
+
+    const row = rollUp.cycles[0]!;
+    expect(row.totalTickets).toBe(single.totalTickets);
+    expect(row.completedTickets).toBe(single.completedTickets);
+    expect(row.completedPoints).toBe(single.completedPoints);
+    expect(row.totalPoints).toBe(single.totalPoints);
+    expect(row.completionRate).toBeCloseTo(single.completionRate);
+    // …and the roll-up totals equal the single cycle, there being only one.
+    expect(rollUp.completedTickets).toBe(single.completedTickets);
+    expect(rollUp.totalPoints).toBe(single.totalPoints);
   });
 
   it("returns a zeroed result (no NaN) for a workspace with no cycles", async () => {


### PR DESCRIPTION
## What

The Metrics page led with a single cycle, so the workspace-wide question — *how much have we delivered, and is it trending up?* — meant walking the dropdown one cycle at a time.

Front and centre is now the **all-cycles roll-up**: every cycle's Ticket metrics summed (velocity, tickets tracked, completion, merged PRs), with a line chart plotting each metric across cycles oldest → newest. The single-cycle view moves below it, unchanged, behind the same dropdown.

## How

- New `getAllCyclesMetrics` service method + `protectedProcedure`. **Batched**: one query for the cycles, one for all their tickets, one pass over the workspace's merged PRs — not 3N queries.
- Cycles with no tickets are dropped from the series, so an auto-generated empty future cycle doesn't flatten the chart.
- A PR falling inside two overlapping cycle windows is counted once in the roll-up.
- `getPrTurnaround` refactored onto a shared `getMergedPrDurations` helper; behaviour unchanged.
- Chart series are toggleable, and any flat-zero series (typically "PRs merged" in a workspace with no GitHub webhook data) starts hidden rather than sitting on the axis floor pretending to be a trend.
- Removes the bar-list velocity-trend widget — the chart supersedes it. `getVelocityTrend` stays on the router, now unused by the UI.

Still live-computed and Ticket-based; nothing persisted to `SprintMetrics`. ADR-0047 amended.

No migration, no schema change.

## Testing

- 6 new unit tests covering the roll-up: cross-cycle sums, empty-cycle exclusion, the overlapping-window dedup, unmeasurable PRs (no `opened` event) producing no `NaN`, and the zero-cycle case.
- `npm run test` (unit): 234 files / 2380 tests green. `npx tsc --noEmit`: clean.
- Verified end-to-end in the browser against a seeded local `dev-fixture` workspace (6 cycles, ~42 tickets).

## Reviewer notes — two things worth knowing

**1. recharts is broken under `next dev --turbo` (pre-existing, not introduced here).** Any statically-imported recharts chart throws `TypeError: createSelector expects all input-selectors to be functions … [selectChartDataWithIndexesIfNotInPanorama(), undefined]` and trips the error boundary. This already takes down `/time` and the admin feedback analytics page on `main` — I confirmed the crash there before touching anything. I verified this feature on plain `next dev` (no `--turbo`), where it renders correctly.

**I have not checked whether the production build is affected**, so this PR does not establish that the chart works on Vercel. Worth confirming on the preview deploy before merging.

**2.** An unrelated integration test, `workspaceHomeStats.integration.test.ts` → "populates the 7-day sparkline with correct day counts + today flag", fails when run in a non-UTC timezone. It anchors its seed data to a fixed date but the service computes `isToday` against the real clock, so the `true` flag lands in a different bucket under e.g. Europe/Berlin than under UTC. It fails locally and **passes in CI** (which runs UTC) — so it is not blocking this PR. Pre-existing and untouched here; flagged separately.
