### PR TITLE
feat(matrix): create an unencrypted room from the picker

### DIFF
--- a/src/app/_components/MatrixServerSettings.tsx
+++ b/src/app/_components/MatrixServerSettings.tsx
@@ -163,6 +163,7 @@ export function MatrixServerSettings({
         onClose={handleClose}
         title="Register a Matrix server"
         size="lg"
+        transitionProps={{ duration: 0 }}
       >
         <Stack gap="md">
           <Text size="sm" className="text-text-muted">
@@ -238,6 +239,7 @@ export function MatrixServerSettings({
         onClose={() => setBrowsingServerId(null)}
         title="Rooms this bot can reach"
         size="lg"
+        transitionProps={{ duration: 0 }}
       >
         <Stack gap="md">
           <Text size="sm" className="text-text-muted">
@@ -248,6 +250,7 @@ export function MatrixServerSettings({
             <MatrixRoomPicker
               workspaceId={workspace.id}
               serverId={browsingServerId}
+              canCreateRooms={false}
             />
           )}
         </Stack>

--- a/src/app/_components/matrix/MatrixRoomBinding.tsx
+++ b/src/app/_components/matrix/MatrixRoomBinding.tsx
@@ -153,12 +153,14 @@ export function MatrixRoomBinding({
         onClose={closePicker}
         title={projectId ? "Choose this project's room" : "Choose the default room"}
         size="lg"
+        transitionProps={{ duration: 0 }}
       >
         <Stack gap="md">
           {serverId && (
             <MatrixRoomPicker
               workspaceId={workspaceId}
               serverId={serverId}
+              projectId={projectId}
               selectedRoomId={chosen?.roomId ?? binding?.room?.roomId ?? null}
               onSelect={setChosen}
             />

--- a/src/app/_components/matrix/MatrixRoomPicker.tsx
+++ b/src/app/_components/matrix/MatrixRoomPicker.tsx
@@ -1,6 +1,17 @@
 "use client";
 
-import { Alert, Button, Loader, Radio, Stack, Text } from "@mantine/core";
+import {
+  Alert,
+  Button,
+  Divider,
+  Group,
+  Loader,
+  MultiSelect,
+  Radio,
+  Stack,
+  Text,
+  TextInput,
+} from "@mantine/core";
 import { IconAlertTriangle } from "@tabler/icons-react";
 import { useState } from "react";
 import { api } from "~/trpc/react";
@@ -16,6 +27,10 @@ interface MatrixRoomPickerProps {
   serverId: string;
   selectedRoomId?: string | null;
   onSelect?: (room: MatrixRoomChoice) => void;
+  /** Where a newly created room gets bound. Null binds the workspace default. */
+  projectId?: string | null;
+  /** Hide the create affordance where creating-and-binding would be the wrong verb. */
+  canCreateRooms?: boolean;
 }
 
 /**
@@ -87,8 +102,13 @@ export function MatrixRoomPicker({
   serverId,
   selectedRoomId,
   onSelect,
+  projectId = null,
+  canCreateRooms = true,
 }: MatrixRoomPickerProps) {
   const [acceptingRoomId, setAcceptingRoomId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [newRoomName, setNewRoomName] = useState("");
+  const [inviteMxids, setInviteMxids] = useState<string[]>([]);
   const utils = api.useUtils();
   const roomsQuery = api.matrixServer.rooms.useQuery({ workspaceId, serverId });
 
@@ -98,6 +118,22 @@ export function MatrixRoomPicker({
       // before it can be offered as a destination.
       void utils.matrixServer.rooms.invalidate({ workspaceId, serverId });
       onSelect?.(room);
+    },
+  });
+
+  const membersQuery = api.matrixRoom.invitableMembers.useQuery(
+    { workspaceId },
+    { enabled: creating },
+  );
+
+  const createRoom = api.matrixRoom.createRoom.useMutation({
+    onSuccess: (room) => {
+      void utils.matrixServer.rooms.invalidate({ workspaceId, serverId });
+      setCreating(false);
+      setNewRoomName("");
+      setInviteMxids([]);
+      // Created rooms are unencrypted by construction, so this is immediately usable.
+      onSelect?.({ roomId: room.roomId, name: room.name, isEncrypted: false });
     },
   });
 
@@ -123,17 +159,17 @@ export function MatrixRoomPicker({
   const joined = roomsQuery.data?.joined ?? [];
   const invited = roomsQuery.data?.invited ?? [];
 
-  if (joined.length === 0 && invited.length === 0) {
-    return (
-      <Alert color="yellow" variant="light" icon={<IconAlertTriangle size={16} />}>
-        This bot has not joined any rooms yet, and has no pending invites. Invite it
-        to a room from your Matrix client, then check back.
-      </Alert>
-    );
-  }
+  const hasNoRooms = joined.length === 0 && invited.length === 0;
 
   return (
     <Stack gap="md">
+      {hasNoRooms && (
+        <Alert color="yellow" variant="light" icon={<IconAlertTriangle size={16} />}>
+          This bot has not joined any rooms yet, and has no pending invites. Invite it
+          to a room from your Matrix client, or create one below.
+        </Alert>
+      )}
+
       {joined.length > 0 && (
         <Stack gap={4}>
           {joined.map((room) => (
@@ -207,6 +243,77 @@ export function MatrixRoomPicker({
             </Alert>
           )}
         </Stack>
+      )}
+
+      <Divider />
+
+      {creating ? (
+        <Stack gap="xs">
+          <Text size="xs" fw={600} className="text-text-secondary">
+            New room
+          </Text>
+          <Text size="xs" className="text-text-muted">
+            Created without encryption, so the bot can post to it. Encryption cannot be
+            turned off later, which is why an existing encrypted room cannot be reused.
+          </Text>
+          <TextInput
+            label="Room name"
+            placeholder="Project updates"
+            value={newRoomName}
+            onChange={(event) => setNewRoomName(event.currentTarget.value)}
+          />
+          <MultiSelect
+            label="Invite"
+            placeholder={
+              (membersQuery.data ?? []).length === 0
+                ? "No workspace members have paired Matrix yet"
+                : "Choose people to invite"
+            }
+            description="Only workspace members who have paired their Matrix account can be invited."
+            data={(membersQuery.data ?? []).map((member) => ({
+              value: member.mxid,
+              label: `${member.name} (${member.mxid})`,
+            }))}
+            value={inviteMxids}
+            onChange={setInviteMxids}
+            searchable
+            disabled={(membersQuery.data ?? []).length === 0}
+          />
+
+          {createRoom.error && (
+            <Alert color="red" variant="light">
+              {createRoom.error.message}
+            </Alert>
+          )}
+
+          <Group gap="xs">
+            <Button
+              size="xs"
+              loading={createRoom.isPending}
+              disabled={!newRoomName.trim()}
+              onClick={() =>
+                createRoom.mutate({
+                  workspaceId,
+                  projectId,
+                  serverId,
+                  name: newRoomName.trim(),
+                  inviteMxids,
+                })
+              }
+            >
+              Create and bind
+            </Button>
+            <Button size="xs" variant="subtle" onClick={() => setCreating(false)}>
+              Cancel
+            </Button>
+          </Group>
+        </Stack>
+      ) : (
+        canCreateRooms && (
+          <Button size="xs" variant="subtle" onClick={() => setCreating(true)}>
+            Create an unencrypted room
+          </Button>
+        )
       )}
     </Stack>
   );

--- a/src/app/_components/matrix/PostToMatrixButton.tsx
+++ b/src/app/_components/matrix/PostToMatrixButton.tsx
@@ -286,6 +286,7 @@ export function PostToMatrixButton({
             <MatrixRoomPicker
               workspaceId={workspaceId}
               serverId={serverId}
+              projectId={projectId}
               selectedRoomId={chosen?.roomId ?? null}
               onSelect={setChosen}
             />

--- a/src/app/_components/matrix/__tests__/MatrixRoomPicker.test.tsx
+++ b/src/app/_components/matrix/__tests__/MatrixRoomPicker.test.tsx
@@ -27,11 +27,25 @@ const queryHolder: {
 
 const acceptMutate = vi.fn();
 
+const createRoomMutate = vi.fn();
+
 vi.mock("~/trpc/react", () => ({
   api: {
     useUtils: () => ({
       matrixServer: { rooms: { invalidate: vi.fn() } },
     }),
+    matrixRoom: {
+      invitableMembers: {
+        useQuery: () => ({ data: [], isLoading: false, error: null }),
+      },
+      createRoom: {
+        useMutation: () => ({
+          mutate: createRoomMutate,
+          isPending: false,
+          error: null,
+        }),
+      },
+    },
     matrixServer: {
       rooms: {
         useQuery: () => queryHolder.current,
@@ -86,6 +100,8 @@ describe("MatrixRoomPicker", () => {
     renderPicker();
 
     expect(screen.getByText(/has not joined any rooms yet/i)).toBeTruthy();
+    // Creating one is now the offered way out of that state.
+    expect(screen.getByText("Create an unencrypted room")).toBeTruthy();
   });
 
   test("surfaces a homeserver failure instead of showing an empty list", () => {

--- a/src/app/_components/matrix/__tests__/PostToMatrixButton.test.tsx
+++ b/src/app/_components/matrix/__tests__/PostToMatrixButton.test.tsx
@@ -41,6 +41,12 @@ vi.mock("~/trpc/react", () => ({
       },
     },
     matrixRoom: {
+      invitableMembers: {
+        useQuery: () => ({ data: [], isLoading: false, error: null }),
+      },
+      createRoom: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false, error: null }),
+      },
       getBinding: {
         useQuery: () => ({
           data: { mode: "inherit", room: null, effective: state.effective },

--- a/src/server/api/routers/__tests__/matrixRoom.test.ts
+++ b/src/server/api/routers/__tests__/matrixRoom.test.ts
@@ -373,3 +373,106 @@ describe("matrixRoom.getBinding", () => {
     ).rejects.toThrow(/not a member of this workspace/);
   });
 });
+
+describe("matrixRoom.createRoom", () => {
+  const OK = (body: unknown) =>
+    ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+  const ERR = (status: number, body: unknown = {}) =>
+    ({ ok: false, status, json: async () => body }) as unknown as Response;
+
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    asWorkspaceRole("member");
+    asProjectOwner();
+    dbMock.integration.findFirst.mockResolvedValue({
+      id: SERVER,
+      providerConfig: {
+        homeserverUrl: "http://localhost:8448",
+        botUserId: "@bot:stub.local",
+      },
+    } as never);
+    dbMock.integrationCredential.findMany.mockResolvedValue([
+      { key: "syt_tok", keyType: "matrix_access_token", isEncrypted: false },
+    ] as never);
+  });
+
+  it("creates the room, then binds it", async () => {
+    fetchMock.mockResolvedValue(OK({ room_id: "!fresh:stub.local" }));
+    dbMock.channelLink.create.mockResolvedValue({
+      id: "link-new",
+      externalId: "!fresh:stub.local",
+    } as never);
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.createRoom({
+        workspaceId: WORKSPACE,
+        projectId: PROJECT,
+        serverId: SERVER,
+        name: "Project updates",
+        inviteMxids: ["@a:stub.local"],
+      }),
+    ).resolves.toMatchObject({ roomId: "!fresh:stub.local", name: "Project updates" });
+
+    const created = dbMock.channelLink.create.mock.calls[0]![0] as {
+      data: Record<string, unknown>;
+    };
+    expect(created.data).toMatchObject({
+      externalId: "!fresh:stub.local",
+      projectId: PROJECT,
+      isActive: true,
+      direction: "outbound",
+    });
+  });
+
+  it("leaves NO binding behind when the homeserver refuses to create the room", async () => {
+    fetchMock.mockResolvedValue(ERR(403, { errcode: "M_FORBIDDEN" }));
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.createRoom({
+        workspaceId: WORKSPACE,
+        projectId: PROJECT,
+        serverId: SERVER,
+        name: "Project updates",
+      }),
+    ).rejects.toThrow(/could not create the room/i);
+
+    // The whole reason creation precedes binding: a project must never end up pointing
+    // at a room that does not exist.
+    expect(dbMock.channelLink.create).not.toHaveBeenCalled();
+  });
+
+  it("leaves no binding behind when the homeserver is unreachable", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.createRoom({
+        workspaceId: WORKSPACE,
+        projectId: PROJECT,
+        serverId: SERVER,
+        name: "Project updates",
+      }),
+    ).rejects.toThrow(/could not create the room/i);
+    expect(dbMock.channelLink.create).not.toHaveBeenCalled();
+  });
+
+  it("requires owner/admin to create a room as the workspace default", async () => {
+    asWorkspaceRole("member");
+
+    const caller = createMockCaller({ userId: USER, db: dbMock });
+    await expect(
+      caller.matrixRoom.createRoom({
+        workspaceId: WORKSPACE,
+        projectId: null,
+        serverId: SERVER,
+        name: "Everything",
+      }),
+    ).rejects.toThrow(/requires the owner or admin role/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/api/routers/matrixRoom.ts
+++ b/src/server/api/routers/matrixRoom.ts
@@ -26,6 +26,9 @@ import {
 import { OUTBOUND } from "~/server/services/channelLinkService";
 import { MATRIX_CHANNEL_PROVIDER } from "~/server/services/matrix/constants";
 import { resolveMatrixDestination } from "~/server/services/matrix/resolveMatrixDestination";
+import { getMatrixClientForServer } from "~/server/services/matrix/matrixServer";
+import { SHARED_MATRIX_INTEGRATION_WHERE } from "~/server/utils/matrixGatewayIntegration";
+import { reportHandledError } from "~/lib/reportHandledError";
 
 /** A project lead configures their own project's room; only admins set the default. */
 async function assertCanBind(
@@ -268,6 +271,129 @@ export const matrixRoomRouter = createTRPCRouter({
         },
       });
       return { off: true };
+    }),
+
+  /**
+   * Workspace members whose Matrix ID we know, so they can be invited to a new room.
+   *
+   * The only source of MXIDs is `IntegrationUserMapping` under the *shared gateway*
+   * integration — that mapping is created when someone pairs their Matrix account for
+   * DMs. So this lists people who have paired, which is a smaller set than "workspace
+   * members" and is worth saying plainly in the UI rather than silently omitting people.
+   */
+  invitableMembers: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const membership = await getWorkspaceMembership(
+        ctx.db,
+        ctx.session.user.id,
+        input.workspaceId,
+      );
+      if (!membership) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You are not a member of this workspace.",
+        });
+      }
+
+      const gateway = await ctx.db.integration.findFirst({
+        where: SHARED_MATRIX_INTEGRATION_WHERE,
+        select: { id: true },
+      });
+      if (!gateway) return [];
+
+      const members = await ctx.db.workspaceUser.findMany({
+        where: { workspaceId: input.workspaceId },
+        select: { userId: true, user: { select: { name: true, email: true } } },
+      });
+
+      const mappings = await ctx.db.integrationUserMapping.findMany({
+        where: {
+          integrationId: gateway.id,
+          userId: { in: members.map((m) => m.userId) },
+        },
+        select: { userId: true, externalUserId: true },
+      });
+
+      const byUser = new Map(mappings.map((m) => [m.userId, m.externalUserId]));
+
+      return members.flatMap((member) => {
+        const mxid = byUser.get(member.userId);
+        if (!mxid) return [];
+        return [
+          {
+            userId: member.userId,
+            mxid,
+            name: member.user.name ?? member.user.email ?? mxid,
+          },
+        ];
+      });
+    }),
+
+  /**
+   * Create an unencrypted room, invite people, and bind it — in that order.
+   *
+   * The order matters for failure: nothing is bound until the room demonstrably exists,
+   * so a homeserver that refuses cannot leave a project pointing at a room that was
+   * never created. Invites are best-effort *after* creation, because a single bad MXID
+   * should not throw away a room that already exists and is already usable.
+   */
+  createRoom: humanOnlyProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        projectId: z.string().nullable().optional(),
+        serverId: z.string(),
+        name: z.string().trim().min(1).max(100),
+        inviteMxids: z.array(z.string()).max(50).optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const projectId = input.projectId ?? null;
+      await assertCanBind(ctx.db, ctx.session.user.id, input.workspaceId, projectId);
+
+      const { client, config } = await getMatrixClientForServer(
+        ctx.db,
+        input.serverId,
+        input.workspaceId,
+      );
+
+      let roomId: string;
+      try {
+        ({ roomId } = await client.createRoom({
+          name: input.name,
+          invite: input.inviteMxids ?? [],
+        }));
+      } catch (error) {
+        reportHandledError(error, {
+          area: "matrix-create-room",
+          context: { homeserverUrl: config.homeserverUrl, serverId: input.serverId },
+        });
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            error instanceof Error
+              ? `The homeserver could not create the room: ${error.message}`
+              : "The homeserver could not create the room.",
+        });
+      }
+
+      // Only now is there something worth binding.
+      const link = await ctx.db.channelLink.create({
+        data: {
+          provider: MATRIX_CHANNEL_PROVIDER,
+          direction: OUTBOUND,
+          externalId: roomId,
+          displayName: input.name,
+          workspaceId: input.workspaceId,
+          projectId,
+          isActive: true,
+          serverIntegrationId: input.serverId,
+          createdById: ctx.session.user.id,
+        },
+      });
+
+      return { roomId, name: input.name, channelLinkId: link.id };
     }),
 
   /** Back to Inherit: remove the row entirely so resolution falls through again. */

