### PR TITLE
fix(home): persist mention reads and stop kanban-done actions returning as overdue

### DIFF
--- a/src/app/_components/home/YourWorkPanel.tsx
+++ b/src/app/_components/home/YourWorkPanel.tsx
@@ -157,9 +157,7 @@ export function YourWorkPanel() {
   const driProjects = dri?.projects ?? [];
   const driCount = driGoals.length + driKeyResults.length + driProjects.length;
   const recentMeetings = (meetings ?? []).slice(0, 5);
-  const mentions = (mentionData?.notifications ?? [])
-    .filter((mention) => mention.readAt === null)
-    .slice(0, 5);
+  const mentions = (mentionData?.notifications ?? []).slice(0, 5);
 
   const personalSectionsEmpty =
     !isLoading &&

--- a/src/app/_components/home/YourWorkPanel.tsx
+++ b/src/app/_components/home/YourWorkPanel.tsx
@@ -97,12 +97,14 @@ export function YourWorkPanel() {
 
   // Mention notifications — the ADR-0045 pipeline writes these rows; this
   // inbox is their first reader. User-scoped, not workspace-scoped: a mention
-  // follows the person.
+  // follows the person. Only unread ones render — marking read removes the
+  // row for good. Fetch a deep page: the list mixes read and unread, and a
+  // burst of read mentions must not push unread ones off the page.
   const utils = api.useUtils();
   const { data: mentionData, isLoading: mentionsLoading } =
     api.notification.list.useQuery({
       category: NOTIFICATION_CATEGORIES.MENTION,
-      limit: 5,
+      limit: 50,
     });
   const { data: unreadMentions } = api.notification.unreadCount.useQuery({
     category: NOTIFICATION_CATEGORIES.MENTION,
@@ -121,8 +123,15 @@ export function YourWorkPanel() {
   if (!workspaceId || !workspaceSlug) return null;
 
   const now = new Date();
+  // status === 'ACTIVE' alone is not enough: legacy rows completed from the
+  // kanban board carry kanbanStatus DONE/CANCELLED with status still ACTIVE.
   const active = (actions ?? [])
-    .filter((a) => a.status === 'ACTIVE')
+    .filter(
+      (a) =>
+        a.status === 'ACTIVE' &&
+        a.kanbanStatus !== 'DONE' &&
+        a.kanbanStatus !== 'CANCELLED',
+    )
     .sort((a, b) => {
       if (!a.dueDate && !b.dueDate) return 0;
       if (!a.dueDate) return 1;
@@ -147,7 +156,9 @@ export function YourWorkPanel() {
   const driProjects = dri?.projects ?? [];
   const driCount = driGoals.length + driKeyResults.length + driProjects.length;
   const recentMeetings = (meetings ?? []).slice(0, 5);
-  const mentions = mentionData?.notifications ?? [];
+  const mentions = (mentionData?.notifications ?? [])
+    .filter((mention) => mention.readAt === null)
+    .slice(0, 5);
 
   const personalSectionsEmpty =
     !isLoading &&
@@ -284,7 +295,6 @@ export function YourWorkPanel() {
             )}
           </div>
           {mentions.map((mention) => {
-            const isUnread = mention.readAt === null;
             const row = (
               <>
                 <IconAt
@@ -292,26 +302,19 @@ export function YourWorkPanel() {
                   stroke={1.75}
                   style={{ color: 'var(--color-text-muted)', flexShrink: 0 }}
                 />
-                <span
-                  className={
-                    isUnread
-                      ? `${styles.rowLabel} ${styles.rowLabelUnread}`
-                      : styles.rowLabel
-                  }
-                >
+                <span className={`${styles.rowLabel} ${styles.rowLabelUnread}`}>
                   {mention.title}
                   {mention.message ? ` — ${mention.message}` : ''}
                 </span>
-                {isUnread && <span className={styles.unreadDot} aria-label="Unread" />}
+                <span className={styles.unreadDot} aria-label="Unread" />
                 <span className={styles.rowMeta}>
                   {formatDue(new Date(mention.createdAt))}
                 </span>
               </>
             );
             // Opening a mention reads it — mark before the navigation unmounts us.
-            const readOnOpen = () => {
-              if (isUnread) markRead.mutate({ notificationId: mention.id });
-            };
+            const readOnOpen = () =>
+              markRead.mutate({ notificationId: mention.id });
             return mention.deeplink ? (
               <UnstyledButton
                 key={mention.id}

--- a/src/app/_components/home/YourWorkPanel.tsx
+++ b/src/app/_components/home/YourWorkPanel.tsx
@@ -98,13 +98,14 @@ export function YourWorkPanel() {
   // Mention notifications — the ADR-0045 pipeline writes these rows; this
   // inbox is their first reader. User-scoped, not workspace-scoped: a mention
   // follows the person. Only unread ones render — marking read removes the
-  // row for good. Fetch a deep page: the list mixes read and unread, and a
-  // burst of read mentions must not push unread ones off the page.
+  // row for good. Filtered server-side so any volume of read mentions can't
+  // crowd out an unread one.
   const utils = api.useUtils();
   const { data: mentionData, isLoading: mentionsLoading } =
     api.notification.list.useQuery({
       category: NOTIFICATION_CATEGORIES.MENTION,
-      limit: 50,
+      unreadOnly: true,
+      limit: 5,
     });
   const { data: unreadMentions } = api.notification.unreadCount.useQuery({
     category: NOTIFICATION_CATEGORIES.MENTION,

--- a/src/app/_components/home/activity/AttentionPanel.tsx
+++ b/src/app/_components/home/activity/AttentionPanel.tsx
@@ -74,10 +74,14 @@ export function AttentionPanel() {
 
   const startOfToday = new Date();
   startOfToday.setHours(0, 0, 0, 0);
+  // status === 'ACTIVE' alone is not enough: legacy rows completed from the
+  // kanban board carry kanbanStatus DONE/CANCELLED with status still ACTIVE.
   const overdue = (actions ?? [])
     .filter(
       (a) =>
         a.status === 'ACTIVE' &&
+        a.kanbanStatus !== 'DONE' &&
+        a.kanbanStatus !== 'CANCELLED' &&
         a.dueDate !== null &&
         new Date(a.dueDate) < startOfToday,
     )

--- a/src/app/_components/home/activity/AttentionPanel.tsx
+++ b/src/app/_components/home/activity/AttentionPanel.tsx
@@ -32,12 +32,13 @@ export function AttentionPanel() {
 
   // Mentions are user-scoped, not workspace-scoped: a mention follows the
   // person. Only unread ones render here — processed items leave the page.
-  // Fetch a deep page: the list mixes read and unread, and a burst of read
-  // mentions must not push unread ones (which the badge counts) off the page.
+  // Filtered server-side so any volume of read mentions can't crowd out an
+  // unread one (which the badge counts).
   const { data: mentionData, isLoading: mentionsLoading } =
     api.notification.list.useQuery({
       category: NOTIFICATION_CATEGORIES.MENTION,
-      limit: 50,
+      unreadOnly: true,
+      limit: MAX_ROWS,
     });
   const { data: unreadCount } = api.notification.unreadCount.useQuery({
     category: NOTIFICATION_CATEGORIES.MENTION,

--- a/src/app/_components/home/activity/AttentionPanel.tsx
+++ b/src/app/_components/home/activity/AttentionPanel.tsx
@@ -68,9 +68,7 @@ export function AttentionPanel() {
 
   if (!workspaceId || !workspaceSlug) return null;
 
-  const unreadMentions = (mentionData?.notifications ?? [])
-    .filter((m) => m.readAt === null)
-    .slice(0, MAX_ROWS);
+  const unreadMentions = (mentionData?.notifications ?? []).slice(0, MAX_ROWS);
   const waitingRows = waiting ?? [];
 
   const startOfToday = new Date();

--- a/src/app/_components/home/activity/TodayPanel.tsx
+++ b/src/app/_components/home/activity/TodayPanel.tsx
@@ -50,8 +50,14 @@ export function TodayPanel() {
   const startOfTomorrow = new Date(startOfToday.getTime() + 24 * 60 * 60 * 1000);
   const weekOut = new Date(startOfToday.getTime() + 7 * 24 * 60 * 60 * 1000);
 
+  // status === 'ACTIVE' alone is not enough: legacy rows completed from the
+  // kanban board carry kanbanStatus DONE/CANCELLED with status still ACTIVE.
   const active = (actions ?? []).filter(
-    (a) => a.status === 'ACTIVE' && a.dueDate !== null,
+    (a) =>
+      a.status === 'ACTIVE' &&
+      a.kanbanStatus !== 'DONE' &&
+      a.kanbanStatus !== 'CANCELLED' &&
+      a.dueDate !== null,
   );
   const dueToday = active.filter((a) => {
     const due = new Date(a.dueDate ?? 0);

--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -1610,6 +1610,23 @@ describe("action router (mocked)", () => {
       expect(updatedWith()).toMatchObject({ status: "CANCELLED" });
     });
 
+    it("updateKanbanStatus re-sending the current column never resurrects", async () => {
+      // Pre-lockstep rows completed via checkbox: status COMPLETED but the
+      // kanban column untouched. A same-column reorder re-sends that column
+      // and must not flip the action back to ACTIVE or clear its timestamp.
+      stubKanbanRow({
+        status: "COMPLETED",
+        kanbanStatus: "TODO",
+        completedAt: new Date(),
+      });
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.updateKanbanStatus({ actionId: "a1", kanbanStatus: "TODO" });
+
+      expect(updatedWith().status).toBeUndefined();
+      expect(updatedWith().completedAt).toBeUndefined();
+    });
+
     it("updateKanbanStatus never resurrects a DRAFT row", async () => {
       stubKanbanRow({ status: "DRAFT", kanbanStatus: "TODO" });
 
@@ -1677,6 +1694,33 @@ describe("action router (mocked)", () => {
         status: "ACTIVE",
         completedAt: null,
       });
+    });
+
+    it("update re-sending the current column never resurrects", async () => {
+      // A full-payload edit (rename, due date, …) that includes the current,
+      // unchanged kanban column must not flip a completed action to ACTIVE
+      // or clear its timestamp.
+      stubUpdateRow({
+        status: "COMPLETED",
+        kanbanStatus: "TODO",
+        completedAt: new Date(),
+      });
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.update({ id: "a1", name: "Renamed", kanbanStatus: "TODO" });
+
+      expect(updatedWith().status).toBeUndefined();
+      expect(updatedWith().completedAt).toBeUndefined();
+    });
+
+    it("update re-sending DONE still repairs a legacy DONE-but-ACTIVE row", async () => {
+      stubUpdateRow({ status: "ACTIVE", kanbanStatus: "DONE", completedAt: null });
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.update({ id: "a1", kanbanStatus: "DONE" });
+
+      expect(updatedWith()).toMatchObject({ status: "COMPLETED" });
+      expect(updatedWith().completedAt).toBeInstanceOf(Date);
     });
 
     it("update with an explicit status wins over the kanban sync", async () => {

--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -1516,4 +1516,149 @@ describe("action router (mocked)", () => {
       expect(result).toEqual({ count: 3, actionIds });
     });
   });
+
+  // ────────────────────────────────────────────────────────────────────
+  // kanbanStatus ↔ status lockstep
+  //
+  // Completing an action from the kanban side (updateKanbanStatus, or
+  // update with only kanbanStatus) must move the coarse `status` field
+  // too. List views (home-page overdue, "Assigned to you") filter on
+  // status === "ACTIVE", so a kanban DONE that left status ACTIVE
+  // resurrected the "done" action on every page load.
+  // ────────────────────────────────────────────────────────────────────
+  describe("kanbanStatus ↔ status lockstep", () => {
+    const callerId = "caller-1";
+
+    /** The row updateKanbanStatus fetches (access check + current state). */
+    function stubKanbanRow(row: { status: string; kanbanStatus: string | null; completedAt?: Date | null }) {
+      dbMock.action.findFirst.mockResolvedValue({
+        id: "a1",
+        status: row.status,
+        kanbanStatus: row.kanbanStatus,
+        completedAt: row.completedAt ?? null,
+        projectId: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.action.update.mockResolvedValue({
+        id: "a1",
+        project: null,
+        assignees: [],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dbMock.actionStatusChange.create.mockResolvedValue({} as any);
+    }
+
+    function updatedWith() {
+      return dbMock.action.update.mock.calls[0]![0]!.data as Record<string, unknown>;
+    }
+
+    it("updateKanbanStatus DONE completes the coarse status", async () => {
+      stubKanbanRow({ status: "ACTIVE", kanbanStatus: "TODO" });
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.updateKanbanStatus({ actionId: "a1", kanbanStatus: "DONE" });
+
+      expect(updatedWith()).toMatchObject({ kanbanStatus: "DONE", status: "COMPLETED" });
+      expect(updatedWith().completedAt).toBeInstanceOf(Date);
+    });
+
+    it("updateKanbanStatus DONE repairs a legacy DONE-but-ACTIVE row", async () => {
+      // The bug's leftover data shape: kanban already DONE, status still ACTIVE.
+      stubKanbanRow({ status: "ACTIVE", kanbanStatus: "DONE", completedAt: new Date() });
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.updateKanbanStatus({ actionId: "a1", kanbanStatus: "DONE" });
+
+      expect(updatedWith()).toMatchObject({ status: "COMPLETED" });
+    });
+
+    it("updateKanbanStatus out of DONE reactivates the coarse status", async () => {
+      stubKanbanRow({ status: "COMPLETED", kanbanStatus: "DONE", completedAt: new Date() });
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.updateKanbanStatus({ actionId: "a1", kanbanStatus: "IN_PROGRESS" });
+
+      expect(updatedWith()).toMatchObject({
+        kanbanStatus: "IN_PROGRESS",
+        status: "ACTIVE",
+        completedAt: null,
+      });
+    });
+
+    it("updateKanbanStatus CANCELLED cancels the coarse status", async () => {
+      stubKanbanRow({ status: "ACTIVE", kanbanStatus: "TODO" });
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.updateKanbanStatus({ actionId: "a1", kanbanStatus: "CANCELLED" });
+
+      expect(updatedWith()).toMatchObject({ status: "CANCELLED" });
+    });
+
+    it("updateKanbanStatus never resurrects a DRAFT row", async () => {
+      stubKanbanRow({ status: "DRAFT", kanbanStatus: "TODO" });
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.updateKanbanStatus({ actionId: "a1", kanbanStatus: "IN_PROGRESS" });
+
+      expect(updatedWith().status).toBeUndefined();
+    });
+
+    /** The row `update` fetches — one shape serves the access check and currentAction. */
+    function stubUpdateRow(row: { status: string; kanbanStatus: string | null }) {
+      dbMock.action.findUnique.mockResolvedValue({
+        createdById: callerId,
+        projectId: null,
+        assignees: [],
+        status: row.status,
+        kanbanStatus: row.kanbanStatus,
+        completedAt: null,
+        scheduledStart: null,
+        scheduledEnd: null,
+        dueDate: null,
+        workspaceId: null,
+        name: "X",
+        description: null,
+        priority: "Quick",
+        epicId: null,
+        effortEstimate: null,
+        project: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+      dbMock.action.update.mockResolvedValue({
+        id: "a1",
+        workspaceId: null,
+        dailyPlanActions: [],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+    }
+
+    it("update with kanbanStatus DONE alone completes the coarse status", async () => {
+      stubUpdateRow({ status: "ACTIVE", kanbanStatus: "TODO" });
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.update({ id: "a1", kanbanStatus: "DONE" });
+
+      expect(updatedWith()).toMatchObject({ kanbanStatus: "DONE", status: "COMPLETED" });
+      expect(updatedWith().completedAt).toBeInstanceOf(Date);
+    });
+
+    it("update leaving DONE alone reactivates the coarse status", async () => {
+      stubUpdateRow({ status: "COMPLETED", kanbanStatus: "DONE" });
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.update({ id: "a1", kanbanStatus: "TODO" });
+
+      expect(updatedWith()).toMatchObject({ kanbanStatus: "TODO", status: "ACTIVE" });
+    });
+
+    it("update with an explicit status wins over the kanban sync", async () => {
+      stubUpdateRow({ status: "ACTIVE", kanbanStatus: "TODO" });
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.update({ id: "a1", kanbanStatus: "DONE", status: "ACTIVE" });
+
+      expect(updatedWith()).toMatchObject({ kanbanStatus: "DONE", status: "ACTIVE" });
+    });
+  });
 });

--- a/src/server/api/routers/__tests__/action.test.ts
+++ b/src/server/api/routers/__tests__/action.test.ts
@@ -1571,6 +1571,21 @@ describe("action router (mocked)", () => {
       await caller.action.updateKanbanStatus({ actionId: "a1", kanbanStatus: "DONE" });
 
       expect(updatedWith()).toMatchObject({ status: "COMPLETED" });
+      // Timestamp already present — must not be rewritten.
+      expect(updatedWith().completedAt).toBeUndefined();
+    });
+
+    it("updateKanbanStatus DONE backfills a missing completedAt on a legacy row", async () => {
+      // Same legacy shape but completedAt was never written; wasCompleted is
+      // true here, so gating the timestamp on it would leave a COMPLETED row
+      // with a null completedAt forever.
+      stubKanbanRow({ status: "ACTIVE", kanbanStatus: "DONE", completedAt: null });
+
+      const caller = createMockCaller({ userId: callerId, db: dbMock });
+      await caller.action.updateKanbanStatus({ actionId: "a1", kanbanStatus: "DONE" });
+
+      expect(updatedWith()).toMatchObject({ status: "COMPLETED" });
+      expect(updatedWith().completedAt).toBeInstanceOf(Date);
     });
 
     it("updateKanbanStatus out of DONE reactivates the coarse status", async () => {
@@ -1605,14 +1620,18 @@ describe("action router (mocked)", () => {
     });
 
     /** The row `update` fetches — one shape serves the access check and currentAction. */
-    function stubUpdateRow(row: { status: string; kanbanStatus: string | null }) {
+    function stubUpdateRow(row: {
+      status: string;
+      kanbanStatus: string | null;
+      completedAt?: Date | null;
+    }) {
       dbMock.action.findUnique.mockResolvedValue({
         createdById: callerId,
         projectId: null,
         assignees: [],
         status: row.status,
         kanbanStatus: row.kanbanStatus,
-        completedAt: null,
+        completedAt: row.completedAt ?? null,
         scheduledStart: null,
         scheduledEnd: null,
         dueDate: null,
@@ -1644,12 +1663,20 @@ describe("action router (mocked)", () => {
     });
 
     it("update leaving DONE alone reactivates the coarse status", async () => {
-      stubUpdateRow({ status: "COMPLETED", kanbanStatus: "DONE" });
+      stubUpdateRow({
+        status: "COMPLETED",
+        kanbanStatus: "DONE",
+        completedAt: new Date(),
+      });
 
       const caller = createMockCaller({ userId: callerId, db: dbMock });
       await caller.action.update({ id: "a1", kanbanStatus: "TODO" });
 
-      expect(updatedWith()).toMatchObject({ kanbanStatus: "TODO", status: "ACTIVE" });
+      expect(updatedWith()).toMatchObject({
+        kanbanStatus: "TODO",
+        status: "ACTIVE",
+        completedAt: null,
+      });
     });
 
     it("update with an explicit status wins over the kanban sync", async () => {

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -779,6 +779,22 @@ export const actionRouter = createTRPCRouter({
         ...updateData,
         ...(isCompleting && !wasCompleted && { completedAt: new Date() }),
         ...(isUncompleting && wasCompleted && { completedAt: null }),
+        // Callers that complete via kanbanStatus alone must move the coarse
+        // `status` too — list views filter on status === "ACTIVE" and would
+        // otherwise keep showing a kanban-DONE action (and vice versa). An
+        // explicit `status` in the input always wins; DELETED/DRAFT rows are
+        // left alone so a kanban move can't resurrect them.
+        ...(updateData.status === undefined &&
+          updateData.kanbanStatus !== undefined &&
+          currentAction &&
+          ["ACTIVE", "COMPLETED", "CANCELLED"].includes(currentAction.status) && {
+            status:
+              updateData.kanbanStatus === "DONE"
+                ? ("COMPLETED" as const)
+                : updateData.kanbanStatus === "CANCELLED"
+                  ? ("CANCELLED" as const)
+                  : ("ACTIVE" as const),
+          }),
         ...(updateData.priority !== undefined && { kanbanOrder: null }),
       };
 
@@ -971,6 +987,7 @@ export const actionRouter = createTRPCRouter({
         },
         select: {
           id: true,
+          status: true,
           kanbanStatus: true,
           completedAt: true,
           projectId: true,
@@ -995,11 +1012,25 @@ export const actionRouter = createTRPCRouter({
       const isUncompleting = input.kanbanStatus !== "DONE";
       const wasCompleted = action.kanbanStatus === "DONE";
 
-      // Prepare update data with completion timestamp
+      // Prepare update data with completion timestamp. The coarse `status`
+      // field moves in lockstep: list views (home overdue, "Assigned to you")
+      // filter on status === "ACTIVE", so a kanban DONE that left status
+      // ACTIVE would resurrect the action there on every load. DELETED/DRAFT
+      // rows are left alone — kanban moves must not resurrect them.
+      const statusForKanban =
+        input.kanbanStatus === "DONE"
+          ? ("COMPLETED" as const)
+          : input.kanbanStatus === "CANCELLED"
+            ? ("CANCELLED" as const)
+            : ("ACTIVE" as const);
+      const shouldSyncStatus =
+        ["ACTIVE", "COMPLETED", "CANCELLED"].includes(action.status) &&
+        action.status !== statusForKanban;
       const updateData = {
         kanbanStatus: input.kanbanStatus,
         ...(isCompleting && !wasCompleted && { completedAt: new Date() }),
         ...(isUncompleting && wasCompleted && { completedAt: null }),
+        ...(shouldSyncStatus && { status: statusForKanban }),
       };
 
       // Update the kanban status

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -777,8 +777,10 @@ export const actionRouter = createTRPCRouter({
       // Clear kanbanOrder when priority is updated to restore automatic sorting
       const finalUpdateData = {
         ...updateData,
-        ...(isCompleting && !wasCompleted && { completedAt: new Date() }),
-        ...(isUncompleting && wasCompleted && { completedAt: null }),
+        // Gated on the stored timestamp, not wasCompleted, so re-completing a
+        // legacy row (kanban DONE, completedAt never written) backfills it.
+        ...(isCompleting && !currentAction?.completedAt && { completedAt: new Date() }),
+        ...(isUncompleting && currentAction?.completedAt && { completedAt: null }),
         // Callers that complete via kanbanStatus alone must move the coarse
         // `status` too — list views filter on status === "ACTIVE" and would
         // otherwise keep showing a kanban-DONE action (and vice versa). An
@@ -1026,10 +1028,14 @@ export const actionRouter = createTRPCRouter({
       const shouldSyncStatus =
         ["ACTIVE", "COMPLETED", "CANCELLED"].includes(action.status) &&
         action.status !== statusForKanban;
+      // completedAt is gated on the stored timestamp, not on wasCompleted:
+      // on the legacy repair path (kanbanStatus already DONE, status still
+      // ACTIVE, completedAt never written) wasCompleted is true and would
+      // leave a COMPLETED row with a null completedAt.
       const updateData = {
         kanbanStatus: input.kanbanStatus,
-        ...(isCompleting && !wasCompleted && { completedAt: new Date() }),
-        ...(isUncompleting && wasCompleted && { completedAt: null }),
+        ...(isCompleting && !action.completedAt && { completedAt: new Date() }),
+        ...(isUncompleting && action.completedAt && { completedAt: null }),
         ...(shouldSyncStatus && { status: statusForKanban }),
       };
 

--- a/src/server/api/routers/action.ts
+++ b/src/server/api/routers/action.ts
@@ -775,21 +775,34 @@ export const actionRouter = createTRPCRouter({
 
       // Set completedAt timestamp when completing, clear when uncompleting
       // Clear kanbanOrder when priority is updated to restore automatic sorting
+      // A kanban column actually changing, as opposed to a full payload
+      // re-sending the current column: un-completing must only happen on a
+      // real change, or any unrelated edit that includes kanbanStatus would
+      // resurrect a completed action and clear its timestamp.
+      const kanbanChanged =
+        updateData.kanbanStatus !== undefined &&
+        updateData.kanbanStatus !== currentAction?.kanbanStatus;
       const finalUpdateData = {
         ...updateData,
         // Gated on the stored timestamp, not wasCompleted, so re-completing a
         // legacy row (kanban DONE, completedAt never written) backfills it.
         ...(isCompleting && !currentAction?.completedAt && { completedAt: new Date() }),
-        ...(isUncompleting && currentAction?.completedAt && { completedAt: null }),
+        ...((updateData.status === "ACTIVE" ||
+          (kanbanChanged && updateData.kanbanStatus !== "DONE")) &&
+          currentAction?.completedAt && { completedAt: null }),
         // Callers that complete via kanbanStatus alone must move the coarse
         // `status` too — list views filter on status === "ACTIVE" and would
         // otherwise keep showing a kanban-DONE action (and vice versa). An
         // explicit `status` in the input always wins; DELETED/DRAFT rows are
-        // left alone so a kanban move can't resurrect them.
+        // left alone; the sync toward ACTIVE fires only on a real column
+        // change, while DONE/CANCELLED also repair an already-matching column.
         ...(updateData.status === undefined &&
           updateData.kanbanStatus !== undefined &&
           currentAction &&
-          ["ACTIVE", "COMPLETED", "CANCELLED"].includes(currentAction.status) && {
+          ["ACTIVE", "COMPLETED", "CANCELLED"].includes(currentAction.status) &&
+          (updateData.kanbanStatus === "DONE" ||
+            updateData.kanbanStatus === "CANCELLED" ||
+            kanbanChanged) && {
             status:
               updateData.kanbanStatus === "DONE"
                 ? ("COMPLETED" as const)
@@ -1018,24 +1031,39 @@ export const actionRouter = createTRPCRouter({
       // field moves in lockstep: list views (home overdue, "Assigned to you")
       // filter on status === "ACTIVE", so a kanban DONE that left status
       // ACTIVE would resurrect the action there on every load. DELETED/DRAFT
-      // rows are left alone — kanban moves must not resurrect them.
+      // rows are left alone — kanban moves must not resurrect them. Toward
+      // DONE/CANCELLED the sync fires even without a column change so legacy
+      // rows get repaired; toward ACTIVE only on a real column change —
+      // re-sending the current column (e.g. a same-column reorder) must not
+      // resurrect an action whose status was completed by another path.
+      const kanbanChanged = input.kanbanStatus !== action.kanbanStatus;
       const statusForKanban =
         input.kanbanStatus === "DONE"
           ? ("COMPLETED" as const)
           : input.kanbanStatus === "CANCELLED"
             ? ("CANCELLED" as const)
             : ("ACTIVE" as const);
+      const statusIsSyncable = ["ACTIVE", "COMPLETED", "CANCELLED"].includes(
+        action.status,
+      );
       const shouldSyncStatus =
-        ["ACTIVE", "COMPLETED", "CANCELLED"].includes(action.status) &&
-        action.status !== statusForKanban;
+        statusIsSyncable &&
+        action.status !== statusForKanban &&
+        (statusForKanban !== "ACTIVE" || kanbanChanged);
       // completedAt is gated on the stored timestamp, not on wasCompleted:
       // on the legacy repair path (kanbanStatus already DONE, status still
       // ACTIVE, completedAt never written) wasCompleted is true and would
-      // leave a COMPLETED row with a null completedAt.
+      // leave a COMPLETED row with a null completedAt. Clearing follows the
+      // same rule as the ACTIVE sync: only on a real column change.
       const updateData = {
         kanbanStatus: input.kanbanStatus,
-        ...(isCompleting && !action.completedAt && { completedAt: new Date() }),
-        ...(isUncompleting && action.completedAt && { completedAt: null }),
+        ...(statusIsSyncable &&
+          isCompleting &&
+          !action.completedAt && { completedAt: new Date() }),
+        ...(statusIsSyncable &&
+          isUncompleting &&
+          kanbanChanged &&
+          action.completedAt && { completedAt: null }),
         ...(shouldSyncStatus && { status: statusForKanban }),
       };
 

--- a/src/server/api/routers/notification.ts
+++ b/src/server/api/routers/notification.ts
@@ -63,6 +63,7 @@ export const notificationRouter = createTRPCRouter({
       z
         .object({
           category: z.enum(CATEGORY_LIST).optional(),
+          unreadOnly: z.boolean().optional(),
           limit: z.number().int().min(1).max(50).default(20),
           cursor: z.string().optional(),
         })
@@ -74,6 +75,7 @@ export const notificationRouter = createTRPCRouter({
         where: {
           userId: ctx.session.user.id,
           ...(input?.category ? { category: input.category } : {}),
+          ...(input?.unreadOnly ? { readAt: null } : {}),
           ...firedWindow(),
         },
         orderBy: [{ createdAt: "desc" }, { id: "desc" }],


### PR DESCRIPTION
### **User description**
## What

Two home-page bugs reported from daily use:

1. **Mentions didn't stay dismissed.** The command-layout home (`YourWorkPanel`) listed read and unread mentions alike — "Mark all read" only removed the bold, and every reload brought the rows back. Both home inboxes now render unread mentions only, filtered **server-side** (`notification.list` gained `unreadOnly`), so any volume of read mentions can't crowd out an unread one. Marking a mention read removes it for good.

2. **A "done" action kept returning as Overdue.** The action detail page's status control calls `action.updateKanbanStatus`, which set `kanbanStatus: DONE` + `completedAt` but left the coarse `status` field `ACTIVE` — and the home page's lists filter on `status === 'ACTIVE'`, so the completed action reappeared on every load.

## How

- `updateKanbanStatus` (and `update` when the caller passes only `kanbanStatus`) now move `status` in lockstep: DONE → COMPLETED, CANCELLED → CANCELLED, any other column → ACTIVE. DELETED/DRAFT rows are never touched, and an explicit `status` in the input always wins.
- **Resurrection guard:** the ACTIVE-direction sync (and the `completedAt` clear) fires only on a *real* column change — a full-payload edit or same-column reorder that re-sends the current column can't flip a checkbox-completed action back to ACTIVE. DONE/CANCELLED sync unconditionally so legacy rows get repaired.
- `completedAt` is gated on the stored timestamp (not `wasCompleted`), so re-completing a legacy row backfills a missing timestamp.
- The home panels (`AttentionPanel`, `TodayPanel`, `YourWorkPanel`) additionally exclude `kanbanStatus DONE/CANCELLED` rows client-side, so **existing** legacy rows (status ACTIVE + kanbanStatus DONE) stop rendering immediately, without a data backfill.

## Testing

- 12 unit tests on the lockstep: both mutations, legacy-row repair + timestamp backfill, CANCELLED mapping, DRAFT no-resurrect, same-column-resend no-resurrect, explicit-status-wins. Full unit suite green; `tsc` clean.
- Verified in the dev fixture on **both** home layouts: seeded an action in the exact bug shape (status ACTIVE + kanbanStatus DONE, overdue) — it no longer renders; "Mark all read" survives a hard reload on both layouts.

No schema changes — safe for main.


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Sync coarse `status` with `kanbanStatus` on updates

- Guard against resurrecting completed actions on re-sends

- Add `unreadOnly` filter to `notification.list`

- Home panels hide kanban DONE/CANCELLED legacy rows

- 12 new unit tests for the lockstep logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["notification.list"] -- "new unreadOnly filter" --> B["YourWorkPanel / AttentionPanel show unread mentions only"]
  C["action.update / updateKanbanStatus"] -- "kanbanStatus → status lockstep" --> D["DONE→COMPLETED, CANCELLED→CANCELLED, else ACTIVE"]
  D -- "resurrection guard" --> E["ACTIVE sync only on real column change"]
  F["Home panels (Attention/Today/YourWork)"] -- "exclude kanbanStatus DONE/CANCELLED" --> G["legacy rows stop rendering"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.ts</strong><dd><code>Sync coarse status with kanbanStatus in both mutations</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/action.ts

<ul><li><code>update</code> now derives <code>status</code> from <code>kanbanStatus</code> when no explicit status is <br>passed (DONE→COMPLETED, CANCELLED→CANCELLED, else ACTIVE), skipping <br>DELETED/DRAFT rows.<br> <li> <code>updateKanbanStatus</code> selects <code>status</code> and applies the same lockstep via <br><code>shouldSyncStatus</code>/<code>statusForKanban</code>.<br> <li> <code>completedAt</code> is now gated on the stored timestamp so legacy rows get a <br>backfilled timestamp; clearing happens only on a real column change.<br> <li> Added <code>kanbanChanged</code> guard so full-payload edits or same-column <br>reorders can't resurrect completed actions.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/584/files#diff-5b198a3cc9e3495e32e4dcdf28771f225d15998a0c3ab9de63ef7f12941d1dbb">+70/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>YourWorkPanel.tsx</strong><dd><code>Render only unread mentions and hide kanban-done actions</code>&nbsp; </dd></summary>
<hr>

src/app/_components/home/YourWorkPanel.tsx

<ul><li>Mentions query now passes <code>unreadOnly: true</code>; read/unread branching <br>removed from row rendering.<br> <li> Unread dot and unread label style always applied; <code>readOnOpen</code> always <br>marks read.<br> <li> Active actions filter excludes <code>kanbanStatus</code> DONE/CANCELLED.<br> <li> Mentions list capped at 5 client-side.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/584/files#diff-71418f6266964f8d08641387305f6b186b7c4219082166976a90418900487ea6">+17/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AttentionPanel.tsx</strong><dd><code>Server-side unread mentions and kanban-done exclusion</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/home/activity/AttentionPanel.tsx

<ul><li>Mentions query uses <code>unreadOnly: true</code> with <code>limit: MAX_ROWS</code> instead of <br>deep 50-row fetch plus client filter.<br> <li> Removed client-side <code>readAt === null</code> filtering.<br> <li> Overdue filter excludes <code>kanbanStatus</code> DONE/CANCELLED.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/584/files#diff-d33211d90f6ccfa306f753ff60f8854000ab3892201becbc499c5b4a90570195">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TodayPanel.tsx</strong><dd><code>Exclude kanban done/cancelled actions from Today list</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/home/activity/TodayPanel.tsx

<ul><li>Active actions filter now also excludes <code>kanbanStatus</code> DONE/CANCELLED.<br> <li> Added explanatory comment about legacy rows.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/584/files#diff-a7e48fdbd264d7f08110ded619aed9c9a5cbd78f644115a5a09a42dbe2d36ee0">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>notification.ts</strong><dd><code>Add server-side unreadOnly filter to notification.list</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/notification.ts

<ul><li>Added optional <code>unreadOnly</code> boolean to the <code>list</code> input schema.<br> <li> Applies <code>readAt: null</code> to the query <code>where</code> clause when set.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/584/files#diff-7a4d7ed5cb5604efb6f21f81571ba47677e6cd15dad28e7b7ae60d0a9df394b6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.test.ts</strong><dd><code>Unit tests for kanbanStatus/status lockstep behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/__tests__/action.test.ts

<ul><li>New <code>kanbanStatus ↔ status lockstep</code> describe block with 12 tests.<br> <li> Covers DONE/CANCELLED/reactivation mapping, legacy row repair, <br>completedAt backfill and no-rewrite.<br> <li> Covers resurrection guards (same-column re-send, DRAFT rows) and <br>explicit-status-wins.<br> <li> Added <code>stubKanbanRow</code>/<code>stubUpdateRow</code> helpers for both mutations.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/584/files#diff-1f49e232606ea60cceb17f43536f374c6e1ad7e88b96115c502088f6e4556999">+216/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

