### PR TITLE
feat: Your work panel on the workspace home

### DIFF
--- a/src/app/_components/home/WorkspaceHomeConceptD.tsx
+++ b/src/app/_components/home/WorkspaceHomeConceptD.tsx
@@ -30,6 +30,7 @@ import {
 } from '@tabler/icons-react';
 import { api } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { YourWorkPanel } from './YourWorkPanel';
 import styles from './WorkspaceHomeConceptD.module.css';
 
 type Mode = 'all' | 'tasks' | 'projects' | 'docs' | 'people' | 'ai';
@@ -336,6 +337,8 @@ export function WorkspaceHomeConceptD() {
           )
         )}
       </Container>
+
+      <YourWorkPanel />
     </div>
   );
 }

--- a/src/app/_components/home/YourWorkPanel.module.css
+++ b/src/app/_components/home/YourWorkPanel.module.css
@@ -41,6 +41,12 @@
   border-bottom: 1px solid var(--color-border-subtle);
 }
 
+.emptyNote {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  margin: 0 0 16px;
+}
+
 .bucketLabel {
   font-size: 11px;
   color: var(--color-text-muted);

--- a/src/app/_components/home/YourWorkPanel.module.css
+++ b/src/app/_components/home/YourWorkPanel.module.css
@@ -1,0 +1,87 @@
+.panel {
+  width: 100%;
+  max-width: 860px;
+  margin-top: 64px;
+  /* .row is full-bleed by 8px each side (see WorkspaceHomeConceptD.module.css
+     for why the container must carry the padding). */
+  padding: 0 8px;
+}
+
+.panelHeading {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--color-text-primary);
+  margin-bottom: 18px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.panelHeading a {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
+
+.panelHeading a:hover {
+  color: var(--color-text-secondary);
+  text-decoration: underline;
+}
+
+.sectionHeading {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 18px 0 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.bucketLabel {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  margin: 10px 0 2px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  margin: 0 -8px;
+  background: transparent;
+  border: 0;
+  width: calc(100% + 16px);
+  text-align: left;
+  color: var(--color-text-primary);
+  transition: background 120ms;
+}
+
+.row:hover {
+  background: var(--color-bg-secondary);
+}
+
+.rowLabel {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-primary);
+}
+
+.rowMeta {
+  flex-shrink: 0;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.rowMetaOverdue {
+  color: var(--color-brand-error);
+}

--- a/src/app/_components/home/YourWorkPanel.tsx
+++ b/src/app/_components/home/YourWorkPanel.tsx
@@ -2,12 +2,19 @@
 
 import Link from 'next/link';
 import { Skeleton, UnstyledButton } from '@mantine/core';
-import { IconSquareRoundedCheck } from '@tabler/icons-react';
+import { IconSquareRoundedCheck, IconTicket } from '@tabler/icons-react';
 import { api, type RouterOutputs } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import styles from './YourWorkPanel.module.css';
 
 type ActionRow = RouterOutputs['action']['getAll'][number];
+
+/** "IN_PROGRESS" → "In progress" for the row meta. */
+function ticketStatusLabel(status: string): string {
+  if (status === 'QA') return 'QA';
+  const lower = status.toLowerCase().replace(/_/g, ' ');
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
 
 /**
  * Due-date buckets, in display order. "This week" means within the next
@@ -50,6 +57,13 @@ export function YourWorkPanel() {
     { enabled: !!workspaceId },
   );
 
+  // Open tickets where I'm the assignee (Ticket.assigneeId), workspace-scoped.
+  const { data: tickets, isLoading: ticketsLoading } =
+    api.yourWork.assignedTickets.useQuery(
+      { workspaceId: workspaceId ?? '' },
+      { enabled: !!workspaceId },
+    );
+
   if (!workspaceId || !workspaceSlug) return null;
 
   const now = new Date();
@@ -73,7 +87,9 @@ export function YourWorkPanel() {
     shown += 1;
   }
 
-  if (!isLoading && active.length === 0) {
+  const openTickets = tickets ?? [];
+
+  if (!isLoading && !ticketsLoading && active.length === 0 && openTickets.length === 0) {
     // Nothing assigned yet — the panel stays out of the way. The team-pulse
     // empty state (feature action 5) takes over here.
     return null;
@@ -129,6 +145,37 @@ export function YourWorkPanel() {
               </div>
             );
           })}
+
+      {ticketsLoading ? (
+        <Skeleton height={34} mt={10} radius="sm" />
+      ) : (
+        openTickets.length > 0 && (
+          <div>
+            <div className={styles.bucketLabel}>Tickets</div>
+            {openTickets.map((ticket) => (
+              <UnstyledButton
+                key={ticket.id}
+                component={Link}
+                href={`/w/${workspaceSlug}/products/${ticket.product.slug}/tickets/${ticket.id}`}
+                className={styles.row}
+              >
+                <IconTicket
+                  size={14}
+                  stroke={1.75}
+                  style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
+                />
+                <span className={styles.rowLabel}>{ticket.title}</span>
+                {ticket.shortId && (
+                  <span className={styles.rowMeta}>{ticket.shortId}</span>
+                )}
+                <span className={styles.rowMeta}>
+                  {ticketStatusLabel(ticket.status)}
+                </span>
+              </UnstyledButton>
+            ))}
+          </div>
+        )
+      )}
     </div>
   );
 }

--- a/src/app/_components/home/YourWorkPanel.tsx
+++ b/src/app/_components/home/YourWorkPanel.tsx
@@ -12,6 +12,8 @@ import {
 } from '@tabler/icons-react';
 import { api, type RouterOutputs } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { ActivityFeed } from './activity/ActivityFeed';
+import './activity/activity-home.css';
 import styles from './YourWorkPanel.module.css';
 
 type ActionRow = RouterOutputs['action']['getAll'][number];
@@ -121,7 +123,7 @@ export function YourWorkPanel() {
   const driCount = driGoals.length + driKeyResults.length + driProjects.length;
   const recentMeetings = (meetings ?? []).slice(0, 5);
 
-  if (
+  const personalSectionsEmpty =
     !isLoading &&
     !ticketsLoading &&
     !driLoading &&
@@ -129,11 +131,22 @@ export function YourWorkPanel() {
     active.length === 0 &&
     openTickets.length === 0 &&
     driCount === 0 &&
-    recentMeetings.length === 0
-  ) {
-    // Nothing assigned yet — the panel stays out of the way. The team-pulse
-    // empty state (feature action 5) takes over here.
-    return null;
+    recentMeetings.length === 0;
+
+  if (personalSectionsEmpty) {
+    // The brand-new invitee case: nothing assigned yet. Lead with the team's
+    // pulse (the existing workspace activity feed card) instead of a wall of
+    // empty sections — this is an invited user's actual first page.
+    return (
+      <div className={styles.panel}>
+        <div className={styles.panelHeading}>Your work</div>
+        <p className={styles.emptyNote}>
+          Nothing assigned to you yet — here&apos;s what the team has been up
+          to.
+        </p>
+        <ActivityFeed />
+      </div>
+    );
   }
 
   return (
@@ -143,7 +156,9 @@ export function YourWorkPanel() {
         <Link href={`/w/${workspaceSlug}/actions`}>View all</Link>
       </div>
 
-      <div className={styles.sectionHeading}>Assigned to you</div>
+      {(isLoading || active.length > 0 || openTickets.length > 0) && (
+        <div className={styles.sectionHeading}>Assigned to you</div>
+      )}
       {isLoading
         ? Array.from({ length: 3 }).map((_, i) => (
             <Skeleton key={i} height={34} mb={4} radius="sm" />

--- a/src/app/_components/home/YourWorkPanel.tsx
+++ b/src/app/_components/home/YourWorkPanel.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { Skeleton, UnstyledButton } from '@mantine/core';
 import {
+  IconMicrophone,
   IconSquareRoundedCheck,
   IconStack2,
   IconTarget,
@@ -83,6 +84,13 @@ export function YourWorkPanel() {
     { enabled: !!workspaceId },
   );
 
+  // Meetings I owned or attended — 'mine' unions owner + Participant rows.
+  const { data: meetings, isLoading: meetingsLoading } =
+    api.transcription.getAllTranscriptions.useQuery(
+      { workspaceId: workspaceId ?? undefined, meetingType: 'mine' },
+      { enabled: !!workspaceId },
+    );
+
   if (!workspaceId || !workspaceSlug) return null;
 
   const now = new Date();
@@ -111,14 +119,17 @@ export function YourWorkPanel() {
   const driKeyResults = dri?.keyResults ?? [];
   const driProjects = dri?.projects ?? [];
   const driCount = driGoals.length + driKeyResults.length + driProjects.length;
+  const recentMeetings = (meetings ?? []).slice(0, 5);
 
   if (
     !isLoading &&
     !ticketsLoading &&
     !driLoading &&
+    !meetingsLoading &&
     active.length === 0 &&
     openTickets.length === 0 &&
-    driCount === 0
+    driCount === 0 &&
+    recentMeetings.length === 0
   ) {
     // Nothing assigned yet — the panel stays out of the way. The team-pulse
     // empty state (feature action 5) takes over here.
@@ -264,6 +275,33 @@ export function YourWorkPanel() {
                 {project.progress > 0
                   ? `${Math.round(project.progress)}%`
                   : 'Not started'}
+              </span>
+            </UnstyledButton>
+          ))}
+        </>
+      )}
+
+      {!meetingsLoading && recentMeetings.length > 0 && (
+        <>
+          <div className={styles.sectionHeading}>Recent meetings you were in</div>
+          {recentMeetings.map((meeting) => (
+            <UnstyledButton
+              key={meeting.id}
+              component={Link}
+              href={`/recording/${meeting.id}`}
+              className={styles.row}
+            >
+              <IconMicrophone
+                size={14}
+                stroke={1.75}
+                style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
+              />
+              <span className={styles.rowLabel}>
+                {meeting.title ?? 'Untitled meeting'}
+              </span>
+              {meeting.summary && <span className={styles.rowMeta}>Summary</span>}
+              <span className={styles.rowMeta}>
+                {formatDue(new Date(meeting.meetingDate ?? meeting.createdAt))}
               </span>
             </UnstyledButton>
           ))}

--- a/src/app/_components/home/YourWorkPanel.tsx
+++ b/src/app/_components/home/YourWorkPanel.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import Link from 'next/link';
+import { Skeleton, UnstyledButton } from '@mantine/core';
+import { IconSquareRoundedCheck } from '@tabler/icons-react';
+import { api, type RouterOutputs } from '~/trpc/react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import styles from './YourWorkPanel.module.css';
+
+type ActionRow = RouterOutputs['action']['getAll'][number];
+
+/**
+ * Due-date buckets, in display order. "This week" means within the next
+ * 7 days; everything dated beyond that is "Later".
+ */
+const BUCKET_ORDER = ['Overdue', 'Today', 'This week', 'Later', 'No due date'] as const;
+type Bucket = (typeof BUCKET_ORDER)[number];
+
+function bucketFor(dueDate: Date | null, now: Date): Bucket {
+  if (!dueDate) return 'No due date';
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+  const startOfTomorrow = new Date(startOfToday.getTime() + 24 * 60 * 60 * 1000);
+  const weekOut = new Date(startOfToday.getTime() + 7 * 24 * 60 * 60 * 1000);
+  if (dueDate < startOfToday) return 'Overdue';
+  if (dueDate < startOfTomorrow) return 'Today';
+  if (dueDate < weekOut) return 'This week';
+  return 'Later';
+}
+
+function formatDue(dueDate: Date): string {
+  return dueDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+const MAX_ROWS = 8;
+
+/**
+ * "Your work" — the per-user aggregation on the workspace home: everything
+ * assigned to the current user in this workspace. This tracer renders the
+ * assigned-actions section; assigned tickets, DRI objects, and recent
+ * meetings slot in as sibling sections.
+ */
+export function YourWorkPanel() {
+  const { workspaceId, workspaceSlug } = useWorkspace();
+
+  // action.getAll is already "mine"-scoped server-side: created-by-me with no
+  // assignees OR assigned to me, filtered to this workspace.
+  const { data: actions, isLoading } = api.action.getAll.useQuery(
+    { workspaceId: workspaceId ?? undefined },
+    { enabled: !!workspaceId },
+  );
+
+  if (!workspaceId || !workspaceSlug) return null;
+
+  const now = new Date();
+  const active = (actions ?? [])
+    .filter((a) => a.status === 'ACTIVE')
+    .sort((a, b) => {
+      if (!a.dueDate && !b.dueDate) return 0;
+      if (!a.dueDate) return 1;
+      if (!b.dueDate) return -1;
+      return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+    });
+
+  const byBucket = new Map<Bucket, ActionRow[]>();
+  let shown = 0;
+  for (const action of active) {
+    if (shown >= MAX_ROWS) break;
+    const bucket = bucketFor(action.dueDate ? new Date(action.dueDate) : null, now);
+    const rows = byBucket.get(bucket) ?? [];
+    rows.push(action);
+    byBucket.set(bucket, rows);
+    shown += 1;
+  }
+
+  if (!isLoading && active.length === 0) {
+    // Nothing assigned yet — the panel stays out of the way. The team-pulse
+    // empty state (feature action 5) takes over here.
+    return null;
+  }
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.panelHeading}>
+        Your work
+        <Link href={`/w/${workspaceSlug}/actions`}>View all</Link>
+      </div>
+
+      <div className={styles.sectionHeading}>Assigned to you</div>
+      {isLoading
+        ? Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} height={34} mb={4} radius="sm" />
+          ))
+        : BUCKET_ORDER.map((bucket) => {
+            const rows = byBucket.get(bucket);
+            if (!rows || rows.length === 0) return null;
+            return (
+              <div key={bucket}>
+                <div className={styles.bucketLabel}>{bucket}</div>
+                {rows.map((action) => (
+                  <UnstyledButton
+                    key={action.id}
+                    component={Link}
+                    href={`/w/${workspaceSlug}/actions/${action.id}`}
+                    className={styles.row}
+                  >
+                    <IconSquareRoundedCheck
+                      size={14}
+                      stroke={1.75}
+                      style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
+                    />
+                    <span className={styles.rowLabel}>{action.name}</span>
+                    {action.project && (
+                      <span className={styles.rowMeta}>{action.project.name}</span>
+                    )}
+                    {action.dueDate && (
+                      <span
+                        className={
+                          bucket === 'Overdue'
+                            ? `${styles.rowMeta} ${styles.rowMetaOverdue}`
+                            : styles.rowMeta
+                        }
+                      >
+                        {formatDue(new Date(action.dueDate))}
+                      </span>
+                    )}
+                  </UnstyledButton>
+                ))}
+              </div>
+            );
+          })}
+    </div>
+  );
+}

