### PR TITLE
refactor: durable rate limiting via shared Upstash-backed helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,8 @@
         "@trpc/server": "^11.0.0-rc.446",
         "@types/jsonwebtoken": "^9.0.9",
         "@types/turndown": "^5.0.6",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.38.2",
         "@vercel/analytics": "^1.5.0",
         "@vercel/blob": "^0.27.3",
         "@xyflow/react": "^12.10.2",
@@ -10447,6 +10449,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.2",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.2.tgz",
+      "integrity": "sha512-RZ+JaRCVIS+ZTGnjOnDMr+/0aqDxsBb5rV6aW+Pys4SGELwr5lwE3UbLHRCHqMQ5Ulxj0b/CFBHfbmE175Otog==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vercel/analytics": {
       "version": "1.5.0",
@@ -23747,6 +23782,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/underscore": {
       "version": "1.13.8",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,8 @@
     "@trpc/server": "^11.0.0-rc.446",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/turndown": "^5.0.6",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.2",
     "@vercel/analytics": "^1.5.0",
     "@vercel/blob": "^0.27.3",
     "@xyflow/react": "^12.10.2",

--- a/scripts/load-test-rate-limit.ts
+++ b/scripts/load-test-rate-limit.ts
@@ -1,0 +1,113 @@
+/**
+ * Verifies the shared rate limiter holds across serverless scale-out
+ * (ticket silver.brook, acceptance: "verified by a load test, not by unit
+ * tests alone").
+ *
+ * Fires N requests at a rate-limited endpoint with enough concurrency that
+ * Vercel fans them across multiple lambda instances, then reports the status
+ * distribution. With the OLD in-memory limiter each warm instance had its own
+ * window, so a burst comfortably exceeding the configured limit still saw
+ * ~zero 429s. With Upstash configured, allowed responses must not exceed the
+ * configured limit (small overshoot tolerated for sliding-window edges).
+ *
+ * Usage (against a preview or prod deploy — POSTs the forms endpoint by
+ * default, which is public):
+ *
+ *   npx tsx scripts/load-test-rate-limit.ts \
+ *     --url https://<deploy>/api/forms/<slug>/submit \
+ *     --count 30 --concurrency 10 --expect-limit 5
+ *
+ * Notes:
+ * - The forms endpoint's per-IP limit is 5/min, so from one machine 30
+ *   requests should yield ≤~6 non-429 responses when the shared store works.
+ * - Sends an intentionally empty body ({data:{}}), so allowed requests are
+ *   422 validation responses — they still consumed rate-limit budget. Counted
+ *   as "allowed" below. No submissions are created.
+ */
+
+interface Args {
+  url: string;
+  count: number;
+  concurrency: number;
+  expectLimit: number | null;
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const get = (flag: string): string | undefined => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  const url = get("--url");
+  if (!url) {
+    console.error(
+      "Usage: npx tsx scripts/load-test-rate-limit.ts --url <endpoint> [--count 30] [--concurrency 10] [--expect-limit 5]",
+    );
+    process.exit(1);
+  }
+  return {
+    url,
+    count: Number(get("--count") ?? 30),
+    concurrency: Number(get("--concurrency") ?? 10),
+    expectLimit: get("--expect-limit") ? Number(get("--expect-limit")) : null,
+  };
+}
+
+async function main() {
+  const args = parseArgs();
+  const statuses = new Map<number, number>();
+  let retryAfterSeen = false;
+
+  let next = 0;
+  async function worker() {
+    while (next < args.count) {
+      next += 1;
+      try {
+        const res = await fetch(args.url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ data: {} }),
+        });
+        statuses.set(res.status, (statuses.get(res.status) ?? 0) + 1);
+        if (res.status === 429 && res.headers.get("retry-after")) {
+          retryAfterSeen = true;
+        }
+      } catch (error) {
+        statuses.set(-1, (statuses.get(-1) ?? 0) + 1);
+        console.error("request failed:", error);
+      }
+    }
+  }
+
+  const started = Date.now();
+  await Promise.all(
+    Array.from({ length: args.concurrency }, () => worker()),
+  );
+  const elapsed = ((Date.now() - started) / 1000).toFixed(1);
+
+  const allowed = [...statuses.entries()]
+    .filter(([code]) => code !== 429 && code !== -1)
+    .reduce((sum, [, n]) => sum + n, 0);
+  const limited = statuses.get(429) ?? 0;
+
+  console.log(`\n${args.count} requests in ${elapsed}s → status counts:`);
+  for (const [code, n] of [...statuses.entries()].sort()) {
+    console.log(`  ${code === -1 ? "network-error" : code}: ${n}`);
+  }
+  console.log(`\nallowed (non-429): ${allowed}, limited (429): ${limited}`);
+  console.log(`429s carried Retry-After: ${retryAfterSeen ? "yes" : "NO"}`);
+
+  if (args.expectLimit !== null) {
+    // Sliding windows can let a couple extra through at the boundary.
+    const tolerance = Math.ceil(args.expectLimit * 0.4) + 1;
+    const holds = allowed <= args.expectLimit + tolerance;
+    console.log(
+      holds
+        ? `PASS: allowed ${allowed} ≤ limit ${args.expectLimit} (+${tolerance} tolerance) — the limit holds across instances`
+        : `FAIL: allowed ${allowed} > limit ${args.expectLimit} (+${tolerance} tolerance) — limits are NOT shared (is Upstash configured on this deploy?)`,
+    );
+    process.exit(holds ? 0 : 1);
+  }
+}
+
+void main();

