### PR TITLE
feat: V1 Decision Log projection core

### DIFF
--- a/prisma/migrations/20260814090000_add_adr_decision_log/migration.sql
+++ b/prisma/migrations/20260814090000_add_adr_decision_log/migration.sql
@@ -1,0 +1,183 @@
+-- CreateEnum
+CREATE TYPE "AdrStatus" AS ENUM ('PROPOSED', 'ACCEPTED', 'SUPERSEDED', 'DEPRECATED', 'UNKNOWN');
+
+-- CreateEnum
+CREATE TYPE "AdrLinkType" AS ENUM ('SUPERSEDES', 'MENTIONS');
+
+-- AlterTable
+ALTER TABLE "WorkspaceRepository" ADD COLUMN     "productId" TEXT;
+
+-- CreateTable
+CREATE TABLE "AdrSyncConfig" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "repositoryId" TEXT NOT NULL,
+    "shortCode" TEXT NOT NULL,
+    "adrPaths" TEXT[] DEFAULT ARRAY['docs/adr']::TEXT[],
+    "integrationId" TEXT,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "lastTreeSha" TEXT,
+    "lastCommitSha" TEXT,
+    "lastSyncedAt" TIMESTAMP(3),
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AdrSyncConfig_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdrDocument" (
+    "id" TEXT NOT NULL,
+    "repositoryId" TEXT NOT NULL,
+    "path" TEXT NOT NULL,
+    "number" INTEGER,
+    "slug" TEXT,
+    "title" TEXT NOT NULL,
+    "status" "AdrStatus" NOT NULL DEFAULT 'UNKNOWN',
+    "statusRaw" TEXT,
+    "decidedAt" TIMESTAMP(3),
+    "body" TEXT NOT NULL,
+    "contentHash" TEXT NOT NULL,
+    "lastSeenSha" TEXT NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AdrDocument_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdrLink" (
+    "id" TEXT NOT NULL,
+    "type" "AdrLinkType" NOT NULL,
+    "fromId" TEXT NOT NULL,
+    "toId" TEXT NOT NULL,
+    "evidence" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdrLink_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdrTicketLink" (
+    "id" TEXT NOT NULL,
+    "adrId" TEXT NOT NULL,
+    "ticketId" TEXT,
+    "featureId" TEXT,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdrTicketLink_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdrSyncRun" (
+    "id" TEXT NOT NULL,
+    "configId" TEXT NOT NULL,
+    "trigger" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'running',
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finishedAt" TIMESTAMP(3),
+    "error" TEXT,
+    "created" INTEGER NOT NULL DEFAULT 0,
+    "updated" INTEGER NOT NULL DEFAULT 0,
+    "skipped" INTEGER NOT NULL DEFAULT 0,
+    "deleted" INTEGER NOT NULL DEFAULT 0,
+    "failed" INTEGER NOT NULL DEFAULT 0,
+    "items" JSONB,
+    "triggeredById" TEXT,
+
+    CONSTRAINT "AdrSyncRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AdrSyncConfig_repositoryId_idx" ON "AdrSyncConfig"("repositoryId");
+
+-- CreateIndex
+CREATE INDEX "AdrSyncConfig_integrationId_idx" ON "AdrSyncConfig"("integrationId");
+
+-- CreateIndex
+CREATE INDEX "AdrSyncConfig_createdById_idx" ON "AdrSyncConfig"("createdById");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdrSyncConfig_workspaceId_repositoryId_key" ON "AdrSyncConfig"("workspaceId", "repositoryId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdrSyncConfig_workspaceId_shortCode_key" ON "AdrSyncConfig"("workspaceId", "shortCode");
+
+-- CreateIndex
+CREATE INDEX "AdrDocument_repositoryId_deletedAt_idx" ON "AdrDocument"("repositoryId", "deletedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdrDocument_repositoryId_path_key" ON "AdrDocument"("repositoryId", "path");
+
+-- CreateIndex
+CREATE INDEX "AdrLink_toId_idx" ON "AdrLink"("toId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdrLink_fromId_toId_type_key" ON "AdrLink"("fromId", "toId", "type");
+
+-- CreateIndex
+CREATE INDEX "AdrTicketLink_ticketId_idx" ON "AdrTicketLink"("ticketId");
+
+-- CreateIndex
+CREATE INDEX "AdrTicketLink_featureId_idx" ON "AdrTicketLink"("featureId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdrTicketLink_adrId_ticketId_key" ON "AdrTicketLink"("adrId", "ticketId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdrTicketLink_adrId_featureId_key" ON "AdrTicketLink"("adrId", "featureId");
+
+-- CreateIndex
+CREATE INDEX "AdrSyncRun_configId_startedAt_idx" ON "AdrSyncRun"("configId", "startedAt");
+
+-- CreateIndex
+CREATE INDEX "AdrSyncRun_triggeredById_idx" ON "AdrSyncRun"("triggeredById");
+
+-- CreateIndex
+CREATE INDEX "WorkspaceRepository_productId_idx" ON "WorkspaceRepository"("productId");
+
+-- AddForeignKey
+ALTER TABLE "WorkspaceRepository" ADD CONSTRAINT "WorkspaceRepository_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrSyncConfig" ADD CONSTRAINT "AdrSyncConfig_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrSyncConfig" ADD CONSTRAINT "AdrSyncConfig_repositoryId_fkey" FOREIGN KEY ("repositoryId") REFERENCES "WorkspaceRepository"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrSyncConfig" ADD CONSTRAINT "AdrSyncConfig_integrationId_fkey" FOREIGN KEY ("integrationId") REFERENCES "Integration"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrSyncConfig" ADD CONSTRAINT "AdrSyncConfig_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrDocument" ADD CONSTRAINT "AdrDocument_repositoryId_fkey" FOREIGN KEY ("repositoryId") REFERENCES "WorkspaceRepository"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrLink" ADD CONSTRAINT "AdrLink_fromId_fkey" FOREIGN KEY ("fromId") REFERENCES "AdrDocument"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrLink" ADD CONSTRAINT "AdrLink_toId_fkey" FOREIGN KEY ("toId") REFERENCES "AdrDocument"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrTicketLink" ADD CONSTRAINT "AdrTicketLink_adrId_fkey" FOREIGN KEY ("adrId") REFERENCES "AdrDocument"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrTicketLink" ADD CONSTRAINT "AdrTicketLink_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrTicketLink" ADD CONSTRAINT "AdrTicketLink_featureId_fkey" FOREIGN KEY ("featureId") REFERENCES "Feature"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrTicketLink" ADD CONSTRAINT "AdrTicketLink_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrSyncRun" ADD CONSTRAINT "AdrSyncRun_configId_fkey" FOREIGN KEY ("configId") REFERENCES "AdrSyncConfig"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdrSyncRun" ADD CONSTRAINT "AdrSyncRun_triggeredById_fkey" FOREIGN KEY ("triggeredById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -276,6 +276,9 @@ model User {
   requirementsChecked   Requirement[]         @relation("RequirementCheckedBy")
   ticketSyncConfigs     TicketSyncConfig[]    @relation("TicketSyncConfigCreatedBy")
   ticketSyncRuns        TicketSyncRun[]       @relation("TicketSyncRunTriggeredBy")
+  adrSyncConfigs        AdrSyncConfig[]       @relation("AdrSyncConfigCreatedBy")
+  adrSyncRuns           AdrSyncRun[]          @relation("AdrSyncRunTriggeredBy")
+  adrTicketLinks        AdrTicketLink[]       @relation("AdrTicketLinkCreatedBy")
 
   // One2b agent schema additions
   phone            Bytes?  @map("phone_encrypted") @db.ByteA
@@ -444,6 +447,8 @@ model Workspace {
   integrations            Integration[]
   // GitHub repo connection (ADR-0020): repos this workspace tracks
   workspaceRepositories   WorkspaceRepository[]
+  // Decision Log (ADR projection)
+  adrSyncConfigs          AdrSyncConfig[]
   // Notification override relations
   notificationOverrides   WorkspaceNotificationOverride[]
   // Slack channel config relation
@@ -1465,6 +1470,7 @@ model Integration {
   // GitHub repo connection (ADR-0020): repos a workspace tracks via this installation
   workspaceRepositories   WorkspaceRepository[]
   syncConfigs             TicketSyncConfig[]
+  adrSyncConfigs          AdrSyncConfig[]
   // Outbound routing (matrix-server rows): rooms bound through this server, and the
   // log of what has been posted through it.
   outboundChannelLinks    ChannelLink[]            @relation("ChannelLinkServer")
@@ -4153,6 +4159,7 @@ model Product {
   ticketSyncConfigs TicketSyncConfig[]
   featureDrafts     MeetingFeatureDraft[]
   epics             Epic[]
+  repositories      WorkspaceRepository[]
 
   @@unique([workspaceId, slug])
   @@index([workspaceId])
@@ -4240,6 +4247,7 @@ model Feature {
   comments            FeatureComment[]
   pages               FeaturePage[]
   keyResultLinks      KeyResultFeature[] // Key results this feature executes (ADR-0050)
+  adrLinks            AdrTicketLink[]
 
   @@index([productId])
   @@index([goalId])
@@ -4621,6 +4629,7 @@ model Ticket {
   depsIn    TicketDependency[] @relation("TicketDepsIn")
   tags      TicketTag[]
   syncs     TicketSync[]
+  adrLinks  AdrTicketLink[]
 
   @@unique([productId, number])
   @@unique([productId, shortId])
@@ -4945,6 +4954,9 @@ model WorkspaceRepository {
   fullName       String
   installationId String?
   addedById      String?
+  /// Optional product assignment (Decision Log): ADRs derive their product
+  /// through the repo. Null = workspace-level repo (e.g. shared architecture).
+  productId      String?
   syncStatus     String    @default("pending")
   lastSyncedAt   DateTime?
   createdAt      DateTime  @default(now())
@@ -4952,10 +4964,15 @@ model WorkspaceRepository {
   workspace   Workspace   @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   integration Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade)
   addedBy     User?       @relation("WorkspaceRepositoryAddedBy", fields: [addedById], references: [id], onDelete: SetNull)
+  product     Product?    @relation(fields: [productId], references: [id], onDelete: SetNull)
+
+  adrSyncConfigs AdrSyncConfig[]
+  adrDocuments   AdrDocument[]
 
   @@unique([workspaceId, fullName])
   @@index([workspaceId])
   @@index([integrationId])
+  @@index([productId])
 }
 
 model TicketSyncConfig {
@@ -5075,6 +5092,159 @@ model TicketSyncRun {
   triggeredBy   User?            @relation("TicketSyncRunTriggeredBy", fields: [triggeredById], references: [id], onDelete: SetNull)
   revertedByRun TicketSyncRun?   @relation("TicketSyncRunRevertedBy", fields: [revertedByRunId], references: [id], onDelete: SetNull)
   revertedRuns  TicketSyncRun[]  @relation("TicketSyncRunRevertedBy")
+
+  @@index([configId, startedAt])
+  @@index([triggeredById])
+}
+
+// ── Decision Log (cross-repo ADR projection) ────────────────────────────────
+// Read-only projection of ADR markdown files from enrolled GitHub repos. Git
+// is the source of truth; every row here is derived and re-derivable, except
+// AdrTicketLink which is user-authored linkage and must survive repo
+// disconnection. Documents are only ever soft-deleted (deletedAt).
+
+enum AdrStatus {
+  PROPOSED
+  ACCEPTED
+  SUPERSEDED
+  DEPRECATED
+  UNKNOWN
+}
+
+enum AdrLinkType {
+  SUPERSEDES
+  MENTIONS
+}
+
+model AdrSyncConfig {
+  id           String   @id @default(cuid())
+  workspaceId  String
+  repositoryId String
+  /// Workspace-unique label prefix; ADRs render as `SHORTCODE-NUMBER`
+  /// (e.g. API-0003). A label, not a key — collisions are flagged, not refused.
+  shortCode    String
+  /// Repo-relative directories searched for ADR markdown files.
+  adrPaths     String[] @default(["docs/adr"])
+  /// Null means DISCONNECTED — disconnect is a soft state change, never a row
+  /// delete, so documents, links and run history always survive (ADR-0042).
+  integrationId String?
+  enabled       Boolean  @default(true)
+  /// Git tree SHA(s) covering adrPaths at the last successful pull — the sync
+  /// short-circuit key: unchanged tree ⇒ zero file fetches for this repo.
+  lastTreeSha   String?
+  /// Default-branch head commit at the last successful pull; GitHub deep links
+  /// pin here rather than at HEAD.
+  lastCommitSha String?
+  lastSyncedAt  DateTime?
+  createdById   String
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  workspace   Workspace           @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  repository  WorkspaceRepository @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
+  integration Integration?        @relation(fields: [integrationId], references: [id], onDelete: SetNull)
+  createdBy   User                @relation("AdrSyncConfigCreatedBy", fields: [createdById], references: [id])
+  runs        AdrSyncRun[]
+
+  @@unique([workspaceId, repositoryId])
+  @@unique([workspaceId, shortCode])
+  @@index([repositoryId])
+  @@index([integrationId])
+  @@index([createdById])
+}
+
+model AdrDocument {
+  id           String    @id @default(cuid())
+  repositoryId String
+  /// Repo-relative file path — the stable half of the natural key.
+  path         String
+  /// Sequence number parsed from the filename (`0003-...`); null when absent.
+  number       Int?
+  slug         String?
+  title        String
+  status       AdrStatus @default(UNKNOWN)
+  /// Verbatim status string from the file (drives SUPERSEDES derivation).
+  statusRaw    String?
+  decidedAt    DateTime?
+  /// Full markdown content as last synced.
+  body         String    @db.Text
+  /// Git blob SHA from the tree listing — an unchanged blob is skipped
+  /// without a content fetch.
+  contentHash  String
+  /// Blob SHA last seen for this file.
+  lastSeenSha  String
+  /// Set when the file vanished from the repo; documents are never hard-deleted.
+  deletedAt    DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  repository  WorkspaceRepository @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
+  linksFrom   AdrLink[]           @relation("AdrLinkFrom")
+  linksTo     AdrLink[]           @relation("AdrLinkTo")
+  ticketLinks AdrTicketLink[]
+
+  @@unique([repositoryId, path])
+  @@index([repositoryId, deletedAt])
+}
+
+model AdrLink {
+  id        String      @id @default(cuid())
+  type      AdrLinkType
+  /// SUPERSEDES points from superseder to superseded.
+  fromId    String
+  toId      String
+  /// The matched line supporting a MENTIONS edge ("detected" provenance).
+  evidence  String?
+  createdAt DateTime    @default(now())
+
+  from AdrDocument @relation("AdrLinkFrom", fields: [fromId], references: [id], onDelete: Cascade)
+  to   AdrDocument @relation("AdrLinkTo", fields: [toId], references: [id], onDelete: Cascade)
+
+  @@unique([fromId, toId, type])
+  @@index([toId])
+}
+
+model AdrTicketLink {
+  id          String   @id @default(cuid())
+  adrId       String
+  ticketId    String?
+  featureId   String?
+  createdById String
+  createdAt   DateTime @default(now())
+
+  adr       AdrDocument @relation(fields: [adrId], references: [id], onDelete: Cascade)
+  ticket    Ticket?     @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  feature   Feature?    @relation(fields: [featureId], references: [id], onDelete: Cascade)
+  createdBy User        @relation("AdrTicketLinkCreatedBy", fields: [createdById], references: [id])
+
+  @@unique([adrId, ticketId])
+  @@unique([adrId, featureId])
+  @@index([ticketId])
+  @@index([featureId])
+}
+
+model AdrSyncRun {
+  id         String    @id @default(cuid())
+  configId   String
+  /// manual | cron | webhook
+  trigger    String
+  /// running | success | unchanged | error
+  status     String    @default("running")
+  startedAt  DateTime  @default(now())
+  finishedAt DateTime?
+  error      String?
+  created    Int       @default(0)
+  updated    Int       @default(0)
+  skipped    Int       @default(0)
+  deleted    Int       @default(0)
+  failed     Int       @default(0)
+  /// Per-file outcomes: [{ path, action, reason? }]
+  items      Json?
+  /// Who triggered the run; null for cron runs.
+  triggeredById String?
+
+  config      AdrSyncConfig @relation(fields: [configId], references: [id], onDelete: Cascade)
+  triggeredBy User?         @relation("AdrSyncRunTriggeredBy", fields: [triggeredById], references: [id], onDelete: SetNull)
 
   @@index([configId, startedAt])
   @@index([triggeredById])

--- a/src/app/(sidemenu)/w/[workspaceSlug]/decisions/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/decisions/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Badge, Container, Group, Skeleton, Table, Text, Title } from "@mantine/core";
+import Link from "next/link";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import { api } from "~/trpc/react";
+
+/**
+ * Decision Log — workspace-level index of ADRs projected read-only from every
+ * enrolled repo. Git is the source of truth; there is deliberately no write
+ * path to ADR content anywhere in this UI.
+ */
+
+const STATUS_COLOR: Record<string, string> = {
+  PROPOSED: "blue",
+  ACCEPTED: "green",
+  SUPERSEDED: "orange",
+  DEPRECATED: "red",
+};
+
+function StatusChip({ status, statusRaw }: { status: string; statusRaw: string | null }) {
+  if (status === "UNKNOWN") {
+    return (
+      <Badge variant="light" color="gray" title={statusRaw ?? undefined}>
+        no status
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="light" color={STATUS_COLOR[status] ?? "gray"} title={statusRaw ?? undefined}>
+      {status.toLowerCase()}
+    </Badge>
+  );
+}
+
+export default function DecisionsPage() {
+  const { workspace, workspaceId, isLoading } = useWorkspace();
+
+  const { data: adrs, isLoading: adrsLoading } = api.adr.list.useQuery(
+    { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId },
+  );
+
+  if (isLoading || (workspace && adrsLoading)) {
+    return (
+      <Container size="xl" className="py-8">
+        <Skeleton height={40} width={240} mb="lg" />
+        <Skeleton height={300} />
+      </Container>
+    );
+  }
+
+  if (!workspace) {
+    return (
+      <Container size="xl" className="py-8">
+        <Text className="text-text-secondary">Workspace not found</Text>
+      </Container>
+    );
+  }
+
+  return (
+    <Container size="xl" className="py-8">
+      <Group justify="space-between" mb="lg">
+        <div>
+          <Title order={2}>Decisions</Title>
+          <Text size="sm" className="text-text-secondary">
+            Architectural decision records across this workspace&apos;s enrolled
+            repos. Read-only — git is the source of truth.
+          </Text>
+        </div>
+      </Group>
+
+      {!adrs || adrs.length === 0 ? (
+        <Text className="text-text-secondary">
+          No decisions synced yet. Enrol repositories under{" "}
+          <Link
+            href={`/w/${workspace.slug}/settings/decisions`}
+            className="text-brand-primary hover:underline"
+          >
+            Settings → Decisions
+          </Link>
+          , then run a sync.
+        </Text>
+      ) : (
+        <Table striped highlightOnHover>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Label</Table.Th>
+              <Table.Th>Title</Table.Th>
+              <Table.Th>Repository</Table.Th>
+              <Table.Th>Status</Table.Th>
+              <Table.Th>Decided</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {adrs.map((adr) => (
+              <Table.Tr key={adr.id}>
+                <Table.Td>
+                  <Text size="sm" fw={600} className="whitespace-nowrap">
+                    {adr.label ?? "—"}
+                  </Text>
+                </Table.Td>
+                <Table.Td>
+                  <Text size="sm">{adr.title}</Text>
+                </Table.Td>
+                <Table.Td>
+                  <Badge variant="outline" color="gray">
+                    {adr.repository.fullName}
+                  </Badge>
+                </Table.Td>
+                <Table.Td>
+                  <StatusChip status={adr.status} statusRaw={adr.statusRaw} />
+                </Table.Td>
+                <Table.Td>
+                  <Text size="sm" className="text-text-secondary whitespace-nowrap">
+                    {adr.decidedAt
+                      ? new Date(adr.decidedAt).toLocaleDateString()
+                      : "—"}
+                  </Text>
+                </Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+      )}
+    </Container>
+  );
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/decisions/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/decisions/page.tsx
@@ -1,6 +1,21 @@
 "use client";
 
-import { Badge, Container, Group, Skeleton, Table, Text, Title } from "@mantine/core";
+import { useMemo, useState } from "react";
+import {
+  Badge,
+  Container,
+  Group,
+  MultiSelect,
+  Select,
+  Skeleton,
+  Table,
+  Text,
+  TextInput,
+  Title,
+  Tooltip,
+} from "@mantine/core";
+import { IconAlertTriangle, IconSearch } from "@tabler/icons-react";
+import { useDebouncedValue } from "@mantine/hooks";
 import Link from "next/link";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
@@ -17,6 +32,16 @@ const STATUS_COLOR: Record<string, string> = {
   SUPERSEDED: "orange",
   DEPRECATED: "red",
 };
+
+const STATUS_OPTIONS = [
+  { value: "PROPOSED", label: "Proposed" },
+  { value: "ACCEPTED", label: "Accepted" },
+  { value: "SUPERSEDED", label: "Superseded" },
+  { value: "DEPRECATED", label: "Deprecated" },
+  { value: "UNKNOWN", label: "No status" },
+] as const;
+
+type AdrStatusValue = (typeof STATUS_OPTIONS)[number]["value"];
 
 function StatusChip({ status, statusRaw }: { status: string; statusRaw: string | null }) {
   if (status === "UNKNOWN") {
@@ -36,12 +61,56 @@ function StatusChip({ status, statusRaw }: { status: string; statusRaw: string |
 export default function DecisionsPage() {
   const { workspace, workspaceId, isLoading } = useWorkspace();
 
+  const [repoFilter, setRepoFilter] = useState<string[]>([]);
+  const [statusFilter, setStatusFilter] = useState<string[]>([]);
+  const [productFilter, setProductFilter] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch] = useDebouncedValue(search, 250);
+
   const { data: adrs, isLoading: adrsLoading } = api.adr.list.useQuery(
+    {
+      workspaceId: workspaceId ?? "",
+      repositoryIds: repoFilter.length > 0 ? repoFilter : undefined,
+      statuses:
+        statusFilter.length > 0 ? (statusFilter as AdrStatusValue[]) : undefined,
+      productId: productFilter ?? undefined,
+      search: debouncedSearch.trim() || undefined,
+    },
+    { enabled: !!workspaceId },
+  );
+
+  const { data: configs } = api.adr.listConfigs.useQuery(
+    { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId },
+  );
+  const { data: products } = api.product.product.list.useQuery(
     { workspaceId: workspaceId ?? "" },
     { enabled: !!workspaceId },
   );
 
-  if (isLoading || (workspace && adrsLoading)) {
+  const repoOptions = useMemo(
+    () =>
+      (configs ?? []).map((c) => ({
+        value: c.repositoryId,
+        label: c.repository.fullName,
+      })),
+    [configs],
+  );
+  const productOptions = useMemo(
+    () => [
+      { value: "workspace", label: "Workspace-level (no product)" },
+      ...(products ?? []).map((p) => ({ value: p.id, label: p.name })),
+    ],
+    [products],
+  );
+
+  const hasFilters =
+    repoFilter.length > 0 ||
+    statusFilter.length > 0 ||
+    productFilter !== null ||
+    debouncedSearch.trim().length > 0;
+
+  if (isLoading) {
     return (
       <Container size="xl" className="py-8">
         <Skeleton height={40} width={240} mb="lg" />
@@ -70,16 +139,67 @@ export default function DecisionsPage() {
         </div>
       </Group>
 
-      {!adrs || adrs.length === 0 ? (
+      <Group mb="md" gap="sm" align="flex-end" wrap="wrap">
+        <TextInput
+          size="sm"
+          w={240}
+          leftSection={<IconSearch size={14} />}
+          placeholder="Search title and body…"
+          value={search}
+          onChange={(e) => setSearch(e.currentTarget.value)}
+          aria-label="Search decisions"
+        />
+        <MultiSelect
+          size="sm"
+          w={240}
+          data={repoOptions}
+          value={repoFilter}
+          onChange={setRepoFilter}
+          placeholder="All repositories"
+          clearable
+          searchable
+          aria-label="Filter by repository"
+        />
+        <MultiSelect
+          size="sm"
+          w={200}
+          data={[...STATUS_OPTIONS]}
+          value={statusFilter}
+          onChange={setStatusFilter}
+          placeholder="All statuses"
+          clearable
+          aria-label="Filter by status"
+        />
+        <Select
+          size="sm"
+          w={220}
+          data={productOptions}
+          value={productFilter}
+          onChange={setProductFilter}
+          placeholder="All products"
+          clearable
+          aria-label="Filter by product"
+        />
+      </Group>
+
+      {adrsLoading ? (
+        <Skeleton height={300} />
+      ) : !adrs || adrs.length === 0 ? (
         <Text className="text-text-secondary">
-          No decisions synced yet. Enrol repositories under{" "}
-          <Link
-            href={`/w/${workspace.slug}/settings/decisions`}
-            className="text-brand-primary hover:underline"
-          >
-            Settings → Decisions
-          </Link>
-          , then run a sync.
+          {hasFilters ? (
+            "No decisions match these filters."
+          ) : (
+            <>
+              No decisions synced yet. Enrol repositories under{" "}
+              <Link
+                href={`/w/${workspace.slug}/settings/decisions`}
+                className="text-brand-primary hover:underline"
+              >
+                Settings → Decisions
+              </Link>
+              , then run a sync.
+            </>
+          )}
         </Text>
       ) : (
         <Table striped highlightOnHover>
@@ -88,6 +208,7 @@ export default function DecisionsPage() {
               <Table.Th>Label</Table.Th>
               <Table.Th>Title</Table.Th>
               <Table.Th>Repository</Table.Th>
+              <Table.Th>Product</Table.Th>
               <Table.Th>Status</Table.Th>
               <Table.Th>Decided</Table.Th>
             </Table.Tr>
@@ -96,9 +217,20 @@ export default function DecisionsPage() {
             {adrs.map((adr) => (
               <Table.Tr key={adr.id}>
                 <Table.Td>
-                  <Text size="sm" fw={600} className="whitespace-nowrap">
-                    {adr.label ?? "—"}
-                  </Text>
+                  <Group gap={4} wrap="nowrap">
+                    <Text size="sm" fw={600} className="whitespace-nowrap">
+                      {adr.label ?? "—"}
+                    </Text>
+                    {adr.isDuplicateLabel ? (
+                      <Tooltip label="Duplicate label — another decision shares this number. Consider renumbering in the repo.">
+                        <IconAlertTriangle
+                          size={14}
+                          className="text-brand-warning"
+                          aria-label="Duplicate label"
+                        />
+                      </Tooltip>
+                    ) : null}
+                  </Group>
                 </Table.Td>
                 <Table.Td>
                   <Text size="sm">{adr.title}</Text>
@@ -107,6 +239,11 @@ export default function DecisionsPage() {
                   <Badge variant="outline" color="gray">
                     {adr.repository.fullName}
                   </Badge>
+                </Table.Td>
+                <Table.Td>
+                  <Text size="sm" className="text-text-secondary">
+                    {adr.repository.product?.name ?? "Workspace"}
+                  </Text>
                 </Table.Td>
                 <Table.Td>
                   <StatusChip status={adr.status} statusRaw={adr.statusRaw} />

--- a/src/app/(sidemenu)/w/[workspaceSlug]/decisions/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/decisions/page.tsx
@@ -67,7 +67,11 @@ export default function DecisionsPage() {
   const [search, setSearch] = useState("");
   const [debouncedSearch] = useDebouncedValue(search, 250);
 
-  const { data: adrs, isLoading: adrsLoading } = api.adr.list.useQuery(
+  const {
+    data: adrs,
+    isLoading: adrsLoading,
+    error: adrsError,
+  } = api.adr.list.useQuery(
     {
       workspaceId: workspaceId ?? "",
       repositoryIds: repoFilter.length > 0 ? repoFilter : undefined,
@@ -184,6 +188,12 @@ export default function DecisionsPage() {
 
       {adrsLoading ? (
         <Skeleton height={300} />
+      ) : adrsError ? (
+        <Text className="text-text-secondary">
+          {adrsError.data?.code === "FORBIDDEN"
+            ? "You don't have access to this workspace's decisions — they are visible to workspace members only."
+            : `Couldn't load decisions: ${adrsError.message}`}
+        </Text>
       ) : !adrs || adrs.length === 0 ? (
         <Text className="text-text-secondary">
           {hasFilters ? (

--- a/src/app/(sidemenu)/w/[workspaceSlug]/settings/decisions/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/settings/decisions/page.tsx
@@ -156,13 +156,24 @@ export default function DecisionsSettingsPage() {
   const [syncingConfigId, setSyncingConfigId] = useState<string | null>(null);
   const syncNow = api.adr.syncNow.useMutation({
     onSuccess: async (result) => {
+      // The engine returns error RESULTS rather than throwing — branch on
+      // status or the real reason would be discarded.
+      if (result.status === "error") {
+        notifications.show({
+          title: "Sync failed",
+          message: result.error ?? "Unknown error",
+          color: "red",
+        });
+        await utils.adr.listRuns.invalidate();
+        return;
+      }
       notifications.show({
         title: result.status === "unchanged" ? "Already up to date" : "Synced",
         message:
           result.status === "unchanged"
             ? "No changes since the last sync."
             : `${result.created} created, ${result.updated} updated, ${result.skipped} skipped, ${result.deleted} removed${result.failed > 0 ? `, ${result.failed} failed` : ""}.`,
-        color: result.status === "error" ? "red" : "green",
+        color: "green",
       });
       await Promise.all([
         utils.adr.listRuns.invalidate(),

--- a/src/app/(sidemenu)/w/[workspaceSlug]/settings/decisions/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/settings/decisions/page.tsx
@@ -17,7 +17,12 @@ import {
   TextInput,
   Title,
 } from "@mantine/core";
-import { IconAlertTriangle, IconBrandGithub, IconSearch } from "@tabler/icons-react";
+import {
+  IconAlertTriangle,
+  IconBrandGithub,
+  IconRefresh,
+  IconSearch,
+} from "@tabler/icons-react";
 import { notifications } from "@mantine/notifications";
 import { api } from "~/trpc/react";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
@@ -136,6 +141,39 @@ export default function DecisionsSettingsPage() {
       notifications.show({ title: "Couldn't disable", message: error.message, color: "red" }),
   });
 
+  const { data: runs } = api.adr.listRuns.useQuery(
+    { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId, refetchInterval: 15_000 },
+  );
+  const lastRunByConfig = useMemo(() => {
+    const byConfig = new Map<string, NonNullable<typeof runs>[number]>();
+    for (const run of runs ?? []) {
+      if (!byConfig.has(run.configId)) byConfig.set(run.configId, run);
+    }
+    return byConfig;
+  }, [runs]);
+
+  const [syncingConfigId, setSyncingConfigId] = useState<string | null>(null);
+  const syncNow = api.adr.syncNow.useMutation({
+    onSuccess: async (result) => {
+      notifications.show({
+        title: result.status === "unchanged" ? "Already up to date" : "Synced",
+        message:
+          result.status === "unchanged"
+            ? "No changes since the last sync."
+            : `${result.created} created, ${result.updated} updated, ${result.skipped} skipped, ${result.deleted} removed${result.failed > 0 ? `, ${result.failed} failed` : ""}.`,
+        color: result.status === "error" ? "red" : "green",
+      });
+      await Promise.all([
+        utils.adr.listRuns.invalidate(),
+        utils.adr.listConfigs.invalidate(),
+        utils.adr.list.invalidate(),
+      ]);
+    },
+    onError: (error) =>
+      notifications.show({ title: "Sync failed", message: error.message, color: "red" }),
+  });
+
   const setProduct = api.adr.setRepositoryProduct.useMutation({
     onSuccess: async () => {
       await Promise.all([
@@ -248,6 +286,7 @@ export default function DecisionsSettingsPage() {
                   <Table.Th>Short code</Table.Th>
                   <Table.Th>ADR paths</Table.Th>
                   <Table.Th>Product</Table.Th>
+                  <Table.Th>Last run</Table.Th>
                 </Table.Tr>
               </Table.Thead>
               <Table.Tbody>
@@ -379,6 +418,60 @@ export default function DecisionsSettingsPage() {
                           aria-label={`Product for ${repo.fullName}`}
                         />
                       </Table.Td>
+                      <Table.Td>
+                        {config ? (
+                          <Group gap="xs" wrap="nowrap">
+                            {(() => {
+                              const lastRun = lastRunByConfig.get(config.id);
+                              if (!lastRun) {
+                                return (
+                                  <Badge size="xs" variant="light" color="gray">
+                                    never synced
+                                  </Badge>
+                                );
+                              }
+                              const color =
+                                lastRun.status === "error"
+                                  ? "red"
+                                  : lastRun.status === "running"
+                                    ? "blue"
+                                    : "green";
+                              return (
+                                <Badge
+                                  size="xs"
+                                  variant="light"
+                                  color={color}
+                                  title={lastRun.error ?? undefined}
+                                >
+                                  {lastRun.status} ·{" "}
+                                  {new Date(lastRun.startedAt).toLocaleString()}
+                                </Badge>
+                              );
+                            })()}
+                            <Button
+                              size="compact-xs"
+                              variant="subtle"
+                              leftSection={<IconRefresh size={12} />}
+                              loading={syncNow.isPending && syncingConfigId === config.id}
+                              disabled={!config.enabled || !workspaceId}
+                              onClick={() => {
+                                if (!workspaceId) return;
+                                setSyncingConfigId(config.id);
+                                syncNow.mutate(
+                                  { workspaceId, configId: config.id },
+                                  { onSettled: () => setSyncingConfigId(null) },
+                                );
+                              }}
+                            >
+                              Sync now
+                            </Button>
+                          </Group>
+                        ) : (
+                          <Text size="xs" className="text-text-muted">
+                            not enrolled
+                          </Text>
+                        )}
+                      </Table.Td>
                     </Table.Tr>
                   );
                 })}
@@ -395,10 +488,101 @@ export default function DecisionsSettingsPage() {
               >
                 Save enrolment
               </Button>
+              <Button
+                variant="light"
+                size="sm"
+                leftSection={<IconRefresh size={14} />}
+                loading={syncNow.isPending && syncingConfigId === "all"}
+                disabled={
+                  !workspaceId ||
+                  (configs ?? []).filter((c) => c.enabled).length === 0
+                }
+                onClick={async () => {
+                  if (!workspaceId) return;
+                  setSyncingConfigId("all");
+                  try {
+                    // Sequential on purpose: one repo's failure surfaces its
+                    // own run record without aborting the rest.
+                    for (const config of (configs ?? []).filter((c) => c.enabled)) {
+                      await syncNow.mutateAsync({ workspaceId, configId: config.id });
+                    }
+                  } catch {
+                    // Per-config errors already notified by the mutation.
+                  } finally {
+                    setSyncingConfigId(null);
+                  }
+                }}
+              >
+                Sync all
+              </Button>
             </Group>
           </Stack>
         </Paper>
       )}
+
+      {(runs ?? []).length > 0 ? (
+        <Paper p="lg" withBorder className="bg-surface-secondary" mt="lg">
+          <Stack gap="md">
+            <Title order={4}>Recent sync runs</Title>
+            <Table verticalSpacing="xs">
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Repository</Table.Th>
+                  <Table.Th>Trigger</Table.Th>
+                  <Table.Th>Status</Table.Th>
+                  <Table.Th>Outcome</Table.Th>
+                  <Table.Th>Started</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {(runs ?? []).map((run) => (
+                  <Table.Tr key={run.id}>
+                    <Table.Td>
+                      <Text size="sm">{run.config.repository.fullName}</Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="sm" className="text-text-secondary">
+                        {run.trigger}
+                        {run.triggeredBy?.name ? ` · ${run.triggeredBy.name}` : ""}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge
+                        size="xs"
+                        variant="light"
+                        color={
+                          run.status === "error"
+                            ? "red"
+                            : run.status === "running"
+                              ? "blue"
+                              : run.status === "unchanged"
+                                ? "gray"
+                                : "green"
+                        }
+                        title={run.error ?? undefined}
+                      >
+                        {run.status}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="xs" className="text-text-secondary">
+                        {run.status === "unchanged"
+                          ? "—"
+                          : `${run.created} created · ${run.updated} updated · ${run.skipped} skipped · ${run.deleted} removed${run.failed > 0 ? ` · ${run.failed} failed` : ""}`}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="xs" className="text-text-secondary whitespace-nowrap">
+                        {new Date(run.startedAt).toLocaleString()}
+                      </Text>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </Stack>
+        </Paper>
+      ) : null}
     </Container>
   );
 }

--- a/src/app/(sidemenu)/w/[workspaceSlug]/settings/decisions/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/settings/decisions/page.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Alert,
+  Badge,
+  Button,
+  Checkbox,
+  Container,
+  Group,
+  Paper,
+  Select,
+  Skeleton,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+  Title,
+} from "@mantine/core";
+import { IconAlertTriangle, IconBrandGithub, IconSearch } from "@tabler/icons-react";
+import { notifications } from "@mantine/notifications";
+import { api } from "~/trpc/react";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import { suggestShortCode } from "~/lib/adr/shortCode";
+
+/**
+ * Decision Log enrolment (settings → decisions): bulk multi-select over the
+ * workspace's tracked repos with auto-suggested short codes, ADR path probe,
+ * and product assignment. Modeled on GithubRepositoriesCard (ADR-0020).
+ */
+
+interface RowState {
+  enrolled: boolean;
+  shortCode: string;
+  /** Comma-separated in the input; split on save. */
+  adrPaths: string;
+}
+
+export default function DecisionsSettingsPage() {
+  const { workspace, workspaceId, userRole, isLoading } = useWorkspace();
+  const isOwnerOrAdmin = userRole === "owner" || userRole === "admin";
+  const utils = api.useUtils();
+
+  const { data: connection, isLoading: reposLoading } =
+    api.github.getGithubConnectionState.useQuery(
+      { workspaceId: workspaceId ?? "" },
+      { enabled: !!workspaceId },
+    );
+  const { data: configs, isLoading: configsLoading } =
+    api.adr.listConfigs.useQuery(
+      { workspaceId: workspaceId ?? "" },
+      { enabled: !!workspaceId },
+    );
+  const { data: products } = api.product.product.list.useQuery(
+    { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId && isOwnerOrAdmin },
+  );
+
+  const repos = useMemo(() => connection?.repos ?? [], [connection?.repos]);
+  const configByRepoId = useMemo(
+    () => new Map((configs ?? []).map((c) => [c.repositoryId, c])),
+    [configs],
+  );
+
+  // Per-repo editable row state, seeded once from configs + suggestions.
+  const [rows, setRows] = useState<Record<string, RowState>>({});
+  const seeded = useRef(false);
+  useEffect(() => {
+    if (seeded.current || reposLoading || configsLoading || repos.length === 0)
+      return;
+    const taken = new Set((configs ?? []).map((c) => c.shortCode));
+    const next: Record<string, RowState> = {};
+    for (const repo of repos) {
+      const config = configByRepoId.get(repo.id);
+      if (config) {
+        next[repo.id] = {
+          enrolled: config.enabled,
+          shortCode: config.shortCode,
+          adrPaths: config.adrPaths.join(", "),
+        };
+      } else {
+        const suggestion = suggestShortCode(repo.name, taken);
+        taken.add(suggestion);
+        next[repo.id] = {
+          enrolled: false,
+          shortCode: suggestion,
+          adrPaths: "docs/adr",
+        };
+      }
+    }
+    setRows(next);
+    seeded.current = true;
+  }, [repos, configs, configByRepoId, reposLoading, configsLoading]);
+
+  const updateRow = (repoId: string, patch: Partial<RowState>) => {
+    setRows((prev) => ({
+      ...prev,
+      [repoId]: { ...(prev[repoId] ?? { enrolled: false, shortCode: "", adrPaths: "docs/adr" }), ...patch },
+    }));
+  };
+
+  // Path probe results, keyed by repo id.
+  const [probeResults, setProbeResults] = useState<
+    Record<string, Array<{ path: string; exists: boolean; markdownCount: number }>>
+  >({});
+  const probe = api.adr.probePaths.useMutation({
+    onError: (error) =>
+      notifications.show({ title: "Probe failed", message: error.message, color: "red" }),
+  });
+  const [probingRepoId, setProbingRepoId] = useState<string | null>(null);
+
+  const upsert = api.adr.upsertConfigs.useMutation({
+    onSuccess: async () => {
+      notifications.show({
+        title: "Saved",
+        message: "ADR sync enrolment updated.",
+        color: "green",
+      });
+      await utils.adr.listConfigs.invalidate();
+      await utils.adr.list.invalidate();
+    },
+    onError: (error) =>
+      notifications.show({ title: "Couldn't save", message: error.message, color: "red" }),
+  });
+
+  const disable = api.adr.disableConfig.useMutation({
+    onSuccess: async () => {
+      notifications.show({
+        title: "Disabled",
+        message: "Sync disabled. Synced decisions and links are retained.",
+        color: "green",
+      });
+      await utils.adr.listConfigs.invalidate();
+    },
+    onError: (error) =>
+      notifications.show({ title: "Couldn't disable", message: error.message, color: "red" }),
+  });
+
+  const setProduct = api.adr.setRepositoryProduct.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.adr.listConfigs.invalidate(),
+        utils.github.getGithubConnectionState.invalidate(),
+      ]);
+    },
+    onError: (error) =>
+      notifications.show({ title: "Couldn't assign product", message: error.message, color: "red" }),
+  });
+
+  if (isLoading || reposLoading || configsLoading) {
+    return (
+      <Container size="xl" className="py-8">
+        <Skeleton height={40} width={280} mb="lg" />
+        <Skeleton height={320} />
+      </Container>
+    );
+  }
+
+  if (!workspace) {
+    return (
+      <Container size="xl" className="py-8">
+        <Text className="text-text-secondary">Workspace not found</Text>
+      </Container>
+    );
+  }
+
+  if (!isOwnerOrAdmin) {
+    return (
+      <Container size="xl" className="py-8">
+        <Title order={2} mb="sm">
+          Decision sync
+        </Title>
+        <Text size="sm" className="text-text-secondary">
+          Only workspace owners and admins can manage ADR sync enrolment.
+        </Text>
+      </Container>
+    );
+  }
+
+  const handleSave = () => {
+    if (!workspaceId) return;
+    const enrolledConfigs = repos
+      .filter((repo) => rows[repo.id]?.enrolled)
+      .map((repo) => {
+        const row = rows[repo.id]!;
+        return {
+          repositoryId: repo.id,
+          shortCode: row.shortCode.trim().toUpperCase(),
+          adrPaths: row.adrPaths
+            .split(",")
+            .map((p) => p.trim().replace(/^\/+|\/+$/g, ""))
+            .filter((p) => p.length > 0),
+          enabled: true,
+        };
+      });
+    if (enrolledConfigs.length === 0) {
+      notifications.show({
+        title: "Nothing to save",
+        message: "Select at least one repository to enrol.",
+        color: "yellow",
+      });
+      return;
+    }
+    upsert.mutate({ workspaceId, configs: enrolledConfigs });
+  };
+
+  const productOptions = (products ?? []).map((p) => ({
+    value: p.id,
+    label: p.name,
+  }));
+
+  return (
+    <Container size="xl" className="py-8">
+      <Group gap="sm" mb="xs">
+        <IconBrandGithub size={22} className="text-text-primary" />
+        <Title order={2}>Decision sync</Title>
+      </Group>
+      <Text size="sm" className="text-text-secondary" mb="lg">
+        Project ADR markdown files from this workspace&apos;s tracked GitHub
+        repos into the Decision Log. Read-only — git stays the source of truth.
+      </Text>
+
+      <Alert
+        icon={<IconAlertTriangle size={16} />}
+        color="yellow"
+        variant="light"
+        mb="lg"
+        title="Visibility"
+      >
+        ADR content from enrolled repositories becomes readable by all members
+        of this workspace — including members who cannot access the repository
+        on GitHub.
+      </Alert>
+
+      {repos.length === 0 ? (
+        <Text size="sm" className="text-text-secondary">
+          No tracked repositories. Add repositories under workspace integrations
+          first.
+        </Text>
+      ) : (
+        <Paper p="lg" withBorder className="bg-surface-secondary">
+          <Stack gap="md">
+            <Table verticalSpacing="sm">
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Sync</Table.Th>
+                  <Table.Th>Repository</Table.Th>
+                  <Table.Th>Short code</Table.Th>
+                  <Table.Th>ADR paths</Table.Th>
+                  <Table.Th>Product</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {repos.map((repo) => {
+                  const row = rows[repo.id];
+                  const config = configByRepoId.get(repo.id);
+                  const probed = probeResults[repo.id];
+                  return (
+                    <Table.Tr key={repo.id}>
+                      <Table.Td>
+                        <Checkbox
+                          checked={row?.enrolled ?? false}
+                          onChange={(e) => {
+                            const enrolled = e.currentTarget.checked;
+                            if (!enrolled && config?.enabled && workspaceId) {
+                              disable.mutate({ workspaceId, configId: config.id });
+                            }
+                            updateRow(repo.id, { enrolled });
+                          }}
+                          aria-label={`Enrol ${repo.fullName}`}
+                        />
+                      </Table.Td>
+                      <Table.Td>
+                        <Stack gap={2}>
+                          <Text size="sm" className="text-text-primary">
+                            {repo.fullName}
+                          </Text>
+                          {config && !config.enabled ? (
+                            <Badge size="xs" variant="light" color="gray">
+                              disabled — data retained
+                            </Badge>
+                          ) : null}
+                        </Stack>
+                      </Table.Td>
+                      <Table.Td>
+                        <TextInput
+                          size="xs"
+                          w={110}
+                          value={row?.shortCode ?? ""}
+                          onChange={(e) =>
+                            updateRow(repo.id, {
+                              shortCode: e.currentTarget.value.toUpperCase(),
+                            })
+                          }
+                          disabled={!row?.enrolled}
+                          aria-label={`Short code for ${repo.fullName}`}
+                        />
+                      </Table.Td>
+                      <Table.Td>
+                        <Stack gap={4}>
+                          <Group gap="xs" wrap="nowrap">
+                            <TextInput
+                              size="xs"
+                              w={200}
+                              value={row?.adrPaths ?? ""}
+                              onChange={(e) =>
+                                updateRow(repo.id, { adrPaths: e.currentTarget.value })
+                              }
+                              disabled={!row?.enrolled}
+                              placeholder="docs/adr"
+                              aria-label={`ADR paths for ${repo.fullName}`}
+                            />
+                            <Button
+                              size="compact-xs"
+                              variant="subtle"
+                              color="gray"
+                              leftSection={<IconSearch size={12} />}
+                              loading={probe.isPending && probingRepoId === repo.id}
+                              disabled={!row?.enrolled || !workspaceId}
+                              onClick={() => {
+                                if (!workspaceId || !row) return;
+                                setProbingRepoId(repo.id);
+                                probe.mutate(
+                                  {
+                                    workspaceId,
+                                    repositoryId: repo.id,
+                                    adrPaths: row.adrPaths
+                                      .split(",")
+                                      .map((p) => p.trim())
+                                      .filter((p) => p.length > 0),
+                                  },
+                                  {
+                                    onSuccess: (result) =>
+                                      setProbeResults((prev) => ({
+                                        ...prev,
+                                        [repo.id]: result,
+                                      })),
+                                    onSettled: () => setProbingRepoId(null),
+                                  },
+                                );
+                              }}
+                            >
+                              Probe
+                            </Button>
+                          </Group>
+                          {probed ? (
+                            <Group gap={6}>
+                              {probed.map((p) => (
+                                <Badge
+                                  key={p.path}
+                                  size="xs"
+                                  variant="light"
+                                  color={p.exists ? "green" : "red"}
+                                >
+                                  {p.path}:{" "}
+                                  {p.exists ? `${p.markdownCount} files` : "not found"}
+                                </Badge>
+                              ))}
+                            </Group>
+                          ) : null}
+                        </Stack>
+                      </Table.Td>
+                      <Table.Td>
+                        <Select
+                          size="xs"
+                          w={180}
+                          data={productOptions}
+                          value={repo.productId ?? null}
+                          placeholder="Workspace-level"
+                          clearable
+                          onChange={(value) => {
+                            if (!workspaceId) return;
+                            setProduct.mutate({
+                              workspaceId,
+                              repositoryId: repo.id,
+                              productId: value,
+                            });
+                          }}
+                          aria-label={`Product for ${repo.fullName}`}
+                        />
+                      </Table.Td>
+                    </Table.Tr>
+                  );
+                })}
+              </Table.Tbody>
+            </Table>
+
+            <Group>
+              <Button
+                variant="filled"
+                color="brand"
+                size="sm"
+                loading={upsert.isPending}
+                onClick={handleSave}
+              >
+                Save enrolment
+              </Button>
+            </Group>
+          </Stack>
+        </Paper>
+      )}
+    </Container>
+  );
+}

--- a/src/lib/adr/__tests__/shortCode.test.ts
+++ b/src/lib/adr/__tests__/shortCode.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { suggestShortCode } from "../shortCode";
+
+describe("suggestShortCode", () => {
+  it("uses the last (most distinctive) word of the repo name", () => {
+    expect(suggestShortCode("clear-api")).toBe("API");
+    expect(suggestShortCode("clear-context-pipeline")).toBe("PIPE");
+  });
+
+  it("truncates a single-word name to four letters", () => {
+    expect(suggestShortCode("exponential")).toBe("EXPO");
+  });
+
+  it("de-conflicts by extending with the word's own letters", () => {
+    const taken = new Set(["PIPE"]);
+    expect(suggestShortCode("clear-context-pipeline", taken)).toBe("PIPEL");
+  });
+
+  it("falls back to numeric suffixes when letters run out", () => {
+    const taken = new Set(["API"]);
+    expect(suggestShortCode("clear-api", taken)).toBe("API2");
+  });
+
+  it("never starts with a digit", () => {
+    expect(/^[A-Z]/.test(suggestShortCode("2fa-service"))).toBe(true);
+  });
+});

--- a/src/lib/adr/shortCode.ts
+++ b/src/lib/adr/shortCode.ts
@@ -1,0 +1,45 @@
+/**
+ * Short-code auto-suggest for ADR enrolment (Decision Log). A short code is a
+ * workspace-unique label prefix — ADRs render as `SHORTCODE-NUMBER`
+ * (API-0003). Suggestions favour the most distinctive word of the repo name
+ * and de-conflict by extending with further letters (PIPE → PIPEL → …), then
+ * digits — never by inventing unrelated suffixes.
+ */
+
+const MAX_LEN = 10;
+const BASE_LEN = 4;
+
+/** Uppercase alphanumeric word candidates from a repo name, most distinctive last. */
+function words(repoName: string): string[] {
+  return repoName
+    .split(/[^a-zA-Z0-9]+/)
+    .filter((w) => w.length > 0)
+    .map((w) => w.toUpperCase());
+}
+
+export function suggestShortCode(
+  repoName: string,
+  taken: ReadonlySet<string> = new Set(),
+): string {
+  const parts = words(repoName);
+  // Last word tends to be the distinctive one ("clear-api" → API,
+  // "clear-context-pipeline" → PIPELINE). Fall back to the whole name.
+  const source = parts[parts.length - 1] ?? "ADR";
+  // Short codes must start with a letter; strip leading digits.
+  const letters = source.replace(/^[0-9]+/, "") || "ADR";
+
+  const base = letters.slice(0, Math.min(BASE_LEN, MAX_LEN));
+  if (!taken.has(base)) return base;
+
+  // Extend with the word's own next letters first…
+  for (let len = base.length + 1; len <= Math.min(letters.length, MAX_LEN); len++) {
+    const candidate = letters.slice(0, len);
+    if (!taken.has(candidate)) return candidate;
+  }
+  // …then fall back to numeric suffixes.
+  for (let n = 2; n < 100; n++) {
+    const candidate = `${base.slice(0, MAX_LEN - String(n).length)}${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return base;
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -2,6 +2,7 @@ import { postRouter } from "~/server/api/routers/post";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 import { actionRouter } from "./routers/action";
 import { adminRouter } from "./routers/admin";
+import { adrRouter } from "./routers/adr";
 import { projectRouter } from "./routers/project";
 import { searchRouter } from "./routers/search";
 import { toolRouter } from "./routers/tool";
@@ -101,6 +102,7 @@ export const appRouter = createTRPCRouter({
   search: searchRouter,
   action: actionRouter,
   admin: adminRouter,
+  adr: adrRouter,
   tools: toolRouter,
   video: videoRouter,
   goal: goalRouter,

--- a/src/server/api/routers/__tests__/adr.test.ts
+++ b/src/server/api/routers/__tests__/adr.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Authz tests for the Decision Log router (`adr`), per the feature's privacy
+ * decision:
+ *
+ * - every procedure is human-only (ADR-0049): an external-agent principal
+ *   (`isAgent` shadow user) is denied on EVERY procedure;
+ * - reads gate at `edit` permission (minimum workspace role `member`) — a
+ *   viewer-tier member is denied on `list`;
+ * - config mutations gate at admin (`manage_members`) — a plain member is
+ *   denied on `upsertConfigs` / `syncNow` / `disableConfig` /
+ *   `setRepositoryProduct` / `probePaths`.
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety"). Denial style imitates
+ * credentialExposure.test.ts / workspaceMembers.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "0".repeat(64);
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const USER_ID = "user-1";
+const WORKSPACE_ID = "ws-1";
+
+function caller(db: DeepMockProxy<PrismaClient>) {
+  return createMockCaller({ userId: USER_ID, db: db as unknown as PrismaClient });
+}
+
+/** humanOnlyProcedure reads the principal's isAgent flag. */
+function asHuman(db: DeepMockProxy<PrismaClient>) {
+  db.user.findUnique.mockResolvedValue({ isAgent: false } as never);
+}
+function asAgentPrincipal(db: DeepMockProxy<PrismaClient>) {
+  db.user.findUnique.mockResolvedValue({ isAgent: true } as never);
+}
+
+/** Satisfy requireWorkspaceMembership at a given workspace role. */
+function withWorkspaceRole(db: DeepMockProxy<PrismaClient>, role: string) {
+  db.workspaceUser.findUnique.mockResolvedValue({
+    userId: USER_ID,
+    workspaceId: WORKSPACE_ID,
+    role,
+  } as never);
+  db.workspace.findUnique.mockResolvedValue({
+    id: WORKSPACE_ID,
+    ownerId: "someone-else",
+  } as never);
+}
+
+describe("adr router authz", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+  });
+
+  describe("agent principals are denied on every procedure", () => {
+    const calls: Array<[string, (c: ReturnType<typeof caller>) => Promise<unknown>]> = [
+      ["list", (c) => c.adr.list({ workspaceId: WORKSPACE_ID })],
+      ["listConfigs", (c) => c.adr.listConfigs({ workspaceId: WORKSPACE_ID })],
+      [
+        "upsertConfigs",
+        (c) =>
+          c.adr.upsertConfigs({
+            workspaceId: WORKSPACE_ID,
+            configs: [{ repositoryId: "repo-1", shortCode: "API", adrPaths: ["docs/adr"], enabled: true }],
+          }),
+      ],
+      ["disableConfig", (c) => c.adr.disableConfig({ workspaceId: WORKSPACE_ID, configId: "cfg-1" })],
+      [
+        "setRepositoryProduct",
+        (c) =>
+          c.adr.setRepositoryProduct({
+            workspaceId: WORKSPACE_ID,
+            repositoryId: "repo-1",
+            productId: null,
+          }),
+      ],
+      [
+        "probePaths",
+        (c) =>
+          c.adr.probePaths({
+            workspaceId: WORKSPACE_ID,
+            repositoryId: "repo-1",
+            adrPaths: ["docs/adr"],
+          }),
+      ],
+      ["syncNow", (c) => c.adr.syncNow({ workspaceId: WORKSPACE_ID, configId: "cfg-1" })],
+    ];
+
+    for (const [name, call] of calls) {
+      it(`denies an agent principal on ${name}`, async () => {
+        asAgentPrincipal(db);
+        // Even as a workspace OWNER, the agent principal must be refused.
+        withWorkspaceRole(db, "owner");
+
+        await expect(call(caller(db))).rejects.toThrow(
+          /not available to external agents/i,
+        );
+      });
+    }
+  });
+
+  describe("viewer-tier members are denied on reads", () => {
+    it("denies a viewer on list — ADR content is member-visible, not viewer-visible", async () => {
+      asHuman(db);
+      withWorkspaceRole(db, "viewer");
+
+      await expect(
+        caller(db).adr.list({ workspaceId: WORKSPACE_ID }),
+      ).rejects.toThrow();
+    });
+
+    it("denies a viewer on listConfigs", async () => {
+      asHuman(db);
+      withWorkspaceRole(db, "viewer");
+
+      await expect(
+        caller(db).adr.listConfigs({ workspaceId: WORKSPACE_ID }),
+      ).rejects.toThrow();
+    });
+
+    it("allows a plain member on list", async () => {
+      asHuman(db);
+      withWorkspaceRole(db, "member");
+      db.adrSyncConfig.findMany.mockResolvedValue([] as never);
+      db.adrDocument.findMany.mockResolvedValue([] as never);
+
+      await expect(
+        caller(db).adr.list({ workspaceId: WORKSPACE_ID }),
+      ).resolves.toEqual([]);
+    });
+  });
+
+  describe("config mutations are admin-only", () => {
+    const mutations: Array<[string, (c: ReturnType<typeof caller>) => Promise<unknown>]> = [
+      [
+        "upsertConfigs",
+        (c) =>
+          c.adr.upsertConfigs({
+            workspaceId: WORKSPACE_ID,
+            configs: [{ repositoryId: "repo-1", shortCode: "API", adrPaths: ["docs/adr"], enabled: true }],
+          }),
+      ],
+      ["disableConfig", (c) => c.adr.disableConfig({ workspaceId: WORKSPACE_ID, configId: "cfg-1" })],
+      [
+        "setRepositoryProduct",
+        (c) =>
+          c.adr.setRepositoryProduct({
+            workspaceId: WORKSPACE_ID,
+            repositoryId: "repo-1",
+            productId: null,
+          }),
+      ],
+      [
+        "probePaths",
+        (c) =>
+          c.adr.probePaths({
+            workspaceId: WORKSPACE_ID,
+            repositoryId: "repo-1",
+            adrPaths: ["docs/adr"],
+          }),
+      ],
+      ["syncNow", (c) => c.adr.syncNow({ workspaceId: WORKSPACE_ID, configId: "cfg-1" })],
+    ];
+
+    for (const [name, call] of mutations) {
+      it(`denies a plain member on ${name}`, async () => {
+        asHuman(db);
+        withWorkspaceRole(db, "member");
+
+        await expect(call(caller(db))).rejects.toThrow();
+      });
+    }
+
+    it("allows an admin on disableConfig (and keeps it a soft state change)", async () => {
+      asHuman(db);
+      withWorkspaceRole(db, "admin");
+      db.adrSyncConfig.findFirst.mockResolvedValue({ id: "cfg-1" } as never);
+      db.adrSyncConfig.update.mockResolvedValue({ id: "cfg-1", enabled: false } as never);
+
+      await caller(db).adr.disableConfig({
+        workspaceId: WORKSPACE_ID,
+        configId: "cfg-1",
+      });
+
+      expect(db.adrSyncConfig.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { enabled: false, integrationId: null },
+        }),
+      );
+      expect(db.adrDocument.deleteMany).not.toHaveBeenCalled();
+      expect(db.adrTicketLink.deleteMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/api/routers/adr.ts
+++ b/src/server/api/routers/adr.ts
@@ -279,6 +279,37 @@ export const adrRouter = createTRPCRouter({
       return results;
     }),
 
+  /** Recent sync runs (the ledger), workspace-wide or for one config. */
+  listRuns: humanOnlyProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        configId: z.string().optional(),
+        limit: z.number().min(1).max(100).default(30),
+      }),
+    )
+    .use(requireWorkspaceMembership("edit"))
+    .query(async ({ ctx, input }) => {
+      return ctx.db.adrSyncRun.findMany({
+        where: {
+          config: { workspaceId: input.workspaceId },
+          ...(input.configId ? { configId: input.configId } : {}),
+        },
+        include: {
+          config: {
+            select: {
+              id: true,
+              shortCode: true,
+              repository: { select: { fullName: true } },
+            },
+          },
+          triggeredBy: { select: { id: true, name: true } },
+        },
+        orderBy: { startedAt: "desc" },
+        take: input.limit,
+      });
+    }),
+
   /**
    * Disable a config: soft state change only. Nulls the integration link and
    * flips `enabled` off; documents, links and run history are all retained

--- a/src/server/api/routers/adr.ts
+++ b/src/server/api/routers/adr.ts
@@ -1,0 +1,238 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { createTRPCRouter, humanOnlyProcedure } from "~/server/api/trpc";
+import { requireWorkspaceMembership } from "~/server/services/access";
+import { runAdrSync } from "~/server/services/adrSync/engine";
+import {
+  GITHUB_INSTALLATION_PROVIDER,
+  GITHUB_INSTALLATION_TYPE,
+} from "~/server/services/github/connectionState";
+
+/**
+ * Decision Log router (ADR projection).
+ *
+ * Gating (deliberate, per the feature's privacy decision):
+ * - every procedure builds on `humanOnlyProcedure` — external-agent
+ *   principals are denied outright (ADR-0049);
+ * - reads gate at `edit` permission (minimum workspace role `member`) — ADR
+ *   content is member-visible, NOT viewer-visible;
+ * - config mutations gate at `manage_members` (admin);
+ * - there is deliberately NO write path to ADR content anywhere here — git is
+ *   the source of truth and the projection is one-way.
+ */
+
+const shortCodeSchema = z
+  .string()
+  .min(2)
+  .max(10)
+  .regex(/^[A-Z][A-Z0-9]*$/, "Short code must be uppercase letters/digits");
+
+export const adrRouter = createTRPCRouter({
+  /** Non-deleted ADRs across the workspace's enrolled repos. */
+  list: humanOnlyProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("edit"))
+    .query(async ({ ctx, input }) => {
+      const configs = await ctx.db.adrSyncConfig.findMany({
+        where: { workspaceId: input.workspaceId },
+        select: { repositoryId: true, shortCode: true },
+      });
+      const shortCodeByRepo = new Map(
+        configs.map((c) => [c.repositoryId, c.shortCode]),
+      );
+
+      const documents = await ctx.db.adrDocument.findMany({
+        where: {
+          repositoryId: { in: configs.map((c) => c.repositoryId) },
+          deletedAt: null,
+        },
+        select: {
+          id: true,
+          repositoryId: true,
+          path: true,
+          number: true,
+          slug: true,
+          title: true,
+          status: true,
+          statusRaw: true,
+          decidedAt: true,
+          updatedAt: true,
+          repository: {
+            select: {
+              id: true,
+              fullName: true,
+              productId: true,
+              product: { select: { id: true, name: true, slug: true } },
+            },
+          },
+        },
+        orderBy: [{ decidedAt: { sort: "desc", nulls: "last" } }, { path: "asc" }],
+      });
+
+      return documents.map((doc) => ({
+        ...doc,
+        shortCode: shortCodeByRepo.get(doc.repositoryId) ?? null,
+        label:
+          doc.number !== null
+            ? `${shortCodeByRepo.get(doc.repositoryId) ?? "ADR"}-${String(doc.number).padStart(4, "0")}`
+            : null,
+      }));
+    }),
+
+  /** The workspace's ADR sync configs (enrolment state), with repo info. */
+  listConfigs: humanOnlyProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("edit"))
+    .query(async ({ ctx, input }) => {
+      return ctx.db.adrSyncConfig.findMany({
+        where: { workspaceId: input.workspaceId },
+        include: {
+          repository: {
+            select: {
+              id: true,
+              fullName: true,
+              owner: true,
+              name: true,
+              productId: true,
+              product: { select: { id: true, name: true, slug: true } },
+            },
+          },
+        },
+        orderBy: { createdAt: "asc" },
+      });
+    }),
+
+  /**
+   * Bulk enrolment: create or update sync configs for many repos in one
+   * submission. Admin only. Short codes must be workspace-unique — both
+   * within the submission and against existing configs of other repos.
+   */
+  upsertConfigs: humanOnlyProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        configs: z
+          .array(
+            z.object({
+              repositoryId: z.string(),
+              shortCode: shortCodeSchema,
+              adrPaths: z.array(z.string().min(1)).min(1).default(["docs/adr"]),
+              enabled: z.boolean().default(true),
+            }),
+          )
+          .min(1),
+      }),
+    )
+    .use(requireWorkspaceMembership("manage_members"))
+    .mutation(async ({ ctx, input }) => {
+      const codes = input.configs.map((c) => c.shortCode);
+      if (new Set(codes).size !== codes.length) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Short codes must be unique within the submission",
+        });
+      }
+
+      const repos = await ctx.db.workspaceRepository.findMany({
+        where: {
+          workspaceId: input.workspaceId,
+          id: { in: input.configs.map((c) => c.repositoryId) },
+        },
+        select: { id: true },
+      });
+      const knownRepoIds = new Set(repos.map((r) => r.id));
+      const unknown = input.configs.filter((c) => !knownRepoIds.has(c.repositoryId));
+      if (unknown.length > 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "One or more repositories are not tracked by this workspace",
+        });
+      }
+
+      // Codes taken by OTHER repos' configs collide; re-submitting a repo's
+      // own code is fine.
+      const existingConfigs = await ctx.db.adrSyncConfig.findMany({
+        where: { workspaceId: input.workspaceId },
+        select: { repositoryId: true, shortCode: true },
+      });
+      const takenByOther = new Set(
+        existingConfigs
+          .filter(
+            (existing) =>
+              !input.configs.some((c) => c.repositoryId === existing.repositoryId),
+          )
+          .map((existing) => existing.shortCode),
+      );
+      const collisions = codes.filter((code) => takenByOther.has(code));
+      if (collisions.length > 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Short code already in use: ${collisions.join(", ")}`,
+        });
+      }
+
+      const installation = await ctx.db.integration.findFirst({
+        where: {
+          workspaceId: input.workspaceId,
+          provider: GITHUB_INSTALLATION_PROVIDER,
+          type: GITHUB_INSTALLATION_TYPE,
+          status: "ACTIVE",
+        },
+        select: { id: true },
+      });
+      if (!installation) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "GitHub App is not installed for this workspace",
+        });
+      }
+
+      const results = [];
+      for (const config of input.configs) {
+        results.push(
+          await ctx.db.adrSyncConfig.upsert({
+            where: {
+              workspaceId_repositoryId: {
+                workspaceId: input.workspaceId,
+                repositoryId: config.repositoryId,
+              },
+            },
+            create: {
+              workspaceId: input.workspaceId,
+              repositoryId: config.repositoryId,
+              shortCode: config.shortCode,
+              adrPaths: config.adrPaths,
+              enabled: config.enabled,
+              integrationId: installation.id,
+              createdById: ctx.session.user.id,
+            },
+            update: {
+              shortCode: config.shortCode,
+              adrPaths: config.adrPaths,
+              enabled: config.enabled,
+              // Re-enrolling reconnects a previously disconnected config.
+              integrationId: installation.id,
+            },
+          }),
+        );
+      }
+      return results;
+    }),
+
+  /** Run one config's sync immediately. Admin only. */
+  syncNow: humanOnlyProcedure
+    .input(z.object({ workspaceId: z.string(), configId: z.string() }))
+    .use(requireWorkspaceMembership("manage_members"))
+    .mutation(async ({ ctx, input }) => {
+      const config = await ctx.db.adrSyncConfig.findFirst({
+        where: { id: input.configId, workspaceId: input.workspaceId },
+        select: { id: true },
+      });
+      if (!config) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Sync config not found" });
+      }
+      return runAdrSync(ctx.db, config.id, "manual", {
+        triggeredById: ctx.session.user.id,
+      });
+    }),
+});

--- a/src/server/api/routers/adr.ts
+++ b/src/server/api/routers/adr.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, humanOnlyProcedure } from "~/server/api/trpc";
 import { requireWorkspaceMembership } from "~/server/services/access";
-import { runAdrSync } from "~/server/services/adrSync/engine";
+import { probeAdrPaths, runAdrSync } from "~/server/services/adrSync/engine";
+import { readInstallationId } from "~/server/services/adrSync/github";
 import {
   GITHUB_INSTALLATION_PROVIDER,
   GITHUB_INSTALLATION_TYPE,
@@ -217,6 +218,108 @@ export const adrRouter = createTRPCRouter({
         );
       }
       return results;
+    }),
+
+  /**
+   * Disable a config: soft state change only. Nulls the integration link and
+   * flips `enabled` off; documents, links and run history are all retained
+   * (ADR-0042 precedent).
+   */
+  disableConfig: humanOnlyProcedure
+    .input(z.object({ workspaceId: z.string(), configId: z.string() }))
+    .use(requireWorkspaceMembership("manage_members"))
+    .mutation(async ({ ctx, input }) => {
+      const config = await ctx.db.adrSyncConfig.findFirst({
+        where: { id: input.configId, workspaceId: input.workspaceId },
+        select: { id: true },
+      });
+      if (!config) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Sync config not found" });
+      }
+      return ctx.db.adrSyncConfig.update({
+        where: { id: config.id },
+        data: { enabled: false, integrationId: null },
+      });
+    }),
+
+  /**
+   * Assign (or clear) a repo's product. ADRs derive their product through the
+   * repo; null means workspace-level (e.g. a shared architecture repo).
+   */
+  setRepositoryProduct: humanOnlyProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        repositoryId: z.string(),
+        productId: z.string().nullable(),
+      }),
+    )
+    .use(requireWorkspaceMembership("manage_members"))
+    .mutation(async ({ ctx, input }) => {
+      const repository = await ctx.db.workspaceRepository.findFirst({
+        where: { id: input.repositoryId, workspaceId: input.workspaceId },
+        select: { id: true },
+      });
+      if (!repository) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Repository not found" });
+      }
+      if (input.productId !== null) {
+        const product = await ctx.db.product.findFirst({
+          where: { id: input.productId, workspaceId: input.workspaceId },
+          select: { id: true },
+        });
+        if (!product) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Product not found" });
+        }
+      }
+      return ctx.db.workspaceRepository.update({
+        where: { id: repository.id },
+        data: { productId: input.productId },
+      });
+    }),
+
+  /**
+   * Pre-enrolment probe: does each candidate path exist, and how many markdown
+   * files does it hold? Read-only against GitHub; writes nothing.
+   */
+  probePaths: humanOnlyProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        repositoryId: z.string(),
+        adrPaths: z.array(z.string().min(1)).min(1),
+      }),
+    )
+    .use(requireWorkspaceMembership("manage_members"))
+    .mutation(async ({ ctx, input }) => {
+      const repository = await ctx.db.workspaceRepository.findFirst({
+        where: { id: input.repositoryId, workspaceId: input.workspaceId },
+        select: { id: true },
+      });
+      if (!repository) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Repository not found" });
+      }
+      const installation = await ctx.db.integration.findFirst({
+        where: {
+          workspaceId: input.workspaceId,
+          provider: GITHUB_INSTALLATION_PROVIDER,
+          type: GITHUB_INSTALLATION_TYPE,
+          status: "ACTIVE",
+        },
+        select: { providerConfig: true },
+      });
+      const installationId = readInstallationId(installation?.providerConfig);
+      if (!installationId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "GitHub App is not installed for this workspace",
+        });
+      }
+      return probeAdrPaths(ctx.db, {
+        repositoryId: repository.id,
+        adrPaths: input.adrPaths,
+        installationId,
+      });
     }),
 
   /** Run one config's sync immediately. Admin only. */

--- a/src/server/api/routers/adr.ts
+++ b/src/server/api/routers/adr.ts
@@ -247,36 +247,73 @@ export const adrRouter = createTRPCRouter({
         });
       }
 
-      const results = [];
-      for (const config of input.configs) {
-        results.push(
-          await ctx.db.adrSyncConfig.upsert({
-            where: {
-              workspaceId_repositoryId: {
-                workspaceId: input.workspaceId,
-                repositoryId: config.repositoryId,
+      // One transaction so a multi-repo save never half-applies. Codes being
+      // swapped WITHIN the submission (A takes B's code and vice versa) would
+      // trip the unique constraint mid-loop, so existing rows in the
+      // submission are first parked on placeholder codes to free theirs.
+      try {
+        return await ctx.db.$transaction(async (tx) => {
+          const existingInSubmission = existingConfigs.filter((existing) =>
+            input.configs.some((c) => c.repositoryId === existing.repositoryId),
+          );
+          for (const existing of existingInSubmission) {
+            await tx.adrSyncConfig.update({
+              where: {
+                workspaceId_repositoryId: {
+                  workspaceId: input.workspaceId,
+                  repositoryId: existing.repositoryId,
+                },
               },
-            },
-            create: {
-              workspaceId: input.workspaceId,
-              repositoryId: config.repositoryId,
-              shortCode: config.shortCode,
-              adrPaths: config.adrPaths,
-              enabled: config.enabled,
-              integrationId: installation.id,
-              createdById: ctx.session.user.id,
-            },
-            update: {
-              shortCode: config.shortCode,
-              adrPaths: config.adrPaths,
-              enabled: config.enabled,
-              // Re-enrolling reconnects a previously disconnected config.
-              integrationId: installation.id,
-            },
-          }),
-        );
+              // repositoryId is unique per workspace, so this placeholder is too.
+              data: { shortCode: `~swap~${existing.repositoryId}` },
+            });
+          }
+
+          const results = [];
+          for (const config of input.configs) {
+            results.push(
+              await tx.adrSyncConfig.upsert({
+                where: {
+                  workspaceId_repositoryId: {
+                    workspaceId: input.workspaceId,
+                    repositoryId: config.repositoryId,
+                  },
+                },
+                create: {
+                  workspaceId: input.workspaceId,
+                  repositoryId: config.repositoryId,
+                  shortCode: config.shortCode,
+                  adrPaths: config.adrPaths,
+                  enabled: config.enabled,
+                  integrationId: installation.id,
+                  createdById: ctx.session.user.id,
+                },
+                update: {
+                  shortCode: config.shortCode,
+                  adrPaths: config.adrPaths,
+                  enabled: config.enabled,
+                  // Re-enrolling reconnects a previously disconnected config.
+                  integrationId: installation.id,
+                },
+              }),
+            );
+          }
+          return results;
+        });
+      } catch (error) {
+        if (
+          error &&
+          typeof error === "object" &&
+          "code" in error &&
+          (error as { code?: string }).code === "P2002"
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "A short code in this submission collides with an existing one",
+          });
+        }
+        throw error;
       }
-      return results;
     }),
 
   /** Recent sync runs (the ledger), workspace-wide or for one config. */

--- a/src/server/api/routers/adr.ts
+++ b/src/server/api/routers/adr.ts
@@ -29,9 +29,25 @@ const shortCodeSchema = z
   .regex(/^[A-Z][A-Z0-9]*$/, "Short code must be uppercase letters/digits");
 
 export const adrRouter = createTRPCRouter({
-  /** Non-deleted ADRs across the workspace's enrolled repos. */
+  /**
+   * Non-deleted ADRs across the workspace's enrolled repos, with optional
+   * repo/status/product filters and free-text search over title and body.
+   * Duplicate labels (this workspace has real ones) are flagged against the
+   * FULL set, not the filtered view — a label is a label, not a key.
+   */
   list: humanOnlyProcedure
-    .input(z.object({ workspaceId: z.string() }))
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        repositoryIds: z.array(z.string()).optional(),
+        statuses: z
+          .array(z.enum(["PROPOSED", "ACCEPTED", "SUPERSEDED", "DEPRECATED", "UNKNOWN"]))
+          .optional(),
+        /** Filter to one product's repos; "workspace" = repos with no product. */
+        productId: z.string().optional(),
+        search: z.string().max(200).optional(),
+      }),
+    )
     .use(requireWorkspaceMembership("edit"))
     .query(async ({ ctx, input }) => {
       const configs = await ctx.db.adrSyncConfig.findMany({
@@ -41,11 +57,47 @@ export const adrRouter = createTRPCRouter({
       const shortCodeByRepo = new Map(
         configs.map((c) => [c.repositoryId, c.shortCode]),
       );
+      const enrolledRepoIds = configs.map((c) => c.repositoryId);
 
+      // Duplicate-label detection runs over the full non-deleted set so a
+      // filtered view still flags collisions hidden outside it.
+      const allLabels = await ctx.db.adrDocument.findMany({
+        where: { repositoryId: { in: enrolledRepoIds }, deletedAt: null },
+        select: { repositoryId: true, number: true },
+      });
+      const labelCounts = new Map<string, number>();
+      for (const doc of allLabels) {
+        if (doc.number === null) continue;
+        const label = `${shortCodeByRepo.get(doc.repositoryId) ?? "ADR"}-${doc.number}`;
+        labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+      }
+
+      const search = input.search?.trim();
       const documents = await ctx.db.adrDocument.findMany({
         where: {
-          repositoryId: { in: configs.map((c) => c.repositoryId) },
+          repositoryId: {
+            in: input.repositoryIds?.length
+              ? enrolledRepoIds.filter((id) => input.repositoryIds!.includes(id))
+              : enrolledRepoIds,
+          },
           deletedAt: null,
+          ...(input.statuses?.length ? { status: { in: input.statuses } } : {}),
+          ...(input.productId
+            ? {
+                repository:
+                  input.productId === "workspace"
+                    ? { productId: null }
+                    : { productId: input.productId },
+              }
+            : {}),
+          ...(search
+            ? {
+                OR: [
+                  { title: { contains: search, mode: "insensitive" as const } },
+                  { body: { contains: search, mode: "insensitive" as const } },
+                ],
+              }
+            : {}),
         },
         select: {
           id: true,
@@ -70,14 +122,21 @@ export const adrRouter = createTRPCRouter({
         orderBy: [{ decidedAt: { sort: "desc", nulls: "last" } }, { path: "asc" }],
       });
 
-      return documents.map((doc) => ({
-        ...doc,
-        shortCode: shortCodeByRepo.get(doc.repositoryId) ?? null,
-        label:
-          doc.number !== null
-            ? `${shortCodeByRepo.get(doc.repositoryId) ?? "ADR"}-${String(doc.number).padStart(4, "0")}`
-            : null,
-      }));
+      return documents.map((doc) => {
+        const shortCode = shortCodeByRepo.get(doc.repositoryId) ?? null;
+        const labelKey =
+          doc.number !== null ? `${shortCode ?? "ADR"}-${doc.number}` : null;
+        return {
+          ...doc,
+          shortCode,
+          label:
+            doc.number !== null
+              ? `${shortCode ?? "ADR"}-${String(doc.number).padStart(4, "0")}`
+              : null,
+          isDuplicateLabel:
+            labelKey !== null && (labelCounts.get(labelKey) ?? 0) > 1,
+        };
+      });
     }),
 
   /** The workspace's ADR sync configs (enrolment state), with repo info. */

--- a/src/server/services/adrSync/__tests__/engine.test.ts
+++ b/src/server/services/adrSync/__tests__/engine.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Engine-seam tests for the ADR sync (imitating ticketSync's engine tests):
+ * the engine is driven with a plain fake {@link AdrRemote} and a deep-mocked
+ * PrismaClient — no network, no DB. The budget rules are asserted here as
+ * behaviour, not implementation: the tree-SHA short-circuit performs ZERO
+ * blob fetches, unchanged blobs are skipped from the tree listing alone, and
+ * a parse/fetch failure records a per-file item without failing the run.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import { combineTreeShas, runAdrSync } from "../engine";
+import type { AdrRemote } from "../github";
+
+const db = mockDeep<PrismaClient>() as DeepMockProxy<PrismaClient>;
+
+const CONFIG = {
+  id: "cfg1",
+  workspaceId: "ws1",
+  repositoryId: "repo1",
+  shortCode: "API",
+  adrPaths: ["docs/adr"],
+  integrationId: "int1",
+  enabled: true,
+  lastTreeSha: null as string | null,
+  lastCommitSha: null as string | null,
+  lastSyncedAt: null as Date | null,
+  createdById: "user1",
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+  repository: { id: "repo1", owner: "acme", name: "api" },
+  integration: { providerConfig: { installationId: 42 } },
+};
+
+const ADR_CONTENT = `# ADR-0001: Use Postgres
+
+Status: Accepted
+`;
+
+/** Fake remote: one repo with docs/adr/0001-use-postgres.md at blob sha b1. */
+function makeRemote(overrides?: Partial<AdrRemote>): {
+  remote: AdrRemote;
+  calls: { getBlob: number };
+} {
+  const calls = { getBlob: 0 };
+  const remote: AdrRemote = {
+    getHead: vi.fn(async () => ({ commitSha: "c1", treeSha: "root1" })),
+    getTree: vi.fn(async (_o, _r, sha, recursive) => {
+      if (sha === "root1" && !recursive) {
+        return [{ path: "docs", type: "tree" as const, sha: "t-docs" }];
+      }
+      if (sha === "t-docs" && !recursive) {
+        return [{ path: "adr", type: "tree" as const, sha: "t-adr" }];
+      }
+      if (sha === "t-adr") {
+        return [
+          { path: "0001-use-postgres.md", type: "blob" as const, sha: "b1" },
+          { path: "README.txt", type: "blob" as const, sha: "b2" },
+        ];
+      }
+      return [];
+    }),
+    getBlob: vi.fn(async () => {
+      calls.getBlob++;
+      return ADR_CONTENT;
+    }),
+    ...overrides,
+  };
+  return { remote, calls };
+}
+
+beforeEach(() => {
+  mockReset(db);
+  db.adrSyncRun.create.mockResolvedValue({ id: "run1" } as never);
+  db.adrSyncRun.update.mockResolvedValue({} as never);
+  db.adrSyncConfig.update.mockResolvedValue({} as never);
+  db.adrDocument.findMany.mockResolvedValue([]);
+  db.adrDocument.create.mockResolvedValue({} as never);
+  db.adrDocument.update.mockResolvedValue({} as never);
+});
+
+describe("runAdrSync", () => {
+  it("creates a document per matching markdown file on first sync", async () => {
+    db.adrSyncConfig.findUnique.mockResolvedValue(CONFIG as never);
+    const { remote } = makeRemote();
+
+    const result = await runAdrSync(db, "cfg1", "manual", {
+      remoteFactory: async () => remote,
+    });
+
+    expect(result.status).toBe("success");
+    expect(result.created).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(db.adrDocument.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          repositoryId: "repo1",
+          path: "docs/adr/0001-use-postgres.md",
+          number: 1,
+          title: "Use Postgres",
+          status: "ACCEPTED",
+          contentHash: "b1",
+          lastSeenSha: "b1",
+        }),
+      }),
+    );
+    // Config advances its short-circuit keys.
+    expect(db.adrSyncConfig.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          lastCommitSha: "c1",
+          lastTreeSha: combineTreeShas([{ path: "docs/adr", sha: "t-adr" }]),
+        }),
+      }),
+    );
+  });
+
+  it("short-circuits as unchanged with ZERO blob fetches when the tree SHA matches", async () => {
+    db.adrSyncConfig.findUnique.mockResolvedValue({
+      ...CONFIG,
+      lastTreeSha: combineTreeShas([{ path: "docs/adr", sha: "t-adr" }]),
+    } as never);
+    const { remote, calls } = makeRemote();
+
+    const result = await runAdrSync(db, "cfg1", "cron", {
+      remoteFactory: async () => remote,
+    });
+
+    expect(result.status).toBe("unchanged");
+    expect(calls.getBlob).toBe(0);
+    expect(db.adrDocument.create).not.toHaveBeenCalled();
+    expect(db.adrSyncRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "unchanged" }),
+      }),
+    );
+  });
+
+  it("skips an unchanged blob from the tree listing alone (no content fetch)", async () => {
+    db.adrSyncConfig.findUnique.mockResolvedValue(CONFIG as never);
+    db.adrDocument.findMany.mockResolvedValue([
+      {
+        id: "doc1",
+        path: "docs/adr/0001-use-postgres.md",
+        contentHash: "b1",
+        deletedAt: null,
+      },
+    ] as never);
+    const { remote, calls } = makeRemote();
+
+    const result = await runAdrSync(db, "cfg1", "manual", {
+      remoteFactory: async () => remote,
+    });
+
+    expect(result.status).toBe("success");
+    expect(result.skipped).toBe(1);
+    expect(result.created).toBe(0);
+    expect(calls.getBlob).toBe(0);
+  });
+
+  it("soft-deletes a document whose file vanished, never hard-deletes", async () => {
+    db.adrSyncConfig.findUnique.mockResolvedValue(CONFIG as never);
+    db.adrDocument.findMany.mockResolvedValue([
+      {
+        id: "doc-gone",
+        path: "docs/adr/0000-removed.md",
+        contentHash: "old",
+        deletedAt: null,
+      },
+    ] as never);
+    const { remote } = makeRemote();
+
+    const result = await runAdrSync(db, "cfg1", "manual", {
+      remoteFactory: async () => remote,
+    });
+
+    expect(result.deleted).toBe(1);
+    expect(db.adrDocument.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "doc-gone" },
+        data: expect.objectContaining({ deletedAt: expect.any(Date) }),
+      }),
+    );
+    expect(db.adrDocument.delete).not.toHaveBeenCalled();
+    expect(db.adrDocument.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("records a per-file failure and continues instead of failing the run", async () => {
+    db.adrSyncConfig.findUnique.mockResolvedValue(CONFIG as never);
+    const { remote } = makeRemote({
+      getBlob: vi.fn(async () => {
+        throw new Error("boom: blob unreadable");
+      }),
+    });
+
+    const result = await runAdrSync(db, "cfg1", "manual", {
+      remoteFactory: async () => remote,
+    });
+
+    expect(result.status).toBe("success");
+    expect(result.failed).toBe(1);
+    expect(result.items).toContainEqual(
+      expect.objectContaining({
+        path: "docs/adr/0001-use-postgres.md",
+        action: "failed",
+        reason: expect.stringContaining("boom"),
+      }),
+    );
+  });
+
+  it("skips an unfilled template file and records it in the run items", async () => {
+    db.adrSyncConfig.findUnique.mockResolvedValue(CONFIG as never);
+    const { remote } = makeRemote({
+      getBlob: vi.fn(
+        async () =>
+          `# Template\n\nStatus: Proposed | Accepted | Rejected | Deprecated | Superseded\n`,
+      ),
+    });
+
+    const result = await runAdrSync(db, "cfg1", "manual", {
+      remoteFactory: async () => remote,
+    });
+
+    expect(result.status).toBe("success");
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.items).toContainEqual(
+      expect.objectContaining({ action: "skipped-template" }),
+    );
+  });
+
+  it("errors the run (not the sweep) when the config is disconnected", async () => {
+    db.adrSyncConfig.findUnique.mockResolvedValue({
+      ...CONFIG,
+      integrationId: null,
+      integration: null,
+    } as never);
+
+    const result = await runAdrSync(db, "cfg1", "manual", {
+      remoteFactory: async () => makeRemote().remote,
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("disconnected");
+    expect(db.adrSyncRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: "error" }),
+      }),
+    );
+  });
+});

--- a/src/server/services/adrSync/__tests__/engine.test.ts
+++ b/src/server/services/adrSync/__tests__/engine.test.ts
@@ -208,6 +208,19 @@ describe("runAdrSync", () => {
         reason: expect.stringContaining("boom"),
       }),
     );
+    // The per-file outcome is persisted onto the run ledger, not just returned.
+    expect(db.adrSyncRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "run1" },
+        data: expect.objectContaining({
+          status: "success",
+          failed: 1,
+          items: expect.arrayContaining([
+            expect.objectContaining({ action: "failed" }),
+          ]),
+        }),
+      }),
+    );
   });
 
   it("skips an unfilled template file and records it in the run items", async () => {

--- a/src/server/services/adrSync/__tests__/engine.test.ts
+++ b/src/server/services/adrSync/__tests__/engine.test.ts
@@ -49,18 +49,27 @@ function makeRemote(overrides?: Partial<AdrRemote>): {
     getHead: vi.fn(async () => ({ commitSha: "c1", treeSha: "root1" })),
     getTree: vi.fn(async (_o, _r, sha, recursive) => {
       if (sha === "root1" && !recursive) {
-        return [{ path: "docs", type: "tree" as const, sha: "t-docs" }];
+        return {
+          truncated: false,
+          entries: [{ path: "docs", type: "tree" as const, sha: "t-docs" }],
+        };
       }
       if (sha === "t-docs" && !recursive) {
-        return [{ path: "adr", type: "tree" as const, sha: "t-adr" }];
+        return {
+          truncated: false,
+          entries: [{ path: "adr", type: "tree" as const, sha: "t-adr" }],
+        };
       }
       if (sha === "t-adr") {
-        return [
-          { path: "0001-use-postgres.md", type: "blob" as const, sha: "b1" },
-          { path: "README.txt", type: "blob" as const, sha: "b2" },
-        ];
+        return {
+          truncated: false,
+          entries: [
+            { path: "0001-use-postgres.md", type: "blob" as const, sha: "b1" },
+            { path: "README.txt", type: "blob" as const, sha: "b2" },
+          ],
+        };
       }
-      return [];
+      return { truncated: false, entries: [] };
     }),
     getBlob: vi.fn(async () => {
       calls.getBlob++;
@@ -242,6 +251,56 @@ describe("runAdrSync", () => {
     expect(result.items).toContainEqual(
       expect.objectContaining({ action: "skipped-template" }),
     );
+  });
+
+  it("does NOT advance lastTreeSha when any file failed, so the next run retries", async () => {
+    db.adrSyncConfig.findUnique.mockResolvedValue(CONFIG as never);
+    const { remote } = makeRemote({
+      getBlob: vi.fn(async () => {
+        throw new Error("rate limited");
+      }),
+    });
+
+    await runAdrSync(db, "cfg1", "manual", {
+      remoteFactory: async () => remote,
+    });
+
+    expect(db.adrSyncConfig.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ lastTreeSha: null }),
+      }),
+    );
+  });
+
+  it("fails the run on a truncated tree listing instead of mass-soft-deleting", async () => {
+    db.adrSyncConfig.findUnique.mockResolvedValue(CONFIG as never);
+    db.adrDocument.findMany.mockResolvedValue([
+      {
+        id: "doc1",
+        path: "docs/adr/0001-use-postgres.md",
+        contentHash: "b1",
+        deletedAt: null,
+      },
+    ] as never);
+    const base = makeRemote();
+    const { remote } = makeRemote({
+      getTree: vi.fn(async (o, r, sha, recursive) => {
+        if (sha === "t-adr" && recursive) {
+          return { truncated: true, entries: [] };
+        }
+        return base.remote.getTree(o, r, sha, recursive);
+      }),
+    });
+
+    const result = await runAdrSync(db, "cfg1", "manual", {
+      remoteFactory: async () => remote,
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("truncated");
+    // No soft-deletes and no short-circuit key advanced.
+    expect(db.adrDocument.update).not.toHaveBeenCalled();
+    expect(db.adrSyncConfig.update).not.toHaveBeenCalled();
   });
 
   it("errors the run (not the sweep) when the config is disconnected", async () => {

--- a/src/server/services/adrSync/__tests__/parser.test.ts
+++ b/src/server/services/adrSync/__tests__/parser.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Parser tests fixtured from the real ADR formats found in the wild across
+ * this workspace's repos (see the Decision Log PRD): YAML frontmatter,
+ * `# ADR 0001 — Title` + bulleted Status, plain `Status:` line, and no
+ * status at all — plus the unfilled template and duplicate-number pairs.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseAdr } from "../parser";
+
+const FRONTMATTER_ADR = `---
+status: Accepted
+date: 2026-01-15
+---
+
+# ADR-0017: Markdown as the canonical content format
+
+## Context
+
+Everything is markdown.
+`;
+
+const HEADING_BULLET_ADR = `# ADR 0001 — Activity feed storage
+
+- **Status**: Accepted
+- **Date**: 2025-11-02
+
+## Context
+`;
+
+const PLAIN_STATUS_ADR = `# Use Celery for pipeline jobs
+
+Status: Superseded by ADR-0002
+
+## Context
+`;
+
+const NO_STATUS_ADR = `# Some early decision
+
+## Context
+
+We never wrote a status line.
+`;
+
+describe("parseAdr", () => {
+  it("parses number and slug from the filename", () => {
+    const parsed = parseAdr({
+      path: "docs/adr/0017-markdown-canonical-content-format.md",
+      content: FRONTMATTER_ADR,
+    });
+    expect(parsed.number).toBe(17);
+    expect(parsed.slug).toBe("markdown-canonical-content-format");
+  });
+
+  it("reads status and date from YAML frontmatter", () => {
+    const parsed = parseAdr({
+      path: "docs/adr/0017-markdown.md",
+      content: FRONTMATTER_ADR,
+    });
+    expect(parsed.status).toBe("ACCEPTED");
+    expect(parsed.statusRaw).toBe("Accepted");
+    expect(parsed.decidedAt?.getUTCFullYear()).toBe(2026);
+  });
+
+  it("strips the ADR-number prefix from the title", () => {
+    const parsed = parseAdr({
+      path: "docs/adr/0017-markdown.md",
+      content: FRONTMATTER_ADR,
+    });
+    expect(parsed.title).toBe("Markdown as the canonical content format");
+  });
+
+  it("reads a bulleted bold Status line under an em-dash heading", () => {
+    const parsed = parseAdr({
+      path: "docs/adr/0001-activity-feed-storage.md",
+      content: HEADING_BULLET_ADR,
+    });
+    expect(parsed.title).toBe("Activity feed storage");
+    expect(parsed.number).toBe(1);
+    expect(parsed.status).toBe("ACCEPTED");
+    expect(parsed.decidedAt).not.toBeNull();
+  });
+
+  it("reads a plain Status: line and preserves the verbatim string", () => {
+    const parsed = parseAdr({
+      path: "docs/adr/0001-celery.md",
+      content: PLAIN_STATUS_ADR,
+    });
+    expect(parsed.status).toBe("SUPERSEDED");
+    expect(parsed.statusRaw).toBe("Superseded by ADR-0002");
+  });
+
+  it("maps a missing status to UNKNOWN instead of failing", () => {
+    const parsed = parseAdr({
+      path: "docs/adr/0002-early.md",
+      content: NO_STATUS_ADR,
+    });
+    expect(parsed.status).toBe("UNKNOWN");
+    expect(parsed.statusRaw).toBeNull();
+    expect(parsed.isTemplate).toBe(false);
+  });
+
+  it("handles a file with no number prefix", () => {
+    const parsed = parseAdr({
+      path: "docs/adr/template.md",
+      content: NO_STATUS_ADR,
+    });
+    expect(parsed.number).toBeNull();
+    expect(parsed.slug).toBe("template");
+  });
+
+  it("detects the unfilled template alternation as a template", () => {
+    const parsed = parseAdr({
+      path: "docs/adr/template.md",
+      content: `# Title\n\nStatus: Proposed | Accepted | Rejected | Deprecated | Superseded\n`,
+    });
+    expect(parsed.isTemplate).toBe(true);
+    expect(parsed.status).toBe("UNKNOWN");
+  });
+
+  it("falls back to the filename slug when there is no heading", () => {
+    const parsed = parseAdr({
+      path: "docs/adr/0009-connected-accounts.md",
+      content: "Just prose, no heading.\n",
+    });
+    expect(parsed.title).toBe("connected accounts");
+  });
+});

--- a/src/server/services/adrSync/__tests__/parser.test.ts
+++ b/src/server/services/adrSync/__tests__/parser.test.ts
@@ -125,4 +125,104 @@ describe("parseAdr", () => {
     });
     expect(parsed.title).toBe("connected accounts");
   });
+
+  // ── Fixtures verbatim from real ADRs in the wild ──────────────────────────
+
+  it("reads the `## Status` section format (exponential's dominant format)", () => {
+    // Verbatim head of exponential's docs/adr/0001-activity-feed-storage.md
+    const parsed = parseAdr({
+      path: "docs/adr/0001-activity-feed-storage.md",
+      content: `# Activity feed: two storage paths, union at read
+
+## Status
+
+Accepted — 2026-05-14.
+
+⚠️ **Accuracy caveat (2026-06-14):** the GitHub half of this ADR (decisions #3–#5
+`,
+    });
+    expect(parsed.title).toBe("Activity feed: two storage paths, union at read");
+    expect(parsed.status).toBe("ACCEPTED");
+    expect(parsed.statusRaw).toBe("Accepted — 2026-05-14.");
+    expect(parsed.decidedAt?.toISOString().slice(0, 10)).toBe("2026-05-14");
+  });
+
+  it("reads a bold Deferred-status under a `## Status` heading as UNKNOWN with verbatim raw", () => {
+    // Verbatim from exponential's docs/adr/0019-persist-polled-commits.md
+    const parsed = parseAdr({
+      path: "docs/adr/0019-persist-polled-commits.md",
+      content: `# Persist polled commits
+
+## Status
+
+**Deferred — 2026-06-14.** **Declaration premise superseded by
+[ADR-0020](0020-github-repo-association-via-app-installation.md).**
+`,
+    });
+    expect(parsed.status).toBe("UNKNOWN");
+    expect(parsed.statusRaw).toContain("Deferred — 2026-06-14.");
+  });
+
+  it("reads the `# ADR-NNNN: Title` + plain Status line format", () => {
+    // Verbatim head of exponential's docs/adr/0029-ai-bug-fixer-workflow.md
+    const parsed = parseAdr({
+      path: "docs/adr/0029-ai-bug-fixer-workflow.md",
+      content: `# ADR-0029: Autonomous AI bug-fixer via GitHub Actions
+
+Status: Accepted
+
+## Context
+`,
+    });
+    expect(parsed.title).toBe("Autonomous AI bug-fixer via GitHub Actions");
+    expect(parsed.number).toBe(29);
+    expect(parsed.status).toBe("ACCEPTED");
+  });
+
+  it("handles a no-status ADR that opens straight into Context (mastra's format)", () => {
+    // Verbatim head of mastra's docs/adr/0001-robust-tool-inputs.md
+    const parsed = parseAdr({
+      path: "docs/adr/0001-robust-tool-inputs.md",
+      content: `# Robust tool inputs: coerce to preserve intent, never invent it
+
+## Context
+
+Agent tools (called by Zoe et al. from the exponential chat surface) repeatedly
+`,
+    });
+    expect(parsed.status).toBe("UNKNOWN");
+    expect(parsed.statusRaw).toBeNull();
+    expect(parsed.title).toBe(
+      "Robust tool inputs: coerce to preserve intent, never invent it",
+    );
+  });
+
+  it("parses a lowercase status and a parenthesised date", () => {
+    const lower = parseAdr({
+      path: "docs/adr/0056-x.md",
+      content: `# X\n\nStatus: accepted\n`,
+    });
+    expect(lower.status).toBe("ACCEPTED");
+    const dated = parseAdr({
+      path: "docs/adr/0044-welcome-flow.md",
+      content: `# Welcome flow\n\nStatus: Accepted (2026-07-17)\n`,
+    });
+    expect(dated.status).toBe("ACCEPTED");
+    expect(dated.decidedAt?.toISOString().slice(0, 10)).toBe("2026-07-17");
+  });
+
+  it("tolerates a duplicate-number pair — both parse, identity is a label not a key", () => {
+    // exponential itself has two 0055s.
+    const a = parseAdr({
+      path: "docs/adr/0055-outcomes-deprecated-and-removed-from-the-product.md",
+      content: `# Outcomes deprecated\n\nStatus: Accepted\n`,
+    });
+    const b = parseAdr({
+      path: "docs/adr/0055-password-credential-in-its-own-table.md",
+      content: `# Password credential in its own table\n\nStatus: Accepted\n`,
+    });
+    expect(a.number).toBe(55);
+    expect(b.number).toBe(55);
+    expect(a.slug).not.toBe(b.slug);
+  });
 });

--- a/src/server/services/adrSync/engine.ts
+++ b/src/server/services/adrSync/engine.ts
@@ -75,8 +75,13 @@ async function resolveDirTreeSha(
   let currentSha = rootTreeSha;
   const segments = dirPath.split("/").filter((s) => s.length > 0);
   for (const segment of segments) {
-    const entries = await remote.getTree(owner, repo, currentSha);
-    const next = entries.find((e) => e.type === "tree" && e.path === segment);
+    const listing = await remote.getTree(owner, repo, currentSha);
+    if (listing.truncated) {
+      throw new Error(`Tree listing truncated while resolving ${dirPath}`);
+    }
+    const next = listing.entries.find(
+      (e) => e.type === "tree" && e.path === segment,
+    );
     if (!next) return null;
     currentSha = next.sha;
   }
@@ -122,16 +127,21 @@ export async function probeAdrPaths(
       results.push({ path: dirPath, exists: false, markdownCount: 0 });
       continue;
     }
-    const entries = await remote.getTree(
+    const listing = await remote.getTree(
       repository.owner,
       repository.name,
       dirSha,
       true,
     );
+    if (listing.truncated) {
+      throw new Error(
+        `Tree listing for ${dirPath} was truncated by GitHub — path covers too many files`,
+      );
+    }
     results.push({
       path: dirPath,
       exists: true,
-      markdownCount: entries.filter(
+      markdownCount: listing.entries.filter(
         (e) => e.type === "blob" && /\.md$/i.test(e.path),
       ).length,
     });
@@ -247,16 +257,19 @@ export async function runAdrSync(
       };
     }
 
-    // List every markdown blob under the enrolled dirs.
+    // List every markdown blob under the enrolled dirs. A truncated listing
+    // must fail the run: files missing from it would read as deletions and
+    // the advanced tree SHA would lock the loss in as "unchanged".
     const blobs: Array<{ path: string; sha: string }> = [];
     for (const dir of dirShas) {
       if (!dir.sha) continue;
-      const entries: AdrTreeEntry[] = await remote.getTree(
-        owner,
-        repoName,
-        dir.sha,
-        true,
-      );
+      const listing = await remote.getTree(owner, repoName, dir.sha, true);
+      if (listing.truncated) {
+        return await fail(
+          `Tree listing for ${dir.path} was truncated by GitHub — path covers too many files to sync safely`,
+        );
+      }
+      const entries: AdrTreeEntry[] = listing.entries;
       for (const entry of entries) {
         if (entry.type === "blob" && /\.md$/i.test(entry.path)) {
           blobs.push({ path: `${dir.path}/${entry.path}`, sha: entry.sha });
@@ -357,7 +370,11 @@ export async function runAdrSync(
     await db.adrSyncConfig.update({
       where: { id: configId },
       data: {
-        lastTreeSha: combined,
+        // Advance the short-circuit key only on a CLEAN run: a transient blob
+        // fetch failure would otherwise be locked in — the next run would see
+        // an unchanged tree and short-circuit past the retry forever on a
+        // quiet repo. Unchanged blobs still skip via their blob SHA.
+        lastTreeSha: failed === 0 ? combined : null,
         lastCommitSha: head.commitSha,
         lastSyncedAt: now(),
       },

--- a/src/server/services/adrSync/engine.ts
+++ b/src/server/services/adrSync/engine.ts
@@ -83,6 +83,62 @@ async function resolveDirTreeSha(
   return currentSha;
 }
 
+/**
+ * Pre-enrolment probe: how many markdown files live under each candidate dir?
+ * Read-only against GitHub; touches no rows. Backs the settings page's
+ * detected-count preview.
+ */
+export async function probeAdrPaths(
+  db: PrismaClient,
+  params: {
+    repositoryId: string;
+    adrPaths: string[];
+    /** The workspace's GitHub App installation integration id. */
+    installationId: number;
+  },
+  deps?: AdrSyncDeps,
+): Promise<Array<{ path: string; exists: boolean; markdownCount: number }>> {
+  const remoteFactory = deps?.remoteFactory ?? createInstallationAdrRemote;
+  const repository = await db.workspaceRepository.findUnique({
+    where: { id: params.repositoryId },
+    select: { owner: true, name: true },
+  });
+  if (!repository) {
+    throw new Error("Repository not found");
+  }
+  const remote = await remoteFactory(params.installationId);
+  const head = await remote.getHead(repository.owner, repository.name);
+
+  const results: Array<{ path: string; exists: boolean; markdownCount: number }> = [];
+  for (const dirPath of params.adrPaths) {
+    const dirSha = await resolveDirTreeSha(
+      remote,
+      repository.owner,
+      repository.name,
+      head.treeSha,
+      dirPath,
+    );
+    if (!dirSha) {
+      results.push({ path: dirPath, exists: false, markdownCount: 0 });
+      continue;
+    }
+    const entries = await remote.getTree(
+      repository.owner,
+      repository.name,
+      dirSha,
+      true,
+    );
+    results.push({
+      path: dirPath,
+      exists: true,
+      markdownCount: entries.filter(
+        (e) => e.type === "blob" && /\.md$/i.test(e.path),
+      ).length,
+    });
+  }
+  return results;
+}
+
 export async function runAdrSync(
   db: PrismaClient,
   configId: string,

--- a/src/server/services/adrSync/engine.ts
+++ b/src/server/services/adrSync/engine.ts
@@ -1,0 +1,338 @@
+import type { PrismaClient, Prisma } from "@prisma/client";
+import { parseAdr } from "./parser";
+import {
+  createInstallationAdrRemote,
+  readInstallationId,
+  type AdrRemote,
+  type AdrRemoteFactory,
+  type AdrTreeEntry,
+} from "./github";
+
+/**
+ * adrSync/engine — one sync run for a repo's ADR enrolment.
+ *
+ * One-way, read-only projection of ADR markdown files out of git (the source
+ * of truth) into `AdrDocument` rows keyed by repo+path. Budget rules are
+ * day-one requirements, not optimisations:
+ * - the run short-circuits as `unchanged` (zero file fetches) when the tree
+ *   SHA(s) covering `adrPaths` match the last successful pull;
+ * - an unchanged file (same blob SHA) is skipped from the tree listing alone;
+ * - a parse failure records a per-file item and continues — a malformed ADR
+ *   is normal and never fails the run;
+ * - vanished files are soft-deleted (`deletedAt`), never hard-deleted.
+ */
+
+export interface AdrSyncRunItem {
+  path: string;
+  action:
+    | "created"
+    | "updated"
+    | "skipped"
+    | "skipped-template"
+    | "deleted"
+    | "failed";
+  reason?: string;
+}
+
+export interface AdrSyncResult {
+  runId: string | null; // null only when the config itself failed to load
+  status: "success" | "unchanged" | "error";
+  created: number;
+  updated: number;
+  skipped: number;
+  deleted: number;
+  failed: number;
+  items: AdrSyncRunItem[];
+  error?: string;
+}
+
+export interface AdrSyncDeps {
+  remoteFactory?: AdrRemoteFactory;
+  now?: () => Date;
+}
+
+/**
+ * The short-circuit key over possibly-several enrolled dirs: stable join of
+ * `path:treeSha` (or `path:absent`) so adding/removing/moving a dir changes it.
+ */
+export function combineTreeShas(
+  entries: Array<{ path: string; sha: string | null }>,
+): string {
+  return [...entries]
+    .sort((a, b) => a.path.localeCompare(b.path))
+    .map((e) => `${e.path}:${e.sha ?? "absent"}`)
+    .join("\n");
+}
+
+/** Walk the root tree down to `dirPath`, returning that dir's tree SHA (null when absent). */
+async function resolveDirTreeSha(
+  remote: AdrRemote,
+  owner: string,
+  repo: string,
+  rootTreeSha: string,
+  dirPath: string,
+): Promise<string | null> {
+  let currentSha = rootTreeSha;
+  const segments = dirPath.split("/").filter((s) => s.length > 0);
+  for (const segment of segments) {
+    const entries = await remote.getTree(owner, repo, currentSha);
+    const next = entries.find((e) => e.type === "tree" && e.path === segment);
+    if (!next) return null;
+    currentSha = next.sha;
+  }
+  return currentSha;
+}
+
+export async function runAdrSync(
+  db: PrismaClient,
+  configId: string,
+  trigger: "manual" | "cron" | "webhook",
+  deps?: AdrSyncDeps & { triggeredById?: string },
+): Promise<AdrSyncResult> {
+  const now = deps?.now ?? (() => new Date());
+  const remoteFactory = deps?.remoteFactory ?? createInstallationAdrRemote;
+
+  const config = await db.adrSyncConfig.findUnique({
+    where: { id: configId },
+    include: {
+      repository: { select: { id: true, owner: true, name: true } },
+      integration: { select: { providerConfig: true } },
+    },
+  });
+  if (!config) {
+    return {
+      runId: null,
+      status: "error",
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      deleted: 0,
+      failed: 0,
+      items: [],
+      error: "Sync config not found",
+    };
+  }
+
+  const run = await db.adrSyncRun.create({
+    data: {
+      configId,
+      trigger,
+      status: "running",
+      startedAt: now(),
+      triggeredById: deps?.triggeredById ?? null,
+    },
+  });
+
+  const fail = async (message: string): Promise<AdrSyncResult> => {
+    await db.adrSyncRun.update({
+      where: { id: run.id },
+      data: { status: "error", finishedAt: now(), error: message },
+    });
+    return {
+      runId: run.id,
+      status: "error",
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      deleted: 0,
+      failed: 0,
+      items: [],
+      error: message,
+    };
+  };
+
+  try {
+    if (!config.integrationId || !config.integration) {
+      return await fail("Repository is disconnected (no integration)");
+    }
+    const installationId = readInstallationId(
+      config.integration.providerConfig,
+    );
+    if (!installationId) {
+      return await fail("Integration has no usable GitHub installation id");
+    }
+
+    const remote = await remoteFactory(installationId);
+    const { owner, name: repoName } = config.repository;
+
+    const head = await remote.getHead(owner, repoName);
+
+    // Resolve the tree SHA covering each enrolled dir; the combined value is
+    // the short-circuit key.
+    const dirShas: Array<{ path: string; sha: string | null }> = [];
+    for (const dirPath of config.adrPaths) {
+      dirShas.push({
+        path: dirPath,
+        sha: await resolveDirTreeSha(
+          remote,
+          owner,
+          repoName,
+          head.treeSha,
+          dirPath,
+        ),
+      });
+    }
+    const combined = combineTreeShas(dirShas);
+
+    if (config.lastTreeSha !== null && combined === config.lastTreeSha) {
+      await db.adrSyncRun.update({
+        where: { id: run.id },
+        data: { status: "unchanged", finishedAt: now() },
+      });
+      return {
+        runId: run.id,
+        status: "unchanged",
+        created: 0,
+        updated: 0,
+        skipped: 0,
+        deleted: 0,
+        failed: 0,
+        items: [],
+      };
+    }
+
+    // List every markdown blob under the enrolled dirs.
+    const blobs: Array<{ path: string; sha: string }> = [];
+    for (const dir of dirShas) {
+      if (!dir.sha) continue;
+      const entries: AdrTreeEntry[] = await remote.getTree(
+        owner,
+        repoName,
+        dir.sha,
+        true,
+      );
+      for (const entry of entries) {
+        if (entry.type === "blob" && /\.md$/i.test(entry.path)) {
+          blobs.push({ path: `${dir.path}/${entry.path}`, sha: entry.sha });
+        }
+      }
+    }
+
+    const existing = await db.adrDocument.findMany({
+      where: { repositoryId: config.repository.id },
+      select: {
+        id: true,
+        path: true,
+        contentHash: true,
+        deletedAt: true,
+      },
+    });
+    const existingByPath = new Map(existing.map((d) => [d.path, d]));
+
+    const items: AdrSyncRunItem[] = [];
+    let created = 0;
+    let updated = 0;
+    let skipped = 0;
+    let deleted = 0;
+    let failed = 0;
+
+    const seenPaths = new Set<string>();
+    for (const blob of blobs) {
+      seenPaths.add(blob.path);
+      const prior = existingByPath.get(blob.path);
+
+      // Blob-SHA skip: unchanged file ⇒ no content fetch at all.
+      if (prior && prior.contentHash === blob.sha && prior.deletedAt === null) {
+        skipped++;
+        items.push({ path: blob.path, action: "skipped", reason: "unchanged" });
+        continue;
+      }
+
+      try {
+        const content = await remote.getBlob(owner, repoName, blob.sha);
+        const parsed = parseAdr({ path: blob.path, content });
+
+        if (parsed.isTemplate) {
+          skipped++;
+          items.push({
+            path: blob.path,
+            action: "skipped-template",
+            reason: `status is the template alternation: ${parsed.statusRaw ?? ""}`,
+          });
+          continue;
+        }
+
+        const data = {
+          number: parsed.number,
+          slug: parsed.slug,
+          title: parsed.title,
+          status: parsed.status,
+          statusRaw: parsed.statusRaw,
+          decidedAt: parsed.decidedAt,
+          body: content,
+          contentHash: blob.sha,
+          lastSeenSha: blob.sha,
+          deletedAt: null,
+        };
+        if (prior) {
+          await db.adrDocument.update({ where: { id: prior.id }, data });
+          updated++;
+          items.push({ path: blob.path, action: "updated" });
+        } else {
+          await db.adrDocument.create({
+            data: { repositoryId: config.repository.id, path: blob.path, ...data },
+          });
+          created++;
+          items.push({ path: blob.path, action: "created" });
+        }
+      } catch (error) {
+        // Never fail the run on one file.
+        failed++;
+        items.push({
+          path: blob.path,
+          action: "failed",
+          reason: error instanceof Error ? error.message : "unknown error",
+        });
+      }
+    }
+
+    // Soft-delete documents whose file vanished from the repo.
+    for (const doc of existing) {
+      if (!seenPaths.has(doc.path) && doc.deletedAt === null) {
+        await db.adrDocument.update({
+          where: { id: doc.id },
+          data: { deletedAt: now() },
+        });
+        deleted++;
+        items.push({ path: doc.path, action: "deleted", reason: "file removed from repo" });
+      }
+    }
+
+    await db.adrSyncConfig.update({
+      where: { id: configId },
+      data: {
+        lastTreeSha: combined,
+        lastCommitSha: head.commitSha,
+        lastSyncedAt: now(),
+      },
+    });
+    await db.adrSyncRun.update({
+      where: { id: run.id },
+      data: {
+        status: "success",
+        finishedAt: now(),
+        created,
+        updated,
+        skipped,
+        deleted,
+        failed,
+        items: items as unknown as Prisma.InputJsonValue,
+      },
+    });
+
+    return {
+      runId: run.id,
+      status: "success",
+      created,
+      updated,
+      skipped,
+      deleted,
+      failed,
+      items,
+    };
+  } catch (error) {
+    return await fail(
+      error instanceof Error ? error.message : "unknown error",
+    );
+  }
+}

--- a/src/server/services/adrSync/github.ts
+++ b/src/server/services/adrSync/github.ts
@@ -17,6 +17,16 @@ export interface AdrTreeEntry {
   sha: string;
 }
 
+export interface AdrTreeListing {
+  entries: AdrTreeEntry[];
+  /**
+   * GitHub truncates very large recursive listings (~100k entries / 7MB).
+   * A truncated listing must NEVER drive a sync: files absent from it would
+   * be mistaken for deletions.
+   */
+  truncated: boolean;
+}
+
 export interface AdrRemote {
   /** Default-branch head: commit SHA and its root tree SHA. */
   getHead(
@@ -29,7 +39,7 @@ export interface AdrRemote {
     repo: string,
     treeSha: string,
     recursive?: boolean,
-  ): Promise<AdrTreeEntry[]>;
+  ): Promise<AdrTreeListing>;
   /** Fetch one blob's content, decoded to UTF-8. */
   getBlob(owner: string, repo: string, blobSha: string): Promise<string>;
 }
@@ -73,18 +83,21 @@ export const createInstallationAdrRemote: AdrRemoteFactory = async (
         tree_sha: treeSha,
         ...(recursive ? { recursive: "true" } : {}),
       });
-      return (data.tree ?? [])
-        .filter(
-          (e): e is typeof e & { path: string; sha: string } =>
-            typeof e.path === "string" &&
-            typeof e.sha === "string" &&
-            (e.type === "blob" || e.type === "tree"),
-        )
-        .map((e) => ({
-          path: e.path,
-          type: e.type as "blob" | "tree",
-          sha: e.sha,
-        }));
+      return {
+        truncated: data.truncated === true,
+        entries: (data.tree ?? [])
+          .filter(
+            (e): e is typeof e & { path: string; sha: string } =>
+              typeof e.path === "string" &&
+              typeof e.sha === "string" &&
+              (e.type === "blob" || e.type === "tree"),
+          )
+          .map((e) => ({
+            path: e.path,
+            type: e.type as "blob" | "tree",
+            sha: e.sha,
+          })),
+      };
     },
     async getBlob(owner, repo, blobSha) {
       const { data } = await octokit.rest.git.getBlob({

--- a/src/server/services/adrSync/github.ts
+++ b/src/server/services/adrSync/github.ts
@@ -1,0 +1,108 @@
+import { App } from "octokit";
+
+/**
+ * adrSync/github — the thin GitHub surface the sync engine needs, behind an
+ * interface so tests drive the engine with a plain fake (same rationale as
+ * ticketSync's remote adapter).
+ *
+ * Auth follows the ADR-0020 pattern exactly: the workspace's single GitHub App
+ * installation `Integration` row carries `providerConfig.installationId`, and
+ * we mint an installation Octokit per run via `app.getInstallationOctokit`.
+ */
+
+export interface AdrTreeEntry {
+  /** Path relative to the tree the listing was taken from. */
+  path: string;
+  type: "blob" | "tree";
+  sha: string;
+}
+
+export interface AdrRemote {
+  /** Default-branch head: commit SHA and its root tree SHA. */
+  getHead(
+    owner: string,
+    repo: string,
+  ): Promise<{ commitSha: string; treeSha: string }>;
+  /** List a tree's entries. With `recursive`, paths are slash-joined. */
+  getTree(
+    owner: string,
+    repo: string,
+    treeSha: string,
+    recursive?: boolean,
+  ): Promise<AdrTreeEntry[]>;
+  /** Fetch one blob's content, decoded to UTF-8. */
+  getBlob(owner: string, repo: string, blobSha: string): Promise<string>;
+}
+
+export type AdrRemoteFactory = (
+  installationId: number,
+) => Promise<AdrRemote>;
+
+export function isGithubAppEnvConfigured(): boolean {
+  return Boolean(process.env.GITHUB_APP_ID && process.env.GITHUB_PRIVATE_KEY);
+}
+
+/** Real implementation over an installation Octokit. */
+export const createInstallationAdrRemote: AdrRemoteFactory = async (
+  installationId,
+) => {
+  if (!isGithubAppEnvConfigured()) {
+    throw new Error("GitHub App environment is not configured");
+  }
+  const app = new App({
+    appId: process.env.GITHUB_APP_ID!,
+    privateKey: process.env.GITHUB_PRIVATE_KEY!,
+  });
+  const octokit = await app.getInstallationOctokit(installationId);
+
+  return {
+    async getHead(owner, repo) {
+      const { data: repoData } = await octokit.rest.repos.get({ owner, repo });
+      const branch = repoData.default_branch;
+      const { data: commit } = await octokit.rest.repos.getCommit({
+        owner,
+        repo,
+        ref: `heads/${branch}`,
+      });
+      return { commitSha: commit.sha, treeSha: commit.commit.tree.sha };
+    },
+    async getTree(owner, repo, treeSha, recursive) {
+      const { data } = await octokit.rest.git.getTree({
+        owner,
+        repo,
+        tree_sha: treeSha,
+        ...(recursive ? { recursive: "true" } : {}),
+      });
+      return (data.tree ?? [])
+        .filter(
+          (e): e is typeof e & { path: string; sha: string } =>
+            typeof e.path === "string" &&
+            typeof e.sha === "string" &&
+            (e.type === "blob" || e.type === "tree"),
+        )
+        .map((e) => ({
+          path: e.path,
+          type: e.type as "blob" | "tree",
+          sha: e.sha,
+        }));
+    },
+    async getBlob(owner, repo, blobSha) {
+      const { data } = await octokit.rest.git.getBlob({
+        owner,
+        repo,
+        file_sha: blobSha,
+      });
+      return Buffer.from(data.content, "base64").toString("utf8");
+    },
+  };
+};
+
+/** Read the numeric installation id off an Integration's providerConfig. */
+export function readInstallationId(
+  providerConfig: unknown,
+): number | null {
+  if (!providerConfig || typeof providerConfig !== "object") return null;
+  const raw = (providerConfig as Record<string, unknown>).installationId;
+  const id = Number(raw);
+  return Number.isFinite(id) && id > 0 ? id : null;
+}

--- a/src/server/services/adrSync/parser.ts
+++ b/src/server/services/adrSync/parser.ts
@@ -1,0 +1,146 @@
+import type { AdrStatus } from "@prisma/client";
+
+/**
+ * adrSync/parser — lenient, pure parsing of one ADR markdown file.
+ *
+ * ADRs in the wild come in (at least) four formats: YAML frontmatter with a
+ * `status:` key, `# ADR 0001 — Title` headings with a bulleted `**Status**:`
+ * line, a plain `Status: ...` line, and files with no status at all. The
+ * parser never throws on content: anything unparseable degrades field by
+ * field (status → UNKNOWN, title → filename slug) rather than failing the
+ * file. Git stays the source of truth — this only projects.
+ */
+
+export interface ParsedAdr {
+  /** First `#` heading with any `ADR-NNNN` prefix stripped; falls back to the filename slug. */
+  title: string;
+  /** Sequence number from the `NNNN-` filename prefix; null when absent. */
+  number: number | null;
+  /** Filename without the number prefix and `.md` suffix; null when empty. */
+  slug: string | null;
+  status: AdrStatus;
+  /** Verbatim status string from the file (null when no status was found). */
+  statusRaw: string | null;
+  /** Date from frontmatter `date:` or a `Date:` line, when parseable. */
+  decidedAt: Date | null;
+  /**
+   * True when the status is the template alternation ("Proposed | Accepted |
+   * ...") — the file is an unfilled ADR template and should be skipped.
+   */
+  isTemplate: boolean;
+}
+
+/** How many body lines are scanned for a `Status:` / `Date:` line. */
+const HEADER_SCAN_LINES = 15;
+
+const STATUS_LINE_RE = /^[-*\s]*\**Status\**\s*:\s*(.+)$/i;
+const DATE_LINE_RE = /^[-*\s]*\**Date\**\s*:\s*(.+)$/i;
+
+/**
+ * The unfilled-template signature: a status offering the choices instead of
+ * picking one, e.g. "Proposed | Accepted | Rejected | Deprecated | Superseded".
+ */
+const TEMPLATE_STATUS_RE = /proposed\s*\|\s*accepted/i;
+
+function mapStatus(raw: string | null): AdrStatus {
+  if (!raw) return "UNKNOWN";
+  const s = raw.trim().toLowerCase();
+  if (s.startsWith("propos")) return "PROPOSED";
+  if (s.startsWith("accept")) return "ACCEPTED";
+  if (s.includes("supersed")) return "SUPERSEDED";
+  if (s.startsWith("deprecat")) return "DEPRECATED";
+  return "UNKNOWN";
+}
+
+/** Extract simple `key: value` pairs from a leading YAML frontmatter block. */
+function parseFrontmatter(content: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!content.startsWith("---")) return out;
+  const end = content.indexOf("\n---", 3);
+  if (end === -1) return out;
+  const block = content.slice(3, end);
+  for (const line of block.split("\n")) {
+    const m = /^([A-Za-z_][\w-]*)\s*:\s*(.*)$/.exec(line);
+    if (m?.[1] && m[2] !== undefined) {
+      out[m[1].toLowerCase()] = m[2].trim().replace(/^["']|["']$/g, "");
+    }
+  }
+  return out;
+}
+
+function parseDate(raw: string | undefined | null): Date | null {
+  if (!raw) return null;
+  const d = new Date(raw.trim());
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export function parseAdr({
+  path,
+  content,
+}: {
+  path: string;
+  content: string;
+}): ParsedAdr {
+  const filename = path.split("/").pop() ?? path;
+  const base = filename.replace(/\.md$/i, "");
+  const numberMatch = /^(\d{4})-?/.exec(base);
+  const number = numberMatch?.[1] ? parseInt(numberMatch[1], 10) : null;
+  const slugPart = numberMatch ? base.slice(numberMatch[0].length) : base;
+  const slug = slugPart.length > 0 ? slugPart : null;
+
+  const frontmatter = parseFrontmatter(content);
+  const frontmatterEnd = content.startsWith("---")
+    ? content.indexOf("\n---", 3)
+    : -1;
+  const afterFrontmatter =
+    frontmatterEnd !== -1 ? content.slice(frontmatterEnd + 4) : content;
+  const lines = afterFrontmatter.split("\n");
+
+  // Title: first `#` heading, stripped of any ADR-number prefix.
+  let title: string | null = null;
+  for (const line of lines) {
+    const m = /^#\s+(.+)$/.exec(line.trim());
+    if (m?.[1]) {
+      title = m[1].replace(/^ADR[- ]?\d+\s*[—:-]\s*/i, "").trim();
+      break;
+    }
+  }
+  if (!title || title.length === 0) {
+    title = slug ? slug.replace(/-/g, " ") : base;
+  }
+
+  // Status: frontmatter wins, else a `Status:` line in the first N body lines.
+  let statusRaw: string | null = frontmatter.status ?? null;
+  let dateRaw: string | null = frontmatter.date ?? null;
+  const headLines = lines.slice(0, HEADER_SCAN_LINES);
+  if (!statusRaw) {
+    for (const line of headLines) {
+      const m = STATUS_LINE_RE.exec(line);
+      if (m?.[1]) {
+        statusRaw = m[1].replace(/\**\s*$/, "").trim();
+        break;
+      }
+    }
+  }
+  if (!dateRaw) {
+    for (const line of headLines) {
+      const m = DATE_LINE_RE.exec(line);
+      if (m?.[1]) {
+        dateRaw = m[1].replace(/\**\s*$/, "").trim();
+        break;
+      }
+    }
+  }
+
+  const isTemplate = statusRaw !== null && TEMPLATE_STATUS_RE.test(statusRaw);
+
+  return {
+    title,
+    number,
+    slug,
+    status: isTemplate ? "UNKNOWN" : mapStatus(statusRaw),
+    statusRaw,
+    decidedAt: parseDate(dateRaw),
+    isTemplate,
+  };
+}

--- a/src/server/services/adrSync/parser.ts
+++ b/src/server/services/adrSync/parser.ts
@@ -35,6 +35,8 @@ const HEADER_SCAN_LINES = 15;
 
 const STATUS_LINE_RE = /^[-*\s]*\**Status\**\s*:\s*(.+)$/i;
 const DATE_LINE_RE = /^[-*\s]*\**Date\**\s*:\s*(.+)$/i;
+/** `## Status` section heading — the status text is the next non-empty line. */
+const STATUS_HEADING_RE = /^#{2,}\s*Status\s*$/i;
 
 /**
  * The unfilled-template signature: a status offering the choices instead of
@@ -44,10 +46,13 @@ const TEMPLATE_STATUS_RE = /proposed\s*\|\s*accepted/i;
 
 function mapStatus(raw: string | null): AdrStatus {
   if (!raw) return "UNKNOWN";
+  // Anchor at the start: the leading word is the primary state. A trailing
+  // "…superseded by NNNN" is an edge (derived separately), not the state —
+  // e.g. "Deferred — premise superseded by ADR-0020" must NOT map SUPERSEDED.
   const s = raw.trim().toLowerCase();
   if (s.startsWith("propos")) return "PROPOSED";
   if (s.startsWith("accept")) return "ACCEPTED";
-  if (s.includes("supersed")) return "SUPERSEDED";
+  if (s.startsWith("supersed")) return "SUPERSEDED";
   if (s.startsWith("deprecat")) return "DEPRECATED";
   return "UNKNOWN";
 }
@@ -109,7 +114,10 @@ export function parseAdr({
     title = slug ? slug.replace(/-/g, " ") : base;
   }
 
-  // Status: frontmatter wins, else a `Status:` line in the first N body lines.
+  // Status, in order of precedence: frontmatter `status:`; a `Status: ...`
+  // line; a `## Status` section heading whose next non-empty line is the
+  // status text (the dominant format in this workspace's own repos). Scanning
+  // is bounded to the first N body lines.
   let statusRaw: string | null = frontmatter.status ?? null;
   let dateRaw: string | null = frontmatter.date ?? null;
   const headLines = lines.slice(0, HEADER_SCAN_LINES);
@@ -122,6 +130,19 @@ export function parseAdr({
       }
     }
   }
+  if (!statusRaw) {
+    for (let i = 0; i < headLines.length; i++) {
+      if (!STATUS_HEADING_RE.test(headLines[i]?.trim() ?? "")) continue;
+      for (let j = i + 1; j < lines.length && j < i + 1 + HEADER_SCAN_LINES; j++) {
+        const candidate = lines[j]?.trim() ?? "";
+        if (candidate.length === 0) continue;
+        if (candidate.startsWith("#")) break; // next section — no status text
+        statusRaw = candidate.replace(/^\**|\**$/g, "").trim();
+        break;
+      }
+      break;
+    }
+  }
   if (!dateRaw) {
     for (const line of headLines) {
       const m = DATE_LINE_RE.exec(line);
@@ -130,6 +151,11 @@ export function parseAdr({
         break;
       }
     }
+  }
+  // "Accepted — 2026-05-14." style: the date lives inside the status text.
+  if (!dateRaw && statusRaw) {
+    const m = /\b(\d{4}-\d{2}-\d{2})\b/.exec(statusRaw);
+    if (m?.[1]) dateRaw = m[1];
   }
 
   const isTemplate = statusRaw !== null && TEMPLATE_STATUS_RE.test(statusRaw);


### PR DESCRIPTION
## What

The read-only ADR projection end to end (Decision Log V1): schema (five new models + nullable `WorkspaceRepository.productId`), the lenient multi-format parser, the sync engine over the GitHub App installation Octokit (`src/server/services/adrSync/` mirroring `ticketSync/`), bulk enrolment settings with shortCode auto-suggest and product assignment, and the workspace Decisions index at `/w/[workspaceSlug]/decisions`. Manual sync only — cron is V3, link derivation and detail page are V2.

**Feature**: Decision Log — cross-repo ADR viewer (`cmsso8h5w0008i504of0r4nzo`), scope V1.

⚠️ **Migration**: `prisma/migrations/20260814090000_add_adr_decision_log/` is created but **not applied** — James runs `npx prisma migrate dev` manually per repo policy.

Parser note: the PRD's colon-form `Status:` regex alone would have parsed all 65 of this repo's own ADRs as UNKNOWN — the dominant real format is a `## Status` section heading. The parser handles both plus frontmatter, validated by sweeping all 67 real ADRs across exponential+mastra (61 ACCEPTED / 1 PROPOSED / 5 correctly-UNKNOWN, zero title/number failures).

## Acceptance criteria

- [ ] All 12 V1 requirement rows on the feature are met (bulk enrolment with unique shortCode + path globs; upsert keyed by repo+path; lenient parse with UNKNOWN; template skip; per-file failure tolerance; soft-delete only; index with filters + search; duplicate-label flag; product derived through repo; visibility warning; agent + viewer denial; no write path to ADR content)
- [ ] Migration created but run by James manually — never automated, no `db push`
- [ ] Parser/engine/router tests in place per the Agent PRD testing decisions

---

Ships: cold.wasp

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cmssoxchj0001ju04nzpi9lkx)
