### PR TITLE
fix: default-deny middleware route gating — /w/ workspace routes were unprotected

### DIFF
--- a/e2e/route-gating.spec.ts
+++ b/e2e/route-gating.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Middleware route gating (ticket foggy.carp).
+ *
+ * The middleware is default-deny: every page requires a session except the
+ * enumerated public surfaces. These specs pin the two behaviours that rotted
+ * under the old protected-prefix allowlist — a logged-out visitor on a
+ * workspace URL must be redirected to /signin (not left on a broken shell),
+ * and genuinely public routes must keep rendering logged-out — so the next
+ * route addition cannot silently regress either.
+ */
+
+import { test, expect } from "@playwright/test";
+import { loadFixture } from "./fixture-data";
+
+const fixture = loadFixture();
+
+test.describe("logged out", () => {
+  // Every other spec runs with the seeded storageState; these must not.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("a workspace URL redirects to /signin with a callbackUrl back to it", async ({
+    page,
+  }) => {
+    const target = `/w/${fixture.workspaceSlug}/projects`;
+    await page.goto(target);
+
+    await page.waitForURL((url) => url.pathname === "/signin");
+    const callbackUrl = new URL(page.url()).searchParams.get("callbackUrl");
+    expect(callbackUrl).toBe(target);
+
+    // The point of the bug: the visitor gets the sign-in page, not a broken
+    // app shell full of failing queries.
+    await expect(page.getByPlaceholder("you@company.com")).toBeVisible();
+  });
+
+  test("a workspace URL keeps its query string through the redirect", async ({
+    page,
+  }) => {
+    await page.goto(`/w/${fixture.workspaceSlug}/projects?tab=tasks`);
+    await page.waitForURL((url) => url.pathname === "/signin");
+    expect(new URL(page.url()).searchParams.get("callbackUrl")).toBe(
+      `/w/${fixture.workspaceSlug}/projects?tab=tasks`,
+    );
+  });
+
+  test("an arbitrary unknown path is gated too (default-deny)", async ({
+    page,
+  }) => {
+    await page.goto("/definitely-not-a-public-route");
+    await page.waitForURL((url) => url.pathname === "/signin");
+  });
+
+  for (const path of ["/", "/signin", "/auth/verify-request", "/privacy"]) {
+    test(`public route ${path} renders logged out`, async ({ page }) => {
+      const response = await page.goto(path);
+      expect(response?.status()).toBeLessThan(400);
+      expect(new URL(page.url()).pathname).toBe(path);
+    });
+  }
+});
+
+test("a signed-in member still reaches their workspace", async ({ page }) => {
+  await page.goto(`/w/${fixture.workspaceSlug}/projects`);
+  await expect(page).toHaveURL(new RegExp(`/w/${fixture.workspaceSlug}/projects`));
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,55 +2,82 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { auth } from '~/server/auth';
 
+/**
+ * Route gating is DEFAULT-DENY (ticket foggy.carp): every page requires a
+ * session unless its path is enumerated below. The previous shape — an
+ * allowlist of *protected* prefixes — went stale the moment workspace-scoped
+ * routing (`/w/[workspaceSlug]/...`) shipped without being added to it, which
+ * left logged-out visitors on a broken app shell full of failing queries.
+ * A deny-by-default list cannot rot that way: a new authenticated route is
+ * gated the day it is added, and forgetting to list a new *public* route
+ * fails loudly (a redirect to /signin) instead of silently.
+ *
+ * This is first-impression gating, not the security boundary: data access is
+ * enforced by tRPC `protectedProcedure`, `/admin` re-checks `isAdmin` in its
+ * own server layout, and a signed-in member visiting a workspace they don't
+ * belong to is redirected out by WorkspaceProvider's FORBIDDEN/NOT_FOUND
+ * handling.
+ */
+
+/** Public pages matched exactly. */
+const PUBLIC_EXACT = new Set([
+  '/', // marketing home
+  '/signin', // also excluded by the matcher; kept for clarity
+  '/web3', // wallet sign-in
+  '/desktop-auth', // desktop-shell auth handoff renders its own signed-out state
+  '/privacy',
+  '/terms',
+  '/roadmap', // public product roadmap (embeds Loom)
+  // File conventions served through the middleware matcher.
+  '/llms.txt',
+  '/robots.txt',
+  '/sitemap.xml',
+  '/manifest.webmanifest',
+]);
+
+/** Public sections matched by prefix (note trailing slashes: `/f/` must not
+ * open up `/features`). */
+const PUBLIC_PREFIXES = [
+  '/p/', // published Knowledge Pages (ADR-0038)
+  '/f/', // public forms intake (ADR-0029)
+  '/auth/verify-request', // sign-in code redemption happens logged-out
+  '/invite/', // token pages render their own signed-out state
+  '/team-invite/',
+  // Marketing pages from the (home) route group.
+  '/blog',
+  '/explore',
+  '/learn',
+  '/product-timeline',
+  '/features/', // marketing feature pages — bare /features is the app's
+];
+
+function isPublicPath(pathname: string): boolean {
+  if (PUBLIC_EXACT.has(pathname)) return true;
+  return PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
 export async function middleware(request: NextRequest) {
   // For testing different themes in development
   const requestHeaders = new Headers(request.headers);
   const testDomain = request.nextUrl.searchParams.get('theme');
-  
+
   if (testDomain) {
     requestHeaders.set('host', `${testDomain}`);
   }
 
-  // Handle authentication for protected routes
   const { pathname } = request.nextUrl;
-  
-  // Define protected routes that require authentication
-  const protectedRoutes = [
-    '/home',
-    '/act', 
-    '/plan',
-    '/projects',
-    '/goals',
-    '/outcomes',
-    '/integrations',
-    '/workflows',
-    '/journal',
-    '/meetings',
-    '/videos',
-    '/settings',  // All settings pages require auth
-    '/days',
-    '/recordings',
-    '/agent',
-    '/actions',
-  ];
 
-  // Skip authentication check for certain paths
-  const publicPaths = ['/', '/signin'];
-  const isPublicPath = publicPaths.some(path => pathname === path);
-  
-  // Check if the current path is a protected route
-  const isProtectedRoute = protectedRoutes.some(route => 
-    pathname.startsWith(route) || pathname === route
-  );
-
-  if (isProtectedRoute && !isPublicPath) {
-    // Get the session
+  if (!isPublicPath(pathname)) {
     const session = await auth();
-    
-    // If no session, redirect to login
+
     if (!session?.user) {
       const loginUrl = new URL('/signin', request.url);
-      loginUrl.searchParams.set('callbackUrl', pathname);
+      // Preserve the query string so e.g. a shared filtered view survives
+      // the round-trip through sign-in.
+      loginUrl.searchParams.set(
+        'callbackUrl',
+        pathname + request.nextUrl.search,
+      );
       return NextResponse.redirect(loginUrl);
     }
   }
@@ -66,7 +93,7 @@ export const config = {
   matcher: [
     /*
      * Match all request paths except for the ones starting with:
-     * - api (API routes)
+     * - api (API routes gate themselves: auth(), HMAC, CRON_SECRET)
      * - monitoring (Sentry browser-event tunnel)
      * - _next/static (static files)
      * - _next/image (image optimization files)
@@ -75,4 +102,4 @@ export const config = {
      */
     '/((?!api|monitoring|_next/static|_next/image|favicon.ico|signin).*)',
   ],
-}; 
+};


### PR DESCRIPTION
## What

[src/middleware.ts](src/middleware.ts) gated routes with a hardcoded allowlist of legacy top-level paths that predates workspace-scoped routing — `/w/[workspaceSlug]/...` was never added, so a logged-out visitor opening a shared workspace link got the app shell and a stream of failing queries instead of a redirect to sign-in.

This inverts the shape to **default-deny**: every page requires a session unless enumerated as public (marketing pages from the `(home)` group, `/signin`, `/auth/verify-request` for logged-out code redemption, published pages `/p/`, public forms `/f/`, invite token pages, `/privacy` + `/terms` + `/roadmap`, `/web3`, `/desktop-auth`, and the robots/sitemap/manifest file conventions). A new authenticated route is gated the day it's added; forgetting to list a new *public* route fails loudly (a visible redirect) instead of silently.

Details:
- The redirect carries `callbackUrl` including the query string, so `/w/x/projects?tab=tasks` survives the round-trip through sign-in.
- One subtlety from the route map: `/features/[slug]` is a marketing page but bare `/features` is the authenticated app's — the prefix list uses trailing slashes to keep `/f/` from opening `/features` and `/features/` from opening `/features` itself.
- Cross-workspace visitors (member of A opening B) were already handled deliberately: `WorkspaceProvider` redirects `FORBIDDEN`/`NOT_FOUND` out of the shell. Data access stays enforced by tRPC `protectedProcedure`; `/admin` re-checks `isAdmin` server-side. Middleware is the first-impression gate, not the security boundary — per the ticket's note, that boundary now also sits on a patched Next.js (15.5.23, PR 564).

## Acceptance criteria

- [x] An unauthenticated request to a `/w/<slug>/...` URL redirects to `/signin` with a `callbackUrl` that returns the user to the page after login
- [x] Route protection is default-deny with enumerated public exceptions, not an allowlist of protected prefixes
- [x] Genuinely public routes still render logged-out: `/`, `/signin`, published pages `/p/[slugId]`, public forms `/f/[slug]` (e2e-pinned for `/`, `/signin`, `/auth/verify-request`, `/privacy`; `/p/`+`/f/` are in the public list and their templates are unchanged)
- [x] A member of workspace A visiting workspace B is handled deliberately (existing `WorkspaceProvider` redirect on FORBIDDEN/NOT_FOUND)
- [x] E2E coverage for the logged-out redirect (`e2e/route-gating.spec.ts`: redirect + callbackUrl + query preservation + default-deny on unknown paths + public routes render + signed-in member still reaches the workspace)

Full Playwright suite green (38 tests) with the new middleware.

---

Ships: foggy.carp
