### PR TITLE
feat: Invite-aware welcome variant

### DIFF
--- a/src/app/_components/welcome/GettingStarted.tsx
+++ b/src/app/_components/welcome/GettingStarted.tsx
@@ -6,6 +6,7 @@ import { Loader } from "@mantine/core";
 import { useWelcomeSetup } from "./useWelcomeSetup";
 import { WelcomeChatView } from "./WelcomeChatView";
 import { WelcomeChecklistView } from "./WelcomeChecklistView";
+import { WelcomeInvited } from "./WelcomeInvited";
 import { COPY } from "./welcomeCopy";
 import styles from "./Welcome.module.css";
 
@@ -45,6 +46,26 @@ export function GettingStarted() {
     return (
       <div className="flex h-[60vh] items-center justify-center">
         <Loader size="sm" color="blue" />
+      </div>
+    );
+  }
+
+  // Invited variant: the user joined someone else's workspace via an
+  // invitation — no chat/checklist (and no view toggle), just the shortened
+  // "you're in" flow. The explore exit stays available like everywhere else.
+  if (setup.invitedContext) {
+    return (
+      <div style={{ position: "relative" }}>
+        <div className={styles.topBar}>
+          <button
+            type="button"
+            className={styles.exploreLink}
+            onClick={() => void setup.exploreOnOwn()}
+          >
+            {COPY.chips.explore}
+          </button>
+        </div>
+        <WelcomeInvited setup={setup} />
       </div>
     );
   }

--- a/src/app/_components/welcome/WelcomeInvited.tsx
+++ b/src/app/_components/welcome/WelcomeInvited.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { IconArrowRight, IconCalendar, IconCheck } from "@tabler/icons-react";
+import { COPY } from "./welcomeCopy";
+import { type StepAnswer, type WelcomeSetupApi } from "./useWelcomeSetup";
+import { AskBlock } from "./AskBlock";
+import styles from "./Welcome.module.css";
+
+/**
+ * Invited welcome variant — shown instead of the chat/checklist flow when the
+ * user joined someone else's workspace via an invitation. Deliberately lean:
+ * acknowledge the team they joined, offer the one step that is still personal
+ * (calendar connect), and hand them straight to the workspace home. No goal /
+ * action / plan steps — onboarding artifacts must never land in the shared
+ * workspace, so the variant simply never offers them.
+ */
+export function WelcomeInvited({ setup }: { setup: WelcomeSetupApi }) {
+  const invited = setup.invitedContext;
+  if (!invited) return null;
+
+  const calDone = setup.isStepDone("cal");
+  const calLabel =
+    setup.state?.calendar === "skipped"
+      ? COPY.invited.calSkipped
+      : setup.state?.calendar === "outlook"
+        ? COPY.calChips.outlook
+        : setup.state?.calendar === "google"
+          ? COPY.calChips.google
+          : setup.calendarConnected
+            ? COPY.invited.calConnected
+            : "";
+
+  const handleCalAnswer = (answer: StepAnswer) => {
+    // Google/Outlook navigate into the OAuth flow (the page resumes from
+    // server state on return); "skipped" resolves in place.
+    void setup.answerStep("cal", answer);
+  };
+
+  return (
+    <div className={styles.obRoot}>
+      <div className={styles.obHead}>
+        <h1>{COPY.invited.title(invited.workspaceName)}</h1>
+        <p>
+          {invited.inviterName
+            ? COPY.invited.subtitleWithInviter(invited.inviterName)
+            : COPY.invited.subtitle}
+        </p>
+      </div>
+
+      <div
+        className={`${styles.stepCard} ${calDone ? styles.cardDone : styles.cardNext}`}
+      >
+        <div className={styles.stepCardRow} style={{ cursor: "default" }}>
+          <div className={styles.stepCardIcon}>
+            {calDone ? <IconCheck size={16} /> : <IconCalendar size={16} />}
+          </div>
+          <div style={{ minWidth: 0 }}>
+            <div className={styles.stepCardTitle}>
+              {COPY.invited.calTitle}
+              {!calDone && (
+                <span className={styles.stepCardOptional}>OPTIONAL</span>
+              )}
+            </div>
+            {!calDone && (
+              <div className={styles.stepCardDesc}>{COPY.invited.calDesc}</div>
+            )}
+          </div>
+          {calDone && (
+            <span className={styles.stepCardMade}>
+              <IconCheck size={12} />
+              {calLabel}
+            </span>
+          )}
+        </div>
+        {!calDone && (
+          <div className={styles.stepDialog}>
+            <AskBlock
+              step="cal"
+              state={setup.state}
+              onAnswer={handleCalAnswer}
+              disabled={setup.isAnswerPending}
+              hideQuestion
+            />
+          </div>
+        )}
+      </div>
+
+      <div style={{ marginTop: 24 }}>
+        <button
+          type="button"
+          className={styles.doneCta}
+          onClick={() =>
+            void setup.completeAndNavigate(`/w/${invited.workspaceSlug}/home`)
+          }
+        >
+          {COPY.invited.cta(invited.workspaceName)}
+          <IconArrowRight size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/_components/welcome/useWelcomeSetup.ts
+++ b/src/app/_components/welcome/useWelcomeSetup.ts
@@ -231,27 +231,39 @@ export function useWelcomeSetup() {
   }, [router]);
 
   /**
+   * Mark welcome complete (best-effort, guarded against double fire) and
+   * leave for `path`. Shared by the explore exit and the invited variant's
+   * "Take me to {workspace}" CTA.
+   */
+  const completeAndNavigate = useCallback(
+    async (path: string) => {
+      if (!data?.welcomeCompletedAt && !completedRef.current) {
+        completedRef.current = true;
+        try {
+          await completeWelcome.mutateAsync();
+        } catch {
+          // onError resets completedRef so a later attempt can retry; still
+          // leave — no destination below gates on welcome completion.
+        }
+      }
+      router.push(path);
+    },
+    [data, completeWelcome, router],
+  );
+
+  /**
    * "I'll explore on my own" — a real exit, not a chat reply. Marks welcome
    * complete (so /home stops bouncing back here for the 24h new-user window)
    * and lands the user on their default workspace home.
    */
   const exploreOnOwn = useCallback(async () => {
-    if (!data?.welcomeCompletedAt && !completedRef.current) {
-      completedRef.current = true;
-      try {
-        await completeWelcome.mutateAsync();
-      } catch {
-        // onError resets completedRef so a later attempt can retry; still
-        // leave — neither destination below gates on welcome completion.
-      }
-    }
     // Fallback is /today, NOT /home: /home bounces incomplete-welcome users
     // back here during the 24h new-user window, which would turn a failed
     // completeWelcome + unresolved workspace query into a loop.
-    router.push(
+    await completeAndNavigate(
       defaultWorkspace?.slug ? `/w/${defaultWorkspace.slug}/home` : "/today",
     );
-  }, [data, completeWelcome, defaultWorkspace, router]);
+  }, [completeAndNavigate, defaultWorkspace]);
 
   const isAnswerPending =
     createGoal.isPending ||