--- a/src/server/services/matrix/MatrixClient.ts
+++ b/src/server/services/matrix/MatrixClient.ts
@@ -275,6 +275,44 @@ export class MatrixClient {
     return { eventId: body.event_id ?? "" };
   }
 
+  /**
+   * Create a private room that is deliberately NOT encrypted.
+   *
+   * The omission is the entire point. Element turns on encryption for new private rooms
+   * by default, and encryption is irreversible — there is no un-encrypting a room — so a
+   * workspace that has only ever made rooms through a client ends up with a picker of
+   * nothing but greyed-out rows. This is the escape hatch, and it works precisely
+   * because `initial_state` carries no `m.room.encryption` event.
+   *
+   * `preset: private_chat` keeps the room invite-only; the bot is the creator and so is
+   * already joined.
+   */
+  async createRoom({
+    name,
+    invite = [],
+    topic,
+  }: {
+    name: string;
+    invite?: readonly string[];
+    topic?: string;
+  }): Promise<{ roomId: string }> {
+    const body = await this.request<{ room_id?: string }>("POST", "/createRoom", {
+      name,
+      ...(topic ? { topic } : {}),
+      preset: "private_chat",
+      invite: [...invite],
+      // Explicitly empty. Adding an m.room.encryption event here would permanently make
+      // the room unreachable to this bot, which is the problem this method exists to
+      // solve.
+      initial_state: [],
+    });
+
+    if (!body.room_id) {
+      throw new MatrixApiError("The homeserver created no room.", 502);
+    }
+    return { roomId: body.room_id };
+  }
+
   /** Accept an invite (or join a public room) by id or alias. */
   async join(roomIdOrAlias: string): Promise<{ roomId: string }> {
     const body = await this.request<{ room_id?: string }>(

--- a/src/server/services/matrix/__tests__/MatrixClient.test.ts
+++ b/src/server/services/matrix/__tests__/MatrixClient.test.ts
@@ -345,3 +345,52 @@ describe("MatrixClient.join", () => {
     });
   });
 });
