### PR TITLE
feat: V3 Decision Log cron sync, rate-limit short-circuit & ticket linking

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/decisions/[adrId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/decisions/[adrId]/page.tsx
@@ -17,6 +17,7 @@ import { IconArrowLeft, IconBrandGithub } from "@tabler/icons-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { MarkdownRenderer } from "~/app/_components/shared/MarkdownRenderer";
+import { ImplementedByPicker } from "~/app/_components/decisions/ImplementedByPicker";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { api } from "~/trpc/react";
 
@@ -187,6 +188,15 @@ export default function DecisionDetailPage() {
           ))}
         </Stack>
       ) : null}
+
+      <Divider my="lg" />
+
+      <ImplementedByPicker
+        workspaceId={workspaceId ?? ""}
+        adrId={adr.id}
+        links={adr.ticketLinks}
+        canEdit
+      />
 
       <Divider my="lg" />
 

--- a/src/app/_components/decisions/DecisionsIndex.tsx
+++ b/src/app/_components/decisions/DecisionsIndex.tsx
@@ -208,6 +208,7 @@ export function DecisionsIndex({
               <Table.Th>Product</Table.Th>
               <Table.Th>Status</Table.Th>
               <Table.Th>Decided</Table.Th>
+              <Table.Th>Links</Table.Th>
             </Table.Tr>
           </Table.Thead>
           <Table.Tbody>
@@ -269,6 +270,11 @@ export function DecisionsIndex({
                     {adr.decidedAt
                       ? new Date(adr.decidedAt).toLocaleDateString()
                       : "—"}
+                  </Text>
+                </Table.Td>
+                <Table.Td>
+                  <Text size="sm" className="text-text-secondary">
+                    {adr._count.ticketLinks > 0 ? adr._count.ticketLinks : "—"}
                   </Text>
                 </Table.Td>
               </Table.Tr>

--- a/src/app/_components/decisions/ImplementedByPicker.tsx
+++ b/src/app/_components/decisions/ImplementedByPicker.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Group,
+  Select,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from "@mantine/core";
+import { IconPlus, IconX } from "@tabler/icons-react";
+import { notifications } from "@mantine/notifications";
+import { api } from "~/trpc/react";
+
+/**
+ * "Implemented by" — the Decision Log's ONLY writable surface. Links an ADR
+ * to the tickets/features that implement it. The links are user-authored
+ * data: they survive repo disconnection and soft-deletion of the document.
+ * ADR content itself stays read-only everywhere.
+ */
+
+interface LinkedTicket {
+  id: string;
+  ticket: {
+    id: string;
+    shortId: string | null;
+    number: number;
+    title: string;
+    status: string;
+  } | null;
+  feature: { id: string; name: string; status: string } | null;
+}
+
+interface ImplementedByPickerProps {
+  workspaceId: string;
+  adrId: string;
+  links: LinkedTicket[];
+  /** Only members get the mutation UI; the list itself is always shown. */
+  canEdit: boolean;
+}
+
+export function ImplementedByPicker({
+  workspaceId,
+  adrId,
+  links,
+  canEdit,
+}: ImplementedByPickerProps) {
+  const utils = api.useUtils();
+  const [adding, setAdding] = useState(false);
+  const [productId, setProductId] = useState<string | null>(null);
+
+  const { data: products } = api.product.product.list.useQuery(
+    { workspaceId },
+    { enabled: adding },
+  );
+  const { data: tickets } = api.product.ticket.list.useQuery(
+    { productId: productId ?? "" },
+    { enabled: adding && !!productId },
+  );
+  const { data: features } = api.product.feature.list.useQuery(
+    { productId: productId ?? "" },
+    { enabled: adding && !!productId },
+  );
+
+  const invalidate = async () => {
+    await utils.adr.get.invalidate({ workspaceId, adrId });
+    await utils.adr.list.invalidate();
+  };
+
+  const link = api.adr.linkTicket.useMutation({
+    onSuccess: invalidate,
+    onError: (error) =>
+      notifications.show({ title: "Couldn't link", message: error.message, color: "red" }),
+  });
+  const unlink = api.adr.unlinkTicket.useMutation({
+    onSuccess: invalidate,
+    onError: (error) =>
+      notifications.show({ title: "Couldn't unlink", message: error.message, color: "red" }),
+  });
+
+  const linkedTicketIds = new Set(
+    links.map((l) => l.ticket?.id).filter(Boolean) as string[],
+  );
+  const linkedFeatureIds = new Set(
+    links.map((l) => l.feature?.id).filter(Boolean) as string[],
+  );
+
+  return (
+    <Stack gap="xs">
+      <Title order={5} className="text-text-secondary">
+        Implemented by
+      </Title>
+
+      {links.length === 0 ? (
+        <Text size="sm" className="text-text-muted">
+          No linked tickets or features yet.
+        </Text>
+      ) : (
+        <Stack gap={4}>
+          {links.map((l) => (
+            <Group key={l.id} gap="xs" wrap="nowrap">
+              <Badge variant="light" color={l.ticket ? "blue" : "grape"}>
+                {l.ticket ? "ticket" : "feature"}
+              </Badge>
+              <Text size="sm" className="min-w-0 flex-1 truncate">
+                {l.ticket
+                  ? `${l.ticket.shortId ?? `#${l.ticket.number}`} — ${l.ticket.title}`
+                  : (l.feature?.name ?? "—")}
+              </Text>
+              <Text size="xs" className="text-text-muted whitespace-nowrap">
+                {(l.ticket?.status ?? l.feature?.status ?? "").toLowerCase()}
+              </Text>
+              {canEdit ? (
+                <Tooltip label="Unlink">
+                  <ActionIcon
+                    variant="subtle"
+                    color="gray"
+                    size="sm"
+                    aria-label="Unlink"
+                    loading={unlink.isPending && unlink.variables?.linkId === l.id}
+                    onClick={() => unlink.mutate({ workspaceId, linkId: l.id })}
+                  >
+                    <IconX size={14} />
+                  </ActionIcon>
+                </Tooltip>
+              ) : null}
+            </Group>
+          ))}
+        </Stack>
+      )}
+
+      {canEdit ? (
+        !adding ? (
+          <Button
+            variant="subtle"
+            size="compact-sm"
+            leftSection={<IconPlus size={14} />}
+            onClick={() => setAdding(true)}
+            className="self-start"
+          >
+            Link ticket or feature
+          </Button>
+        ) : (
+          <Group gap="xs" align="flex-end" wrap="wrap">
+            <Select
+              size="xs"
+              w={180}
+              label="Product"
+              data={(products ?? []).map((p) => ({ value: p.id, label: p.name }))}
+              value={productId}
+              onChange={setProductId}
+              searchable
+              aria-label="Product"
+            />
+            <Select
+              size="xs"
+              w={260}
+              label="Ticket"
+              placeholder={productId ? "Pick a ticket…" : "Pick a product first"}
+              data={(tickets ?? [])
+                .filter((t) => !linkedTicketIds.has(t.id))
+                .map((t) => ({
+                  value: t.id,
+                  label: `${t.shortId ?? `#${t.number}`} — ${t.title}`,
+                }))}
+              value={null}
+              onChange={(ticketId) => {
+                if (ticketId) link.mutate({ workspaceId, adrId, ticketId });
+              }}
+              searchable
+              disabled={!productId || link.isPending}
+              aria-label="Ticket"
+            />
+            <Select
+              size="xs"
+              w={220}
+              label="Feature"
+              placeholder={productId ? "Pick a feature…" : "Pick a product first"}
+              data={(features ?? [])
+                .filter((f) => !linkedFeatureIds.has(f.id))
+                .map((f) => ({ value: f.id, label: f.name }))}
+              value={null}
+              onChange={(featureId) => {
+                if (featureId) link.mutate({ workspaceId, adrId, featureId });
+              }}
+              searchable
+              disabled={!productId || link.isPending}
+              aria-label="Feature"
+            />
+            <Button
+              variant="subtle"
+              color="gray"
+              size="compact-sm"
+              onClick={() => setAdding(false)}
+            >
+              Done
+            </Button>
+          </Group>
+        )
+      ) : null}
+    </Stack>
+  );
+}

--- a/src/app/api/cron/adr-sync/route.ts
+++ b/src/app/api/cron/adr-sync/route.ts
@@ -12,6 +12,11 @@ import { runDueAdrSyncs } from "~/server/services/adrSync/scheduler";
  * Overlap and stale-run guarding live in the scheduler; this route only
  * authenticates (CRON_SECRET) and reports the sweep summary.
  */
+// The sweep is sequential across every workspace's configs, and a newly
+// enrolled repo's first sync fetches every blob — don't let the platform
+// default kill it mid-sweep (cf. auto-summarize-meetings).
+export const maxDuration = 300;
+
 export async function GET(_request: NextRequest) {
   try {
     const headersList = await headers();

--- a/src/app/api/cron/adr-sync/route.ts
+++ b/src/app/api/cron/adr-sync/route.ts
@@ -1,0 +1,53 @@
+import { timingSafeEqual } from "node:crypto";
+import { type NextRequest, NextResponse } from "next/server";
+import { headers } from "next/headers";
+
+import { db } from "~/server/db";
+import { runDueAdrSyncs } from "~/server/services/adrSync/scheduler";
+
+/**
+ * Cron endpoint: hourly ADR projection sweep for every enabled Decision Log
+ * sync config (see vercel.json). The rate-limit budget lives in the engine —
+ * an unchanged repo costs ~1 API call via the tree-SHA short-circuit.
+ * Overlap and stale-run guarding live in the scheduler; this route only
+ * authenticates (CRON_SECRET) and reports the sweep summary.
+ */
+export async function GET(_request: NextRequest) {
+  try {
+    const headersList = await headers();
+    const authHeader = headersList.get("authorization");
+    const cronSecret = process.env.CRON_SECRET;
+
+    // Fail closed: this endpoint sweeps every workspace's enrolled repos. A
+    // missing CRON_SECRET must not silently open it to unauthenticated callers.
+    if (!cronSecret) {
+      console.error("[Cron] adr-sync: CRON_SECRET is not configured — refusing to run");
+      return NextResponse.json(
+        { error: "CRON_SECRET is not configured" },
+        { status: 503 },
+      );
+    }
+    const expected = Buffer.from(`Bearer ${cronSecret}`);
+    const provided = Buffer.from(authHeader ?? "");
+    if (
+      provided.length !== expected.length ||
+      !timingSafeEqual(provided, expected)
+    ) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const result = await runDueAdrSyncs(db, new Date());
+    const errors = result.items.filter((i) => i.outcome === "error");
+    if (errors.length > 0) {
+      console.error("[Cron] adr-sync sweep errors:", errors);
+    }
+
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    console.error("[Cron] adr-sync sweep failed:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/server/api/routers/__tests__/adr.test.ts
+++ b/src/server/api/routers/__tests__/adr.test.ts
@@ -145,6 +145,19 @@ describe("adr router authz", () => {
           }),
       ],
       ["syncNow", (c) => c.adr.syncNow({ workspaceId: WORKSPACE_ID, configId: "cfg-1" })],
+      [
+        "linkTicket",
+        (c) =>
+          c.adr.linkTicket({
+            workspaceId: WORKSPACE_ID,
+            adrId: "adr-1",
+            ticketId: "t-1",
+          }),
+      ],
+      [
+        "unlinkTicket",
+        (c) => c.adr.unlinkTicket({ workspaceId: WORKSPACE_ID, linkId: "link-1" }),
+      ],
     ];
 
     for (const [name, call] of calls) {
@@ -188,6 +201,68 @@ describe("adr router authz", () => {
       await expect(
         caller(db).adr.list({ workspaceId: WORKSPACE_ID }),
       ).resolves.toEqual([]);
+    });
+
+    it("denies a viewer on linkTicket, allows a member (idempotent)", async () => {
+      asHuman(db);
+      withWorkspaceRole(db, "viewer");
+      await expect(
+        caller(db).adr.linkTicket({
+          workspaceId: WORKSPACE_ID,
+          adrId: "adr-1",
+          ticketId: "t-1",
+        }),
+      ).rejects.toThrow();
+
+      withWorkspaceRole(db, "member");
+      db.adrDocument.findFirst.mockResolvedValue({ id: "adr-1" } as never);
+      db.ticket.findFirst.mockResolvedValue({ id: "t-1" } as never);
+      db.adrTicketLink.findFirst.mockResolvedValue(null);
+      db.adrTicketLink.create.mockResolvedValue({ id: "link-1" } as never);
+
+      await expect(
+        caller(db).adr.linkTicket({
+          workspaceId: WORKSPACE_ID,
+          adrId: "adr-1",
+          ticketId: "t-1",
+        }),
+      ).resolves.toMatchObject({ id: "link-1" });
+      expect(db.adrTicketLink.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            adrId: "adr-1",
+            ticketId: "t-1",
+            featureId: null,
+            createdById: USER_ID,
+          }),
+        }),
+      );
+
+      // Re-linking the same pair returns the existing row, creates nothing new.
+      db.adrTicketLink.findFirst.mockResolvedValue({ id: "link-1" } as never);
+      db.adrTicketLink.create.mockClear();
+      await caller(db).adr.linkTicket({
+        workspaceId: WORKSPACE_ID,
+        adrId: "adr-1",
+        ticketId: "t-1",
+      });
+      expect(db.adrTicketLink.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects a linkTicket naming both or neither target", async () => {
+      asHuman(db);
+      withWorkspaceRole(db, "member");
+      await expect(
+        caller(db).adr.linkTicket({
+          workspaceId: WORKSPACE_ID,
+          adrId: "adr-1",
+          ticketId: "t-1",
+          featureId: "f-1",
+        }),
+      ).rejects.toThrow();
+      await expect(
+        caller(db).adr.linkTicket({ workspaceId: WORKSPACE_ID, adrId: "adr-1" }),
+      ).rejects.toThrow();
     });
   });
 

--- a/src/server/api/routers/__tests__/adr.test.ts
+++ b/src/server/api/routers/__tests__/adr.test.ts
@@ -307,6 +307,37 @@ describe("adr router authz", () => {
       });
     }
 
+    it("a disabled repo's documents and links stay visible on the index", async () => {
+      // Soft-disconnect end to end: disableConfig flips state only, so the
+      // list (which keys off enrolment, not enabled) keeps serving the docs
+      // and their user-authored links.
+      asHuman(db);
+      withWorkspaceRole(db, "member");
+      db.adrSyncConfig.findMany.mockResolvedValue([
+        { repositoryId: "repo-1", shortCode: "API" },
+      ] as never);
+      db.adrDocument.findMany.mockResolvedValue([
+        {
+          id: "doc-1",
+          repositoryId: "repo-1",
+          path: "docs/adr/0001-x.md",
+          number: 1,
+          slug: "x",
+          title: "X",
+          status: "ACCEPTED",
+          statusRaw: "Accepted",
+          decidedAt: null,
+          updatedAt: new Date(),
+          repository: { id: "repo-1", fullName: "acme/api", productId: null, product: null },
+          _count: { ticketLinks: 2 },
+        },
+      ] as never);
+
+      const rows = await caller(db).adr.list({ workspaceId: WORKSPACE_ID });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ label: "API-0001", _count: { ticketLinks: 2 } });
+    });
+
     it("allows an admin on disableConfig (and keeps it a soft state change)", async () => {
       asHuman(db);
       withWorkspaceRole(db, "admin");

--- a/src/server/api/routers/adr.ts
+++ b/src/server/api/routers/adr.ts
@@ -486,14 +486,35 @@ export const adrRouter = createTRPCRouter({
         },
       });
       if (existing) return existing;
-      return ctx.db.adrTicketLink.create({
-        data: {
-          adrId: adr.id,
-          ticketId: input.ticketId ?? null,
-          featureId: input.featureId ?? null,
-          createdById: ctx.session.user.id,
-        },
-      });
+      try {
+        return await ctx.db.adrTicketLink.create({
+          data: {
+            adrId: adr.id,
+            ticketId: input.ticketId ?? null,
+            featureId: input.featureId ?? null,
+            createdById: ctx.session.user.id,
+          },
+        });
+      } catch (error) {
+        // Two rapid clicks can race past the findFirst; the DB unique holds
+        // the line — treat the loser as the idempotent success it is.
+        if (
+          error &&
+          typeof error === "object" &&
+          "code" in error &&
+          (error as { code?: string }).code === "P2002"
+        ) {
+          const raced = await ctx.db.adrTicketLink.findFirst({
+            where: {
+              adrId: adr.id,
+              ticketId: input.ticketId ?? null,
+              featureId: input.featureId ?? null,
+            },
+          });
+          if (raced) return raced;
+        }
+        throw error;
+      }
     }),
 
   /** Remove one implemented-by link. */

