### PR TITLE
ci: stop the merge hooks swallowing the CLI's error

### DIFF
--- a/.github/workflows/exponential-promote.yml
+++ b/.github/workflows/exponential-promote.yml
@@ -59,8 +59,17 @@ jobs:
             fi
           } | sort -u > /tmp/prs
           jq -R -s -c 'split("\n") | map(select(length > 0))' /tmp/prs > /tmp/prs.json
-          exponential tickets list \
-            --product "$EXPO_PRODUCT" --workspace "$EXPO_WORKSPACE" --json > /tmp/all.json
+          # The CLI reports failures as a JSON error object on STDOUT, not stderr
+          # -- so a bare `> /tmp/all.json` redirects the message into the file and
+          # the step dies with a naked "exit 1" and not one line of log. That is
+          # how a missing workspace grant presented: indistinguishable from any
+          # other failure. Echo whatever landed in the file before giving up.
+          if ! exponential tickets list \
+                 --product "$EXPO_PRODUCT" --workspace "$EXPO_WORKSPACE" \
+                 --json > /tmp/all.json; then
+            echo "::error title=Exponential CLI failed::$(head -c 800 /tmp/all.json)"
+            exit 1
+          fi
           jq --slurpfile prs /tmp/prs.json \
             '[.tickets[] | select(.prUrl != null and (.prUrl as $u | $prs[0] | index($u)))]' \
             /tmp/all.json > /tmp/tickets.json

--- a/.github/workflows/exponential-requirements.yml
+++ b/.github/workflows/exponential-requirements.yml
@@ -68,8 +68,17 @@ jobs:
             fi
           } | sort -u > /tmp/prs
           jq -R -s -c 'split("\n") | map(select(length > 0))' /tmp/prs > /tmp/prs.json
-          exponential tickets list \
-            --product "$EXPO_PRODUCT" --workspace "$EXPO_WORKSPACE" --json > /tmp/all.json
+          # The CLI reports failures as a JSON error object on STDOUT, not stderr
+          # -- so a bare `> /tmp/all.json` redirects the message into the file and
+          # the step dies with a naked "exit 1" and not one line of log. That is
+          # how a missing workspace grant presented: indistinguishable from any
+          # other failure. Echo whatever landed in the file before giving up.
+          if ! exponential tickets list \
+                 --product "$EXPO_PRODUCT" --workspace "$EXPO_WORKSPACE" \
+                 --json > /tmp/all.json; then
+            echo "::error title=Exponential CLI failed::$(head -c 800 /tmp/all.json)"
+            exit 1
+          fi
           jq --slurpfile prs /tmp/prs.json \
             '[.tickets[] | select(.prUrl != null and (.prUrl as $u | $prs[0] | index($u)))]' \
             /tmp/all.json > /tmp/tickets.json


### PR DESCRIPTION
Follow-up to #560. That PR got the hooks past `Auth` and past the `git log` guard — but they still fail, and the reason is invisible.

## The problem

Both hooks list tickets with `--json` redirected to a file:

```bash
exponential tickets list --product … --workspace … --json > /tmp/all.json
```

The CLI reports failures as a **JSON error object on stdout**, not stderr. That redirect therefore sends the error message into the file, and the step dies with a naked `exit 1` and not one line of log.

Runs [31606073331](https://github.com/positonic/exponential/actions/runs/31606073331) and [31606073345](https://github.com/positonic/exponential/actions/runs/31606073345) are the case in point: `Auth` logs `Successfully authenticated!`, then the next step fails in 1.4 seconds with **zero output** — indistinguishable from a crash, a `jq` error, or a network fault. The credential is valid; it just cannot see the workspace, and the message saying so was written to a file nobody reads.

## The fix

Capture the failure and echo it as an annotation. Verified by extracting the real patched step out of the workflow and running it against the live CLI.

**Failure path** — a workspace the key cannot see:

```
::error title=Exponential CLI failed::{
  "error": {
    "code": "UNKNOWN",
    "message": "Workspace \"no-such-ws\" not found. Available: artizen, clear, …"
  }
}
exit=1
```

**Happy path** — unchanged:

```
Matched 2 ticket(s).
exit=0
```

The `not found` message names the workspaces the principal *can* see, which is exactly what distinguishes a missing grant from a typo — the diagnostic that was missing this whole time these hooks were down.

## Note

This does not by itself turn the hooks green; the CI key still needs its `syntrofi` grant (`externalAgent.grantWorkspaces`, human-only). It makes the next failure legible instead of silent.
