### PR TITLE
perf: stream cycle detail data with the RSC payload

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/CycleDetailClient.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/CycleDetailClient.tsx
@@ -20,7 +20,6 @@ import { IconArrowLeft } from "@tabler/icons-react";
 import { DateInput } from "@mantine/dates";
 import { modals } from "@mantine/modals";
 import { api } from "~/trpc/react";
-import { useWorkspace } from "~/providers/WorkspaceProvider";
 
 const STATUS_OPTIONS = [
   { value: "PLANNED", label: "Planned" },
@@ -36,7 +35,7 @@ export function CycleDetailClient() {
   const params = useParams();
   const cycleId = params.cycleId as string;
   const productSlug = params.productSlug as string;
-  const { workspace } = useWorkspace();
+  const workspaceSlug = params.workspaceSlug as string;
   const utils = api.useUtils();
 
   const { data: cycle, isLoading } = api.product.cycle.getById.useQuery(
@@ -97,9 +96,7 @@ export function CycleDetailClient() {
           workspaceId: cycle.workspaceId,
         });
       }
-      if (workspace) {
-        router.push(`/w/${workspace.slug}/products/${productSlug}/cycles`);
-      }
+      router.push(`/w/${workspaceSlug}/products/${productSlug}/cycles`);
     },
   });
 