--- a/src/server/api/routers/adr.ts
+++ b/src/server/api/routers/adr.ts
@@ -125,6 +125,7 @@ export const adrRouter = createTRPCRouter({
               product: { select: { id: true, name: true, slug: true } },
             },
           },
+          _count: { select: { ticketLinks: true } },
         },
         orderBy: [{ decidedAt: { sort: "desc", nulls: "last" } }, { path: "asc" }],
       });
@@ -192,6 +193,23 @@ export const adrRouter = createTRPCRouter({
                 },
               },
             },
+          },
+          ticketLinks: {
+            include: {
+              ticket: {
+                select: {
+                  id: true,
+                  shortId: true,
+                  number: true,
+                  title: true,
+                  status: true,
+                  productId: true,
+                },
+              },
+              feature: { select: { id: true, name: true, status: true } },
+              createdBy: { select: { id: true, name: true } },
+            },
+            orderBy: { createdAt: "asc" },
           },
         },
       });
@@ -412,6 +430,89 @@ export const adrRouter = createTRPCRouter({
         }
         throw error;
       }
+    }),
+
+  /**
+   * Link an implementing ticket OR feature to an ADR — the Decision Log's
+   * only writable surface. User-authored data: it survives repo
+   * disconnection and even soft-deletion of the document.
+   */
+  linkTicket: humanOnlyProcedure
+    .input(
+      z
+        .object({
+          workspaceId: z.string(),
+          adrId: z.string(),
+          ticketId: z.string().optional(),
+          featureId: z.string().optional(),
+        })
+        .refine(
+          (v) => (v.ticketId ? !v.featureId : !!v.featureId),
+          "Provide exactly one of ticketId or featureId",
+        ),
+    )
+    .use(requireWorkspaceMembership("edit"))
+    .mutation(async ({ ctx, input }) => {
+      const adr = await ctx.db.adrDocument.findFirst({
+        where: { id: input.adrId, repository: { workspaceId: input.workspaceId } },
+        select: { id: true },
+      });
+      if (!adr) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Decision not found" });
+      }
+      if (input.ticketId) {
+        const ticket = await ctx.db.ticket.findFirst({
+          where: { id: input.ticketId, product: { workspaceId: input.workspaceId } },
+          select: { id: true },
+        });
+        if (!ticket) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Ticket not found" });
+        }
+      }
+      if (input.featureId) {
+        const feature = await ctx.db.feature.findFirst({
+          where: { id: input.featureId, product: { workspaceId: input.workspaceId } },
+          select: { id: true },
+        });
+        if (!feature) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Feature not found" });
+        }
+      }
+      const existing = await ctx.db.adrTicketLink.findFirst({
+        where: {
+          adrId: adr.id,
+          ticketId: input.ticketId ?? null,
+          featureId: input.featureId ?? null,
+        },
+      });
+      if (existing) return existing;
+      return ctx.db.adrTicketLink.create({
+        data: {
+          adrId: adr.id,
+          ticketId: input.ticketId ?? null,
+          featureId: input.featureId ?? null,
+          createdById: ctx.session.user.id,
+        },
+      });
+    }),
+
+  /** Remove one implemented-by link. */
+  unlinkTicket: humanOnlyProcedure
+    .input(z.object({ workspaceId: z.string(), linkId: z.string() }))
+    .use(requireWorkspaceMembership("edit"))
+    .mutation(async ({ ctx, input }) => {
+      const link = await ctx.db.adrTicketLink.findFirst({
+        where: {
+          id: input.linkId,
+          adr: { repository: { workspaceId: input.workspaceId } },
+        },
+        select: { id: true },
+      });
+      if (!link) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Link not found" });
+      }
+      await ctx.db.adrTicketLink.delete({ where: { id: link.id } });
+      return { deleted: true };
     }),
 
   /** Recent sync runs (the ledger), workspace-wide or for one config. */

