### PR TITLE
feat: show priority and sort by it on the product roadmap board

### DIFF
--- a/src/app/_components/products/ProductRoadmapBoard.tsx
+++ b/src/app/_components/products/ProductRoadmapBoard.tsx
@@ -30,7 +30,7 @@ import {
   Text,
   Tooltip,
 } from '@mantine/core';
-import { IconRoute } from '@tabler/icons-react';
+import { IconArrowsSort, IconRoute } from '@tabler/icons-react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
 import { api } from '~/trpc/react';
 import type { RouterOutputs } from '~/trpc/react';
@@ -42,6 +42,10 @@ import {
   HIDDEN_FEATURE_STATUSES,
   type FeatureStatus,
 } from '~/lib/feature-statuses';
+import {
+  PriorityIcon,
+  PRIORITY_LABELS,
+} from '~/app/_components/product/PriorityIcon';
 
 type RoadmapFeature =
   RouterOutputs['product']['feature']['listForWorkspace'][number];
@@ -150,6 +154,15 @@ function FeatureCardBody({ feature }: { feature: RoadmapFeature }) {
       </Text>
       <Group mt="xs" gap="xs" justify="space-between" wrap="nowrap">
         <ProductBadge product={feature.product} />
+        <Tooltip
+          label={PRIORITY_LABELS[feature.priority ?? 4] ?? 'No priority'}
+          position="top"
+          withArrow
+        >
+          <span className="flex shrink-0 items-center text-text-muted">
+            <PriorityIcon priority={feature.priority} size={14} />
+          </span>
+        </Tooltip>
       </Group>
     </>
   );
@@ -242,13 +255,22 @@ function FeatureCard({
 }
 
 // ---------------------------------------------------------------------------
-// Helpers - bucket a feature list into status columns.
+// Helpers - bucket a feature list into status columns, each column sorted by
+// priority (0 = Urgent first; unset sorts after the explicit "No priority" 4).
 // ---------------------------------------------------------------------------
+
+function priorityRank(f: RoadmapFeature) {
+  return f.priority ?? 5;
+}
 
 function bucketByStatus(features: RoadmapFeature[]) {
   const map: Record<string, RoadmapFeature[]> = {};
   for (const col of FEATURE_STATUSES) map[col.value] = [];
   for (const f of features) (map[f.status] ??= []).push(f);
+  // Stable sort: equal priorities keep the query's updatedAt-desc order.
+  for (const list of Object.values(map)) {
+    list.sort((a, b) => priorityRank(a) - priorityRank(b));
+  }
   return map;
 }
 
@@ -674,6 +696,18 @@ export function ProductRoadmapBoard() {
           }}
         />
       </div>
+      <Tooltip
+        label="Cards in each column are ordered by priority (Urgent first)"
+        position="bottom"
+        withArrow
+      >
+        <Group gap={4} wrap="nowrap">
+          <IconArrowsSort size={14} className="text-text-muted" />
+          <Text size="xs" className="text-text-muted">
+            Sorted by priority
+          </Text>
+        </Group>
+      </Tooltip>
       <Tooltip
         label="By default, SHIPPED shows only features updated this quarter"
         position="bottom"

