### PR TITLE
feat: Content-Security-Policy — enforce safe subset, report-only full policy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,72 @@
 import "./src/env.js";
 import { withSentryConfig } from "@sentry/nextjs";
 
+/**
+ * CSP rollout (ticket crisp.clover) is two-stage:
+ *
+ * 1. NOW — an **enforcing** header carrying only directives that cannot break
+ *    the app (`frame-ancestors`, `object-src`, `base-uri`; none of the app's
+ *    markup uses <object>/<base>, and frame-ancestors mirrors the existing
+ *    X-Frame-Options: SAMEORIGIN), plus a **Report-Only** header with the
+ *    full policy so real traffic surfaces every violation in Sentry without
+ *    ever blocking a user.
+ * 2. LATER — after the report-only soak shows no false positives, move the
+ *    full policy into the enforcing header (and tighten script-src towards
+ *    nonces once off 'unsafe-inline').
+ *
+ * `script-src 'unsafe-inline'` is required by Next.js's inline bootstrap
+ * scripts until a nonce strategy is adopted; 'unsafe-eval' is dev-only
+ * (eval sourcemaps). Origins listed: Google Analytics (@next/third-parties),
+ * the OpenAI realtime voice session, and Loom embeds. Sentry and Vercel
+ * Analytics both go through same-origin paths (/monitoring tunnel,
+ * /_vercel/insights), so 'self' covers them.
+ */
+const isDev = process.env.NODE_ENV !== "production";
+
+/**
+ * Sentry ingests CSP violation reports on its `security` endpoint, derived
+ * from the public DSN (https://<key>@<host>/<projectId>).
+ */
+function sentryCspReportUri() {
+  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  if (!dsn) return null;
+  try {
+    const url = new URL(dsn);
+    const projectId = url.pathname.replace(/^\//, "");
+    if (!url.username || !projectId) return null;
+    return `https://${url.host}/api/${projectId}/security/?sentry_key=${url.username}`;
+  } catch {
+    return null;
+  }
+}
+
+function contentSecurityPolicyReportOnly() {
+  const reportUri = sentryCspReportUri();
+  const directives = [
+    "default-src 'self'",
+    `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://www.googletagmanager.com`,
+    "style-src 'self' 'unsafe-inline'",
+    // Published pages and CRM avatars embed images from arbitrary origins.
+    "img-src 'self' blob: data: https:",
+    "font-src 'self' data:",
+    "connect-src 'self' https://api.openai.com wss://api.openai.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com",
+    "media-src 'self' blob: data: https:",
+    "frame-src 'self' https://www.loom.com https://www.youtube.com https://www.youtube-nocookie.com",
+    "worker-src 'self' blob:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ];
+  if (reportUri) directives.push(`report-uri ${reportUri}`);
+  return directives.join("; ");
+}
+
+// Enforced from day one: nothing in the app can trip these, and
+// frame-ancestors deliberately agrees with X-Frame-Options: SAMEORIGIN.
+// (frame-ancestors is ignored in Report-Only headers, so it must live here.)
+const CSP_ENFORCED =
+  "frame-ancestors 'self'; object-src 'none'; base-uri 'self'";
+
 /** @type {import("next").NextConfig} */
 const config = {
   eslint: { ignoreDuringBuilds: true },
@@ -28,6 +94,11 @@ const config = {
         source: '/(.*)',
         headers: [
           { key: 'X-DNS-Prefetch-Control', value: 'on' },
+          { key: 'Content-Security-Policy', value: CSP_ENFORCED },
+          {
+            key: 'Content-Security-Policy-Report-Only',
+            value: contentSecurityPolicyReportOnly(),
+          },
           { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
           { key: 'X-Content-Type-Options', value: 'nosniff' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },


### PR DESCRIPTION
## What

Adds `Content-Security-Policy` to the header block in [next.config.js](next.config.js) — the one baseline header that was missing, and the browser-level backstop for the app's user-authored-content surfaces (`/p/[slugId]` published pages, `/f/[slug]` forms, Markdown prose everywhere).

Shipped as the ticket's staged rollout, both stages in one deploy:

1. **Enforcing header (now)**: `frame-ancestors 'self'; object-src 'none'; base-uri 'self'`. Provably inert for this app (no `<object>`/`<base>` in any template; `frame-ancestors` mirrors the existing `X-Frame-Options: SAMEORIGIN`, satisfying the "agree with each other" criterion). `frame-ancestors` is ignored in Report-Only headers, so it must live in the enforcing header to do anything.
2. **Report-Only header (full policy)**: `default-src 'self'` plus allowances for Next's inline bootstrap (`'unsafe-inline'` script-src until a nonce strategy), Mantine/Tailwind inline styles, Google Analytics, the OpenAI realtime voice session, Loom embeds, and wide `img/media-src` for user-embedded content. Violations report to **Sentry's security endpoint**, derived from the public DSN at build time. Sentry (`/monitoring` tunnel) and Vercel Analytics (`/_vercel/insights`) are same-origin, so `'self'` covers both.

**Follow-up after the report-only soak** (deliberately not in this PR): review Sentry's `csp-violation` events after a week of real traffic, fold any legitimate origins in, then move the full policy into the enforcing header — and longer-term, adopt nonces to drop `'unsafe-inline'` from script-src.

## Verification

- Production build succeeds with the config
- Both headers present and well-formed on responses (curl-verified)
- Zero CSP console violations on `/signin`, the marketing home, and the authenticated app shell (incl. the Zoe chat drawer)
- Full Playwright e2e suite green (30/30) against a server serving the headers
- The dev database has no published pages/forms to browse locally — that surface is exactly what the report-only soak covers, with violations visible in Sentry

## Acceptance criteria

- [x] `Content-Security-Policy-Report-Only` shipped first, with violations reported and visible (Sentry security endpoint)
- [ ] Report-only run against real traffic long enough to shake out false positives (starts when this merges)
- [x] Enforcing CSP shipped with `frame-ancestors`, `object-src none` and `base-uri self` (the full policy moves over after the soak)
- [x] Key pages verified with no console CSP errors (published-page surface covered by the soak, see Verification)
- [x] Sentry error reporting through `/monitoring` still works under the enforcing policy (tunnel is same-origin; enforcing directives don't touch connect-src)
- [x] `X-Frame-Options` and CSP `frame-ancestors` agree with each other

---

Ships: crisp.clover
