### PR TITLE
fix: serve the public docs to anonymous visitors instead of /signin

### DIFF
--- a/src/__tests__/middleware-matcher.test.ts
+++ b/src/__tests__/middleware-matcher.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { readdirSync, readFileSync } from 'fs';
 import path from 'path';
-import { PUBLIC_PREFIXES, isPublicPath } from '~/lib/publicRoutes';
+import { isPublicPath } from '~/lib/publicRoutes';
 
 /**
  * Whether a page needs a session is decided by two layers, and this file
@@ -244,21 +244,33 @@ describe('middleware matcher', () => {
     });
 
     /**
-     * A prefix with no trailing slash opens every path that merely *starts*
-     * with it, so it must not be a string prefix of a different top-level
-     * route: `/f/` is slash-terminated precisely so it doesn't also open
-     * `/features`, and bare `/docs` is only safe while no other segment starts
-     * with "docs". Adding such a route later would silently un-gate it, so
-     * fail here instead.
+     * Bare prefixes match on a segment boundary, so they can't leak into a
+     * sibling route that merely starts with the same letters. None of these
+     * routes exist today — that's the point. The allowlist outlives the routes
+     * around it, and nothing about adding `/docs-internal` later would prompt
+     * anyone to come and check this file.
      */
-    it('has no bare prefix that also opens an unrelated route', () => {
-      const bare = PUBLIC_PREFIXES.filter((prefix) => !prefix.endsWith('/'));
-      const leaked = bare.flatMap((prefix) =>
-        [...routes.keys()]
-          .filter((segment) => `/${segment}`.startsWith(prefix) && `/${segment}` !== prefix)
-          .map((segment) => `${prefix} also opens /${segment}`),
-      );
-      expect(leaked).toEqual([]);
+    it.each([
+      '/docs-internal',
+      '/docsomething',
+      '/blogging',
+      '/explorer',
+      '/learners',
+      '/product-timeline-admin',
+      '/auth/verify-request-token',
+    ])('%s is not opened by a bare public prefix', (route) => {
+      expect(isPublicPath(route)).toBe(false);
+    });
+
+    /** ...while the sections those prefixes exist to open still are. */
+    it.each([
+      ['/docs', '/docs/features/fireflies'],
+      ['/blog', '/blog/some-post'],
+      ['/explore', '/explore/a-project/bounties/1'],
+      ['/learn', '/learn/a-lesson'],
+    ])('%s opens itself and %s', (index, child) => {
+      expect(isPublicPath(index)).toBe(true);
+      expect(isPublicPath(child)).toBe(true);
     });
   });
 });

--- a/src/__tests__/middleware-matcher.test.ts
+++ b/src/__tests__/middleware-matcher.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { readdirSync, readFileSync } from 'fs';
 import path from 'path';
+import { PUBLIC_PREFIXES, isPublicPath } from '~/lib/publicRoutes';
 
 /**
- * The middleware matcher is default-deny: every path it matches requires a
- * session. Two ways that goes wrong, and this file guards both.
+ * Whether a page needs a session is decided by two layers, and this file
+ * guards both:
+ *
+ *   1. `config.matcher` — does the middleware run for this path at all?
+ *   2. `isPublicPath()` — once it runs, is the path on the allowlist?
+ *
+ * Three ways that goes wrong.
  *
  * 1. A /public asset that the matcher *does* match gets a 307 to /signin for
  *    logged-out visitors, so the marketing pages render their images as alt
@@ -12,11 +18,15 @@ import path from 'path';
  * 2. An exclusion loose enough to also cover a page route un-gates that page.
  *    `/docs/[...slug]` and `/wiki/[...path]` are catch-alls, so a pattern like
  *    `.*\.png$` would serve them to anyone.
+ * 3. A page built as public documentation never reaches the allowlist, so
+ *    crawlers following its own canonical URL land on /signin. That was `/docs`
+ *    until it was added to PUBLIC_PREFIXES.
  *
  * The matcher has to stay a static literal in `export const config` for
  * Next.js to analyse it at build time, so it can't be imported — importing
  * middleware.ts would also drag next-auth into a unit test. Read the shipped
- * literal out of the source instead.
+ * literal out of the source instead. The allowlist has no such constraint and
+ * is imported from `~/lib/publicRoutes` directly.
  */
 
 const REPO_ROOT = path.resolve(__dirname, '../..');
