### PR TITLE
fix: render meeting-summary markdown properly in app and Matrix posts

### DIFF
--- a/src/app/_components/FirefliesSummaryRenderer.tsx
+++ b/src/app/_components/FirefliesSummaryRenderer.tsx
@@ -159,10 +159,12 @@ function renderSummarySections(summary: FirefliesSummary) {
           <Accordion.Panel>
             {summary.detailed_breakdown?.trim() ? (
               // Rich themed write-up (markdown). Older summaries that predate
-              // this field fall back to the flat bullet list below.
+              // this field fall back to the flat bullet list below. Compact,
+              // not prose: prose renders `##` as full-size article headings,
+              // which dwarf the accordion's own section titles.
               <MarkdownRenderer
                 content={summary.detailed_breakdown}
-                variant="prose"
+                variant="compact"
               />
             ) : (
               <List>

--- a/src/app/_components/meeting/SummaryTab.tsx
+++ b/src/app/_components/meeting/SummaryTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Textarea, Button, Loader } from "@mantine/core";
+import { Button, Loader, Stack, Text } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import {
   IconSparkles,
@@ -15,11 +15,21 @@ import {
 } from "@tabler/icons-react";
 import { SmartContentRenderer } from "~/app/_components/SmartContentRenderer";
 import { FirefliesSummaryDisplay } from "~/app/_components/FirefliesSummaryRenderer";
+import { MarkdownInput } from "~/app/_components/shared/MarkdownInput";
+import { parseFirefliesSummary } from "~/lib/fireflies-summary";
 import { ActionsList } from "~/app/_components/actions/ActionsList";
 import type { MeetingViewModel } from "~/lib/meeting-view-model";
 import type { RouterOutputs } from "~/trpc/react";
 
 type TranscriptAction = RouterOutputs["action"]["getByTranscription"][number];
+
+/**
+ * What Edit puts on screen. Structured summaries (Fireflies-shaped JSON) edit
+ * their two prose fields; everything else edits the raw string.
+ */
+type EditDraft =
+  | { kind: "structured"; overview: string; breakdown: string }
+  | { kind: "freeform"; text: string };
 
 interface SummaryTabProps {
   vm: MeetingViewModel;
@@ -56,22 +66,49 @@ export function SummaryTab({
   onIdeateFeatures,
   onRegenerate,
 }: SummaryTabProps) {
-  const [isEditing, setIsEditing] = useState(false);
-  const [draft, setDraft] = useState("");
+  const [draft, setDraft] = useState<EditDraft | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
   const hasSummary = Boolean(vm.firefliesSummary ?? vm.plainSummary);
 
   function startEdit() {
-    setDraft(rawSummary ?? "");
-    setIsEditing(true);
+    // Structured summaries are stored as JSON; editing that raw string is
+    // hostile, so expose the two prose fields instead and merge them back on
+    // save. Anything else (plain text / markdown) is edited as-is.
+    const parsed = parseFirefliesSummary(rawSummary);
+    if (parsed) {
+      setDraft({
+        kind: "structured",
+        overview: typeof parsed.overview === "string" ? parsed.overview : "",
+        breakdown:
+          typeof parsed.detailed_breakdown === "string"
+            ? parsed.detailed_breakdown
+            : "",
+      });
+    } else {
+      setDraft({ kind: "freeform", text: rawSummary ?? "" });
+    }
+  }
+
+  function serializeDraft(current: EditDraft): string {
+    if (current.kind === "freeform") return current.text;
+    // Merge the edited prose back into the stored JSON so untouched fields
+    // (keywords, bullets, chapters…) survive the edit.
+    const base: Record<string, unknown> = {
+      ...(parseFirefliesSummary(rawSummary) ?? {}),
+    };
+    base.overview = current.overview;
+    if (current.breakdown.trim()) base.detailed_breakdown = current.breakdown;
+    else delete base.detailed_breakdown;
+    return JSON.stringify(base);
   }
 
   async function save() {
+    if (!draft) return;
     setIsSaving(true);
     try {
-      await onSaveSummary(draft);
-      setIsEditing(false);
+      await onSaveSummary(serializeDraft(draft));
+      setDraft(null);
     } catch {
       // onSaveSummary surfaces its own error notification; stay in edit mode.
     } finally {
@@ -95,21 +132,49 @@ export function SummaryTab({
           {generatedStamp && <span className="mp-tldr__stamp">generated {generatedStamp}</span>}
         </div>
 
-        {isEditing ? (
+        {draft ? (
           <>
-            <Textarea
-              value={draft}
-              onChange={(e) => setDraft(e.currentTarget.value)}
-              autosize
-              minRows={6}
-              maxRows={20}
-              placeholder="Enter a summary…"
-            />
+            {draft.kind === "structured" ? (
+              <Stack gap="sm">
+                <div>
+                  <Text size="xs" fw={600} c="dimmed" mb={4}>
+                    Overview
+                  </Text>
+                  <MarkdownInput
+                    value={draft.overview}
+                    onChange={(value) => setDraft({ ...draft, overview: value })}
+                    placeholder="What was the meeting about?"
+                    minRows={4}
+                    maxRows={12}
+                  />
+                </div>
+                <div>
+                  <Text size="xs" fw={600} c="dimmed" mb={4}>
+                    Detailed breakdown
+                  </Text>
+                  <MarkdownInput
+                    value={draft.breakdown}
+                    onChange={(value) => setDraft({ ...draft, breakdown: value })}
+                    placeholder="Themed sections, decisions, action items…"
+                    minRows={8}
+                    maxRows={24}
+                  />
+                </div>
+              </Stack>
+            ) : (
+              <MarkdownInput
+                value={draft.text}
+                onChange={(value) => setDraft({ ...draft, text: value })}
+                placeholder="Enter a summary…"
+                minRows={6}
+                maxRows={20}
+              />
+            )}
             <div className="mp-tldr__foot">
               <Button size="xs" loading={isSaving} onClick={() => void save()}>
                 Save
               </Button>
-              <Button size="xs" variant="subtle" onClick={() => setIsEditing(false)}>
+              <Button size="xs" variant="subtle" onClick={() => setDraft(null)}>
                 Cancel
               </Button>
             </div>

--- a/src/app/_components/meeting/__tests__/SummaryTab.test.tsx
+++ b/src/app/_components/meeting/__tests__/SummaryTab.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * The Edit flow's contract: a structured (Fireflies-JSON) summary is edited as
+ * its two prose fields — never as raw JSON — and saving merges them back into
+ * the stored object without dropping the fields that weren't on screen.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "~/test/test-utils";
+
+import { SummaryTab } from "~/app/_components/meeting/SummaryTab";
+import type { MeetingViewModel } from "~/lib/meeting-view-model";
+
+// Children with their own data dependencies; irrelevant to the edit flow.
+vi.mock("~/app/_components/actions/ActionsList", () => ({
+  ActionsList: () => null,
+}));
+vi.mock("~/app/_components/SmartContentRenderer", () => ({
+  SmartContentRenderer: () => null,
+}));
+vi.mock("~/app/_components/FirefliesSummaryRenderer", () => ({
+  FirefliesSummaryDisplay: () => null,
+}));
+
+const STORED = {
+  overview: "What happened.",
+  detailed_breakdown: "## Theme\n- **Decision:** ship it",
+  shorthand_bullet: ["one", "two"],
+  keywords: ["kept"],
+};
+
+function vmWith(summary: MeetingViewModel["firefliesSummary"]): MeetingViewModel {
+  return {
+    meetingType: null,
+    firefliesSummary: summary,
+    plainSummary: summary ? null : "Plain notes.",
+    durationLabel: null,
+    participants: [],
+    chapters: [],
+    keyMoments: [],
+    decisions: [],
+    questions: [],
+    hasVideo: false,
+    captureCount: 0,
+    transcriptCount: 0,
+  };
+}
+
+function renderTab(rawSummary: string, onSaveSummary = vi.fn()) {
+  render(
+    <SummaryTab
+      vm={vmWith(rawSummary.startsWith("{") ? STORED : null)}
+      rawSummary={rawSummary}
+      generatedStamp={null}
+      actions={[]}
+      isActionsLoading={false}
+      hasTranscript={true}
+      isCreatingActions={false}
+      isIdeatingFeatures={false}
+      isGeneratingSummary={false}
+      onSaveSummary={onSaveSummary}
+      onCreateActions={vi.fn()}
+      onIdeateFeatures={vi.fn()}
+      onRegenerate={vi.fn()}
+    />,
+  );
+  return onSaveSummary;
+}
+
+describe("SummaryTab edit flow", () => {
+  test("edits a structured summary as prose fields, not raw JSON", () => {
+    renderTab(JSON.stringify(STORED));
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    const overview = screen.getByPlaceholderText<HTMLTextAreaElement>(
+      "What was the meeting about?",
+    );
+    const breakdown = screen.getByPlaceholderText<HTMLTextAreaElement>(
+      "Themed sections, decisions, action items…",
+    );
+    expect(overview.value).toBe("What happened.");
+    expect(breakdown.value).toBe("## Theme\n- **Decision:** ship it");
+    // The raw JSON must never be the editing surface.
+    expect(screen.queryByDisplayValue(JSON.stringify(STORED))).toBeNull();
+  });
+
+  test("saving merges edited prose back and keeps untouched fields", async () => {
+    const onSave = renderTab(JSON.stringify(STORED));
+
+    fireEvent.click(screen.getByText("Edit"));
+    fireEvent.change(screen.getByPlaceholderText("What was the meeting about?"), {
+      target: { value: "New overview." },
+    });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const saved = JSON.parse(onSave.mock.calls[0]![0] as string) as Record<
+      string,
+      unknown
+    >;
+    expect(saved.overview).toBe("New overview.");
+    expect(saved.detailed_breakdown).toBe(STORED.detailed_breakdown);
+    expect(saved.shorthand_bullet).toEqual(["one", "two"]);
+    expect(saved.keywords).toEqual(["kept"]);
+  });
+
+  test("clearing the breakdown removes the field so the flat fallback renders", async () => {
+    const onSave = renderTab(JSON.stringify(STORED));
+
+    fireEvent.click(screen.getByText("Edit"));
+    fireEvent.change(
+      screen.getByPlaceholderText("Themed sections, decisions, action items…"),
+      { target: { value: "  " } },
+    );
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const saved = JSON.parse(onSave.mock.calls[0]![0] as string) as Record<
+      string,
+      unknown
+    >;
+    expect("detailed_breakdown" in saved).toBe(false);
+  });
+
+  test("edits a plain summary as-is", async () => {
+    const onSave = renderTab("Just some notes.");
+
+    fireEvent.click(screen.getByText("Edit"));
+    const input = screen.getByPlaceholderText<HTMLTextAreaElement>(
+      "Enter a summary…",
+    );
+    expect(input.value).toBe("Just some notes.");
+    fireEvent.change(input, { target: { value: "Edited notes." } });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith("Edited notes."));
+  });
+});

--- a/src/server/services/matrix/__tests__/renderMeetingSummary.test.ts
+++ b/src/server/services/matrix/__tests__/renderMeetingSummary.test.ts
@@ -74,6 +74,23 @@ describe("markdownToMatrixHtml", () => {
       "<p>line one<br/>line two</p><p>next para</p>",
     );
   });
+
+  it("keeps loosely-spaced bullets in one list", () => {
+    expect(markdownToMatrixHtml("- one\n\n- two")).toBe(
+      "<ul><li>one</li><li>two</li></ul>",
+    );
+  });
+
+  it("nests tab-indented bullets", () => {
+    expect(markdownToMatrixHtml("- top\n\t- nested")).toBe(
+      "<ul><li>top<ul><li>nested</li></ul></li></ul>",
+    );
+  });
+
+  it("passes fenced code through verbatim instead of parsing it as structure", () => {
+    const html = markdownToMatrixHtml("```\n# not a heading\n- not a bullet\n```");
+    expect(html).toBe("<pre><code># not a heading\n- not a bullet</code></pre>");
+  });
 });
 
 describe("markdownToPlainText", () => {
@@ -84,6 +101,10 @@ describe("markdownToPlainText", () => {
     expect(text).toContain("clear-pipeline shared with Ewan");
     expect(text).toContain("• Update: A seismic ingestion approach was shared.");
     expect(text).toContain("  • Including the delivery playbook.");
+  });
+
+  it("keeps fenced code content verbatim, dropping only the fence markers", () => {
+    expect(markdownToPlainText("```\n# kept as-is\n```")).toBe("# kept as-is");
   });
 });
 
@@ -145,5 +166,10 @@ describe("renderMeetingSummary", () => {
     const { text, html } = renderMeetingSummary(meeting("We agreed to ship on Friday."));
     expect(text).toContain("We agreed to ship on Friday.");
     expect(html).toContain("<p>We agreed to ship on Friday.</p>");
+  });
+
+  it("emits no stray blank block when the meeting has no summary", () => {
+    const { text } = renderMeetingSummary(meeting(null));
+    expect(text).not.toContain("\n\n\n");
   });
 });

--- a/src/server/services/matrix/__tests__/renderMeetingSummary.test.ts
+++ b/src/server/services/matrix/__tests__/renderMeetingSummary.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The summary that lands in a Matrix room must not leak raw Markdown: the
+ * summarizer's `detailed_breakdown` is a `##`-sectioned write-up with `**bold**`
+ * and nested bullets, Matrix renders neither, so the HTML body converts it to
+ * real tags and the text body strips it to plain text.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  extractSummarySections,
+  markdownToMatrixHtml,
+  markdownToPlainText,
+  renderMeetingSummary,
+  type MeetingForSummary,
+} from "~/server/services/matrix/renderMeetingSummary";
+
+const BREAKDOWN = [
+  "## clear-pipeline shared with Ewan",
+  "- **Update:** A seismic ingestion approach was shared.",
+  "- **Decision:** Await feedback before updating the API schema.",
+  "",
+  "## Action Items",
+  "**James**",
+  "- Provide guidance on Notion access.",
+  "  - Including the delivery playbook.",
+].join("\n");
+
+function meeting(summary: string | null): MeetingForSummary {
+  return {
+    id: "meeting-1",
+    title: "Weekly sync",
+    summary,
+    meetingDate: new Date("2026-08-10T10:00:00Z"),
+    createdAt: new Date("2026-08-10T10:00:00Z"),
+    workspaceId: "ws-1",
+    project: { id: "proj-1", name: "Apollo" },
+    actions: [],
+  };
+}
+
+describe("markdownToMatrixHtml", () => {
+  it("renders headings as bold paragraphs, below the message's own titles", () => {
+    const html = markdownToMatrixHtml("## Section One\nSome prose.");
+    expect(html).toContain("<p><strong>Section One</strong></p>");
+    expect(html).not.toContain("##");
+    // The message reserves h4 (title) and h5 (section labels) for itself.
+    expect(html).not.toMatch(/<h[1-6]/);
+  });
+
+  it("converts bullets to a list and nests by indentation", () => {
+    const html = markdownToMatrixHtml("- top\n  - nested\n- second");
+    expect(html).toBe("<ul><li>top<ul><li>nested</li></ul></li><li>second</li></ul>");
+  });
+
+  it("converts inline markup", () => {
+    const html = markdownToMatrixHtml(
+      "**Decision:** use `remark` — see [docs](https://example.org/docs)",
+    );
+    expect(html).toContain("<strong>Decision:</strong>");
+    expect(html).toContain("<code>remark</code>");
+    expect(html).toContain('<a href="https://example.org/docs">docs</a>');
+    expect(html).not.toContain("**");
+  });
+
+  it("escapes HTML in the source text", () => {
+    const html = markdownToMatrixHtml("- <script>alert(1)</script>");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("joins consecutive prose lines into one paragraph with line breaks", () => {
+    expect(markdownToMatrixHtml("line one\nline two\n\nnext para")).toBe(
+      "<p>line one<br/>line two</p><p>next para</p>",
+    );
+  });
+});
+
+describe("markdownToPlainText", () => {
+  it("strips heading markers and inline markup, keeps bullets readable", () => {
+    const text = markdownToPlainText(BREAKDOWN);
+    expect(text).not.toContain("##");
+    expect(text).not.toContain("**");
+    expect(text).toContain("clear-pipeline shared with Ewan");
+    expect(text).toContain("• Update: A seismic ingestion approach was shared.");
+    expect(text).toContain("  • Including the delivery playbook.");
+  });
+});
+
+describe("extractSummarySections", () => {
+  it("splits a Fireflies-shaped summary into humanized sections in order", () => {
+    const sections = extractSummarySections(
+      JSON.stringify({
+        overview: "What happened.",
+        detailed_breakdown: BREAKDOWN,
+        shorthand_bullet: ["one", "two"],
+      }),
+    );
+    expect(sections.map((s) => s.title)).toEqual([
+      "Overview",
+      "Detailed breakdown",
+      "Shorthand bullet",
+    ]);
+    // Arrays become markdown bullets so both emitters format them uniformly.
+    expect(sections[2]!.content).toBe("- one\n- two");
+  });
+
+  it("treats a non-JSON summary as a single untitled prose section", () => {
+    expect(extractSummarySections("Just some notes.")).toEqual([
+      { title: null, content: "Just some notes." },
+    ]);
+  });
+
+  it("falls back to the raw string for an object with no usable prose", () => {
+    const raw = JSON.stringify({ transcript_chapters: [{ title: "x" }] });
+    expect(extractSummarySections(raw)).toEqual([{ title: null, content: raw }]);
+  });
+});
+
+describe("renderMeetingSummary", () => {
+  it("emits section labels as h5 and converted markdown in the HTML body", () => {
+    const { html } = renderMeetingSummary(
+      meeting(JSON.stringify({ overview: "Short.", detailed_breakdown: BREAKDOWN })),
+    );
+    expect(html).toContain("<h4>📋 Weekly sync</h4>");
+    expect(html).toContain("<h5>Overview</h5>");
+    expect(html).toContain("<h5>Detailed breakdown</h5>");
+    expect(html).toContain("<p><strong>clear-pipeline shared with Ewan</strong></p>");
+    expect(html).toContain("<li><strong>Update:</strong>");
+    expect(html).not.toContain("##");
+    expect(html).not.toContain("**");
+  });
+
+  it("keeps the text body free of markdown markers", () => {
+    const { text } = renderMeetingSummary(
+      meeting(JSON.stringify({ overview: "Short.", detailed_breakdown: BREAKDOWN })),
+    );
+    expect(text).toContain("Overview\nShort.");
+    expect(text).toContain("Detailed breakdown\nclear-pipeline shared with Ewan");
+    expect(text).not.toContain("##");
+    expect(text).not.toContain("**");
+  });
+
+  it("still renders a plain prose summary verbatim", () => {
+    const { text, html } = renderMeetingSummary(meeting("We agreed to ship on Friday."));
+    expect(text).toContain("We agreed to ship on Friday.");
+    expect(html).toContain("<p>We agreed to ship on Friday.</p>");
+  });
+});

--- a/src/server/services/matrix/__tests__/renderMeetingSummary.test.ts
+++ b/src/server/services/matrix/__tests__/renderMeetingSummary.test.ts
@@ -81,6 +81,12 @@ describe("markdownToMatrixHtml", () => {
     );
   });
 
+  it("renders numbered lists as ordered lists", () => {
+    expect(markdownToMatrixHtml("1. first\n2. second")).toBe(
+      "<ol><li>first</li><li>second</li></ol>",
+    );
+  });
+
   it("nests tab-indented bullets", () => {
     expect(markdownToMatrixHtml("- top\n\t- nested")).toBe(
       "<ul><li>top<ul><li>nested</li></ul></li></ul>",
@@ -105,6 +111,10 @@ describe("markdownToPlainText", () => {
 
   it("keeps fenced code content verbatim, dropping only the fence markers", () => {
     expect(markdownToPlainText("```\n# kept as-is\n```")).toBe("# kept as-is");
+  });
+
+  it("keeps numbered markers as written, stripping only inline markup", () => {
+    expect(markdownToPlainText("1. **First** thing")).toBe("1. First thing");
   });
 });
 

--- a/src/server/services/matrix/renderMeetingSummary.ts
+++ b/src/server/services/matrix/renderMeetingSummary.ts
@@ -10,6 +10,11 @@
  * try/catch for this reason. A summary that will not parse is treated as prose rather
  * than discarded: the text is what the reader wants, and losing it to a parse error
  * would be worse than showing it unstructured.
+ *
+ * Summary prose is Markdown (the AI summarizer's `detailed_breakdown` is a themed
+ * `##`-sectioned write-up), and Matrix renders neither `##` nor `**` — so both bodies
+ * convert it: the HTML body to real tags, the text body to plain text. Without this,
+ * rooms see the markup literally.
  */
 
 import { getPublicBaseUrlFromEnv } from "~/lib/urls";
@@ -30,6 +35,14 @@ export interface RenderedSummary {
   html: string;
 }
 
+/** One titled block of the outgoing message. */
+export interface SummarySection {
+  /** Humanized field name ("Overview"); null when the summary is one prose blob. */
+  title: string | null;
+  /** Markdown-ish content, converted per-format by the text/HTML emitters. */
+  content: string;
+}
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, "&amp;")
@@ -39,12 +52,12 @@ function escapeHtml(value: string): string {
 }
 
 /**
- * Pull readable prose out of whatever shape the summary is in.
+ * Pull readable sections out of whatever shape the summary is in.
  *
  * Fireflies-derived summaries are objects with named sections; older and hand-written
  * ones are plain strings. Both reach this function.
  */
-export function extractSummaryText(rawSummary: string): string {
+export function extractSummarySections(rawSummary: string): SummarySection[] {
   const trimmed = rawSummary.trim();
 
   let parsed: unknown;
@@ -52,32 +65,35 @@ export function extractSummaryText(rawSummary: string): string {
     parsed = JSON.parse(trimmed);
   } catch {
     // Not JSON at all — it is already the prose we want.
-    return trimmed;
+    return [{ title: null, content: trimmed }];
   }
 
-  if (typeof parsed === "string") return parsed.trim();
-  if (parsed === null || typeof parsed !== "object") return trimmed;
+  if (typeof parsed === "string") return [{ title: null, content: parsed.trim() }];
+  if (parsed === null || typeof parsed !== "object") {
+    return [{ title: null, content: trimmed }];
+  }
 
   const record = parsed as Record<string, unknown>;
-  const sections: string[] = [];
+  const sections: SummarySection[] = [];
 
   for (const [key, value] of Object.entries(record)) {
     const rendered = renderSection(value);
     if (!rendered) continue;
-    sections.push(`${humanizeKey(key)}\n${rendered}`);
+    sections.push({ title: humanizeKey(key), content: rendered });
   }
 
   // An object we could not get any prose out of is more useful shown raw than dropped.
-  return sections.length > 0 ? sections.join("\n\n") : trimmed;
+  return sections.length > 0 ? sections : [{ title: null, content: trimmed }];
 }
 
 function renderSection(value: unknown): string | null {
   if (typeof value === "string") return value.trim() || null;
   if (Array.isArray(value)) {
+    // As markdown bullets, so both emitters format them like any other list.
     const items = value
       .map((entry) => (typeof entry === "string" ? entry.trim() : null))
       .filter((entry): entry is string => !!entry)
-      .map((entry) => `• ${entry}`);
+      .map((entry) => `- ${entry}`);
     return items.length > 0 ? items.join("\n") : null;
   }
   return null;
@@ -90,6 +106,125 @@ function humanizeKey(key: string): string {
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
     .trim();
   return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
+/** Inline markdown (code, bold, links) → HTML. Input must already be escaped. */
+function inlineMarkdownToHtml(escaped: string): string {
+  return escaped
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, '<a href="$2">$1</a>');
+}
+
+/** Inline markdown → readable plain text (`**x**` → `x`, `[t](u)` → `t (u)`). */
+function stripInlineMarkdown(line: string): string {
+  return line
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, "$1 ($2)");
+}
+
+interface ListItem {
+  html: string;
+  children: ListItem[];
+}
+
+/** Emit a parsed bullet tree as properly nested `<ul>`s. */
+function renderList(items: ListItem[]): string {
+  const lis = items
+    .map(
+      (item) =>
+        `<li>${item.html}${item.children.length > 0 ? renderList(item.children) : ""}</li>`,
+    )
+    .join("");
+  return `<ul>${lis}</ul>`;
+}
+
+/**
+ * The Markdown subset the summarizer emits (`##` headings, `- ` bullets nested by
+ * indentation, `**bold**`, inline code, links) → Matrix-safe HTML. Headings render
+ * as bold paragraphs, not `<h*>`: the message already carries its own `<h4>` title
+ * and `<h5>` section labels, and a summary's inner headings must sit below both.
+ * Unknown constructs degrade to escaped paragraph text — never dropped.
+ */
+export function markdownToMatrixHtml(markdown: string): string {
+  const out: string[] = [];
+  let paragraph: string[] = [];
+  // Bullet runs are collected into a tree first so nesting emits valid HTML.
+  let listRoots: ListItem[] = [];
+  let listStack: { depth: number; item: ListItem }[] = [];
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return;
+    out.push(`<p>${paragraph.join("<br/>")}</p>`);
+    paragraph = [];
+  };
+  const flushList = () => {
+    if (listRoots.length === 0) return;
+    out.push(renderList(listRoots));
+    listRoots = [];
+    listStack = [];
+  };
+
+  for (const rawLine of markdown.split("\n")) {
+    const line = rawLine.trimEnd();
+
+    const bullet = /^(\s*)[-*]\s+(.*)$/.exec(line);
+    if (bullet) {
+      flushParagraph();
+      const depth = Math.floor(bullet[1]!.length / 2);
+      const item: ListItem = {
+        html: inlineMarkdownToHtml(escapeHtml(bullet[2]!)),
+        children: [],
+      };
+      while (listStack.length > 0 && listStack[listStack.length - 1]!.depth >= depth) {
+        listStack.pop();
+      }
+      const parent = listStack[listStack.length - 1];
+      if (parent) parent.item.children.push(item);
+      else listRoots.push(item);
+      listStack.push({ depth, item });
+      continue;
+    }
+
+    flushList();
+
+    const heading = /^\s*#{1,6}\s+(.*)$/.exec(line);
+    if (heading) {
+      flushParagraph();
+      out.push(`<p><strong>${inlineMarkdownToHtml(escapeHtml(heading[1]!))}</strong></p>`);
+      continue;
+    }
+
+    if (line.trim().length === 0) {
+      flushParagraph();
+      continue;
+    }
+
+    paragraph.push(inlineMarkdownToHtml(escapeHtml(line)));
+  }
+
+  flushList();
+  flushParagraph();
+  return out.join("");
+}
+
+/**
+ * The same Markdown subset → plain text for the fallback `body`: heading markers
+ * dropped, bullets become `•` (indentation kept), inline markup stripped.
+ */
+export function markdownToPlainText(markdown: string): string {
+  return markdown
+    .split("\n")
+    .map((rawLine) => {
+      const line = rawLine.trimEnd();
+      const bullet = /^(\s*)[-*]\s+(.*)$/.exec(line);
+      if (bullet) return `${bullet[1]}• ${stripInlineMarkdown(bullet[2]!)}`;
+      const heading = /^\s*#{1,6}\s+(.*)$/.exec(line);
+      if (heading) return stripInlineMarkdown(heading[1]!);
+      return stripInlineMarkdown(line);
+    })
+    .join("\n");
 }
 
 /**
@@ -114,27 +249,40 @@ function formatMeetingDate(meeting: MeetingForSummary): string {
 export function renderMeetingSummary(meeting: MeetingForSummary): RenderedSummary {
   const title = meeting.title?.trim() ?? "Untitled meeting";
   const date = formatMeetingDate(meeting);
-  const body = meeting.summary ? extractSummaryText(meeting.summary) : "";
+  const sections = meeting.summary ? extractSummarySections(meeting.summary) : [];
   const actionCount = meeting.actions.length;
   const actionLine = `${actionCount} action item${actionCount === 1 ? "" : "s"}`;
   const url = meetingUrl(meeting);
   const project = meeting.project?.name;
 
+  const textBody = sections
+    .map((s) =>
+      s.title
+        ? `${s.title}\n${markdownToPlainText(s.content)}`
+        : markdownToPlainText(s.content),
+    )
+    .join("\n\n");
+
   const textParts = [
     `📋 ${title}`,
     project ? `${date} · ${project}` : date,
     "",
-    body,
+    textBody,
     "",
     actionLine,
     url,
   ];
 
-  const htmlBody = escapeHtml(body).replace(/\n/g, "<br/>");
+  const htmlBody = sections
+    .map(
+      (s) =>
+        `${s.title ? `<h5>${escapeHtml(s.title)}</h5>` : ""}${markdownToMatrixHtml(s.content)}`,
+    )
+    .join("");
   const html = [
     `<h4>📋 ${escapeHtml(title)}</h4>`,
     `<p><em>${escapeHtml(project ? `${date} · ${project}` : date)}</em></p>`,
-    `<p>${htmlBody}</p>`,
+    htmlBody,
     `<p>${escapeHtml(actionLine)} — <a href="${escapeHtml(url)}">open in Exponential</a></p>`,
   ].join("");
 

--- a/src/server/services/matrix/renderMeetingSummary.ts
+++ b/src/server/services/matrix/renderMeetingSummary.ts
@@ -127,17 +127,21 @@ function stripInlineMarkdown(line: string): string {
 interface ListItem {
   html: string;
   children: ListItem[];
+  /** Whether this item was written with a numeric marker (`1.` / `1)`). */
+  ordered: boolean;
 }
 
-/** Emit a parsed bullet tree as properly nested `<ul>`s. */
+/** Emit a parsed list tree as properly nested `<ul>`/`<ol>`s (first item's
+ *  marker decides the tag for its level). */
 function renderList(items: ListItem[]): string {
+  const tag = items[0]?.ordered ? "ol" : "ul";
   const lis = items
     .map(
       (item) =>
         `<li>${item.html}${item.children.length > 0 ? renderList(item.children) : ""}</li>`,
     )
     .join("");
-  return `<ul>${lis}</ul>`;
+  return `<${tag}>${lis}</${tag}>`;
 }
 
 /**
@@ -192,15 +196,16 @@ export function markdownToMatrixHtml(markdown: string): string {
       continue;
     }
 
-    const bullet = /^([ \t]*)[-*]\s+(.*)$/.exec(line);
+    const bullet = /^([ \t]*)([-*]|\d+[.)])\s+(.*)$/.exec(line);
     if (bullet) {
       flushParagraph();
       // Tabs count as one character otherwise, collapsing real nesting.
       const indent = bullet[1]!.replace(/\t/g, "  ");
       const depth = Math.floor(indent.length / 2);
       const item: ListItem = {
-        html: inlineMarkdownToHtml(escapeHtml(bullet[2]!)),
+        html: inlineMarkdownToHtml(escapeHtml(bullet[3]!)),
         children: [],
+        ordered: /^\d/.test(bullet[2]!),
       };
       while (listStack.length > 0 && listStack[listStack.length - 1]!.depth >= depth) {
         listStack.pop();
@@ -253,8 +258,13 @@ export function markdownToPlainText(markdown: string): string {
         return null;
       }
       if (inFence) return rawLine;
-      const bullet = /^(\s*)[-*]\s+(.*)$/.exec(line);
-      if (bullet) return `${bullet[1]}• ${stripInlineMarkdown(bullet[2]!)}`;
+      const bullet = /^([ \t]*)[-*]\s+(.*)$/.exec(line);
+      if (bullet)
+        return `${bullet[1]!.replace(/\t/g, "  ")}• ${stripInlineMarkdown(bullet[2]!)}`;
+      // Numbered markers stay as written — `1.` is already readable text.
+      const numbered = /^([ \t]*)(\d+[.)])\s+(.*)$/.exec(line);
+      if (numbered)
+        return `${numbered[1]!.replace(/\t/g, "  ")}${numbered[2]} ${stripInlineMarkdown(numbered[3]!)}`;
       const heading = /^\s*#{1,6}\s+(.*)$/.exec(line);
       if (heading) return stripInlineMarkdown(heading[1]!);
       return stripInlineMarkdown(line);

--- a/src/server/services/matrix/renderMeetingSummary.ts
+++ b/src/server/services/matrix/renderMeetingSummary.ts
@@ -153,6 +153,9 @@ export function markdownToMatrixHtml(markdown: string): string {
   // Bullet runs are collected into a tree first so nesting emits valid HTML.
   let listRoots: ListItem[] = [];
   let listStack: { depth: number; item: ListItem }[] = [];
+  // Fenced code blocks pass through verbatim (escaped) — their `#`/`- ` lines
+  // are content, not structure.
+  let fenceLines: string[] | null = null;
 
   const flushParagraph = () => {
     if (paragraph.length === 0) return;
@@ -165,14 +168,36 @@ export function markdownToMatrixHtml(markdown: string): string {
     listRoots = [];
     listStack = [];
   };
+  const flushFence = () => {
+    if (fenceLines === null) return;
+    out.push(`<pre><code>${fenceLines.map(escapeHtml).join("\n")}</code></pre>`);
+    fenceLines = null;
+  };
 
   for (const rawLine of markdown.split("\n")) {
     const line = rawLine.trimEnd();
 
-    const bullet = /^(\s*)[-*]\s+(.*)$/.exec(line);
+    if (/^\s*```/.test(line)) {
+      if (fenceLines === null) {
+        flushParagraph();
+        flushList();
+        fenceLines = [];
+      } else {
+        flushFence();
+      }
+      continue;
+    }
+    if (fenceLines !== null) {
+      fenceLines.push(rawLine);
+      continue;
+    }
+
+    const bullet = /^([ \t]*)[-*]\s+(.*)$/.exec(line);
     if (bullet) {
       flushParagraph();
-      const depth = Math.floor(bullet[1]!.length / 2);
+      // Tabs count as one character otherwise, collapsing real nesting.
+      const indent = bullet[1]!.replace(/\t/g, "  ");
+      const depth = Math.floor(indent.length / 2);
       const item: ListItem = {
         html: inlineMarkdownToHtml(escapeHtml(bullet[2]!)),
         children: [],
@@ -187,6 +212,13 @@ export function markdownToMatrixHtml(markdown: string): string {
       continue;
     }
 
+    if (line.trim().length === 0) {
+      // A blank line must not close an open list: loosely-spaced bullets are
+      // still one list, and a following bullet continues it.
+      flushParagraph();
+      continue;
+    }
+
     flushList();
 
     const heading = /^\s*#{1,6}\s+(.*)$/.exec(line);
@@ -196,14 +228,10 @@ export function markdownToMatrixHtml(markdown: string): string {
       continue;
     }
 
-    if (line.trim().length === 0) {
-      flushParagraph();
-      continue;
-    }
-
     paragraph.push(inlineMarkdownToHtml(escapeHtml(line)));
   }
 
+  flushFence();
   flushList();
   flushParagraph();
   return out.join("");
@@ -214,16 +242,24 @@ export function markdownToMatrixHtml(markdown: string): string {
  * dropped, bullets become `•` (indentation kept), inline markup stripped.
  */
 export function markdownToPlainText(markdown: string): string {
+  let inFence = false;
   return markdown
     .split("\n")
     .map((rawLine) => {
       const line = rawLine.trimEnd();
+      if (/^\s*```/.test(line)) {
+        // Fence markers are markup; the lines between them are content.
+        inFence = !inFence;
+        return null;
+      }
+      if (inFence) return rawLine;
       const bullet = /^(\s*)[-*]\s+(.*)$/.exec(line);
       if (bullet) return `${bullet[1]}• ${stripInlineMarkdown(bullet[2]!)}`;
       const heading = /^\s*#{1,6}\s+(.*)$/.exec(line);
       if (heading) return stripInlineMarkdown(heading[1]!);
       return stripInlineMarkdown(line);
     })
+    .filter((line): line is string => line !== null)
     .join("\n");
 }
 
@@ -263,11 +299,11 @@ export function renderMeetingSummary(meeting: MeetingForSummary): RenderedSummar
     )
     .join("\n\n");
 
+  // No stray blank block when the meeting has no summary text at all.
   const textParts = [
     `📋 ${title}`,
     project ? `${date} · ${project}` : date,
-    "",
-    textBody,
+    ...(textBody ? ["", textBody] : []),
     "",
     actionLine,
     url,


### PR DESCRIPTION
### **User description**
## What

- Render the AI summary's `detailed_breakdown` with the compact Markdown variant on the recording page, so its `##` section headings sit below the accordion's own titles instead of dwarfing them.
- Replace the raw-JSON summary Edit textarea with a structured editor: Overview + Detailed breakdown as MarkdownInputs that merge back into the stored JSON (untouched fields survive); plain summaries get a freeform Markdown editor.
- Convert summary Markdown when posting to Matrix: real tags in `formatted_body` (h5 section labels, bold headings, nested lists, strong/code/links) and stripped plain text in the fallback `body` — rooms no longer see literal `##` and `**`.
- Tests: 12 new renderMeetingSummary unit tests + 4 SummaryTab edit-flow component tests.

## Why

Generated summaries are themed `##`-sectioned Markdown by design; the display, edit, and Matrix-post surfaces all mishandled that markup (oversized headings, raw-JSON editing, literal markdown in rooms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Convert summary Markdown to HTML/plain text for Matrix

- Replace raw-JSON summary editing with structured MarkdownInputs

- Render `detailed_breakdown` with compact Markdown variant

- Add unit and component tests for both flows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  S["Stored summary (JSON/markdown)"] -- "compact variant" --> R["Recording page renderer"]
  S -- "parse + merge back" --> E["Structured MarkdownInput editor"]
  S -- "extractSummarySections" --> M["renderMeetingSummary"]
  M -- "markdownToMatrixHtml" --> H["formatted_body HTML"]
  M -- "markdownToPlainText" --> T["fallback text body"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renderMeetingSummary.ts</strong><dd><code>Convert summary markdown to Matrix HTML and plain text</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/matrix/renderMeetingSummary.ts

<ul><li>Replaced <code>extractSummaryText</code> with <code>extractSummarySections</code> returning <br>titled sections<br> <li> Added <code>markdownToMatrixHtml</code> (headings as bold paragraphs, nested <code>ul</code>/<code>ol</code>, <br>code fences, inline markup, escaping)<br> <li> Added <code>markdownToPlainText</code> stripping markers while keeping <br>bullets/numbers readable<br> <li> Renders section labels as <code>h5</code> and omits stray blank block when no <br>summary</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/580/files#diff-c68a9e4a56a83599ca53fd1e6f248966d964e09b00c156ce086d66a7b85d0eb7">+208/-14</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SummaryTab.tsx</strong><dd><code>Structured markdown editor replacing raw JSON textarea</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/meeting/SummaryTab.tsx

<ul><li>Replaced boolean edit state with an <code>EditDraft</code> union (structured vs <br>freeform)<br> <li> Structured summaries edited via Overview + Detailed breakdown <br><code>MarkdownInput</code>s<br> <li> Save merges edited prose back into stored JSON, preserving untouched <br>fields<br> <li> Empty breakdown removes the <code>detailed_breakdown</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/580/files#diff-6a18dddcfe9e546368d2c809d6b29146f62e1c9fe100750d24204c5dc3e94151">+82/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renderMeetingSummary.test.ts</strong><dd><code>Unit tests for Matrix markdown rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/matrix/__tests__/renderMeetingSummary.test.ts

<ul><li>New tests for <code>markdownToMatrixHtml</code> (lists, nesting, inline markup, <br>escaping, fences)<br> <li> New tests for <code>markdownToPlainText</code> marker stripping<br> <li> Tests for <code>extractSummarySections</code> shapes and fallbacks<br> <li> End-to-end assertions on rendered text/HTML bodies</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/580/files#diff-5497b6650985c23587b46b2eff368cd7b2c2f6da59a5e9f5d579088883cb29e7">+185/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SummaryTab.test.tsx</strong><dd><code>Component tests for SummaryTab edit flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/meeting/__tests__/SummaryTab.test.tsx

<ul><li>New component tests for the summary edit flow<br> <li> Asserts structured summaries edit prose fields, not raw JSON<br> <li> Verifies save merges fields and drops empty breakdown<br> <li> Verifies plain summaries edit as-is</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/580/files#diff-5a26e207f726313797d198cf5912434f8e8f273d4043b5031ef009bcc869e243">+138/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FirefliesSummaryRenderer.tsx</strong><dd><code>Use compact markdown variant for detailed breakdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/FirefliesSummaryRenderer.tsx

<ul><li>Switched <code>detailed_breakdown</code> rendering from <code>prose</code> to <code>compact</code> variant<br> <li> Added comment explaining heading-size conflict with accordion titles</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/580/files#diff-d6fc6c8800d145f0cada605694b4f040505012164ae1e02ccbe0ce459de95dac">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

