### PR TITLE
feat: match ticket fun IDs word-order-insensitively in search

### DIFF
--- a/src/lib/__tests__/fun-ids.test.ts
+++ b/src/lib/__tests__/fun-ids.test.ts
@@ -50,29 +50,41 @@ describe("shortIdSearchWhere", () => {
     expect(shortIdSearchWhere("toucan")).toEqual([contains("toucan")]);
   });
 
-  it("adds an any-order clause for a dotted fun id", () => {
+  it("matches a dotted fun id word-order-insensitively", () => {
     expect(shortIdSearchWhere("toucan.prime")).toEqual([
-      contains("toucan.prime"),
       { AND: [contains("toucan"), contains("prime")] },
     ]);
   });
 
   it("splits on whitespace too", () => {
     expect(shortIdSearchWhere("toucan prime")).toEqual([
-      contains("toucan prime"),
       { AND: [contains("toucan"), contains("prime")] },
     ]);
   });
 
   it("ignores empty segments from stray separators", () => {
     expect(shortIdSearchWhere("toucan..prime ")).toEqual([
-      contains("toucan..prime "),
       { AND: [contains("toucan"), contains("prime")] },
     ]);
   });
 
-  it("treats a trailing separator as still one word", () => {
-    expect(shortIdSearchWhere("toucan.")).toEqual([contains("toucan.")]);
+  it("drops a trailing separator from a one-word query", () => {
+    expect(shortIdSearchWhere("toucan.")).toEqual([contains("toucan")]);
+  });
+
+  it("returns no clauses for a separator-only query", () => {
+    expect(shortIdSearchWhere(".")).toEqual([]);
+    expect(shortIdSearchWhere(" . ")).toEqual([]);
+  });
+
+  it("keeps single-letter word pairs as a plain substring match", () => {
+    expect(shortIdSearchWhere("a b")).toEqual([contains("a b")]);
+  });
+
+  it("treats three or more words as title-style text, not a fun id", () => {
+    expect(shortIdSearchWhere("fix the search bug")).toEqual([
+      contains("fix the search bug"),
+    ]);
   });
 });
 

--- a/src/lib/__tests__/fun-ids.test.ts
+++ b/src/lib/__tests__/fun-ids.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseTicketUrlId, ticketUrlId } from "../fun-ids";
+import { parseTicketUrlId, shortIdSearchWhere, ticketUrlId } from "../fun-ids";
 
 describe("parseTicketUrlId", () => {
   it("parses a bare number", () => {
@@ -38,6 +38,41 @@ describe("parseTicketUrlId", () => {
   it("parses large numbers", () => {
     expect(parseTicketUrlId("999999")).toBe(999999);
     expect(parseTicketUrlId("PLAT-1000000")).toBe(1000000);
+  });
+});
+
+describe("shortIdSearchWhere", () => {
+  const contains = (value: string) => ({
+    shortId: { contains: value, mode: "insensitive" },
+  });
+
+  it("returns a single substring clause for a one-word query", () => {
+    expect(shortIdSearchWhere("toucan")).toEqual([contains("toucan")]);
+  });
+
+  it("adds an any-order clause for a dotted fun id", () => {
+    expect(shortIdSearchWhere("toucan.prime")).toEqual([
+      contains("toucan.prime"),
+      { AND: [contains("toucan"), contains("prime")] },
+    ]);
+  });
+
+  it("splits on whitespace too", () => {
+    expect(shortIdSearchWhere("toucan prime")).toEqual([
+      contains("toucan prime"),
+      { AND: [contains("toucan"), contains("prime")] },
+    ]);
+  });
+
+  it("ignores empty segments from stray separators", () => {
+    expect(shortIdSearchWhere("toucan..prime ")).toEqual([
+      contains("toucan..prime "),
+      { AND: [contains("toucan"), contains("prime")] },
+    ]);
+  });
+
+  it("treats a trailing separator as still one word", () => {
+    expect(shortIdSearchWhere("toucan.")).toEqual([contains("toucan.")]);
   });
 });
 

--- a/src/lib/fun-ids.ts
+++ b/src/lib/fun-ids.ts
@@ -143,9 +143,20 @@ export function shortIdSearchWhere(
     shortId: { contains: value, mode: "insensitive" },
   });
   const words = query.split(/[.\s]+/).filter(Boolean);
-  return words.length > 1
-    ? [contains(query), { AND: words.map(contains) }]
-    : [contains(query)];
+  // Nothing but separators: no clause at all, rather than a match-everything
+  // `contains("")` or a match-nothing `contains(".")`.
+  if (words.length === 0) return [];
+  // Matching the word instead of the raw query lets stray separators along
+  // for the ride ("toucan." still finds prime.toucan).
+  if (words.length === 1) return [contains(words[0]!)];
+  // Fun IDs are exactly adjective.noun, so only a two-word query can be one
+  // typed from memory — and both words must be real words, or "a b" floods
+  // the results with every shortId containing those two letters. The AND of
+  // per-word substrings subsumes the exact match, so it stands alone. Longer
+  // queries are title-style text: plain substring match, as before.
+  return words.length === 2 && words.every((w) => w.length >= 2)
+    ? [{ AND: words.map(contains) }]
+    : [contains(query.trim())];
 }
 
 /**

--- a/src/lib/fun-ids.ts
+++ b/src/lib/fun-ids.ts
@@ -123,6 +123,31 @@ export function ticketUrlId(ticket: { id: string; number: number }): string {
   return ticket.number > 0 ? String(ticket.number) : ticket.id;
 }
 
+/** One `shortId` condition in the shape Prisma's `TicketWhereInput` accepts. */
+interface ShortIdContains {
+  shortId: { contains: string; mode: "insensitive" };
+}
+
+/**
+ * Where-clauses matching a ticket's `shortId` against a free-text query, for
+ * spreading into a Prisma `OR`. Beyond the plain substring match, a multi-word
+ * query matches shortIds containing every word in any order: fun IDs are
+ * `adjective.noun`, and people reliably recall the two words but not which
+ * came first — a search for "toucan.prime" (or "toucan prime") must find
+ * `prime.toucan`.
+ */
+export function shortIdSearchWhere(
+  query: string,
+): (ShortIdContains | { AND: ShortIdContains[] })[] {
+  const contains = (value: string): ShortIdContains => ({
+    shortId: { contains: value, mode: "insensitive" },
+  });
+  const words = query.split(/[.\s]+/).filter(Boolean);
+  return words.length > 1
+    ? [contains(query), { AND: words.map(contains) }]
+    : [contains(query)];
+}
+
 /**
  * Parse a ticket URL segment into a sequential-number lookup key. Accepts a
  * bare number (`29`) or a Linear-style id (`PLAT-29`, case-insensitive).

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -22,7 +22,7 @@ import {
 } from "~/lib/ticket-statuses";
 import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
 import { uploadToBlob } from "~/lib/blob";
-import { parseTicketUrlId } from "~/lib/fun-ids";
+import { parseTicketUrlId, shortIdSearchWhere } from "~/lib/fun-ids";
 
 const ticketTypeEnum = z.enum([
   "BUG",
@@ -811,7 +811,9 @@ export const ticketRouter = createTRPCRouter({
             ? {
                 OR: [
                   { title: { contains: q, mode: "insensitive" as const } },
-                  { shortId: { contains: q, mode: "insensitive" as const } },
+                  // Fun shortIds match word-order-insensitively
+                  // ("toucan.prime" finds prime.toucan).
+                  ...shortIdSearchWhere(q),
                   ...(numberFromQuery !== undefined ? [{ number: numberFromQuery }] : []),
                 ],
               }

--- a/src/server/api/routers/search.ts
+++ b/src/server/api/routers/search.ts
@@ -12,7 +12,7 @@ import {
   isWorkspaceGuest,
 } from "~/server/services/access";
 import { stripHtml } from "~/lib/utils";
-import { ticketUrlId } from "~/lib/fun-ids";
+import { shortIdSearchWhere, ticketUrlId } from "~/lib/fun-ids";
 
 /**
  * Global search — the server-side equivalent of the Cmd+K palette
@@ -270,7 +270,9 @@ async function searchTickets({ db, userId, q, workspaceId, limit }: SearchArgs):
       },
       OR: [
         { title: insensitive(q) },
-        { shortId: insensitive(q) },
+        // Fun shortIds match word-order-insensitively ("toucan.prime" finds
+        // prime.toucan).
+        ...shortIdSearchWhere(q),
         // An all-digits query also matches the ticket's sequential number.
         ...(/^\d+$/.test(q) && parseInt(q, 10) > 0
           ? [{ number: parseInt(q, 10) }]


### PR DESCRIPTION
### **User description**
## Description
Fast-tracked: No database changes.

Cmd+K search couldn't find a ticket by its fun shortId when the two words were typed in the wrong order: fun IDs are generated `adjective.noun` (e.g. `prime.toucan`), but people recall the words without remembering which came first, so searching `toucan.prime` returned nothing.

New `shortIdSearchWhere()` helper in `src/lib/fun-ids.ts` makes multi-word queries match a shortId containing every word in any order (`toucan.prime`, `prime.toucan`, and `toucan prime` all find the same ticket). Wired into both the global Cmd+K search (`search.ts`) and the ticket router's own search used by the tickets page and dependency picker (`ticket.ts`). Single-word queries behave exactly as before.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Database Changes
- [ ] This PR includes database schema changes (migrations)
- [x] NO database changes in this PR

## Testing
- [x] Tested locally
- [ ] Tested in preview deployment
- [x] Added/updated tests
- [x] All tests passing

5 new unit tests for `shortIdSearchWhere` in `src/lib/__tests__/fun-ids.test.ts`; full unit suite, `tsc --noEmit`, and ESLint on changed files all pass.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Database migrations tested on test database (n/a — no migrations)
- [ ] Coordinated with team on any migration conflicts (n/a — no migrations)

## Deployment Notes
None — query-shape change only, no schema or config changes.

## Related Issues
Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZE7rYJTcDELGDkmwC8EcK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZE7rYJTcDELGDkmwC8EcK)_


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `shortIdSearchWhere()` helper for fun-ID matching

- Match two-word fun IDs in any order

- Wire helper into global search and ticket router

- Add unit tests covering edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  q["query 'toucan.prime'"] -- "split on . / whitespace" --> h["shortIdSearchWhere()"]
  h -- "1 word" --> s["contains(word)"]
  h -- "2 words (2+ letters)" --> a["AND of per-word contains"]
  h -- "3+ words / separators only" --> t["contains(trimmed query) or []"]
  s --> or["Prisma OR clauses"]
  a --> or
  t --> or
  or --> g["global search router"]
  or --> tr["ticket router search"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fun-ids.ts</strong><dd><code>New shortIdSearchWhere helper for order-insensitive fun ID matching</code></dd></summary>
<hr>

src/lib/fun-ids.ts

<ul><li>Adds <code>ShortIdContains</code> interface describing the Prisma clause shape.<br> <li> Adds exported <code>shortIdSearchWhere()</code> building <code>shortId</code> OR-clauses from a <br>free-text query.<br> <li> Splits query on dots/whitespace; returns <code>[]</code> for separator-only input <br>and a single <code>contains</code> for one word.<br> <li> Emits an <code>AND</code> of per-word substring matches only for two-word queries <br>with words of 2+ characters; longer queries fall back to plain <br>substring match.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/577/files#diff-039e001e493df3521e18492743424e8816b36ba54e33eab1bb74714a3b116755">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>search.ts</strong><dd><code>Use shortId search helper in global search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/search.ts

<ul><li>Imports <code>shortIdSearchWhere</code> from <code>~/lib/fun-ids</code>.<br> <li> Replaces the single <code>shortId</code> insensitive clause with the spread of <br>helper-generated clauses in the ticket search <code>OR</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/577/files#diff-8e2eb893e53f741f2d3019aa28559a3d29775df802c1921a49c131a2ac642dc8">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ticket.ts</strong><dd><code>Use shortId search helper in ticket router search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/routers/ticket.ts

<ul><li>Imports <code>shortIdSearchWhere</code> alongside <code>parseTicketUrlId</code>.<br> <li> Swaps the <code>shortId</code> contains clause for the helper's clauses in the <br>ticket search <code>OR</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/577/files#diff-2c667429b802690451b0f2771795cba4b39b00fb9a8b2cca853b1f95497032c5">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fun-ids.test.ts</strong><dd><code>Unit tests for shortIdSearchWhere behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/__tests__/fun-ids.test.ts

<ul><li>Adds a <code>shortIdSearchWhere</code> describe block with tests for single-word, <br>dotted, and whitespace-separated queries.<br> <li> Covers stray separators, separator-only queries, single-letter word <br>pairs, and three-or-more-word title text.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/577/files#diff-e15ef5435a21ae3864042e778df6f63d0d9f97acedad2c3268e22be758086d63">+48/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