--- a/src/app/_components/home/YourWorkPanel.tsx
+++ b/src/app/_components/home/YourWorkPanel.tsx
@@ -2,7 +2,13 @@
 
 import Link from 'next/link';
 import { Skeleton, UnstyledButton } from '@mantine/core';
-import { IconSquareRoundedCheck, IconTicket } from '@tabler/icons-react';
+import {
+  IconSquareRoundedCheck,
+  IconStack2,
+  IconTarget,
+  IconTicket,
+  IconTrendingUp,
+} from '@tabler/icons-react';
 import { api, type RouterOutputs } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import styles from './YourWorkPanel.module.css';
@@ -14,6 +20,13 @@ function ticketStatusLabel(status: string): string {
   if (status === 'QA') return 'QA';
   const lower = status.toLowerCase().replace(/_/g, ' ');
   return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
+
+/** "on-track" / "at-risk" → "On track" / "At risk". */
+function healthLabel(health: string | null): string {
+  if (!health) return 'No update';
+  const words = health.replace(/-/g, ' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
 /**
@@ -64,6 +77,12 @@ export function YourWorkPanel() {
       { enabled: !!workspaceId },
     );
 
+  // Objectives / key results / projects where I'm the DRI.
+  const { data: dri, isLoading: driLoading } = api.yourWork.driItems.useQuery(
+    { workspaceId: workspaceId ?? '' },
+    { enabled: !!workspaceId },
+  );
+
   if (!workspaceId || !workspaceSlug) return null;
 
   const now = new Date();
@@ -88,8 +107,19 @@ export function YourWorkPanel() {
   }
 
   const openTickets = tickets ?? [];
+  const driGoals = dri?.goals ?? [];
+  const driKeyResults = dri?.keyResults ?? [];
+  const driProjects = dri?.projects ?? [];
+  const driCount = driGoals.length + driKeyResults.length + driProjects.length;
 
-  if (!isLoading && !ticketsLoading && active.length === 0 && openTickets.length === 0) {
+  if (
+    !isLoading &&
+    !ticketsLoading &&
+    !driLoading &&
+    active.length === 0 &&
+    openTickets.length === 0 &&
+    driCount === 0
+  ) {
     // Nothing assigned yet — the panel stays out of the way. The team-pulse
     // empty state (feature action 5) takes over here.
     return null;
@@ -175,6 +205,69 @@ export function YourWorkPanel() {
             ))}
           </div>
         )
+      )}
+
+      {!driLoading && driCount > 0 && (
+        <>
+          <div className={styles.sectionHeading}>You&apos;re the DRI</div>
+          {driGoals.map((goal) => (
+            <UnstyledButton
+              key={`goal-${goal.id}`}
+              component={Link}
+              href={`/w/${workspaceSlug}/goals/${goal.id}`}
+              className={styles.row}
+            >
+              <IconTarget
+                size={14}
+                stroke={1.75}
+                style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
+              />
+              <span className={styles.rowLabel}>{goal.title}</span>
+              <span className={styles.rowMeta}>Objective</span>
+              <span className={styles.rowMeta}>{healthLabel(goal.health)}</span>
+            </UnstyledButton>
+          ))}
+          {driKeyResults.map((kr) => (
+            <UnstyledButton
+              key={`kr-${kr.id}`}
+              component={Link}
+              href={`/w/${workspaceSlug}/goals/${kr.goalId}`}
+              className={styles.row}
+            >
+              <IconTrendingUp
+                size={14}
+                stroke={1.75}
+                style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
+              />
+              <span className={styles.rowLabel}>{kr.title}</span>
+              <span className={styles.rowMeta}>Key result</span>
+              <span className={styles.rowMeta}>
+                {healthLabel(kr.statusOverride ?? kr.status)}
+              </span>
+            </UnstyledButton>
+          ))}
+          {driProjects.map((project) => (
+            <UnstyledButton
+              key={`project-${project.id}`}
+              component={Link}
+              href={`/w/${workspaceSlug}/projects/${project.slug}`}
+              className={styles.row}
+            >
+              <IconStack2
+                size={14}
+                stroke={1.75}
+                style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
+              />
+              <span className={styles.rowLabel}>{project.name}</span>
+              <span className={styles.rowMeta}>Project</span>
+              <span className={styles.rowMeta}>
+                {project.progress > 0
+                  ? `${Math.round(project.progress)}%`
+                  : 'Not started'}
+              </span>
+            </UnstyledButton>
+          ))}
+        </>
       )}
     </div>
   );

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -90,6 +90,7 @@ import { documentRouter } from "./routers/document";
 import { voiceRouter } from "./routers/voice";
 import { pageRouter } from "./routers/page";
 import { pageCommentRouter } from "./routers/pageComment";
+import { yourWorkRouter } from "./routers/yourWork";
 /**
  * This is the primary router for your server.
  *
@@ -182,6 +183,7 @@ export const appRouter = createTRPCRouter({
   voice: voiceRouter,
   page: pageRouter,
   pageComment: pageCommentRouter,
+  yourWork: yourWorkRouter,
   // Plugin system
   pluginConfig: pluginConfigRouter,
   okr: keyResultRouter,

--- a/src/server/api/routers/yourWork.ts
+++ b/src/server/api/routers/yourWork.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { requireWorkspaceMembership } from "~/server/services/access/middleware";
+
+/**
+ * Per-user "Your work" aggregation backing the workspace-home panel
+ * (feature: Personal home). Every procedure reads existing per-entity
+ * fields — no schema changes; the weekly work digest gatherer
+ * (`weeklyWorkDigest/gather.ts`) is the reference for the query shapes.
+ */
+export const yourWorkRouter = createTRPCRouter({
+  /**
+   * Open tickets assigned to the current user in this workspace. Same query
+   * arm as the digest gatherer (Ticket.assigneeId is indexed).
+   */
+  assignedTickets: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
+    .query(async ({ ctx, input }) => {
+      return ctx.db.ticket.findMany({
+        where: {
+          assigneeId: ctx.session.user.id,
+          status: { notIn: ["DONE", "DEPLOYED", "ARCHIVED"] },
+          product: { workspaceId: input.workspaceId },
+        },
+        orderBy: { updatedAt: "desc" },
+        take: 8,
+        select: {
+          id: true,
+          shortId: true,
+          number: true,
+          title: true,
+          status: true,
+          product: { select: { slug: true } },
+        },
+      });
+    }),
+});

--- a/src/server/api/routers/yourWork.ts
+++ b/src/server/api/routers/yourWork.ts
@@ -35,4 +35,55 @@ export const yourWorkRouter = createTRPCRouter({
         },
       });
     }),
