### PR TITLE
refactor: Fix the broken seams in the invite to first-session path

### DIFF
--- a/src/app/_components/welcome/GettingStarted.tsx
+++ b/src/app/_components/welcome/GettingStarted.tsx
@@ -6,6 +6,7 @@ import { Loader } from "@mantine/core";
 import { useWelcomeSetup } from "./useWelcomeSetup";
 import { WelcomeChatView } from "./WelcomeChatView";
 import { WelcomeChecklistView } from "./WelcomeChecklistView";
+import { COPY } from "./welcomeCopy";
 import styles from "./Welcome.module.css";
 
 type ViewMode = "chat" | "checklist";
@@ -50,27 +51,38 @@ export function GettingStarted() {
 
   return (
     <div style={{ position: "relative" }}>
-      <div className={styles.viewToggle} role="tablist" aria-label="Setup view">
-        <button
-          type="button"
-          role="tab"
-          aria-selected={view === "chat"}
-          className={view === "chat" ? styles.toggleOn : undefined}
-          onClick={() => switchView("chat")}
-        >
-          <IconMessageChatbot size={13} />
-          Chat
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={view === "checklist"}
-          className={view === "checklist" ? styles.toggleOn : undefined}
-          onClick={() => switchView("checklist")}
-        >
-          <IconListCheck size={13} />
-          Checklist
-        </button>
+      <div className={styles.topBar}>
+        {!setup.allDone && (
+          <button
+            type="button"
+            className={styles.exploreLink}
+            onClick={() => void setup.exploreOnOwn()}
+          >
+            {COPY.chips.explore}
+          </button>
+        )}
+        <div className={styles.viewToggle} role="tablist" aria-label="Setup view">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === "chat"}
+            className={view === "chat" ? styles.toggleOn : undefined}
+            onClick={() => switchView("chat")}
+          >
+            <IconMessageChatbot size={13} />
+            Chat
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === "checklist"}
+            className={view === "checklist" ? styles.toggleOn : undefined}
+            onClick={() => switchView("checklist")}
+          >
+            <IconListCheck size={13} />
+            Checklist
+          </button>
+        </div>
       </div>
       {view === "chat" ? (
         <WelcomeChatView setup={setup} />

--- a/src/app/_components/welcome/Welcome.module.css
+++ b/src/app/_components/welcome/Welcome.module.css
@@ -1,12 +1,31 @@
 /* Getting started (welcome) page — ported from the design handoff
    (styles-onboarding.css) onto the app's semantic color tokens. */
 
-/* ===== View toggle (Chat / Checklist) ===== */
-.viewToggle {
+/* ===== Top bar (explore exit + view toggle) ===== */
+.topBar {
   position: absolute;
   top: 0;
   right: 0;
   z-index: 15;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.exploreLink {
+  border: 0;
+  background: none;
+  padding: 0;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+.exploreLink:hover {
+  color: var(--color-text-secondary);
+  text-decoration: underline;
+}
+
+/* ===== View toggle (Chat / Checklist) ===== */
+.viewToggle {
   display: flex;
   gap: 2px;
   background: var(--color-bg-secondary);

--- a/src/app/_components/welcome/WelcomeChatView.tsx
+++ b/src/app/_components/welcome/WelcomeChatView.tsx
@@ -191,7 +191,9 @@ export function WelcomeChatView({ setup }: { setup: WelcomeSetupApi }) {
   const explore = useCallback(() => {
     setActive(null);
     push("user", COPY.chips.explore);
-    void say(<span>{COPY.exploreReply}</span>, 800);
+    void say(<span>{COPY.exploreReply}</span>, 800).then(() =>
+      setupRef.current.exploreOnOwn(),
+    );
   }, [push, say]);
 
   // Scripted opening — waits for setup state so returning users resume.

--- a/src/app/_components/welcome/useWelcomeSetup.ts
+++ b/src/app/_components/welcome/useWelcomeSetup.ts
@@ -242,11 +242,14 @@ export function useWelcomeSetup() {
         await completeWelcome.mutateAsync();
       } catch {
         // onError resets completedRef so a later attempt can retry; still
-        // leave — the workspace home doesn't gate on welcome completion.
+        // leave — neither destination below gates on welcome completion.
       }
     }
+    // Fallback is /today, NOT /home: /home bounces incomplete-welcome users
+    // back here during the 24h new-user window, which would turn a failed
+    // completeWelcome + unresolved workspace query into a loop.
     router.push(
-      defaultWorkspace?.slug ? `/w/${defaultWorkspace.slug}/home` : "/home",
+      defaultWorkspace?.slug ? `/w/${defaultWorkspace.slug}/home` : "/today",
     );
   }, [data, completeWelcome, defaultWorkspace, router]);
 

--- a/src/app/_components/welcome/useWelcomeSetup.ts
+++ b/src/app/_components/welcome/useWelcomeSetup.ts
@@ -59,6 +59,7 @@ export function useWelcomeSetup() {
   const router = useRouter();
 
   const { data, isLoading } = api.welcome.getSetup.useQuery();
+  const { data: defaultWorkspace } = api.workspace.getDefault.useQuery();
   const state = data?.state ?? null;
   const calendarConnected = data?.calendarConnected ?? false;
   // False while Google is verifying our calendar scopes and this user isn't an
@@ -229,6 +230,26 @@ export function useWelcomeSetup() {
     router.push("/today");
   }, [router]);
 
+  /**
+   * "I'll explore on my own" — a real exit, not a chat reply. Marks welcome
+   * complete (so /home stops bouncing back here for the 24h new-user window)
+   * and lands the user on their default workspace home.
+   */
+  const exploreOnOwn = useCallback(async () => {
+    if (!data?.welcomeCompletedAt && !completedRef.current) {
+      completedRef.current = true;
+      try {
+        await completeWelcome.mutateAsync();
+      } catch {
+        // onError resets completedRef so a later attempt can retry; still
+        // leave — the workspace home doesn't gate on welcome completion.
+      }
+    }
+    router.push(
+      defaultWorkspace?.slug ? `/w/${defaultWorkspace.slug}/home` : "/home",
+    );
+  }, [data, completeWelcome, defaultWorkspace, router]);
+
   const isAnswerPending =
     createGoal.isPending ||
     createAction.isPending ||
@@ -249,6 +270,7 @@ export function useWelcomeSetup() {
     answerStep,
     isAnswerPending,
     goToToday,
+    exploreOnOwn,
   };
 }
 

--- a/src/app/_components/welcome/welcomeCopy.ts
+++ b/src/app/_components/welcome/welcomeCopy.ts
@@ -124,7 +124,7 @@ export const COPY = {
     sub: "As you complete setup, this diagram lights up — watch the left sidebar too.",
   },
   exploreReply:
-    "Totally fine. I'll keep your setup progress up top — flip to the Checklist view whenever you're ready, or just ask me anything down here.",
+    "Totally fine — dropping you into your workspace to look around. I'm always in the corner if you need a hand.",
   freeTextFallback:
     "Let's get you set up first — it only takes a minute, then Zoe can help with anything. Want to continue?",
   railSub: {

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -70,12 +70,14 @@ export default function InviteAcceptPage() {
 
   // Invite signups are auto-accepted during user creation, so the invitee
   // returns here to an already-used invitation. That's success, not an error —
-  // send them straight into the workspace instead of dead-ending.
+  // send them straight into the workspace instead of dead-ending. Gated on
+  // actual membership (not isForCurrentUser): an invitee who was later
+  // removed from the workspace would only bounce off the access gate.
   const shouldAutoRedirect =
     !!invitation &&
     invitation.status === "accepted" &&
     invitation.isLoggedIn &&
-    (invitation.isForCurrentUser || invitation.isMember);
+    invitation.isMember;
   const workspaceSlug = invitation?.workspace.slug;
 
   useEffect(() => {

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -21,7 +21,7 @@ import {
 } from "@tabler/icons-react";
 import { useParams, useRouter } from "next/navigation";
 import { signIn, signOut } from "next-auth/react";
-import { type FormEvent, useMemo, useState } from "react";
+import { type FormEvent, useEffect, useMemo, useState } from "react";
 import { api, type RouterOutputs } from "~/trpc/react";
 import { PRODUCT_NAME } from "~/lib/brand";
 import {
@@ -68,7 +68,23 @@ export default function InviteAcceptPage() {
     },
   });
 
-  if (isLoading) {
+  // Invite signups are auto-accepted during user creation, so the invitee
+  // returns here to an already-used invitation. That's success, not an error —
+  // send them straight into the workspace instead of dead-ending.
+  const shouldAutoRedirect =
+    !!invitation &&
+    invitation.status === "accepted" &&
+    invitation.isLoggedIn &&
+    (invitation.isForCurrentUser || invitation.isMember);
+  const workspaceSlug = invitation?.workspace.slug;
+
+  useEffect(() => {
+    if (shouldAutoRedirect && workspaceSlug) {
+      router.replace(`/w/${workspaceSlug}`);
+    }
+  }, [shouldAutoRedirect, workspaceSlug, router]);
+
+  if (isLoading || shouldAutoRedirect) {
     return (
       <Container size="sm" className="py-16">
         <Card className="bg-surface-secondary border-border-primary" withBorder>

--- a/src/server/api/routers/__tests__/welcome.test.ts
+++ b/src/server/api/routers/__tests__/welcome.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for `resolveWorkspaceId` — the enforcement point for the
+ * "onboarding artifacts never land in a shared workspace" acceptance
+ * criterion of the welcome flow.
+ *
+ * Mocked Prisma via `vitest-mock-extended` (see CLAUDE.md "Test database
+ * safety" — mocked is the default; these branches need no real DB).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+// `../welcome` imports `~/server/api/trpc`, whose next-auth import chain
+// doesn't resolve under vitest — stub it like the other router tests do.
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+import { resolveWorkspaceId } from "../welcome";
+
+const db = mockDeep<PrismaClient>();
+const USER = "user-1";
+const OTHER_USER = "user-2";
+
+beforeEach(() => {
+  mockReset(db);
+});
+
+describe("resolveWorkspaceId", () => {
+  it("uses the default workspace when it is the user's own personal workspace", async () => {
+    db.user.findUnique.mockResolvedValue({ defaultWorkspaceId: "ws-own-personal" } as never);
+    db.workspace.findUnique.mockResolvedValue({
+      id: "ws-own-personal",
+      type: "personal",
+      ownerId: USER,
+    } as never);
+
+    await expect(resolveWorkspaceId(db, USER)).resolves.toBe("ws-own-personal");
+    expect(db.workspace.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the owned personal workspace when the default is a team workspace", async () => {
+    db.user.findUnique.mockResolvedValue({ defaultWorkspaceId: "ws-team" } as never);
+    db.workspace.findUnique.mockResolvedValue({
+      id: "ws-team",
+      type: "team",
+      ownerId: OTHER_USER,
+    } as never);
+    db.workspace.findFirst.mockResolvedValue({ id: "ws-personal" } as never);
+
+    await expect(resolveWorkspaceId(db, USER)).resolves.toBe("ws-personal");
+    expect(db.workspace.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { ownerId: USER, type: "personal" },
+      }),
+    );
+  });
+
+  it("falls back to the owned personal workspace when the default is someone ELSE's personal workspace", async () => {
+    // The review's High finding: type === "personal" alone is not enough —
+    // a user can be invited into another user's personal workspace and have
+    // it set as their default by signup auto-accept.
+    db.user.findUnique.mockResolvedValue({ defaultWorkspaceId: "ws-their-personal" } as never);
+    db.workspace.findUnique.mockResolvedValue({
+      id: "ws-their-personal",
+      type: "personal",
+      ownerId: OTHER_USER,
+    } as never);
+    db.workspace.findFirst.mockResolvedValue({ id: "ws-personal" } as never);
+
+    await expect(resolveWorkspaceId(db, USER)).resolves.toBe("ws-personal");
+  });
+
+  it("keeps the previous resolution order when no personal workspace exists", async () => {
+    db.user.findUnique.mockResolvedValue({ defaultWorkspaceId: "ws-team" } as never);
+    db.workspace.findUnique.mockResolvedValue({
+      id: "ws-team",
+      type: "team",
+      ownerId: OTHER_USER,
+    } as never);
+    db.workspace.findFirst.mockResolvedValue(null as never);
+
+    // Default exists but is shared, no owned personal → default wins.
+    await expect(resolveWorkspaceId(db, USER)).resolves.toBe("ws-team");
+  });
+
+  it("falls back to the earliest membership when there is no default and no personal workspace", async () => {
+    db.user.findUnique.mockResolvedValue({ defaultWorkspaceId: null } as never);
+    db.workspace.findFirst.mockResolvedValue(null as never);
+    db.workspaceUser.findFirst.mockResolvedValue({ workspaceId: "ws-member" } as never);
+
+    await expect(resolveWorkspaceId(db, USER)).resolves.toBe("ws-member");
+    expect(db.workspaceUser.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: USER },
+        orderBy: { joinedAt: "asc" },
+      }),
+    );
+  });
+
+  it("returns null for a user with no workspace ties at all", async () => {
+    db.user.findUnique.mockResolvedValue({ defaultWorkspaceId: null } as never);
+    db.workspace.findFirst.mockResolvedValue(null as never);
+    db.workspaceUser.findFirst.mockResolvedValue(null as never);
+
+    await expect(resolveWorkspaceId(db, USER)).resolves.toBeNull();
+  });
+});

--- a/src/server/api/routers/matrixServer.ts
+++ b/src/server/api/routers/matrixServer.ts
@@ -30,7 +30,7 @@ import {
   getMatrixClientForServer,
   listMatrixServers,
 } from "~/server/services/matrix/matrixServer";
-import { reportHandledError } from "~/lib/reportHandledError";
+import { reportHandledErrorServer } from "~/server/utils/reportHandledErrorServer";
 import {
   assertSafeHomeserverUrl,
   UnsafeHomeserverUrlError,
@@ -260,7 +260,7 @@ export const matrixServerRouter = createTRPCRouter({
           invited: invites.map(toRoomChoice).sort(byName),
         };
       } catch (error) {
-        reportHandledError(error, {
+        reportHandledErrorServer(error, {
           area: "matrix-room-list",
           context: { homeserverUrl: config.homeserverUrl, serverId: input.serverId },
         });
@@ -314,7 +314,7 @@ export const matrixServerRouter = createTRPCRouter({
         return toRoomChoice(summary ?? invite);
       } catch (error) {
         if (error instanceof TRPCError) throw error;
-        reportHandledError(error, {
+        reportHandledErrorServer(error, {
           area: "matrix-accept-invite",
           context: {
             homeserverUrl: config.homeserverUrl,

--- a/src/server/api/routers/team.ts
+++ b/src/server/api/routers/team.ts
@@ -3,6 +3,7 @@ import { createTRPCRouter, protectedProcedure, publicProcedure } from "~/server/
 import { TRPCError } from "@trpc/server";
 import { generateSecureToken, generateTeamInviteUrl } from "~/server/utils/tokens";
 import { sendTeamInvitationEmail } from "~/server/services/EmailService";
+import { reportHandledError } from "~/lib/reportHandledError";
 
 export const teamRouter = createTRPCRouter({
   // Create a new team
@@ -322,6 +323,10 @@ export const teamRouter = createTRPCRouter({
           inviteUrl,
         }).catch((err: unknown) => {
           console.error("[team.addMember] Failed to send invitation email:", err);
+          reportHandledError(err, {
+            area: "team-invitation-email",
+            context: { teamId: input.teamId, recipientEmail: input.email },
+          });
         });
 
         return {
@@ -669,6 +674,13 @@ export const teamRouter = createTRPCRouter({
         inviteUrl,
       }).catch((err: unknown) => {
         console.error("[team.resendInvitation] Failed to send invitation email:", err);
+        reportHandledError(err, {
+          area: "team-invitation-email",
+          context: {
+            teamId: invitation.teamId,
+            recipientEmail: invitation.email,
+          },
+        });
       });
 
       return {

--- a/src/server/api/routers/team.ts
+++ b/src/server/api/routers/team.ts
@@ -3,7 +3,7 @@ import { createTRPCRouter, protectedProcedure, publicProcedure } from "~/server/
 import { TRPCError } from "@trpc/server";
 import { generateSecureToken, generateTeamInviteUrl } from "~/server/utils/tokens";
 import { sendTeamInvitationEmail } from "~/server/services/EmailService";
-import { reportHandledError } from "~/lib/reportHandledError";
+import { reportHandledErrorServer } from "~/server/utils/reportHandledErrorServer";
 
 export const teamRouter = createTRPCRouter({
   // Create a new team
@@ -323,7 +323,7 @@ export const teamRouter = createTRPCRouter({
           inviteUrl,
         }).catch((err: unknown) => {
           console.error("[team.addMember] Failed to send invitation email:", err);
-          reportHandledError(err, {
+          reportHandledErrorServer(err, {
             area: "team-invitation-email",
             context: { teamId: input.teamId, recipientEmail: input.email },
           });
@@ -674,7 +674,7 @@ export const teamRouter = createTRPCRouter({
         inviteUrl,
       }).catch((err: unknown) => {
         console.error("[team.resendInvitation] Failed to send invitation email:", err);
-        reportHandledError(err, {
+        reportHandledErrorServer(err, {
           area: "team-invitation-email",
           context: {
             teamId: invitation.teamId,

--- a/src/server/api/routers/welcome.ts
+++ b/src/server/api/routers/welcome.ts
@@ -62,8 +62,11 @@ async function saveSetupState(
  * user the default is the shared team workspace (invite auto-accept overrides
  * it at signup), and a throwaway onboarding goal like "Get fit" must never be
  * visible to the rest of the team.
+ *
+ * Exported for tests — this is the enforcement point for the "onboarding
+ * artifacts never land in a shared workspace" acceptance criterion.
  */
-async function resolveWorkspaceId(
+export async function resolveWorkspaceId(
   db: PrismaClient,
   userId: string,
 ): Promise<string | null> {
@@ -74,10 +77,15 @@ async function resolveWorkspaceId(
   const defaultWorkspace = user?.defaultWorkspaceId
     ? await db.workspace.findUnique({
         where: { id: user.defaultWorkspaceId },
-        select: { id: true, type: true },
+        select: { id: true, type: true, ownerId: true },
       })
     : null;
-  if (defaultWorkspace?.type === "personal") return defaultWorkspace.id;
+  // Ownership matters, not just type: a user can be invited into someone
+  // ELSE's personal workspace (addMember has no type gate), and auto-accept
+  // makes that their default — their onboarding goal must not land there.
+  if (defaultWorkspace?.type === "personal" && defaultWorkspace.ownerId === userId) {
+    return defaultWorkspace.id;
+  }
 
   // Default is shared (team/organization) or unset — use the personal
   // workspace the user owns (auto-created at signup).

--- a/src/server/api/routers/welcome.ts
+++ b/src/server/api/routers/welcome.ts
@@ -56,7 +56,13 @@ async function saveSetupState(
   return state;
 }
 
-/** Objects created during setup land in the user's default (usually personal) workspace. */
+/**
+ * Objects created during setup land in the user's PERSONAL workspace. The
+ * default workspace is used only when it is itself personal: for an invited
+ * user the default is the shared team workspace (invite auto-accept overrides
+ * it at signup), and a throwaway onboarding goal like "Get fit" must never be
+ * visible to the rest of the team.
+ */
 async function resolveWorkspaceId(
   db: PrismaClient,
   userId: string,
@@ -65,8 +71,25 @@ async function resolveWorkspaceId(
     where: { id: userId },
     select: { defaultWorkspaceId: true },
   });
-  if (user?.defaultWorkspaceId) return user.defaultWorkspaceId;
+  const defaultWorkspace = user?.defaultWorkspaceId
+    ? await db.workspace.findUnique({
+        where: { id: user.defaultWorkspaceId },
+        select: { id: true, type: true },
+      })
+    : null;
+  if (defaultWorkspace?.type === "personal") return defaultWorkspace.id;
 
+  // Default is shared (team/organization) or unset — use the personal
+  // workspace the user owns (auto-created at signup).
+  const personal = await db.workspace.findFirst({
+    where: { ownerId: userId, type: "personal" },
+    orderBy: { createdAt: "asc" },
+    select: { id: true },
+  });
+  if (personal) return personal.id;
+
+  // No personal workspace exists — keep the previous resolution order.
+  if (defaultWorkspace) return defaultWorkspace.id;
   const membership = await db.workspaceUser.findFirst({
     where: { userId },
     orderBy: { joinedAt: "asc" },

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -36,7 +36,7 @@ import {
   DigestRateLimitError,
 } from "~/server/services/activity/weeklyWorkDigest/digest";
 import { recordActivity } from "~/server/services/activity/recordActivity";
-import { reportHandledError } from "~/lib/reportHandledError";
+import { reportHandledErrorServer } from "~/server/utils/reportHandledErrorServer";
 import {
   getOrGenerateWeeklyNarrative,
   NarrativeRateLimitError,
@@ -664,7 +664,7 @@ export const workspaceRouter = createTRPCRouter({
                 "[workspace.addMember] Failed to send member-added email:",
                 err,
               );
-              reportHandledError(err, {
+              reportHandledErrorServer(err, {
                 area: "workspace-member-added-email",
                 context: {
                   workspaceId: input.workspaceId,
@@ -752,7 +752,7 @@ export const workspaceRouter = createTRPCRouter({
           inviteUrl,
         }).catch((err: unknown) => {
           console.error("[workspace.addMember] Failed to send invitation email:", err);
-          reportHandledError(err, {
+          reportHandledErrorServer(err, {
             area: "workspace-invitation-email",
             context: { workspaceId: input.workspaceId, recipientEmail: input.email },
           });
@@ -1174,7 +1174,7 @@ export const workspaceRouter = createTRPCRouter({
         inviteUrl,
       }).catch((err: unknown) => {
         console.error("[workspace.resendInvitation] Failed to send invitation email:", err);
-        reportHandledError(err, {
+        reportHandledErrorServer(err, {
           area: "workspace-invitation-email",
           context: {
             workspaceId: invitation.workspaceId,

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -36,6 +36,7 @@ import {
   DigestRateLimitError,
 } from "~/server/services/activity/weeklyWorkDigest/digest";
 import { recordActivity } from "~/server/services/activity/recordActivity";
+import { reportHandledError } from "~/lib/reportHandledError";
 import {
   getOrGenerateWeeklyNarrative,
   NarrativeRateLimitError,
@@ -663,6 +664,13 @@ export const workspaceRouter = createTRPCRouter({
                 "[workspace.addMember] Failed to send member-added email:",
                 err,
               );
+              reportHandledError(err, {
+                area: "workspace-member-added-email",
+                context: {
+                  workspaceId: input.workspaceId,
+                  recipientEmail: newMember.user.email ?? "",
+                },
+              });
             });
           }
         }
@@ -744,6 +752,10 @@ export const workspaceRouter = createTRPCRouter({
           inviteUrl,
         }).catch((err: unknown) => {
           console.error("[workspace.addMember] Failed to send invitation email:", err);
+          reportHandledError(err, {
+            area: "workspace-invitation-email",
+            context: { workspaceId: input.workspaceId, recipientEmail: input.email },
+          });
         });
 
         return {
@@ -1162,6 +1174,13 @@ export const workspaceRouter = createTRPCRouter({
         inviteUrl,
       }).catch((err: unknown) => {
         console.error("[workspace.resendInvitation] Failed to send invitation email:", err);
+        reportHandledError(err, {
+          area: "workspace-invitation-email",
+          context: {
+            workspaceId: invitation.workspaceId,
+            recipientEmail: invitation.email,
+          },
+        });
       });
 
       return {

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -1321,6 +1321,20 @@ export const workspaceRouter = createTRPCRouter({
 
       const { members, _count, ...workspaceRest } = invitation.workspace;
 
+      // Whether the logged-in viewer already belongs to the workspace — e.g.
+      // an invitee whose invitation was auto-accepted during signup.
+      const isMember = ctx.session?.user?.id
+        ? (await ctx.db.workspaceUser.findUnique({
+            where: {
+              userId_workspaceId: {
+                userId: ctx.session.user.id,
+                workspaceId: invitation.workspaceId,
+              },
+            },
+            select: { userId: true },
+          })) !== null
+        : false;
+
       return {
         ...invitation,
         workspace: {
@@ -1331,6 +1345,7 @@ export const workspaceRouter = createTRPCRouter({
         isExpired: invitation.expiresAt < new Date(),
         isLoggedIn: !!ctx.session?.user,
         isForCurrentUser: invitation.email === ctx.session?.user?.email,
+        isMember,
       };
     }),
 

--- a/src/server/auth/__tests__/acceptPendingInvitations.test.ts
+++ b/src/server/auth/__tests__/acceptPendingInvitations.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for `acceptPendingInvitationsForUser` — specifically the
+ * workspace-join activity event added for auto-accepted invites: exactly one
+ * `workspace_member/created` event for a genuinely new member, none when the
+ * user already belonged to the workspace.
+ *
+ * Mocked Prisma via `vitest-mock-extended` (see CLAUDE.md "Test database
+ * safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+import { acceptPendingInvitationsForUser } from "../acceptPendingInvitations";
+
+const db = mockDeep<PrismaClient>();
+const USER = "user-1";
+const EMAIL = "invitee@example.com";
+
+const invitation = {
+  id: "inv-1",
+  workspaceId: "ws-1",
+  email: EMAIL,
+  role: "member",
+};
+
+beforeEach(() => {
+  mockReset(db);
+  db.teamInvitation.findMany.mockResolvedValue([] as never);
+  db.$transaction.mockResolvedValue([] as never);
+});
+
+describe("acceptPendingInvitationsForUser", () => {
+  it("emits exactly one workspace_member/created event for a new member", async () => {
+    db.workspaceInvitation.findMany.mockResolvedValue([invitation] as never);
+    db.workspaceUser.findUnique.mockResolvedValue(null as never); // not a member yet
+    db.user.findUnique.mockResolvedValue({ name: "Invitee" } as never);
+
+    const result = await acceptPendingInvitationsForUser(db, USER, EMAIL);
+
+    expect(result).toBe("ws-1");
+    expect(db.workspaceActivityEvent.create).toHaveBeenCalledTimes(1);
+    expect(db.workspaceActivityEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        workspaceId: "ws-1",
+        userId: USER,
+        entityType: "workspace_member",
+        entityId: USER,
+        action: "created",
+        metadata: { name: "Invitee" },
+      }),
+    });
+  });
+
+  it("emits no event when the user was already a member", async () => {
+    db.workspaceInvitation.findMany.mockResolvedValue([invitation] as never);
+    db.workspaceUser.findUnique.mockResolvedValue({ userId: USER } as never); // existing member
+
+    const result = await acceptPendingInvitationsForUser(db, USER, EMAIL);
+
+    // The invitation is still marked accepted (returned workspaceId), but the
+    // feed must not announce a join that didn't happen.
+    expect(result).toBe("ws-1");
+    expect(db.workspaceActivityEvent.create).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the email in event metadata when the user has no name", async () => {
+    db.workspaceInvitation.findMany.mockResolvedValue([invitation] as never);
+    db.workspaceUser.findUnique.mockResolvedValue(null as never);
+    db.user.findUnique.mockResolvedValue({ name: null } as never);
+
+    await acceptPendingInvitationsForUser(db, USER, EMAIL);
+
+    expect(db.workspaceActivityEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ metadata: { name: EMAIL } }),
+    });
+  });
+});

--- a/src/server/auth/acceptPendingInvitations.ts
+++ b/src/server/auth/acceptPendingInvitations.ts
@@ -1,0 +1,124 @@
+import type { PrismaClient } from "@prisma/client";
+import { recordActivity } from "~/server/services/activity/recordActivity";
+
+/**
+ * Auto-accept any pending workspace and team invitations matching this user's
+ * email. Covers the case where an invitee signs up (or signs in) via a route
+ * other than the invite accept page — e.g. OAuth, direct magic link, or a
+ * magic link whose callbackUrl no longer points at /invite/<token>.
+ *
+ * Extracted from `config.ts` so the join-event behavior is unit-testable
+ * without dragging the whole NextAuth config (providers, env) into a test.
+ *
+ * Returns the workspaceId of the first accepted invite, if any (caller may
+ * want to set it as the user's default workspace).
+ */
+export async function acceptPendingInvitationsForUser(
+  db: PrismaClient,
+  userId: string,
+  email: string,
+): Promise<string | null> {
+  const now = new Date();
+  let firstAcceptedWorkspaceId: string | null = null;
+
+  try {
+    const pendingWorkspaceInvites = await db.workspaceInvitation.findMany({
+      where: { email, status: "pending", expiresAt: { gt: now } },
+      orderBy: { createdAt: "asc" },
+    });
+
+    for (const invitation of pendingWorkspaceInvites) {
+      try {
+        // The upsert below no-ops for existing members, so remember whether
+        // this acceptance actually adds them — only real joins get a feed event.
+        const wasAlreadyMember =
+          (await db.workspaceUser.findUnique({
+            where: {
+              userId_workspaceId: {
+                userId,
+                workspaceId: invitation.workspaceId,
+              },
+            },
+            select: { userId: true },
+          })) !== null;
+
+        await db.$transaction([
+          db.workspaceInvitation.update({
+            where: { id: invitation.id },
+            data: { status: "accepted", acceptedAt: now },
+          }),
+          db.workspaceUser.upsert({
+            where: {
+              userId_workspaceId: {
+                userId,
+                workspaceId: invitation.workspaceId,
+              },
+            },
+            create: {
+              userId,
+              workspaceId: invitation.workspaceId,
+              role: invitation.role,
+            },
+            update: {},
+          }),
+        ]);
+        if (!firstAcceptedWorkspaceId) {
+          firstAcceptedWorkspaceId = invitation.workspaceId;
+        }
+
+        // Mirror workspace.acceptInvitation: a "joined the workspace" event so
+        // auto-accepted invitees show up in the team feed too.
+        if (!wasAlreadyMember) {
+          const member = await db.user.findUnique({
+            where: { id: userId },
+            select: { name: true },
+          });
+          await recordActivity(db, {
+            workspaceId: invitation.workspaceId,
+            userId,
+            entityType: "workspace_member",
+            entityId: userId,
+            action: "created",
+            metadata: { name: member?.name ?? email },
+          });
+        }
+      } catch (error) {
+        console.error(
+          `[Auth] Failed to auto-accept workspace invitation ${invitation.id}:`,
+          error
+        );
+      }
+    }
+
+    const pendingTeamInvites = await db.teamInvitation.findMany({
+      where: { email, status: "pending", expiresAt: { gt: now } },
+    });
+
+    for (const invitation of pendingTeamInvites) {
+      try {
+        await db.$transaction([
+          db.teamInvitation.update({
+            where: { id: invitation.id },
+            data: { status: "accepted", acceptedAt: now },
+          }),
+          db.teamUser.upsert({
+            where: {
+              userId_teamId: { userId, teamId: invitation.teamId },
+            },
+            create: { userId, teamId: invitation.teamId, role: invitation.role },
+            update: {},
+          }),
+        ]);
+      } catch (error) {
+        console.error(
+          `[Auth] Failed to auto-accept team invitation ${invitation.id}:`,
+          error
+        );
+      }
+    }
+  } catch (error) {
+    console.error("[Auth] Failed to process pending invitations:", error);
+  }
+
+  return firstAcceptedWorkspaceId;
+}

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -8,6 +8,7 @@ import NotionProvider from "next-auth/providers/notion";
 import Postmark from "next-auth/providers/postmark";
 
 import { db } from "~/server/db";
+import { recordActivity } from "~/server/services/activity/recordActivity";
 import { sendSignInCodeEmail, sendWelcomeEmail, sendWelcomeWithSignInCodeEmail } from "~/server/services/EmailService";
 import { generateSignInCode, SIGN_IN_CODE_TTL_SECONDS } from "~/lib/signInCode";
 import { verifyAuthCode, verifyPkce } from "~/server/utils/native-auth";
@@ -46,6 +47,19 @@ async function acceptPendingInvitationsForUser(
 
     for (const invitation of pendingWorkspaceInvites) {
       try {
+        // The upsert below no-ops for existing members, so remember whether
+        // this acceptance actually adds them — only real joins get a feed event.
+        const wasAlreadyMember =
+          (await db.workspaceUser.findUnique({
+            where: {
+              userId_workspaceId: {
+                userId,
+                workspaceId: invitation.workspaceId,
+              },
+            },
+            select: { userId: true },
+          })) !== null;
+
         await db.$transaction([
           db.workspaceInvitation.update({
             where: { id: invitation.id },
@@ -68,6 +82,23 @@ async function acceptPendingInvitationsForUser(
         ]);
         if (!firstAcceptedWorkspaceId) {
           firstAcceptedWorkspaceId = invitation.workspaceId;
+        }
+
+        // Mirror workspace.acceptInvitation: a "joined the workspace" event so
+        // auto-accepted invitees show up in the team feed too.
+        if (!wasAlreadyMember) {
+          const member = await db.user.findUnique({
+            where: { id: userId },
+            select: { name: true },
+          });
+          await recordActivity(db, {
+            workspaceId: invitation.workspaceId,
+            userId,
+            entityType: "workspace_member",
+            entityId: userId,
+            action: "created",
+            metadata: { name: member?.name ?? email },
+          });
         }
       } catch (error) {
         console.error(

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -8,7 +8,7 @@ import NotionProvider from "next-auth/providers/notion";
 import Postmark from "next-auth/providers/postmark";
 
 import { db } from "~/server/db";
-import { recordActivity } from "~/server/services/activity/recordActivity";
+import { acceptPendingInvitationsForUser } from "~/server/auth/acceptPendingInvitations";
 import { sendSignInCodeEmail, sendWelcomeEmail, sendWelcomeWithSignInCodeEmail } from "~/server/services/EmailService";
 import { generateSignInCode, SIGN_IN_CODE_TTL_SECONDS } from "~/lib/signInCode";
 import { verifyAuthCode, verifyPkce } from "~/server/utils/native-auth";
@@ -22,124 +22,6 @@ import { verifyAuthCode, verifyPkce } from "~/server/utils/native-auth";
  * (`getConfiguredProviders`) so the UI button stays in sync.
  */
 export const MICROSOFT_LOGIN_ENABLED = false;
-
-/**
- * Auto-accept any pending workspace and team invitations matching this user's
- * email. Covers the case where an invitee signs up (or signs in) via a route
- * other than the invite accept page — e.g. OAuth, direct magic link, or a
- * magic link whose callbackUrl no longer points at /invite/<token>.
- *
- * Returns the workspaceId of the first accepted invite, if any (caller may
- * want to set it as the user's default workspace).
- */
-async function acceptPendingInvitationsForUser(
-  userId: string,
-  email: string
-): Promise<string | null> {
-  const now = new Date();
-  let firstAcceptedWorkspaceId: string | null = null;
-
-  try {
-    const pendingWorkspaceInvites = await db.workspaceInvitation.findMany({
-      where: { email, status: "pending", expiresAt: { gt: now } },
-      orderBy: { createdAt: "asc" },
-    });
-
-    for (const invitation of pendingWorkspaceInvites) {
-      try {
-        // The upsert below no-ops for existing members, so remember whether
-        // this acceptance actually adds them — only real joins get a feed event.
-        const wasAlreadyMember =
-          (await db.workspaceUser.findUnique({
-            where: {
-              userId_workspaceId: {
-                userId,
-                workspaceId: invitation.workspaceId,
-              },
-            },
-            select: { userId: true },
-          })) !== null;
-
-        await db.$transaction([
-          db.workspaceInvitation.update({
-            where: { id: invitation.id },
-            data: { status: "accepted", acceptedAt: now },
-          }),
-          db.workspaceUser.upsert({
-            where: {
-              userId_workspaceId: {
-                userId,
-                workspaceId: invitation.workspaceId,
-              },
-            },
-            create: {
-              userId,
-              workspaceId: invitation.workspaceId,
-              role: invitation.role,
-            },
-            update: {},
-          }),
-        ]);
-        if (!firstAcceptedWorkspaceId) {
-          firstAcceptedWorkspaceId = invitation.workspaceId;
-        }
-
-        // Mirror workspace.acceptInvitation: a "joined the workspace" event so
-        // auto-accepted invitees show up in the team feed too.
-        if (!wasAlreadyMember) {
-          const member = await db.user.findUnique({
-            where: { id: userId },
-            select: { name: true },
-          });
-          await recordActivity(db, {
-            workspaceId: invitation.workspaceId,
-            userId,
-            entityType: "workspace_member",
-            entityId: userId,
-            action: "created",
-            metadata: { name: member?.name ?? email },
-          });
-        }
-      } catch (error) {
-        console.error(
-          `[Auth] Failed to auto-accept workspace invitation ${invitation.id}:`,
-          error
-        );
-      }
-    }
-
-    const pendingTeamInvites = await db.teamInvitation.findMany({
-      where: { email, status: "pending", expiresAt: { gt: now } },
-    });
-
-    for (const invitation of pendingTeamInvites) {
-      try {
-        await db.$transaction([
-          db.teamInvitation.update({
-            where: { id: invitation.id },
-            data: { status: "accepted", acceptedAt: now },
-          }),
-          db.teamUser.upsert({
-            where: {
-              userId_teamId: { userId, teamId: invitation.teamId },
-            },
-            create: { userId, teamId: invitation.teamId, role: invitation.role },
-            update: {},
-          }),
-        ]);
-      } catch (error) {
-        console.error(
-          `[Auth] Failed to auto-accept team invitation ${invitation.id}:`,
-          error
-        );
-      }
-    }
-  } catch (error) {
-    console.error("[Auth] Failed to process pending invitations:", error);
-  }
-
-  return firstAcceptedWorkspaceId;
-}
 
 /**
  * Module augmentation for `next-auth` types. Allows us to add custom properties to the `session`
@@ -448,7 +330,7 @@ export const authConfig = {
       });
 
       // Auto-accept any pending invitations that arrived after the user signed up
-      await acceptPendingInvitationsForUser(existingUser.id, user.email);
+      await acceptPendingInvitationsForUser(db, existingUser.id, user.email);
 
       // If user exists and this is the same provider they used before, allow sign in
       if (existingUser && account?.provider) {
@@ -536,6 +418,7 @@ export const authConfig = {
       // Prefer an invited workspace as the user's default so they land there
       // instead of their empty Personal workspace after sign-up.
       const firstAcceptedWorkspaceId = await acceptPendingInvitationsForUser(
+        db,
         user.id,
         user.email
       );

--- a/src/server/utils/__tests__/tokens.test.ts
+++ b/src/server/utils/__tests__/tokens.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { generateInviteUrl, generateTeamInviteUrl } from "../tokens";
+
+// tokens.ts pulls in ~/lib/urls, whose request-scoped half imports
+// next/headers; the env-only helper under test never calls it.
+vi.mock("next/headers", () => ({ headers: () => new Headers() }));
+
+describe("invite URL generation", () => {
+  const originalNextAuthUrl = process.env.NEXTAUTH_URL;
+  const originalPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+  beforeEach(() => {
+    delete process.env.NEXTAUTH_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  });
+
+  afterEach(() => {
+    if (originalNextAuthUrl === undefined) delete process.env.NEXTAUTH_URL;
+    else process.env.NEXTAUTH_URL = originalNextAuthUrl;
+    if (originalPublicAppUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
+    else process.env.NEXT_PUBLIC_APP_URL = originalPublicAppUrl;
+  });
+
+  it("uses the public app URL when NEXTAUTH_URL is unset", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+
+    expect(generateInviteUrl("tok123")).toBe(
+      "https://app.example.com/invite/tok123",
+    );
+    expect(generateTeamInviteUrl("tok123")).toBe(
+      "https://app.example.com/team-invite/tok123",
+    );
+  });
+
+  it("ignores NEXTAUTH_URL entirely", () => {
+    process.env.NEXTAUTH_URL = "http://localhost:3000";
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+
+    expect(generateInviteUrl("tok123")).toBe(
+      "https://app.example.com/invite/tok123",
+    );
+  });
+
+  it("falls back to the production URL when no env is set", () => {
+    expect(generateInviteUrl("tok123")).toBe(
+      "https://www.exponential.im/invite/tok123",
+    );
+  });
+});

--- a/src/server/utils/reportHandledErrorServer.ts
+++ b/src/server/utils/reportHandledErrorServer.ts
@@ -1,0 +1,92 @@
+import * as Sentry from "@sentry/nextjs";
+
+import { db } from "~/server/db";
+import { ingestSentryBug } from "~/server/services/sentry/SentryBugService";
+import {
+  buildClientErrorBody,
+  buildClientErrorBug,
+  shouldFileClientError,
+  type ClientErrorReport,
+} from "~/server/services/clientErrors/clientErrorBug";
+
+/**
+ * Server-side twin of `~/lib/reportHandledError`.
+ *
+ * The client helper reports its Bug-ticket half through a relative
+ * `fetch("/api/client-errors")` — which on the server rejects outright
+ * (undici needs an absolute URL) and would be unauthenticated anyway (no
+ * session cookie rides a server-originated fetch). So server call sites use
+ * this variant, which captures to Sentry the same way and files the Bug
+ * Ticket by calling the same services the route handler wraps.
+ *
+ * Same contract: best-effort by construction — reporting an error must never
+ * raise one, so every failure here is swallowed. Same `CLIENT_ERROR_BUGS`
+ * env gate as the route, so per-environment filing stays one decision.
+ */
+
+/** Same "bug" labels the /api/client-errors route files under. */
+const CLIENT_ERROR_LABELS = [
+  { name: "client-error", slug: "client-error", color: "avatar-orange" },
+  { name: "bug", slug: "bug", color: "avatar-red" },
+] as const;
+
+function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (typeof error === "number" || typeof error === "boolean") return String(error);
+  if (typeof error === "object" && error !== null) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+    try {
+      return JSON.stringify(error).slice(0, 500);
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+export function reportHandledErrorServer(
+  error: unknown,
+  options: {
+    /** Where this happened — becomes the ticket's culprit and part of its dedup key. */
+    area: string;
+    /** The classification the caller already made, if any. Governs whether a ticket is filed at all. */
+    kind?: string;
+    /** Extra context rendered in the ticket body and attached to the Sentry event. */
+    context?: Record<string, string>;
+  },
+): void {
+  const { area, kind, context } = options;
+
+  try {
+    Sentry.captureException(error, {
+      tags: { area, ...(kind ? { failureKind: kind } : {}) },
+      ...(context ? { extra: context } : {}),
+    });
+  } catch {
+    // A Sentry SDK that isn't initialised, or a transport that refuses.
+  }
+
+  if (!process.env.CLIENT_ERROR_BUGS) return;
+  if (!shouldFileClientError(kind)) return;
+
+  const message = messageOf(error);
+  if (!message.trim()) return;
+
+  const report: ClientErrorReport = {
+    area,
+    kind,
+    message: message.slice(0, 2000),
+    context,
+  };
+
+  // Fire-and-forget, like the client helper's fetch. Dedup on the error
+  // fingerprint happens inside ingestSentryBug.
+  void ingestSentryBug(db, buildClientErrorBug(report), {
+    body: buildClientErrorBody(report),
+    labels: CLIENT_ERROR_LABELS,
+  }).catch((ingestError: unknown) => {
+    console.error(`[reportHandledErrorServer] could not file a bug (${area}):`, ingestError);
+  });
+}

--- a/src/server/utils/tokens.ts
+++ b/src/server/utils/tokens.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "crypto";
+import { getPublicBaseUrlFromEnv } from "~/lib/urls";
 
 /**
  * Generate a cryptographically secure random token
@@ -9,12 +10,13 @@ export function generateSecureToken(length = 32): string {
 }
 
 /**
- * Generate an invite URL with the given token
+ * Generate an invite URL with the given token. Uses the shared public-base-URL
+ * helper (NEXT_PUBLIC_APP_URL, prod fallback) — never NEXTAUTH_URL, which is
+ * unset in some deploys and would send invite emails to localhost.
  * @param token - The invitation token
  */
 export function generateInviteUrl(token: string): string {
-  const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
-  return `${baseUrl}/invite/${token}`;
+  return `${getPublicBaseUrlFromEnv()}/invite/${token}`;
 }
 
 /**
@@ -22,6 +24,5 @@ export function generateInviteUrl(token: string): string {
  * @param token - The team invitation token
  */
 export function generateTeamInviteUrl(token: string): string {
-  const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
-  return `${baseUrl}/team-invite/${token}`;
+  return `${getPublicBaseUrlFromEnv()}/team-invite/${token}`;
 }


### PR DESCRIPTION
## What

Six small, independent fixes that make the invite → signup → first session coherent. One commit per fix:

1. **"I'll explore on my own" is a real exit** — marks welcome complete (`user.completeWelcome`) and navigates to the default workspace home; rendered as a persistent quiet link in both the Chat and Checklist welcome views.
2. **No more "Invitation Already Used" dead end** — a logged-in invitee (or existing member) opening an accepted invite link is redirected straight to `/w/<slug>`; `getInvitationByToken` now reports viewer membership.
3. **Join activity for auto-accepted invites** — `acceptPendingInvitationsForUser` now emits the same `workspace_member joined` event as `workspace.acceptInvitation`, so invite signups appear in the team feed.
4. **Invite links use the shared public-URL helper** — `generateInviteUrl` / `generateTeamInviteUrl` no longer read `NEXTAUTH_URL` (localhost fallback); covered by unit tests.
5. **Invite email failures are reported** — all five invite / member-added send sites route their catch through `reportHandledError()` (Sentry + Bug ticket) instead of only console-logging; the mutations still succeed.
6. **Onboarding artifacts stay private** — `welcome.createGoal` / `createAction` land in the user's personal workspace when their default workspace is a shared team/organization workspace.

## Acceptance criteria

- [x] Clicking "I'll explore on my own" leaves /welcome, sets `welcomeCompletedAt`, and the affordance exists in both welcome views
- [x] A logged-in invitee opening an already-used invite link lands in the workspace without a manual click
- [x] Invites auto-accepted at signup produce a workspace-member joined activity event visible in the team feed
- [x] Invite emails link to the public app URL regardless of `NEXTAUTH_URL`
- [x] A failed invite/member-added email send is reported via `reportHandledError()` (Sentry + Bug ticket), not just logged
- [x] Onboarding goal/action never become visible to other members of a shared workspace

All six verified against a local dev server (real NextAuth sign-in for the auto-accept path, forced Postmark failure for the email path, per-member goal-listing check for workspace privacy).

---

Ships: slow.drift

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cmsq4agbk000pju048d2och6q)
