### PR TITLE
feat(mastra): let agents set the do-date (scheduledStart) on created actions

### DIFF
--- a/src/server/api/routers/__tests__/mastra.integration.test.ts
+++ b/src/server/api/routers/__tests__/mastra.integration.test.ts
@@ -347,7 +347,7 @@ describe("mastra action creation — do-date (scheduledStart) handling", () => {
     db = getTestDb();
   });
 
-  it("createAction persists an explicit scheduledStart alongside dueDate", async () => {
+  it("createAction persists an explicit scheduledStart (dueDate stays null)", async () => {
     const user = await createUser(db);
     const project = await createProject(db, { createdById: user.id });
 
@@ -415,14 +415,20 @@ describe("mastra action creation — do-date (scheduledStart) handling", () => {
   it("quickCreateAction: without explicit dates the text parser still sets the do-date", async () => {
     const user = await createUser(db);
 
+    // chrono resolves "today" to the current instant, so assert against a
+    // tight window around the call instead of comparing day strings — the
+    // latter flakes if the run crosses midnight between parse and assert.
+    const before = Date.now();
     const caller = createTestCaller(user.id);
     const { action } = await caller.mastra.quickCreateAction({
       text: "Buy milk today",
     });
+    const after = Date.now();
 
     const persisted = await db.action.findUnique({ where: { id: action.id } });
     expect(persisted?.scheduledStart).not.toBeNull();
-    const today = new Date();
-    expect(persisted?.scheduledStart?.toDateString()).toBe(today.toDateString());
+    const scheduled = persisted!.scheduledStart!.getTime();
+    expect(scheduled).toBeGreaterThanOrEqual(before - 60_000);
+    expect(scheduled).toBeLessThanOrEqual(after + 60_000);
   });
 });

--- a/src/server/api/routers/__tests__/mastra.integration.test.ts
+++ b/src/server/api/routers/__tests__/mastra.integration.test.ts
@@ -17,6 +17,7 @@ import {
   createWorkspace,
   addWorkspaceMember,
   createGoal,
+  createProject,
 } from "~/test/factories";
 
 describe("mastra.addGoalComment", () => {
@@ -336,5 +337,92 @@ describe("mastra.createCrmContact (legacy) workspace resolution", () => {
     expect(result.created).toBe(true);
     const persisted = await db.crmContact.findUnique({ where: { id: result.contactId! } });
     expect(persisted?.workspaceId).toBe(ws.id);
+  });
+});
+
+describe("mastra action creation — do-date (scheduledStart) handling", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  it("createAction persists an explicit scheduledStart alongside dueDate", async () => {
+    const user = await createUser(db);
+    const project = await createProject(db, { createdById: user.id });
+
+    const doDate = "2026-08-14T00:00:00.000Z";
+    const caller = createTestCaller(user.id);
+    const { action } = await caller.mastra.createAction({
+      projectId: project.id,
+      name: "Ship the fix",
+      priority: "Quick",
+      scheduledStart: doDate,
+    });
+
+    expect(action.scheduledStart).toBe(doDate);
+    const persisted = await db.action.findUnique({ where: { id: action.id } });
+    expect(persisted?.scheduledStart?.toISOString()).toBe(doDate);
+    expect(persisted?.dueDate).toBeNull();
+  });
+
+  it("createAction rejects a malformed scheduledStart instead of persisting Invalid Date", async () => {
+    const user = await createUser(db);
+    const project = await createProject(db, { createdById: user.id });
+
+    const caller = createTestCaller(user.id);
+    await expect(
+      caller.mastra.createAction({
+        projectId: project.id,
+        name: "Bad date",
+        priority: "Quick",
+        scheduledStart: "not-a-date",
+      }),
+    ).rejects.toThrow(/scheduledStart/);
+  });
+
+  it("quickCreateAction: explicit scheduledStart wins over the text-parsed date", async () => {
+    const user = await createUser(db);
+
+    // Text says "tomorrow", but the agent resolved the user's intent to an
+    // explicit do-date — the explicit value must win.
+    const doDate = "2026-08-14T00:00:00.000Z";
+    const caller = createTestCaller(user.id);
+    const { action } = await caller.mastra.quickCreateAction({
+      text: "Buy milk tomorrow",
+      scheduledStart: doDate,
+    });
+
+    const persisted = await db.action.findUnique({ where: { id: action.id } });
+    expect(persisted?.scheduledStart?.toISOString()).toBe(doDate);
+  });
+
+  it("quickCreateAction: explicit scheduledStart applies when the rewritten text has no date phrase", async () => {
+    const user = await createUser(db);
+
+    const doDate = "2026-08-14T00:00:00.000Z";
+    const caller = createTestCaller(user.id);
+    const { action } = await caller.mastra.quickCreateAction({
+      text: "Buy milk",
+      scheduledStart: doDate,
+    });
+
+    expect(action.scheduledStart).toBe(doDate);
+    const persisted = await db.action.findUnique({ where: { id: action.id } });
+    expect(persisted?.scheduledStart?.toISOString()).toBe(doDate);
+  });
+
+  it("quickCreateAction: without explicit dates the text parser still sets the do-date", async () => {
+    const user = await createUser(db);
+
+    const caller = createTestCaller(user.id);
+    const { action } = await caller.mastra.quickCreateAction({
+      text: "Buy milk today",
+    });
+
+    const persisted = await db.action.findUnique({ where: { id: action.id } });
+    expect(persisted?.scheduledStart).not.toBeNull();
+    const today = new Date();
+    expect(persisted?.scheduledStart?.toDateString()).toBe(today.toDateString());
   });
 });

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -1186,7 +1186,7 @@ export const mastraRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
-      console.log(`🎯 [tRPC quickCreateAction] RECEIVED: text="${input.text}", projectId=${input.projectId || "none"}, priority=${input.priority ?? "none"}, scheduledStart=${input.scheduledStart ?? "none"}, dueDate=${input.dueDate ?? "none"}`);
+      console.log(`🎯 [tRPC quickCreateAction] RECEIVED: text="${input.text}", projectId=${input.projectId ?? "none"}, priority=${input.priority ?? "none"}, scheduledStart=${input.scheduledStart ?? "none"}, dueDate=${input.dueDate ?? "none"}`);
 
       // Use the same parsing logic as action.quickCreate
       const { parseActionInput } = await import("~/server/services/parsing/parseActionInput");

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -1113,13 +1113,14 @@ export const mastraRouter = createTRPCRouter({
       name: z.string().min(1),
       description: z.string().optional(),
       priority: z.enum(PRIORITY_VALUES),
-      dueDate: z.string().optional(), // ISO string
+      dueDate: z.string().optional(), // ISO string — deadline
+      scheduledStart: z.string().optional(), // ISO string — do-date (the day the user plans to DO it; what /today keys on)
     }))
     .mutation(async ({ ctx, input }) => {
       // Use authenticated user's ID from session
       const userId = ctx.session.user.id;
 
-      console.log(`🔧 [tRPC createAction] RECEIVED: projectId=${input.projectId}, name="${input.name}", priority=${input.priority}, dueDate=${input.dueDate || "none"}, userId=${userId}`);
+      console.log(`🔧 [tRPC createAction] RECEIVED: projectId=${input.projectId}, name="${input.name}", priority=${input.priority}, dueDate=${input.dueDate || "none"}, scheduledStart=${input.scheduledStart || "none"}, userId=${userId}`);
 
       // Verify user has access to this project via all access paths
       const access = await getProjectAccess(ctx.db, userId, input.projectId);
@@ -1141,7 +1142,8 @@ export const mastraRouter = createTRPCRouter({
           name: input.name,
           description: input.description,
           priority: input.priority,
-          dueDate: input.dueDate ? new Date(input.dueDate) : null,
+          dueDate: parseAgentDate(input.dueDate, "dueDate"),
+          scheduledStart: parseAgentDate(input.scheduledStart, "scheduledStart"),
           projectId: input.projectId,
           createdById: userId,
           workspaceId: mastraProject?.workspaceId ?? null,
@@ -1158,6 +1160,7 @@ export const mastraRouter = createTRPCRouter({
           status: action.status,
           priority: action.priority,
           dueDate: action.dueDate?.toISOString(),
+          scheduledStart: action.scheduledStart?.toISOString(),
           projectId: action.projectId,
         }
       };
@@ -1171,11 +1174,18 @@ export const mastraRouter = createTRPCRouter({
       // Canonical priority enum. Optional and backward-compatible: when omitted,
       // the action falls back to "Quick" (the historical hardcoded value).
       priority: z.enum(PRIORITY_VALUES).optional(),
+      // Explicit dates (ISO strings). Agents often rewrite the user's request
+      // into a clean action name, dropping the date phrase the text parser
+      // relies on — an explicit value survives that rewrite and wins over
+      // whatever the parser extracts. scheduledStart is the do-date /today
+      // keys on; dueDate is the deadline.
+      scheduledStart: z.string().optional(),
+      dueDate: z.string().optional(),
     }))
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
-      console.log(`🎯 [tRPC quickCreateAction] RECEIVED: text="${input.text}", projectId=${input.projectId || "none"}, priority=${input.priority ?? "none"}`);
+      console.log(`🎯 [tRPC quickCreateAction] RECEIVED: text="${input.text}", projectId=${input.projectId || "none"}, priority=${input.priority ?? "none"}, scheduledStart=${input.scheduledStart ?? "none"}, dueDate=${input.dueDate ?? "none"}`);
 
       // Use the same parsing logic as action.quickCreate
       const { parseActionInput } = await import("~/server/services/parsing/parseActionInput");
@@ -1194,6 +1204,17 @@ export const mastraRouter = createTRPCRouter({
         }
         parsed.projectId = input.projectId;
       }
+
+      // Explicit dates win over text-parsed ones (same precedence rationale as
+      // projectId above). When neither is passed, the parsed values stand.
+      const scheduledStart =
+        input.scheduledStart !== undefined
+          ? parseAgentDate(input.scheduledStart, "scheduledStart")
+          : parsed.scheduledStart;
+      const dueDate =
+        input.dueDate !== undefined
+          ? parseAgentDate(input.dueDate, "dueDate")
+          : parsed.dueDate;
 
       // Get kanban order if project specified
       let kanbanOrder: number | null = null;
@@ -1223,8 +1244,8 @@ export const mastraRouter = createTRPCRouter({
           priority: input.priority ?? "Quick",
           status: "ACTIVE",
           createdById: userId,
-          scheduledStart: parsed.scheduledStart,
-          dueDate: parsed.dueDate,
+          scheduledStart,
+          dueDate,
           source: deriveActionSource(ctx.tokenType),
           kanbanStatus: parsed.projectId ? "TODO" : null,
           kanbanOrder,
@@ -1244,6 +1265,7 @@ export const mastraRouter = createTRPCRouter({
           name: action.name,
           priority: action.priority,
           dueDate: action.dueDate?.toISOString(),
+          scheduledStart: action.scheduledStart?.toISOString(),
           project: action.project,
         },
         parsing: parsed.parsingMetadata,

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -1113,14 +1113,14 @@ export const mastraRouter = createTRPCRouter({
       name: z.string().min(1),
       description: z.string().optional(),
       priority: z.enum(PRIORITY_VALUES),
-      dueDate: z.string().optional(), // ISO string — deadline
-      scheduledStart: z.string().optional(), // ISO string — do-date (the day the user plans to DO it; what /today keys on)
+      dueDate: z.string().min(1).optional(), // ISO string — deadline
+      scheduledStart: z.string().min(1).optional(), // ISO string — do-date (the day the user plans to DO it; what /today keys on)
     }))
     .mutation(async ({ ctx, input }) => {
       // Use authenticated user's ID from session
       const userId = ctx.session.user.id;
 
-      console.log(`🔧 [tRPC createAction] RECEIVED: projectId=${input.projectId}, name="${input.name}", priority=${input.priority}, dueDate=${input.dueDate || "none"}, scheduledStart=${input.scheduledStart || "none"}, userId=${userId}`);
+      console.log(`🔧 [tRPC createAction] RECEIVED: projectId=${input.projectId}, name="${input.name}", priority=${input.priority}, dueDate=${input.dueDate ?? "none"}, scheduledStart=${input.scheduledStart ?? "none"}, userId=${userId}`);
 
       // Verify user has access to this project via all access paths
       const access = await getProjectAccess(ctx.db, userId, input.projectId);
@@ -1178,9 +1178,10 @@ export const mastraRouter = createTRPCRouter({
       // into a clean action name, dropping the date phrase the text parser
       // relies on — an explicit value survives that rewrite and wins over
       // whatever the parser extracts. scheduledStart is the do-date /today
-      // keys on; dueDate is the deadline.
-      scheduledStart: z.string().optional(),
-      dueDate: z.string().optional(),
+      // keys on; dueDate is the deadline. min(1) keeps a blank string from
+      // silently clearing the text-parsed date via the precedence logic.
+      scheduledStart: z.string().min(1).optional(),
+      dueDate: z.string().min(1).optional(),
     }))
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;


### PR DESCRIPTION
### **User description**
## What

- `mastra.createAction`: new optional `scheduledStart` ISO input (there was no do-date input at all — only `dueDate`), validated via `parseAgentDate`.
- `mastra.quickCreateAction`: new optional `scheduledStart`/`dueDate` ISO inputs; explicit values win over the text-parsed dates, mirroring the existing `projectId` precedence.
- Both responses now echo `scheduledStart` so agents can report what was saved.
- 5 new integration tests covering explicit dates, precedence over text parsing, and malformed-date rejection.

## Why

Asking Zoe on /today to "save a new action for today" created the action with no `scheduledStart`, so it never showed on the Today page: date extraction only sees the tool's `text` param, and agents rewrite task names, silently dropping the date phrase.

Agent-side counterpart: positonic/mastra#65 (backward-compatible in either merge order — zod strips unknown keys until both land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add optional `scheduledStart` input to `mastra.createAction`

- Add explicit `scheduledStart`/`dueDate` to `quickCreateAction`

- Explicit dates override text-parsed dates

- Echo `scheduledStart` in responses; add integration tests


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Agent tool call"] -- "scheduledStart / dueDate (ISO)" --> B["mastra.createAction"]
  A -- "text + explicit dates" --> C["mastra.quickCreateAction"]
  C -- "parseActionInput" --> D["parsed dates"]
  D -- "overridden by explicit" --> E["parseAgentDate validation"]
  B --> E
  E --> F["action row (scheduledStart)"]
  F --> G["/today view + response echo"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mastra.ts</strong><dd><code>Support explicit do-date inputs in action-creation procedures</code></dd></summary>
<hr>

src/server/api/routers/mastra.ts

<ul><li><code>createAction</code>: new optional <code>scheduledStart</code> ISO input; <code>dueDate</code> now <br><code>min(1)</code>; both parsed via <code>parseAgentDate</code> so malformed values are <br>rejected instead of stored as Invalid Date.<br> <li> <code>quickCreateAction</code>: new optional <code>scheduledStart</code>/<code>dueDate</code> ISO inputs that <br>take precedence over text-parsed dates (mirrors <code>projectId</code> precedence).<br> <li> Both mutation responses now return <code>scheduledStart</code> as an ISO string.<br> <li> Debug logs extended with the new date fields and switched to nullish <br>coalescing.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/588/files#diff-afd76ed5d04839b106766464d541d99c9b1d0e8b28477ea826c7dcf52db960bb">+29/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mastra.integration.test.ts</strong><dd><code>Integration tests for scheduledStart handling and precedence</code></dd></summary>
<hr>

src/server/api/routers/__tests__/mastra.integration.test.ts

<ul><li>New describe block with 5 integration tests for do-date handling.<br> <li> Covers explicit <code>scheduledStart</code> persistence with null <code>dueDate</code>, <br>malformed-date rejection, and explicit value winning over text-parsed <br>date.<br> <li> Verifies text parser still sets the do-date when no explicit date is <br>given, asserting a time window to avoid midnight flakiness.<br> <li> Imports <code>createProject</code> factory.</ul>


</details>


  </td>
  <td><a href="https://github.com/positonic/exponential/pull/588/files#diff-536247da66eef9b5a0944941283ffe5fd9e9b24475df4764a3fc64e4ff56f224">+94/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