+
+  /**
+   * Objectives, key results, and projects where the current user is the DRI.
+   * These fields (Goal.driUserId, KeyResult.driUserId, Project.driId) are
+   * written by the OKR/project editors but had no read path until this panel.
+   */
+  driItems: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const [goals, keyResults, projects] = await Promise.all([
+        ctx.db.goal.findMany({
+          where: {
+            driUserId: userId,
+            workspaceId: input.workspaceId,
+            status: { in: ["planned", "active"] },
+          },
+          orderBy: { id: "desc" },
+          take: 6,
+          select: { id: true, title: true, health: true },
+        }),
+        ctx.db.keyResult.findMany({
+          where: {
+            driUserId: userId,
+            workspaceId: input.workspaceId,
+            status: { not: "achieved" },
+          },
+          orderBy: { updatedAt: "desc" },
+          take: 6,
+          select: {
+            id: true,
+            title: true,
+            goalId: true,
+            status: true,
+            statusOverride: true,
+          },
+        }),
+        ctx.db.project.findMany({
+          where: {
+            driId: userId,
+            workspaceId: input.workspaceId,
+            status: "ACTIVE",
+          },
+          orderBy: { createdAt: "desc" },
+          take: 6,
+          select: { id: true, name: true, slug: true, progress: true },
+        }),
+      ]);
+      return { goals, keyResults, projects };
+    }),
 });