--- a/src/server/services/adrSync/__tests__/scheduler.test.ts
+++ b/src/server/services/adrSync/__tests__/scheduler.test.ts
@@ -9,7 +9,8 @@ import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
 import type { PrismaClient } from "@prisma/client";
 
 import { runDueAdrSyncs, STALE_RUN_MINUTES } from "../scheduler";
-import type { AdrSyncResult } from "../engine";
+import { combineTreeShas, type AdrSyncResult } from "../engine";
+import type { AdrRemote } from "../github";
 
 const db = mockDeep<PrismaClient>() as DeepMockProxy<PrismaClient>;
 
@@ -124,6 +125,71 @@ describe("runDueAdrSyncs", () => {
       detail: expect.stringContaining("exploded"),
     });
     expect(result.items[1]?.outcome).toBe("ran");
+  });
+
+  it("cron sweep of an unchanged repo costs the tree walk only — ZERO blob fetches", async () => {
+    // End-to-end through the REAL engine: scheduler → runAdrSync → fake
+    // remote. This is the hourly rate-limit budget requirement, asserted on
+    // the cron path itself.
+    db.adrSyncConfig.findMany.mockResolvedValue([
+      { id: "cfg1", repositoryId: "repo1" },
+    ] as never);
+    db.adrSyncConfig.findUnique.mockResolvedValue({
+      id: "cfg1",
+      workspaceId: "ws1",
+      repositoryId: "repo1",
+      shortCode: "API",
+      adrPaths: ["docs/adr"],
+      integrationId: "int1",
+      enabled: true,
+      // Matches what the fake remote will report — the short-circuit key.
+      lastTreeSha: combineTreeShas([{ path: "docs/adr", sha: "t-adr" }]),
+      lastCommitSha: "c0",
+      lastSyncedAt: new Date("2026-08-14T11:00:00Z"),
+      createdById: "user1",
+      createdAt: new Date("2026-08-01"),
+      updatedAt: new Date("2026-08-01"),
+      repository: { id: "repo1", owner: "acme", name: "api" },
+      integration: { providerConfig: { installationId: 42 } },
+    } as never);
+    db.adrSyncRun.create.mockResolvedValue({ id: "run1" } as never);
+
+    const apiCalls = { getHead: 0, getTree: 0, getBlob: 0 };
+    const remote: AdrRemote = {
+      getHead: async () => {
+        apiCalls.getHead++;
+        return { commitSha: "c1", treeSha: "root1" };
+      },
+      getTree: async (_o, _r, sha) => {
+        apiCalls.getTree++;
+        if (sha === "root1")
+          return {
+            truncated: false,
+            entries: [{ path: "docs", type: "tree" as const, sha: "t-docs" }],
+          };
+        if (sha === "t-docs")
+          return {
+            truncated: false,
+            entries: [{ path: "adr", type: "tree" as const, sha: "t-adr" }],
+          };
+        return { truncated: false, entries: [] };
+      },
+      getBlob: async () => {
+        apiCalls.getBlob++;
+        return "";
+      },
+    };
+
+    const result = await runDueAdrSyncs(db, NOW, {
+      remoteFactory: async () => remote,
+    });
+
+    expect(result.items[0]?.outcome).toBe("unchanged");
+    expect(apiCalls.getBlob).toBe(0);
+    // Head + the two-level walk to docs/adr — the ~1-call-per-repo budget.
+    expect(apiCalls.getHead).toBe(1);
+    expect(apiCalls.getTree).toBe(2);
+    expect(db.adrDocument.findMany).not.toHaveBeenCalled();
   });
 
   it("surfaces an engine error result as an error item", async () => {

--- a/src/server/services/adrSync/__tests__/scheduler.test.ts
+++ b/src/server/services/adrSync/__tests__/scheduler.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Scheduler-seam tests for the hourly ADR sweep (imitating
+ * ticketSync/scheduler.test.ts): mocked Prisma, injected fake runner — no
+ * network, no DB.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import { runDueAdrSyncs, STALE_RUN_MINUTES } from "../scheduler";
+import type { AdrSyncResult } from "../engine";
+
+const db = mockDeep<PrismaClient>() as DeepMockProxy<PrismaClient>;
+
+const NOW = new Date("2026-08-14T12:00:00Z");
+
+function okResult(overrides?: Partial<AdrSyncResult>): AdrSyncResult {
+  return {
+    runId: "run-x",
+    status: "success",
+    created: 1,
+    updated: 0,
+    skipped: 2,
+    deleted: 0,
+    failed: 0,
+    items: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockReset(db);
+  db.adrSyncRun.findFirst.mockResolvedValue(null);
+  db.adrSyncRun.update.mockResolvedValue({} as never);
+});
+
+describe("runDueAdrSyncs", () => {
+  it("sweeps every enabled, connected config", async () => {
+    db.adrSyncConfig.findMany.mockResolvedValue([
+      { id: "cfg1", repositoryId: "r1" },
+      { id: "cfg2", repositoryId: "r2" },
+    ] as never);
+    const runSync = vi.fn().mockResolvedValue(okResult());
+
+    const result = await runDueAdrSyncs(db, NOW, { runSync });
+
+    expect(result.swept).toBe(2);
+    expect(runSync).toHaveBeenCalledTimes(2);
+    expect(result.items.every((i) => i.outcome === "ran")).toBe(true);
+    // The where clause is the disconnected-never-due guard.
+    expect(db.adrSyncConfig.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { enabled: true, integrationId: { not: null } },
+      }),
+    );
+  });
+
+  it("reports an unchanged repo distinctly", async () => {
+    db.adrSyncConfig.findMany.mockResolvedValue([
+      { id: "cfg1", repositoryId: "r1" },
+    ] as never);
+    const runSync = vi.fn().mockResolvedValue(okResult({ status: "unchanged" }));
+
+    const result = await runDueAdrSyncs(db, NOW, { runSync });
+
+    expect(result.items[0]?.outcome).toBe("unchanged");
+  });
+
+  it("skips a config whose run is still in flight", async () => {
+    db.adrSyncConfig.findMany.mockResolvedValue([
+      { id: "cfg1", repositoryId: "r1" },
+    ] as never);
+    db.adrSyncRun.findFirst.mockResolvedValue({
+      id: "run-live",
+      startedAt: new Date(NOW.getTime() - 5 * 60_000),
+    } as never);
+    const runSync = vi.fn();
+
+    const result = await runDueAdrSyncs(db, NOW, { runSync });
+
+    expect(result.items[0]?.outcome).toBe("skipped-running");
+    expect(runSync).not.toHaveBeenCalled();
+  });
+
+  it("marks a stale in-flight run as crashed and proceeds", async () => {
+    db.adrSyncConfig.findMany.mockResolvedValue([
+      { id: "cfg1", repositoryId: "r1" },
+    ] as never);
+    db.adrSyncRun.findFirst.mockResolvedValue({
+      id: "run-stale",
+      startedAt: new Date(NOW.getTime() - (STALE_RUN_MINUTES + 1) * 60_000),
+    } as never);
+    const runSync = vi.fn().mockResolvedValue(okResult());
+
+    const result = await runDueAdrSyncs(db, NOW, { runSync });
+
+    expect(db.adrSyncRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "run-stale" },
+        data: expect.objectContaining({ status: "error" }),
+      }),
+    );
+    expect(runSync).toHaveBeenCalled();
+    expect(result.items[0]?.outcome).toBe("ran");
+  });
+
+  it("one config's failure never blocks the others", async () => {
+    db.adrSyncConfig.findMany.mockResolvedValue([
+      { id: "cfg-bad", repositoryId: "r1" },
+      { id: "cfg-good", repositoryId: "r2" },
+    ] as never);
+    const runSync = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("octokit exploded"))
+      .mockResolvedValueOnce(okResult());
+
+    const result = await runDueAdrSyncs(db, NOW, { runSync });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0]).toMatchObject({
+      configId: "cfg-bad",
+      outcome: "error",
+      detail: expect.stringContaining("exploded"),
+    });
+    expect(result.items[1]?.outcome).toBe("ran");
+  });
+
+  it("surfaces an engine error result as an error item", async () => {
+    db.adrSyncConfig.findMany.mockResolvedValue([
+      { id: "cfg1", repositoryId: "r1" },
+    ] as never);
+    const runSync = vi
+      .fn()
+      .mockResolvedValue(okResult({ status: "error", error: "tree truncated" }));
+
+    const result = await runDueAdrSyncs(db, NOW, { runSync });
+
+    expect(result.items[0]).toMatchObject({
+      outcome: "error",
+      detail: "tree truncated",
+    });
+  });
+});

