### PR TITLE
feat: Mentions inbox reading the existing notification pipeline

### DIFF
--- a/prisma/migrations/20260812214409_add_notification_read_at/migration.sql
+++ b/prisma/migrations/20260812214409_add_notification_read_at/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Notification" ADD COLUMN "readAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "Notification_userId_readAt_idx" ON "Notification"("userId", "readAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2044,6 +2044,9 @@ model Notification {
   deeplink     String?
   dedupeKey    String
   scheduledFor DateTime?
+  /// In-app read state (null = unread). Set by the inbox UI; delivery
+  /// channels never touch it.
+  readAt       DateTime?
   createdAt    DateTime               @default(now())
   updatedAt    DateTime               @updatedAt
   user         User                   @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -2051,6 +2054,7 @@ model Notification {
 
   @@unique([dedupeKey, userId])
   @@index([userId])
+  @@index([userId, readAt])
   @@index([category])
   @@index([scheduledFor])
   @@index([createdAt])

--- a/src/app/_components/home/YourWorkPanel.module.css
+++ b/src/app/_components/home/YourWorkPanel.module.css
@@ -39,6 +39,65 @@
   margin: 18px 0 10px;
   padding-bottom: 6px;
   border-bottom: 1px solid var(--color-border-subtle);
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.sectionHeadingLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.unreadBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 8px;
+  background: var(--brand-500);
+  color: var(--color-text-inverse);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.sectionAction {
+  border: 0;
+  background: none;
+  padding: 0;
+  color: var(--color-text-muted);
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+  cursor: pointer;
+}
+
+.sectionAction:hover {
+  color: var(--color-text-secondary);
+  text-decoration: underline;
+}
+
+.sectionAction:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.rowLabelUnread {
+  font-weight: 600;
+}
+
+.unreadDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--brand-400);
+  flex-shrink: 0;
 }
 
 .emptyNote {

--- a/src/app/_components/home/YourWorkPanel.tsx
+++ b/src/app/_components/home/YourWorkPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from '@tabler/icons-react';
 import { api, type RouterOutputs } from '~/trpc/react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { NOTIFICATION_CATEGORIES } from '~/server/services/notifications/emit/constants';
 import { ActivityFeed } from './activity/ActivityFeed';
 import './activity/activity-home.css';
 import styles from './YourWorkPanel.module.css';
@@ -99,9 +100,12 @@ export function YourWorkPanel() {
   // follows the person.
   const utils = api.useUtils();
   const { data: mentionData, isLoading: mentionsLoading } =
-    api.notification.list.useQuery({ category: 'mention', limit: 5 });
+    api.notification.list.useQuery({
+      category: NOTIFICATION_CATEGORIES.MENTION,
+      limit: 5,
+    });
   const { data: unreadMentions } = api.notification.unreadCount.useQuery({
-    category: 'mention',
+    category: NOTIFICATION_CATEGORIES.MENTION,
   });
   const invalidateInbox = () => {
     void utils.notification.list.invalidate();
@@ -270,7 +274,9 @@ export function YourWorkPanel() {
               <button
                 type="button"
                 className={styles.sectionAction}
-                onClick={() => markAllRead.mutate({ category: 'mention' })}
+                onClick={() =>
+                  markAllRead.mutate({ category: NOTIFICATION_CATEGORIES.MENTION })
+                }
                 disabled={markAllRead.isPending}
               >
                 Mark all read

--- a/src/app/_components/home/YourWorkPanel.tsx
+++ b/src/app/_components/home/YourWorkPanel.tsx
@@ -97,8 +97,22 @@ export function YourWorkPanel() {
   // Mention notifications — the ADR-0045 pipeline writes these rows; this
   // inbox is their first reader. User-scoped, not workspace-scoped: a mention
   // follows the person.
+  const utils = api.useUtils();
   const { data: mentionData, isLoading: mentionsLoading } =
     api.notification.list.useQuery({ category: 'mention', limit: 5 });
+  const { data: unreadMentions } = api.notification.unreadCount.useQuery({
+    category: 'mention',
+  });
+  const invalidateInbox = () => {
+    void utils.notification.list.invalidate();
+    void utils.notification.unreadCount.invalidate();
+  };
+  const markRead = api.notification.markRead.useMutation({
+    onSuccess: invalidateInbox,
+  });
+  const markAllRead = api.notification.markAllRead.useMutation({
+    onSuccess: invalidateInbox,
+  });
 
   if (!workspaceId || !workspaceSlug) return null;
 
@@ -245,8 +259,26 @@ export function YourWorkPanel() {
 
       {!mentionsLoading && mentions.length > 0 && (
         <>
-          <div className={styles.sectionHeading}>Mentions</div>
+          <div className={styles.sectionHeading}>
+            <span className={styles.sectionHeadingLabel}>
+              Mentions
+              {(unreadMentions ?? 0) > 0 && (
+                <span className={styles.unreadBadge}>{unreadMentions}</span>
+              )}
+            </span>
+            {(unreadMentions ?? 0) > 0 && (
+              <button
+                type="button"
+                className={styles.sectionAction}
+                onClick={() => markAllRead.mutate({ category: 'mention' })}
+                disabled={markAllRead.isPending}
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
           {mentions.map((mention) => {
+            const isUnread = mention.readAt === null;
             const row = (
               <>
                 <IconAt
@@ -254,28 +286,44 @@ export function YourWorkPanel() {
                   stroke={1.75}
                   style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
                 />
-                <span className={styles.rowLabel}>
+                <span
+                  className={
+                    isUnread
+                      ? `${styles.rowLabel} ${styles.rowLabelUnread}`
+                      : styles.rowLabel
+                  }
+                >
                   {mention.title}
                   {mention.message ? ` — ${mention.message}` : ''}
                 </span>
+                {isUnread && <span className={styles.unreadDot} aria-label="Unread" />}
                 <span className={styles.rowMeta}>
                   {formatDue(new Date(mention.createdAt))}
                 </span>
               </>
             );
+            // Opening a mention reads it — mark before the navigation unmounts us.
+            const readOnOpen = () => {
+              if (isUnread) markRead.mutate({ notificationId: mention.id });
+            };
             return mention.deeplink ? (
               <UnstyledButton
                 key={mention.id}
                 component={Link}
                 href={mention.deeplink}
                 className={styles.row}
+                onClick={readOnOpen}
               >
                 {row}
               </UnstyledButton>
             ) : (
-              <div key={mention.id} className={styles.row}>
+              <UnstyledButton
+                key={mention.id}
+                className={styles.row}
+                onClick={readOnOpen}
+              >
                 {row}
-              </div>
+              </UnstyledButton>
             );
           })}
         </>

--- a/src/app/_components/home/YourWorkPanel.tsx
+++ b/src/app/_components/home/YourWorkPanel.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { Skeleton, UnstyledButton } from '@mantine/core';
 import {
+  IconAt,
   IconMicrophone,
   IconSquareRoundedCheck,
   IconStack2,
@@ -93,6 +94,12 @@ export function YourWorkPanel() {
       { enabled: !!workspaceId },
     );
 
+  // Mention notifications — the ADR-0045 pipeline writes these rows; this
+  // inbox is their first reader. User-scoped, not workspace-scoped: a mention
+  // follows the person.
+  const { data: mentionData, isLoading: mentionsLoading } =
+    api.notification.list.useQuery({ category: 'mention', limit: 5 });
+
   if (!workspaceId || !workspaceSlug) return null;
 
   const now = new Date();
@@ -122,16 +129,19 @@ export function YourWorkPanel() {
   const driProjects = dri?.projects ?? [];
   const driCount = driGoals.length + driKeyResults.length + driProjects.length;
   const recentMeetings = (meetings ?? []).slice(0, 5);
+  const mentions = mentionData?.notifications ?? [];
 
   const personalSectionsEmpty =
     !isLoading &&
     !ticketsLoading &&
     !driLoading &&
     !meetingsLoading &&
+    !mentionsLoading &&
     active.length === 0 &&
     openTickets.length === 0 &&
     driCount === 0 &&
-    recentMeetings.length === 0;
+    recentMeetings.length === 0 &&
+    mentions.length === 0;
 
   if (personalSectionsEmpty) {
     // The brand-new invitee case: nothing assigned yet. Lead with the team's
@@ -231,6 +241,44 @@ export function YourWorkPanel() {
             ))}
           </div>
         )
+      )}
+
+      {!mentionsLoading && mentions.length > 0 && (
+        <>
+          <div className={styles.sectionHeading}>Mentions</div>
+          {mentions.map((mention) => {
+            const row = (
+              <>
+                <IconAt
+                  size={14}
+                  stroke={1.75}
+                  style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
+                />
+                <span className={styles.rowLabel}>
+                  {mention.title}
+                  {mention.message ? ` — ${mention.message}` : ''}
+                </span>
+                <span className={styles.rowMeta}>
+                  {formatDue(new Date(mention.createdAt))}
+                </span>
+              </>
+            );
+            return mention.deeplink ? (
+              <UnstyledButton
+                key={mention.id}
+                component={Link}
+                href={mention.deeplink}
+                className={styles.row}
+              >
+                {row}
+              </UnstyledButton>
+            ) : (
+              <div key={mention.id} className={styles.row}>
+                {row}
+              </div>
+            );
+          })}
+        </>
       )}
 
       {!driLoading && driCount > 0 && (

--- a/src/server/api/routers/__tests__/notificationList.test.ts
+++ b/src/server/api/routers/__tests__/notificationList.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for notification.list cursor pagination.
+ *
+ * Regression test for an off-by-one: the query fetches `limit + 1` rows to
+ * detect a next page, and the (limit+1)-th row was popped AND used as the
+ * nextCursor. Because the follow-up query passes `skip: 1` (skip the cursor
+ * row itself), that popped row was never returned on any page — every page
+ * boundary silently dropped one notification. The cursor must instead be the
+ * last row actually returned.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      /* noop */
+    }
+  },
+}));
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const USER_ID = "user-1";
+
+/** 7 notifications, newest first (n1 newest … n7 oldest) — the DB order. */
+const ALL_ROWS = Array.from({ length: 7 }, (_, i) => ({
+  id: `n${i + 1}`,
+  category: "mention",
+  title: `Mention ${i + 1}`,
+  message: null,
+  deeplink: null,
+  createdAt: new Date(Date.UTC(2026, 0, 31 - i)),
+  readAt: null,
+}));
+
+/**
+ * Simulate Prisma's cursor pagination over the fixed row set: `cursor` is
+ * inclusive (positions the window ON that row), `skip` then skips from there,
+ * `take` limits. This is exactly the semantics the router relies on.
+ */
+function fakeFindMany(args: { cursor?: { id: string }; skip?: number; take?: number }) {
+  let start = 0;
+  if (args.cursor) {
+    start = ALL_ROWS.findIndex((r) => r.id === args.cursor!.id);
+    if (start === -1) throw new Error(`cursor ${args.cursor.id} not found`);
+  }
+  start += args.skip ?? 0;
+  return Promise.resolve(ALL_ROWS.slice(start, start + (args.take ?? ALL_ROWS.length)));
+}
+
+describe("notification.list cursor pagination", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    dbMock.notification.findMany.mockImplementation(fakeFindMany as never);
+  });
+
+  it("pages are contiguous — no dropped or duplicated rows across the boundary", async () => {
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+
+    // Page 1: rows 1–3, cursor points at the LAST RETURNED row (n3), not the
+    // peeked 4th row — otherwise n4 would be skipped by the next query's skip:1.
+    const page1 = await caller.notification.list({ limit: 3 });
+    expect(page1.notifications.map((n) => n.id)).toEqual(["n1", "n2", "n3"]);
+    expect(page1.nextCursor).toBe("n3");
+
+    // Page 2 resumes from that cursor.
+    const page2 = await caller.notification.list({ limit: 3, cursor: page1.nextCursor });
+    expect(page2.notifications.map((n) => n.id)).toEqual(["n4", "n5", "n6"]);
+    expect(page2.nextCursor).toBe("n6");
+
+    // The second query carried the inclusive cursor + skip:1 + peek row.
+    expect(dbMock.notification.findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ cursor: { id: "n3" }, skip: 1, take: 4 }),
+    );
+
+    // Page 3: the final partial page, no further cursor.
+    const page3 = await caller.notification.list({ limit: 3, cursor: page2.nextCursor });
+    expect(page3.notifications.map((n) => n.id)).toEqual(["n7"]);
+    expect(page3.nextCursor).toBeUndefined();
+
+    // Contiguity: the three pages together are exactly the 7 rows, in order.
+    const walked = [page1, page2, page3].flatMap((p) => p.notifications.map((n) => n.id));
+    expect(walked).toEqual(ALL_ROWS.map((r) => r.id));
+  });
+
+  it("orders newest-first with an id tie-break for determinism", async () => {
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await caller.notification.list({ limit: 3 });
+    expect(dbMock.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      }),
+    );
+  });
+});

