### PR TITLE
feat(home): tiered daily workspace home on the Activity layout

### DIFF
--- a/scripts/dev-fixture/enrich-home.ts
+++ b/scripts/dev-fixture/enrich-home.ts
@@ -1,0 +1,230 @@
+/**
+ * Enrich the dev-fixture workspace so the Activity home page's daily tiers all
+ * have something to render: an active cycle with the fixture user's tickets,
+ * a QA ticket "waiting on you", overdue/today actions, unread mention
+ * notifications, a DRI key result with no check-ins (stale-check-in nudge),
+ * recent knowledge pages, and other-user activity events for the
+ * "since yesterday" digest.
+ *
+ * Idempotent like seed.ts: stable slugs/dedupe keys, upsert-or-find
+ * throughout. Run after `npm run dev:seed-fixture`:
+ *
+ *   npx tsx scripts/dev-fixture/enrich-home.ts
+ */
+import { PrismaClient } from "@prisma/client";
+import { loadDevEnvOrThrow } from "./env";
+import { FIXTURE } from "./seed";
+
+loadDevEnvOrThrow();
+
+const db = new PrismaClient();
+
+const DAY = 24 * 60 * 60 * 1000;
+
+async function main() {
+  const user = await db.user.findUniqueOrThrow({
+    where: { email: FIXTURE.userEmail },
+  });
+  const workspace = await db.workspace.findUniqueOrThrow({
+    where: { slug: FIXTURE.workspaceSlug },
+  });
+  const product = await db.product.findUniqueOrThrow({
+    where: {
+      workspaceId_slug: { workspaceId: workspace.id, slug: FIXTURE.productSlug },
+    },
+  });
+
+  // The daily tiers live on the Activity layout.
+  await db.workspace.update({
+    where: { id: workspace.id },
+    data: { homeLayout: "activity" },
+  });
+
+  // ---- current cycle with the fixture user's tickets ----
+  const now = new Date();
+  const cycle = await db.list.upsert({
+    where: {
+      workspaceId_slug: { workspaceId: workspace.id, slug: "fixture-cycle-12" },
+    },
+    update: {
+      status: "ACTIVE",
+      startDate: new Date(now.getTime() - 5 * DAY),
+      endDate: new Date(now.getTime() + 9 * DAY),
+    },
+    create: {
+      workspaceId: workspace.id,
+      slug: "fixture-cycle-12",
+      name: "Cycle 12",
+      listType: "SPRINT",
+      status: "ACTIVE",
+      startDate: new Date(now.getTime() - 5 * DAY),
+      endDate: new Date(now.getTime() + 9 * DAY),
+      cycleGoal: "Ship the tiered daily home and make it feel effortless.",
+      createdById: user.id,
+    },
+  });
+
+  const tickets = await db.ticket.findMany({
+    where: { productId: product.id },
+    orderBy: { number: "asc" },
+  });
+  const statusPlan = ["IN_PROGRESS", "COMMITTED", "DONE"] as const;
+  for (let i = 0; i < Math.min(3, tickets.length); i++) {
+    await db.ticket.update({
+      where: { id: tickets[i]!.id },
+      data: {
+        cycleId: cycle.id,
+        assigneeId: user.id,
+        status: statusPlan[i],
+      },
+    });
+  }
+  // A QA ticket outside the cycle, assigned to the user — "waiting on you".
+  if (tickets[3]) {
+    await db.ticket.update({
+      where: { id: tickets[3].id },
+      data: { status: "QA", assigneeId: user.id, cycleId: null },
+    });
+  }
+
+  // ---- actions: one overdue, one due today ----
+  for (const [name, offsetDays] of [
+    ["Chase the overdue fixture invoice", -2],
+    ["Review today's fixture standup notes", 0],
+  ] as const) {
+    const existing = await db.action.findFirst({
+      where: { name, workspaceId: workspace.id },
+    });
+    const dueDate = new Date(now.getTime() + offsetDays * DAY);
+    if (existing) {
+      await db.action.update({
+        where: { id: existing.id },
+        data: { dueDate, status: "ACTIVE" },
+      });
+    } else {
+      await db.action.create({
+        data: {
+          name,
+          dueDate,
+          status: "ACTIVE",
+          createdById: user.id,
+          workspaceId: workspace.id,
+        },
+      });
+    }
+  }
+
+  // ---- unread mention notifications ----
+  for (const [key, title, message] of [
+    [
+      "fixture-mention-1",
+      "Ada mentioned you on Fixture objective",
+      "@Dev can you sanity-check the Q3 target?",
+    ],
+    [
+      "fixture-mention-2",
+      "Grace mentioned you on ticket FIX-2",
+      "@Dev the accordion fix looks ready for QA",
+    ],
+  ] as const) {
+    await db.notification.upsert({
+      where: { dedupeKey_userId: { dedupeKey: key, userId: user.id } },
+      update: { readAt: null },
+      create: {
+        userId: user.id,
+        category: "mention",
+        title,
+        message,
+        dedupeKey: key,
+        deeplink: `/w/${FIXTURE.workspaceSlug}/goals`,
+      },
+    });
+  }
+
+  // ---- DRI key result with no check-ins (stale nudge) + at-risk health ----
+  const kr = await db.keyResult.findFirst({
+    where: { title: FIXTURE.keyResultTitle, workspaceId: workspace.id },
+  });
+  if (kr) {
+    await db.keyResult.update({
+      where: { id: kr.id },
+      data: { driUserId: user.id, status: "at-risk" },
+    });
+    const goal = await db.goal.findUnique({ where: { id: kr.goalId } });
+    if (goal) {
+      await db.goal.update({
+        where: { id: goal.id },
+        data: { driUserId: user.id, status: "active" },
+      });
+    }
+  }
+
+  // ---- recent pages ----
+  for (const title of ["Cycle 12 retro notes", "Home page design scratchpad"]) {
+    const existing = await db.knowledgePage.findFirst({
+      where: { title, workspaceId: workspace.id },
+    });
+    if (!existing) {
+      await db.knowledgePage.create({
+        data: {
+          title,
+          workspaceId: workspace.id,
+          createdById: user.id,
+        },
+      });
+    }
+  }
+
+  // ---- other-user activity since yesterday ----
+  const bot = await db.user.upsert({
+    where: { email: "dev-fixture-bot@exponential.test" },
+    update: {},
+    create: {
+      email: "dev-fixture-bot@exponential.test",
+      name: "Fixture Bot",
+      emailVerified: new Date(),
+    },
+  });
+  const recent = await db.workspaceActivityEvent.count({
+    where: {
+      workspaceId: workspace.id,
+      userId: bot.id,
+      createdAt: { gte: new Date(now.getTime() - DAY) },
+    },
+  });
+  if (recent === 0) {
+    await db.workspaceActivityEvent.createMany({
+      data: [
+        ...tickets.slice(0, 3).map((t) => ({
+          workspaceId: workspace.id,
+          userId: bot.id,
+          entityType: "ticket",
+          entityId: t.id,
+          action: "status_changed",
+        })),
+        {
+          workspaceId: workspace.id,
+          userId: bot.id,
+          entityType: "goal",
+          entityId: "fixture-goal",
+          action: "created",
+        },
+      ],
+    });
+  }
+
+  console.log(
+    `[enrich-home] dev-fixture home enriched: cycle ${cycle.name}, ` +
+      `${Math.min(3, tickets.length)} cycle tickets, mentions, actions, pages, activity.`,
+  );
+  console.log(
+    `[enrich-home] open http://localhost:PORT/w/${FIXTURE.workspaceSlug}/home`,
+  );
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(() => db.$disconnect());

--- a/src/app/(sidemenu)/w/[workspaceSlug]/activity/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/activity/page.tsx
@@ -4,6 +4,9 @@ import { Container } from '@mantine/core';
 import { Heatmap } from '~/app/_components/home/activity/Heatmap';
 import { WeekInReview } from '~/app/_components/home/activity/WeekInReview';
 import { WorkspaceActivityFullFeed } from '~/app/_components/home/activity/WorkspaceActivityFullFeed';
+// The wsa-week / wsa-heatmap / wsa-analytics rules live here. FullFeed also
+// imports it, but this page must not depend on that transitively.
+import '~/app/_components/home/activity/activity-home.css';
 
 /**
  * `/w/[workspaceSlug]/activity` — the workspace's activity destination:

--- a/src/app/(sidemenu)/w/[workspaceSlug]/activity/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/activity/page.tsx
@@ -1,15 +1,29 @@
 'use client';
 
+import { Container } from '@mantine/core';
+import { Heatmap } from '~/app/_components/home/activity/Heatmap';
+import { WeekInReview } from '~/app/_components/home/activity/WeekInReview';
 import { WorkspaceActivityFullFeed } from '~/app/_components/home/activity/WorkspaceActivityFullFeed';
 
 /**
- * `/w/[workspaceSlug]/activity` — the full paginated `WorkspaceActivityEvent`
- * history for the current workspace. Reached from the "All activity →" CTA
- * and "View older activity" footer in the home Activity feed card.
+ * `/w/[workspaceSlug]/activity` — the workspace's activity destination:
+ * week-in-review and contribution heatmap up top (relocated from the home
+ * page, where weekly-cadence charts fought with the daily tiers), then the
+ * full paginated `WorkspaceActivityEvent` history. Reached from the home
+ * page's "Since yesterday" digest line and "All activity" CTAs.
+ *
+ * The `activity-layout` wrapper is required: the `--activity-*` tokens these
+ * cards consume are scoped to it in globals.css.
  */
 export default function WorkspaceActivityPage() {
   return (
-    <div className="flex h-full flex-col text-text-primary">
+    <div className="activity-layout flex h-full flex-col text-text-primary">
+      <Container size="md" className="w-full pt-8">
+        <div className="wsa-analytics">
+          <WeekInReview />
+          <Heatmap />
+        </div>
+      </Container>
       <WorkspaceActivityFullFeed />
     </div>
   );

--- a/src/app/_components/home/activity/AttentionPanel.tsx
+++ b/src/app/_components/home/activity/AttentionPanel.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import Link from 'next/link';
+import { Skeleton, UnstyledButton } from '@mantine/core';
+import {
+  IconAt,
+  IconBellRinging,
+  IconClockExclamation,
+  IconTicket,
+} from '@tabler/icons-react';
+import { api } from '~/trpc/react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { NOTIFICATION_CATEGORIES } from '~/server/services/notifications/emit/constants';
+import {
+  compactAge,
+  ticketDisplayId,
+} from '~/app/_components/product/overview/overviewShared';
+
+const MAX_ROWS = 5;
+
+/**
+ * Tier 1 of the daily home: "Needs your attention" — the only content that is
+ * genuinely new each day. Three subsections, each of which vanishes when
+ * empty: unread mentions (reading them shrinks the card — that's the reward
+ * loop), QA tickets waiting on you to promote (with a "PR merged" chip when
+ * the merge webhook has landed), and overdue actions. When all three are
+ * empty the whole card disappears.
+ */
+export function AttentionPanel() {
+  const { workspaceId, workspaceSlug } = useWorkspace();
+  const utils = api.useUtils();
+
+  // Mentions are user-scoped, not workspace-scoped: a mention follows the
+  // person. Only unread ones render here — processed items leave the page.
+  const { data: mentionData, isLoading: mentionsLoading } =
+    api.notification.list.useQuery({
+      category: NOTIFICATION_CATEGORIES.MENTION,
+      limit: 10,
+    });
+  const { data: unreadCount } = api.notification.unreadCount.useQuery({
+    category: NOTIFICATION_CATEGORIES.MENTION,
+  });
+  const invalidateInbox = () => {
+    void utils.notification.list.invalidate();
+    void utils.notification.unreadCount.invalidate();
+  };
+  const markRead = api.notification.markRead.useMutation({
+    onSuccess: invalidateInbox,
+  });
+  const markAllRead = api.notification.markAllRead.useMutation({
+    onSuccess: invalidateInbox,
+  });
+
+  const { data: waiting, isLoading: waitingLoading } =
+    api.yourWork.waitingOnYou.useQuery(
+      { workspaceId: workspaceId ?? '' },
+      { enabled: !!workspaceId },
+    );
+
+  // action.getAll is already "mine"-scoped server-side.
+  const { data: actions, isLoading: actionsLoading } = api.action.getAll.useQuery(
+    { workspaceId: workspaceId ?? undefined },
+    { enabled: !!workspaceId },
+  );
+
+  if (!workspaceId || !workspaceSlug) return null;
+
+  const unreadMentions = (mentionData?.notifications ?? [])
+    .filter((m) => m.readAt === null)
+    .slice(0, MAX_ROWS);
+  const waitingRows = waiting ?? [];
+
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  const overdue = (actions ?? [])
+    .filter(
+      (a) =>
+        a.status === 'ACTIVE' &&
+        a.dueDate !== null &&
+        new Date(a.dueDate) < startOfToday,
+    )
+    .sort(
+      (a, b) =>
+        new Date(a.dueDate ?? 0).getTime() - new Date(b.dueDate ?? 0).getTime(),
+    )
+    .slice(0, MAX_ROWS);
+
+  const isLoading = mentionsLoading || waitingLoading || actionsLoading;
+  const total = unreadMentions.length + waitingRows.length + overdue.length;
+
+  if (!isLoading && total === 0) return null;
+
+  return (
+    <section className="wsa-card">
+      <div className="wsa-card__head">
+        <h2 className="wsa-card__title">
+          <IconBellRinging size={14} stroke={1.8} />
+          Needs your attention
+          {total > 0 && <span className="wsa-card__count">{total}</span>}
+        </h2>
+      </div>
+
+      {isLoading && total === 0 ? (
+        <>
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} height={34} mb={4} radius="sm" />
+          ))}
+        </>
+      ) : (
+        <>
+          {unreadMentions.length > 0 && (
+            <>
+              <div className="wsa-sub">
+                <span className="wsa-sub__label">
+                  Mentions
+                  <span className="wsa-sub__badge">{unreadCount ?? unreadMentions.length}</span>
+                </span>
+                <button
+                  type="button"
+                  className="wsa-sub__action"
+                  onClick={() =>
+                    markAllRead.mutate({
+                      category: NOTIFICATION_CATEGORIES.MENTION,
+                    })
+                  }
+                  disabled={markAllRead.isPending}
+                >
+                  Mark all read
+                </button>
+              </div>
+              {unreadMentions.map((mention) => {
+                const row = (
+                  <>
+                    <span className="wsa-item__icon">
+                      <IconAt size={14} stroke={1.75} />
+                    </span>
+                    <span className="wsa-item__label wsa-item__label--unread">
+                      {mention.title}
+                      {mention.message && (
+                        <span className="wsa-item__sub">{mention.message}</span>
+                      )}
+                    </span>
+                    <span className="wsa-item__meta">
+                      <span className="wsa-item__dot" aria-label="Unread" />
+                      {compactAge(mention.createdAt)}
+                    </span>
+                  </>
+                );
+                // Opening a mention reads it — mark before navigation unmounts us.
+                const readOnOpen = () =>
+                  markRead.mutate({ notificationId: mention.id });
+                return mention.deeplink ? (
+                  <UnstyledButton
+                    key={mention.id}
+                    component={Link}
+                    href={mention.deeplink}
+                    className="wsa-item"
+                    onClick={readOnOpen}
+                  >
+                    {row}
+                  </UnstyledButton>
+                ) : (
+                  <UnstyledButton
+                    key={mention.id}
+                    className="wsa-item"
+                    onClick={readOnOpen}
+                  >
+                    {row}
+                  </UnstyledButton>
+                );
+              })}
+            </>
+          )}
+
+          {waitingRows.length > 0 && (
+            <>
+              <div className="wsa-sub">
+                <span className="wsa-sub__label">Waiting on you</span>
+              </div>
+              {waitingRows.map((ticket) => (
+                <UnstyledButton
+                  key={ticket.id}
+                  component={Link}
+                  href={`/w/${workspaceSlug}/products/${ticket.product.slug}/tickets/${ticket.id}`}
+                  className="wsa-item"
+                >
+                  <span className="wsa-item__icon">
+                    <IconTicket size={14} stroke={1.75} />
+                  </span>
+                  <span className="wsa-item__label">
+                    {ticket.title}
+                    <span className="wsa-item__sub">
+                      {ticketDisplayId(ticket.product, ticket)} · in QA
+                    </span>
+                  </span>
+                  <span className="wsa-item__meta">
+                    {ticket.prMerged && (
+                      <span className="wsa-item__chip wsa-item__chip--go">
+                        PR merged — promote?
+                      </span>
+                    )}
+                    {compactAge(ticket.updatedAt)}
+                  </span>
+                </UnstyledButton>
+              ))}
+            </>
+          )}
+
+          {overdue.length > 0 && (
+            <>
+              <div className="wsa-sub">
+                <span className="wsa-sub__label">Overdue</span>
+              </div>
+              {overdue.map((action) => (
+                <UnstyledButton
+                  key={action.id}
+                  component={Link}
+                  href={`/w/${workspaceSlug}/actions/${action.id}`}
+                  className="wsa-item"
+                >
+                  <span className="wsa-item__icon">
+                    <IconClockExclamation size={14} stroke={1.75} />
+                  </span>
+                  <span className="wsa-item__label">
+                    {action.name}
+                    {action.project && (
+                      <span className="wsa-item__sub">{action.project.name}</span>
+                    )}
+                  </span>
+                  <span className="wsa-item__meta">
+                    <span className="wsa-item__chip wsa-item__chip--warn">
+                      {action.dueDate
+                        ? `due ${compactAge(action.dueDate)} ago`
+                        : 'overdue'}
+                    </span>
+                  </span>
+                </UnstyledButton>
+              ))}
+            </>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/app/_components/home/activity/AttentionPanel.tsx
+++ b/src/app/_components/home/activity/AttentionPanel.tsx
@@ -32,10 +32,12 @@ export function AttentionPanel() {
 
   // Mentions are user-scoped, not workspace-scoped: a mention follows the
   // person. Only unread ones render here — processed items leave the page.
+  // Fetch a deep page: the list mixes read and unread, and a burst of read
+  // mentions must not push unread ones (which the badge counts) off the page.
   const { data: mentionData, isLoading: mentionsLoading } =
     api.notification.list.useQuery({
       category: NOTIFICATION_CATEGORIES.MENTION,
-      limit: 10,
+      limit: 50,
     });
   const { data: unreadCount } = api.notification.unreadCount.useQuery({
     category: NOTIFICATION_CATEGORIES.MENTION,

--- a/src/app/_components/home/activity/CycleCard.tsx
+++ b/src/app/_components/home/activity/CycleCard.tsx
@@ -76,8 +76,10 @@ function SingleCycle({ cycle }: { cycle: CycleData }) {
             }
           >
             {over
-              ? `${Math.abs(daysLeft)} days over`
-              : `${daysLeft} days left`}
+              ? `${Math.abs(daysLeft)} ${Math.abs(daysLeft) === 1 ? 'day' : 'days'} over`
+              : daysLeft === 0
+                ? 'Last day'
+                : `${daysLeft} ${daysLeft === 1 ? 'day' : 'days'} left`}
           </span>
         )}
       </div>

--- a/src/app/_components/home/activity/CycleCard.tsx
+++ b/src/app/_components/home/activity/CycleCard.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import Link from 'next/link';
+import { Skeleton, UnstyledButton } from '@mantine/core';
+import { IconRepeat, IconTicket } from '@tabler/icons-react';
+import { api, type RouterOutputs } from '~/trpc/react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { STATUS_LABELS } from '~/lib/ticket-statuses';
+import {
+  statusCss,
+  ticketDisplayId,
+} from '~/app/_components/product/overview/overviewShared';
+
+type CycleData = RouterOutputs['yourWork']['currentCycles'][number];
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function fmtDate(d: Date | string): string {
+  return new Date(d).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/**
+ * One current cycle: countdown, done-vs-time progress (the time marker on the
+ * track shows whether completion is keeping pace with the calendar, same
+ * pace thresholds as the product overview's CycleHero), the cycle goal, and
+ * the caller's tickets in it. Tier 2 of the daily home — "what am I
+ * committed to".
+ */
+function SingleCycle({ cycle }: { cycle: CycleData }) {
+  const { workspaceSlug } = useWorkspace();
+  const now = Date.now();
+
+  const end = cycle.endDate ? new Date(cycle.endDate).getTime() : null;
+  const start = cycle.startDate ? new Date(cycle.startDate).getTime() : null;
+  const daysLeft = end !== null ? Math.ceil((end - now) / DAY) : null;
+  const over = daysLeft !== null && daysLeft < 0;
+
+  const donePct =
+    cycle.committed > 0
+      ? Math.min(100, Math.max(0, (cycle.completed / cycle.committed) * 100))
+      : 0;
+  const timePct =
+    start !== null && end !== null && end > start
+      ? Math.min(100, Math.max(0, ((now - start) / (end - start)) * 100))
+      : null;
+  const pace =
+    timePct === null
+      ? null
+      : donePct >= timePct + 15
+        ? 'ahead'
+        : donePct + 1 >= timePct
+          ? 'ontrack'
+          : 'behind';
+
+  const unit = cycle.usesPoints ? 'pts' : 'tickets';
+  const range =
+    cycle.startDate && cycle.endDate
+      ? `${fmtDate(cycle.startDate)} – ${fmtDate(cycle.endDate)}`
+      : null;
+
+  return (
+    <section className="wsa-card">
+      <div className="wsa-card__head">
+        <h2 className="wsa-card__title">
+          <IconRepeat size={14} stroke={1.8} />
+          {cycle.name}
+          {range && <span className="wsa-card__count">{range}</span>}
+        </h2>
+        {daysLeft !== null && (
+          <span
+            className={
+              over ? 'wsa-cycle__days wsa-cycle__days--over' : 'wsa-cycle__days'
+            }
+          >
+            {over
+              ? `${Math.abs(daysLeft)} days over`
+              : `${daysLeft} days left`}
+          </span>
+        )}
+      </div>
+
+      {cycle.cycleGoal && <p className="wsa-cycle__goal">{cycle.cycleGoal}</p>}
+
+      {cycle.committed > 0 && (
+        <>
+          <div className="wsa-cycle__track">
+            <div className="wsa-cycle__fill" style={{ width: `${donePct}%` }} />
+            {timePct !== null && (
+              <div
+                className="wsa-cycle__timemark"
+                style={{ left: `${timePct}%` }}
+                title={`${Math.round(timePct)}% of the cycle has elapsed`}
+              />
+            )}
+          </div>
+          <div
+            className={
+              pace === 'ahead'
+                ? 'wsa-cycle__pace wsa-cycle__pace--ahead'
+                : pace === 'behind'
+                  ? 'wsa-cycle__pace wsa-cycle__pace--behind'
+                  : 'wsa-cycle__pace'
+            }
+          >
+            {cycle.completed} of {cycle.committed} {unit} done
+            {pace === 'ahead' && (
+              <>
+                {' '}
+                — <b>ahead of pace</b>
+              </>
+            )}
+            {pace === 'ontrack' && (
+              <>
+                {' '}
+                — <b>on pace</b>
+              </>
+            )}
+            {pace === 'behind' && (
+              <>
+                {' '}
+                — <b>behind pace</b>
+              </>
+            )}
+          </div>
+        </>
+      )}
+
+      {cycle.myTickets.length > 0 ? (
+        <>
+          <div className="wsa-sub">
+            <span className="wsa-sub__label">
+              Yours in this cycle
+              {cycle.myOpenCount > 0 && (
+                <span className="wsa-card__count">{cycle.myOpenCount} open</span>
+              )}
+            </span>
+          </div>
+          {cycle.myTickets.map((ticket) => (
+            <UnstyledButton
+              key={ticket.id}
+              component={Link}
+              href={`/w/${workspaceSlug}/products/${ticket.product.slug}/tickets/${ticket.id}`}
+              className="wsa-item"
+            >
+              <span className="wsa-item__icon">
+                <IconTicket size={14} stroke={1.75} />
+              </span>
+              <span className="wsa-item__label">
+                {ticket.title}
+                <span className="wsa-item__sub">
+                  {ticketDisplayId(ticket.product, ticket)}
+                </span>
+              </span>
+              <span className="wsa-item__meta">
+                <span
+                  className="wsa-item__chip"
+                  style={{ color: statusCss(ticket.status) }}
+                >
+                  {STATUS_LABELS[ticket.status] ?? ticket.status}
+                </span>
+              </span>
+            </UnstyledButton>
+          ))}
+        </>
+      ) : (
+        <p className="wsa-card__caption" style={{ marginTop: 10 }}>
+          Nothing assigned to you in this cycle.
+        </p>
+      )}
+    </section>
+  );
+}
+
+/**
+ * The current cycle block(s) for the workspace — usually one card, one per
+ * parallel team cycle otherwise. Hidden entirely when the workspace runs no
+ * cycles, so non-sprint workspaces never see an empty shell.
+ */
+export function CycleCards() {
+  const { workspaceId } = useWorkspace();
+  const { data: cycles, isLoading } = api.yourWork.currentCycles.useQuery(
+    { workspaceId: workspaceId ?? '' },
+    { enabled: !!workspaceId },
+  );
+
+  if (isLoading) return <Skeleton height={120} radius={12} />;
+  if (!cycles || cycles.length === 0) return null;
+
+  return (
+    <>
+      {cycles.map((cycle) => (
+        <SingleCycle key={cycle.id} cycle={cycle} />
+      ))}
+    </>
+  );
+}

--- a/src/app/_components/home/activity/OnTrackPanel.tsx
+++ b/src/app/_components/home/activity/OnTrackPanel.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import Link from 'next/link';
+import { Skeleton, UnstyledButton } from '@mantine/core';
+import {
+  IconStack2,
+  IconTarget,
+  IconTrendingUp,
+} from '@tabler/icons-react';
+import { api } from '~/trpc/react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { compactAge } from '~/app/_components/product/overview/overviewShared';
+
+/** "on-track" → "On track" for chip and row meta text. */
+function healthLabel(health: string | null): string {
+  if (!health) return 'No update';
+  const words = health.replace(/-/g, ' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+const HEALTH_DOT: Record<string, string> = {
+  'on-track': 'wsa-health__dot wsa-health__dot--on-track',
+  'at-risk': 'wsa-health__dot wsa-health__dot--at-risk',
+  'off-track': 'wsa-health__dot wsa-health__dot--off-track',
+};
+
+/**
+ * Tier 3 of the daily home: "is what I own on track?" — compressed hard.
+ * DRI items render as aggregate health chips; only problem items (at-risk,
+ * off-track, no update) get rows. When everything is healthy the card
+ * collapses to a single all-clear line, and the stale-check-in nudge lists
+ * DRI key results with no check-in since Monday, deep-linking into the OKR
+ * drawer. Hidden entirely when the caller is DRI on nothing.
+ */
+export function OnTrackPanel() {
+  const { workspaceId, workspaceSlug } = useWorkspace();
+
+  const { data: dri, isLoading: driLoading } = api.yourWork.driItems.useQuery(
+    { workspaceId: workspaceId ?? '' },
+    { enabled: !!workspaceId },
+  );
+  const { data: stale, isLoading: staleLoading } =
+    api.yourWork.staleCheckins.useQuery(
+      { workspaceId: workspaceId ?? '' },
+      { enabled: !!workspaceId },
+    );
+
+  if (!workspaceId || !workspaceSlug) return null;
+
+  const goals = dri?.goals ?? [];
+  const keyResults = dri?.keyResults ?? [];
+  const projects = dri?.projects ?? [];
+  const staleKrs = stale ?? [];
+  const driCount = goals.length + keyResults.length + projects.length;
+  const isLoading = driLoading || staleLoading;
+
+  if (isLoading) return <Skeleton height={80} radius={12} />;
+  if (driCount === 0 && staleKrs.length === 0) return null;
+
+  // Effective health per item: goals carry `health`, KRs carry
+  // statusOverride ?? status; projects have no health signal, so they count
+  // as "on track" unless stalled at 0 progress.
+  const healthOf = (h: string | null) => h ?? 'no-update';
+  const items = [
+    ...goals.map((g) => ({
+      key: `goal-${g.id}`,
+      title: g.title,
+      kind: 'Objective',
+      health: healthOf(g.health),
+      href: `/w/${workspaceSlug}/goals/${g.id}`,
+      icon: IconTarget,
+    })),
+    ...keyResults.map((kr) => ({
+      key: `kr-${kr.id}`,
+      title: kr.title,
+      kind: 'Key result',
+      health: healthOf(kr.statusOverride ?? kr.status),
+      href: `/w/${workspaceSlug}/goals?tab=okrs&drawer=${encodeURIComponent(`keyResult:${kr.id}`)}`,
+      icon: IconTrendingUp,
+    })),
+    ...projects.map((p) => ({
+      key: `project-${p.id}`,
+      title: p.name,
+      kind: 'Project',
+      health: 'on-track',
+      href: `/w/${workspaceSlug}/projects/${p.slug}`,
+      icon: IconStack2,
+    })),
+  ];
+
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    counts.set(item.health, (counts.get(item.health) ?? 0) + 1);
+  }
+  const problems = items.filter((i) => i.health !== 'on-track');
+  const allClear = problems.length === 0 && staleKrs.length === 0;
+
+  return (
+    <section className="wsa-card">
+      <div className="wsa-card__head">
+        <h2 className="wsa-card__title">
+          <IconTarget size={14} stroke={1.8} />
+          You&apos;re the DRI
+          {driCount > 0 && <span className="wsa-card__count">{driCount}</span>}
+        </h2>
+        <Link href={`/w/${workspaceSlug}/goals`} className="wsa-sub__action">
+          Goals →
+        </Link>
+      </div>
+
+      {driCount > 0 && (
+        <div className="wsa-health">
+          {['on-track', 'at-risk', 'off-track', 'no-update']
+            .filter((h) => (counts.get(h) ?? 0) > 0)
+            .map((h) => (
+              <span key={h} className="wsa-health__chip">
+                <span className={HEALTH_DOT[h] ?? 'wsa-health__dot'} />
+                {counts.get(h)} {healthLabel(h === 'no-update' ? null : h).toLowerCase()}
+              </span>
+            ))}
+        </div>
+      )}
+
+      {allClear ? (
+        <p className="wsa-health__allclear">
+          Everything you own is on track and checked in.
+        </p>
+      ) : (
+        <>
+          {problems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <UnstyledButton
+                key={item.key}
+                component={Link}
+                href={item.href}
+                className="wsa-item"
+              >
+                <span className="wsa-item__icon">
+                  <Icon size={14} stroke={1.75} />
+                </span>
+                <span className="wsa-item__label">
+                  {item.title}
+                  <span className="wsa-item__sub">{item.kind}</span>
+                </span>
+                <span className="wsa-item__meta">
+                  <span
+                    className={
+                      item.health === 'no-update'
+                        ? 'wsa-item__chip'
+                        : 'wsa-item__chip wsa-item__chip--warn'
+                    }
+                  >
+                    {healthLabel(item.health === 'no-update' ? null : item.health)}
+                  </span>
+                </span>
+              </UnstyledButton>
+            );
+          })}
+
+          {staleKrs.length > 0 && (
+            <>
+              <div className="wsa-sub">
+                <span className="wsa-sub__label">
+                  Need a check-in this week
+                  <span className="wsa-sub__badge">{staleKrs.length}</span>
+                </span>
+              </div>
+              {staleKrs.map((kr) => (
+                <UnstyledButton
+                  key={kr.id}
+                  component={Link}
+                  href={`/w/${workspaceSlug}/goals?tab=okrs&drawer=${encodeURIComponent(`keyResult:${kr.id}`)}`}
+                  className="wsa-item"
+                >
+                  <span className="wsa-item__icon">
+                    <IconTrendingUp size={14} stroke={1.75} />
+                  </span>
+                  <span className="wsa-item__label">{kr.title}</span>
+                  <span className="wsa-item__meta">
+                    {kr.lastCheckIn
+                      ? `last check-in ${compactAge(kr.lastCheckIn)} ago`
+                      : 'never checked in'}
+                  </span>
+                </UnstyledButton>
+              ))}
+            </>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/app/_components/home/activity/ResumptionStrip.tsx
+++ b/src/app/_components/home/activity/ResumptionStrip.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import Link from 'next/link';
+import { UnstyledButton } from '@mantine/core';
+import { IconFileText, IconMicrophone } from '@tabler/icons-react';
+import { api } from '~/trpc/react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { compactAge } from '~/app/_components/product/overview/overviewShared';
+
+const MAX_ROWS = 3;
+
+/**
+ * Bottom-of-page resumption strip: "pick up where you left off". Two small
+ * cards — pages you recently touched and meetings you were in. Low urgency,
+ * high utility, deliberately last. Each card hides when empty; the strip
+ * hides when both are.
+ */
+export function ResumptionStrip() {
+  const { workspaceId, workspaceSlug } = useWorkspace();
+
+  const { data: pages } = api.yourWork.recentPages.useQuery(
+    { workspaceId: workspaceId ?? '' },
+    { enabled: !!workspaceId },
+  );
+  const { data: meetings } = api.transcription.getAllTranscriptions.useQuery(
+    { workspaceId: workspaceId ?? undefined, meetingType: 'mine' },
+    { enabled: !!workspaceId },
+  );
+
+  if (!workspaceId || !workspaceSlug) return null;
+
+  const recentPages = (pages ?? []).slice(0, MAX_ROWS);
+  const recentMeetings = (meetings ?? []).slice(0, MAX_ROWS);
+  if (recentPages.length === 0 && recentMeetings.length === 0) return null;
+
+  return (
+    <div className="wsa-resume">
+      {recentPages.length > 0 && (
+        <section className="wsa-card">
+          <div className="wsa-card__head">
+            <h2 className="wsa-card__title">
+              <IconFileText size={14} stroke={1.8} />
+              Recent pages
+            </h2>
+            <Link href={`/w/${workspaceSlug}/pages`} className="wsa-sub__action">
+              All pages →
+            </Link>
+          </div>
+          {recentPages.map((page) => (
+            <UnstyledButton
+              key={page.id}
+              component={Link}
+              href={`/w/${workspaceSlug}/pages/${page.id}`}
+              className="wsa-item"
+            >
+              <span className="wsa-item__icon">
+                <IconFileText size={14} stroke={1.75} />
+              </span>
+              <span className="wsa-item__label">
+                {page.title || 'Untitled page'}
+                {page.project && (
+                  <span className="wsa-item__sub">{page.project.name}</span>
+                )}
+              </span>
+              <span className="wsa-item__meta">{compactAge(page.updatedAt)}</span>
+            </UnstyledButton>
+          ))}
+        </section>
+      )}
+
+      {recentMeetings.length > 0 && (
+        <section className="wsa-card">
+          <div className="wsa-card__head">
+            <h2 className="wsa-card__title">
+              <IconMicrophone size={14} stroke={1.8} />
+              Recent meetings
+            </h2>
+          </div>
+          {recentMeetings.map((meeting) => (
+            <UnstyledButton
+              key={meeting.id}
+              component={Link}
+              href={`/recording/${meeting.id}`}
+              className="wsa-item"
+            >
+              <span className="wsa-item__icon">
+                <IconMicrophone size={14} stroke={1.75} />
+              </span>
+              <span className="wsa-item__label">
+                {meeting.title ?? 'Untitled meeting'}
+              </span>
+              <span className="wsa-item__meta">
+                {compactAge(meeting.meetingDate ?? meeting.createdAt)}
+              </span>
+            </UnstyledButton>
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/app/_components/home/activity/SinceYesterdayLine.tsx
+++ b/src/app/_components/home/activity/SinceYesterdayLine.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo } from 'react';
+import { api } from '~/trpc/react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+
+type Group = { entityType: string; action: string; count: number };
+
+/**
+ * Turns the raw (entityType, action) counts into at most four human phrases,
+ * most-to-least specific, with a "+n other updates" tail. The buckets are
+ * deliberately coarse — this line is a periscope, not a feed.
+ */
+function summarize(groups: Group[]): string[] {
+  let moved = 0;
+  let created = 0;
+  let completed = 0;
+  let comments = 0;
+  let checkins = 0;
+  let meetings = 0;
+  let other = 0;
+
+  for (const g of groups) {
+    if (g.entityType.endsWith('_comment') || g.action === 'commented') {
+      comments += g.count;
+    } else if (g.entityType === 'ticket' && g.action === 'status_changed') {
+      moved += g.count;
+    } else if (g.action === 'completed') {
+      completed += g.count;
+    } else if (g.action === 'checked_in' || g.entityType === 'okr_checkin') {
+      checkins += g.count;
+    } else if (g.entityType === 'meeting' || g.entityType === 'channel_summary') {
+      meetings += g.count;
+    } else if (g.action === 'created') {
+      created += g.count;
+    } else {
+      other += g.count;
+    }
+  }
+
+  const s = (n: number) => (n === 1 ? '' : 's');
+  const phrases: string[] = [];
+  if (moved > 0) phrases.push(`${moved} ticket move${s(moved)}`);
+  if (completed > 0) phrases.push(`${completed} completion${s(completed)}`);
+  if (created > 0) phrases.push(`${created} new item${s(created)}`);
+  if (comments > 0) phrases.push(`${comments} comment${s(comments)}`);
+  if (checkins > 0) phrases.push(`${checkins} check-in${s(checkins)}`);
+  if (meetings > 0) phrases.push(`${meetings} meeting update${s(meetings)}`);
+  if (other > 0) phrases.push(`${other} other update${s(other)}`);
+
+  // At most four phrases; roll the overflow into the last slot.
+  if (phrases.length > 4) {
+    return [...phrases.slice(0, 3), 'and more'];
+  }
+  return phrases;
+}
+
+/**
+ * One-line "since yesterday" team digest — what other people did in this
+ * workspace while you were away, linking to the full feed at /activity. The
+ * embedded feed this replaces was a firehose; the home page gets a periscope.
+ * Hidden when nothing happened (a quiet workspace shouldn't announce it).
+ */
+export function SinceYesterdayLine() {
+  const { workspaceId, workspaceSlug } = useWorkspace();
+
+  // Start of yesterday in the viewer's timezone. Stable within a render
+  // session — recomputing per render would churn the query key.
+  const since = useMemo(() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    d.setDate(d.getDate() - 1);
+    return d;
+  }, []);
+
+  const { data: groups } = api.yourWork.sinceYesterday.useQuery(
+    { workspaceId: workspaceId ?? '', since },
+    { enabled: !!workspaceId },
+  );
+
+  if (!workspaceId || !workspaceSlug || !groups) return null;
+
+  const phrases = summarize(groups);
+  if (phrases.length === 0) return null;
+
+  return (
+    <div className="wsa-sinceline">
+      <span className="wsa-sinceline__text">
+        Since yesterday: <b>{phrases.join(' · ')}</b>
+      </span>
+      <Link href={`/w/${workspaceSlug}/activity`} className="wsa-sinceline__link">
+        All activity →
+      </Link>
+    </div>
+  );
+}

--- a/src/app/_components/home/activity/TodayPanel.tsx
+++ b/src/app/_components/home/activity/TodayPanel.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import Link from 'next/link';
+import { Skeleton, UnstyledButton } from '@mantine/core';
+import {
+  IconSquareRoundedCheck,
+  IconSun,
+  IconTicket,
+} from '@tabler/icons-react';
+import { api } from '~/trpc/react';
+import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { STATUS_LABELS } from '~/lib/ticket-statuses';
+import {
+  statusCss,
+  ticketDisplayId,
+} from '~/app/_components/product/overview/overviewShared';
+
+const MAX_ROWS = 6;
+
+/**
+ * Tier 2 of the daily home, alongside the cycle card: actions due today or
+ * this week, plus open tickets assigned to the caller that are NOT in a
+ * current cycle (in-cycle tickets already render in the cycle card — this
+ * panel dedupes against it so nothing appears twice). Overdue actions belong
+ * to the attention tier, not here. Hidden when empty.
+ */
+export function TodayPanel() {
+  const { workspaceId, workspaceSlug } = useWorkspace();
+
+  const { data: actions, isLoading: actionsLoading } = api.action.getAll.useQuery(
+    { workspaceId: workspaceId ?? undefined },
+    { enabled: !!workspaceId },
+  );
+  const { data: tickets, isLoading: ticketsLoading } =
+    api.yourWork.assignedTickets.useQuery(
+      { workspaceId: workspaceId ?? '' },
+      { enabled: !!workspaceId },
+    );
+  // Same query the cycle card runs — React Query dedupes, so this costs
+  // nothing extra and lets us hide tickets the cycle card already shows.
+  const { data: cycles } = api.yourWork.currentCycles.useQuery(
+    { workspaceId: workspaceId ?? '' },
+    { enabled: !!workspaceId },
+  );
+
+  if (!workspaceId || !workspaceSlug) return null;
+
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  const startOfTomorrow = new Date(startOfToday.getTime() + 24 * 60 * 60 * 1000);
+  const weekOut = new Date(startOfToday.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  const active = (actions ?? []).filter(
+    (a) => a.status === 'ACTIVE' && a.dueDate !== null,
+  );
+  const dueToday = active.filter((a) => {
+    const due = new Date(a.dueDate ?? 0);
+    return due >= startOfToday && due < startOfTomorrow;
+  });
+  const dueThisWeek = active.filter((a) => {
+    const due = new Date(a.dueDate ?? 0);
+    return due >= startOfTomorrow && due < weekOut;
+  });
+
+  const cycleIds = new Set((cycles ?? []).map((c) => c.id));
+  const outOfCycleTickets = (tickets ?? [])
+    .filter((t) => t.cycleId === null || !cycleIds.has(t.cycleId))
+    .slice(0, MAX_ROWS);
+
+  const actionRows = [...dueToday, ...dueThisWeek].slice(0, MAX_ROWS);
+  const isLoading = actionsLoading || ticketsLoading;
+  const total = actionRows.length + outOfCycleTickets.length;
+
+  if (!isLoading && total === 0) return null;
+
+  const dueLabel = (dueDate: Date) =>
+    dueDate < startOfTomorrow
+      ? 'today'
+      : dueDate.toLocaleDateString('en-US', { weekday: 'short' });
+
+  return (
+    <section className="wsa-card">
+      <div className="wsa-card__head">
+        <h2 className="wsa-card__title">
+          <IconSun size={14} stroke={1.8} />
+          On your plate
+          {total > 0 && <span className="wsa-card__count">{total}</span>}
+        </h2>
+        <Link href={`/w/${workspaceSlug}/actions`} className="wsa-sub__action">
+          View all →
+        </Link>
+      </div>
+
+      {isLoading && total === 0 ? (
+        <>
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} height={34} mb={4} radius="sm" />
+          ))}
+        </>
+      ) : (
+        <>
+          {actionRows.map((action) => (
+            <UnstyledButton
+              key={action.id}
+              component={Link}
+              href={`/w/${workspaceSlug}/actions/${action.id}`}
+              className="wsa-item"
+            >
+              <span className="wsa-item__icon">
+                <IconSquareRoundedCheck size={14} stroke={1.75} />
+              </span>
+              <span className="wsa-item__label">
+                {action.name}
+                {action.project && (
+                  <span className="wsa-item__sub">{action.project.name}</span>
+                )}
+              </span>
+              <span className="wsa-item__meta">
+                {action.dueDate && dueLabel(new Date(action.dueDate))}
+              </span>
+            </UnstyledButton>
+          ))}
+
+          {outOfCycleTickets.length > 0 && (
+            <>
+              <div className="wsa-sub">
+                <span className="wsa-sub__label">Your open tickets</span>
+              </div>
+              {outOfCycleTickets.map((ticket) => (
+                <UnstyledButton
+                  key={ticket.id}
+                  component={Link}
+                  href={`/w/${workspaceSlug}/products/${ticket.product.slug}/tickets/${ticket.id}`}
+                  className="wsa-item"
+                >
+                  <span className="wsa-item__icon">
+                    <IconTicket size={14} stroke={1.75} />
+                  </span>
+                  <span className="wsa-item__label">
+                    {ticket.title}
+                    <span className="wsa-item__sub">
+                      {ticketDisplayId(ticket.product, ticket)}
+                    </span>
+                  </span>
+                  <span className="wsa-item__meta">
+                    <span
+                      className="wsa-item__chip"
+                      style={{ color: statusCss(ticket.status) }}
+                    >
+                      {STATUS_LABELS[ticket.status] ?? ticket.status}
+                    </span>
+                  </span>
+                </UnstyledButton>
+              ))}
+            </>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/app/_components/home/activity/activity-home.css
+++ b/src/app/_components/home/activity/activity-home.css
@@ -22,16 +22,23 @@
   grid-template-columns: minmax(0, 1fr) 360px;
   grid-template-areas:
     'hero hero'
-    'week week'
     'main rail';
   gap: 32px;
   align-items: start;
 }
 
 .wsa__hero   { grid-area: hero; }
-.wsa__week   { grid-area: week; }
 .wsa__main   { grid-area: main; display: flex; flex-direction: column; gap: 24px; }
 .wsa__rail   { grid-area: rail; display: flex; flex-direction: column; gap: 24px; }
+
+/* The /activity page reuses .wsa-week and .wsa-heatmap outside the home grid;
+   this wrapper stacks them above the full feed. */
+.wsa-analytics {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-bottom: 24px;
+}
 
 /* Collapse the right-rail at the medium breakpoint. */
 @media (max-width: 1240px) {
@@ -39,7 +46,6 @@
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas:
       'hero'
-      'week'
       'main'
       'rail';
   }
@@ -1302,6 +1308,297 @@
     width: 100%;
     justify-content: space-between;
   }
+}
+
+/* --------------------------------------------------------------------------
+   DAILY TIERS — attention / cycle / today / on-track / resumption rows
+   Shared row idiom for the tiered daily cards on the Activity home.
+   -------------------------------------------------------------------------- */
+.wsa-item {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  width: 100%;
+  padding: 9px 6px;
+  border-radius: 7px;
+  text-align: left;
+  color: inherit;
+  text-decoration: none;
+}
+
+.wsa-item:hover {
+  background: var(--color-surface-hover);
+}
+
+.wsa-item__icon {
+  display: grid;
+  place-items: center;
+  color: var(--color-text-muted);
+}
+
+.wsa-item__label {
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wsa-item__label--unread {
+  font-weight: 600;
+}
+
+.wsa-item__sub {
+  display: block;
+  font-size: 11.5px;
+  font-weight: 400;
+  color: var(--color-text-muted);
+  line-height: 1.3;
+  margin-top: 1px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wsa-item__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.wsa-item__chip {
+  font-size: 10.5px;
+  font-weight: 600;
+  padding: 1px 7px;
+  border-radius: 10px;
+  background: var(--color-surface-muted);
+  color: var(--color-text-secondary);
+}
+
+.wsa-item__chip--go {
+  color: var(--activity-accent-crm);
+  background: var(--activity-accent-crm-soft);
+  border: 1px solid var(--activity-accent-crm-border);
+}
+
+.wsa-item__chip--warn {
+  color: var(--activity-accent-due);
+  background: var(--activity-accent-due-soft);
+  border: 1px solid var(--activity-accent-due-border);
+}
+
+.wsa-item__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--color-brand-primary);
+}
+
+/* Subsection label inside a tier card ("Mentions", "Waiting on you", …) */
+.wsa-sub {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin: 14px 0 4px;
+  padding: 0 6px;
+}
+
+.wsa-sub:first-of-type { margin-top: 0; }
+
+.wsa-sub__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.wsa-sub__badge {
+  font-size: 10.5px;
+  font-weight: 600;
+  padding: 0 6px;
+  border-radius: 8px;
+  background: var(--color-brand-primary);
+  color: var(--color-text-inverse);
+  font-variant-numeric: tabular-nums;
+}
+
+.wsa-sub__action {
+  background: transparent;
+  border: 0;
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.wsa-sub__action:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-hover);
+}
+
+/* ---- cycle card ---- */
+.wsa-cycle__top {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.wsa-cycle__days {
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  padding: 2px 9px;
+  border-radius: 100px;
+  color: var(--color-text-secondary);
+  background: var(--color-surface-muted);
+  white-space: nowrap;
+}
+
+.wsa-cycle__days--over {
+  color: var(--activity-accent-due);
+  background: var(--activity-accent-due-soft);
+  border: 1px solid var(--activity-accent-due-border);
+}
+
+.wsa-cycle__goal {
+  font-size: 13px;
+  font-style: italic;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  margin: 8px 0 0;
+}
+
+.wsa-cycle__track {
+  position: relative;
+  height: 6px;
+  border-radius: 4px;
+  background: var(--color-surface-muted);
+  margin: 14px 0 6px;
+  overflow: hidden;
+}
+
+.wsa-cycle__fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: 4px;
+  background: linear-gradient(90deg, var(--brand-500), var(--brand-400));
+}
+
+.wsa-cycle__timemark {
+  position: absolute;
+  top: -2px;
+  bottom: -2px;
+  width: 2px;
+  background: var(--color-text-muted);
+}
+
+.wsa-cycle__pace {
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 8px;
+}
+
+.wsa-cycle__pace b {
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.wsa-cycle__pace--ahead b   { color: var(--activity-accent-crm); }
+.wsa-cycle__pace--behind b  { color: var(--activity-accent-okr); }
+
+/* ---- on-track health chips ---- */
+.wsa-health {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+
+.wsa-health__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 3px 10px;
+  border-radius: 100px;
+  border: 1px solid var(--color-border-primary);
+  background: var(--color-surface-primary);
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.wsa-health__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-text-muted);
+}
+
+.wsa-health__dot--on-track  { background: var(--activity-accent-crm); }
+.wsa-health__dot--at-risk   { background: var(--activity-accent-okr); }
+.wsa-health__dot--off-track { background: var(--activity-accent-due); }
+
+.wsa-health__allclear {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  margin: 2px 0 0;
+}
+
+/* ---- since-yesterday digest line ---- */
+.wsa-sinceline {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  border: 1px solid var(--color-border-primary);
+  background: var(--color-surface-secondary);
+  border-radius: 12px;
+  padding: 13px 18px;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.wsa-sinceline__text b {
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.wsa-sinceline__link {
+  margin-left: auto;
+  font-size: 12.5px;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.wsa-sinceline__link:hover { color: var(--color-text-primary); }
+
+/* ---- resumption strip ---- */
+.wsa-resume {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+@media (max-width: 860px) {
+  .wsa-resume { grid-template-columns: 1fr; }
 }
 
 /* --------------------------------------------------------------------------

--- a/src/app/_components/home/activity/index.tsx
+++ b/src/app/_components/home/activity/index.tsx
@@ -1,22 +1,35 @@
 'use client';
 
 import { ActiveProjects } from './ActiveProjects';
-import { ActivityFeed } from './ActivityFeed';
+import { AttentionPanel } from './AttentionPanel';
+import { CycleCards } from './CycleCard';
 import { GithubReposPanel } from './GithubReposPanel';
-import { Heatmap } from './Heatmap';
 import { Hero } from './Hero';
-import { WeekInReview } from './WeekInReview';
+import { OnTrackPanel } from './OnTrackPanel';
+import { ResumptionStrip } from './ResumptionStrip';
+import { SinceYesterdayLine } from './SinceYesterdayLine';
+import { TodayPanel } from './TodayPanel';
 import { WhatsAppGroupsPanel } from './WhatsAppGroupsPanel';
 import './activity-home.css';
 
 /**
- * Top-level layout for the Activity workspace home.
+ * Top-level layout for the Activity workspace home — the daily page, ordered
+ * by the three questions a returning user asks:
  *
- * Sections by area:
- *   `hero` — `Hero` (this-week / streak / active projects)
- *   `week` — `WeekInReview` (sparkline + multi-week stats)
- *   `main` — `Heatmap` + `ActivityFeed`
- *   `rail` — `ActiveProjects` + `GithubReposPanel` + `WhatsAppGroupsPanel`
+ *   1. What needs my attention?  — `AttentionPanel` (mentions, waiting-on-you,
+ *      overdue). The only genuinely new content each day, so it leads.
+ *   2. What am I committed to?   — `CycleCards` (current cycle + your tickets
+ *      in it) and `TodayPanel` (due today/this week + out-of-cycle tickets).
+ *   3. Is what I own on track?   — `OnTrackPanel` (DRI health chips +
+ *      stale-check-in nudge), compressed to signals, not lists.
+ *
+ * Below the tiers: `SinceYesterdayLine` (one-line team digest linking to
+ * /activity) and `ResumptionStrip` (recent pages/meetings). Every card hides
+ * itself when empty, so the page shrinks as the day is processed.
+ *
+ * The weekly analytics that used to live here (`WeekInReview`, `Heatmap`,
+ * the embedded `ActivityFeed`) moved to the /activity page — weekly-cadence
+ * charts fight with daily content.
  */
 export function WorkspaceHomeActivityLayout() {
   return (
@@ -25,12 +38,13 @@ export function WorkspaceHomeActivityLayout() {
         <div className="wsa__hero">
           <Hero />
         </div>
-        <div className="wsa__week">
-          <WeekInReview />
-        </div>
         <div className="wsa__main">
-          <Heatmap />
-          <ActivityFeed />
+          <AttentionPanel />
+          <CycleCards />
+          <TodayPanel />
+          <OnTrackPanel />
+          <SinceYesterdayLine />
+          <ResumptionStrip />
         </div>
         <div className="wsa__rail">
           <ActiveProjects />

--- a/src/plugins/product/server/currentCycle.ts
+++ b/src/plugins/product/server/currentCycle.ts
@@ -1,0 +1,38 @@
+/**
+ * Read-only "current cycle" selection, shared by the product overview
+ * (`product.getOverview`) and the workspace-home cycle block
+ * (`yourWork.currentCycles`). Cycles are workspace-scoped `List` rows with
+ * `listType: SPRINT`; the canonical status transitions happen lazily in
+ * `cycle.list` (`reconcileCycleStatuses`), so this predicate deliberately
+ * tolerates un-reconciled rows instead of mutating: an ACTIVE sprint that
+ * hasn't ended, a PLANNED one whose window contains `now`, or an ACTIVE one
+ * that ended but was never reconciled to COMPLETED.
+ */
+export function currentCycleWhere(workspaceId: string, now: Date) {
+  return {
+    workspaceId,
+    listType: "SPRINT" as const,
+    OR: [
+      {
+        status: "ACTIVE" as const,
+        OR: [{ endDate: null }, { endDate: { gt: now } }],
+      },
+      {
+        status: "PLANNED" as const,
+        startDate: { lte: now },
+        endDate: { gt: now },
+      },
+      { status: "ACTIVE" as const, endDate: { lte: now } },
+    ],
+  };
+}
+
+/**
+ * Deterministic pick when several sprints qualify (e.g. parallel team cycles
+ * with the same startDate) — id breaks the tie so the same cycle is always
+ * chosen.
+ */
+export const currentCycleOrder = [
+  { startDate: "desc" as const },
+  { id: "desc" as const },
+];

--- a/src/plugins/product/server/routers/product.ts
+++ b/src/plugins/product/server/routers/product.ts
@@ -11,6 +11,7 @@ import {
   COMPLETED_TICKET_STATUSES,
   STATUS_ORDER,
 } from "~/lib/ticket-statuses";
+import { currentCycleWhere, currentCycleOrder } from "../currentCycle";
 
 /**
  * Ensure the caller is a member of the workspace. Throws FORBIDDEN otherwise.
@@ -212,26 +213,12 @@ export const productRouter = createTRPCRouter({
         "QA",
       ] as const;
 
-      // Read-only "current cycle" predicate: an ACTIVE sprint that hasn't
-      // ended, a PLANNED one whose window contains today (covers workspaces
-      // where the lazy reconcile in cycle.list hasn't run yet), or an ACTIVE
-      // one that ended but was never reconciled to COMPLETED. Cycles are
-      // workspace-scoped (List, listType SPRINT), so this matches any current
-      // sprint in the workspace; we prefer the one holding this product's
-      // tickets below.
-      const currentCycleWhere = {
-        workspaceId: product.workspaceId,
-        listType: "SPRINT" as const,
-        OR: [
-          { status: "ACTIVE" as const, OR: [{ endDate: null }, { endDate: { gt: now } }] },
-          {
-            status: "PLANNED" as const,
-            startDate: { lte: now },
-            endDate: { gt: now },
-          },
-          { status: "ACTIVE" as const, endDate: { lte: now } },
-        ],
-      };
+      // Read-only "current cycle" predicate, shared with the workspace-home
+      // cycle block — see ../currentCycle.ts for the reconcile-tolerance
+      // rationale. Cycles are workspace-scoped (List, listType SPRINT), so
+      // this matches any current sprint in the workspace; we prefer the one
+      // holding this product's tickets below.
+      const cycleWhere = currentCycleWhere(product.workspaceId, now);
       const currentCycleSelect = {
         id: true,
         name: true,
@@ -239,13 +226,6 @@ export const productRouter = createTRPCRouter({
         startDate: true,
         endDate: true,
       };
-      // Deterministic pick when several sprints qualify (e.g. parallel team
-      // cycles with the same startDate) — id breaks the tie so the same cycle
-      // is always chosen.
-      const currentCycleOrder = [
-        { startDate: "desc" as const },
-        { id: "desc" as const },
-      ];
 
       const [
         statusGroups,
@@ -276,7 +256,7 @@ export const productRouter = createTRPCRouter({
         // the hero shows "their" cycle rather than an unrelated workspace one.
         ctx.db.list.findFirst({
           where: {
-            ...currentCycleWhere,
+            ...cycleWhere,
             tickets: { some: { productId: input.productId } },
           },
           orderBy: currentCycleOrder,
@@ -285,7 +265,7 @@ export const productRouter = createTRPCRouter({
         // Fallback: the workspace's current cycle even if this product has no
         // tickets in it yet — the hero then prompts to commit tickets.
         ctx.db.list.findFirst({
-          where: currentCycleWhere,
+          where: cycleWhere,
           orderBy: currentCycleOrder,
           select: currentCycleSelect,
         }),

--- a/src/server/api/routers/__tests__/yourWorkHome.test.ts
+++ b/src/server/api/routers/__tests__/yourWorkHome.test.ts
@@ -328,4 +328,19 @@ describe("yourWork.sinceYesterday", () => {
       floorMs - 60_000,
     );
   });
+
+  it("clamps a future `since` down to now", async () => {
+    db.workspaceActivityEvent.groupBy.mockResolvedValue([] as never);
+
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    await caller(db).yourWork.sinceYesterday({
+      workspaceId: WORKSPACE_ID,
+      since: tomorrow,
+    });
+
+    const args = db.workspaceActivityEvent.groupBy.mock.calls[0]?.[0] as {
+      where: { createdAt: { gte: Date } };
+    };
+    expect(args.where.createdAt.gte.getTime()).toBeLessThanOrEqual(Date.now());
+  });
 });

--- a/src/server/api/routers/__tests__/yourWorkHome.test.ts
+++ b/src/server/api/routers/__tests__/yourWorkHome.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Unit tests for the workspace-home `yourWork` procedures added for the
+ * tiered daily home (currentCycles, waitingOnYou, staleCheckins,
+ * sinceYesterday): rollup weighting, the prMerged join, lastCheckIn mapping,
+ * and the since-floor clamp.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const USER_ID = "user-1";
+const WORKSPACE_ID = "ws-1";
+
+function caller(db: DeepMockProxy<PrismaClient>) {
+  return createMockCaller({ userId: USER_ID, db: db as unknown as PrismaClient });
+}
+
+/** Every procedure under test runs the workspace-membership middleware. */
+function stubMembership(db: DeepMockProxy<PrismaClient>) {
+  db.workspaceUser.findUnique.mockResolvedValue({
+    role: "member",
+    workspaceId: WORKSPACE_ID,
+  } as never);
+}
+
+const product = { slug: "prod", name: "Product", funTicketIds: false };
+
+function ticket(over: {
+  id: string;
+  status?: string;
+  points?: number | null;
+  cycleId?: string;
+  assigneeId?: string | null;
+}) {
+  return {
+    id: over.id,
+    shortId: null,
+    number: 1,
+    title: `Ticket ${over.id}`,
+    status: over.status ?? "COMMITTED",
+    points: over.points ?? null,
+    cycleId: over.cycleId ?? "cycle-1",
+    assigneeId: over.assigneeId ?? null,
+    product,
+  };
+}
+
+let db: DeepMockProxy<PrismaClient>;
+
+beforeEach(() => {
+  db = getDbMock();
+  mockReset(db);
+  stubMembership(db);
+});
+
+describe("yourWork.currentCycles", () => {
+  it("returns [] without querying tickets when no cycle is current", async () => {
+    db.list.findMany.mockResolvedValue([] as never);
+
+    const result = await caller(db).yourWork.currentCycles({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(result).toEqual([]);
+    expect(db.ticket.findMany).not.toHaveBeenCalled();
+  });
+
+  it("rolls up by ticket count when no ticket carries points", async () => {
+    db.list.findMany.mockResolvedValue([
+      {
+        id: "cycle-1",
+        name: "Cycle 1",
+        status: "ACTIVE",
+        startDate: null,
+        endDate: null,
+        cycleGoal: "Ship it",
+      },
+    ] as never);
+    db.ticket.findMany.mockResolvedValue([
+      ticket({ id: "a", status: "DONE" }),
+      ticket({ id: "b", status: "IN_PROGRESS", assigneeId: USER_ID }),
+      ticket({ id: "c", status: "COMMITTED" }),
+    ] as never);
+
+    const [cycle] = await caller(db).yourWork.currentCycles({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(cycle).toMatchObject({
+      usesPoints: false,
+      committed: 3,
+      completed: 1,
+      inProgress: 1,
+      cycleGoal: "Ship it",
+      myOpenCount: 1,
+    });
+    expect(cycle?.myTickets.map((t) => t.id)).toEqual(["b"]);
+  });
+
+  it("weights by points when any ticket has them, and sorts my tickets by workflow order", async () => {
+    db.list.findMany.mockResolvedValue([
+      {
+        id: "cycle-1",
+        name: "Cycle 1",
+        status: "ACTIVE",
+        startDate: null,
+        endDate: null,
+        cycleGoal: null,
+      },
+    ] as never);
+    db.ticket.findMany.mockResolvedValue([
+      ticket({ id: "done", status: "DONE", points: 3, assigneeId: USER_ID }),
+      ticket({ id: "wip", status: "IN_PROGRESS", points: 2, assigneeId: USER_ID }),
+      // Pointless ticket contributes 0 weight once usesPoints is on.
+      ticket({ id: "zero", status: "COMMITTED", points: null }),
+    ] as never);
+
+    const [cycle] = await caller(db).yourWork.currentCycles({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(cycle).toMatchObject({
+      usesPoints: true,
+      committed: 5,
+      completed: 3,
+      inProgress: 2,
+    });
+    // IN_PROGRESS (order 4) ranks before DONE (order 7).
+    expect(cycle?.myTickets.map((t) => t.id)).toEqual(["wip", "done"]);
+    // The DONE ticket is mine but not open.
+    expect(cycle?.myOpenCount).toBe(1);
+  });
+
+  it("scopes each cycle's rollup to its own tickets", async () => {
+    db.list.findMany.mockResolvedValue([
+      { id: "cycle-1", name: "A", status: "ACTIVE", startDate: null, endDate: null, cycleGoal: null },
+      { id: "cycle-2", name: "B", status: "ACTIVE", startDate: null, endDate: null, cycleGoal: null },
+    ] as never);
+    db.ticket.findMany.mockResolvedValue([
+      ticket({ id: "a1", cycleId: "cycle-1", status: "DONE" }),
+      ticket({ id: "b1", cycleId: "cycle-2" }),
+      ticket({ id: "b2", cycleId: "cycle-2" }),
+    ] as never);
+
+    const cycles = await caller(db).yourWork.currentCycles({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(cycles.map((c) => c.committed)).toEqual([1, 2]);
+    expect(cycles.map((c) => c.completed)).toEqual([1, 0]);
+  });
+});
+
+describe("yourWork.waitingOnYou", () => {
+  it("flags prMerged only for tickets whose PR has a merged webhook row", async () => {
+    db.ticket.findMany.mockResolvedValue([
+      { ...ticket({ id: "merged" }), prUrl: "https://github.com/x/y/pull/1", updatedAt: new Date() },
+      { ...ticket({ id: "open" }), prUrl: "https://github.com/x/y/pull/2", updatedAt: new Date() },
+      { ...ticket({ id: "nopr" }), prUrl: null, updatedAt: new Date() },
+    ] as never);
+    db.gitHubActivity.findMany.mockResolvedValue([
+      { prUrl: "https://github.com/x/y/pull/1" },
+    ] as never);
+
+    const result = await caller(db).yourWork.waitingOnYou({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(result.map((t) => [t.id, t.prMerged])).toEqual([
+      ["merged", true],
+      ["open", false],
+      ["nopr", false],
+    ]);
+  });
+
+  it("skips the GitHubActivity query when no ticket has a PR", async () => {
+    db.ticket.findMany.mockResolvedValue([
+      { ...ticket({ id: "nopr" }), prUrl: null, updatedAt: new Date() },
+    ] as never);
+
+    const result = await caller(db).yourWork.waitingOnYou({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(result[0]?.prMerged).toBe(false);
+    expect(db.gitHubActivity.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("yourWork.staleCheckins", () => {
+  it("maps the latest check-in to lastCheckIn, null when never checked in", async () => {
+    const lastWeek = new Date("2026-08-01T10:00:00Z");
+    db.keyResult.findMany.mockResolvedValue([
+      {
+        id: 1,
+        title: "KR with history",
+        goalId: 10,
+        status: "on-track",
+        statusOverride: null,
+        checkIns: [{ createdAt: lastWeek }],
+      },
+      {
+        id: 2,
+        title: "Fresh KR",
+        goalId: 10,
+        status: "at-risk",
+        statusOverride: null,
+        checkIns: [],
+      },
+    ] as never);
+
+    const result = await caller(db).yourWork.staleCheckins({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({ id: 1, lastCheckIn: lastWeek }),
+      expect.objectContaining({ id: 2, lastCheckIn: null }),
+    ]);
+    // The raw checkIns array must not leak through.
+    expect(result[0]).not.toHaveProperty("checkIns");
+  });
+});
+
+describe("yourWork.sinceYesterday", () => {
+  it("flattens groupBy counts and excludes the caller's own events", async () => {
+    db.workspaceActivityEvent.groupBy.mockResolvedValue([
+      { entityType: "ticket", action: "status_changed", _count: { _all: 4 } },
+      { entityType: "goal", action: "created", _count: { _all: 1 } },
+    ] as never);
+
+    const result = await caller(db).yourWork.sinceYesterday({
+      workspaceId: WORKSPACE_ID,
+      since: new Date(),
+    });
+
+    expect(result).toEqual([
+      { entityType: "ticket", action: "status_changed", count: 4 },
+      { entityType: "goal", action: "created", count: 1 },
+    ]);
+
+    const args = db.workspaceActivityEvent.groupBy.mock.calls[0]?.[0] as {
+      where: { OR: unknown[]; entityType: { notIn: string[] } };
+    };
+    expect(args.where.entityType.notIn).toContain("ticket_sync_run");
+    expect(args.where.OR).toEqual([
+      { userId: null },
+      { userId: { not: USER_ID } },
+    ]);
+  });
+
+  it("clamps `since` to at most 7 days back", async () => {
+    db.workspaceActivityEvent.groupBy.mockResolvedValue([] as never);
+
+    const monthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    await caller(db).yourWork.sinceYesterday({
+      workspaceId: WORKSPACE_ID,
+      since: monthAgo,
+    });
+
+    const args = db.workspaceActivityEvent.groupBy.mock.calls[0]?.[0] as {
+      where: { createdAt: { gte: Date } };
+    };
+    const floorMs = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    expect(args.where.createdAt.gte.getTime()).toBeGreaterThanOrEqual(
+      floorMs - 60_000,
+    );
+  });
+});

--- a/src/server/api/routers/yourWork.ts
+++ b/src/server/api/routers/yourWork.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
+import { startOfISOWeek, subDays } from "date-fns";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { requireWorkspaceMembership } from "~/server/services/access/middleware";
+import { buildKnowledgePageAccessWhere } from "~/server/services/access/resolvers/knowledgePageResolver";
+import {
+  currentCycleWhere,
+  currentCycleOrder,
+} from "~/plugins/product/server/currentCycle";
+import {
+  COMPLETED_TICKET_STATUSES,
+  STATUS_ORDER,
+} from "~/lib/ticket-statuses";
 
 /**
  * Per-user "Your work" aggregation backing the workspace-home panel
@@ -31,7 +41,8 @@ export const yourWorkRouter = createTRPCRouter({
           number: true,
           title: true,
           status: true,
-          product: { select: { slug: true } },
+          cycleId: true,
+          product: { select: { slug: true, name: true, funTicketIds: true } },
         },
       });
     }),
@@ -85,5 +96,257 @@ export const yourWorkRouter = createTRPCRouter({
         }),
       ]);
       return { goals, keyResults, projects };
+    }),
+
+  /**
+   * Current cycle(s) in the workspace with a completion rollup and the
+   * caller's tickets in each. Same read-only predicate as
+   * `product.getOverview` (see `~/plugins/product/server/currentCycle.ts`) —
+   * deliberately NOT `cycle.list`, whose reconcile/auto-create side effects
+   * a home page shouldn't trigger. Usually one cycle; capped at 3 for
+   * workspaces running parallel team cycles.
+   */
+  currentCycles: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const now = new Date();
+
+      const cycles = await ctx.db.list.findMany({
+        where: currentCycleWhere(input.workspaceId, now),
+        orderBy: currentCycleOrder,
+        take: 3,
+        select: {
+          id: true,
+          name: true,
+          status: true,
+          startDate: true,
+          endDate: true,
+          cycleGoal: true,
+        },
+      });
+      if (cycles.length === 0) return [];
+
+      const cycleTickets = await ctx.db.ticket.findMany({
+        where: { cycleId: { in: cycles.map((c) => c.id) } },
+        select: {
+          id: true,
+          shortId: true,
+          number: true,
+          title: true,
+          status: true,
+          points: true,
+          cycleId: true,
+          assigneeId: true,
+          product: {
+            select: { slug: true, name: true, funTicketIds: true },
+          },
+        },
+      });
+
+      const completedSet = new Set<string>(COMPLETED_TICKET_STATUSES);
+      const statusRank = (s: string) => STATUS_ORDER[s] ?? 99;
+
+      return cycles.map((cycle) => {
+        const tickets = cycleTickets.filter((t) => t.cycleId === cycle.id);
+        // Same weighting as the product-overview rollup: points when any
+        // ticket in the cycle carries them, otherwise ticket count.
+        const usesPoints = tickets.some((t) => (t.points ?? 0) > 0);
+        const weight = (t: { points: number | null }) =>
+          usesPoints ? (t.points ?? 0) : 1;
+        const committed = tickets.reduce((s, t) => s + weight(t), 0);
+        const completed = tickets
+          .filter((t) => completedSet.has(t.status))
+          .reduce((s, t) => s + weight(t), 0);
+        const inProgress = tickets
+          .filter((t) => t.status === "IN_PROGRESS")
+          .reduce((s, t) => s + weight(t), 0);
+
+        const myTickets = tickets
+          .filter((t) => t.assigneeId === userId)
+          .sort((a, b) => statusRank(a.status) - statusRank(b.status))
+          .slice(0, 5)
+          .map(({ id, shortId, number, title, status, product }) => ({
+            id,
+            shortId,
+            number,
+            title,
+            status,
+            product,
+          }));
+        const myOpenCount = tickets.filter(
+          (t) => t.assigneeId === userId && !completedSet.has(t.status),
+        ).length;
+
+        return {
+          id: cycle.id,
+          name: cycle.name,
+          status: cycle.status,
+          startDate: cycle.startDate,
+          endDate: cycle.endDate,
+          cycleGoal: cycle.cycleGoal,
+          usesPoints,
+          committed,
+          completed,
+          inProgress,
+          myTickets,
+          myOpenCount,
+        };
+      });
+    }),
+
+  /**
+   * "Waiting on you": QA tickets that are the caller's to promote — assigned
+   * to them, or created by them and unassigned (agent-shipped work commonly
+   * has no assignee). `prMerged` joins `Ticket.prUrl` against stored
+   * GitHubActivity webhook rows: a merged PR still sitting in QA is the
+   * strongest "promote this" signal, especially while the QA→DONE merge hook
+   * is unreliable.
+   */
+  waitingOnYou: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
+    .query(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const tickets = await ctx.db.ticket.findMany({
+        where: {
+          status: "QA",
+          product: { workspaceId: input.workspaceId },
+          OR: [
+            { assigneeId: userId },
+            { assigneeId: null, createdById: userId },
+          ],
+        },
+        // Oldest first — the longest-waiting item is the most urgent.
+        orderBy: { updatedAt: "asc" },
+        take: 8,
+        select: {
+          id: true,
+          shortId: true,
+          number: true,
+          title: true,
+          prUrl: true,
+          updatedAt: true,
+          product: { select: { slug: true, name: true, funTicketIds: true } },
+        },
+      });
+
+      const prUrls = tickets
+        .map((t) => t.prUrl)
+        .filter((url): url is string => !!url);
+      const mergedRows = prUrls.length
+        ? await ctx.db.gitHubActivity.findMany({
+            where: {
+              workspaceId: input.workspaceId,
+              prUrl: { in: prUrls },
+              prState: "merged",
+            },
+            select: { prUrl: true },
+            distinct: ["prUrl"],
+          })
+        : [];
+      const mergedUrls = new Set(mergedRows.map((r) => r.prUrl));
+
+      return tickets.map((t) => ({
+        ...t,
+        prMerged: !!t.prUrl && mergedUrls.has(t.prUrl),
+      }));
+    }),
+
+  /**
+   * Key results the caller is DRI on with no check-in this ISO week
+   * (Monday-anchored, matching the OKR check-in ritual). A check-in is a
+   * `KeyResultCheckIn` row; there is no cadence field on the model — weekly
+   * is the convention this nudge imposes.
+   */
+  staleCheckins: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
+    .query(async ({ ctx, input }) => {
+      const weekStart = startOfISOWeek(new Date());
+      const stale = await ctx.db.keyResult.findMany({
+        where: {
+          driUserId: ctx.session.user.id,
+          workspaceId: input.workspaceId,
+          status: { not: "achieved" },
+          checkIns: { none: { createdAt: { gte: weekStart } } },
+        },
+        orderBy: { updatedAt: "asc" },
+        take: 6,
+        select: {
+          id: true,
+          title: true,
+          goalId: true,
+          status: true,
+          statusOverride: true,
+          checkIns: {
+            orderBy: { createdAt: "desc" },
+            take: 1,
+            select: { createdAt: true },
+          },
+        },
+      });
+      return stale.map(({ checkIns, ...kr }) => ({
+        ...kr,
+        lastCheckIn: checkIns[0]?.createdAt ?? null,
+      }));
+    }),
+
+  /**
+   * Aggregate counts of other people's workspace activity since `since`
+   * (client-supplied so "yesterday" respects the viewer's timezone; clamped
+   * to 7 days back to bound the scan). The caller's own events are excluded
+   * — this is "what happened while you were away", not a mirror.
+   * `ticket_sync_run` is hidden here for the same reason the feed hides it.
+   */
+  sinceYesterday: protectedProcedure
+    .input(z.object({ workspaceId: z.string(), since: z.date() }))
+    .use(requireWorkspaceMembership("view"))
+    .query(async ({ ctx, input }) => {
+      const floor = subDays(new Date(), 7);
+      const since = input.since > floor ? input.since : floor;
+      const groups = await ctx.db.workspaceActivityEvent.groupBy({
+        by: ["entityType", "action"],
+        where: {
+          workspaceId: input.workspaceId,
+          createdAt: { gte: since },
+          entityType: { notIn: ["ticket_sync_run"] },
+          OR: [{ userId: null }, { userId: { not: ctx.session.user.id } }],
+        },
+        _count: { _all: true },
+      });
+      return groups.map((g) => ({
+        entityType: g.entityType,
+        action: g.action,
+        count: g._count._all,
+      }));
+    }),
+
+  /**
+   * Pages the caller created, most recently updated first — the "pick up
+   * where you left off" strip. `KnowledgePage` has no last-editor field, so
+   * created-by-me ordered by updatedAt is the closest available read.
+   */
+  recentPages: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
+    .query(async ({ ctx, input }) => {
+      return ctx.db.knowledgePage.findMany({
+        where: {
+          AND: [
+            buildKnowledgePageAccessWhere(ctx.session.user.id),
+            { workspaceId: input.workspaceId, createdById: ctx.session.user.id },
+          ],
+        },
+        orderBy: { updatedAt: "desc" },
+        take: 5,
+        select: {
+          id: true,
+          title: true,
+          updatedAt: true,
+          project: { select: { name: true } },
+        },
+      });
     }),
 });

--- a/src/server/api/routers/yourWork.ts
+++ b/src/server/api/routers/yourWork.ts
@@ -129,7 +129,13 @@ export const yourWorkRouter = createTRPCRouter({
       if (cycles.length === 0) return [];
 
       const cycleTickets = await ctx.db.ticket.findMany({
-        where: { cycleId: { in: cycles.map((c) => c.id) } },
+        // The workspace filter is defense-in-depth: cycles are workspace-
+        // scoped and tickets reach a workspace via product, but no DB
+        // constraint forces a ticket's cycle into its own workspace.
+        where: {
+          cycleId: { in: cycles.map((c) => c.id) },
+          product: { workspaceId: input.workspaceId },
+        },
         select: {
           id: true,
           shortId: true,
@@ -304,8 +310,10 @@ export const yourWorkRouter = createTRPCRouter({
     .input(z.object({ workspaceId: z.string(), since: z.date() }))
     .use(requireWorkspaceMembership("view"))
     .query(async ({ ctx, input }) => {
-      const floor = subDays(new Date(), 7);
-      const since = input.since > floor ? input.since : floor;
+      const now = new Date();
+      const floor = subDays(now, 7);
+      // Clamp both ways: no scans older than 7 days, no future windows.
+      const since = input.since > now ? now : input.since > floor ? input.since : floor;
       const groups = await ctx.db.workspaceActivityEvent.groupBy({
         by: ["entityType", "action"],
         where: {


### PR DESCRIPTION
### **User description**
## What

- Restructures the Activity workspace home into three daily tiers: **Needs your attention** (unread mentions with mark-read collapse, QA tickets waiting on you with a "PR merged — promote?" chip from stored GitHubActivity rows, overdue actions), **What you're committed to** (current-cycle cards with days-left / done-vs-time pace / your tickets, plus due-today and out-of-cycle assigned tickets), and **Is what you own on track** (DRI health chips, rows only for problem items, stale-check-in nudge for DRI KRs with no check-in since Monday).
- Adds a one-line **Since yesterday** team digest (own events excluded) linking to /activity, and a resumption strip (recent pages + meetings). Every card hides itself when empty so the page shrinks as the day is processed.
- Moves the weekly analytics (WeekInReview, Heatmap, embedded ActivityFeed) from the home page to /w/[slug]/activity, which becomes the analytics + feed destination.
- Server: five new `yourWork` procedures (currentCycles, waitingOnYou, staleCheckins, sinceYesterday, recentPages), all workspace-membership gated. The cycle query shares the product overview's read-only current-cycle predicate (extracted to `src/plugins/product/server/currentCycle.ts`) and deliberately never triggers `cycle.list`'s reconcile/auto-create side effects.
- Dev fixture: `scripts/dev-fixture/enrich-home.ts` seeds a cycle, cycle tickets, mentions, overdue/today actions, a stale DRI key result, pages and other-user activity so every tier is visually testable.
- 9 new unit tests (rollup weighting, prMerged join, lastCheckIn mapping, since-clamp).

## Why

The workspace home should be the page a user opens every day and it should answer, in order: what needs my attention, what am I committed to, and is what I own on track — without overwhelming them. Weekly-cadence charts fought with that daily content, so they moved to /activity rather than being deleted.

## Known gap

"PRs awaiting your review" is not feasible yet — no user→GitHub-login mapping exists and the webhook handler discards `requested_reviewers`. The QA-ticket version of "waiting on you" ships now.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Restructure Activity home into three daily tiers
  - `AttentionPanel` (mentions, QA waiting-on-you, overdue)
  - `CycleCards` + `TodayPanel` (commitments)
  - `OnTrackPanel` (DRI health + stale check-ins)

- Add `SinceYesterdayLine` digest and `ResumptionStrip`

- Move weekly analytics (WeekInReview, Heatmap, feed) to `/activity`

- Add five `yourWork` procedures, shared cycle predicate, tests, dev fixture


___

### Diagram Walkthrough


```mermaid
flowchart LR
  home["Activity home"] -- "tier 1" --> attention["AttentionPanel: mentions, QA, overdue"]
  home -- "tier 2" --> commit["CycleCards + TodayPanel"]
  home -- "tier 3" --> ontrack["OnTrackPanel: DRI health, stale check-ins"]
  home -- "digest + resume" --> digest["SinceYesterdayLine, ResumptionStrip"]
  home -- "moved analytics" --> activity["/w/[slug]/activity: WeekInReview, Heatmap, full feed"]
  router["yourWork router: currentCycles, waitingOnYou, staleCheckins, sinceYesterday, recentPages"] --> home
  cycleHelper["currentCycle.ts predicate"] --> router
  cycleHelper --> product["product.getOverview"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>yourWork.ts</strong><dd><code>Add five new home procedures and extend assignedTickets</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-8c81e0f09fcab48484314d5207c38398031be837745bf45ad5e12f6e2fd24fce">+272/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AttentionPanel.tsx</strong><dd><code>New tier-1 card for mentions, QA and overdue items</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-d33211d90f6ccfa306f753ff60f8854000ab3892201becbc499c5b4a90570195">+247/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CycleCard.tsx</strong><dd><code>New current-cycle card with pace and your tickets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-de7e160d33c60102d9e1e82ad0037050995fa066c797c5492886634766714927">+201/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>OnTrackPanel.tsx</strong><dd><code>New DRI health chips and stale check-in nudge card</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-a4e0a5d8917226dbe0f51bed9f4144454a25a8f8c5e95a5cba157679c0d4ad86">+193/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TodayPanel.tsx</strong><dd><code>New on-your-plate card with cycle-ticket dedup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-a7e48fdbd264d7f08110ded619aed9c9a5cbd78f644115a5a09a42dbe2d36ee0">+161/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SinceYesterdayLine.tsx</strong><dd><code>New one-line team activity digest with summarizer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-c4ff736f59d358b11eb430475a14278059f316315b96d5ea3978de36463cdb79">+97/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ResumptionStrip.tsx</strong><dd><code>New recent pages and meetings resumption strip</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-b6a8a0218d2ea6d34eb3b9befdd7265e72736e7bd203a65a4accebd1a7d8737f">+101/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.tsx</strong><dd><code>Recompose home layout around the daily tiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-af3eadf2064695190866da78ae0ba3b340a83f2df768d35d40826ce1baa9f54a">+28/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>page.tsx</strong><dd><code>Host relocated week-in-review and heatmap analytics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-5f5da39893000cd0c6b1ddd0a4c1b4996a945c3e31d1166b952e9bcedaa41271">+21/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>activity-home.css</strong><dd><code>Styles for tier rows, cycle, health chips, digest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-5beeb9c22f8d175d4ad28e182edaa5daeab76de2e983441ebda704ccd505591a">+300/-3</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>currentCycle.ts</strong><dd><code>Extract shared read-only current-cycle predicate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-14529bde4a0715fbfdc95567a35e290a8ba219582efafff0af5a134d7fd9b19e">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>enrich-home.ts</strong><dd><code>Idempotent dev fixture seeding all home tiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-58beb1bc4a86abe9ca6118f4da90e14f78e5bf31b3c2a0bc98ef75201ac9c9ae">+230/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>product.ts</strong><dd><code>Reuse extracted current-cycle predicate helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-42fdfc371bf516482c4f54d564895e47783af20d863576815fd83cbe77796891">+9/-29</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>yourWorkHome.test.ts</strong><dd><code>Unit tests for rollups, prMerged join, since clamp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/positonic/exponential/pull/582/files#diff-8d4d7f53101a22334c550d901bf6677fafedde07fe2a0ed91ef87c3283d86734">+346/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