@@ -266,6 +278,8 @@ export function useWelcomeSetup() {
     state,
     calendarConnected,
     googleCalendarAvailable,
+    /** Non-null while an invitee who hasn't finished welcome should see the invited variant. */
+    invitedContext: data?.invitedContext ?? null,
     isStepDone,
     nextStep,
     doneCount,
@@ -273,6 +287,7 @@ export function useWelcomeSetup() {
     answerStep,
     isAnswerPending,
     goToToday,
+    completeAndNavigate,
     exploreOnOwn,
   };
 }

--- a/src/app/_components/welcome/welcomeCopy.ts
+++ b/src/app/_components/welcome/welcomeCopy.ts
@@ -145,6 +145,18 @@ export const COPY = {
     skip: "Skip for now",
   },
   goToToday: "Go to Today",
+  /** Invited variant — shown instead of chat/checklist when the user joined via an invitation. */
+  invited: {
+    title: (workspaceName: string) => `You've joined ${workspaceName}`,
+    subtitleWithInviter: (inviterName: string) =>
+      `${inviterName} invited you — you're in.`,
+    subtitle: "You're in.",
+    calTitle: "Connect your calendar",
+    calDesc: "Optional — meetings and the team's work in one place",
+    calConnected: "Connected",
+    calSkipped: "Skipped",
+    cta: (workspaceName: string) => `Take me to ${workspaceName}`,
+  },
 };
 
 /** Framework diagram cells: Goals → Actions → Today. */

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -79,12 +79,19 @@ export default function InviteAcceptPage() {
     invitation.isLoggedIn &&
     invitation.isMember;
   const workspaceSlug = invitation?.workspace.slug;
+  // A fresh invitee (hasn't finished welcome yet) goes through the invited
+  // welcome variant first; returning members go straight into the workspace.
+  const redirectTarget = invitation?.viewerCompletedWelcome
+    ? workspaceSlug
+      ? `/w/${workspaceSlug}`
+      : null
+    : "/welcome";
 
   useEffect(() => {
-    if (shouldAutoRedirect && workspaceSlug) {
-      router.replace(`/w/${workspaceSlug}`);
+    if (shouldAutoRedirect && redirectTarget) {
+      router.replace(redirectTarget);
     }
-  }, [shouldAutoRedirect, workspaceSlug, router]);
+  }, [shouldAutoRedirect, redirectTarget, router]);
 
   if (isLoading || shouldAutoRedirect) {
     return (

--- a/src/server/api/routers/__tests__/welcome.test.ts
+++ b/src/server/api/routers/__tests__/welcome.test.ts
@@ -29,7 +29,7 @@ vi.mock("~/server/auth", () => ({
   signOut: vi.fn(),
 }));
 
-import { resolveWorkspaceId } from "../welcome";
+import { resolveInvitedContext, resolveWorkspaceId } from "../welcome";
 
 const db = mockDeep<PrismaClient>();
 const USER = "user-1";
@@ -117,5 +117,84 @@ describe("resolveWorkspaceId", () => {
     db.workspaceUser.findFirst.mockResolvedValue(null as never);
 
     await expect(resolveWorkspaceId(db, USER)).resolves.toBeNull();
+  });
+});
+
+describe("resolveInvitedContext", () => {
+  const EMAIL = "invitee@example.com";
+
+  const invitationRow = (overrides?: {
+    ownerId?: string;
+    inviterName?: string | null;
+    inviterEmail?: string | null;
+  }) =>
+    ({
+      workspace: {
+        name: "Dev Fixture",
+        slug: "dev-fixture",
+        type: "team",
+        ownerId: overrides?.ownerId ?? OTHER_USER,
+      },
+      createdBy: {
+        name: overrides?.inviterName === undefined ? "Inviter Name" : overrides.inviterName,
+        email: overrides?.inviterEmail === undefined ? "inviter@example.com" : overrides.inviterEmail,
+      },
+    }) as never;
+
+  it("returns the invited context for a user who joined someone else's workspace", async () => {
+    db.workspaceInvitation.findFirst.mockResolvedValue(invitationRow());
+
+    await expect(resolveInvitedContext(db, USER, EMAIL)).resolves.toEqual({
+      workspaceName: "Dev Fixture",
+      workspaceSlug: "dev-fixture",
+      inviterName: "Inviter Name",
+    });
+    expect(db.workspaceInvitation.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { email: EMAIL, status: "accepted" },
+        orderBy: { acceptedAt: "desc" },
+      }),
+    );
+  });
+
+  it("falls back to the inviter's email when they have no name", async () => {
+    db.workspaceInvitation.findFirst.mockResolvedValue(
+      invitationRow({ inviterName: null }),
+    );
+
+    await expect(resolveInvitedContext(db, USER, EMAIL)).resolves.toEqual(
+      expect.objectContaining({ inviterName: "inviter@example.com" }),
+    );
+  });
+
+  it("reports a null inviterName when the inviter has neither name nor email", async () => {
+    db.workspaceInvitation.findFirst.mockResolvedValue(
+      invitationRow({ inviterName: null, inviterEmail: null }),
+    );
+
+    await expect(resolveInvitedContext(db, USER, EMAIL)).resolves.toEqual(
+      expect.objectContaining({ inviterName: null }),
+    );
+  });
+
+  it("returns null when the latest accepted invitation points at the user's OWN workspace", async () => {
+    // Owner of the workspace — they didn't genuinely join someone else's team.
+    db.workspaceInvitation.findFirst.mockResolvedValue(
+      invitationRow({ ownerId: USER }),
+    );
+
+    await expect(resolveInvitedContext(db, USER, EMAIL)).resolves.toBeNull();
+  });
+
+  it("returns null when the user has no accepted invitation", async () => {
+    db.workspaceInvitation.findFirst.mockResolvedValue(null as never);
+
+    await expect(resolveInvitedContext(db, USER, EMAIL)).resolves.toBeNull();
+  });
+
+  it("returns null without querying when the user has no email", async () => {
+    await expect(resolveInvitedContext(db, USER, null)).resolves.toBeNull();
+    await expect(resolveInvitedContext(db, USER, undefined)).resolves.toBeNull();
+    expect(db.workspaceInvitation.findFirst).not.toHaveBeenCalled();
   });
 });

