### PR TITLE
fix: GitHub webhook fails closed; shared constant-time signature compare

### DIFF
--- a/src/app/api/webhooks/fireflies/route.ts
+++ b/src/app/api/webhooks/fireflies/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { createHmac } from 'crypto';
+import { safeSignatureEquals } from '~/server/utils/webhookSignature';
 import { type Prisma } from '@prisma/client';
 import { db } from '~/server/db';
 import { FirefliesService, type FirefliesTranscript } from '~/server/services/FirefliesService';
@@ -57,9 +58,9 @@ function verifySignatureWithApiKey(payload: string, signature: string, apiKey: s
     
     // Format as expected by Fireflies (with sha256= prefix)
     const expectedSignature = `sha256=${computedSignature}`;
-    
+
     // Constant-time comparison to prevent timing attacks
-    return signature === expectedSignature;
+    return safeSignatureEquals(signature, expectedSignature);
   } catch (error) {
     console.error('Error verifying signature:', error);
     return false;

--- a/src/app/api/webhooks/github/__tests__/route.test.ts
+++ b/src/app/api/webhooks/github/__tests__/route.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for the GitHub webhook's signature verification (public-launch
+ * hardening, ticket quiet.panther).
+ *
+ * The receiver must fail CLOSED when GITHUB_WEBHOOK_SECRET is unset (503,
+ * matching the Notion and Sentry receivers), reject malformed signatures with
+ * a 401 rather than throwing, and accept only correctly signed deliveries.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createHmac } from "crypto";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+vi.mock("~/server/services/github-integration", () => ({
+  githubIntegrationService: {},
+}));
+vi.mock("~/server/services/GitHubActivityService", () => ({
+  githubActivityService: {
+    processPushEvent: vi.fn(),
+    processPullRequestEvent: vi.fn(),
+    processPullRequestReviewEvent: vi.fn(),
+  },
+}));
+
+import type { NextRequest } from "next/server";
+import { POST } from "../route";
+
+const SECRET = "test-github-webhook-secret";
+const PING_BODY = JSON.stringify({ zen: "Keep it logically awesome." });
+
+function sign(body: string, secret: string): string {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+function makeRequest(opts: {
+  body?: string;
+  signature?: string | null;
+  event?: string | null;
+  delivery?: string | null;
+}) {
+  const body = opts.body ?? PING_BODY;
+  const headers = new Headers({ "content-type": "application/json" });
+  if (opts.signature) headers.set("x-hub-signature-256", opts.signature);
+  if (opts.event !== null) headers.set("x-github-event", opts.event ?? "ping");
+  if (opts.delivery !== null)
+    headers.set("x-github-delivery", opts.delivery ?? "test-delivery-1");
+  return new Request("http://localhost/api/webhooks/github", {
+    method: "POST",
+    headers,
+    body,
+  }) as unknown as NextRequest;
+}
+
+describe("GitHub webhook signature verification", () => {
+  const originalSecret = process.env.GITHUB_WEBHOOK_SECRET;
+
+  beforeEach(() => {
+    mockReset(getDbMock());
+    process.env.GITHUB_WEBHOOK_SECRET = SECRET;
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) delete process.env.GITHUB_WEBHOOK_SECRET;
+    else process.env.GITHUB_WEBHOOK_SECRET = originalSecret;
+  });
+
+  it("accepts a correctly signed delivery", async () => {
+    const res = await POST(makeRequest({ signature: sign(PING_BODY, SECRET) }));
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a delivery signed under the wrong secret with 401", async () => {
+    const res = await POST(
+      makeRequest({ signature: sign(PING_BODY, "some-other-secret") }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a malformed, short signature with 401 instead of throwing", async () => {
+    // timingSafeEqual throws on length mismatch; a truncated header used to
+    // surface as an unhandled exception and a 500.
+    const res = await POST(makeRequest({ signature: "sha256=abc" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a signature with the wrong prefix and length with 401", async () => {
+    const res = await POST(
+      makeRequest({ signature: sign(PING_BODY, SECRET).replace("sha256=", "sha1=") }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("refuses every request with 503 when GITHUB_WEBHOOK_SECRET is unset", async () => {
+    delete process.env.GITHUB_WEBHOOK_SECRET;
+    // Even a correctly signed request must be refused: with no configured
+    // secret there is nothing trustworthy to verify against.
+    const res = await POST(makeRequest({ signature: sign(PING_BODY, SECRET) }));
+    expect(res.status).toBe(503);
+  });
+
+  it("rejects a request missing the signature header with 400", async () => {
+    const res = await POST(makeRequest({ signature: null }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -3,35 +3,42 @@ import crypto from "crypto";
 import { db } from "~/server/db";
 import { githubIntegrationService } from "~/server/services/github-integration";
 import { githubActivityService } from "~/server/services/GitHubActivityService";
+import { safeSignatureEquals } from "~/server/utils/webhookSignature";
 
-const WEBHOOK_SECRET = process.env.GITHUB_WEBHOOK_SECRET!;
-
-function verifySignature(payload: string, signature: string): boolean {
-  if (!WEBHOOK_SECRET) {
-    console.warn(
-      "GITHUB_WEBHOOK_SECRET not set - skipping signature verification",
-    );
-    return true; // Allow in development
-  }
-
+function verifySignature(
+  payload: string,
+  signature: string,
+  secret: string,
+): boolean {
   const expectedSignature =
     "sha256=" +
-    crypto.createHmac("sha256", WEBHOOK_SECRET).update(payload).digest("hex");
+    crypto.createHmac("sha256", secret).update(payload).digest("hex");
 
-  return crypto.timingSafeEqual(
-    Buffer.from(signature),
-    Buffer.from(expectedSignature),
-  );
+  return safeSignatureEquals(signature, expectedSignature);
 }
 
 export async function POST(request: NextRequest) {
   try {
+    // Fail closed: without the shared secret we cannot verify a single
+    // delivery, so we must never process one (same rule as the Notion and
+    // Sentry receivers).
+    const secret = process.env.GITHUB_WEBHOOK_SECRET;
+    if (!secret) {
+      console.error(
+        "[GitHubWebhook] GITHUB_WEBHOOK_SECRET is not configured — refusing to process events",
+      );
+      return NextResponse.json(
+        { error: "GITHUB_WEBHOOK_SECRET is not configured" },
+        { status: 503 },
+      );
+    }
+
     const signature = request.headers.get("x-hub-signature-256");
     const event = request.headers.get("x-github-event");
     const delivery = request.headers.get("x-github-delivery");
 
     if (!signature || !event || !delivery) {
-      console.error("Mission required headers", request.headers);
+      console.error("Missing required headers", request.headers);
       return NextResponse.json(
         { error: "Missing required headers" },
         { status: 400 },
@@ -41,7 +48,7 @@ export async function POST(request: NextRequest) {
     const payload = await request.text();
 
     // Verify webhook signature
-    if (!verifySignature(payload, signature)) {
+    if (!verifySignature(payload, signature, secret)) {
       console.error("Invalid webhook signature");
       return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
     }

--- a/src/app/api/webhooks/notion/route.ts
+++ b/src/app/api/webhooks/notion/route.ts
@@ -1,5 +1,6 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac } from "node:crypto";
 import { type NextRequest, NextResponse } from "next/server";
+import { safeSignatureEquals } from "~/server/utils/webhookSignature";
 
 import { db } from "~/server/db";
 import {
@@ -113,8 +114,5 @@ function verifySignature(raw: string, header: string, secret: string): boolean {
   const expected = `sha256=${createHmac("sha256", secret).update(raw).digest("hex")}`;
   const provided = header.includes("=") ? header : `sha256=${header}`;
 
-  const expectedBuf = Buffer.from(expected);
-  const providedBuf = Buffer.from(provided);
-  if (expectedBuf.length !== providedBuf.length) return false;
-  return timingSafeEqual(expectedBuf, providedBuf);
+  return safeSignatureEquals(provided, expected);
 }

--- a/src/app/api/webhooks/slack/route.ts
+++ b/src/app/api/webhooks/slack/route.ts
@@ -7,6 +7,7 @@ import { appRouter } from '~/server/api/root';
 import { parseActionInput } from '~/server/services/parsing';
 import { SlackChannelResolver } from '~/server/services/SlackChannelResolver';
 import { getDecryptedKey } from '~/server/utils/credentialHelper';
+import { safeSignatureEquals } from '~/server/utils/webhookSignature';
 import { PRODUCT_NAME } from '~/lib/brand';
 import { getPublicBaseUrlFromEnv } from '~/lib/urls';
 
@@ -271,10 +272,9 @@ function verifySlackSignature(payload: string, timestamp: string, signature: str
     const computedSignature = `v0=${createHmac('sha256', signingSecret)
       .update(baseString, 'utf8')
       .digest('hex')}`;
-    
-    
+
     // Constant-time comparison
-    return signature === computedSignature;
+    return safeSignatureEquals(signature, computedSignature);
   } catch (error) {
     console.error('Error verifying Slack signature:', error);
     return false;

--- a/src/server/utils/__tests__/webhookSignature.test.ts
+++ b/src/server/utils/__tests__/webhookSignature.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { safeSignatureEquals } from "../webhookSignature";
+
+describe("safeSignatureEquals", () => {
+  it("matches identical strings", () => {
+    expect(safeSignatureEquals("sha256=abcdef", "sha256=abcdef")).toBe(true);
+  });
+
+  it("rejects differing strings of equal length", () => {
+    expect(safeSignatureEquals("sha256=abcdef", "sha256=abcdeg")).toBe(false);
+  });
+
+  it("rejects a shorter string without throwing", () => {
+    // crypto.timingSafeEqual throws on length mismatch — the helper must not.
+    expect(safeSignatureEquals("sha256=a", "sha256=abcdef")).toBe(false);
+  });
+
+  it("rejects a longer string without throwing", () => {
+    expect(safeSignatureEquals("sha256=abcdefabcdef", "sha256=abcdef")).toBe(false);
+  });
+
+  it("rejects the empty string against a non-empty expected value", () => {
+    expect(safeSignatureEquals("", "sha256=abcdef")).toBe(false);
+  });
+});

--- a/src/server/utils/webhookSignature.ts
+++ b/src/server/utils/webhookSignature.ts
@@ -1,0 +1,17 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Constant-time equality for webhook signature strings.
+ *
+ * `crypto.timingSafeEqual` throws when the buffers differ in length, so a
+ * truncated or malformed signature header would turn into a 500 instead of a
+ * 401. Compare lengths first — a length mismatch is simply "no match". The
+ * length check leaks only the expected signature's length, which is public
+ * anyway (a hex HMAC digest of known algorithm).
+ */
+export function safeSignatureEquals(provided: string, expected: string): boolean {
+  const providedBuf = Buffer.from(provided);
+  const expectedBuf = Buffer.from(expected);
+  if (providedBuf.length !== expectedBuf.length) return false;
+  return timingSafeEqual(providedBuf, expectedBuf);
+}


### PR DESCRIPTION
## What

Three fixes to webhook signature verification, converging all receivers on one verified pattern:

**GitHub fails open → now fails closed.** `verifySignature()` returned `true` whenever `GITHUB_WEBHOOK_SECRET` was unset ("allow in development" — but with no environment guard, so it behaved identically in production). A missing/misnamed env var on a deploy silently turned the endpoint into an unauthenticated write path into GitHub integration and activity ingestion. It now refuses with a 503 + error log, matching the Notion and Sentry receivers.

**Malformed signature → 401, not 500.** The caller-supplied signature went straight into `crypto.timingSafeEqual`, which throws on buffer-length mismatch, so a truncated `x-hub-signature-256` produced an unhandled exception. The new shared helper compares lengths first.

**Non-constant-time comparisons converted.** Fireflies and Slack compared HMACs with `===` (one even labelled "Constant-time comparison"); both now use the shared length-checked `timingSafeEqual` helper (`src/server/utils/webhookSignature.ts`), and Notion's correct local implementation was folded into it too.

## Acceptance criteria

- [x] A missing `GITHUB_WEBHOOK_SECRET` causes the route to refuse every request (fail closed, 503) and log an error, matching the Notion and Sentry receivers
- [x] A signature of the wrong length returns 401, not a 500
- [x] Fireflies and Slack signature comparisons are constant-time and length-checked
- [x] Unit tests cover: valid signature accepted, invalid signature rejected, malformed/short signature rejected without throwing, missing secret refuses the request
- [ ] A real GitHub delivery still processes successfully against a configured secret (verify post-deploy: GitHub App → Advanced → Recent Deliveries → Redeliver, expect 200)

---

Ships: quiet.panther