--- a/src/app/_components/Chat.tsx
+++ b/src/app/_components/Chat.tsx
@@ -165,6 +165,15 @@ export default function Chat({ initialMessages, githubSettings, buttons }: ChatP
       });
 
       if (!response.ok) {
+        if (response.status === 429) {
+          const data = (await response.json().catch(() => null)) as
+            | { error?: string }
+            | null;
+          throw new Error(
+            data?.error ??
+              "You've hit the chat rate limit. Please wait a moment and try again.",
+          );
+        }
         throw new Error('Stream request failed');
       }
 

--- a/src/app/api/auth/extension-token/route.ts
+++ b/src/app/api/auth/extension-token/route.ts
@@ -2,35 +2,15 @@ import { type NextRequest, NextResponse } from "next/server";
 import { decode } from "next-auth/jwt";
 import { db } from "~/server/db";
 import { generateJWT } from "~/server/utils/jwt";
+import {
+  checkRateLimit,
+  clientIpFrom,
+  tooManyRequestsInit,
+} from "~/server/utils/rateLimit";
 
-// Simple in-memory rate limiter (best-effort on serverless)
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
-const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+// Shared-store rate limit on this token-issuing path (per IP).
+const RATE_LIMIT_WINDOW_SECONDS = 60;
 const RATE_LIMIT_MAX = 10;