--- a/src/server/api/routers/__tests__/welcome.test.ts
+++ b/src/server/api/routers/__tests__/welcome.test.ts
@@ -129,6 +129,7 @@ describe("resolveInvitedContext", () => {
     inviterEmail?: string | null;
   }) =>
     ({
+      workspaceId: "ws-joined",
       workspace: {
         name: "Dev Fixture",
         slug: "dev-fixture",
@@ -140,6 +141,11 @@ describe("resolveInvitedContext", () => {
         email: overrides?.inviterEmail === undefined ? "inviter@example.com" : overrides.inviterEmail,
       },
     }) as never;
+
+  beforeEach(() => {
+    // Default: the invitee is still a member of the joined workspace.
+    db.workspaceUser.findUnique.mockResolvedValue({ userId: USER } as never);
+  });
 
   it("returns the invited context for a user who joined someone else's workspace", async () => {
     db.workspaceInvitation.findFirst.mockResolvedValue(invitationRow());
@@ -190,6 +196,30 @@ describe("resolveInvitedContext", () => {
     db.workspaceInvitation.findFirst.mockResolvedValue(null as never);
 
     await expect(resolveInvitedContext(db, USER, EMAIL)).resolves.toBeNull();
+  });
+
+  it("returns null when the invitee was later removed from the workspace", async () => {
+    db.workspaceInvitation.findFirst.mockResolvedValue(invitationRow());
+    db.workspaceUser.findUnique.mockResolvedValue(null as never); // membership gone
+
+    await expect(resolveInvitedContext(db, USER, EMAIL)).resolves.toBeNull();
+    expect(db.workspaceUser.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId_workspaceId: { userId: USER, workspaceId: "ws-joined" },
+        },
+      }),
+    );
+  });
+
+  it("treats a whitespace-only inviter name as missing", async () => {
+    db.workspaceInvitation.findFirst.mockResolvedValue(
+      invitationRow({ inviterName: "   " }),
+    );
+
+    await expect(resolveInvitedContext(db, USER, EMAIL)).resolves.toEqual(
+      expect.objectContaining({ inviterName: "inviter@example.com" }),
+    );
   });
 
   it("returns null without querying when the user has no email", async () => {

--- a/src/server/api/routers/welcome.ts
+++ b/src/server/api/routers/welcome.ts
@@ -106,6 +106,48 @@ export async function resolveWorkspaceId(
   return membership?.workspaceId ?? null;
 }
 
+/** What the invited welcome variant needs to know about the joined workspace. */
+export interface InvitedContext {
+  workspaceName: string;
+  workspaceSlug: string;
+  inviterName: string | null;
+}
+
+/**
+ * Detect whether this user is a fresh invitee: their most recently accepted
+ * WorkspaceInvitation, but only when it put them into someone ELSE's
+ * workspace. A user who owns the workspace their latest invitation points at
+ * (e.g. an owner re-invited into their own workspace) is not "invited" — the
+ * welcome page must not pretend they just joined a team.
+ *
+ * Exported for tests — this decides which welcome variant a user sees.
+ */
+export async function resolveInvitedContext(
+  db: PrismaClient,
+  userId: string,
+  email: string | null | undefined,
+): Promise<InvitedContext | null> {
+  if (!email) return null;
+  const invitation = await db.workspaceInvitation.findFirst({
+    where: { email, status: "accepted" },
+    orderBy: { acceptedAt: "desc" },
+    include: {
+      workspace: {
+        select: { name: true, slug: true, type: true, ownerId: true },
+      },
+      createdBy: { select: { name: true, email: true } },
+    },
+  });
+  if (!invitation) return null;
+  if (invitation.workspace.ownerId === userId) return null;
+  return {
+    workspaceName: invitation.workspace.name,
+    workspaceSlug: invitation.workspace.slug,
+    inviterName:
+      invitation.createdBy.name ?? invitation.createdBy.email ?? null,
+  };
+}
+
 export const welcomeRouter = createTRPCRouter({
   /**
    * Everything the welcome page needs to render/resume: the persisted setup
@@ -114,7 +156,7 @@ export const welcomeRouter = createTRPCRouter({
    */
   getSetup: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
-    const [user, calendarAccountCount] = await Promise.all([
+    const [user, calendarAccountCount, invitedContext] = await Promise.all([
       ctx.db.user.findUnique({
         where: { id: userId },
         select: {
@@ -129,6 +171,7 @@ export const welcomeRouter = createTRPCRouter({
           provider: { in: ["google", "microsoft-entra-id"] },
         },
       }),
+      resolveInvitedContext(ctx.db, userId, ctx.session.user.email),
     ]);
 
     return {
@@ -139,6 +182,10 @@ export const welcomeRouter = createTRPCRouter({
       // aren't allowlisted testers the step isn't "not connected", it's not
       // available — the Google half of the step is hidden rather than offered.
       googleCalendarAvailable: isGoogleOAuthTester(ctx.session.user.email),
+      // Only a live signal while welcome is in progress: once completed, a
+      // return visit to /welcome must not flip an ordinary user's finished
+      // flow into the invited variant.
+      invitedContext: user?.welcomeCompletedAt ? null : invitedContext,
       state: parseSetupState(user?.welcomeSetupState),
     };
   }),

--- a/src/server/api/routers/welcome.ts
+++ b/src/server/api/routers/welcome.ts
@@ -140,11 +140,29 @@ export async function resolveInvitedContext(
   });
   if (!invitation) return null;
   if (invitation.workspace.ownerId === userId) return null;
+
+  // Only genuine CURRENT members: an invitee who was later removed must not
+  // see "You've joined {workspace}" with a CTA into a workspace whose access
+  // gate will reject them (and must not be shown its name/inviter at all).
+  const membership = await db.workspaceUser.findUnique({
+    where: {
+      userId_workspaceId: { userId, workspaceId: invitation.workspaceId },
+    },
+    select: { userId: true },
+  });
+  if (!membership) return null;
+
+  // `??` alone would let a whitespace-only stored name through and render
+  // "  invited you" — treat blank as missing.
+  const inviterName =
+    invitation.createdBy.name?.trim() ||
+    invitation.createdBy.email?.trim() ||
+    null;
+
   return {
     workspaceName: invitation.workspace.name,
     workspaceSlug: invitation.workspace.slug,
-    inviterName:
-      invitation.createdBy.name ?? invitation.createdBy.email ?? null,
+    inviterName,
   };
 }
 

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -1342,17 +1342,26 @@ export const workspaceRouter = createTRPCRouter({
 
       // Whether the logged-in viewer already belongs to the workspace — e.g.
       // an invitee whose invitation was auto-accepted during signup.
-      const isMember = ctx.session?.user?.id
-        ? (await ctx.db.workspaceUser.findUnique({
-            where: {
-              userId_workspaceId: {
-                userId: ctx.session.user.id,
-                workspaceId: invitation.workspaceId,
-              },
-            },
-            select: { userId: true },
-          })) !== null
-        : false;
+      const viewerId = ctx.session?.user?.id;
+      const [isMember, viewer] = viewerId
+        ? await Promise.all([
+            ctx.db.workspaceUser
+              .findUnique({
+                where: {
+                  userId_workspaceId: {
+                    userId: viewerId,
+                    workspaceId: invitation.workspaceId,
+                  },
+                },
+                select: { userId: true },
+              })
+              .then((membership) => membership !== null),
+            ctx.db.user.findUnique({
+              where: { id: viewerId },
+              select: { welcomeCompletedAt: true },
+            }),
+          ])
+        : [false, null];
 
       return {
         ...invitation,
@@ -1365,6 +1374,13 @@ export const workspaceRouter = createTRPCRouter({
         isLoggedIn: !!ctx.session?.user,
         isForCurrentUser: invitation.email === ctx.session?.user?.email,
         isMember,
+        // Logged-out viewers default to true so nothing changes for them —
+        // only a logged-in member who hasn't finished welcome gets routed
+        // through /welcome instead of straight into the workspace.
+        viewerCompletedWelcome: viewerId
+          ? viewer?.welcomeCompletedAt !== null &&
+            viewer?.welcomeCompletedAt !== undefined
+          : true,
       };
     }),
 


### PR DESCRIPTION
### **User description**
## What

Invited signups used to bypass /welcome entirely (the gate only fires from /home, which the invite flow never touches). They now get a shortened, **invite-aware welcome variant**, per the refinement agreed on the ticket:

1. **Server-side detection, no query params** — `welcome.getSetup` returns `invitedContext` from the user's most recently *accepted* `WorkspaceInvitation`, only when it put them into someone else's workspace (an owner re-invited into their own workspace is not "invited"). Nulled once welcome is completed.
2. **Invite page routes fresh invitees through /welcome** — the accepted-member auto-redirect sends viewers who haven't finished welcome to `/welcome`; returning members still go straight to `/w/<slug>`.
3. **The variant itself** — "You've joined {workspace}" with "{inviter} invited you — you're in." (inviter attribution survives auto-accepted invites via the invitation's `createdBy`; degrades gracefully when absent). Goal/action/plan steps are dropped; the **calendar connect is the only surviving step** (reuses the existing `AskBlock` cal step, including the Google-verification gating). Primary CTA "Take me to {workspace}" completes welcome and lands on `/w/<slug>/home` — where the Your work panel's team-pulse empty state orients them. The persistent "I'll explore on my own" exit works unchanged.

## Acceptance criteria

- [x] A new user signing up via an invite link sees an onboarding that acknowledges the team they joined
- [x] No onboarding artifacts (goals/actions) are written into the shared workspace — the variant never offers those steps
- [x] The skip exit works here as everywhere
- [x] Ordinary (non-invited) new users still get the unchanged 4-step welcome

Verified live against a local dev server with the dev-fixture workspace: invited variant renders with attribution; CTA completes welcome and lands on the workspace home; DB confirms no goal/action rows; `/invite/<token>` redirects a fresh invitee to `/welcome`; and — the sharpest test — a fresh user who *owns* the workspace their accepted invitation points at still gets the normal 4-step welcome (ownership guard). 6 new unit tests cover the detection logic; full suite green (2649).

---

Ships: prime.toucan

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cmsq4b2oe0001in04y6js3jwn)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add server-side invited-signup detection in `welcome.getSetup`

- New shortened invited welcome variant (calendar-only step)

- Route fresh invitees from invite page to `/welcome`

- Unit tests for `resolveInvitedContext` edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["/invite/[token]"] -- "member, welcome incomplete" --> B["/welcome"]
  A -- "member, welcome done" --> C["/w/{slug}"]
  B --> D["welcome.getSetup → invitedContext"]
  D -- "invited" --> E["WelcomeInvited: joined team + calendar step"]
  D -- "not invited" --> F["Chat / Checklist 4-step flow"]
  E -- "completeAndNavigate" --> G["/w/{slug}/home"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>welcome.ts</strong><dd><code>Add `resolveInvitedContext` and expose `invitedContext` in `getSetup`</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/576/files#diff-0bb40f6dedc288631f49d9dbc59e64f1b23b047bf7865ca93bdd757675b5d777">+66/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WelcomeInvited.tsx</strong><dd><code>New invited welcome variant component with calendar step</code>&nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/576/files#diff-39784b11422b6c2d3de61bb220995af38adf57e0ed9c5acf19a7638d1443347e">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>useWelcomeSetup.ts</strong><dd><code>Expose `invitedContext` and shared `completeAndNavigate` helper</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/576/files#diff-b7631ca8ccacb7ad5d1470959ce2c1fd41b68aac5042f10c586a26e33a323e45">+26/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>GettingStarted.tsx</strong><dd><code>Render invited variant instead of chat/checklist views</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/576/files#diff-30dce4ac30d40cd7fb1a1b2ba83f5c4e5f5b5b8c6d85ac7b875b2596a8410ce3">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>welcomeCopy.ts</strong><dd><code>Add copy strings for the invited variant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/576/files#diff-805062a8bffbedbe6868627b707996268993325dd3d56d7ecf0a48aa5228cd23">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>workspace.ts</strong><dd><code>Return `viewerCompletedWelcome` from `getInvitationByToken`</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/576/files#diff-b94d59060e1c78a6a505a0a58d90bb366e921cdd053126776199f6abcee0f846">+27/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Redirect fresh invitees to `/welcome` instead of workspace</code></dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/576/files#diff-73c22ad002c46aa25771d8e244d322edcbfb0f1c74a3fc518706a620f293bcba">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>welcome.test.ts</strong><dd><code>Tests for invited-context resolution and fallbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/576/files#diff-fdaccdd63494c3b2f8340cf5554574c19c81e7079afb026688204980d93970da">+110/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