--- a/src/server/services/adrSync/__tests__/scheduler.test.ts
+++ b/src/server/services/adrSync/__tests__/scheduler.test.ts
@@ -96,9 +96,11 @@ describe("runDueAdrSyncs", () => {
 
     const result = await runDueAdrSyncs(db, NOW, { runSync });
 
-    expect(db.adrSyncRun.update).toHaveBeenCalledWith(
+    // Guarded on status so a run that finished in the race window is never
+    // clobbered back to "error".
+    expect(db.adrSyncRun.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: "run-stale" },
+        where: { id: "run-stale", status: "running" },
         data: expect.objectContaining({ status: "error" }),
       }),
     );

--- a/src/server/services/adrSync/scheduler.ts
+++ b/src/server/services/adrSync/scheduler.ts
@@ -65,9 +65,11 @@ export async function runDueAdrSyncs(
           });
           continue;
         }
-        // Presumed crashed — unblock the config and record why.
-        await db.adrSyncRun.update({
-          where: { id: inFlight.id },
+        // Presumed crashed — unblock the config and record why. Guarded on
+        // status so a run that finished in the race window since findFirst
+        // is never clobbered back to "error".
+        await db.adrSyncRun.updateMany({
+          where: { id: inFlight.id, status: "running" },
           data: {
             status: "error",
             finishedAt: now,

--- a/src/server/services/adrSync/scheduler.ts
+++ b/src/server/services/adrSync/scheduler.ts
@@ -1,0 +1,118 @@
+import type { PrismaClient } from "@prisma/client";
+import { runAdrSync, type AdrSyncResult } from "./engine";
+import type { AdrRemoteFactory } from "./github";
+
+/**
+ * adrSync/scheduler — one cron sweep over every enabled ADR sync config
+ * (copying ticketSync/scheduler's shape). Guards:
+ * - disconnected configs (null integrationId, ADR-0042 semantics) are a
+ *   deliberate user state, not a broken credential — they are simply never
+ *   due, so they don't pile errored runs into the ledger every hour;
+ * - overlap: a run still marked `running` blocks new runs for its config,
+ *   unless it started more than {@link STALE_RUN_MINUTES} ago — then it is
+ *   presumed crashed, marked errored, and the sweep proceeds;
+ * - one config's failure never blocks the others.
+ *
+ * The rate-limit budget lives in the engine: an unchanged repo costs the
+ * tree walk only (zero blob fetches) and closes its run as `unchanged`.
+ */
+
+export const STALE_RUN_MINUTES = 30;
+
+export interface AdrSweepItem {
+  configId: string;
+  repositoryId: string;
+  outcome: "ran" | "unchanged" | "skipped-running" | "error";
+  detail?: string;
+  result?: Pick<
+    AdrSyncResult,
+    "created" | "updated" | "skipped" | "deleted" | "failed"
+  >;
+}
+
+type SyncRunner = typeof runAdrSync;
+
+export async function runDueAdrSyncs(
+  db: PrismaClient,
+  now: Date,
+  deps?: { remoteFactory?: AdrRemoteFactory; runSync?: SyncRunner },
+): Promise<{ swept: number; items: AdrSweepItem[] }> {
+  const runSync = deps?.runSync ?? runAdrSync;
+
+  const configs = await db.adrSyncConfig.findMany({
+    where: { enabled: true, integrationId: { not: null } },
+    select: { id: true, repositoryId: true },
+  });
+
+  const items: AdrSweepItem[] = [];
+  const staleBefore = new Date(now.getTime() - STALE_RUN_MINUTES * 60_000);
+
+  for (const config of configs) {
+    try {
+      const inFlight = await db.adrSyncRun.findFirst({
+        where: { configId: config.id, status: "running" },
+        orderBy: { startedAt: "desc" },
+        select: { id: true, startedAt: true },
+      });
+
+      if (inFlight) {
+        if (inFlight.startedAt > staleBefore) {
+          items.push({
+            configId: config.id,
+            repositoryId: config.repositoryId,
+            outcome: "skipped-running",
+            detail: `run ${inFlight.id} still in flight`,
+          });
+          continue;
+        }
+        // Presumed crashed — unblock the config and record why.
+        await db.adrSyncRun.update({
+          where: { id: inFlight.id },
+          data: {
+            status: "error",
+            finishedAt: now,
+            error: `presumed crashed after ${STALE_RUN_MINUTES} minutes; superseded by a newer sweep`,
+          },
+        });
+      }
+
+      const result = await runSync(db, config.id, "cron", {
+        remoteFactory: deps?.remoteFactory,
+      });
+      if (result.status === "error") {
+        // The engine already recorded the errored run; surface it here too so
+        // the sweep summary shows it.
+        items.push({
+          configId: config.id,
+          repositoryId: config.repositoryId,
+          outcome: "error",
+          detail: result.error,
+        });
+        continue;
+      }
+      items.push({
+        configId: config.id,
+        repositoryId: config.repositoryId,
+        outcome: result.status === "unchanged" ? "unchanged" : "ran",
+        result: {
+          created: result.created,
+          updated: result.updated,
+          skipped: result.skipped,
+          deleted: result.deleted,
+          failed: result.failed,
+        },
+      });
+    } catch (error) {
+      // A failure before the engine could record anything (config vanished,
+      // run insert failed) must not stop the sweep.
+      items.push({
+        configId: config.id,
+        repositoryId: config.repositoryId,
+        outcome: "error",
+        detail: error instanceof Error ? error.message : "unknown error",
+      });
+    }
+  }
+
+  return { swept: configs.length, items };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -33,6 +33,10 @@
     {
       "path": "/api/cron/process-notifications",
       "schedule": "*/2 * * * *"
+    },
+    {
+      "path": "/api/cron/adr-sync",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## What

Maintenance-free sync + the Decision Log's only writable surface (V3): hourly cron at `/api/cron/adr-sync` (CRON_SECRET with timingSafeEqual, fails closed) sweeping every enabled+connected config via `runDueAdrSyncs` (overlap guard, 30-min stale-run recovery, per-config failure isolation, disconnected-never-due); the GitHub rate-limit budget proven on the cron path (an unchanged repo costs 1 getHead + the dir walk, zero blob fetches); `linkTicket`/`unlinkTicket` with the Implemented-by picker on the detail page and a Links column on the index; and soft-disconnect semantics end to end (documents and user-authored links survive `disableConfig`).

**Feature**: Decision Log — cross-repo ADR viewer (`cmsso8h5w0008i504of0r4nzo`), scope V3. Builds on #590 (V1) and #591 (V2). No schema changes.

## Acceptance criteria

- [ ] All 3 V3 requirement rows on the feature are met (hourly reconcile with short-circuit; user-authored links survive disconnection; disable/disconnect retains everything)
- [ ] Cron route fails closed without `CRON_SECRET`

---

Ships: misty.elk

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cmssoxim00009ju04itkrn4x0)