### PR DESCRIPTION
## What

A per-user **"Your work" panel** on the command-layout workspace home: everything assigned to me, things I'm directly responsible for, and meetings I was in — with an empty state that leads with team activity so a fresh invitee still sees a living page. Backed by existing per-entity queries unified behind a new `yourWork` tRPC router; **no schema changes**. One commit per section:

1. **Tracer: "Assigned to you"** — the current user's actions via `action.getAll`'s existing "mine" semantics, workspace-scoped, grouped by due date (Overdue / Today / This week / Later / No due date).
2. **Assigned tickets** — new `yourWork.assignedTickets` (Ticket.assigneeId, indexed; same arm as the weekly work digest gatherer), with status labels and links into the product board.
3. **"You're the DRI"** — first read paths over `Goal.driUserId`, `KeyResult.driUserId`, `Project.driId` (`yourWork.driItems`), with health/progress meta.
4. **"Recent meetings you were in"** — `transcription.getAllTranscriptions` with `meetingType: 'mine'` (owner + participant union), linking to the recording detail.
5. **Team-pulse empty state** — a fresh member with nothing assigned sees "nothing assigned to you yet" plus the existing workspace ActivityFeed card, never a wall of empty sections.

## Acceptance criteria

- [x] Workspace home shows the current user's assigned actions and tickets, grouped/sorted usefully (due date first)
- [x] Objectives, key results, and projects where the user is DRI are listed (first read paths over the existing DRI fields)
- [x] Meetings the user attended appear (owner or participant)
- [x] A user with nothing assigned sees team activity, not a wall of empty sections
- [x] All sections respect workspace scoping and access control (`requireWorkspaceMembership("view")` on the new procedures; existing access-checked queries elsewhere)

Each section was verified in a local dev server against the dev-fixture workspace with two members — including the negative case (another member's actions absent) and the fresh-invitee empty state.

---

Ships: lively.vale

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cmsq4am85000tju04ygnb7m1r)
