### PR TITLE
fix(ticket-sync): make the Notion badge deep-link for adoption-era sync records

### DIFF
--- a/src/app/_components/product/NotionSyncBadge.tsx
+++ b/src/app/_components/product/NotionSyncBadge.tsx
@@ -2,9 +2,11 @@
 
 import { ActionIcon, Tooltip } from "@mantine/core";
 import { IconBrandNotion } from "@tabler/icons-react";
+import { notionPageUrl } from "~/lib/notionUrl";
 
 export interface TicketSyncLinkView {
   provider: string;
+  externalId: string;
   externalUrl: string | null;
   lastSyncedAt: Date | string;
   tombstonedAt: Date | string | null;
@@ -25,6 +27,10 @@ export function NotionSyncBadge({
   const sync = syncs?.find((s) => s.provider === "notion");
   if (!sync) return null;
 
+  // Adoption-era sync records stored only the page id; derive the canonical
+  // URL so their badges deep-link too.
+  const href = sync.externalUrl ?? notionPageUrl(sync.externalId);
+
   const label = sync.tombstonedAt
     ? "Notion counterpart archived"
     : `Synced with Notion · last synced ${new Date(sync.lastSyncedAt).toLocaleString()}`;
@@ -38,10 +44,10 @@ export function NotionSyncBadge({
 
   return (
     <Tooltip label={label} withArrow>
-      {sync.externalUrl ? (
+      {href ? (
         <ActionIcon
           component="a"
-          href={sync.externalUrl}
+          href={href}
           target="_blank"
           rel="noopener noreferrer"
           variant="subtle"

--- a/src/lib/__tests__/notionUrl.test.ts
+++ b/src/lib/__tests__/notionUrl.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { notionPageUrl } from "../notionUrl";
+
+describe("notionPageUrl", () => {
+  it("strips dashes from a UUID page id", () => {
+    expect(notionPageUrl("26c94ef8-97a9-8134-a83b-000000000000")).toBe(
+      "https://www.notion.so/26c94ef897a98134a83b000000000000",
+    );
+  });
+
+  it("accepts an already-bare 32-hex id", () => {
+    expect(notionPageUrl("26c94ef897a98134a83b000000000000")).toBe(
+      "https://www.notion.so/26c94ef897a98134a83b000000000000",
+    );
+  });
+
+  it("returns null for anything that is not a Notion page id", () => {
+    expect(notionPageUrl("")).toBeNull();
+    expect(notionPageUrl("not-a-page-id")).toBeNull();
+    expect(notionPageUrl("26c94ef897a98134a83b0000000000")).toBeNull(); // too short
+    expect(notionPageUrl("javascript:alert(1)")).toBeNull();
+  });
+});

--- a/src/lib/notionUrl.ts
+++ b/src/lib/notionUrl.ts
@@ -1,0 +1,10 @@
+/**
+ * Canonical Notion page URL derived from a page id. Notion serves
+ * https://www.notion.so/<32-hex-id> for any page the viewer can access, so
+ * this is a safe deep-link fallback for sync records that predate URL
+ * capture (the adoption cohort stored only the page id).
+ */
+export function notionPageUrl(pageId: string): string | null {
+  const hex = pageId.replace(/-/g, "");
+  return /^[0-9a-f]{32}$/i.test(hex) ? `https://www.notion.so/${hex}` : null;
+}

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -163,6 +163,7 @@ export const ticketRouter = createTRPCRouter({
           syncs: {
             select: {
               provider: true,
+              externalId: true,
               externalUrl: true,
               lastSyncedAt: true,
               tombstonedAt: true,
@@ -236,6 +237,7 @@ export const ticketRouter = createTRPCRouter({
           syncs: {
             select: {
               provider: true,
+              externalId: true,
               externalUrl: true,
               lastSyncedAt: true,
               tombstonedAt: true,

--- a/src/server/services/ticketSync/engine.ts
+++ b/src/server/services/ticketSync/engine.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@prisma/client";
 import type { PrismaClient, TicketStatus, TicketType } from "@prisma/client";
+import { notionPageUrl } from "~/lib/notionUrl";
 import { createTicketWithNumber } from "~/plugins/product/server/services/createTicket";
 import { recordActivity } from "~/server/services/activity/recordActivity";
 import {
@@ -317,6 +318,7 @@ export async function runInboundTicketSync(
               ticketId: ticket.id,
               provider: config.provider,
               externalId: ticket.notionPageId,
+              externalUrl: notionPageUrl(ticket.notionPageId),
               // No snapshot: the first merge treats differences as two-sided
               // changes and resolves by last-write-wins.
               snapshot: Prisma.DbNull,


### PR DESCRIPTION
## What

- Add `notionPageUrl()` helper deriving the canonical `https://www.notion.so/<id>` URL from a Notion page id
- `NotionSyncBadge` falls back to deriving the deep link from `externalId` when the sync record has no `externalUrl` — fixes every existing URL-less row with no backfill
- The inbound sync adoption pass now stamps `externalUrl` at creation time
- `ticket.list` / `ticket.getById` selects include `externalId` to feed the fallback

## Why

Tickets adopted into sync records from stored Notion provenance (the pre-sync import cohort, e.g. clear ticket 473) were created without `externalUrl`, so the Notion icon on the ticket page rendered as a plain non-clickable glyph. The pull only backfills the URL for pages that changed since, so unchanged pages never became clickable.