### PR TITLE
fix: send invited existing users straight to their new workspace, with a joined banner

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx
@@ -7,6 +7,7 @@ import { WorkspaceHomeConceptD as WorkspaceHomeCommand } from '~/app/_components
 import { WorkspaceHomeActivity } from '~/app/_components/home/WorkspaceHomeActivity';
 import { WorkspaceHomeCoaching } from '~/app/_components/home/WorkspaceHomeCoaching';
 import { GithubConnectCta } from '~/app/_components/home/GithubConnectCta';
+import { JoinedWorkspaceBanner } from '~/app/_components/home/JoinedWorkspaceBanner';
 import { validateHomeLayout } from '~/app/_components/home/HomeLayoutPicker';
 
 function WorkspaceHomeContent() {
@@ -45,6 +46,7 @@ function WorkspaceHomeContent() {
 
   return (
     <>
+      <JoinedWorkspaceBanner />
       {/* Activity layout shows GitHub in the rail widget; other layouts have no
           rail, so they keep the top Connect banner. */}
       {layout !== 'activity' && <GithubConnectCta />}

--- a/src/app/_components/home/JoinedWorkspaceBanner.tsx
+++ b/src/app/_components/home/JoinedWorkspaceBanner.tsx
@@ -33,6 +33,11 @@ function JoinedWorkspaceBannerInner({ workspaceId }: { workspaceId: string }) {
   const [dismissed, setDismissed] = useLocalStorage<boolean>({
     key: `joined-workspace-banner-dismissed:${workspaceId}`,
     defaultValue: false,
+    // Read synchronously on first client render — the deferred default would
+    // make a previously-dismissed banner flash (and fire its query) on every
+    // home visit. Safe here: SSR and first client render both output null
+    // regardless (query data hasn't loaded), so hydration can't mismatch.
+    getInitialValueInEffect: false,
   });
 
   const { data } = api.workspace.getRecentJoinContext.useQuery(

--- a/src/app/_components/home/JoinedWorkspaceBanner.tsx
+++ b/src/app/_components/home/JoinedWorkspaceBanner.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import {
+  ActionIcon,
+  Button,
+  Container,
+  Group,
+  Paper,
+  Text,
+  ThemeIcon,
+} from "@mantine/core";
+import { IconConfetti, IconX } from "@tabler/icons-react";
+import Link from "next/link";
+import { useLocalStorage } from "@mantine/hooks";
+import { api } from "~/trpc/react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+
+/**
+ * "You've joined this workspace" confirmation on the workspace home, shown to
+ * a recent joiner (see `workspace.getRecentJoinContext`: member, not the
+ * owner, joined within the last 7 days) with a pointer at where to start.
+ * Dismissal is per-workspace in localStorage — worst case the banner
+ * reappears on another device inside the 7-day window, which is harmless.
+ */
+export function JoinedWorkspaceBanner() {
+  const { workspaceId } = useWorkspace();
+  if (!workspaceId) return null;
+  // Keyed mount so the localStorage hook never sees its key change mid-life.
+  return <JoinedWorkspaceBannerInner key={workspaceId} workspaceId={workspaceId} />;
+}
+
+function JoinedWorkspaceBannerInner({ workspaceId }: { workspaceId: string }) {
+  const [dismissed, setDismissed] = useLocalStorage<boolean>({
+    key: `joined-workspace-banner-dismissed:${workspaceId}`,
+    defaultValue: false,
+  });
+
+  const { data } = api.workspace.getRecentJoinContext.useQuery(
+    { workspaceId },
+    { enabled: !dismissed },
+  );
+
+  if (dismissed || !data) return null;
+
+  return (
+    <Container size="lg" className="pt-8">
+      <Paper
+        p="md"
+        radius="md"
+        className="border border-accent-indigo/20 bg-gradient-to-r from-accent-indigo/10 to-accent-periwinkle/10"
+      >
+        <Group justify="space-between" wrap="nowrap" gap="md">
+          <Group gap="md" wrap="nowrap">
+            <ThemeIcon size="lg" radius="xl" variant="light" color="indigo">
+              <IconConfetti size={18} />
+            </ThemeIcon>
+            <div>
+              <Text fw={600} size="sm" className="text-text-primary">
+                You&apos;ve joined {data.workspaceName}
+              </Text>
+              <Text size="xs" className="text-text-secondary">
+                {data.inviterName
+                  ? `${data.inviterName} invited you — start with the team's projects to see what everyone is working on.`
+                  : "Start with the team's projects to see what everyone is working on."}
+              </Text>
+            </div>
+          </Group>
+          <Group gap="xs" wrap="nowrap" className="flex-shrink-0">
+            <Button
+              component={Link}
+              href={`/w/${data.workspaceSlug}/projects`}
+              variant="light"
+              size="xs"
+            >
+              Browse projects
+            </Button>
+            <ActionIcon
+              variant="subtle"
+              size="sm"
+              onClick={() => setDismissed(true)}
+              aria-label="Dismiss joined-workspace banner"
+            >
+              <IconX size={14} />
+            </ActionIcon>
+          </Group>
+        </Group>
+      </Paper>
+    </Container>
+  );
+}

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -79,13 +79,14 @@ export default function InviteAcceptPage() {
     invitation.isLoggedIn &&
     invitation.isMember;
   const workspaceSlug = invitation?.workspace.slug;
-  // A fresh invitee (hasn't finished welcome yet) goes through the invited
-  // welcome variant first; returning members go straight into the workspace.
-  const redirectTarget = invitation?.viewerCompletedWelcome
-    ? workspaceSlug
+  // Only a fresh invitee (brand-new account, welcome unfinished) goes through
+  // the invited welcome variant first; existing users land straight in the
+  // workspace they were just added to.
+  const redirectTarget = invitation?.viewerShouldSeeWelcome
+    ? "/welcome"
+    : workspaceSlug
       ? `/w/${workspaceSlug}`
-      : null
-    : "/welcome";
+      : null;
 
   useEffect(() => {
     if (shouldAutoRedirect && redirectTarget) {

--- a/src/server/api/routers/__tests__/workspaceInvitationRedirect.test.ts
+++ b/src/server/api/routers/__tests__/workspaceInvitationRedirect.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Unit tests for the invited-user landing flow:
+ *
+ * - `workspace.getInvitationByToken`'s `viewerShouldSeeWelcome` — the invite
+ *   accept page routes a signed-in invitee by this flag: only a genuinely NEW
+ *   account (welcome unfinished AND account under the 24h new-user window —
+ *   the same rule /home applies via resolveNewUserRedirect) goes through
+ *   /welcome; an existing user lands straight in the workspace they were
+ *   added to.
+ * - `workspace.getRecentJoinContext` — feeds the "You've joined this
+ *   workspace" banner on the workspace home; non-null only for a recent
+ *   non-owner joiner.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const USER_ID = "user-1";
+const WORKSPACE_ID = "ws-1";
+const TOKEN = "invite-token-1";
+const HOUR_MS = 60 * 60 * 1000;
+
+function mockInvitation(dbMock: DeepMockProxy<PrismaClient>) {
+  dbMock.workspaceInvitation.findUnique.mockResolvedValue({
+    id: "inv-1",
+    token: TOKEN,
+    email: `${USER_ID}@test.com`,
+    role: "member",
+    status: "accepted",
+    workspaceId: WORKSPACE_ID,
+    expiresAt: new Date(Date.now() + 24 * HOUR_MS),
+    acceptedAt: new Date(),
+    createdAt: new Date(),
+    workspace: {
+      id: WORKSPACE_ID,
+      name: "CLEAR",
+      slug: "clear",
+      type: "team",
+      _count: { members: 2 },
+      members: [],
+    },
+    createdBy: { name: "James Farrell", email: "james@test.com", image: null },
+  } as never);
+}
+
+function mockViewer(
+  dbMock: DeepMockProxy<PrismaClient>,
+  opts: {
+    accountAgeMs: number | null;
+    welcomeCompletedAt: Date | null;
+  },
+) {
+  // Membership lookup (isMember) — the viewer belongs to the workspace.
+  dbMock.workspaceUser.findUnique.mockResolvedValue({ userId: USER_ID } as never);
+  dbMock.user.findUnique.mockResolvedValue({
+    welcomeCompletedAt: opts.welcomeCompletedAt,
+    ownedWorkspaces:
+      opts.accountAgeMs === null
+        ? []
+        : [{ createdAt: new Date(Date.now() - opts.accountAgeMs) }],
+  } as never);
+}
+
+describe("workspace.getInvitationByToken — viewerShouldSeeWelcome", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    mockInvitation(dbMock);
+  });
+
+  it("routes a brand-new invitee (fresh account, welcome unfinished) through /welcome", async () => {
+    mockViewer(dbMock, { accountAgeMs: 1 * HOUR_MS, welcomeCompletedAt: null });
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    const result = await caller.workspace.getInvitationByToken({ token: TOKEN });
+
+    expect(result.viewerShouldSeeWelcome).toBe(true);
+    expect(result.isMember).toBe(true);
+  });
+
+  it("sends an existing user (old account, welcome never finished) straight to the workspace", async () => {
+    mockViewer(dbMock, {
+      accountAgeMs: 30 * 24 * HOUR_MS,
+      welcomeCompletedAt: null,
+    });
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    const result = await caller.workspace.getInvitationByToken({ token: TOKEN });
+
+    expect(result.viewerShouldSeeWelcome).toBe(false);
+  });
+
+  it("never routes a user who already completed welcome through /welcome, even on a fresh account", async () => {
+    mockViewer(dbMock, {
+      accountAgeMs: 1 * HOUR_MS,
+      welcomeCompletedAt: new Date(),
+    });
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    const result = await caller.workspace.getInvitationByToken({ token: TOKEN });
+
+    expect(result.viewerShouldSeeWelcome).toBe(false);
+  });
+
+  it("classifies a viewer owning no workspace as existing (no /welcome detour)", async () => {
+    mockViewer(dbMock, { accountAgeMs: null, welcomeCompletedAt: null });
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    const result = await caller.workspace.getInvitationByToken({ token: TOKEN });
+
+    expect(result.viewerShouldSeeWelcome).toBe(false);
+  });
+});
+
+describe("workspace.getRecentJoinContext", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+  });
+
+  function mockMembership(opts: { joinedAgoMs: number; ownerId?: string }) {
+    dbMock.workspaceUser.findUnique.mockResolvedValue({
+      joinedAt: new Date(Date.now() - opts.joinedAgoMs),
+      workspace: {
+        ownerId: opts.ownerId ?? "someone-else",
+        name: "CLEAR",
+        slug: "clear",
+      },
+    } as never);
+  }
+
+  it("returns join context (with inviter) for a member who joined recently via an invitation", async () => {
+    mockMembership({ joinedAgoMs: 2 * HOUR_MS });
+    dbMock.workspaceInvitation.findFirst.mockResolvedValue({
+      createdBy: { name: "James Farrell", email: "james@test.com" },
+    } as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    const result = await caller.workspace.getRecentJoinContext({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(result).toMatchObject({
+      workspaceName: "CLEAR",
+      workspaceSlug: "clear",
+      inviterName: "James Farrell",
+    });
+  });
+
+  it("still returns context (without inviter) for a member added directly, no invitation row", async () => {
+    mockMembership({ joinedAgoMs: 2 * HOUR_MS });
+    dbMock.workspaceInvitation.findFirst.mockResolvedValue(null as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    const result = await caller.workspace.getRecentJoinContext({
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(result).toMatchObject({ workspaceName: "CLEAR", inviterName: null });
+  });
+
+  it("returns null once the join is older than the 7-day window", async () => {
+    mockMembership({ joinedAgoMs: 8 * 24 * HOUR_MS });
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.workspace.getRecentJoinContext({ workspaceId: WORKSPACE_ID }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null for the workspace owner", async () => {
+    mockMembership({ joinedAgoMs: 2 * HOUR_MS, ownerId: USER_ID });
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.workspace.getRecentJoinContext({ workspaceId: WORKSPACE_ID }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null for a non-member", async () => {
+    dbMock.workspaceUser.findUnique.mockResolvedValue(null as never);
+
+    const caller = createMockCaller({ userId: USER_ID, db: dbMock });
+    await expect(
+      caller.workspace.getRecentJoinContext({ workspaceId: WORKSPACE_ID }),
+    ).resolves.toBeNull();
+  });
+});

--- a/src/server/api/routers/workspace.ts
+++ b/src/server/api/routers/workspace.ts
@@ -21,6 +21,7 @@ import {
   sendWorkspaceMemberAddedEmail,
 } from "~/server/services/EmailService";
 import { getPublicBaseUrlFromEnv } from "~/lib/urls";
+import { resolveNewUserRedirect } from "~/server/services/welcome/resolveNewUserRedirect";
 import { uploadToBlob, deleteFromBlob } from "~/lib/blob";
 import { getWorkspaceHomeStats } from "~/server/services/activity/workspaceHomeStats";
 import { getWorkspaceFocusSummary } from "~/server/services/activity/workspaceFocusSummary";
@@ -1444,7 +1445,17 @@ export const workspaceRouter = createTRPCRouter({
               .then((membership) => membership !== null),
             ctx.db.user.findUnique({
               where: { id: viewerId },
-              select: { welcomeCompletedAt: true },
+              select: {
+                welcomeCompletedAt: true,
+                // User has no createdAt column; the earliest owned workspace
+                // (the auto-created Personal one) stands in for account
+                // creation time — same proxy /home uses.
+                ownedWorkspaces: {
+                  orderBy: { createdAt: "asc" },
+                  take: 1,
+                  select: { createdAt: true },
+                },
+              },
             }),
           ])
         : [false, null];
@@ -1460,13 +1471,76 @@ export const workspaceRouter = createTRPCRouter({
         isLoggedIn: !!ctx.session?.user,
         isForCurrentUser: invitation.email === ctx.session?.user?.email,
         isMember,
-        // Logged-out viewers default to true so nothing changes for them —
-        // only a logged-in member who hasn't finished welcome gets routed
-        // through /welcome instead of straight into the workspace.
-        viewerCompletedWelcome: viewerId
-          ? viewer?.welcomeCompletedAt !== null &&
-            viewer?.welcomeCompletedAt !== undefined
-          : true,
+        // Only a genuinely NEW invitee (account under the new-user window,
+        // welcome unfinished — the same rule /home applies) is routed through
+        // the invited welcome variant. An existing user who was added to a
+        // workspace goes straight into it; /welcome would be a detour for an
+        // account that's already set up. Logged-out viewers default to false —
+        // they get the landing page anyway.
+        viewerShouldSeeWelcome: viewer
+          ? resolveNewUserRedirect({
+              createdAt: viewer.ownedWorkspaces[0]?.createdAt ?? null,
+              welcomeCompletedAt: viewer.welcomeCompletedAt,
+            }) !== null
+          : false,
+      };
+    }),
+
+  /**
+   * Context for the "You've joined this workspace" banner on the workspace
+   * home. Non-null only while the viewer is a recent joiner: a member (not
+   * the owner) whose membership started inside the last 7 days. The inviter
+   * name comes from the accepted invitation matching their email when one
+   * exists — members can also be added directly, so a missing invitation
+   * still shows the banner, just without the inviter line.
+   */
+  getRecentJoinContext: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const RECENT_JOIN_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+      const userId = ctx.session.user.id;
+
+      const membership = await ctx.db.workspaceUser.findUnique({
+        where: {
+          userId_workspaceId: { userId, workspaceId: input.workspaceId },
+        },
+        select: {
+          joinedAt: true,
+          workspace: { select: { ownerId: true, name: true, slug: true } },
+        },
+      });
+      if (!membership) return null;
+      if (membership.workspace.ownerId === userId) return null;
+
+      const joinedAgoMs = Date.now() - membership.joinedAt.getTime();
+      if (joinedAgoMs > RECENT_JOIN_WINDOW_MS) return null;
+
+      const email = ctx.session.user.email;
+      const invitation = email
+        ? await ctx.db.workspaceInvitation.findFirst({
+            where: {
+              email,
+              workspaceId: input.workspaceId,
+              status: "accepted",
+            },
+            orderBy: { acceptedAt: "desc" },
+            select: { createdBy: { select: { name: true, email: true } } },
+          })
+        : null;
+
+      // `??` alone would let a whitespace-only stored name through and render
+      // "  invited you" — treat blank as missing (same rule as the welcome
+      // page's resolveInvitedContext).
+      const inviterName =
+        invitation?.createdBy.name?.trim() ||
+        invitation?.createdBy.email?.trim() ||
+        null;
+
+      return {
+        workspaceName: membership.workspace.name,
+        workspaceSlug: membership.workspace.slug,
+        joinedAt: membership.joinedAt,
+        inviterName,
       };
     }),
 


### PR DESCRIPTION
### **User description**
## What

- Invite accept page no longer routes existing users to `/welcome`: only a genuinely new invitee (account under the 24h new-user window with welcome unfinished — the same `resolveNewUserRedirect` rule `/home` applies) goes through the invited welcome variant; everyone else lands straight on `/w/<slug>/home`.
- New `workspace.getRecentJoinContext` query + dismissible `JoinedWorkspaceBanner` on the workspace home: a non-owner member who joined within the last 7 days sees "You've joined {workspace}" with the inviter's name (when an accepted invitation exists) and a Browse-projects pointer. Dismissal is per-workspace in localStorage.
- Unit tests for both: the `viewerShouldSeeWelcome` routing decision (new/existing/completed/no-workspace viewers) and `getRecentJoinContext` (recent join with/without invitation, 7-day expiry, owner, non-member).

## Why

An existing user invited to a workspace was dropped on the `/welcome` getting-started page after signing in, instead of the workspace they just joined — and the workspace home gave no confirmation they'd joined or where to start.

Verified in the browser against a seeded fixture: banner renders for a recent non-owner member, dismiss persists across reload, owners never see it.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Route only genuinely new invitees to `/welcome`

- Existing invitees land directly in workspace

- New `getRecentJoinContext` query + joined banner

- Unit tests for routing flag and query


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Invite accept page"] -- "viewerShouldSeeWelcome" --> B["/welcome (new account only)"]
  A -- "existing user" --> C["/w/slug/home"]
  C --> D["JoinedWorkspaceBanner"]
  D -- "getRecentJoinContext" --> E["workspace router"]
  D -- "dismiss" --> F["localStorage per workspace"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspace.ts</strong><dd><code>New-user welcome flag and recent-join context query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/workspace.ts

<ul><li>Replaced <code>viewerCompletedWelcome</code> with <code>viewerShouldSeeWelcome</code>, computed <br>via <code>resolveNewUserRedirect</code> using earliest owned workspace <code>createdAt</code> as <br>account age proxy.<br> <li> Logged-out viewers now default to <code>false</code> (no welcome detour).<br> <li> Added new <code>getRecentJoinContext</code> protected query returning workspace <br>name/slug, <code>joinedAt</code> and inviter name for non-owner members who joined <br>within 7 days.<br> <li> Inviter name falls back from name to email, treating blank strings as <br>missing.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/585/files#diff-b94d59060e1c78a6a505a0a58d90bb366e921cdd053126776199f6abcee0f846">+82/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JoinedWorkspaceBanner.tsx</strong><dd><code>Add dismissible joined-workspace banner component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/_components/home/JoinedWorkspaceBanner.tsx

<ul><li>New client component rendering a dismissible "You've joined <br>{workspace}" banner with inviter name and Browse projects link.<br> <li> Uses <code>getRecentJoinContext</code> query, disabled when dismissed.<br> <li> Dismissal persisted per-workspace in localStorage with <br><code>getInitialValueInEffect: false</code> to avoid flashing.<br> <li> Wrapper keys the inner component by <code>workspaceId</code> to keep the storage <br>key stable.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/585/files#diff-0019a76e1bf73a6b4ea5967f248ecf1d29ea78cbd2d5a5cc6b46c21149e9d1a7">+95/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Render joined banner on workspace home</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx

<ul><li>Imports and renders <code>JoinedWorkspaceBanner</code> at the top of the workspace <br>home content.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/585/files#diff-cb8fc31ca7858c60c5248da93261ebdeacda7388f1c0576ff71f0f25ee3d1221">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Redirect existing invitees straight to the workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/invite/[token]/page.tsx

<ul><li>Redirect logic now keys off <code>viewerShouldSeeWelcome</code> instead of <br><code>viewerCompletedWelcome</code>.<br> <li> Existing users are sent to <code>/w/<slug></code> instead of <code>/welcome</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/585/files#diff-73c22ad002c46aa25771d8e244d322edcbfb0f1c74a3fc518706a620f293bcba">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workspaceInvitationRedirect.test.ts</strong><dd><code>Tests for invite redirect flag and join context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/api/routers/__tests__/workspaceInvitationRedirect.test.ts

<ul><li>New Vitest suite using <code>mockDeep<PrismaClient>()</code> and mocked auth/openai modules.<br> <li> Covers <code>viewerShouldSeeWelcome</code> for new, existing, welcome-completed and <br>workspace-less viewers.<br> <li> Covers <code>getRecentJoinContext</code> for recent join with/without invitation, <br>7-day expiry, owner and non-member cases.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/585/files#diff-61d6a03f4cd7ae2bacc8f29dc32372f0596b0244c47d1c62302c248f31772f70">+254/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

