### PR TITLE
fix: Land the member-added email on the invite page, not a signin wall

### DIFF
--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -122,6 +122,20 @@ export default function InviteAcceptPage() {
     );
   }
 
+  // A signed-out visitor gets the landing page (sign-in options with their
+  // email prefilled) whether the invitation is still pending or was already
+  // accepted. The accepted case is the "you've been added" email for existing
+  // users: membership is already granted, so the only job left is signing in —
+  // bouncing them to an anonymous /signin wall or an "Already Used" card is a
+  // dead end. Expired *pending* invites still fall through to the expired card.
+  if (
+    !invitation.isLoggedIn &&
+    (invitation.status === "accepted" ||
+      (invitation.status === "pending" && !invitation.isExpired))
+  ) {
+    return <InviteLandingPage token={token} invitation={invitation} />;
+  }
+
   if (invitation.isExpired) {
     return (
       <Container size="sm" className="py-16">
@@ -166,10 +180,6 @@ export default function InviteAcceptPage() {
         </Card>
       </Container>
     );
-  }
-
-  if (!invitation.isLoggedIn) {
-    return <InviteLandingPage token={token} invitation={invitation} />;
   }
 
   if (!invitation.isForCurrentUser) {
@@ -293,6 +303,10 @@ function InviteLandingPage({
 }) {
   const router = useRouter();
   const callbackUrl = `/invite/${token}`;
+  // The "member added" email for existing users lands here with an
+  // already-accepted invitation: membership is granted, so the page's job is
+  // just getting them signed in — the copy drops the join/accept framing.
+  const alreadyMember = invitation.status === "accepted";
   const workspaceName = invitation.workspace.name;
   const workspaceSlug = invitation.workspace.slug;
   const workspaceInitial = workspaceName.charAt(0).toUpperCase();
@@ -402,19 +416,31 @@ function InviteLandingPage({
             <div className="eyebrow">
               <span className="eyebrow__dot" aria-hidden="true" />
               <span>
-                You&apos;ve been invited · expires in {daysUntilExpiry} days
+                {alreadyMember
+                  ? "You're a member · sign in to continue"
+                  : `You've been invited · expires in ${daysUntilExpiry} days`}
               </span>
             </div>
 
             <h1 className="auth-title">
-              Join{" "}
+              {alreadyMember ? "Open" : "Join"}{" "}
               <span className="auth-title__brand">{workspaceName}</span> on{" "}
               {PRODUCT_NAME}
             </h1>
             <p className="auth-sub">
-              <b>{inviterName}</b> invited you to collaborate on the{" "}
-              <b>{workspaceName}</b> workspace — where the team runs its
-              rituals, projects and OKRs together.
+              {alreadyMember ? (
+                <>
+                  <b>{inviterName}</b> added you to the <b>{workspaceName}</b>{" "}
+                  workspace — sign in below and you&apos;ll land right inside
+                  it.
+                </>
+              ) : (
+                <>
+                  <b>{inviterName}</b> invited you to collaborate on the{" "}
+                  <b>{workspaceName}</b> workspace — where the team runs its
+                  rituals, projects and OKRs together.
+                </>
+              )}
             </p>
 
             <div className="invite-card">
@@ -548,13 +574,17 @@ function InviteLandingPage({
                 type="submit"
                 disabled={isBusy}
               >
-                <span>Accept invite &amp; join {workspaceName}</span>
+                <span>
+                  {alreadyMember
+                    ? `Sign in & open ${workspaceName}`
+                    : `Accept invite & join ${workspaceName}`}
+                </span>
                 <ArrowRightGlyph />
               </button>
             </form>
 
             <p className="terms">
-              By joining, you agree to our{" "}
+              By {alreadyMember ? "signing in" : "joining"}, you agree to our{" "}
               <a href="/terms">Terms of Service</a> and{" "}
               <a href="/privacy">Privacy Policy</a>, and to share your name and
               email with members of <b>{workspaceName}</b>.

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -127,30 +127,47 @@ export default function InviteAcceptPage() {
   // accepted. The accepted case is the "you've been added" email for existing
   // users: membership is already granted, so the only job left is signing in —
   // bouncing them to an anonymous /signin wall or an "Already Used" card is a
-  // dead end. Expired *pending* invites still fall through to the expired card.
+  // dead end. Expiry still gates both: this page is public and shows the
+  // workspace name, inviter and member count, so a forwarded link shouldn't
+  // keep serving that forever — and removeMember expires the row on the way
+  // out, which is what stops a removed member's link from still rendering.
   if (
     !invitation.isLoggedIn &&
-    (invitation.status === "accepted" ||
-      (invitation.status === "pending" && !invitation.isExpired))
+    !invitation.isExpired &&
+    (invitation.status === "accepted" || invitation.status === "pending")
   ) {
     return <InviteLandingPage token={token} invitation={invitation} />;
   }
 
   if (invitation.isExpired) {
+    // An accepted invitation's link is the "you've been added" email, not a
+    // join offer — "ask the admin for a new invitation" is the wrong advice
+    // for someone who may still be a member, so point them at the workspace.
+    const wasAdded = invitation.status === "accepted";
     return (
       <Container size="sm" className="py-16">
         <Card className="bg-surface-secondary border-border-primary" withBorder>
           <Stack gap="md" align="center" className="py-8">
             <IconClock size={48} className="text-yellow-500" />
             <Title order={2} className="text-text-primary">
-              Invitation Expired
+              {wasAdded ? "Link Expired" : "Invitation Expired"}
             </Title>
             <Text className="text-text-secondary text-center">
-              This invitation has expired. Please contact the workspace admin to
-              request a new invitation.
+              {wasAdded
+                ? `This link has expired. If you still have access to ${invitation.workspace.name}, open it below and sign in when asked.`
+                : "This invitation has expired. Please contact the workspace admin to request a new invitation."}
             </Text>
-            <Button variant="light" onClick={() => router.push("/")}>
-              Go to Home
+            <Button
+              variant="light"
+              onClick={() =>
+                router.push(
+                  wasAdded ? `/w/${invitation.workspace.slug}` : "/"
+                )
+              }
+            >
+              {wasAdded
+                ? `Open ${invitation.workspace.name}`
+                : "Go to Home"}
             </Button>
           </Stack>
         </Card>

--- a/src/server/api/routers/__tests__/workspaceAddMember.test.ts
+++ b/src/server/api/routers/__tests__/workspaceAddMember.test.ts
@@ -141,7 +141,11 @@ describe("workspace.addMember (existing user)", () => {
 
   it("emails a /invite/<token> landing link backed by an accepted invitation", async () => {
     stubExistingUserPath(db);
-    db.workspaceInvitation.upsert.mockResolvedValue({} as never);
+    // Prisma returns the stored row; the CTA is built from *its* token.
+    db.workspaceInvitation.upsert.mockImplementation(
+      (args: { create: { token: string } }) =>
+        ({ token: args.create.token }) as never,
+    );
 
     const result = await caller(db).workspace.addMember({
       workspaceId: WORKSPACE_ID,
@@ -168,6 +172,29 @@ describe("workspace.addMember (existing user)", () => {
     expect(sendTeamInvitationEmail).not.toHaveBeenCalled();
   });
 
+  it("keeps an existing invitation's token so an already-sent link still works", async () => {
+    stubExistingUserPath(db);
+    // This address was invited by email first, then added once the account
+    // existed: the earlier email is still clickable, so its token must survive.
+    const EXISTING_TOKEN = "a".repeat(64);
+    db.workspaceInvitation.upsert.mockResolvedValue({
+      token: EXISTING_TOKEN,
+    } as never);
+
+    await caller(db).workspace.addMember({
+      workspaceId: WORKSPACE_ID,
+      email: INVITEE_EMAIL,
+      role: "member",
+    });
+
+    // Nothing in the update payload may rotate the token.
+    const upsertArgs = db.workspaceInvitation.upsert.mock.calls[0]![0];
+    expect(upsertArgs.update).not.toHaveProperty("token");
+
+    const emailArgs = vi.mocked(sendWorkspaceMemberAddedEmail).mock.calls[0]![0];
+    expect(emailArgs.ctaUrl).toContain(`/invite/${EXISTING_TOKEN}`);
+  });
+
   it("falls back to the workspace URL when the landing token can't be stored", async () => {
     stubExistingUserPath(db);
     db.workspaceInvitation.upsert.mockRejectedValue(new Error("db down"));
@@ -185,5 +212,65 @@ describe("workspace.addMember (existing user)", () => {
     const emailArgs = vi.mocked(sendWorkspaceMemberAddedEmail).mock.calls[0]![0];
     expect(emailArgs.ctaUrl).toContain("/w/clear");
     expect(emailArgs.ctaUrl).not.toContain("/invite/");
+  });
+});
+
+describe("workspace.removeMember (invite landing cleanup)", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+  });
+
+  it("expires the member's invitation so its landing page stops rendering", async () => {
+    db.user.findUnique.mockResolvedValueOnce({ isAgent: false } as never);
+    db.workspaceUser.findUnique
+      .mockResolvedValueOnce({ role: "owner" } as never)
+      .mockResolvedValueOnce({
+        role: "member",
+        user: { email: INVITEE_EMAIL },
+      } as never);
+    db.workspaceUser.delete.mockResolvedValue({} as never);
+    db.externalAgent.findMany.mockResolvedValue([] as never);
+    db.workspaceInvitation.updateMany.mockResolvedValue({ count: 1 } as never);
+
+    const before = Date.now();
+    const result = await caller(db).workspace.removeMember({
+      workspaceId: WORKSPACE_ID,
+      userId: INVITEE_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(db.workspaceInvitation.updateMany).toHaveBeenCalledTimes(1);
+    const args = db.workspaceInvitation.updateMany.mock.calls[0]![0]!;
+    expect(args.where).toMatchObject({
+      workspaceId: WORKSPACE_ID,
+      email: INVITEE_EMAIL,
+    });
+    expect((args.data as { expiresAt: Date }).expiresAt.getTime()).toBeGreaterThanOrEqual(
+      before,
+    );
+  });
+
+  it("still removes the member when expiring the invitation fails", async () => {
+    db.user.findUnique.mockResolvedValueOnce({ isAgent: false } as never);
+    db.workspaceUser.findUnique
+      .mockResolvedValueOnce({ role: "owner" } as never)
+      .mockResolvedValueOnce({
+        role: "member",
+        user: { email: INVITEE_EMAIL },
+      } as never);
+    db.workspaceUser.delete.mockResolvedValue({} as never);
+    db.externalAgent.findMany.mockResolvedValue([] as never);
+    db.workspaceInvitation.updateMany.mockRejectedValue(new Error("db down"));
+
+    const result = await caller(db).workspace.removeMember({
+      workspaceId: WORKSPACE_ID,
+      userId: INVITEE_ID,
+    });
+
+    expect(result.success).toBe(true);
+    expect(db.workspaceUser.delete).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/api/routers/__tests__/workspaceAddMember.test.ts
+++ b/src/server/api/routers/__tests__/workspaceAddMember.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for `workspace.addMember`'s existing-user branch: the "you've
+ * been added" email must land on the public /invite/<token> page (which
+ * prefills the recipient's email and offers a one-click sign-in code), never
+ * on the bare /w/<slug> URL that bounces a signed-out recipient onto an
+ * anonymous /signin wall.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+vi.mock("~/server/services/EmailService", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/server/services/EmailService")>();
+  return {
+    ...actual,
+    sendTeamInvitationEmail: vi.fn().mockResolvedValue(undefined),
+    sendWorkspaceMemberAddedEmail: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+import {
+  sendWorkspaceMemberAddedEmail,
+  sendTeamInvitationEmail,
+} from "~/server/services/EmailService";
+
+const ADMIN_ID = "admin-1";
+const INVITEE_ID = "invitee-1";
+const INVITEE_EMAIL = "invitee@example.com";
+const WORKSPACE_ID = "ws-1";
+
+function caller(db: DeepMockProxy<PrismaClient>) {
+  return createMockCaller({ userId: ADMIN_ID, db: db as unknown as PrismaClient });
+}
+
+/**
+ * Stub the existing-user happy path. Call-order sensitive:
+ * `user.findUnique` is hit first by humanOnlyProcedure (isAgent check on the
+ * caller) and then to look up the invitee; `workspaceUser.findUnique` first
+ * checks the caller's role, then whether the invitee is already a member.
+ */
+function stubExistingUserPath(db: DeepMockProxy<PrismaClient>) {
+  db.user.findUnique
+    .mockResolvedValueOnce({ isAgent: false } as never)
+    .mockResolvedValueOnce({
+      id: INVITEE_ID,
+      email: INVITEE_EMAIL,
+      name: "Invitee",
+    } as never);
+  db.workspaceUser.findUnique
+    .mockResolvedValueOnce({ role: "owner" } as never)
+    .mockResolvedValueOnce(null);
+  db.workspaceUser.create.mockResolvedValue({
+    userId: INVITEE_ID,
+    workspaceId: WORKSPACE_ID,
+    role: "member",
+    user: {
+      id: INVITEE_ID,
+      name: "Invitee",
+      email: INVITEE_EMAIL,
+      image: null,
+    },
+  } as never);
+  db.workspace.findUnique.mockResolvedValue({
+    name: "Clear",
+    slug: "clear",
+  } as never);
+}
+
+describe("workspace.addMember (existing user)", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+    vi.mocked(sendWorkspaceMemberAddedEmail).mockClear();
+    vi.mocked(sendWorkspaceMemberAddedEmail).mockResolvedValue(undefined);
+    vi.mocked(sendTeamInvitationEmail).mockClear();
+  });
+
+  it("emails a /invite/<token> landing link backed by an accepted invitation", async () => {
+    stubExistingUserPath(db);
+    db.workspaceInvitation.upsert.mockResolvedValue({} as never);
+
+    const result = await caller(db).workspace.addMember({
+      workspaceId: WORKSPACE_ID,
+      email: INVITEE_EMAIL,
+      role: "member",
+    });
+
+    expect(result.type).toBe("member_added");
+
+    // The landing record is minted as already-accepted: membership is granted
+    // in this same mutation, the token only identifies the sign-in landing.
+    expect(db.workspaceInvitation.upsert).toHaveBeenCalledTimes(1);
+    const upsertArgs = db.workspaceInvitation.upsert.mock.calls[0]![0];
+    expect(upsertArgs.create.status).toBe("accepted");
+    expect(upsertArgs.update.status).toBe("accepted");
+    const token = upsertArgs.create.token;
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+
+    expect(sendWorkspaceMemberAddedEmail).toHaveBeenCalledTimes(1);
+    const emailArgs = vi.mocked(sendWorkspaceMemberAddedEmail).mock.calls[0]![0];
+    expect(emailArgs.to).toBe(INVITEE_EMAIL);
+    expect(emailArgs.ctaUrl).toContain(`/invite/${token}`);
+    // The new-user invitation email must not fire on this branch.
+    expect(sendTeamInvitationEmail).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the workspace URL when the landing token can't be stored", async () => {
+    stubExistingUserPath(db);
+    db.workspaceInvitation.upsert.mockRejectedValue(new Error("db down"));
+
+    const result = await caller(db).workspace.addMember({
+      workspaceId: WORKSPACE_ID,
+      email: INVITEE_EMAIL,
+      role: "member",
+    });
+
+    // Membership was created before the email step — the mutation must not
+    // fail because the nicer landing link couldn't be minted.
+    expect(result.type).toBe("member_added");
+    expect(sendWorkspaceMemberAddedEmail).toHaveBeenCalledTimes(1);
+    const emailArgs = vi.mocked(sendWorkspaceMemberAddedEmail).mock.calls[0]![0];
+    expect(emailArgs.ctaUrl).toContain("/w/clear");
+    expect(emailArgs.ctaUrl).not.toContain("/invite/");
+  });
+});

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -661,16 +661,19 @@ export const workspaceRouter = createTRPCRouter({
             // rather than failing the mutation — membership already exists.
             let ctaUrl = `${getPublicBaseUrlFromEnv()}/w/${workspace.slug}`;
             try {
-              const landingToken = generateSecureToken();
-              await ctx.db.workspaceInvitation.upsert({
+              const landing = await ctx.db.workspaceInvitation.upsert({
                 where: {
                   workspaceId_email: {
                     workspaceId: input.workspaceId,
                     email: input.email,
                   },
                 },
+                // The token is deliberately absent from `update`: this address
+                // may already have a pending invitation whose token is sitting
+                // in an email someone can still click. Rotating it here would
+                // dead-end that link on "Invalid Invitation"; reusing the row's
+                // existing token instead re-points it at the accepted landing.
                 update: {
-                  token: landingToken,
                   role: input.role,
                   status: "accepted",
                   acceptedAt: new Date(),
@@ -681,19 +684,29 @@ export const workspaceRouter = createTRPCRouter({
                   workspaceId: input.workspaceId,
                   email: input.email,
                   role: input.role,
-                  token: landingToken,
+                  token: generateSecureToken(),
                   status: "accepted",
                   acceptedAt: new Date(),
                   expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
                   createdById: ctx.session.user.id,
                 },
               });
-              ctaUrl = generateInviteUrl(landingToken);
+              ctaUrl = generateInviteUrl(landing.token);
             } catch (err: unknown) {
+              // Degrading to the bare /w/<slug> link silently would put the
+              // recipient back on the signin wall this path exists to avoid,
+              // so it goes to Sentry rather than only to the server log.
               console.error(
                 "[workspace.addMember] Failed to mint invite landing token, falling back to workspace URL:",
                 err,
               );
+              reportHandledErrorServer(err, {
+                area: "workspace-member-added-landing-token",
+                context: {
+                  workspaceId: input.workspaceId,
+                  recipientEmail: newMember.user.email ?? "",
+                },
+              });
             }
             sendWorkspaceMemberAddedEmail({
               to: newMember.user.email,
@@ -847,6 +860,7 @@ export const workspaceRouter = createTRPCRouter({
             workspaceId: input.workspaceId,
           },
         },
+        include: { user: { select: { email: true } } },
       });
 
       if (memberToRemove?.role === "owner") {
@@ -869,6 +883,36 @@ export const workspaceRouter = createTRPCRouter({
       // Delegation invariant (ADR-0049): the removed member's external agents
       // lose their memberships here too — agent access never outlives its owner's.
       await cascadeOwnerRemovedFromWorkspace(ctx.db, input.userId, input.workspaceId);
+
+      // Retire any invitation row for this address. Its token renders a public
+      // landing page carrying the workspace name, inviter and member count, and
+      // addMember now mints one of these for existing users — without this it
+      // would keep serving that after the member is gone. Expiring rather than
+      // deleting keeps the invitation history intact. Non-fatal: the member is
+      // already out, so a failure here must not fail the mutation.
+      if (memberToRemove?.user.email) {
+        try {
+          await ctx.db.workspaceInvitation.updateMany({
+            where: {
+              workspaceId: input.workspaceId,
+              email: memberToRemove.user.email,
+            },
+            data: { expiresAt: new Date() },
+          });
+        } catch (err: unknown) {
+          console.error(
+            "[workspace.removeMember] Failed to expire invitation for removed member:",
+            err,
+          );
+          reportHandledErrorServer(err, {
+            area: "workspace-remove-member-invitation-expiry",
+            context: {
+              workspaceId: input.workspaceId,
+              removedUserId: input.userId,
+            },
+          });
+        }
+      }
 
       return { success: true };
     }),

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -650,7 +650,51 @@ export const workspaceRouter = createTRPCRouter({
               },
             );
           } else {
-            const workspaceUrl = `${getPublicBaseUrlFromEnv()}/w/${workspace.slug}`;
+            // Land the email on /invite/<token> rather than the bare
+            // workspace URL: the recipient is usually signed out in the
+            // browser their mail client opens, and a /w/<slug> link just
+            // bounces them off middleware onto an anonymous /signin wall.
+            // The invite landing page is public, survives mail scanners
+            // (the token identifies, it doesn't authenticate — ADR-0056),
+            // prefills their email and offers a one-click sign-in code.
+            // If minting the record fails, fall back to the workspace URL
+            // rather than failing the mutation — membership already exists.
+            let ctaUrl = `${getPublicBaseUrlFromEnv()}/w/${workspace.slug}`;
+            try {
+              const landingToken = generateSecureToken();
+              await ctx.db.workspaceInvitation.upsert({
+                where: {
+                  workspaceId_email: {
+                    workspaceId: input.workspaceId,
+                    email: input.email,
+                  },
+                },
+                update: {
+                  token: landingToken,
+                  role: input.role,
+                  status: "accepted",
+                  acceptedAt: new Date(),
+                  expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+                  createdById: ctx.session.user.id,
+                },
+                create: {
+                  workspaceId: input.workspaceId,
+                  email: input.email,
+                  role: input.role,
+                  token: landingToken,
+                  status: "accepted",
+                  acceptedAt: new Date(),
+                  expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+                  createdById: ctx.session.user.id,
+                },
+              });
+              ctaUrl = generateInviteUrl(landingToken);
+            } catch (err: unknown) {
+              console.error(
+                "[workspace.addMember] Failed to mint invite landing token, falling back to workspace URL:",
+                err,
+              );
+            }
             sendWorkspaceMemberAddedEmail({
               to: newMember.user.email,
               workspaceName: workspace.name ?? "a workspace",
@@ -658,7 +702,7 @@ export const workspaceRouter = createTRPCRouter({
                 ctx.session.user.name ??
                 ctx.session.user.email ??
                 "A workspace member",
-              workspaceUrl,
+              ctaUrl,
             }).catch((err: unknown) => {
               console.error(
                 "[workspace.addMember] Failed to send member-added email:",

--- a/src/server/services/EmailService.ts
+++ b/src/server/services/EmailService.ts
@@ -20,6 +20,21 @@ import {
 
 const POSTMARK_API_URL = "https://api.postmarkapp.com/email";
 
+/**
+ * Escape a value before interpolating it into an email's HTML body.
+ *
+ * Workspace and person names are attacker-writable text that lands in someone
+ * else's inbox, where injected markup reads as part of a legitimate email.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 interface PostmarkConfig {
   apiKey: string | null;
   from: string;
@@ -641,6 +656,11 @@ export async function sendWorkspaceMemberAddedEmail(params: {
   const { to, workspaceName, inviterName, ctaUrl } = params;
   const brandColor = EMAIL_BRAND_COLOR;
   const appName = PRODUCT_NAME;
+  // Names come from whoever did the adding; the address is validated but still
+  // interpolated into markup. Escape everything that reaches the HTML body.
+  const safeTo = escapeHtml(to);
+  const safeWorkspaceName = escapeHtml(workspaceName);
+  const safeInviterName = escapeHtml(inviterName);
 
   const htmlBody = `
 <!DOCTYPE html>
@@ -650,7 +670,7 @@ export async function sendWorkspaceMemberAddedEmail(params: {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="light">
   <meta name="supported-color-schemes" content="light">
-  <title>You've been added to ${workspaceName} on ${appName}</title>
+  <title>You've been added to ${safeWorkspaceName} on ${appName}</title>
 </head>
 <body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f9fafb;">
   <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="min-width: 100%; background-color: #f9fafb;">
@@ -661,7 +681,7 @@ export async function sendWorkspaceMemberAddedEmail(params: {
           <tr>
             <td style="padding: 32px 32px 24px; text-align: center;">
               <h1 style="margin: 0; font-size: 20px; font-weight: 600; color: #111827;">
-                You've been added to ${workspaceName}
+                You've been added to ${safeWorkspaceName}
               </h1>
             </td>
           </tr>
@@ -670,7 +690,7 @@ export async function sendWorkspaceMemberAddedEmail(params: {
           <tr>
             <td style="padding: 0 32px;">
               <p style="margin: 0 0 24px; font-size: 15px; line-height: 1.6; color: #4b5563;">
-                <strong>${inviterName}</strong> has added you to the <strong>${workspaceName}</strong> workspace on ${appName}.
+                <strong>${safeInviterName}</strong> has added you to the <strong>${safeWorkspaceName}</strong> workspace on ${appName}.
               </p>
 
               <!-- CTA Button -->
@@ -685,7 +705,7 @@ export async function sendWorkspaceMemberAddedEmail(params: {
               </table>
 
               <p style="margin: 0 0 24px; font-size: 13px; line-height: 1.6; color: #6b7280;">
-                If you're not signed in on this device, sign in as <strong>${to}</strong> — we'll email you a short sign-in code, or use Google or Microsoft.
+                If you're not signed in on this device, sign in as <strong>${safeTo}</strong> — we'll email you a short sign-in code, or use Google or Microsoft.
               </p>
 
               <!-- Fallback Link -->
@@ -702,7 +722,7 @@ export async function sendWorkspaceMemberAddedEmail(params: {
           <tr>
             <td style="padding: 24px 32px 32px;">
               <p style="margin: 0; font-size: 13px; color: #9ca3af; border-top: 1px solid #e5e7eb; padding-top: 24px;">
-                If you weren't expecting to be added to this workspace, you can ignore this email or contact ${inviterName} to be removed.
+                If you weren't expecting to be added to this workspace, you can ignore this email or contact ${safeInviterName} to be removed.
               </p>
             </td>
           </tr>

--- a/src/server/services/EmailService.ts
+++ b/src/server/services/EmailService.ts
@@ -627,16 +627,18 @@ If you weren't expecting this invitation, you can safely ignore this email.
 
 /**
  * Send a notification email to an existing user who has just been added to a workspace.
- * Unlike the invitation email, the recipient already has an account, so the CTA links
- * them straight into the workspace rather than to a sign-up flow.
+ * Unlike the invitation email, the recipient already has an account. The CTA still goes
+ * through the /invite/<token> landing page (not the bare workspace URL): they're usually
+ * signed out where they read email, and the landing page prefills their address and
+ * offers a one-click sign-in code instead of an anonymous /signin wall.
  */
 export async function sendWorkspaceMemberAddedEmail(params: {
   to: string;
   workspaceName: string;
   inviterName: string;
-  workspaceUrl: string;
+  ctaUrl: string;
 }): Promise<void> {
-  const { to, workspaceName, inviterName, workspaceUrl } = params;
+  const { to, workspaceName, inviterName, ctaUrl } = params;
   const brandColor = EMAIL_BRAND_COLOR;
   const appName = PRODUCT_NAME;
 
@@ -675,19 +677,23 @@ export async function sendWorkspaceMemberAddedEmail(params: {
               <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
                 <tr>
                   <td align="center" style="padding: 8px 0 24px;">
-                    <a href="${workspaceUrl}" target="_blank" style="display: inline-block; padding: 14px 32px; background-color: ${brandColor}; color: #ffffff; text-decoration: none; font-size: 15px; font-weight: 600; border-radius: 6px;">
+                    <a href="${ctaUrl}" target="_blank" style="display: inline-block; padding: 14px 32px; background-color: ${brandColor}; color: #ffffff; text-decoration: none; font-size: 15px; font-weight: 600; border-radius: 6px;">
                       Open Workspace
                     </a>
                   </td>
                 </tr>
               </table>
 
+              <p style="margin: 0 0 24px; font-size: 13px; line-height: 1.6; color: #6b7280;">
+                If you're not signed in on this device, sign in as <strong>${to}</strong> — we'll email you a short sign-in code, or use Google or Microsoft.
+              </p>
+
               <!-- Fallback Link -->
               <p style="margin: 0 0 8px; font-size: 13px; color: #6b7280;">
                 Or copy and paste this link into your browser:
               </p>
               <p style="margin: 0 0 24px; font-size: 12px; color: #9ca3af; word-break: break-all;">
-                ${workspaceUrl}
+                ${ctaUrl}
               </p>
             </td>
           </tr>
@@ -713,7 +719,9 @@ You've been added to ${workspaceName}
 
 ${inviterName} has added you to the ${workspaceName} workspace on ${appName}.
 
-Open the workspace: ${workspaceUrl}
+Open the workspace: ${ctaUrl}
+
+If you're not signed in on this device, sign in as ${to} — we'll email you a short sign-in code, or use Google or Microsoft.
 
 If you weren't expecting to be added to this workspace, you can ignore this email or contact ${inviterName} to be removed.
 `.trim();


### PR DESCRIPTION
### **User description**
## Description
When the invited address already had an account, `workspace.addMember` granted membership and emailed a bare `/w/<slug>` link. The recipient is usually signed out in the browser their mail client opens, so middleware bounced them to an anonymous `/signin?callbackUrl=/w/<slug>` — no invite context, no prefilled email (observed against a real invitee behind a Mimecast-style scanner). Auto-login links stay off the table per ADR-0056: the scanner renders the destination page at click time and would spend any single-use token.

The member-added email now routes through the existing `/invite/<token>` landing page instead:

- **`workspace.addMember`** (existing-user branch) mints a `WorkspaceInvitation` in status `accepted` — membership is still granted in the same mutation; the token only *identifies* the landing, it authenticates nothing — and links the email there, falling back to the workspace URL if the record can't be stored.
- **The invite page** serves its landing view (prefilled email, one-click sign-in code per ADR-0056, OAuth buttons) to signed-out visitors of accepted invitations instead of the "Invitation Already Used" dead end. Copy drops the join/accept framing for existing members ("Open *X* on Exponential", "Sign in & open X"). After sign-in, the existing auto-redirect from #565 carries them straight into the workspace.
- **Email copy** now says which address to sign in with and that a code / Google / Microsoft sign-in awaits, so the sign-in step never comes as a surprise.

New flow: click email → public landing page (scanner-safe) → email prefilled, one click to get a code or one tap on OAuth → auto-redirect into the workspace.

Note: emails already sent still carry the old `/w/<slug>` link; removing and re-adding a member re-sends the new email.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Database Changes
- [ ] This PR includes database schema changes (migrations)
- [x] NO database changes in this PR

## Testing
- [ ] Tested locally
- [ ] Tested in preview deployment
- [x] Added/updated tests
- [x] All tests passing

Added `workspaceAddMember.test.ts` (mocked Prisma, no real DB) pinning: the member-added email links to `/invite/<token>` backed by an accepted invitation, and falls back to the workspace URL when the landing record can't be stored. Full unit suite (2,645 tests), `next lint`, and `tsc --noEmit` pass.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Database migrations tested on test database (n/a — no migrations)
- [ ] Coordinated with team on any migration conflicts (n/a — no migrations)

## Deployment Notes
None — no migrations, no env changes. Safe for fast-track to main.

## Related Issues
Follows up on #565 (invite-to-first-session path) and ADR-0056 (sign-in codes replace magic links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUZTcpUDd6he2PKRLdodSg

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUZTcpUDd6he2PKRLdodSg)_


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Member-added email now links to `/invite/<token>` landing

- Invite page serves landing view for accepted invitations

- `removeMember` expires invitation rows to kill landing

- HTML-escape names in member-added email; new unit tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["workspace.addMember (existing user)"] -- "upsert accepted invitation" --> B["WorkspaceInvitation token"]
  B -- "generateInviteUrl" --> C["member-added email CTA"]
  C -- "click while signed out" --> D["/invite/<token> landing page"]
  D -- "prefilled email + code/OAuth" --> E["/w/<slug> workspace"]
  F["workspace.removeMember"] -- "expire invitation" --> B
  B -- "upsert fails" --> G["fallback /w/<slug> URL + Sentry"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.ts</strong><dd><code>Mint accepted-invite landing token and expire it on removal</code></dd></summary>
<hr>

src/server/api/routers/workspace.ts

<ul><li><code>addMember</code> upserts a <code>WorkspaceInvitation</code> in <code>accepted</code> status for <br>existing users and links the email to <code>/invite/<token></code><br> <li> Preserves an existing row's token (not rotated) so previously sent <br>links keep working<br> <li> Falls back to the <code>/w/<slug></code> URL and reports to Sentry via <br><code>reportHandledErrorServer</code> when minting fails<br> <li> <code>removeMember</code> now loads the member email and expires matching <br>invitations (non-fatal on error)</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/575/files#diff-b94d59060e1c78a6a505a0a58d90bb366e921cdd053126776199f6abcee0f846">+90/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Serve invite landing page for accepted invitations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/invite/[token]/page.tsx

<ul><li>Signed-out visitors get the landing page for both <code>pending</code> and <code>accepted</code> <br>invitations, removing the "Invitation Already Used" dead end<br> <li> Expired accepted links show "Link Expired" copy with an "Open <workspace>" CTA<br> <li> Landing copy switches to sign-in framing (<code>Open</code>, <code>Sign in & open X</code>) when <br>already a member</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/575/files#diff-73c22ad002c46aa25771d8e244d322edcbfb0f1c74a3fc518706a620f293bcba">+63/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EmailService.ts</strong><dd><code>Use CTA URL and escape HTML in member-added email</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/EmailService.ts

<ul><li>Renames <code>workspaceUrl</code> param to <code>ctaUrl</code> for the member-added email<br> <li> Adds <code>escapeHtml()</code> and applies it to recipient, workspace and inviter <br>names in the HTML body<br> <li> Adds copy explaining which address to sign in with and the code/OAuth <br>options</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/575/files#diff-7efb63f19977ee348b1afbdb35fb8de2ac2bfa66d1cc9fcbb1c957a5959b7fcd">+39/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspaceAddMember.test.ts</strong><dd><code>Add unit tests for addMember/removeMember invite landing</code>&nbsp; </dd></summary>
<hr>

src/server/api/routers/__tests__/workspaceAddMember.test.ts

<ul><li>New mocked-Prisma unit tests for <code>workspace.addMember</code> existing-user <br>branch<br> <li> Covers accepted-invitation minting, token preservation, and <br>workspace-URL fallback on DB failure<br> <li> Covers <code>removeMember</code> expiring the invitation and succeeding when that <br>fails</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/575/files#diff-8b7c42c337481ec37e07e4436443c036654223d672d57512e34118f865de9c17">+276/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