+
+describe("MatrixClient.createRoom", () => {
+  it("creates a private room with NO encryption initial state", async () => {
+    fetchMock.mockResolvedValue(OK({ room_id: "!new:example.org" }));
+
+    await expect(
+      makeClient().createRoom({ name: "Project updates", invite: ["@a:example.org"] }),
+    ).resolves.toEqual({ roomId: "!new:example.org" });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe("https://matrix.example.org/_matrix/client/v3/createRoom");
+    expect((init as RequestInit).method).toBe("POST");
+
+    const body = JSON.parse((init as RequestInit).body as string) as {
+      preset: string;
+      invite: string[];
+      initial_state: { type?: string }[];
+      name: string;
+    };
+    expect(body.name).toBe("Project updates");
+    expect(body.preset).toBe("private_chat");
+    expect(body.invite).toEqual(["@a:example.org"]);
+    // The omission IS the feature. Encryption is irreversible, so an m.room.encryption
+    // event here would permanently lock the bot out of the room it just made.
+    expect(body.initial_state).toEqual([]);
+    expect(
+      body.initial_state.some((event) => event.type === "m.room.encryption"),
+    ).toBe(false);
+    expect(JSON.stringify(body)).not.toContain("m.room.encryption");
+  });
+
+  it("works with no invitees", async () => {
+    fetchMock.mockResolvedValue(OK({ room_id: "!solo:example.org" }));
+    await expect(makeClient().createRoom({ name: "Solo" })).resolves.toEqual({
+      roomId: "!solo:example.org",
+    });
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0]![1] as RequestInit).body as string,
+    ) as { invite: string[] };
+    expect(body.invite).toEqual([]);
+  });
+
+  it("treats a response without a room id as a failure, not a silent success", async () => {
+    fetchMock.mockResolvedValue(OK({}));
+    await expect(makeClient().createRoom({ name: "Nope" })).rejects.toThrow(
+      /created no room/i,
+    );
+  });
+});


