### PR TITLE
feat: V2 Decision Log detail page, supersession & cross-repo mentions

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/decisions/[adrId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/decisions/[adrId]/page.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import {
+  Anchor,
+  Badge,
+  Button,
+  Container,
+  Divider,
+  Group,
+  Paper,
+  Skeleton,
+  Stack,
+  Text,
+  Title,
+} from "@mantine/core";
+import { IconArrowLeft, IconBrandGithub } from "@tabler/icons-react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import { api } from "~/trpc/react";
+
+/**
+ * ADR detail page. Deliberately read-only: git is the source of truth and
+ * there is NO write path to ADR content — not disabled, absent. The GitHub
+ * link pins at the last-synced commit, never HEAD, so it always shows the
+ * exact text projected here.
+ */
+
+const STATUS_COLOR: Record<string, string> = {
+  PROPOSED: "blue",
+  ACCEPTED: "green",
+  SUPERSEDED: "orange",
+  DEPRECATED: "red",
+};
+
+export default function DecisionDetailPage() {
+  const { workspace, workspaceId, isLoading } = useWorkspace();
+  const params = useParams<{ adrId: string; workspaceSlug: string }>();
+  const adrId = params?.adrId ?? "";
+
+  const {
+    data: adr,
+    isLoading: adrLoading,
+    error,
+  } = api.adr.get.useQuery(
+    { workspaceId: workspaceId ?? "", adrId },
+    { enabled: !!workspaceId && !!adrId },
+  );
+
+  if (isLoading || (workspace && adrLoading)) {
+    return (
+      <Container size="md" className="py-8">
+        <Skeleton height={40} width={280} mb="lg" />
+        <Skeleton height={400} />
+      </Container>
+    );
+  }
+
+  if (!workspace) {
+    return (
+      <Container size="md" className="py-8">
+        <Text className="text-text-secondary">Workspace not found</Text>
+      </Container>
+    );
+  }
+
+  if (error ?? !adr) {
+    return (
+      <Container size="md" className="py-8">
+        <Text className="text-text-secondary">
+          {error?.data?.code === "FORBIDDEN"
+            ? "You don't have access to this decision — it is visible to workspace members only."
+            : "Decision not found."}
+        </Text>
+      </Container>
+    );
+  }
+
+  const supersededBy = adr.linksTo.filter((l) => l.type === "SUPERSEDES");
+  const supersedes = adr.linksFrom.filter((l) => l.type === "SUPERSEDES");
+  const mentions = [
+    ...adr.linksFrom
+      .filter((l) => l.type === "MENTIONS")
+      .map((l) => ({ id: l.id, doc: l.to, evidence: l.evidence, direction: "out" as const })),
+    ...adr.linksTo
+      .filter((l) => l.type === "MENTIONS")
+      .map((l) => ({ id: l.id, doc: l.from, evidence: l.evidence, direction: "in" as const })),
+  ];
+
+  const decisionHref = (id: string) => `/w/${workspace.slug}/decisions/${id}`;
+
+  return (
+    <Container size="md" className="py-8">
+      <Anchor
+        component={Link}
+        href={`/w/${workspace.slug}/decisions`}
+        size="sm"
+        className="text-text-secondary"
+      >
+        <Group gap={4} wrap="nowrap">
+          <IconArrowLeft size={14} />
+          All decisions
+        </Group>
+      </Anchor>
+
+      <Group justify="space-between" align="flex-start" mt="md" mb="xs" wrap="nowrap">
+        <div>
+          <Group gap="sm" mb={4}>
+            {adr.label ? (
+              <Text size="sm" fw={700} className="text-text-secondary">
+                {adr.label}
+              </Text>
+            ) : null}
+            {adr.status === "UNKNOWN" ? (
+              <Badge variant="light" color="gray" title={adr.statusRaw ?? undefined}>
+                no status
+              </Badge>
+            ) : (
+              <Badge
+                variant="light"
+                color={STATUS_COLOR[adr.status] ?? "gray"}
+                title={adr.statusRaw ?? undefined}
+              >
+                {adr.status.toLowerCase()}
+              </Badge>
+            )}
+            {adr.deletedAt ? (
+              <Badge variant="light" color="red">
+                removed from repo
+              </Badge>
+            ) : null}
+          </Group>
+          <Title order={2}>{adr.title}</Title>
+          <Group gap="xs" mt={6}>
+            <Badge variant="outline" color="gray">
+              {adr.repository.fullName}
+            </Badge>
+            {adr.repository.product ? (
+              <Badge variant="outline" color="gray">
+                {adr.repository.product.name}
+              </Badge>
+            ) : (
+              <Badge variant="outline" color="gray">
+                workspace-wide
+              </Badge>
+            )}
+            {adr.decidedAt ? (
+              <Text size="sm" className="text-text-secondary">
+                {new Date(adr.decidedAt).toLocaleDateString()}
+              </Text>
+            ) : null}
+          </Group>
+        </div>
+        <Button
+          component="a"
+          href={adr.githubUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          variant="light"
+          size="sm"
+          leftSection={<IconBrandGithub size={16} />}
+        >
+          View on GitHub
+        </Button>
+      </Group>
+
+      {supersededBy.length > 0 || supersedes.length > 0 ? (
+        <Stack gap={4} mb="md" mt="md">
+          {supersededBy.map((link) => (
+            <Text key={link.id} size="sm" className="text-text-secondary">
+              Superseded by{" "}
+              <Anchor component={Link} href={decisionHref(link.from.id)} size="sm">
+                {link.from.label ?? link.from.title}
+              </Anchor>{" "}
+              — {link.from.title}
+            </Text>
+          ))}
+          {supersedes.map((link) => (
+            <Text key={link.id} size="sm" className="text-text-secondary">
+              Supersedes{" "}
+              <Anchor component={Link} href={decisionHref(link.to.id)} size="sm">
+                {link.to.label ?? link.to.title}
+              </Anchor>{" "}
+              — {link.to.title}
+            </Text>
+          ))}
+        </Stack>
+      ) : null}
+
+      <Divider my="lg" />
+
+      <MarkdownRenderer content={adr.body} variant="prose" />
+
+      {mentions.length > 0 ? (
+        <>
+          <Divider my="lg" />
+          <Title order={5} className="text-text-secondary" mb="xs">
+            Related (detected)
+          </Title>
+          <Stack gap="xs">
+            {mentions.map((mention) => (
+              <Paper key={mention.id} p="sm" withBorder className="bg-surface-secondary">
+                <Text size="sm">
+                  <Anchor
+                    component={Link}
+                    href={decisionHref(mention.doc.id)}
+                    size="sm"
+                    className="text-text-secondary"
+                  >
+                    {mention.doc.label ?? mention.doc.title}
+                  </Anchor>{" "}
+                  <Text span size="sm" className="text-text-muted">
+                    — {mention.doc.title}
+                    {mention.direction === "in" ? " (mentions this decision)" : ""}
+                  </Text>
+                </Text>
+                {mention.evidence ? (
+                  <Text size="xs" className="text-text-muted" mt={4} lineClamp={2}>
+                    “{mention.evidence}”
+                  </Text>
+                ) : null}
+              </Paper>
+            ))}
+          </Stack>
+        </>
+      ) : null}
+    </Container>
+  );
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/decisions/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/decisions/page.tsx
@@ -228,7 +228,13 @@ export default function DecisionsPage() {
               <Table.Tr key={adr.id}>
                 <Table.Td>
                   <Group gap={4} wrap="nowrap">
-                    <Text size="sm" fw={600} className="whitespace-nowrap">
+                    <Text
+                      component={Link}
+                      href={`/w/${workspace.slug}/decisions/${adr.id}`}
+                      size="sm"
+                      fw={600}
+                      className="whitespace-nowrap text-brand-primary hover:underline"
+                    >
                       {adr.label ?? "—"}
                     </Text>
                     {adr.isDuplicateLabel ? (
@@ -243,7 +249,14 @@ export default function DecisionsPage() {
                   </Group>
                 </Table.Td>
                 <Table.Td>
-                  <Text size="sm">{adr.title}</Text>
+                  <Text
+                    component={Link}
+                    href={`/w/${workspace.slug}/decisions/${adr.id}`}
+                    size="sm"
+                    className="hover:underline"
+                  >
+                    {adr.title}
+                  </Text>
                 </Table.Td>
                 <Table.Td>
                   <Badge variant="outline" color="gray">

--- a/src/app/(sidemenu)/w/[workspaceSlug]/decisions/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/decisions/page.tsx
@@ -1,118 +1,16 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import {
-  Badge,
-  Container,
-  Group,
-  MultiSelect,
-  Select,
-  Skeleton,
-  Table,
-  Text,
-  TextInput,
-  Title,
-  Tooltip,
-} from "@mantine/core";
-import { IconAlertTriangle, IconSearch } from "@tabler/icons-react";
-import { useDebouncedValue } from "@mantine/hooks";
-import Link from "next/link";
+import { Container, Group, Skeleton, Text, Title } from "@mantine/core";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
-import { api } from "~/trpc/react";
+import { DecisionsIndex } from "~/app/_components/decisions/DecisionsIndex";
 
 /**
  * Decision Log — workspace-level index of ADRs projected read-only from every
  * enrolled repo. Git is the source of truth; there is deliberately no write
  * path to ADR content anywhere in this UI.
  */
-
-const STATUS_COLOR: Record<string, string> = {
-  PROPOSED: "blue",
-  ACCEPTED: "green",
-  SUPERSEDED: "orange",
-  DEPRECATED: "red",
-};
-
-const STATUS_OPTIONS = [
-  { value: "PROPOSED", label: "Proposed" },
-  { value: "ACCEPTED", label: "Accepted" },
-  { value: "SUPERSEDED", label: "Superseded" },
-  { value: "DEPRECATED", label: "Deprecated" },
-  { value: "UNKNOWN", label: "No status" },
-] as const;
-
-type AdrStatusValue = (typeof STATUS_OPTIONS)[number]["value"];
-
-function StatusChip({ status, statusRaw }: { status: string; statusRaw: string | null }) {
-  if (status === "UNKNOWN") {
-    return (
-      <Badge variant="light" color="gray" title={statusRaw ?? undefined}>
-        no status
-      </Badge>
-    );
-  }
-  return (
-    <Badge variant="light" color={STATUS_COLOR[status] ?? "gray"} title={statusRaw ?? undefined}>
-      {status.toLowerCase()}
-    </Badge>
-  );
-}
-
 export default function DecisionsPage() {
   const { workspace, workspaceId, isLoading } = useWorkspace();
-
-  const [repoFilter, setRepoFilter] = useState<string[]>([]);
-  const [statusFilter, setStatusFilter] = useState<string[]>([]);
-  const [productFilter, setProductFilter] = useState<string | null>(null);
-  const [search, setSearch] = useState("");
-  const [debouncedSearch] = useDebouncedValue(search, 250);
-
-  const {
-    data: adrs,
-    isLoading: adrsLoading,
-    error: adrsError,
-  } = api.adr.list.useQuery(
-    {
-      workspaceId: workspaceId ?? "",
-      repositoryIds: repoFilter.length > 0 ? repoFilter : undefined,
-      statuses:
-        statusFilter.length > 0 ? (statusFilter as AdrStatusValue[]) : undefined,
-      productId: productFilter ?? undefined,
-      search: debouncedSearch.trim() || undefined,
-    },
-    { enabled: !!workspaceId },
-  );
-
-  const { data: configs } = api.adr.listConfigs.useQuery(
-    { workspaceId: workspaceId ?? "" },
-    { enabled: !!workspaceId },
-  );
-  const { data: products } = api.product.product.list.useQuery(
-    { workspaceId: workspaceId ?? "" },
-    { enabled: !!workspaceId },
-  );
-
-  const repoOptions = useMemo(
-    () =>
-      (configs ?? []).map((c) => ({
-        value: c.repositoryId,
-        label: c.repository.fullName,
-      })),
-    [configs],
-  );
-  const productOptions = useMemo(
-    () => [
-      { value: "workspace", label: "Workspace-level (no product)" },
-      ...(products ?? []).map((p) => ({ value: p.id, label: p.name })),
-    ],
-    [products],
-  );
-
-  const hasFilters =
-    repoFilter.length > 0 ||
-    statusFilter.length > 0 ||
-    productFilter !== null ||
-    debouncedSearch.trim().length > 0;
 
   if (isLoading) {
     return (
@@ -123,7 +21,7 @@ export default function DecisionsPage() {
     );
   }
 
-  if (!workspace) {
+  if (!workspace || !workspaceId) {
     return (
       <Container size="xl" className="py-8">
         <Text className="text-text-secondary">Workspace not found</Text>
@@ -142,147 +40,7 @@ export default function DecisionsPage() {
           </Text>
         </div>
       </Group>
-
-      <Group mb="md" gap="sm" align="flex-end" wrap="wrap">
-        <TextInput
-          size="sm"
-          w={240}
-          leftSection={<IconSearch size={14} />}
-          placeholder="Search title and body…"
-          value={search}
-          onChange={(e) => setSearch(e.currentTarget.value)}
-          aria-label="Search decisions"
-        />
-        <MultiSelect
-          size="sm"
-          w={240}
-          data={repoOptions}
-          value={repoFilter}
-          onChange={setRepoFilter}
-          placeholder="All repositories"
-          clearable
-          searchable
-          aria-label="Filter by repository"
-        />
-        <MultiSelect
-          size="sm"
-          w={200}
-          data={[...STATUS_OPTIONS]}
-          value={statusFilter}
-          onChange={setStatusFilter}
-          placeholder="All statuses"
-          clearable
-          aria-label="Filter by status"
-        />
-        <Select
-          size="sm"
-          w={220}
-          data={productOptions}
-          value={productFilter}
-          onChange={setProductFilter}
-          placeholder="All products"
-          clearable
-          aria-label="Filter by product"
-        />
-      </Group>
-
-      {adrsLoading ? (
-        <Skeleton height={300} />
-      ) : adrsError ? (
-        <Text className="text-text-secondary">
-          {adrsError.data?.code === "FORBIDDEN"
-            ? "You don't have access to this workspace's decisions — they are visible to workspace members only."
-            : `Couldn't load decisions: ${adrsError.message}`}
-        </Text>
-      ) : !adrs || adrs.length === 0 ? (
-        <Text className="text-text-secondary">
-          {hasFilters ? (
-            "No decisions match these filters."
-          ) : (
-            <>
-              No decisions synced yet. Enrol repositories under{" "}
-              <Link
-                href={`/w/${workspace.slug}/settings/decisions`}
-                className="text-brand-primary hover:underline"
-              >
-                Settings → Decisions
-              </Link>
-              , then run a sync.
-            </>
-          )}
-        </Text>
-      ) : (
-        <Table striped highlightOnHover>
-          <Table.Thead>
-            <Table.Tr>
-              <Table.Th>Label</Table.Th>
-              <Table.Th>Title</Table.Th>
-              <Table.Th>Repository</Table.Th>
-              <Table.Th>Product</Table.Th>
-              <Table.Th>Status</Table.Th>
-              <Table.Th>Decided</Table.Th>
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
-            {adrs.map((adr) => (
-              <Table.Tr key={adr.id}>
-                <Table.Td>
-                  <Group gap={4} wrap="nowrap">
-                    <Text
-                      component={Link}
-                      href={`/w/${workspace.slug}/decisions/${adr.id}`}
-                      size="sm"
-                      fw={600}
-                      className="whitespace-nowrap text-brand-primary hover:underline"
-                    >
-                      {adr.label ?? "—"}
-                    </Text>
-                    {adr.isDuplicateLabel ? (
-                      <Tooltip label="Duplicate label — another decision shares this number. Consider renumbering in the repo.">
-                        <IconAlertTriangle
-                          size={14}
-                          className="text-brand-warning"
-                          aria-label="Duplicate label"
-                        />
-                      </Tooltip>
-                    ) : null}
-                  </Group>
-                </Table.Td>
-                <Table.Td>
-                  <Text
-                    component={Link}
-                    href={`/w/${workspace.slug}/decisions/${adr.id}`}
-                    size="sm"
-                    className="hover:underline"
-                  >
-                    {adr.title}
-                  </Text>
-                </Table.Td>
-                <Table.Td>
-                  <Badge variant="outline" color="gray">
-                    {adr.repository.fullName}
-                  </Badge>
-                </Table.Td>
-                <Table.Td>
-                  <Text size="sm" className="text-text-secondary">
-                    {adr.repository.product?.name ?? "Workspace"}
-                  </Text>
-                </Table.Td>
-                <Table.Td>
-                  <StatusChip status={adr.status} statusRaw={adr.statusRaw} />
-                </Table.Td>
-                <Table.Td>
-                  <Text size="sm" className="text-text-secondary whitespace-nowrap">
-                    {adr.decidedAt
-                      ? new Date(adr.decidedAt).toLocaleDateString()
-                      : "—"}
-                  </Text>
-                </Table.Td>
-              </Table.Tr>
-            ))}
-          </Table.Tbody>
-        </Table>
-      )}
+      <DecisionsIndex workspaceId={workspaceId} workspaceSlug={workspace.slug} />
     </Container>
   );
 }

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/decisions/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/decisions/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Container, Skeleton, Text, Title } from "@mantine/core";
+import { useParams } from "next/navigation";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import { api } from "~/trpc/react";
+import { DecisionsIndex } from "~/app/_components/decisions/DecisionsIndex";
+
+/**
+ * Product Decisions lens: the workspace Decision Log pre-filtered to this
+ * product's repos, PLUS workspace-level (null-product) ADRs rendered with a
+ * "workspace-wide" marker — a workspace-global decision applies to every
+ * product until proven otherwise.
+ */
+export default function ProductDecisionsPage() {
+  const params = useParams();
+  const productSlug = params?.productSlug as string;
+  const { workspace, workspaceId, isLoading } = useWorkspace();
+
+  const { data: product, isLoading: productLoading } =
+    api.product.product.getBySlug.useQuery(
+      { workspaceId: workspaceId ?? "", slug: productSlug },
+      { enabled: !!workspaceId && !!productSlug },
+    );
+
+  if (isLoading || productLoading) {
+    return (
+      <Container size="xl" className="py-8">
+        <Skeleton height={40} width={240} mb="lg" />
+        <Skeleton height={300} />
+      </Container>
+    );
+  }
+
+  if (!workspace || !workspaceId || !product) {
+    return (
+      <Container size="xl" className="py-8">
+        <Text className="text-text-secondary">Product not found</Text>
+      </Container>
+    );
+  }
+
+  return (
+    <Container size="xl" className="py-8">
+      <Title order={2} mb={4}>
+        Decisions
+      </Title>
+      <Text size="sm" className="text-text-secondary" mb="lg">
+        Architectural decisions from {product.name}&apos;s repositories, plus
+        workspace-wide decisions. Read-only — git is the source of truth.
+      </Text>
+      <DecisionsIndex
+        workspaceId={workspaceId}
+        workspaceSlug={workspace.slug}
+        lockedProductId={product.id}
+      />
+    </Container>
+  );
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/layout.tsx
@@ -8,6 +8,7 @@ import {
   IconBulb,
   IconCalendarClock,
   IconClipboardList,
+  IconGavel,
   IconSettings,
   IconPlus,
   IconAffiliate,
@@ -39,6 +40,7 @@ const tabs = [
   { value: "graph", href: "/graph", label: "Graph", icon: IconAffiliate },
   { value: "cycles", href: "/cycles", label: "Cycles", icon: IconCalendarClock },
   { value: "insights", href: "/insights", label: "Insights", icon: IconTargetArrow },
+  { value: "decisions", href: "/decisions", label: "Decisions", icon: IconGavel },
   { value: "retro", href: "/retrospectives", label: "Retro", icon: IconClipboardList },
 ] as const;
 

--- a/src/app/_components/decisions/DecisionsIndex.tsx
+++ b/src/app/_components/decisions/DecisionsIndex.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Badge,
+  Group,
+  MultiSelect,
+  Select,
+  Skeleton,
+  Table,
+  Text,
+  TextInput,
+  Tooltip,
+} from "@mantine/core";
+import { IconAlertTriangle, IconSearch } from "@tabler/icons-react";
+import { useDebouncedValue } from "@mantine/hooks";
+import Link from "next/link";
+import { api } from "~/trpc/react";
+
+/**
+ * The Decision Log index table + filters, shared between the workspace page
+ * (/w/[slug]/decisions) and the product Decisions lens
+ * (/w/[slug]/products/[productSlug]/decisions). Read-only by design — git is
+ * the source of truth and no write path to ADR content exists.
+ *
+ * With `lockedProductId` the index is pre-filtered to that product's repos
+ * PLUS workspace-level (null-product) ADRs, which render with a
+ * "workspace-wide" marker; the product filter control is hidden.
+ */
+
+const STATUS_COLOR: Record<string, string> = {
+  PROPOSED: "blue",
+  ACCEPTED: "green",
+  SUPERSEDED: "orange",
+  DEPRECATED: "red",
+};
+
+const STATUS_OPTIONS = [
+  { value: "PROPOSED", label: "Proposed" },
+  { value: "ACCEPTED", label: "Accepted" },
+  { value: "SUPERSEDED", label: "Superseded" },
+  { value: "DEPRECATED", label: "Deprecated" },
+  { value: "UNKNOWN", label: "No status" },
+] as const;
+
+type AdrStatusValue = (typeof STATUS_OPTIONS)[number]["value"];
+
+function StatusChip({ status, statusRaw }: { status: string; statusRaw: string | null }) {
+  if (status === "UNKNOWN") {
+    return (
+      <Badge variant="light" color="gray" title={statusRaw ?? undefined}>
+        no status
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="light" color={STATUS_COLOR[status] ?? "gray"} title={statusRaw ?? undefined}>
+      {status.toLowerCase()}
+    </Badge>
+  );
+}
+
+interface DecisionsIndexProps {
+  workspaceId: string;
+  workspaceSlug: string;
+  /** Pre-filter to this product's repos + workspace-wide ADRs. */
+  lockedProductId?: string;
+}
+
+export function DecisionsIndex({
+  workspaceId,
+  workspaceSlug,
+  lockedProductId,
+}: DecisionsIndexProps) {
+  const [repoFilter, setRepoFilter] = useState<string[]>([]);
+  const [statusFilter, setStatusFilter] = useState<string[]>([]);
+  const [productFilter, setProductFilter] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch] = useDebouncedValue(search, 250);
+
+  const {
+    data: adrs,
+    isLoading: adrsLoading,
+    error: adrsError,
+  } = api.adr.list.useQuery(
+    {
+      workspaceId,
+      repositoryIds: repoFilter.length > 0 ? repoFilter : undefined,
+      statuses:
+        statusFilter.length > 0 ? (statusFilter as AdrStatusValue[]) : undefined,
+      productId: lockedProductId ?? productFilter ?? undefined,
+      includeWorkspaceWide: lockedProductId ? true : undefined,
+      search: debouncedSearch.trim() || undefined,
+    },
+    { enabled: !!workspaceId },
+  );
+
+  const { data: configs } = api.adr.listConfigs.useQuery(
+    { workspaceId },
+    { enabled: !!workspaceId },
+  );
+  const { data: products } = api.product.product.list.useQuery(
+    { workspaceId },
+    { enabled: !!workspaceId && !lockedProductId },
+  );
+
+  const repoOptions = useMemo(
+    () =>
+      (configs ?? []).map((c) => ({
+        value: c.repositoryId,
+        label: c.repository.fullName,
+      })),
+    [configs],
+  );
+  const productOptions = useMemo(
+    () => [
+      { value: "workspace", label: "Workspace-level (no product)" },
+      ...(products ?? []).map((p) => ({ value: p.id, label: p.name })),
+    ],
+    [products],
+  );
+
+  const hasFilters =
+    repoFilter.length > 0 ||
+    statusFilter.length > 0 ||
+    productFilter !== null ||
+    debouncedSearch.trim().length > 0;
+
+  return (
+    <>
+      <Group mb="md" gap="sm" align="flex-end" wrap="wrap">
+        <TextInput
+          size="sm"
+          w={240}
+          leftSection={<IconSearch size={14} />}
+          placeholder="Search title and body…"
+          value={search}
+          onChange={(e) => setSearch(e.currentTarget.value)}
+          aria-label="Search decisions"
+        />
+        <MultiSelect
+          size="sm"
+          w={240}
+          data={repoOptions}
+          value={repoFilter}
+          onChange={setRepoFilter}
+          placeholder="All repositories"
+          clearable
+          searchable
+          aria-label="Filter by repository"
+        />
+        <MultiSelect
+          size="sm"
+          w={200}
+          data={[...STATUS_OPTIONS]}
+          value={statusFilter}
+          onChange={setStatusFilter}
+          placeholder="All statuses"
+          clearable
+          aria-label="Filter by status"
+        />
+        {!lockedProductId ? (
+          <Select
+            size="sm"
+            w={220}
+            data={productOptions}
+            value={productFilter}
+            onChange={setProductFilter}
+            placeholder="All products"
+            clearable
+            aria-label="Filter by product"
+          />
+        ) : null}
+      </Group>
+
+      {adrsLoading ? (
+        <Skeleton height={300} />
+      ) : adrsError ? (
+        <Text className="text-text-secondary">
+          {adrsError.data?.code === "FORBIDDEN"
+            ? "You don't have access to this workspace's decisions — they are visible to workspace members only."
+            : `Couldn't load decisions: ${adrsError.message}`}
+        </Text>
+      ) : !adrs || adrs.length === 0 ? (
+        <Text className="text-text-secondary">
+          {hasFilters ? (
+            "No decisions match these filters."
+          ) : (
+            <>
+              No decisions synced yet. Enrol repositories under{" "}
+              <Link
+                href={`/w/${workspaceSlug}/settings/decisions`}
+                className="text-brand-primary hover:underline"
+              >
+                Settings → Decisions
+              </Link>
+              , then run a sync.
+            </>
+          )}
+        </Text>
+      ) : (
+        <Table striped highlightOnHover>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Label</Table.Th>
+              <Table.Th>Title</Table.Th>
+              <Table.Th>Repository</Table.Th>
+              <Table.Th>Product</Table.Th>
+              <Table.Th>Status</Table.Th>
+              <Table.Th>Decided</Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {adrs.map((adr) => (
+              <Table.Tr key={adr.id}>
+                <Table.Td>
+                  <Group gap={4} wrap="nowrap">
+                    <Text
+                      component={Link}
+                      href={`/w/${workspaceSlug}/decisions/${adr.id}`}
+                      size="sm"
+                      fw={600}
+                      className="whitespace-nowrap text-brand-primary hover:underline"
+                    >
+                      {adr.label ?? "—"}
+                    </Text>
+                    {adr.isDuplicateLabel ? (
+                      <Tooltip label="Duplicate label — another decision shares this number. Consider renumbering in the repo.">
+                        <IconAlertTriangle
+                          size={14}
+                          className="text-brand-warning"
+                          aria-label="Duplicate label"
+                        />
+                      </Tooltip>
+                    ) : null}
+                  </Group>
+                </Table.Td>
+                <Table.Td>
+                  <Text
+                    component={Link}
+                    href={`/w/${workspaceSlug}/decisions/${adr.id}`}
+                    size="sm"
+                    className="hover:underline"
+                  >
+                    {adr.title}
+                  </Text>
+                </Table.Td>
+                <Table.Td>
+                  <Badge variant="outline" color="gray">
+                    {adr.repository.fullName}
+                  </Badge>
+                </Table.Td>
+                <Table.Td>
+                  {adr.repository.productId === null ? (
+                    <Badge variant="light" color="gray">
+                      workspace-wide
+                    </Badge>
+                  ) : (
+                    <Text size="sm" className="text-text-secondary">
+                      {adr.repository.product?.name ?? "—"}
+                    </Text>
+                  )}
+                </Table.Td>
+                <Table.Td>
+                  <StatusChip status={adr.status} statusRaw={adr.statusRaw} />
+                </Table.Td>
+                <Table.Td>
+                  <Text size="sm" className="text-text-secondary whitespace-nowrap">
+                    {adr.decidedAt
+                      ? new Date(adr.decidedAt).toLocaleDateString()
+                      : "—"}
+                  </Text>
+                </Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+      )}
+    </>
+  );
+}

--- a/src/server/api/routers/adr.ts
+++ b/src/server/api/routers/adr.ts
@@ -219,7 +219,10 @@ export const adrRouter = createTRPCRouter({
         label: label(doc.repositoryId, doc.number),
         // Deep link pinned at the last-synced state, never HEAD: the stored
         // body matches this commit even when the file was blob-SHA-skipped.
-        githubUrl: `https://github.com/${doc.repository.fullName}/blob/${config?.lastCommitSha ?? "HEAD"}/${doc.path}`,
+        githubUrl: `https://github.com/${doc.repository.fullName}/blob/${config?.lastCommitSha ?? "HEAD"}/${doc.path
+          .split("/")
+          .map(encodeURIComponent)
+          .join("/")}`,
         linksFrom: doc.linksFrom.map((link) => ({
           ...link,
           to: { ...link.to, label: label(link.to.repositoryId, link.to.number) },

--- a/src/server/api/routers/adr.ts
+++ b/src/server/api/routers/adr.ts
@@ -45,6 +45,11 @@ export const adrRouter = createTRPCRouter({
           .optional(),
         /** Filter to one product's repos; "workspace" = repos with no product. */
         productId: z.string().optional(),
+        /**
+         * With a real productId: ALSO include workspace-level (null-product)
+         * ADRs — the product Decisions lens shows them with a marker.
+         */
+        includeWorkspaceWide: z.boolean().optional(),
         search: z.string().max(200).optional(),
       }),
     )
@@ -87,7 +92,9 @@ export const adrRouter = createTRPCRouter({
                 repository:
                   input.productId === "workspace"
                     ? { productId: null }
-                    : { productId: input.productId },
+                    : input.includeWorkspaceWide
+                      ? { OR: [{ productId: input.productId }, { productId: null }] }
+                      : { productId: input.productId },
               }
             : {}),
           ...(search

--- a/src/server/api/routers/adr.ts
+++ b/src/server/api/routers/adr.ts
@@ -139,6 +139,94 @@ export const adrRouter = createTRPCRouter({
       });
     }),
 
+  /** One ADR with its links, for the detail page. Read-only, like everything here. */
+  get: humanOnlyProcedure
+    .input(z.object({ workspaceId: z.string(), adrId: z.string() }))
+    .use(requireWorkspaceMembership("edit"))
+    .query(async ({ ctx, input }) => {
+      const doc = await ctx.db.adrDocument.findFirst({
+        where: {
+          id: input.adrId,
+          repository: { workspaceId: input.workspaceId },
+        },
+        include: {
+          repository: {
+            select: {
+              id: true,
+              fullName: true,
+              productId: true,
+              product: { select: { id: true, name: true, slug: true } },
+            },
+          },
+          linksFrom: {
+            include: {
+              to: {
+                select: {
+                  id: true,
+                  repositoryId: true,
+                  number: true,
+                  title: true,
+                  status: true,
+                  deletedAt: true,
+                },
+              },
+            },
+          },
+          linksTo: {
+            include: {
+              from: {
+                select: {
+                  id: true,
+                  repositoryId: true,
+                  number: true,
+                  title: true,
+                  status: true,
+                  deletedAt: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      if (!doc) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Decision not found" });
+      }
+
+      const configs = await ctx.db.adrSyncConfig.findMany({
+        where: { workspaceId: input.workspaceId },
+        select: { repositoryId: true, shortCode: true, lastCommitSha: true },
+      });
+      const shortCodeByRepo = new Map(
+        configs.map((c) => [c.repositoryId, c.shortCode]),
+      );
+      const config = configs.find((c) => c.repositoryId === doc.repositoryId);
+
+      const label = (repositoryId: string, number: number | null) =>
+        number !== null
+          ? `${shortCodeByRepo.get(repositoryId) ?? "ADR"}-${String(number).padStart(4, "0")}`
+          : null;
+
+      return {
+        ...doc,
+        shortCode: shortCodeByRepo.get(doc.repositoryId) ?? null,
+        label: label(doc.repositoryId, doc.number),
+        // Deep link pinned at the last-synced state, never HEAD: the stored
+        // body matches this commit even when the file was blob-SHA-skipped.
+        githubUrl: `https://github.com/${doc.repository.fullName}/blob/${config?.lastCommitSha ?? "HEAD"}/${doc.path}`,
+        linksFrom: doc.linksFrom.map((link) => ({
+          ...link,
+          to: { ...link.to, label: label(link.to.repositoryId, link.to.number) },
+        })),
+        linksTo: doc.linksTo.map((link) => ({
+          ...link,
+          from: {
+            ...link.from,
+            label: label(link.from.repositoryId, link.from.number),
+          },
+        })),
+      };
+    }),
+
   /** The workspace's ADR sync configs (enrolment state), with repo info. */
   listConfigs: humanOnlyProcedure
     .input(z.object({ workspaceId: z.string() }))

--- a/src/server/services/adrSync/__tests__/engine.test.ts
+++ b/src/server/services/adrSync/__tests__/engine.test.ts
@@ -85,6 +85,14 @@ beforeEach(() => {
   db.adrSyncRun.create.mockResolvedValue({ id: "run1" } as never);
   db.adrSyncRun.update.mockResolvedValue({} as never);
   db.adrSyncConfig.update.mockResolvedValue({} as never);
+  // Link recompute reads the workspace's enrolled repos.
+  db.adrSyncConfig.findMany.mockResolvedValue([
+    {
+      repositoryId: "repo1",
+      shortCode: "API",
+      repository: { fullName: "acme/api" },
+    },
+  ] as never);
   db.adrDocument.findMany.mockResolvedValue([]);
   db.adrDocument.create.mockResolvedValue({} as never);
   db.adrDocument.update.mockResolvedValue({} as never);
@@ -152,9 +160,13 @@ describe("runAdrSync", () => {
     db.adrDocument.findMany.mockResolvedValue([
       {
         id: "doc1",
+        repositoryId: "repo1",
         path: "docs/adr/0001-use-postgres.md",
         contentHash: "b1",
         deletedAt: null,
+        number: 1,
+        statusRaw: "Accepted",
+        body: "",
       },
     ] as never);
     const { remote, calls } = makeRemote();
@@ -174,9 +186,13 @@ describe("runAdrSync", () => {
     db.adrDocument.findMany.mockResolvedValue([
       {
         id: "doc-gone",
+        repositoryId: "repo1",
         path: "docs/adr/0000-removed.md",
         contentHash: "old",
         deletedAt: null,
+        number: 0,
+        statusRaw: null,
+        body: "",
       },
     ] as never);
     const { remote } = makeRemote();
@@ -327,7 +343,13 @@ describe("runAdrSync", () => {
 
     expect(result.status).toBe("success");
     expect(db.adrLink.deleteMany).toHaveBeenCalledWith({
-      where: { type: "SUPERSEDES", from: { repositoryId: "repo1" } },
+      where: {
+        OR: [
+          { type: "SUPERSEDES", from: { repositoryId: "repo1" } },
+          { type: "MENTIONS", from: { repositoryId: "repo1" } },
+          { type: "MENTIONS", to: { repositoryId: "repo1" } },
+        ],
+      },
     });
     expect(db.adrLink.createMany).toHaveBeenCalledWith({
       data: [
@@ -339,6 +361,59 @@ describe("runAdrSync", () => {
       ],
       skipDuplicates: true,
     });
+  });
+
+  it("recomputes cross-repo MENTIONS in both directions without refetching other repos", async () => {
+    db.adrSyncConfig.findUnique.mockResolvedValue(CONFIG as never);
+    db.adrSyncConfig.findMany.mockResolvedValue([
+      { repositoryId: "repo1", shortCode: "API", repository: { fullName: "acme/api" } },
+      { repositoryId: "repo2", shortCode: "PIPE", repository: { fullName: "acme/pipeline" } },
+    ] as never);
+    db.adrDocument.findMany
+      .mockResolvedValueOnce([] as never) // pre-sync existing docs
+      .mockResolvedValueOnce([
+        // this repo's doc mentions the other repo's ADR by short code…
+        {
+          id: "api-1",
+          repositoryId: "repo1",
+          number: 1,
+          statusRaw: "Accepted",
+          body: "See PIPE-0002 for the other half of this decision.",
+        },
+        // …and the other repo's STORED body names this repo + a number.
+        {
+          id: "pipe-2",
+          repositoryId: "repo2",
+          number: 2,
+          statusRaw: "Accepted",
+          body: "The api half lives in acme/api as 0001.",
+        },
+      ] as never);
+    const { remote } = makeRemote();
+
+    const result = await runAdrSync(db, "cfg1", "manual", {
+      remoteFactory: async () => remote,
+    });
+
+    expect(result.status).toBe("success");
+    const created = db.adrLink.createMany.mock.calls[0]?.[0] as {
+      data: Array<{ type: string; fromId: string; toId: string; evidence: string | null }>;
+    };
+    const mentions = created.data.filter((l) => l.type === "MENTIONS");
+    expect(mentions).toContainEqual(
+      expect.objectContaining({
+        fromId: "api-1",
+        toId: "pipe-2",
+        evidence: expect.stringContaining("PIPE-0002"),
+      }),
+    );
+    expect(mentions).toContainEqual(
+      expect.objectContaining({
+        fromId: "pipe-2",
+        toId: "api-1",
+        evidence: expect.stringContaining("acme/api"),
+      }),
+    );
   });
 
   it("errors the run (not the sweep) when the config is disconnected", async () => {

--- a/src/server/services/adrSync/__tests__/engine.test.ts
+++ b/src/server/services/adrSync/__tests__/engine.test.ts
@@ -82,6 +82,11 @@ function makeRemote(overrides?: Partial<AdrRemote>): {
 
 beforeEach(() => {
   mockReset(db);
+  // Run the $transaction callback against the same mock client.
+  db.$transaction.mockImplementation(
+    (async (fn: (tx: PrismaClient) => Promise<unknown>) =>
+      fn(db as unknown as PrismaClient)) as never,
+  );
   db.adrSyncRun.create.mockResolvedValue({ id: "run1" } as never);
   db.adrSyncRun.update.mockResolvedValue({} as never);
   db.adrSyncConfig.update.mockResolvedValue({} as never);

--- a/src/server/services/adrSync/__tests__/engine.test.ts
+++ b/src/server/services/adrSync/__tests__/engine.test.ts
@@ -303,6 +303,44 @@ describe("runAdrSync", () => {
     expect(db.adrSyncConfig.update).not.toHaveBeenCalled();
   });
 
+  it("recomputes SUPERSEDES edges for the repo after upserting", async () => {
+    db.adrSyncConfig.findUnique.mockResolvedValue(CONFIG as never);
+    // First findMany: existing docs (pre-sync). Second: fresh repo docs for
+    // link derivation, one of which declares supersession.
+    db.adrDocument.findMany
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([
+        {
+          id: "old",
+          repositoryId: "repo1",
+          number: 1,
+          statusRaw: "Superseded by ADR-0002",
+          body: "",
+        },
+        { id: "new", repositoryId: "repo1", number: 2, statusRaw: "Accepted", body: "" },
+      ] as never);
+    const { remote } = makeRemote();
+
+    const result = await runAdrSync(db, "cfg1", "manual", {
+      remoteFactory: async () => remote,
+    });
+
+    expect(result.status).toBe("success");
+    expect(db.adrLink.deleteMany).toHaveBeenCalledWith({
+      where: { type: "SUPERSEDES", from: { repositoryId: "repo1" } },
+    });
+    expect(db.adrLink.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          type: "SUPERSEDES",
+          fromId: "new",
+          toId: "old",
+        }),
+      ],
+      skipDuplicates: true,
+    });
+  });
+
   it("errors the run (not the sweep) when the config is disconnected", async () => {
     db.adrSyncConfig.findUnique.mockResolvedValue({
       ...CONFIG,

--- a/src/server/services/adrSync/__tests__/linkDerivation.test.ts
+++ b/src/server/services/adrSync/__tests__/linkDerivation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { deriveSupersedes } from "../linkDerivation";
+import type { AdrDocForLinks } from "../linkDerivation";
+
+function doc(overrides: Partial<AdrDocForLinks> & { id: string }): AdrDocForLinks {
+  return {
+    repositoryId: "repo1",
+    number: null,
+    statusRaw: null,
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("deriveSupersedes", () => {
+  it("creates an edge from the superseder to the superseded", () => {
+    const docs = [
+      doc({ id: "old", number: 1, statusRaw: "Superseded by ADR-0003" }),
+      doc({ id: "new", number: 3, statusRaw: "Accepted" }),
+    ];
+    expect(deriveSupersedes(docs)).toEqual([
+      {
+        type: "SUPERSEDES",
+        fromId: "new",
+        toId: "old",
+        evidence: "Superseded by ADR-0003",
+      },
+    ]);
+  });
+
+  it("resolves bare numbers and 'ADR NNNN' spellings", () => {
+    const bare = deriveSupersedes([
+      doc({ id: "old", number: 1, statusRaw: "superseded by 0002" }),
+      doc({ id: "new", number: 2 }),
+    ]);
+    expect(bare).toHaveLength(1);
+    expect(bare[0]).toMatchObject({ fromId: "new", toId: "old" });
+
+    const spaced = deriveSupersedes([
+      doc({ id: "old", number: 1, statusRaw: "Superseded by ADR 39" }),
+      doc({ id: "new", number: 39 }),
+    ]);
+    expect(spaced).toHaveLength(1);
+  });
+
+  it("derives from mid-status supersession text (real 'Deferred — premise superseded by' case)", () => {
+    const links = deriveSupersedes([
+      doc({
+        id: "old",
+        number: 19,
+        statusRaw: "Deferred — 2026-06-14. Declaration premise superseded by ADR-0020",
+      }),
+      doc({ id: "new", number: 20 }),
+    ]);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({ fromId: "new", toId: "old" });
+  });
+
+  it("never guesses on an ambiguous number (duplicate 0055 pair)", () => {
+    const links = deriveSupersedes([
+      doc({ id: "old", number: 1, statusRaw: "Superseded by ADR-0055" }),
+      doc({ id: "a", number: 55 }),
+      doc({ id: "b", number: 55 }),
+    ]);
+    expect(links).toEqual([]);
+  });
+
+  it("yields nothing when the referenced number is absent", () => {
+    expect(
+      deriveSupersedes([
+        doc({ id: "old", number: 1, statusRaw: "Superseded by ADR-0099" }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("ignores statuses without supersession text", () => {
+    expect(
+      deriveSupersedes([
+        doc({ id: "a", number: 1, statusRaw: "Accepted — 2026-05-14." }),
+        doc({ id: "b", number: 2, statusRaw: null }),
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/src/server/services/adrSync/__tests__/linkDerivation.test.ts
+++ b/src/server/services/adrSync/__tests__/linkDerivation.test.ts
@@ -161,4 +161,95 @@ describe("deriveMentions", () => {
 
     expect(deriveMentions([source], REPOS, [source, target])).toHaveLength(1);
   });
+
+  // ── False-edge regression cases (false edges are worse than missing ones) ──
+
+  it("does NOT pair a repo name with a bare list marker or count", () => {
+    const source = doc({
+      id: "api-9",
+      repositoryId: "r-api",
+      number: 9,
+      body: "1. Move ingestion to clear-context-pipeline\nWe retry 5 times before calling clear-context-pipeline.\n",
+    });
+    const targets = [
+      doc({ id: "pipe-1", repositoryId: "r-pipe", number: 1 }),
+      doc({ id: "pipe-5", repositoryId: "r-pipe", number: 5 }),
+    ];
+    expect(deriveMentions([source], REPOS, [source, ...targets])).toEqual([]);
+  });
+
+  it("treats a number that exists in the SOURCE repo as a local reference", () => {
+    const source = doc({
+      id: "api-9",
+      repositoryId: "r-api",
+      number: 9,
+      body: "Supersedes ADR-0007; see also clear-context-pipeline.\n",
+    });
+    const local = doc({ id: "api-7", repositoryId: "r-api", number: 7 });
+    const foreign = doc({ id: "pipe-7", repositoryId: "r-pipe", number: 7 });
+
+    expect(
+      deriveMentions([source, local], REPOS, [source, local, foreign]),
+    ).toEqual([]);
+  });
+
+  it("never guesses when the target repo has duplicate numbers", () => {
+    const source = doc({
+      id: "pipe-1",
+      repositoryId: "r-pipe",
+      number: 1,
+      body: "See API-0055 for details.\n",
+    });
+    const dupA = doc({ id: "api-55a", repositoryId: "r-api", number: 55 });
+    const dupB = doc({ id: "api-55b", repositoryId: "r-api", number: 55 });
+
+    expect(deriveMentions([source], REPOS, [source, dupA, dupB])).toEqual([]);
+  });
+
+  it("does not fire a shorter repo name inside a longer one, or inside words", () => {
+    const repos = [
+      ...REPOS,
+      { repositoryId: "r-clear", fullName: "clear/clear", shortCode: "CLR" },
+    ];
+    const source = doc({
+      id: "pipe-1",
+      repositoryId: "r-pipe",
+      number: 1,
+      body: "clear-api handles auth (see 0004). Clearly capital matters.\n",
+    });
+    const clearDoc = doc({ id: "clear-4", repositoryId: "r-clear", number: 4 });
+    const apiDoc = doc({ id: "api-4", repositoryId: "r-api", number: 4 });
+
+    const links = deriveMentions([source], repos, [source, clearDoc, apiDoc]);
+    // "clear-api" + 0004 → r-api's doc; the bare "clear" repo must NOT match
+    // inside "clear-api" or "Clearly".
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({ toId: "api-4" });
+  });
+
+  it("ignores numbers embedded in dates", () => {
+    const source = doc({
+      id: "pipe-1",
+      repositoryId: "r-pipe",
+      number: 1,
+      body: "Released 2026-06-14 alongside clear-api.\n",
+    });
+    const target = doc({ id: "api-6", repositoryId: "r-api", number: 6 });
+    expect(deriveMentions([source], REPOS, [source, target])).toEqual([]);
+  });
+
+  it("escapes regex metacharacters in repo names", () => {
+    const repos = [
+      ...REPOS,
+      { repositoryId: "r-next", fullName: "acme/next.js", shortCode: "NEXT" },
+    ];
+    const source = doc({
+      id: "api-1",
+      repositoryId: "r-api",
+      number: 1,
+      body: "nextXjs is not the same repo, no number here anyway.\n",
+    });
+    // Must not throw and must not match "nextXjs" via an unescaped dot.
+    expect(deriveMentions([source], repos, [source])).toEqual([]);
+  });
 });

--- a/src/server/services/adrSync/__tests__/linkDerivation.test.ts
+++ b/src/server/services/adrSync/__tests__/linkDerivation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { deriveSupersedes } from "../linkDerivation";
-import type { AdrDocForLinks } from "../linkDerivation";
+import { deriveMentions, deriveSupersedes } from "../linkDerivation";
+import type { AdrDocForLinks, RepoIdentity } from "../linkDerivation";
 
 function doc(overrides: Partial<AdrDocForLinks> & { id: string }): AdrDocForLinks {
   return {
@@ -80,5 +80,85 @@ describe("deriveSupersedes", () => {
         doc({ id: "b", number: 2, statusRaw: null }),
       ]),
     ).toEqual([]);
+  });
+});
+
+describe("deriveMentions", () => {
+  const REPOS: RepoIdentity[] = [
+    { repositoryId: "r-api", fullName: "clear/clear-api", shortCode: "API" },
+    { repositoryId: "r-pipe", fullName: "clear/clear-context-pipeline", shortCode: "PIPE" },
+  ];
+
+  it("links a SHORTCODE-NNNN reference to the other repo's doc with the line as evidence", () => {
+    const source = doc({
+      id: "pipe-2",
+      repositoryId: "r-pipe",
+      number: 2,
+      body: "## Context\n\nThe API half of this decision is API-0003.\n",
+    });
+    const target = doc({ id: "api-3", repositoryId: "r-api", number: 3 });
+
+    expect(deriveMentions([source], REPOS, [source, target])).toEqual([
+      {
+        type: "MENTIONS",
+        fromId: "pipe-2",
+        toId: "api-3",
+        evidence: "The API half of this decision is API-0003.",
+      },
+    ]);
+  });
+
+  it("links a bare repo-name mention when a number on the same line identifies the doc", () => {
+    // The motivating CLEAR case: clear-api/0003 and clear-context-pipeline/0002
+    // are two halves of one decision written twice.
+    const source = doc({
+      id: "api-3",
+      repositoryId: "r-api",
+      number: 3,
+      body: "The pipeline half is 0002 in clear-context-pipeline.\n",
+    });
+    const target = doc({ id: "pipe-2", repositoryId: "r-pipe", number: 2 });
+
+    const links = deriveMentions([source], REPOS, [source, target]);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      fromId: "api-3",
+      toId: "pipe-2",
+      evidence: expect.stringContaining("clear-context-pipeline"),
+    });
+  });
+
+  it("never links a doc to its own repo (own short code / own name)", () => {
+    const a = doc({
+      id: "api-1",
+      repositoryId: "r-api",
+      number: 1,
+      body: "Supersedes API-0002; see clear-api 0002.\n",
+    });
+    const b = doc({ id: "api-2", repositoryId: "r-api", number: 2 });
+
+    expect(deriveMentions([a], REPOS, [a, b])).toEqual([]);
+  });
+
+  it("ignores short codes that belong to no enrolled repo", () => {
+    const source = doc({
+      id: "api-1",
+      repositoryId: "r-api",
+      number: 1,
+      body: "Follows RFC-1234 and HTTP-0002 conventions.\n",
+    });
+    expect(deriveMentions([source], REPOS, [source])).toEqual([]);
+  });
+
+  it("dedupes multiple references to the same target", () => {
+    const source = doc({
+      id: "pipe-1",
+      repositoryId: "r-pipe",
+      number: 1,
+      body: "API-0003 is the sibling.\nAgain: API-0003.\n",
+    });
+    const target = doc({ id: "api-3", repositoryId: "r-api", number: 3 });
+
+    expect(deriveMentions([source], REPOS, [source, target])).toHaveLength(1);
   });
 });

--- a/src/server/services/adrSync/engine.ts
+++ b/src/server/services/adrSync/engine.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient, Prisma } from "@prisma/client";
 import { parseAdr } from "./parser";
+import { deriveSupersedes } from "./linkDerivation";
 import {
   createInstallationAdrRemote,
   readInstallationId,
@@ -365,6 +366,31 @@ export async function runAdrSync(
         deleted++;
         items.push({ path: doc.path, action: "deleted", reason: "file removed from repo" });
       }
+    }
+
+    // Recompute derived SUPERSEDES edges for this repo from the fresh docs.
+    // SUPERSEDES is always intra-repo (resolved by number within the repo),
+    // so deleting by from-side repo covers every stale edge. MENTIONS edges
+    // are recomputed separately and never touched here.
+    const repoDocs = await db.adrDocument.findMany({
+      where: { repositoryId: config.repository.id, deletedAt: null },
+      select: {
+        id: true,
+        repositoryId: true,
+        number: true,
+        statusRaw: true,
+        body: true,
+      },
+    });
+    const supersedes = deriveSupersedes(repoDocs);
+    await db.adrLink.deleteMany({
+      where: { type: "SUPERSEDES", from: { repositoryId: config.repository.id } },
+    });
+    if (supersedes.length > 0) {
+      await db.adrLink.createMany({
+        data: supersedes,
+        skipDuplicates: true,
+      });
     }
 
     await db.adrSyncConfig.update({

--- a/src/server/services/adrSync/engine.ts
+++ b/src/server/services/adrSync/engine.ts
@@ -417,22 +417,26 @@ export async function runAdrSync(
       thisRepoDocs,
     );
 
-    await db.adrLink.deleteMany({
-      where: {
-        OR: [
-          { type: "SUPERSEDES", from: { repositoryId: config.repository.id } },
-          { type: "MENTIONS", from: { repositoryId: config.repository.id } },
-          { type: "MENTIONS", to: { repositoryId: config.repository.id } },
-        ],
-      },
-    });
+    // One transaction so a crash between delete and create can't leave the
+    // repo's edges missing until the next changed-tree sync.
     const derivedLinks = [...supersedes, ...mentionsOut, ...mentionsIn];
-    if (derivedLinks.length > 0) {
-      await db.adrLink.createMany({
-        data: derivedLinks,
-        skipDuplicates: true,
+    await db.$transaction(async (tx) => {
+      await tx.adrLink.deleteMany({
+        where: {
+          OR: [
+            { type: "SUPERSEDES", from: { repositoryId: config.repository.id } },
+            { type: "MENTIONS", from: { repositoryId: config.repository.id } },
+            { type: "MENTIONS", to: { repositoryId: config.repository.id } },
+          ],
+        },
       });
-    }
+      if (derivedLinks.length > 0) {
+        await tx.adrLink.createMany({
+          data: derivedLinks,
+          skipDuplicates: true,
+        });
+      }
+    });
 
     await db.adrSyncConfig.update({
       where: { id: configId },
@@ -441,8 +445,11 @@ export async function runAdrSync(
         // fetch failure would otherwise be locked in — the next run would see
         // an unchanged tree and short-circuit past the retry forever on a
         // quiet repo. Unchanged blobs still skip via their blob SHA.
+        // lastCommitSha gets the same guard: a failed file's stored body is
+        // still the OLD text, so pinning its deep link at the new head would
+        // break the "link shows exactly what's projected" invariant.
         lastTreeSha: failed === 0 ? combined : null,
-        lastCommitSha: head.commitSha,
+        lastCommitSha: failed === 0 ? head.commitSha : config.lastCommitSha,
         lastSyncedAt: now(),
       },
     });

--- a/src/server/services/adrSync/engine.ts
+++ b/src/server/services/adrSync/engine.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient, Prisma } from "@prisma/client";
 import { parseAdr } from "./parser";
-import { deriveSupersedes } from "./linkDerivation";
+import { deriveMentions, deriveSupersedes } from "./linkDerivation";
 import {
   createInstallationAdrRemote,
   readInstallationId,
@@ -368,12 +368,32 @@ export async function runAdrSync(
       }
     }
 
-    // Recompute derived SUPERSEDES edges for this repo from the fresh docs.
+    // Recompute derived edges touching this repo from the fresh docs.
+    //
     // SUPERSEDES is always intra-repo (resolved by number within the repo),
-    // so deleting by from-side repo covers every stale edge. MENTIONS edges
-    // are recomputed separately and never touched here.
-    const repoDocs = await db.adrDocument.findMany({
-      where: { repositoryId: config.repository.id, deletedAt: null },
+    // so deleting by from-side repo covers every stale edge.
+    //
+    // MENTIONS is cross-repo, recomputed in both directions WITHOUT any
+    // refetch: outbound from this repo's fresh bodies, and inbound by
+    // re-matching other repos' STORED bodies against this repo's docs.
+    const workspaceConfigs = await db.adrSyncConfig.findMany({
+      where: { workspaceId: config.workspaceId },
+      select: {
+        repositoryId: true,
+        shortCode: true,
+        repository: { select: { fullName: true } },
+      },
+    });
+    const repoIdentities = workspaceConfigs.map((c) => ({
+      repositoryId: c.repositoryId,
+      fullName: c.repository.fullName,
+      shortCode: c.shortCode,
+    }));
+    const allDocs = await db.adrDocument.findMany({
+      where: {
+        repositoryId: { in: workspaceConfigs.map((c) => c.repositoryId) },
+        deletedAt: null,
+      },
       select: {
         id: true,
         repositoryId: true,
@@ -382,13 +402,34 @@ export async function runAdrSync(
         body: true,
       },
     });
-    const supersedes = deriveSupersedes(repoDocs);
+    const thisRepoDocs = allDocs.filter(
+      (d) => d.repositoryId === config.repository.id,
+    );
+    const otherRepoDocs = allDocs.filter(
+      (d) => d.repositoryId !== config.repository.id,
+    );
+
+    const supersedes = deriveSupersedes(thisRepoDocs);
+    const mentionsOut = deriveMentions(thisRepoDocs, repoIdentities, allDocs);
+    const mentionsIn = deriveMentions(
+      otherRepoDocs,
+      repoIdentities,
+      thisRepoDocs,
+    );
+
     await db.adrLink.deleteMany({
-      where: { type: "SUPERSEDES", from: { repositoryId: config.repository.id } },
+      where: {
+        OR: [
+          { type: "SUPERSEDES", from: { repositoryId: config.repository.id } },
+          { type: "MENTIONS", from: { repositoryId: config.repository.id } },
+          { type: "MENTIONS", to: { repositoryId: config.repository.id } },
+        ],
+      },
     });
-    if (supersedes.length > 0) {
+    const derivedLinks = [...supersedes, ...mentionsOut, ...mentionsIn];
+    if (derivedLinks.length > 0) {
       await db.adrLink.createMany({
-        data: supersedes,
+        data: derivedLinks,
         skipDuplicates: true,
       });
     }

--- a/src/server/services/adrSync/linkDerivation.ts
+++ b/src/server/services/adrSync/linkDerivation.ts
@@ -69,20 +69,48 @@ export interface RepoIdentity {
   shortCode: string;
 }
 
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * ADR-shaped number tokens on a line: `ADR-0003`, `ADR 3`, `#0003`, or a
+ * bare leading-zero form (`0003`). A bare `3`, `v2`, `5 times`, or a list
+ * marker `1.` is NOT ADR-shaped — dense per-repo numbering means loose
+ * number matching manufactures false edges out of ordinary prose.
+ */
+function adrShapedNumbers(line: string): number[] {
+  const out: number[] = [];
+  // The bare leading-zero form must not fire inside dates ("2026-06-14") —
+  // hence the digit/dash lookarounds. Sentence-final "…as 0001." stays valid.
+  const re =
+    /(?:\b(?:ADR)[- ]?|#)0*(\d{1,4})\b|(?<![\d-])\b0(\d{1,3})\b(?![\d-])/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(line)) !== null) {
+    const raw = match[1] ?? (match[2] !== undefined ? `0${match[2]}` : undefined);
+    if (raw !== undefined) out.push(parseInt(raw, 10));
+  }
+  return out;
+}
+
 /**
  * MENTIONS edges from `sourceDocs` bodies to other enrolled repos' documents.
  *
  * Two detectors, per the spec:
- * - another enrolled repo's name (case-insensitive; the bare repo name, e.g.
- *   "clear-api", not the owner prefix) → edge to that repo's doc ONLY when a
- *   specific ADR is identifiable on the same line via a number reference;
- *   otherwise the repo-name mention alone cannot pick a target doc, so it
- *   yields nothing (edges connect documents, not repos);
- * - `SHORTCODE-NNNN` (another repo's short code) → edge to that repo's doc
- *   with that number.
+ * - `SHORTCODE-NNNN` (another enrolled repo's short code) → edge to that
+ *   repo's doc with that number;
+ * - another enrolled repo's bare name (boundary-matched, escaped) → edge ONLY
+ *   when an ADR-shaped number on the same line identifies the doc; a repo
+ *   name alone cannot pick a target (edges connect documents, not repos).
  *
- * Evidence is the matched line, verbatim. Self-references (same repo) are the
- * supersession/graph-within-repo domain and are excluded here.
+ * False edges are worse than missing ones, so the same never-guess rule as
+ * deriveSupersedes applies throughout: a number that is duplicated in the
+ * target repo resolves to nothing, and (for the bare-name detector) a number
+ * that also exists in the SOURCE repo is presumed a local reference and
+ * skipped. Self-references (same repo) are excluded — that's the
+ * supersession/within-repo domain.
+ *
+ * Evidence is the matched line, verbatim.
  */
 export function deriveMentions(
   sourceDocs: AdrDocForLinks[],
@@ -90,73 +118,84 @@ export function deriveMentions(
   /** All candidate target docs across enrolled repos (non-deleted). */
   targetDocs: AdrDocForLinks[],
 ): DerivedLink[] {
-  const reposById = new Map(repos.map((r) => [r.repositoryId, r]));
-  const docsByRepoAndNumber = new Map<string, AdrDocForLinks>();
+  // number → docs buckets per repo; ambiguous buckets resolve to nothing.
+  const docsByRepoAndNumber = new Map<string, AdrDocForLinks[]>();
   for (const doc of targetDocs) {
     if (doc.number === null) continue;
-    docsByRepoAndNumber.set(`${doc.repositoryId}:${doc.number}`, doc);
+    const key = `${doc.repositoryId}:${doc.number}`;
+    const bucket = docsByRepoAndNumber.get(key) ?? [];
+    bucket.push(doc);
+    docsByRepoAndNumber.set(key, bucket);
+  }
+  const resolveTarget = (
+    repositoryId: string,
+    number: number,
+  ): AdrDocForLinks | null => {
+    const bucket = docsByRepoAndNumber.get(`${repositoryId}:${number}`) ?? [];
+    return bucket.length === 1 ? bucket[0]! : null; // absent or ambiguous — never guess
+  };
+  const sourceRepoNumbers = new Map<string, Set<number>>();
+  for (const doc of sourceDocs) {
+    if (doc.number === null) continue;
+    const set = sourceRepoNumbers.get(doc.repositoryId) ?? new Set<number>();
+    set.add(doc.number);
+    sourceRepoNumbers.set(doc.repositoryId, set);
   }
   const repoByShortCode = new Map(repos.map((r) => [r.shortCode.toUpperCase(), r]));
 
   const links: DerivedLink[] = [];
   const seen = new Set<string>();
+  const push = (doc: AdrDocForLinks, target: AdrDocForLinks, line: string) => {
+    if (target.id === doc.id) return;
+    const key = `${doc.id}:${target.id}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    links.push({
+      type: "MENTIONS",
+      fromId: doc.id,
+      toId: target.id,
+      evidence: line.trim(),
+    });
+  };
 
   for (const doc of sourceDocs) {
-    const sourceRepo = reposById.get(doc.repositoryId);
     for (const line of doc.body.split("\n")) {
-      // SHORTCODE-NNNN references to OTHER repos.
+      // SHORTCODE-NNNN references to OTHER repos — the precise detector.
       const codeRe = /\b([A-Z][A-Z0-9]{1,9})-0*(\d{1,4})\b/g;
       let match: RegExpExecArray | null;
       while ((match = codeRe.exec(line)) !== null) {
         const repo = repoByShortCode.get(match[1]!.toUpperCase());
         if (!repo || repo.repositoryId === doc.repositoryId) continue;
-        const target = docsByRepoAndNumber.get(
-          `${repo.repositoryId}:${parseInt(match[2]!, 10)}`,
+        const target = resolveTarget(
+          repo.repositoryId,
+          parseInt(match[2]!, 10),
         );
-        if (!target || target.id === doc.id) continue;
-        const key = `${doc.id}:${target.id}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        links.push({
-          type: "MENTIONS",
-          fromId: doc.id,
-          toId: target.id,
-          evidence: line.trim(),
-        });
+        if (target) push(doc, target, line);
       }
 
-      // Bare repo-name mentions ("clear-api") paired with a number reference
-      // on the same line ("clear-api's 0003", "0002 in clear-context-pipeline").
+      // Bare repo-name mentions paired with an ADR-shaped number on the line
+      // ("the pipeline half is 0002 in clear-context-pipeline").
       for (const repo of repos) {
         if (repo.repositoryId === doc.repositoryId) continue;
         const repoName = repo.fullName.split("/").pop() ?? repo.fullName;
         if (repoName.length < 3) continue;
-        if (!line.toLowerCase().includes(repoName.toLowerCase())) continue;
-        // Ignore the line if the "mention" is only this source repo's own name
-        // being a substring (e.g. "clear" inside "clear-api").
-        if (
-          sourceRepo &&
-          repoName.toLowerCase() ===
-            (sourceRepo.fullName.split("/").pop() ?? "").toLowerCase()
-        )
-          continue;
-        const numberMatch = /\b0*(\d{1,4})\b/.exec(
-          line.replace(new RegExp(repoName, "ig"), " "),
+        // Boundary-matched and escaped: "clear" must not fire inside
+        // "clear-api", "api" must not fire inside "capital" or "clear-api".
+        const nameRe = new RegExp(
+          `(?<![\\w-])${escapeRegExp(repoName)}(?![\\w-])`,
+          "i",
         );
-        if (!numberMatch?.[1]) continue;
-        const target = docsByRepoAndNumber.get(
-          `${repo.repositoryId}:${parseInt(numberMatch[1], 10)}`,
-        );
-        if (!target || target.id === doc.id) continue;
-        const key = `${doc.id}:${target.id}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        links.push({
-          type: "MENTIONS",
-          fromId: doc.id,
-          toId: target.id,
-          evidence: line.trim(),
-        });
+        if (!nameRe.test(line)) continue;
+        for (const number of adrShapedNumbers(line)) {
+          // A number that also exists in the source repo is presumed a LOCAL
+          // reference ("Supersedes ADR-0007; see also clear-api") — skip it.
+          if (sourceRepoNumbers.get(doc.repositoryId)?.has(number)) continue;
+          const target = resolveTarget(repo.repositoryId, number);
+          if (target) {
+            push(doc, target, line);
+            break;
+          }
+        }
       }
     }
   }

--- a/src/server/services/adrSync/linkDerivation.ts
+++ b/src/server/services/adrSync/linkDerivation.ts
@@ -1,0 +1,164 @@
+/**
+ * adrSync/linkDerivation — pure derivation of AdrLink edges from projected
+ * document content. Derived, re-derivable, and recomputed on every sync run;
+ * never user-authored (that's AdrTicketLink).
+ *
+ * - SUPERSEDES: from the superseded doc's verbatim `statusRaw` matching
+ *   "superseded by [ADR-]NNNN", resolved by number WITHIN the same repo. The
+ *   edge is normalised to point from the superseder to the superseded.
+ * - MENTIONS: from a body scan for other enrolled repos' full names and
+ *   `SHORTCODE-NNNN` references; each edge carries the matched line as
+ *   evidence.
+ */
+
+export interface AdrDocForLinks {
+  id: string;
+  repositoryId: string;
+  number: number | null;
+  statusRaw: string | null;
+  body: string;
+}
+
+export interface DerivedLink {
+  type: "SUPERSEDES" | "MENTIONS";
+  fromId: string;
+  toId: string;
+  evidence: string | null;
+}
+
+const SUPERSEDED_BY_RE = /superseded by\s+(?:ADR[- ]?)?0*(\d{1,4})\b/i;
+
+/**
+ * SUPERSEDES edges among one repo's documents. A doc whose status says
+ * "superseded by NNNN" produces an edge FROM the doc numbered NNNN TO itself.
+ * Ambiguous numbers (this workspace really has duplicate 0055s) resolve to
+ * nothing — labels are labels, not keys, and we never guess.
+ */
+export function deriveSupersedes(docs: AdrDocForLinks[]): DerivedLink[] {
+  const byNumber = new Map<number, AdrDocForLinks[]>();
+  for (const doc of docs) {
+    if (doc.number === null) continue;
+    const bucket = byNumber.get(doc.number) ?? [];
+    bucket.push(doc);
+    byNumber.set(doc.number, bucket);
+  }
+
+  const links: DerivedLink[] = [];
+  for (const doc of docs) {
+    if (!doc.statusRaw) continue;
+    const match = SUPERSEDED_BY_RE.exec(doc.statusRaw);
+    if (!match?.[1]) continue;
+    const candidates = byNumber.get(parseInt(match[1], 10)) ?? [];
+    if (candidates.length !== 1) continue; // absent or ambiguous — never guess
+    const superseder = candidates[0]!;
+    if (superseder.id === doc.id) continue;
+    links.push({
+      type: "SUPERSEDES",
+      fromId: superseder.id,
+      toId: doc.id,
+      evidence: doc.statusRaw,
+    });
+  }
+  return links;
+}
+
+export interface RepoIdentity {
+  repositoryId: string;
+  /** e.g. "positonic/exponential" */
+  fullName: string;
+  shortCode: string;
+}
+
+/**
+ * MENTIONS edges from `sourceDocs` bodies to other enrolled repos' documents.
+ *
+ * Two detectors, per the spec:
+ * - another enrolled repo's name (case-insensitive; the bare repo name, e.g.
+ *   "clear-api", not the owner prefix) → edge to that repo's doc ONLY when a
+ *   specific ADR is identifiable on the same line via a number reference;
+ *   otherwise the repo-name mention alone cannot pick a target doc, so it
+ *   yields nothing (edges connect documents, not repos);
+ * - `SHORTCODE-NNNN` (another repo's short code) → edge to that repo's doc
+ *   with that number.
+ *
+ * Evidence is the matched line, verbatim. Self-references (same repo) are the
+ * supersession/graph-within-repo domain and are excluded here.
+ */
+export function deriveMentions(
+  sourceDocs: AdrDocForLinks[],
+  repos: RepoIdentity[],
+  /** All candidate target docs across enrolled repos (non-deleted). */
+  targetDocs: AdrDocForLinks[],
+): DerivedLink[] {
+  const reposById = new Map(repos.map((r) => [r.repositoryId, r]));
+  const docsByRepoAndNumber = new Map<string, AdrDocForLinks>();
+  for (const doc of targetDocs) {
+    if (doc.number === null) continue;
+    docsByRepoAndNumber.set(`${doc.repositoryId}:${doc.number}`, doc);
+  }
+  const repoByShortCode = new Map(repos.map((r) => [r.shortCode.toUpperCase(), r]));
+
+  const links: DerivedLink[] = [];
+  const seen = new Set<string>();
+
+  for (const doc of sourceDocs) {
+    const sourceRepo = reposById.get(doc.repositoryId);
+    for (const line of doc.body.split("\n")) {
+      // SHORTCODE-NNNN references to OTHER repos.
+      const codeRe = /\b([A-Z][A-Z0-9]{1,9})-0*(\d{1,4})\b/g;
+      let match: RegExpExecArray | null;
+      while ((match = codeRe.exec(line)) !== null) {
+        const repo = repoByShortCode.get(match[1]!.toUpperCase());
+        if (!repo || repo.repositoryId === doc.repositoryId) continue;
+        const target = docsByRepoAndNumber.get(
+          `${repo.repositoryId}:${parseInt(match[2]!, 10)}`,
+        );
+        if (!target || target.id === doc.id) continue;
+        const key = `${doc.id}:${target.id}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        links.push({
+          type: "MENTIONS",
+          fromId: doc.id,
+          toId: target.id,
+          evidence: line.trim(),
+        });
+      }
+
+      // Bare repo-name mentions ("clear-api") paired with a number reference
+      // on the same line ("clear-api's 0003", "0002 in clear-context-pipeline").
+      for (const repo of repos) {
+        if (repo.repositoryId === doc.repositoryId) continue;
+        const repoName = repo.fullName.split("/").pop() ?? repo.fullName;
+        if (repoName.length < 3) continue;
+        if (!line.toLowerCase().includes(repoName.toLowerCase())) continue;
+        // Ignore the line if the "mention" is only this source repo's own name
+        // being a substring (e.g. "clear" inside "clear-api").
+        if (
+          sourceRepo &&
+          repoName.toLowerCase() ===
+            (sourceRepo.fullName.split("/").pop() ?? "").toLowerCase()
+        )
+          continue;
+        const numberMatch = /\b0*(\d{1,4})\b/.exec(
+          line.replace(new RegExp(repoName, "ig"), " "),
+        );
+        if (!numberMatch?.[1]) continue;
+        const target = docsByRepoAndNumber.get(
+          `${repo.repositoryId}:${parseInt(numberMatch[1], 10)}`,
+        );
+        if (!target || target.id === doc.id) continue;
+        const key = `${doc.id}:${target.id}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        links.push({
+          type: "MENTIONS",
+          fromId: doc.id,
+          toId: target.id,
+          evidence: line.trim(),
+        });
+      }
+    }
+  }
+  return links;
+}


### PR DESCRIPTION
## What

The Decision Log's connective tissue (V2): an ADR detail page with the body rendered via `MarkdownRenderer` (no write path — deliberately absent) and a GitHub deep link pinned at the last-synced commit; SUPERSEDES chain derivation from verbatim status text, rendered as navigable links in both directions; cross-repo MENTIONS edges with quoted evidence, recomputed bidirectionally on every sync without refetching other repos; and a product-page Decisions tab pre-filtered to the product's repos plus workspace-wide ADRs with a marker.

**Feature**: Decision Log — cross-repo ADR viewer (`cmsso8h5w0008i504of0r4nzo`), scope V2. Builds on #590 (V1). No schema changes.

## Acceptance criteria

- [ ] All 4 V2 requirement rows on the feature are met (SUPERSEDES edge + navigable chain; MENTIONS edge with evidence, weaker rendering; GitHub link pinned not HEAD; product lens incl. workspace-wide marker)
- [ ] No write path to ADR content anywhere on the detail page

---

Ships: wide.stork

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cmssoxfif0005ju04emapdciw)