-
-function isRateLimited(ip: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(ip);
-
-  if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-    return false;
-  }
-
-  entry.count++;
-  return entry.count > RATE_LIMIT_MAX;
-}
-
-// Periodic cleanup
-if (typeof globalThis !== "undefined") {
-  const cleanup = () => {
-    const now = Date.now();
-    for (const [ip, entry] of rateLimitMap.entries()) {
-      if (now > entry.resetAt) rateLimitMap.delete(ip);
-    }
-  };
-  setInterval(cleanup, 5 * 60_000).unref?.();
-}
 
 function getSessionCookieName(): string {
   const useSecureCookies =
@@ -80,15 +60,18 @@ export async function POST(request: NextRequest) {
 
   try {
     // Rate limiting
-    const ip =
-      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-      request.headers.get("x-real-ip") ??
-      "unknown";
+    const ip = clientIpFrom(request.headers);
 
-    if (isRateLimited(ip)) {
+    const rateCheck = await checkRateLimit({
+      name: "extension-token",
+      key: ip,
+      limit: RATE_LIMIT_MAX,
+      windowSeconds: RATE_LIMIT_WINDOW_SECONDS,
+    });
+    if (!rateCheck.success) {
       return NextResponse.json(
         { error: "Too many requests" },
-        { status: 429, headers: { ...corsHeaders, "Retry-After": "60" } },
+        tooManyRequestsInit(rateCheck, corsHeaders),
       );
     }
 

--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -10,6 +10,7 @@ interface CoreMessage {
 }
 import { auth } from "~/server/auth";
 import { generateAgentJWT } from "~/server/utils/jwt";
+import { checkRateLimit, clientIpFrom } from "~/server/utils/rateLimit";
 import { db } from "~/server/db";
 import { getDecryptedKey } from "~/server/utils/credentialHelper";
 import { sanitizeAIOutput } from "~/lib/sanitize-output";
@@ -36,6 +37,11 @@ const MASTRA_API_URL = process.env.MASTRA_API_URL ?? "http://localhost:4111";
 
 // Extend Vercel function timeout for streaming AI responses (default is 10s hobby / 60s pro)
 export const maxDuration = 300;
+
+// Chat rate limits (see the block in POST for the spend rationale).
+const CHAT_BURST_LIMIT = 20; // per user per minute
+const CHAT_DAILY_LIMIT = 500; // per user per day
+const CHAT_IP_BURST_LIMIT = 60; // per IP per minute — several users can share an office IP
 
 /**
  * Resolve a Slack channel name (e.g., "#commons-lab-exec") to its channel ID (e.g., "C08XXXXXX")
@@ -96,6 +102,53 @@ export async function POST(req: Request) {
         status: 401,
         headers: { "Content-Type": "application/json" },
       });
+    }
+
+    // Rate limits on the LLM-spend path (this route had none — a single
+    // caller could run up the model bill without ceiling). Three layers,
+    // cheapest proxy for spend we have without a billing store:
+    //  - per-user burst:  CHAT_BURST_LIMIT msgs / minute
+    //  - per-user daily:  CHAT_DAILY_LIMIT msgs / day — with the per-request
+    //    cost ceiling alerted on in computeRequestCost, this bounds one
+    //    user's worst-case daily spend at CHAT_DAILY_LIMIT × that ceiling.
+    //  - per-IP burst: same as user burst but keyed by IP, so a farm of
+    //    sessions behind one address is still capped.
+    const ip = clientIpFrom(req.headers);
+    const [userBurst, userDaily, ipBurst] = await Promise.all([
+      checkRateLimit({
+        name: "chat-user",
+        key: session.user.id,
+        limit: CHAT_BURST_LIMIT,
+        windowSeconds: 60,
+      }),
+      checkRateLimit({
+        name: "chat-user-daily",
+        key: session.user.id,
+        limit: CHAT_DAILY_LIMIT,
+        windowSeconds: 24 * 60 * 60,
+      }),
+      checkRateLimit({
+        name: "chat-ip",
+        key: ip,
+        limit: CHAT_IP_BURST_LIMIT,
+        windowSeconds: 60,
+      }),
+    ]);
+    const blocked = [userBurst, userDaily, ipBurst].find((r) => !r.success);
+    if (blocked) {
+      return new Response(
+        JSON.stringify({
+          error:
+            "You've hit the chat rate limit. Please wait a moment and try again.",
+        }),
+        {
+          status: 429,
+          headers: {
+            "Content-Type": "application/json",
+            "Retry-After": String(blocked.retryAfterSeconds || 60),
+          },
+        },
+      );
     }
 
     const { messages, agentId: rawAgentId, assistantId, workspaceId, projectId, conversationId, platform: rawPlatform } = (await req.json()) as {

--- a/src/app/api/client-errors/route.ts
+++ b/src/app/api/client-errors/route.ts
@@ -10,6 +10,7 @@ import {
   shouldFileClientError,
   type ClientErrorReport,
 } from "~/server/services/clientErrors/clientErrorBug";
+import { checkRateLimit } from "~/server/utils/rateLimit";
 
 /**
  * Files a failure the browser handled gracefully as a Bug Ticket.
@@ -43,24 +44,12 @@ const ReportSchema = z.object({
  * fingerprint — so this only bites when a single user produces many *distinct*
  * errors, which is the runaway case worth stopping.
  *
- * In-memory, so it is per server instance and resets on deploy. That is weaker
- * than it looks on serverless, and deliberately not a database round-trip on a
- * path whose whole job is to be cheap and best-effort. Dedup is the real
- * defence; this is the backstop.
+ * Shared across instances via ~/server/utils/rateLimit (Upstash), so the
+ * ceiling holds under serverless scale-out. Dedup is the real defence; this
+ * is the backstop.
  */
 const MAX_REPORTS_PER_WINDOW = 20;
-const WINDOW_MS = 60 * 60 * 1000;
-const recentByUser = new Map<string, { count: number; resetAt: number }>();
-
-function overRateLimit(userId: string, now: number): boolean {
-  const entry = recentByUser.get(userId);
-  if (!entry || now >= entry.resetAt) {
-    recentByUser.set(userId, { count: 1, resetAt: now + WINDOW_MS });
-    return false;
-  }
-  entry.count += 1;
-  return entry.count > MAX_REPORTS_PER_WINDOW;
-}
+const WINDOW_SECONDS = 60 * 60;
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!process.env.CLIENT_ERROR_BUGS) {
@@ -84,8 +73,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ filed: false, reason: "not-reportable" });
   }
 
-  if (overRateLimit(session.user.id, Date.now())) {
+  const rateCheck = await checkRateLimit({
+    name: "client-errors",
+    key: session.user.id,
+    limit: MAX_REPORTS_PER_WINDOW,
+    windowSeconds: WINDOW_SECONDS,
+  });
+  if (!rateCheck.success) {
     console.warn(`[client-errors] rate limit hit for user ${session.user.id}`);
+    // Deliberately 200: the reporter is fire-and-forget and must not care.
     return NextResponse.json({ filed: false, reason: "rate-limited" });
   }
 

--- a/src/app/api/forms/[slug]/submit/route.ts
+++ b/src/app/api/forms/[slug]/submit/route.ts
@@ -9,65 +9,42 @@ import {
 import { runFormDestinations } from "~/server/services/forms/runDestinations";
 import { emailHashFor } from "~/server/services/crm/createCrmContact";
 import { isTooFastSubmission } from "~/server/services/forms/timeTrap";
+import {
+  checkRateLimit,
+  clientIpFrom,
+  tooManyRequestsInit,
+} from "~/server/utils/rateLimit";
 
 /**
  * Public **Forms intake** (ADR-0029): POST /api/forms/[slug]/submit. Validates
  * against the form's field schema, stores a FormSubmission, then runs the form's
  * destinations synchronously. Unauthenticated — protected by a hidden honeypot
- * field + per-IP/per-email rate limiting (in-memory; ADR-0030 notes Upstash as
- * the real fix).
+ * field, a time trap, and per-IP/per-email rate limiting shared across
+ * instances (ADR-0030/0036: Upstash via ~/server/utils/rateLimit).
  */
 export const dynamic = "force-dynamic";
 
-type LimitMap = Map<string, { count: number; resetAt: number }>;
-const ipLimitMap: LimitMap = new Map();
-const emailLimitMap: LimitMap = new Map();
-const WINDOW_MS = 60_000;
+const WINDOW_SECONDS = 60;
 const IP_MAX = 5;
 const EMAIL_MAX = 3;
-
-function limited(map: LimitMap, key: string, max: number): boolean {
-  const now = Date.now();
-  const entry = map.get(key);
-  if (!entry || now > entry.resetAt) {
-    map.set(key, { count: 1, resetAt: now + WINDOW_MS });
-    return false;
-  }
-  entry.count++;
-  return entry.count > max;
-}
-
-if (typeof globalThis !== "undefined") {
-  const cleanup = () => {
-    const now = Date.now();
-    for (const map of [ipLimitMap, emailLimitMap]) {
-      for (const [key, entry] of map.entries()) {
-        if (now > entry.resetAt) map.delete(key);
-      }
-    }
-  };
-  setInterval(cleanup, 5 * 60_000).unref?.();
-}
-
-function clientIp(request: NextRequest): string {
-  return (
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    request.headers.get("x-real-ip") ??
-    "unknown"
-  );
-}
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ slug: string }> },
 ) {
   const { slug } = await params;
-  const ip = clientIp(request);
+  const ip = clientIpFrom(request.headers);
 
-  if (limited(ipLimitMap, ip, IP_MAX)) {
+  const ipCheck = await checkRateLimit({
+    name: "forms-ip",
+    key: ip,
+    limit: IP_MAX,
+    windowSeconds: WINDOW_SECONDS,
+  });
+  if (!ipCheck.success) {
     return NextResponse.json(
       { ok: false, error: "Too many submissions. Please try again shortly." },
-      { status: 429 },
+      tooManyRequestsInit(ipCheck),
     );
   }
 
@@ -144,11 +121,19 @@ export async function POST(
     emailField && typeof validation.clean[emailField.key] === "string"
       ? (validation.clean[emailField.key] as string)
       : null;
-  if (email && limited(emailLimitMap, email, EMAIL_MAX)) {
-    return NextResponse.json(
-      { ok: false, error: "Too many submissions for this email." },
-      { status: 429 },
-    );
+  if (email) {
+    const emailCheck = await checkRateLimit({
+      name: "forms-email",
+      key: email.toLowerCase(),
+      limit: EMAIL_MAX,
+      windowSeconds: WINDOW_SECONDS,
+    });
+    if (!emailCheck.success) {
+      return NextResponse.json(
+        { ok: false, error: "Too many submissions for this email." },
+        tooManyRequestsInit(emailCheck),
+      );
+    }
   }
 
   const submission = await db.formSubmission.create({

--- a/src/env.js
+++ b/src/env.js
@@ -56,6 +56,11 @@ export const env = createEnv({
     // NEXT_PUBLIC_VAPID_PUBLIC_KEY. Optional: push notifications degrade
     // gracefully when unset (see WebPushService / pushSubscription router).
     VAPID_PRIVATE_KEY: z.string().optional(),
+    // Upstash Redis for shared rate limiting (src/server/utils/rateLimit.ts).
+    // Optional: without them limits fall back to per-instance in-memory
+    // windows, which do not hold across serverless scale-out.
+    UPSTASH_REDIS_REST_URL: z.string().url().optional(),
+    UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
@@ -95,6 +100,8 @@ export const env = createEnv({
     DATABASE_ENCRYPTION_KEY: process.env.DATABASE_ENCRYPTION_KEY,
     DATABASE_ENCRYPTION_KEY_PREVIOUS: process.env.DATABASE_ENCRYPTION_KEY_PREVIOUS,
     VAPID_PRIVATE_KEY: process.env.VAPID_PRIVATE_KEY,
+    UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+    UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
     NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
     NEXT_PUBLIC_VAPID_PUBLIC_KEY: process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,

--- a/src/lib/chat/streamChatResponse.ts
+++ b/src/lib/chat/streamChatResponse.ts
@@ -94,6 +94,18 @@ export async function streamChatResponse(
     });
 
     if (!response.ok) {
+      if (response.status === 429) {
+        // Surface the rate limit rather than failing as a generic transport
+        // error: the "rate limit" wording routes classifyStreamError() to a
+        // non-retryable kind, so auto-retry doesn't hammer a limited user.
+        const data = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(
+          data?.error ??
+            "You've hit the chat rate limit. Please wait a moment and try again.",
+        );
+      }
       throw new Error('Stream request failed');
     }
 

--- a/src/server/utils/__tests__/rateLimit.test.ts
+++ b/src/server/utils/__tests__/rateLimit.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Tests the shared rate limiter (ticket silver.brook).
+ *
+ * The in-memory fallback path is deterministic and tested directly. The
+ * Upstash path is exercised with the SDK mocked: what matters at unit level
+ * is our wrapper behaviour — key namespacing, retry-after computation, and
+ * that a store outage FAILS OPEN instead of crashing the route.
+ */
+
+const limitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@upstash/redis", () => ({
+  Redis: { fromEnv: vi.fn(() => ({})) },
+}));
+vi.mock("@upstash/ratelimit", () => {
+  class MockRatelimit {
+    limit = limitMock;
+    static slidingWindow = vi.fn(() => "sliding-window-config");
+  }
+  return { Ratelimit: MockRatelimit };
+});
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+
+import { checkRateLimit, clientIpFrom } from "../rateLimit";
+
+const HAD_URL = process.env.UPSTASH_REDIS_REST_URL;
+const HAD_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+afterEach(() => {
+  if (HAD_URL === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = HAD_URL;
+  if (HAD_TOKEN === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = HAD_TOKEN;
+  vi.useRealTimers();
+});
+
+describe("checkRateLimit — in-memory fallback (no Upstash env)", () => {
+  beforeEach(() => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  });
+
+  it("allows up to the limit, then blocks with a Retry-After", async () => {
+    const opts = { name: "t-basic", key: "k1", limit: 3, windowSeconds: 60 };
+    for (let i = 0; i < 3; i++) {
+      expect((await checkRateLimit(opts)).success).toBe(true);
+    }
+    const blocked = await checkRateLimit(opts);
+    expect(blocked.success).toBe(false);
+    expect(blocked.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+    expect(blocked.retryAfterSeconds).toBeLessThanOrEqual(60);
+  });
+
+  it("keys are isolated per name and per key", async () => {
+    const base = { limit: 1, windowSeconds: 60 };
+    expect(
+      (await checkRateLimit({ ...base, name: "t-iso", key: "a" })).success,
+    ).toBe(true);
+    expect(
+      (await checkRateLimit({ ...base, name: "t-iso", key: "a" })).success,
+    ).toBe(false);
+    // Different key, same namespace: unaffected.
+    expect(
+      (await checkRateLimit({ ...base, name: "t-iso", key: "b" })).success,
+    ).toBe(true);
+    // Same key, different namespace: unaffected.
+    expect(
+      (await checkRateLimit({ ...base, name: "t-iso2", key: "a" })).success,
+    ).toBe(true);
+  });
+
+  it("resets after the window elapses", async () => {
+    vi.useFakeTimers();
+    const opts = { name: "t-reset", key: "k1", limit: 1, windowSeconds: 60 };
+    expect((await checkRateLimit(opts)).success).toBe(true);
+    expect((await checkRateLimit(opts)).success).toBe(false);
+    vi.advanceTimersByTime(61_000);
+    expect((await checkRateLimit(opts)).success).toBe(true);
+  });
+});
+
+describe("checkRateLimit — Upstash store", () => {
+  beforeEach(() => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://fake.upstash.test";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "fake-token";
+    limitMock.mockReset();
+  });
+
+  it("passes through a success", async () => {
+    limitMock.mockResolvedValue({ success: true, reset: Date.now() + 60_000 });
+    const result = await checkRateLimit({
+      name: "t-up",
+      key: "k1",
+      limit: 5,
+      windowSeconds: 60,
+    });
+    expect(result).toEqual({ success: true, retryAfterSeconds: 0 });
+    expect(limitMock).toHaveBeenCalledWith("k1");
+  });
+
+  it("computes Retry-After from the store's reset time", async () => {
+    limitMock.mockResolvedValue({ success: false, reset: Date.now() + 42_000 });
+    const result = await checkRateLimit({
+      name: "t-up",
+      key: "k1",
+      limit: 5,
+      windowSeconds: 60,
+    });
+    expect(result.success).toBe(false);
+    expect(result.retryAfterSeconds).toBeGreaterThanOrEqual(41);
+    expect(result.retryAfterSeconds).toBeLessThanOrEqual(43);
+  });
+
+  it("fails open when the store errors", async () => {
+    limitMock.mockRejectedValue(new Error("upstash unreachable"));
+    const result = await checkRateLimit({
+      name: "t-up-outage",
+      key: "k1",
+      limit: 5,
+      windowSeconds: 60,
+    });
+    expect(result).toEqual({ success: true, retryAfterSeconds: 0 });
+  });
+});
+
+describe("clientIpFrom", () => {
+  it("takes the first x-forwarded-for hop", () => {
+    const headers = new Headers({
+      "x-forwarded-for": "203.0.113.7, 10.0.0.1",
+    });
+    expect(clientIpFrom(headers)).toBe("203.0.113.7");
+  });
+
+  it("falls back to x-real-ip, then 'unknown'", () => {
+    expect(clientIpFrom(new Headers({ "x-real-ip": "203.0.113.8" }))).toBe(
+      "203.0.113.8",
+    );
+    expect(clientIpFrom(new Headers())).toBe("unknown");
+  });
+});

--- a/src/server/utils/rateLimit.ts
+++ b/src/server/utils/rateLimit.ts
@@ -1,0 +1,177 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Shared rate limiting that survives serverless scale-out (ADR-0030 /
+ * ADR-0036: Upstash is the endorsed store).
+ *
+ * Every earlier limiter in the app was an in-process `Map`, which on Vercel
+ * means one window per warm lambda — the effective limit is the configured
+ * limit times the instance count, and it resets on every cold start. This
+ * helper centralises the pattern:
+ *
+ * - **Upstash configured** (`UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN`):
+ *   sliding-window limits shared by all instances. This is the production mode.
+ * - **Not configured**: an in-memory fixed-window fallback — same behaviour as
+ *   the old per-route Maps, fine for dev. In production this logs a warning
+ *   once so a missing env var is visible instead of silently weakening limits.
+ *
+ * **Store outage fails open, deliberately.** If Upstash is unreachable the
+ * check returns success rather than 500ing the route: every caller here is a
+ * user-facing path (form submit, chat, error reporting, token issue) where
+ * "briefly unlimited" is strictly better than "hard down", and the honeypot /
+ * time-trap / auth defences on those paths still apply. Outages are reported
+ * to Sentry so they are visible, not silent.
+ */
+
+export interface RateLimitResult {
+  success: boolean;
+  /** Seconds until the caller may retry; 0 when success. Use for Retry-After. */
+  retryAfterSeconds: number;
+}
+
+interface RateLimitOptions {
+  /** Limiter namespace, e.g. "forms-ip". Part of the Redis key prefix. */
+  name: string;
+  /** Identity inside the namespace: an IP, user id, or email. */
+  key: string;
+  /** Max requests allowed per window. */
+  limit: number;
+  /** Window length in seconds. */
+  windowSeconds: number;
+}
+
+function upstashRedis(): Redis | null {
+  if (
+    !process.env.UPSTASH_REDIS_REST_URL ||
+    !process.env.UPSTASH_REDIS_REST_TOKEN
+  ) {
+    return null;
+  }
+  return Redis.fromEnv();
+}
+
+// One Ratelimit instance per (name, limit, window) config, so repeated calls
+// reuse the client and its ephemeral cache of already-blocked keys.
+const limiters = new Map<string, Ratelimit>();
+
+function upstashLimiter(opts: RateLimitOptions): Ratelimit | null {
+  const redis = upstashRedis();
+  if (!redis) return null;
+
+  const cacheKey = `${opts.name}:${opts.limit}:${opts.windowSeconds}`;
+  let limiter = limiters.get(cacheKey);
+  if (!limiter) {
+    limiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(opts.limit, `${opts.windowSeconds} s`),
+      prefix: `rl:${opts.name}`,
+    });
+    limiters.set(cacheKey, limiter);
+  }
+  return limiter;
+}
+
+// In-memory fallback (dev, or prod before Upstash is provisioned). Fixed
+// window per instance — the pre-existing behaviour of the per-route Maps.
+type MemoryEntry = { count: number; resetAt: number };
+const memoryWindows = new Map<string, MemoryEntry>();
+let warnedNoStore = false;
+
+if (typeof globalThis !== "undefined") {
+  const cleanup = () => {
+    const now = Date.now();
+    for (const [key, entry] of memoryWindows.entries()) {
+      if (now > entry.resetAt) memoryWindows.delete(key);
+    }
+  };
+  setInterval(cleanup, 5 * 60_000).unref?.();
+}
+
+function memoryCheck(opts: RateLimitOptions): RateLimitResult {
+  if (!warnedNoStore && process.env.NODE_ENV === "production") {
+    warnedNoStore = true;
+    console.warn(
+      "[rateLimit] UPSTASH_REDIS_REST_URL/TOKEN not set — falling back to per-instance in-memory limits, which do not hold across serverless scale-out",
+    );
+  }
+  const now = Date.now();
+  const mapKey = `${opts.name}:${opts.key}`;
+  const entry = memoryWindows.get(mapKey);
+  if (!entry || now > entry.resetAt) {
+    memoryWindows.set(mapKey, {
+      count: 1,
+      resetAt: now + opts.windowSeconds * 1000,
+    });
+    return { success: true, retryAfterSeconds: 0 };
+  }
+  entry.count += 1;
+  if (entry.count <= opts.limit) {
+    return { success: true, retryAfterSeconds: 0 };
+  }
+  return {
+    success: false,
+    retryAfterSeconds: Math.max(1, Math.ceil((entry.resetAt - now) / 1000)),
+  };
+}
+
+/**
+ * Check (and consume) one request against the named limit.
+ *
+ * Never throws. On a store error the request is allowed (fail open, see
+ * module doc) and the error is reported.
+ */
+export async function checkRateLimit(
+  opts: RateLimitOptions,
+): Promise<RateLimitResult> {
+  const limiter = upstashLimiter(opts);
+  if (!limiter) return memoryCheck(opts);
+
+  try {
+    const result = await limiter.limit(opts.key);
+    if (result.success) return { success: true, retryAfterSeconds: 0 };
+    return {
+      success: false,
+      retryAfterSeconds: Math.max(
+        1,
+        Math.ceil((result.reset - Date.now()) / 1000),
+      ),
+    };
+  } catch (error) {
+    console.error(
+      `[rateLimit] store check failed for ${opts.name} — failing open:`,
+      error,
+    );
+    Sentry.captureException(error, {
+      tags: { area: "rate-limit", limiter: opts.name },
+    });
+    return { success: true, retryAfterSeconds: 0 };
+  }
+}
+
+/** Client IP as Vercel presents it; "unknown" groups requests with no header. */
+export function clientIpFrom(headers: Headers): string {
+  return (
+    headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    headers.get("x-real-ip") ??
+    "unknown"
+  );
+}
+
+/**
+ * Standard 429 payload: JSON error plus a Retry-After header so well-behaved
+ * clients can back off instead of failing silently.
+ */
+export function tooManyRequestsInit(
+  result: RateLimitResult,
+  extraHeaders?: Record<string, string>,
+): { status: number; headers: Record<string, string> } {
+  return {
+    status: 429,
+    headers: {
+      "Retry-After": String(result.retryAfterSeconds || 60),
+      ...extraHeaders,
+    },
+  };
+}


### PR DESCRIPTION
## What

Replaces every in-process `Map` rate limiter with one shared, Upstash-backed helper (`src/server/utils/rateLimit.ts`), implementing the fix ADR-0030/ADR-0036 already endorsed. On Vercel the old limiters were per-lambda: the effective limit was `configured × warm instances`, resetting on cold starts — weakest exactly under launch traffic.

**The helper**: Upstash sliding windows when `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` are set; per-instance in-memory fallback otherwise (dev, or prod-before-provisioning, with a one-time warning). **Store outage fails open, deliberately**: user-facing paths prefer "briefly unlimited" over hard-down; outages report to Sentry so they're visible. All 429s carry `Retry-After`.

**Endpoints converted**:
- `/api/forms/[slug]/submit` — 5/min/IP + 3/min/email; honeypot and time trap untouched
- `/api/chat/stream` — previously **no limit at all** on the LLM-spend path; now 20/min/user, 60/min/IP, 500/day/user. The daily cap bounds one user's worst-case daily spend at 500 × the per-request cost ceiling alerted on in `computeRequestCost`.
- `/api/client-errors` — 20/hour/user (shared, was per-instance)
- `/api/auth/extension-token` — 10/min/IP

**Client surfacing**: chat clients now read the 429 JSON and show the rate-limit message ("rate limit" wording routes `classifyStreamError` to non-retryable, so auto-retry doesn't hammer a limited user). The public form already renders the server's error string.

**tRPC global limit considered, deliberately not added here**: every tRPC procedure is session-gated and the uncapped-spend path was `/api/chat/stream`, not tRPC. A blanket limit in the handler risks breaking legitimate bursty UI patterns (bulk updates, kanban drags) for no concrete threat; revisit with real traffic data.

## Ops required before the limits actually hold across instances

1. Create an Upstash Redis database (free tier is fine at this volume)
2. Set `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` in Vercel (all environments)
3. Verify with: `npx tsx scripts/load-test-rate-limit.ts --url https://<deploy>/api/forms/<slug>/submit --count 30 --concurrency 10 --expect-limit 5`

Until then the helper falls back to per-instance windows (status quo, with a prod warning log).

## Acceptance criteria

- [x] A shared-store rate limiter exists as one reusable helper, not re-implemented per route
- [x] Form submit, chat stream, client-errors and extension-token all use it
- [x] `/api/chat/stream` has a per-user and per-IP ceiling, and a documented cap on spend per user per day
- [ ] Limits hold across multiple concurrent instances — `scripts/load-test-rate-limit.ts` is ready; needs Upstash provisioned (ops steps above)
- [x] Exceeding a limit returns 429 with `Retry-After`, and the client surfaces it rather than failing silently
- [x] Store outage fails open for reads but does not crash the route; behaviour is a deliberate documented choice
- [x] Existing honeypot and time-trap defences on the form path are preserved

---

Ships: silver.brook