### PR DESCRIPTION
## What

V2: the escape hatch for the encryption problem. Element encrypts new private rooms by default and encryption is **irreversible**, so a workspace whose rooms were all made through a client sees a V1 picker of nothing but greyed-out rows. This creates a room, invites people, and binds it to the project in one step.

## The omission is the feature

`POST /createRoom` sends `preset: private_chat` and an **empty `initial_state`** — no `m.room.encryption` event. A test asserts the request body contains no mention of it at all, because getting this wrong would permanently lock the bot out of the room it just created. There is no un-encrypting a room.

## Order matters for failure

The room is created first and bound only once it demonstrably exists, so a homeserver that refuses cannot leave a project pointing at a room that was never made. Verified by killing the stub mid-flow: the call errors and the binding count stays at zero.

## Notable decisions

- **Invitees come from workspace members with a known MXID**, which in practice means people who have paired Matrix for DMs (`IntegrationUserMapping` under the shared gateway integration). That is a smaller set than "workspace members", so the UI says so rather than silently omitting people.
- **The empty-state early-return had to go.** A bot in no rooms at all is exactly when creating one is the answer, and the old code returned before the create button could render.
- **The settings picker passes `canCreateRooms={false}`** — browsing a server's rooms is not the place to bind one to a project.

## Verification

Exercised against a stub homeserver through the real HTTP stack:

| Scenario | Result |
|---|---|
| Create + invite + bind | Room created, `encryptionRequested=false`, `preset=private_chat`, invite passed through |
| Bound to the project | `ChannelLink` row active, named, pointing at the new room |
| Post into the new room | `posted` — immediately usable |
| Homeserver down mid-create | Error surfaced, **zero** bindings written |

2610 unit tests green, typecheck clean, lint clean.

## Pre-flight question I could not answer

The ticket asks whether this is still a fast-follow or the main event — i.e. whether the target workspace's rooms are all encrypted. That needs credentials for CLEAR's actual homeserver, which I don't have. It remains James's open question on the PRD; if their rooms are all encrypted, V1's picker is unusable without this and V2 is the point rather than a follow-up.

## Acceptance criteria

- [x] Create an unencrypted room on the selected server, invite the selected members, bind it to the project
- [x] The created room has no `m.room.encryption` state event
- [x] A failed creation leaves no binding behind
- [x] No hardcoded colors; typecheck + lint pass

---

Ships: dark.acorn