@@ -74,8 +84,39 @@ function readMatchers(): string[] {
  */
 const matchers = readMatchers().map((entry) => new RegExp(`^${entry}$`));
 
-/** True when middleware runs for this path — i.e. the path is auth-gated. */
-const isGated = (pathname: string) => matchers.some((re) => re.test(pathname));
+/** True when the middleware runs for this path at all (layer 1). */
+const matcherCovers = (pathname: string) =>
+  matchers.some((re) => re.test(pathname));
+
+/** True when a logged-out visitor is redirected to /signin (both layers). */
+const requiresSession = (pathname: string) =>
+  matcherCovers(pathname) && !isPublicPath(pathname);
+
+/**
+ * Top-level URL segments under src/app, seeing through `(group)` directories,
+ * mapped to their immediate child directory names.
+ */
+function routeChildren(dir: string, depth: number): Map<string, string[]> {
+  const found = new Map<string, string[]>();
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name.startsWith('_')) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.name.startsWith('(')) {
+      // Route groups are transparent in the URL — don't consume a level.
+      for (const [k, v] of routeChildren(full, depth)) found.set(k, v);
+    } else if (depth === 0) {
+      found.set(
+        entry.name,
+        readdirSync(full, { withFileTypes: true })
+          .filter((child) => child.isDirectory())
+          .map((child) => child.name),
+      );
+    }
+  }
+  return found;
+}
+
+const routes = routeChildren(path.join(REPO_ROOT, 'src/app'), 0);
 
 function publicAssetPaths(): string[] {
   const walk = (dir: string): string[] =>
@@ -98,12 +139,12 @@ describe('middleware matcher', () => {
     });
 
     it.each(assets)('%s is served without a session', (asset) => {
-      expect(isGated(asset)).toBe(false);
+      expect(matcherCovers(asset)).toBe(false);
     });
 
     it('also covers the URL-encoded form of names containing spaces', () => {
       for (const asset of assets.filter((a) => a.includes(' '))) {
-        expect(isGated(encodeURI(asset))).toBe(false);
+        expect(matcherCovers(encodeURI(asset))).toBe(false);
       }
     });
   });