--- a/src/server/api/routers/notification.ts
+++ b/src/server/api/routers/notification.ts
@@ -72,7 +72,7 @@ export const notificationRouter = createTRPCRouter({
           // A future scheduledFor means the notification hasn't fired yet.
           OR: [{ scheduledFor: null }, { scheduledFor: { lte: new Date() } }],
         },
-        orderBy: { createdAt: "desc" },
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
         take: limit + 1,
         ...(input?.cursor ? { cursor: { id: input.cursor }, skip: 1 } : {}),
         select: {
@@ -88,7 +88,8 @@ export const notificationRouter = createTRPCRouter({
 
       let nextCursor: string | undefined;
       if (rows.length > limit) {
-        nextCursor = rows.pop()!.id;
+        rows.pop();
+        nextCursor = rows[rows.length - 1]?.id;
       }
       return { notifications: rows, nextCursor };
     }),

--- a/src/server/api/routers/notification.ts
+++ b/src/server/api/routers/notification.ts
@@ -82,6 +82,7 @@ export const notificationRouter = createTRPCRouter({
           message: true,
           deeplink: true,
           createdAt: true,
+          readAt: true,
         },
       });
 
@@ -90,6 +91,54 @@ export const notificationRouter = createTRPCRouter({
         nextCursor = rows.pop()!.id;
       }
       return { notifications: rows, nextCursor };
+    }),
+
+  /**
+   * Mark one Notification read. Scoped to the current user via updateMany so
+   * a foreign id is a silent no-op rather than an oracle; idempotent (an
+   * already-read row keeps its original readAt).
+   */
+  markRead: protectedProcedure
+    .input(z.object({ notificationId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await ctx.db.notification.updateMany({
+        where: {
+          id: input.notificationId,
+          userId: ctx.session.user.id,
+          readAt: null,
+        },
+        data: { readAt: new Date() },
+      });
+      return { success: true };
+    }),
+
+  /** Mark every unread Notification read, optionally within one category. */
+  markAllRead: protectedProcedure
+    .input(z.object({ category: z.string().optional() }).optional())
+    .mutation(async ({ ctx, input }) => {
+      const result = await ctx.db.notification.updateMany({
+        where: {
+          userId: ctx.session.user.id,
+          readAt: null,
+          ...(input?.category ? { category: input.category } : {}),
+        },
+        data: { readAt: new Date() },
+      });
+      return { success: true, count: result.count };
+    }),
+
+  /** Unread Notification count for the badge, optionally per category. */
+  unreadCount: protectedProcedure
+    .input(z.object({ category: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      return ctx.db.notification.count({
+        where: {
+          userId: ctx.session.user.id,
+          readAt: null,
+          ...(input?.category ? { category: input.category } : {}),
+          OR: [{ scheduledFor: null }, { scheduledFor: { lte: new Date() } }],
+        },
+      });
     }),
 
   // Get user notification preferences

--- a/src/server/api/routers/notification.ts
+++ b/src/server/api/routers/notification.ts
@@ -62,7 +62,7 @@ export const notificationRouter = createTRPCRouter({
     .input(
       z
         .object({
-          category: z.string().optional(),
+          category: z.enum(CATEGORY_LIST).optional(),
           limit: z.number().int().min(1).max(50).default(20),
           cursor: z.string().optional(),
         })
@@ -119,7 +119,7 @@ export const notificationRouter = createTRPCRouter({
 
   /** Mark every unread Notification read, optionally within one category. */
   markAllRead: protectedProcedure
-    .input(z.object({ category: z.string().optional() }).optional())
+    .input(z.object({ category: z.enum(CATEGORY_LIST).optional() }).optional())
     .mutation(async ({ ctx, input }) => {
       const result = await ctx.db.notification.updateMany({
         where: {
@@ -135,7 +135,7 @@ export const notificationRouter = createTRPCRouter({
 
   /** Unread Notification count for the badge, optionally per category. */
   unreadCount: protectedProcedure
-    .input(z.object({ category: z.string().optional() }).optional())
+    .input(z.object({ category: z.enum(CATEGORY_LIST).optional() }).optional())
     .query(async ({ ctx, input }) => {
       return ctx.db.notification.count({
         where: {

--- a/src/server/api/routers/notification.ts
+++ b/src/server/api/routers/notification.ts
@@ -46,6 +46,11 @@ async function resolveChannelAvailability(db: PrismaClient, userId: string) {
   };
 }
 
+/** Visibility window shared by list/unreadCount/markAllRead — a future scheduledFor means the notification hasn't fired yet. */
+const firedWindow = () => ({
+  OR: [{ scheduledFor: null }, { scheduledFor: { lte: new Date() } }],
+});
+
 export const notificationRouter = createTRPCRouter({
   /**
    * List the current user's Notification rows — the read side of the
@@ -69,8 +74,7 @@ export const notificationRouter = createTRPCRouter({
         where: {
           userId: ctx.session.user.id,
           ...(input?.category ? { category: input.category } : {}),
-          // A future scheduledFor means the notification hasn't fired yet.
-          OR: [{ scheduledFor: null }, { scheduledFor: { lte: new Date() } }],
+          ...firedWindow(),
         },
         orderBy: [{ createdAt: "desc" }, { id: "desc" }],
         take: limit + 1,
@@ -122,6 +126,7 @@ export const notificationRouter = createTRPCRouter({
           userId: ctx.session.user.id,
           readAt: null,
           ...(input?.category ? { category: input.category } : {}),
+          ...firedWindow(),
         },
         data: { readAt: new Date() },
       });
@@ -137,7 +142,7 @@ export const notificationRouter = createTRPCRouter({
           userId: ctx.session.user.id,
           readAt: null,
           ...(input?.category ? { category: input.category } : {}),
-          OR: [{ scheduledFor: null }, { scheduledFor: { lte: new Date() } }],
+          ...firedWindow(),
         },
       });
     }),

--- a/src/server/api/routers/notification.ts
+++ b/src/server/api/routers/notification.ts
@@ -47,6 +47,51 @@ async function resolveChannelAvailability(db: PrismaClient, userId: string) {
 }
 
 export const notificationRouter = createTRPCRouter({
+  /**
+   * List the current user's Notification rows — the read side of the
+   * ADR-0045 pipeline (which until this query only ever wrote them).
+   * Newest first, cursor-paginated, optionally narrowed to one category
+   * (e.g. "mention" for the home-panel inbox).
+   */
+  list: protectedProcedure
+    .input(
+      z
+        .object({
+          category: z.string().optional(),
+          limit: z.number().int().min(1).max(50).default(20),
+          cursor: z.string().optional(),
+        })
+        .optional(),
+    )
+    .query(async ({ ctx, input }) => {
+      const limit = input?.limit ?? 20;
+      const rows = await ctx.db.notification.findMany({
+        where: {
+          userId: ctx.session.user.id,
+          ...(input?.category ? { category: input.category } : {}),
+          // A future scheduledFor means the notification hasn't fired yet.
+          OR: [{ scheduledFor: null }, { scheduledFor: { lte: new Date() } }],
+        },
+        orderBy: { createdAt: "desc" },
+        take: limit + 1,
+        ...(input?.cursor ? { cursor: { id: input.cursor }, skip: 1 } : {}),
+        select: {
+          id: true,
+          category: true,
+          title: true,
+          message: true,
+          deeplink: true,
+          createdAt: true,
+        },
+      });
+
+      let nextCursor: string | undefined;
+      if (rows.length > limit) {
+        nextCursor = rows.pop()!.id;
+      }
+      return { notifications: rows, nextCursor };
+    }),
+
   // Get user notification preferences
   getPreferences: protectedProcedure.query(async ({ ctx }) => {
     const preferences = await ctx.db.notificationPreference.findUnique({


### PR DESCRIPTION
## What

The read side of the ADR-0045 notification pipeline — mention notifications were written end-to-end (`@[Name](userId)` parsing, recipient resolution, deduped Notification rows) but no UI ever read them back. This adds:

1. **Tracer: `notification.list` + Mentions inbox** — first reader of the `Notification` table: current user only, newest first, cursor-paginated, category filter. The Your work panel gains a Mentions section; each row deeplinks to the entity the mention lives on.
2. **Mark-as-read + mark-all, backed by a new `readAt` column** — the ticket pointed at the existing `markNotificationRead` mutation, but that targets the legacy `ScheduledNotification` table and the ADR-0045 table had no read state at all. Per refinement with James: `readAt DateTime?` on `Notification` (+ `(userId, readAt)` index, migration included), `notification.markRead` / `markAllRead` scoped to the current user via `updateMany`. Opening a mention marks it read.
3. **Unread count badge** — `notification.unreadCount` drives a badge on the section heading plus the Mark-all-read affordance; unread rows render bold with a dot.

## Migration

One additive migration: `20260812214409_add_notification_read_at` (nullable column + index — no backfill, no data risk). Note for the shared preview DB: per the develop-sync convention, sync develop after this merges or apply the migration to the preview DB.

## Acceptance criteria

- [x] Being @-mentioned in any comment type surfaces in the mentions inbox
- [x] Read/unread state persists and the unread count matches
- [x] Clicking a mention navigates to the entity it lives on
- [x] Only the current user's notifications are ever returned (every query/mutation filters on `ctx.session.user.id`)

Verified end-to-end in a local dev server: a real action-comment mention → Notification row → inbox row (bold + badge) → click navigates to the action and marks it read → mark-all clears the badge → state persists across reload.

---

Ships: rainy.gecko

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cmsq4b7o20005in04l7mwx4qd)