@@ -159,24 +156,18 @@ export function CycleDetailClient() {
     .filter((t) => t.status === "DONE")
     .reduce((sum, t) => sum + (t.points ?? 0), 0);
 
-  // Only render the back link once the workspace has resolved — otherwise the
-  // slug is undefined and the href becomes "/w/undefined/…" (a broken link).
-  const backPath = workspace
-    ? `/w/${workspace.slug}/products/${productSlug}/cycles`
-    : null;
+  const backPath = `/w/${workspaceSlug}/products/${productSlug}/cycles`;
 
   return (
     <Stack gap="lg">
       {/* Back nav */}
-      {backPath && (
-        <Link
-          href={backPath}
-          className="inline-flex items-center gap-1.5 text-xs text-text-muted hover:text-text-primary transition-colors"
-        >
-          <IconArrowLeft size={14} />
-          Cycles
-        </Link>
-      )}
+      <Link
+        href={backPath}
+        className="inline-flex items-center gap-1.5 text-xs text-text-muted hover:text-text-primary transition-colors"
+      >
+        <IconArrowLeft size={14} />
+        Cycles
+      </Link>
 
       <Group justify="space-between" align="flex-start">
         {isEditingHeader ? (

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/CycleDetailClient.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/CycleDetailClient.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import {
+  Badge,
+  Button,
+  Card,
+  Group,
+  Select,
+  Skeleton,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+  Title,
+} from "@mantine/core";
+import { IconArrowLeft } from "@tabler/icons-react";
+import { DateInput } from "@mantine/dates";
+import { modals } from "@mantine/modals";
+import { api } from "~/trpc/react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+
+const STATUS_OPTIONS = [
+  { value: "PLANNED", label: "Planned" },
+  { value: "ACTIVE", label: "Active" },
+  { value: "COMPLETED", label: "Completed" },
+  { value: "ARCHIVED", label: "Archived" },
+];
+
+type CycleStatus = "PLANNED" | "ACTIVE" | "COMPLETED" | "ARCHIVED";
+
+export function CycleDetailClient() {
+  const router = useRouter();
+  const params = useParams();
+  const cycleId = params.cycleId as string;
+  const productSlug = params.productSlug as string;
+  const { workspace } = useWorkspace();
+  const utils = api.useUtils();
+
+  const { data: cycle, isLoading } = api.product.cycle.getById.useQuery(
+    { id: cycleId },
+    { enabled: !!cycleId },
+  );
+
+  const [status, setStatus] = useState<CycleStatus | null>(null);
+  const [cycleGoal, setCycleGoal] = useState("");
+  const [achievements, setAchievements] = useState("");
+
+  const [isEditingHeader, setIsEditingHeader] = useState(false);
+  const [name, setName] = useState("");
+  const [startDate, setStartDate] = useState<Date | null>(null);
+  const [endDate, setEndDate] = useState<Date | null>(null);
+  const [headerError, setHeaderError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (cycle) {
+      setStatus(cycle.status as CycleStatus);
+      setCycleGoal(cycle.cycleGoal ?? "");
+      setAchievements(cycle.achievements ?? "");
+      setName(cycle.name);
+      setStartDate(cycle.startDate ? new Date(cycle.startDate) : null);
+      setEndDate(cycle.endDate ? new Date(cycle.endDate) : null);
+    }
+  }, [cycle]);
+
+  const updateCycle = api.product.cycle.update.useMutation({
+    onSuccess: async () => {
+      await utils.product.cycle.getById.invalidate({ id: cycleId });
+      if (cycle?.workspaceId) {
+        await utils.product.cycle.list.invalidate({
+          workspaceId: cycle.workspaceId,
+        });
+      }
+    },
+  });
+
+  const updateHeader = api.product.cycle.update.useMutation({
+    onSuccess: async () => {
+      setHeaderError(null);
+      setIsEditingHeader(false);
+      await utils.product.cycle.getById.invalidate({ id: cycleId });
+      if (cycle?.workspaceId) {
+        await utils.product.cycle.list.invalidate({
+          workspaceId: cycle.workspaceId,
+        });
+      }
+    },
+    onError: (err) => setHeaderError(err.message),
+  });
+
+  const deleteCycle = api.product.cycle.delete.useMutation({
+    onSuccess: async () => {
+      if (cycle?.workspaceId) {
+        await utils.product.cycle.list.invalidate({
+          workspaceId: cycle.workspaceId,
+        });
+      }
+      if (workspace) {
+        router.push(`/w/${workspace.slug}/products/${productSlug}/cycles`);
+      }
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <Stack gap="md">
+        <Skeleton height={40} width={300} />
+        <Skeleton height={120} />
+      </Stack>
+    );
+  }
+  if (!cycle) return <Text className="text-text-muted">Cycle not found</Text>;
+
+  const onSave = () => {
+    updateCycle.mutate({
+      id: cycleId,
+      status: status ?? undefined,
+      cycleGoal: cycleGoal.trim() || null,
+      achievements: achievements.trim() || null,
+    });
+  };
+
+  const onSaveHeader = () => {
+    updateHeader.mutate({
+      id: cycleId,
+      name: name.trim(),
+      startDate: startDate ?? null,
+      endDate: endDate ?? null,
+    });
+  };
+
+  const onCancelHeader = () => {
+    if (cycle) {
+      setName(cycle.name);
+      setStartDate(cycle.startDate ? new Date(cycle.startDate) : null);
+      setEndDate(cycle.endDate ? new Date(cycle.endDate) : null);
+    }
+    setHeaderError(null);
+    setIsEditingHeader(false);
+  };
+
+  const onDelete = () => {
+    modals.openConfirmModal({
+      title: "Delete cycle",
+      children: <Text size="sm">This will permanently delete the cycle.</Text>,
+      labels: { confirm: "Delete", cancel: "Cancel" },
+      confirmProps: { color: "red" },
+      onConfirm: () => deleteCycle.mutate({ id: cycleId }),
+    });
+  };
+
+  const totalPoints = cycle.tickets.reduce(
+    (sum, t) => sum + (t.points ?? 0),
+    0,
+  );
+  const donePoints = cycle.tickets
+    .filter((t) => t.status === "DONE")
+    .reduce((sum, t) => sum + (t.points ?? 0), 0);
+
+  // Only render the back link once the workspace has resolved — otherwise the
+  // slug is undefined and the href becomes "/w/undefined/…" (a broken link).
+  const backPath = workspace
+    ? `/w/${workspace.slug}/products/${productSlug}/cycles`
+    : null;
+
+  return (
+    <Stack gap="lg">
+      {/* Back nav */}
+      {backPath && (
+        <Link
+          href={backPath}
+          className="inline-flex items-center gap-1.5 text-xs text-text-muted hover:text-text-primary transition-colors"
+        >
+          <IconArrowLeft size={14} />
+          Cycles
+        </Link>
+      )}
+
+      <Group justify="space-between" align="flex-start">
+        {isEditingHeader ? (
+          <Stack gap="sm" style={{ flex: 1 }} maw={520}>
+            <TextInput
+              label="Name"
+              value={name}
+              onChange={(e) => setName(e.currentTarget.value)}
+              maxLength={120}
+              required
+            />
+            <Group grow>
+              <DateInput
+                label="Start date"
+                value={startDate}
+                onChange={(v) =>
+                  setStartDate(
+                    v ? (typeof v === "string" ? new Date(v) : v) : null,
+                  )
+                }
+                clearable
+              />
+              <DateInput
+                label="End date"
+                value={endDate}
+                onChange={(v) =>
+                  setEndDate(
+                    v ? (typeof v === "string" ? new Date(v) : v) : null,
+                  )
+                }
+                clearable
+              />
+            </Group>
+            {headerError && (
+              <Text size="sm" className="text-text-error">
+                {headerError}
+              </Text>
+            )}
+            <Group>
+              <Button
+                size="sm"
+                onClick={onSaveHeader}
+                loading={updateHeader.isPending}
+                disabled={!name.trim()}
+              >
+                Save
+              </Button>
+              <Button size="sm" variant="subtle" onClick={onCancelHeader}>
+                Cancel
+              </Button>
+            </Group>
+          </Stack>
+        ) : (
+          <div>
+            <Group gap="xs" align="center">
+              <Title order={2} className="text-text-primary">
+                {cycle.name}
+              </Title>
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                onClick={() => setIsEditingHeader(true)}
+              >
+                Edit
+              </Button>
+            </Group>
+            {(cycle.startDate ?? cycle.endDate) && (
+              <Text size="sm" className="text-text-muted mt-1">
+                {cycle.startDate
+                  ? new Date(cycle.startDate).toLocaleDateString()
+                  : "?"}
+                {" - "}
+                {cycle.endDate
+                  ? new Date(cycle.endDate).toLocaleDateString()
+                  : "?"}
+              </Text>
+            )}
+          </div>
+        )}
+        <Group>
+          <Select
+            data={STATUS_OPTIONS}
+            value={status}
+            onChange={(v) => setStatus(v as CycleStatus)}
+            w={160}
+          />
+          <Button color="red" variant="outline" onClick={onDelete}>
+            Delete
+          </Button>
+        </Group>
+      </Group>
+
+      {/* Velocity summary */}
+      <Card className="border border-border-primary bg-surface-secondary">
+        <Group gap="xl">
+          <div>
+            <Text size="xs" className="text-text-muted">
+              Tickets
+            </Text>
+            <Title order={4} className="text-text-primary">
+              {cycle.tickets.length}
+            </Title>
+          </div>
+          <div>
+            <Text size="xs" className="text-text-muted">
+              Completed
+            </Text>
+            <Title order={4} className="text-text-primary">
+              {cycle.tickets.filter((t) => t.status === "DONE").length}
+            </Title>
+          </div>
+          <div>
+            <Text size="xs" className="text-text-muted">
+              Points
+            </Text>
+            <Title order={4} className="text-text-primary">
+              {donePoints} / {totalPoints}
+            </Title>
+          </div>
+        </Group>
+      </Card>
+
+      {/* Goal + achievements */}
+      <Card className="border border-border-primary bg-surface-secondary">
+        <Stack gap="sm">
+          <Title order={5} className="text-text-primary">
+            Cycle goal & achievements
+          </Title>
+          <Textarea
+            label="Goal"
+            placeholder="What we set out to do..."
+            value={cycleGoal}
+            onChange={(e) => setCycleGoal(e.currentTarget.value)}
+            autosize
+            minRows={2}
+          />
+          <Textarea
+            label="Achievements"
+            placeholder="What actually shipped..."
+            value={achievements}
+            onChange={(e) => setAchievements(e.currentTarget.value)}
+            autosize
+            minRows={3}
+          />
+          <Group justify="flex-end">
+            <Button
+              size="sm"
+              onClick={onSave}
+              loading={updateCycle.isPending}
+            >
+              Save
+            </Button>
+          </Group>
+        </Stack>
+      </Card>
+
+      {/* Tickets */}
+      <Card className="border border-border-primary bg-surface-secondary">
+        <Title order={5} className="text-text-primary mb-2">
+          Tickets in this cycle
+        </Title>
+        {cycle.tickets.length === 0 ? (
+          <Text size="sm" className="text-text-muted italic">
+            No tickets assigned yet. Assign tickets to this cycle from the ticket
+            detail page.
+          </Text>
+        ) : (
+          <Stack gap="xs">
+            {cycle.tickets.map((t) => (
+              <Card
+                key={t.id}
+                padding="sm"
+                className="border border-border-primary bg-background-primary"
+              >
+                <Group justify="space-between">
+                  <div>
+                    <Text size="sm" className="text-text-primary">
+                      {t.title}
+                    </Text>
+                    <Group gap="xs" mt={2}>
+                      <Badge size="xs" variant="light">
+                        {t.type.toLowerCase()}
+                      </Badge>
+                      <Badge size="xs" variant="outline">
+                        {t.status.toLowerCase().replace("_", " ")}
+                      </Badge>
+                      {t.points !== null && t.points !== undefined && (
+                        <Badge size="xs" variant="outline">
+                          {t.points} pts
+                        </Badge>
+                      )}
+                    </Group>
+                  </div>
+                  {t.assignee && (
+                    <Text size="xs" className="text-text-muted">
+                      @{t.assignee.name}
+                    </Text>
+                  )}
+                </Group>
+              </Card>
+            ))}
+          </Stack>
+        )}
+      </Card>
+    </Stack>
+  );
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx
@@ -23,7 +23,10 @@ export default async function CycleDetailPage({ params }: PageProps) {
   void api.workspace.getBySlug.prefetch({ slug: workspaceSlug });
 
   // ProductLayout's header query keys on { workspaceId, slug }, so resolve the
-  // workspace id (single indexed lookup) before prefetching it.
+  // workspace id (single indexed lookup) before prefetching it. This is a
+  // slug→id resolution only, not an access-checked read: the id never reaches
+  // the client on its own, and every prefetched procedure above enforces
+  // workspace membership itself before returning data.
   const workspace = await db.workspace.findUnique({
     where: { slug: workspaceSlug },
     select: { id: true },

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx
@@ -1,386 +1,43 @@
-"use client";
+import { api, HydrateClient } from "~/trpc/server";
+import { db } from "~/server/db";
+import { CycleDetailClient } from "./CycleDetailClient";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { useParams, useRouter } from "next/navigation";
-import {
-  Badge,
-  Button,
-  Card,
-  Group,
-  Select,
-  Skeleton,
-  Stack,
-  Text,
-  Textarea,
-  TextInput,
-  Title,
-} from "@mantine/core";
-import { IconArrowLeft } from "@tabler/icons-react";
-import { DateInput } from "@mantine/dates";
-import { modals } from "@mantine/modals";
-import { api } from "~/trpc/react";
-import { useWorkspace } from "~/providers/WorkspaceProvider";
+interface PageProps {
+  params: Promise<{
+    workspaceSlug: string;
+    productSlug: string;
+    cycleId: string;
+  }>;
+}
 
-const STATUS_OPTIONS = [
-  { value: "PLANNED", label: "Planned" },
-  { value: "ACTIVE", label: "Active" },
-  { value: "COMPLETED", label: "Completed" },
-  { value: "ARCHIVED", label: "Archived" },
-];
+/**
+ * Server shell for the cycle detail page. Prefetches the queries the client
+ * tree needs (cycle, workspace, product header) so they stream with the RSC
+ * payload instead of waiting for JS load → client fetch round trips. Inputs
+ * must match the client useQuery keys exactly or the cache won't hit.
+ */
+export default async function CycleDetailPage({ params }: PageProps) {
+  const { workspaceSlug, productSlug, cycleId } = await params;
 
-type CycleStatus = "PLANNED" | "ACTIVE" | "COMPLETED" | "ARCHIVED";
+  void api.product.cycle.getById.prefetch({ id: cycleId });
+  void api.workspace.getBySlug.prefetch({ slug: workspaceSlug });
 
-export default function CycleDetailPage() {
-  const router = useRouter();
-  const params = useParams();
-  const cycleId = params.cycleId as string;
-  const productSlug = params.productSlug as string;
-  const { workspace } = useWorkspace();
-  const utils = api.useUtils();
-
-  const { data: cycle, isLoading } = api.product.cycle.getById.useQuery(
-    { id: cycleId },
-    { enabled: !!cycleId },
-  );
-
-  const [status, setStatus] = useState<CycleStatus | null>(null);
-  const [cycleGoal, setCycleGoal] = useState("");
-  const [achievements, setAchievements] = useState("");
-
-  const [isEditingHeader, setIsEditingHeader] = useState(false);
-  const [name, setName] = useState("");
-  const [startDate, setStartDate] = useState<Date | null>(null);
-  const [endDate, setEndDate] = useState<Date | null>(null);
-  const [headerError, setHeaderError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (cycle) {
-      setStatus(cycle.status as CycleStatus);
-      setCycleGoal(cycle.cycleGoal ?? "");
-      setAchievements(cycle.achievements ?? "");
-      setName(cycle.name);
-      setStartDate(cycle.startDate ? new Date(cycle.startDate) : null);
-      setEndDate(cycle.endDate ? new Date(cycle.endDate) : null);
-    }
-  }, [cycle]);
-
-  const updateCycle = api.product.cycle.update.useMutation({
-    onSuccess: async () => {
-      await utils.product.cycle.getById.invalidate({ id: cycleId });
-      if (cycle?.workspaceId) {
-        await utils.product.cycle.list.invalidate({
-          workspaceId: cycle.workspaceId,
-        });
-      }
-    },
+  // ProductLayout's header query keys on { workspaceId, slug }, so resolve the
+  // workspace id (single indexed lookup) before prefetching it.
+  const workspace = await db.workspace.findUnique({
+    where: { slug: workspaceSlug },
+    select: { id: true },
   });
-
-  const updateHeader = api.product.cycle.update.useMutation({
-    onSuccess: async () => {
-      setHeaderError(null);
-      setIsEditingHeader(false);
-      await utils.product.cycle.getById.invalidate({ id: cycleId });
-      if (cycle?.workspaceId) {
-        await utils.product.cycle.list.invalidate({
-          workspaceId: cycle.workspaceId,
-        });
-      }
-    },
-    onError: (err) => setHeaderError(err.message),
-  });
-
-  const deleteCycle = api.product.cycle.delete.useMutation({
-    onSuccess: async () => {
-      if (cycle?.workspaceId) {
-        await utils.product.cycle.list.invalidate({
-          workspaceId: cycle.workspaceId,
-        });
-      }
-      if (workspace) {
-        router.push(`/w/${workspace.slug}/products/${productSlug}/cycles`);
-      }
-    },
-  });
-
-  if (isLoading) {
-    return (
-      <Stack gap="md">
-        <Skeleton height={40} width={300} />
-        <Skeleton height={120} />
-      </Stack>
-    );
+  if (workspace) {
+    void api.product.product.getBySlug.prefetch({
+      workspaceId: workspace.id,
+      slug: productSlug,
+    });
   }
-  if (!cycle) return <Text className="text-text-muted">Cycle not found</Text>;
-
-  const onSave = () => {
-    updateCycle.mutate({
-      id: cycleId,
-      status: status ?? undefined,
-      cycleGoal: cycleGoal.trim() || null,
-      achievements: achievements.trim() || null,
-    });
-  };
-
-  const onSaveHeader = () => {
-    updateHeader.mutate({
-      id: cycleId,
-      name: name.trim(),
-      startDate: startDate ?? null,
-      endDate: endDate ?? null,
-    });
-  };
-
-  const onCancelHeader = () => {
-    if (cycle) {
-      setName(cycle.name);
-      setStartDate(cycle.startDate ? new Date(cycle.startDate) : null);
-      setEndDate(cycle.endDate ? new Date(cycle.endDate) : null);
-    }
-    setHeaderError(null);
-    setIsEditingHeader(false);
-  };
-
-  const onDelete = () => {
-    modals.openConfirmModal({
-      title: "Delete cycle",
-      children: <Text size="sm">This will permanently delete the cycle.</Text>,
-      labels: { confirm: "Delete", cancel: "Cancel" },
-      confirmProps: { color: "red" },
-      onConfirm: () => deleteCycle.mutate({ id: cycleId }),
-    });
-  };
-
-  const totalPoints = cycle.tickets.reduce(
-    (sum, t) => sum + (t.points ?? 0),
-    0,
-  );
-  const donePoints = cycle.tickets
-    .filter((t) => t.status === "DONE")
-    .reduce((sum, t) => sum + (t.points ?? 0), 0);
-
-  // Only render the back link once the workspace has resolved — otherwise the
-  // slug is undefined and the href becomes "/w/undefined/…" (a broken link).
-  const backPath = workspace
-    ? `/w/${workspace.slug}/products/${productSlug}/cycles`
-    : null;
 
   return (
-    <Stack gap="lg">
-      {/* Back nav */}
-      {backPath && (
-        <Link
-          href={backPath}
-          className="inline-flex items-center gap-1.5 text-xs text-text-muted hover:text-text-primary transition-colors"
-        >
-          <IconArrowLeft size={14} />
-          Cycles
-        </Link>
-      )}
-
-      <Group justify="space-between" align="flex-start">
-        {isEditingHeader ? (
-          <Stack gap="sm" style={{ flex: 1 }} maw={520}>
-            <TextInput
-              label="Name"
-              value={name}
-              onChange={(e) => setName(e.currentTarget.value)}
-              maxLength={120}
-              required
-            />
-            <Group grow>
-              <DateInput
-                label="Start date"
-                value={startDate}
-                onChange={(v) =>
-                  setStartDate(
-                    v ? (typeof v === "string" ? new Date(v) : v) : null,
-                  )
-                }
-                clearable
-              />
-              <DateInput
-                label="End date"
-                value={endDate}
-                onChange={(v) =>
-                  setEndDate(
-                    v ? (typeof v === "string" ? new Date(v) : v) : null,
-                  )
-                }
-                clearable
-              />
-            </Group>
-            {headerError && (
-              <Text size="sm" className="text-text-error">
-                {headerError}
-              </Text>
-            )}
-            <Group>
-              <Button
-                size="sm"
-                onClick={onSaveHeader}
-                loading={updateHeader.isPending}
-                disabled={!name.trim()}
-              >
-                Save
-              </Button>
-              <Button size="sm" variant="subtle" onClick={onCancelHeader}>
-                Cancel
-              </Button>
-            </Group>
-          </Stack>
-        ) : (
-          <div>
-            <Group gap="xs" align="center">
-              <Title order={2} className="text-text-primary">
-                {cycle.name}
-              </Title>
-              <Button
-                size="compact-xs"
-                variant="subtle"
-                onClick={() => setIsEditingHeader(true)}
-              >
-                Edit
-              </Button>
-            </Group>
-            {(cycle.startDate ?? cycle.endDate) && (
-              <Text size="sm" className="text-text-muted mt-1">
-                {cycle.startDate
-                  ? new Date(cycle.startDate).toLocaleDateString()
-                  : "?"}
-                {" - "}
-                {cycle.endDate
-                  ? new Date(cycle.endDate).toLocaleDateString()
-                  : "?"}
-              </Text>
-            )}
-          </div>
-        )}
-        <Group>
-          <Select
-            data={STATUS_OPTIONS}
-            value={status}
-            onChange={(v) => setStatus(v as CycleStatus)}
-            w={160}
-          />
-          <Button color="red" variant="outline" onClick={onDelete}>
-            Delete
-          </Button>
-        </Group>
-      </Group>
-
-      {/* Velocity summary */}
-      <Card className="border border-border-primary bg-surface-secondary">
-        <Group gap="xl">
-          <div>
-            <Text size="xs" className="text-text-muted">
-              Tickets
-            </Text>
-            <Title order={4} className="text-text-primary">
-              {cycle.tickets.length}
-            </Title>
-          </div>
-          <div>
-            <Text size="xs" className="text-text-muted">
-              Completed
-            </Text>
-            <Title order={4} className="text-text-primary">
-              {cycle.tickets.filter((t) => t.status === "DONE").length}
-            </Title>
-          </div>
-          <div>
-            <Text size="xs" className="text-text-muted">
-              Points
-            </Text>
-            <Title order={4} className="text-text-primary">
-              {donePoints} / {totalPoints}
-            </Title>
-          </div>
-        </Group>
-      </Card>
-
-      {/* Goal + achievements */}
-      <Card className="border border-border-primary bg-surface-secondary">
-        <Stack gap="sm">
-          <Title order={5} className="text-text-primary">
-            Cycle goal & achievements
-          </Title>
-          <Textarea
-            label="Goal"
-            placeholder="What we set out to do..."
-            value={cycleGoal}
-            onChange={(e) => setCycleGoal(e.currentTarget.value)}
-            autosize
-            minRows={2}
-          />
-          <Textarea
-            label="Achievements"
-            placeholder="What actually shipped..."
-            value={achievements}
-            onChange={(e) => setAchievements(e.currentTarget.value)}
-            autosize
-            minRows={3}
-          />
-          <Group justify="flex-end">
-            <Button
-              size="sm"
-              onClick={onSave}
-              loading={updateCycle.isPending}
-            >
-              Save
-            </Button>
-          </Group>
-        </Stack>
-      </Card>
-
-      {/* Tickets */}
-      <Card className="border border-border-primary bg-surface-secondary">
-        <Title order={5} className="text-text-primary mb-2">
-          Tickets in this cycle
-        </Title>
-        {cycle.tickets.length === 0 ? (
-          <Text size="sm" className="text-text-muted italic">
-            No tickets assigned yet. Assign tickets to this cycle from the ticket
-            detail page.
-          </Text>
-        ) : (
-          <Stack gap="xs">
-            {cycle.tickets.map((t) => (
-              <Card
-                key={t.id}
-                padding="sm"
-                className="border border-border-primary bg-background-primary"
-              >
-                <Group justify="space-between">
-                  <div>
-                    <Text size="sm" className="text-text-primary">
-                      {t.title}
-                    </Text>
-                    <Group gap="xs" mt={2}>
-                      <Badge size="xs" variant="light">
-                        {t.type.toLowerCase()}
-                      </Badge>
-                      <Badge size="xs" variant="outline">
-                        {t.status.toLowerCase().replace("_", " ")}
-                      </Badge>
-                      {t.points !== null && t.points !== undefined && (
-                        <Badge size="xs" variant="outline">
-                          {t.points} pts
-                        </Badge>
-                      )}
-                    </Group>
-                  </div>
-                  {t.assignee && (
-                    <Text size="xs" className="text-text-muted">
-                      @{t.assignee.name}
-                    </Text>
-                  )}
-                </Group>
-              </Card>
-            ))}
-          </Stack>
-        )}
-      </Card>
-    </Stack>
+    <HydrateClient>
+      <CycleDetailClient />
+    </HydrateClient>
   );
 }

--- a/src/plugins/product/server/routers/cycle.ts
+++ b/src/plugins/product/server/routers/cycle.ts
@@ -317,8 +317,9 @@ export const cycleRouter = createTRPCRouter({
   getById: protectedProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ ctx, input }) => {
-      await loadCycleWithAccess(ctx.db, ctx.session.user.id, input.id);
-
+      // Single fetch instead of loadCycleWithAccess + refetch: each DB round
+      // trip is sequential latency on the page's critical path, so assert
+      // access against the already-loaded row.
       const cycle = await ctx.db.list.findUnique({
         where: { id: input.id },
         include: {
@@ -348,6 +349,7 @@ export const cycleRouter = createTRPCRouter({
       if (!cycle || cycle.listType !== "SPRINT") {
         throw new TRPCError({ code: "NOT_FOUND", message: "Cycle not found" });
       }
+      await assertWorkspaceMember(ctx.db, ctx.session.user.id, cycle.workspaceId);
       return cycle;
     }),
 


### PR DESCRIPTION
### **User description**
## What

- Split the product cycle detail page (`/w/[ws]/products/[product]/cycles/[cycleId]`) into a server shell + `CycleDetailClient`, prefetching `product.cycle.getById`, `workspace.getBySlug` and `product.product.getBySlug` through `HydrateClient` so all three queries stream with the initial document instead of being fetched client-side after JS load.
- Collapsed `product.cycle.getById` from 3–4 sequential DB round trips (existence pre-check → membership → full refetch) to a single fetch plus a membership check against the already-loaded row.

## Why

The cycle detail page paid a full client-side waterfall on load: JS download/parse → `cycle.getById` + `workspace.getBySlug` → `product.getBySlug` (which waits on the workspace result), with each tRPC hop itself multiplied by sequential DB queries. Verified locally with the dev-fixture session that the dehydrated cycle/workspace/product data now ships in the initial HTML and the page renders without post-load data round trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Split cycle detail page into server shell + client component

- Prefetch cycle, workspace, product queries via `HydrateClient`

- Reduce `cycle.getById` to single DB fetch plus membership check

- Derive back-link and post-delete redirect from route params


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["page.tsx (server shell)"] -- "prefetch cycle/workspace/product" --> B["HydrateClient"]
  B -- "dehydrated cache" --> C["CycleDetailClient"]
  C -- "useQuery (cache hit)" --> D["cycle.getById"]
  D -- "single fetch + assertWorkspaceMember" --> E["DB"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Server shell prefetching cycle page queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/page.tsx

<ul><li>Converted from client component to async server component shell<br> <li> Prefetches <code>product.cycle.getById</code> and <code>workspace.getBySlug</code><br> <li> Resolves workspace id via direct <code>db.workspace.findUnique</code> to prefetch <br><code>product.product.getBySlug</code><br> <li> Renders <code>CycleDetailClient</code> inside <code>HydrateClient</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/583/files#diff-f04f2dca8cdb906f9cf22ec215d1dd0531a9791e6726fab6ea8b2a90e726210f">+39/-379</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CycleDetailClient.tsx</strong><dd><code>Extracted client component using route params</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/CycleDetailClient.tsx

<ul><li>New client component holding the previous page UI and mutations<br> <li> Reads <code>workspaceSlug</code>, <code>productSlug</code>, <code>cycleId</code> from <code>useParams</code> instead of <br><code>useWorkspace</code><br> <li> Back-link and post-delete redirect now always available from route <br>params<br> <li> Removed dependency on <code>WorkspaceProvider</code></ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/583/files#diff-1eeabfa4b9c07a35884f1df4494f951a607a9e4708c65aebbb5ba2b9779a810c">+377/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycle.ts</strong><dd><code>Collapse getById DB round trips</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plugins/product/server/routers/cycle.ts

<ul><li>Removed <code>loadCycleWithAccess</code> pre-check/refetch from <code>getById</code><br> <li> Single <code>list.findUnique</code> fetch followed by <code>assertWorkspaceMember</code> on <br>loaded row<br> <li> Reduces sequential DB round trips on the critical path</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/583/files#diff-498883b4d63ffa3c679f3fe2afb5ad58e0d01f24d59783eacd1f9a6673531824">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