--- a/src/app/_components/products/ProductRoadmapBoard.tsx
+++ b/src/app/_components/products/ProductRoadmapBoard.tsx
@@ -159,7 +159,11 @@ function FeatureCardBody({ feature }: { feature: RoadmapFeature }) {
           position="top"
           withArrow
         >
-          <span className="flex shrink-0 items-center text-text-muted">
+          <span
+            role="img"
+            aria-label={PRIORITY_LABELS[feature.priority ?? 4] ?? 'No priority'}
+            className="flex shrink-0 items-center text-text-muted"
+          >
             <PriorityIcon priority={feature.priority} size={14} />
           </span>
         </Tooltip>
@@ -256,14 +260,16 @@ function FeatureCard({
 
 // ---------------------------------------------------------------------------
 // Helpers - bucket a feature list into status columns, each column sorted by
-// priority (0 = Urgent first; unset sorts after the explicit "No priority" 4).
+// priority (0 = Urgent first). Unset ranks the same as the explicit
+// "No priority" 4 - both render the identical label, so they must not order
+// differently.
 // ---------------------------------------------------------------------------
 
 function priorityRank(f: RoadmapFeature) {
-  return f.priority ?? 5;
+  return f.priority ?? 4;
 }
 
-function bucketByStatus(features: RoadmapFeature[]) {
+export function bucketByStatus(features: RoadmapFeature[]) {
   const map: Record<string, RoadmapFeature[]> = {};
   for (const col of FEATURE_STATUSES) map[col.value] = [];
   for (const f of features) (map[f.status] ??= []).push(f);

--- a/src/app/_components/products/ProductRoadmapBoard.tsx
+++ b/src/app/_components/products/ProductRoadmapBoard.tsx
@@ -147,6 +147,7 @@ function ProductBadge({ product }: { product: RoadmapProduct }) {
 }
 
 function FeatureCardBody({ feature }: { feature: RoadmapFeature }) {
+  const priorityLabel = PRIORITY_LABELS[feature.priority ?? 4] ?? 'No priority';
   return (
     <>
       <Text size="sm" fw={500} className="text-text-primary" lineClamp={2}>
@@ -154,14 +155,10 @@ function FeatureCardBody({ feature }: { feature: RoadmapFeature }) {
       </Text>
       <Group mt="xs" gap="xs" justify="space-between" wrap="nowrap">
         <ProductBadge product={feature.product} />
-        <Tooltip
-          label={PRIORITY_LABELS[feature.priority ?? 4] ?? 'No priority'}
-          position="top"
-          withArrow
-        >
+        <Tooltip label={priorityLabel} position="top" withArrow>
           <span
             role="img"
-            aria-label={PRIORITY_LABELS[feature.priority ?? 4] ?? 'No priority'}
+            aria-label={priorityLabel}
             className="flex shrink-0 items-center text-text-muted"
           >
             <PriorityIcon priority={feature.priority} size={14} />

--- a/src/app/_components/products/__tests__/ProductRoadmapBoard.test.ts
+++ b/src/app/_components/products/__tests__/ProductRoadmapBoard.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { bucketByStatus } from "../ProductRoadmapBoard";
+import type { RouterOutputs } from "~/trpc/react";
+import { FEATURE_STATUSES } from "~/lib/feature-statuses";
+
+type RoadmapFeature =
+  RouterOutputs["product"]["feature"]["listForWorkspace"][number];
+
+/** Minimal card-shaped feature; only the fields bucketByStatus reads. */
+function feature(
+  id: string,
+  priority: number | null,
+  status: RoadmapFeature["status"] = "IDEA",
+): RoadmapFeature {
+  return { id, priority, status } as RoadmapFeature;
+}
+
+describe("bucketByStatus", () => {
+  it("creates a bucket for every status", () => {
+    const buckets = bucketByStatus([]);
+    for (const col of FEATURE_STATUSES) {
+      expect(buckets[col.value]).toEqual([]);
+    }
+  });
+
+  it("sorts each column by priority, Urgent (0) first", () => {
+    const buckets = bucketByStatus([
+      feature("low", 3),
+      feature("urgent", 0),
+      feature("medium", 2),
+      feature("high", 1),
+    ]);
+    expect(buckets.IDEA?.map((f) => f.id)).toEqual([
+      "urgent",
+      "high",
+      "medium",
+      "low",
+    ]);
+  });
+
+  it("ranks unset priority the same as the explicit 'No priority' 4", () => {
+    // null and 4 render the identical label, so neither may sort ahead of the
+    // other: ties keep input (updatedAt-desc) order.
+    const buckets = bucketByStatus([
+      feature("unset-first", null),
+      feature("explicit-none", 4),
+      feature("high", 1),
+    ]);
+    expect(buckets.IDEA?.map((f) => f.id)).toEqual([
+      "high",
+      "unset-first",
+      "explicit-none",
+    ]);
+  });
+
+  it("keeps input order for equal priorities (stable sort)", () => {
+    const buckets = bucketByStatus([
+      feature("a", 2),
+      feature("b", 2),
+      feature("c", 2),
+    ]);
+    expect(buckets.IDEA?.map((f) => f.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("buckets features into their own status columns", () => {
+    const buckets = bucketByStatus([
+      feature("idea", 1, "IDEA"),
+      feature("live", 0, "SHIPPED"),
+    ]);
+    expect(buckets.IDEA?.map((f) => f.id)).toEqual(["idea"]);
+    expect(buckets.SHIPPED?.map((f) => f.id)).toEqual(["live"]);
+  });
+});


### PR DESCRIPTION
### **User description**
## What

- Cards on `/w/[workspaceSlug]/products-roadmap` now render each Feature's priority using the existing Linear-style `PriorityIcon` (Urgent `!`, High/Medium/Low bars, dashed for none), with the label in a tooltip and exposed to screen readers via `aria-label`.
- Cards within every status column are sorted by priority — Urgent (0) first; an unset priority ranks the same as the explicit "No priority" (4), since both render the identical label; ties keep the query's `updatedAt`-desc order (stable sort). Applies to both the Objective-swimlane and flat boards via the shared `bucketByStatus`.
- The toolbar gains a "Sorted by priority" indicator so the ordering is self-evident.
- Unit tests cover the sort: Urgent-first order, null/4 equivalence, tie stability, and status bucketing.

## Why

The roadmap board showed no priority at all and ordered cards by `updatedAt`, so there was no way to see what matters most in a column. `feature.listForWorkspace` already returned `priority` — this is UI-only, no schema or API change.

## Verification

- Full unit suite, targeted `tsc --noEmit` and ESLint on the changed files: clean.
- Verified in the browser against the dev-fixture workspace with five demo features (Urgent→none): icons render, column order is Urgent→High→Medium→Low→No priority (the raw query order would have shown the reverse).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Render priority icon with tooltip on roadmap cards

- Sort each status column by priority, Urgent first

- Treat unset priority same as "No priority"

- Add toolbar "Sorted by priority" indicator and unit tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["listForWorkspace features"] -- "bucketByStatus" --> B["status columns"]
  B -- "stable sort by priorityRank (null = 4)" --> C["Urgent-first order"]
  C --> D["FeatureCardBody + PriorityIcon tooltip"]
  C --> E["Toolbar 'Sorted by priority' hint"]
  B --> F["Vitest unit tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProductRoadmapBoard.tsx</strong><dd><code>Display priority icon and sort columns by priority</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/products/ProductRoadmapBoard.tsx

<ul><li>Added <code>PriorityIcon</code> with tooltip and <code>role=img</code>/<code>aria-label</code> to feature <br>cards, computing the label once from <code>PRIORITY_LABELS</code>.<br> <li> Exported <code>bucketByStatus</code> and added a stable per-column sort via new <br><code>priorityRank</code> helper where unset priority ranks as 4.<br> <li> Added a toolbar "Sorted by priority" indicator with <code>IconArrowsSort</code> and <br>explanatory tooltip.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/578/files#diff-129b5337c6e8708088d025e64b1a8c3bc1af809d521c707d02f94ec94e0e401b">+40/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProductRoadmapBoard.test.ts</strong><dd><code>Add unit tests for bucketByStatus priority sorting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/products/__tests__/ProductRoadmapBoard.test.ts

<ul><li>New Vitest suite for <code>bucketByStatus</code> covering bucket creation for all <br>statuses.<br> <li> Tests Urgent-first ordering, null vs explicit 4 equivalence, tie <br>stability, and per-status bucketing.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/578/files#diff-59bbb8b2509db00ee100f477dc6d2932747d63ae406c1f73169f7d2863c45d71">+74/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