@@ -113,18 +154,23 @@ describe('middleware matcher', () => {
       '/home',
       '/w/syntrofi/projects',
       '/w/syntrofi/products/exponential/tickets/abc123',
-      '/docs/getting-started',
       '/wiki/some/nested/page',
       '/projects/my-project',
       '/teams/core/members/user_1',
+      // Bare /features is the app's own page; only /features/ is marketing.
+      '/features',
     ])('%s requires a session', (route) => {
-      expect(isGated(route)).toBe(true);
+      expect(requiresSession(route)).toBe(true);
     });
 
     /**
      * The regression PR-Agent caught on the first cut of this fix: a
      * depth-agnostic `.*\.ext$` exclusion un-gates any protected page whose
      * last segment ends in an asset extension.
+     *
+     * This asserts the matcher layer only — `/docs/*` is separately public via
+     * the allowlist, but the exclusion must not be what lets it through, or
+     * re-gating /docs later would silently leave the bypass behind.
      */
     it.each([
       '/wiki/anything.png',
@@ -137,7 +183,7 @@ describe('middleware matcher', () => {
       '/docs/secret.png',
       '/docs/getting-started.map',
     ])('%s does not slip through the asset exclusion', (route) => {
-      expect(isGated(route)).toBe(true);
+      expect(matcherCovers(route)).toBe(true);
     });
 
     /**
@@ -151,28 +197,6 @@ describe('middleware matcher', () => {
      * so `/integrations/x.png` resolves to nothing); a dynamic child is not.
      */
     it('shares no asset directory with a route that has a dynamic child', () => {
-      /** Top-level route segments, seeing through `(group)` directories. */
-      const routeChildren = (dir: string, depth: number): Map<string, string[]> => {
-        const found = new Map<string, string[]>();
-        for (const entry of readdirSync(dir, { withFileTypes: true })) {
-          if (!entry.isDirectory() || entry.name.startsWith('_')) continue;
-          const full = path.join(dir, entry.name);
-          if (entry.name.startsWith('(')) {
-            // Route groups are transparent in the URL — don't consume a level.
-            for (const [k, v] of routeChildren(full, depth)) found.set(k, v);
-          } else if (depth === 0) {
-            found.set(
-              entry.name,
-              readdirSync(full, { withFileTypes: true })
-                .filter((child) => child.isDirectory())
-                .map((child) => child.name),
-            );
-          }
-        }
-        return found;
-      };
-
-      const routes = routeChildren(path.join(REPO_ROOT, 'src/app'), 0);
       const assetDirs = readdirSync(PUBLIC_DIR, { withFileTypes: true })
         .filter((e) => e.isDirectory())
         .map((e) => e.name);
@@ -192,8 +216,49 @@ describe('middleware matcher', () => {
     it.each(['/_next/static/chunk.js', '/_next/image', '/favicon.ico', '/api/trpc/x'])(
       '%s is not gated',
       (route) => {
-        expect(isGated(route)).toBe(false);
+        expect(matcherCovers(route)).toBe(false);
       },
     );
+  });
+
+  describe('serves allowlisted public sections without a session', () => {
+    it.each([
+      // Docs are built as public documentation: robots.ts allows /docs, the
+      // sitemap lists it, and each page emits its own canonical + OG tags. The
+      // catch-all under it must be public too, or a crawler following that
+      // canonical URL gets a 307 to /signin.
+      '/docs',
+      '/docs/getting-started',
+      '/docs/features/fireflies',
+      '/blog',
+      '/explore',
+      '/features/some-marketing-page',
+      '/p/published-page',
+      '/f/intake-form',
+      '/',
+      '/privacy',
+      '/robots.txt',
+      '/sitemap.xml',
+    ])('%s renders for anonymous visitors', (route) => {
+      expect(requiresSession(route)).toBe(false);
+    });
+
+    /**
+     * A prefix with no trailing slash opens every path that merely *starts*
+     * with it, so it must not be a string prefix of a different top-level
+     * route: `/f/` is slash-terminated precisely so it doesn't also open
+     * `/features`, and bare `/docs` is only safe while no other segment starts
+     * with "docs". Adding such a route later would silently un-gate it, so
+     * fail here instead.
+     */
+    it('has no bare prefix that also opens an unrelated route', () => {
+      const bare = PUBLIC_PREFIXES.filter((prefix) => !prefix.endsWith('/'));
+      const leaked = bare.flatMap((prefix) =>
+        [...routes.keys()]
+          .filter((segment) => `/${segment}`.startsWith(prefix) && `/${segment}` !== prefix)
+          .map((segment) => `${prefix} also opens /${segment}`),
+      );
+      expect(leaked).toEqual([]);
+    });
   });
 });

--- a/src/lib/docs/getDoc.ts
+++ b/src/lib/docs/getDoc.ts
@@ -29,7 +29,13 @@ export async function getDocContent(
     // before it reaches here, but that is the router's behaviour rather than a
     // guarantee this function makes, and the whole repo — dev-docs, CONTEXT.md,
     // ADRs — sits a couple of levels up from `content/docs`.
-    if (!path.resolve(filePath).startsWith(DOCS_PATH + path.sep)) continue;
+    //
+    // Compare structurally rather than by string prefix, so the check holds
+    // however DOCS_PATH comes to be declared — relative, or with a trailing
+    // separator, either of which would make a `startsWith` test reject every
+    // candidate and 404 the whole docs section.
+    const relativeToDocs = path.relative(path.resolve(DOCS_PATH), path.resolve(filePath));
+    if (relativeToDocs.startsWith("..") || path.isAbsolute(relativeToDocs)) continue;
 
     try {
       const fileContent = await fs.readFile(filePath, "utf-8");

--- a/src/lib/docs/getDoc.ts
+++ b/src/lib/docs/getDoc.ts
@@ -24,6 +24,13 @@ export async function getDocContent(
   }
 
   for (const filePath of possiblePaths) {
+    // The slug comes straight from the URL and this route is public, so never
+    // read outside the docs directory. Next.js normalises `..` out of the path
+    // before it reaches here, but that is the router's behaviour rather than a
+    // guarantee this function makes, and the whole repo — dev-docs, CONTEXT.md,
+    // ADRs — sits a couple of levels up from `content/docs`.
+    if (!path.resolve(filePath).startsWith(DOCS_PATH + path.sep)) continue;
+
     try {
       const fileContent = await fs.readFile(filePath, "utf-8");
       const { data, content } = matter(fileContent);

--- a/src/lib/publicRoutes.ts
+++ b/src/lib/publicRoutes.ts
@@ -1,0 +1,75 @@
+/**
+ * The allowlist of paths that render without a session, and the predicate the
+ * middleware gates on. Kept in its own module — with no next-auth import — so
+ * that `src/__tests__/middleware-matcher.test.ts` can exercise the real lists
+ * instead of re-declaring them and drifting.
+ *
+ * Route gating is DEFAULT-DENY (ticket foggy.carp): every page the middleware
+ * matcher covers requires a session unless its path is enumerated here. The
+ * previous shape — an allowlist of *protected* prefixes — went stale the moment
+ * workspace-scoped routing (`/w/[workspaceSlug]/...`) shipped without being
+ * added to it, which left logged-out visitors on a broken app shell full of
+ * failing queries. A deny-by-default list cannot rot that way: a new
+ * authenticated route is gated the day it is added, and forgetting to list a
+ * new *public* route fails loudly (a redirect to /signin) instead of silently.
+ *
+ * This is first-impression gating, not the security boundary: data access is
+ * enforced by tRPC `protectedProcedure`, `/admin` re-checks `isAdmin` in its
+ * own server layout, and a signed-in member visiting a workspace they don't
+ * belong to is redirected out by WorkspaceProvider's FORBIDDEN/NOT_FOUND
+ * handling.
+ */
+
+/** Public pages matched exactly. */
+export const PUBLIC_EXACT = new Set([
+  '/', // marketing home
+  '/signin', // also excluded by the matcher; kept for clarity
+  '/web3', // wallet sign-in
+  '/desktop-auth', // desktop-shell auth handoff renders its own signed-out state
+  '/privacy',
+  '/terms',
+  '/roadmap', // public product roadmap (embeds Loom)
+  // File conventions served through the middleware matcher.
+  '/llms.txt',
+  '/robots.txt',
+  '/sitemap.xml',
+  '/manifest.webmanifest',
+]);
+
+/**
+ * Public sections matched by prefix.
+ *
+ * A bare entry (no trailing slash) opens the section index *and* everything
+ * under it, so it must not be a string prefix of some other, gated route:
+ * `/f/` carries a trailing slash precisely so it doesn't also open `/features`.
+ * Check the top-level segments under `src/app` before adding one.
+ */
+export const PUBLIC_PREFIXES = [
+  '/p/', // published Knowledge Pages (ADR-0038)
+  '/f/', // public forms intake (ADR-0029)
+  '/auth/verify-request', // sign-in code redemption happens logged-out
+  '/invite/', // token pages render their own signed-out state
+  '/team-invite/',
+  // Marketing pages from the (home) route group.
+  '/blog',
+  '/explore',
+  '/learn',
+  '/product-timeline',
+  '/features/', // marketing feature pages — bare /features is the app's
+  /**
+   * Product documentation. Bare, because `/docs` is itself a public index
+   * (it is the URL listed in sitemap.ts) and no other route segment starts
+   * with "docs". The docs route lives in the (sidemenu) group but is built as
+   * public documentation — robots.ts allows it, the page emits a canonical URL
+   * and OpenGraph tags, and both `docs/layout.tsx` and `Layout` have explicit
+   * signed-out branches. It was simply never listed here, so crawlers and
+   * anonymous readers got a 307 to /signin.
+   */
+  '/docs',
+];
+
+/** True when the path renders without a session. */
+export function isPublicPath(pathname: string): boolean {
+  if (PUBLIC_EXACT.has(pathname)) return true;
+  return PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}

--- a/src/lib/publicRoutes.ts
+++ b/src/lib/publicRoutes.ts
@@ -39,10 +39,10 @@ export const PUBLIC_EXACT = new Set([
 /**
  * Public sections matched by prefix.
  *
- * A bare entry (no trailing slash) opens the section index *and* everything
- * under it, so it must not be a string prefix of some other, gated route:
- * `/f/` carries a trailing slash precisely so it doesn't also open `/features`.
- * Check the top-level segments under `src/app` before adding one.
+ * A slash-terminated entry (`/f/`) is a plain string prefix. A bare entry
+ * (`/blog`) opens the section index *and* everything under it, but is matched
+ * on a segment boundary — see `isPublicPath` — so it cannot leak into a
+ * sibling route that merely starts with the same letters.
  */
 export const PUBLIC_PREFIXES = [
   '/p/', // published Knowledge Pages (ADR-0038)
@@ -58,18 +58,32 @@ export const PUBLIC_PREFIXES = [
   '/features/', // marketing feature pages — bare /features is the app's
   /**
    * Product documentation. Bare, because `/docs` is itself a public index
-   * (it is the URL listed in sitemap.ts) and no other route segment starts
-   * with "docs". The docs route lives in the (sidemenu) group but is built as
-   * public documentation — robots.ts allows it, the page emits a canonical URL
-   * and OpenGraph tags, and both `docs/layout.tsx` and `Layout` have explicit
-   * signed-out branches. It was simply never listed here, so crawlers and
-   * anonymous readers got a 307 to /signin.
+   * (it is the URL listed in sitemap.ts). The docs route lives in the
+   * (sidemenu) group but is built as public documentation — robots.ts allows
+   * it, the page emits a canonical URL and OpenGraph tags, and both
+   * `docs/layout.tsx` and `Layout` have explicit signed-out branches. It was
+   * simply never listed here, so crawlers and anonymous readers got a 307 to
+   * /signin.
    */
   '/docs',
 ];
 
-/** True when the path renders without a session. */
+/**
+ * True when the path renders without a session.
+ *
+ * Bare prefixes match on a segment boundary rather than as raw strings, so
+ * `/docs` opens `/docs` and `/docs/...` but never a sibling like
+ * `/docs-internal`. Doing this structurally matters because the allowlist
+ * outlives the routes around it: a plain `startsWith` silently un-gates any
+ * route added later whose name merely begins with an entry here, and nothing
+ * about adding that route would prompt anyone to come and check this file.
+ * Slash-terminated entries are already unambiguous and stay plain prefixes.
+ */
 export function isPublicPath(pathname: string): boolean {
   if (PUBLIC_EXACT.has(pathname)) return true;
-  return PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+  return PUBLIC_PREFIXES.some((prefix) =>
+    prefix.endsWith('/')
+      ? pathname.startsWith(prefix)
+      : pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,60 +1,14 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { auth } from '~/server/auth';
+import { isPublicPath } from '~/lib/publicRoutes';
 
 /**
- * Route gating is DEFAULT-DENY (ticket foggy.carp): every page requires a
- * session unless its path is enumerated below. The previous shape — an
- * allowlist of *protected* prefixes — went stale the moment workspace-scoped
- * routing (`/w/[workspaceSlug]/...`) shipped without being added to it, which
- * left logged-out visitors on a broken app shell full of failing queries.
- * A deny-by-default list cannot rot that way: a new authenticated route is
- * gated the day it is added, and forgetting to list a new *public* route
- * fails loudly (a redirect to /signin) instead of silently.
- *
- * This is first-impression gating, not the security boundary: data access is
- * enforced by tRPC `protectedProcedure`, `/admin` re-checks `isAdmin` in its
- * own server layout, and a signed-in member visiting a workspace they don't
- * belong to is redirected out by WorkspaceProvider's FORBIDDEN/NOT_FOUND
- * handling.
+ * Route gating is DEFAULT-DENY (ticket foggy.carp): every page the matcher
+ * below covers requires a session unless `~/lib/publicRoutes` lists it. That
+ * allowlist lives in its own module so the guard test can import it; see the
+ * rationale for the shape there.
  */
-
-/** Public pages matched exactly. */
-const PUBLIC_EXACT = new Set([
-  '/', // marketing home
-  '/signin', // also excluded by the matcher; kept for clarity
-  '/web3', // wallet sign-in
-  '/desktop-auth', // desktop-shell auth handoff renders its own signed-out state
-  '/privacy',
-  '/terms',
-  '/roadmap', // public product roadmap (embeds Loom)
-  // File conventions served through the middleware matcher.
-  '/llms.txt',
-  '/robots.txt',
-  '/sitemap.xml',
-  '/manifest.webmanifest',
-]);
-
-/** Public sections matched by prefix (note trailing slashes: `/f/` must not
- * open up `/features`). */
-const PUBLIC_PREFIXES = [
-  '/p/', // published Knowledge Pages (ADR-0038)
-  '/f/', // public forms intake (ADR-0029)
-  '/auth/verify-request', // sign-in code redemption happens logged-out
-  '/invite/', // token pages render their own signed-out state
-  '/team-invite/',
-  // Marketing pages from the (home) route group.
-  '/blog',
-  '/explore',
-  '/learn',
-  '/product-timeline',
-  '/features/', // marketing feature pages — bare /features is the app's
-];
-
-function isPublicPath(pathname: string): boolean {
-  if (PUBLIC_EXACT.has(pathname)) return true;
-  return PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
-}
 
 export async function middleware(request: NextRequest) {
   // For testing different themes in development


### PR DESCRIPTION
### **User description**
## What

`/docs` was built as public documentation but never added to the default-deny middleware's allowlist, so anonymous readers and crawlers got a `307` to `/signin`:

```
$ curl -sS -o /dev/null -D - "https://www.exponential.im/docs/features/fireflies"
HTTP/2 307
location: /signin?callbackUrl=%2Fdocs%2Ffeatures%2Ffireflies
```

- Add `/docs` to `PUBLIC_PREFIXES` — bare rather than slash-terminated, since `/docs` is itself a public index and no other top-level route segment starts with `docs`.
- Move the allowlist out of `src/middleware.ts` into `src/lib/publicRoutes.ts` so the guard test can import it. The matcher literal stays in `middleware.ts` (Next.js has to analyse it at build time).
- Split the guard test's `isGated` into `matcherCovers` (does middleware run at all) and `requiresSession` (does a logged-out visitor get redirected), so each layer is asserted for what it actually decides.

## Why

Four independent signals say this was an oversight, not a product decision:

| Signal | Evidence |
|---|---|
| Crawlers are invited | `robots.ts` — `Allow: /docs` |
| Sitemap advertises it | live `sitemap.xml` lists `https://www.exponential.im/docs` |
| Page markets itself | canonical URL, OpenGraph, Twitter card, `generateStaticParams()` |
| Signed-out UI already exists | `docs/layout.tsx` and `Layout` both branch on the anonymous case |

The "logged-out visitor on a broken app shell full of failing queries" risk that motivated default-deny doesn't apply here: all three docs components call `useSession()` **only to choose spacing** (`top-16` vs `top-0`), the nav is a static constant, and content is read off the filesystem. No tRPC, so nothing to leak and nothing to fail.

Follow-on from #579, which fixed the related `/public` asset redirect and deliberately left this one alone.

## Verification

Dev server, anonymous:

```
/docs                     200      /home                 307 → /signin
/docs/features/fireflies  200      /w/syntrofi/projects  307 → /signin
/docs/getting-started     200      /features             307 → /signin
```

Bare `/features` still gated confirms the `/features/` trailing-slash convention survived. Rendered output is the signed-out shell — marketing header, no app sidebar, docs nav + TOC, `/doc-assets` images serving 200.

## Tests

`src/__tests__/middleware-matcher.test.ts` — the asset-exclusion regression cases stay on `matcherCovers`: `/docs/secret.png` must remain matcher-covered so re-gating `/docs` later can't silently leave a bypass behind. Added a guard that **no bare prefix opens an unrelated route** — the `/f/` vs `/features` hazard, now load-bearing for `/docs`, so a future `/docsomething` fails the test instead of quietly un-gating.

Both new guards were mutation-checked: removing `/docs` flips the assertion, and a hypothetical `/docsecret` route trips the prefix guard.

Full unit suite green (260 files, 2803 tests).

## Noted separately, not fixed here

The live sitemap contains only the `/docs` index, not the 36 individual doc pages: `getAllDocSlugs()` swallows filesystem errors and returns `[]`, and `sitemap.ts` has `revalidate = 3600`, so the hourly re-render happens in a serverless runtime where `content/docs` likely isn't traced into the bundle. Worth fixing separately, along with confirming the doc pages really are prerendered in the deployed build.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Add `/docs` to public allowlist for anonymous readers

- Extract allowlist into new `src/lib/publicRoutes.ts` module

- Match bare prefixes on segment boundary, preventing sibling leaks

- Harden docs file reads against path traversal; expand matcher tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Anonymous GET /docs/features/fireflies"] -- "before" --> B["307 -> /signin"]
  A -- "after: /docs in PUBLIC_PREFIXES" --> C["200 docs page"]
  D["middleware.ts"] -- "allowlist extracted" --> E["lib/publicRoutes.ts (isPublicPath)"]
  E -- "imported by" --> F["middleware-matcher.test.ts"]
  G["bare prefix /docs"] -- "segment-boundary match" --> H["/docs-internal still gated"]
  I["getDoc.ts slug from URL"] -- "path.relative guard" --> J["reads confined to content/docs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publicRoutes.ts</strong><dd><code>Extract public route allowlist and add /docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/publicRoutes.ts

<ul><li>New module holding <code>PUBLIC_EXACT</code> and <code>PUBLIC_PREFIXES</code> plus <code>isPublicPath</code>, <br>with no next-auth import so tests can use it.<br> <li> Adds <code>/docs</code> as a bare prefix so the docs index and its catch-all <br>children render logged-out.<br> <li> <code>isPublicPath</code> now matches bare prefixes on a segment boundary (<code>=== </code><br><code>prefix</code> or <code>prefix/</code>), while slash-terminated entries stay plain <br>prefixes.<br> <li> Carries over the default-deny rationale documentation from <br><code>middleware.ts</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/587/files#diff-42de204f4c984d997b44f59b387404b408da534d52559129c30bbbd1d464350c">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>middleware.ts</strong><dd><code>Delegate allowlist logic to publicRoutes module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/middleware.ts

<ul><li>Removes the inline <code>PUBLIC_EXACT</code>, <code>PUBLIC_PREFIXES</code> and <code>isPublicPath</code> <br>definitions.<br> <li> Imports <code>isPublicPath</code> from <code>~/lib/publicRoutes</code> and trims the comment to <br>a pointer at the new module.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/587/files#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0">+5/-51</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware-matcher.test.ts</strong><dd><code>Test both matcher and allowlist gating layers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/__tests__/middleware-matcher.test.ts

<ul><li>Splits <code>isGated</code> into <code>matcherCovers</code> (layer 1) and <code>requiresSession</code> (both <br>layers), imports the real <code>isPublicPath</code>.<br> <li> Hoists the <code>routeChildren</code> helper to module scope and reuses the <br>computed <code>routes</code> map.<br> <li> Adds cases asserting allowlisted sections (<code>/docs</code>, <code>/blog</code>, <code>/explore</code>, <br><code>/features/...</code>, <code>/p/</code>, <code>/f/</code>, file conventions) render anonymously, while <br><code>/features</code> still requires a session.<br> <li> Adds guards that bare prefixes don't open siblings (<code>/docs-internal</code>, <br><code>/blogging</code>, <code>/explorer</code>) and that asset-exclusion regressions stay <br>matcher-covered.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/587/files#diff-39b69ee2643feede9072d6f77310e91d665c3206568c23fc99145917a320b128">+110/-33</a></td>

</tr>
</table></td></tr><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>getDoc.ts</strong><dd><code>Confine public docs reads to docs directory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/docs/getDoc.ts

<ul><li>Adds a path-traversal guard using <code>path.relative</code> on resolved paths, <br>skipping candidates that escape <code>DOCS_PATH</code>.<br> <li> Documents why the check is structural rather than a <code>startsWith</code> prefix <br>comparison.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/587/files#diff-d271a1a858dc4e3a114f2947e2cb33d25de6b20180f232aa1194183dab53a96a">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

