### PR TITLE
feat: V4 Decision Log graph view & push webhook

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/decisions/graph/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/decisions/graph/page.tsx
@@ -9,8 +9,10 @@ import { api } from "~/trpc/react";
 import { DecisionGraphCanvas } from "~/app/_components/decisions/DecisionGraphCanvas";
 
 /**
- * Decision network graph: ADRs clustered by repo, SUPERSEDES edges solid.
- * Click a node to open the decision. Read-only, like the whole Decision Log.
+ * Decision network graph: ADRs clustered by repo, SUPERSEDES edges solid,
+ * detected MENTIONS edges dashed (the same weaker treatment as the detail
+ * page's Related section). Click a node to open the decision. Read-only,
+ * like the whole Decision Log.
  */
 export default function DecisionsGraphPage() {
   const { workspace, workspaceId, isLoading } = useWorkspace();
@@ -38,10 +40,6 @@ export default function DecisionsGraphPage() {
     );
   }
 
-  const supersedesEdges = (graph?.edges ?? []).filter(
-    (e) => e.type === "SUPERSEDES",
-  );
-
   return (
     <Container size="xl" className="py-8">
       <Anchor
@@ -59,9 +57,32 @@ export default function DecisionsGraphPage() {
       <Title order={2} mt="md" mb={4}>
         Decision graph
       </Title>
-      <Text size="sm" className="text-text-secondary" mb="lg">
-        The decision network across enrolled repos. Click a decision to open it.
-      </Text>
+      <Group justify="space-between" align="center" mb="lg" wrap="wrap">
+        <Text size="sm" className="text-text-secondary">
+          The decision network across enrolled repos. Click a decision to open
+          it.
+        </Text>
+        <Group gap="lg">
+          <Group gap={6} wrap="nowrap">
+            <span
+              aria-hidden
+              className="inline-block h-0 w-8 border-t-2 border-solid border-brand-info"
+            />
+            <Text size="xs" className="text-text-muted">
+              supersedes
+            </Text>
+          </Group>
+          <Group gap={6} wrap="nowrap">
+            <span
+              aria-hidden
+              className="inline-block h-0 w-8 border-t-2 border-dashed border-border-primary"
+            />
+            <Text size="xs" className="text-text-muted">
+              mentions (detected)
+            </Text>
+          </Group>
+        </Group>
+      </Group>
 
       {!graph || graph.nodes.length === 0 ? (
         <Text className="text-text-secondary">
@@ -71,7 +92,7 @@ export default function DecisionsGraphPage() {
         <DecisionGraphCanvas
           repos={graph.repos}
           nodes={graph.nodes}
-          edges={supersedesEdges}
+          edges={graph.edges}
           onNodeClick={(adrId) =>
             router.push(`/w/${workspace.slug}/decisions/${adrId}`)
           }

--- a/src/app/(sidemenu)/w/[workspaceSlug]/decisions/graph/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/decisions/graph/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Anchor, Container, Group, Skeleton, Text, Title } from "@mantine/core";
+import { IconArrowLeft } from "@tabler/icons-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useWorkspace } from "~/providers/WorkspaceProvider";
+import { api } from "~/trpc/react";
+import { DecisionGraphCanvas } from "~/app/_components/decisions/DecisionGraphCanvas";
+
+/**
+ * Decision network graph: ADRs clustered by repo, SUPERSEDES edges solid.
+ * Click a node to open the decision. Read-only, like the whole Decision Log.
+ */
+export default function DecisionsGraphPage() {
+  const { workspace, workspaceId, isLoading } = useWorkspace();
+  const router = useRouter();
+
+  const { data: graph, isLoading: graphLoading } = api.adr.graph.useQuery(
+    { workspaceId: workspaceId ?? "" },
+    { enabled: !!workspaceId },
+  );
+
+  if (isLoading || (workspace && graphLoading)) {
+    return (
+      <Container size="xl" className="py-8">
+        <Skeleton height={40} width={240} mb="lg" />
+        <Skeleton height={500} />
+      </Container>
+    );
+  }
+
+  if (!workspace) {
+    return (
+      <Container size="xl" className="py-8">
+        <Text className="text-text-secondary">Workspace not found</Text>
+      </Container>
+    );
+  }
+
+  const supersedesEdges = (graph?.edges ?? []).filter(
+    (e) => e.type === "SUPERSEDES",
+  );
+
+  return (
+    <Container size="xl" className="py-8">
+      <Anchor
+        component={Link}
+        href={`/w/${workspace.slug}/decisions`}
+        size="sm"
+        className="text-text-secondary"
+      >
+        <Group gap={4} wrap="nowrap">
+          <IconArrowLeft size={14} />
+          All decisions
+        </Group>
+      </Anchor>
+
+      <Title order={2} mt="md" mb={4}>
+        Decision graph
+      </Title>
+      <Text size="sm" className="text-text-secondary" mb="lg">
+        The decision network across enrolled repos. Click a decision to open it.
+      </Text>
+
+      {!graph || graph.nodes.length === 0 ? (
+        <Text className="text-text-secondary">
+          No decisions synced yet — nothing to draw.
+        </Text>
+      ) : (
+        <DecisionGraphCanvas
+          repos={graph.repos}
+          nodes={graph.nodes}
+          edges={supersedesEdges}
+          onNodeClick={(adrId) =>
+            router.push(`/w/${workspace.slug}/decisions/${adrId}`)
+          }
+        />
+      )}
+    </Container>
+  );
+}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/decisions/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/decisions/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { Container, Group, Skeleton, Text, Title } from "@mantine/core";
+import { Button, Container, Group, Skeleton, Text, Title } from "@mantine/core";
+import { IconAffiliate } from "@tabler/icons-react";
+import Link from "next/link";
 import { useWorkspace } from "~/providers/WorkspaceProvider";
 import { DecisionsIndex } from "~/app/_components/decisions/DecisionsIndex";
 
@@ -39,6 +41,15 @@ export default function DecisionsPage() {
             repos. Read-only — git is the source of truth.
           </Text>
         </div>
+        <Button
+          component={Link}
+          href={`/w/${workspace.slug}/decisions/graph`}
+          variant="light"
+          size="sm"
+          leftSection={<IconAffiliate size={16} />}
+        >
+          Graph
+        </Button>
       </Group>
       <DecisionsIndex workspaceId={workspaceId} workspaceSlug={workspace.slug} />
     </Container>

--- a/src/app/_components/decisions/DecisionGraphCanvas.tsx
+++ b/src/app/_components/decisions/DecisionGraphCanvas.tsx
@@ -67,10 +67,12 @@ const STATUS_BORDER: Record<string, string> = {
 export function DecisionGraphCanvas({ repos, nodes, edges, onNodeClick }: Props) {
   const flowNodes: Node[] = useMemo(() => {
     const result: Node[] = [];
-    repos.forEach((repo, repoIndex) => {
+    let columnIndex = 0;
+    for (const repo of repos) {
       const repoDocs = nodes.filter((n) => n.repositoryId === repo.repositoryId);
-      if (repoDocs.length === 0) return;
-      const x = repoIndex * COLUMN_WIDTH;
+      if (repoDocs.length === 0) continue;
+      const x = columnIndex * COLUMN_WIDTH;
+      columnIndex++;
 
       result.push({
         id: `repo:${repo.repositoryId}`,
@@ -117,7 +119,7 @@ export function DecisionGraphCanvas({ repos, nodes, edges, onNodeClick }: Props)
           },
         });
       });
-    });
+    }
     return result;
   }, [repos, nodes]);
 

--- a/src/app/_components/decisions/DecisionGraphCanvas.tsx
+++ b/src/app/_components/decisions/DecisionGraphCanvas.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MarkerType,
+  type Edge,
+  type Node,
+  type NodeMouseHandler,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+/**
+ * Decision network canvas: one node per ADR, clustered by repo (one column
+ * per repo with a header node), solid SUPERSEDES edges and dashed MENTIONS
+ * edges (the same weaker treatment as the detail page's Related section).
+ * Read-only — clicking a node navigates to the decision's detail page.
+ */
+
+export interface DecisionGraphNode {
+  id: string;
+  repositoryId: string;
+  label: string | null;
+  title: string;
+  status: string;
+}
+
+export interface DecisionGraphEdge {
+  id: string;
+  type: "SUPERSEDES" | "MENTIONS";
+  fromId: string;
+  toId: string;
+  evidence: string | null;
+}
+
+export interface DecisionGraphRepo {
+  repositoryId: string;
+  fullName: string;
+  shortCode: string;
+}
+
+interface Props {
+  repos: DecisionGraphRepo[];
+  nodes: DecisionGraphNode[];
+  edges: DecisionGraphEdge[];
+  onNodeClick?: (adrId: string) => void;
+}
+
+const COLUMN_WIDTH = 280;
+const NODE_HEIGHT = 64;
+const NODE_GAP = 18;
+const HEADER_HEIGHT = 40;
+
+const SOLID_EDGE_COLOR = "var(--mantine-color-blue-6)";
+const DASHED_EDGE_COLOR = "var(--color-border-primary)";
+
+const STATUS_BORDER: Record<string, string> = {
+  PROPOSED: "var(--mantine-color-blue-6)",
+  ACCEPTED: "var(--mantine-color-green-6)",
+  SUPERSEDED: "var(--mantine-color-orange-6)",
+  DEPRECATED: "var(--mantine-color-red-6)",
+  UNKNOWN: "var(--color-border-primary)",
+};
+
+export function DecisionGraphCanvas({ repos, nodes, edges, onNodeClick }: Props) {
+  const flowNodes: Node[] = useMemo(() => {
+    const result: Node[] = [];
+    repos.forEach((repo, repoIndex) => {
+      const repoDocs = nodes.filter((n) => n.repositoryId === repo.repositoryId);
+      if (repoDocs.length === 0) return;
+      const x = repoIndex * COLUMN_WIDTH;
+
+      result.push({
+        id: `repo:${repo.repositoryId}`,
+        position: { x, y: 0 },
+        data: { label: repo.fullName },
+        draggable: false,
+        selectable: false,
+        style: {
+          width: COLUMN_WIDTH - 40,
+          height: HEADER_HEIGHT - 10,
+          background: "var(--color-surface-secondary)",
+          border: "1px solid var(--color-border-primary)",
+          borderRadius: 8,
+          color: "var(--color-text-secondary)",
+          fontSize: 12,
+          fontWeight: 600,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        },
+      });
+
+      repoDocs.forEach((doc, docIndex) => {
+        result.push({
+          id: doc.id,
+          position: {
+            x: x + 10,
+            y: HEADER_HEIGHT + docIndex * (NODE_HEIGHT + NODE_GAP),
+          },
+          data: {
+            label: `${doc.label ?? "—"}\n${doc.title.length > 46 ? `${doc.title.slice(0, 46)}…` : doc.title}`,
+          },
+          style: {
+            width: COLUMN_WIDTH - 60,
+            minHeight: NODE_HEIGHT - 12,
+            background: "var(--color-background-primary)",
+            border: `1.5px solid ${STATUS_BORDER[doc.status] ?? STATUS_BORDER.UNKNOWN}`,
+            borderRadius: 8,
+            color: "var(--color-text-primary)",
+            fontSize: 11,
+            whiteSpace: "pre-wrap",
+            padding: 6,
+            cursor: "pointer",
+          },
+        });
+      });
+    });
+    return result;
+  }, [repos, nodes]);
+
+  const flowEdges: Edge[] = useMemo(
+    () =>
+      edges.map((edge) => {
+        const solid = edge.type === "SUPERSEDES";
+        return {
+          id: edge.id,
+          source: edge.fromId,
+          target: edge.toId,
+          label: solid ? "supersedes" : undefined,
+          labelStyle: { fontSize: 9, fill: "var(--color-text-muted)" },
+          labelBgStyle: { fill: "var(--color-background-primary)" },
+          style: solid
+            ? { stroke: SOLID_EDGE_COLOR, strokeWidth: 2 }
+            : {
+                stroke: DASHED_EDGE_COLOR,
+                strokeWidth: 1.5,
+                strokeDasharray: "4 4",
+              },
+          markerEnd: {
+            type: MarkerType.ArrowClosed,
+            color: solid ? SOLID_EDGE_COLOR : DASHED_EDGE_COLOR,
+            width: 16,
+            height: 16,
+          },
+        };
+      }),
+    [edges],
+  );
+
+  const handleNodeClick: NodeMouseHandler = (_event, node) => {
+    if (!node.id.startsWith("repo:")) onNodeClick?.(node.id);
+  };
+
+  return (
+    <div className="h-[70vh] w-full rounded-lg border border-border-primary">
+      <ReactFlow
+        nodes={flowNodes}
+        edges={flowEdges}
+        onNodeClick={handleNodeClick}
+        fitView
+        proOptions={{ hideAttribution: true }}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        edgesFocusable={false}
+      >
+        <Background />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -3,6 +3,7 @@ import crypto from "crypto";
 import { db } from "~/server/db";
 import { githubIntegrationService } from "~/server/services/github-integration";
 import { githubActivityService } from "~/server/services/GitHubActivityService";
+import { triggerAdrSyncFromPush } from "~/server/services/adrSync/webhookTrigger";
 import { safeSignatureEquals } from "~/server/utils/webhookSignature";
 
 function verifySignature(
@@ -65,6 +66,16 @@ export async function POST(request: NextRequest) {
         break;
       case "push":
         await githubActivityService.processPushEvent(data, delivery);
+        // Decision Log fast-follow: a default-branch push touching enrolled
+        // adrPaths lands the ADR within seconds instead of at the next hourly
+        // cron. Best-effort — a failure here must never break the activity
+        // handling above (redelivery is idempotent via the tree-SHA
+        // short-circuit).
+        try {
+          await triggerAdrSyncFromPush(db, data);
+        } catch (error) {
+          console.error("[AdrSync] webhook trigger failed:", error);
+        }
         break;
       case "pull_request":
         await githubActivityService.processPullRequestEvent(data, delivery);

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -1,10 +1,15 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { after, type NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 import { db } from "~/server/db";
 import { githubIntegrationService } from "~/server/services/github-integration";
 import { githubActivityService } from "~/server/services/GitHubActivityService";
 import { triggerAdrSyncFromPush } from "~/server/services/adrSync/webhookTrigger";
 import { safeSignatureEquals } from "~/server/utils/webhookSignature";
+
+// ADR sync work deferred via after() still needs runtime beyond the response;
+// without an explicit budget the platform default can kill a first-enrolment
+// sync mid-run and leave its AdrSyncRun stuck "running".
+export const maxDuration = 120;
 
 function verifySignature(
   payload: string,
@@ -68,14 +73,18 @@ export async function POST(request: NextRequest) {
         await githubActivityService.processPushEvent(data, delivery);
         // Decision Log fast-follow: a default-branch push touching enrolled
         // adrPaths lands the ADR within seconds instead of at the next hourly
-        // cron. Best-effort — a failure here must never break the activity
-        // handling above (redelivery is idempotent via the tree-SHA
-        // short-circuit).
-        try {
-          await triggerAdrSyncFromPush(db, data);
-        } catch (error) {
-          console.error("[AdrSync] webhook trigger failed:", error);
-        }
+        // cron. Deferred with after() so the sync runs OUTSIDE the request
+        // path — a slow first-enrolment sync can neither blow GitHub's 10s
+        // delivery window nor take down the activity handling above. Failures
+        // are contained (redelivery is idempotent via the tree-SHA
+        // short-circuit, and the hourly cron is the backstop).
+        after(async () => {
+          try {
+            await triggerAdrSyncFromPush(db, data);
+          } catch (error) {
+            console.error("[AdrSync] webhook trigger failed:", error);
+          }
+        });
         break;
       case "pull_request":
         await githubActivityService.processPullRequestEvent(data, delivery);

--- a/src/server/api/routers/adr.ts
+++ b/src/server/api/routers/adr.ts
@@ -237,6 +237,65 @@ export const adrRouter = createTRPCRouter({
       };
     }),
 
+  /**
+   * The decision network for the graph view: every non-deleted ADR as a node
+   * (clustered by repo client-side) and every derived edge. Read-only.
+   */
+  graph: humanOnlyProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("edit"))
+    .query(async ({ ctx, input }) => {
+      const configs = await ctx.db.adrSyncConfig.findMany({
+        where: { workspaceId: input.workspaceId },
+        select: {
+          repositoryId: true,
+          shortCode: true,
+          repository: { select: { fullName: true } },
+        },
+      });
+      const shortCodeByRepo = new Map(
+        configs.map((c) => [c.repositoryId, c.shortCode]),
+      );
+      const repoIds = configs.map((c) => c.repositoryId);
+
+      const documents = await ctx.db.adrDocument.findMany({
+        where: { repositoryId: { in: repoIds }, deletedAt: null },
+        select: {
+          id: true,
+          repositoryId: true,
+          number: true,
+          title: true,
+          status: true,
+          decidedAt: true,
+        },
+        orderBy: [{ repositoryId: "asc" }, { number: "asc" }, { path: "asc" }],
+      });
+      const docIds = new Set(documents.map((d) => d.id));
+
+      const links = await ctx.db.adrLink.findMany({
+        where: { from: { repositoryId: { in: repoIds } } },
+        select: { id: true, type: true, fromId: true, toId: true, evidence: true },
+      });
+
+      return {
+        repos: configs.map((c) => ({
+          repositoryId: c.repositoryId,
+          fullName: c.repository.fullName,
+          shortCode: c.shortCode,
+        })),
+        nodes: documents.map((doc) => ({
+          ...doc,
+          label:
+            doc.number !== null
+              ? `${shortCodeByRepo.get(doc.repositoryId) ?? "ADR"}-${String(doc.number).padStart(4, "0")}`
+              : null,
+        })),
+        // Both endpoints must be visible nodes (a soft-deleted doc keeps its
+        // edges in the DB but drops out of the picture).
+        edges: links.filter((l) => docIds.has(l.fromId) && docIds.has(l.toId)),
+      };
+    }),
+
   /** The workspace's ADR sync configs (enrolment state), with repo info. */
   listConfigs: humanOnlyProcedure
     .input(z.object({ workspaceId: z.string() }))

--- a/src/server/services/adrSync/__tests__/webhookTrigger.test.ts
+++ b/src/server/services/adrSync/__tests__/webhookTrigger.test.ts
@@ -63,6 +63,19 @@ describe("pushTouchesAdrPaths", () => {
     ).toBe(false);
   });
 
+  it("treats a possibly-truncated payload (>=20 commits) as matching — err on the cheap side", () => {
+    const commits = Array.from({ length: 20 }, () => ({
+      modified: ["src/unrelated.ts"],
+    }));
+    expect(pushTouchesAdrPaths(push({ commits }), ["docs/adr"])).toBe(true);
+  });
+
+  it("a root enrolment matches every file, mirroring the engine's root sync", () => {
+    expect(
+      pushTouchesAdrPaths(push({ commits: [{ added: ["0001-x.md"] }] }), ["/"]),
+    ).toBe(true);
+  });
+
   it("ignores pushes touching only files outside enrolled dirs", () => {
     expect(
       pushTouchesAdrPaths(
@@ -122,6 +135,21 @@ describe("triggerAdrSyncFromPush", () => {
 
     expect(runSync).not.toHaveBeenCalled();
     expect(result.triggered).toEqual([]);
+  });
+
+  it("skips a config whose run is already in flight (two pushes seconds apart)", async () => {
+    db.adrSyncConfig.findMany.mockResolvedValue([
+      { id: "cfg1", adrPaths: ["docs/adr"] },
+    ] as never);
+    db.adrSyncRun.findFirst.mockResolvedValue({ id: "run-live" } as never);
+    const runSync = vi.fn();
+
+    const result = await triggerAdrSyncFromPush(db, push(), { runSync });
+
+    expect(runSync).not.toHaveBeenCalled();
+    expect(result.triggered).toEqual([
+      { configId: "cfg1", status: "skipped-running" },
+    ]);
   });
 
   it("one enrolment's failure doesn't block another workspace's", async () => {

--- a/src/server/services/adrSync/__tests__/webhookTrigger.test.ts
+++ b/src/server/services/adrSync/__tests__/webhookTrigger.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Webhook-trigger tests: only default-branch pushes touching enrolled
+ * adrPaths enqueue a run; everything else is a no-op. Mocked Prisma +
+ * injected fake runner — no network, no DB.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import {
+  pushTouchesAdrPaths,
+  triggerAdrSyncFromPush,
+  type PushEventLike,
+} from "../webhookTrigger";
+
+const db = mockDeep<PrismaClient>() as DeepMockProxy<PrismaClient>;
+
+function push(overrides?: Partial<PushEventLike>): PushEventLike {
+  return {
+    ref: "refs/heads/main",
+    repository: { full_name: "acme/api", default_branch: "main" },
+    commits: [{ added: ["docs/adr/0009-new-decision.md"], modified: [], removed: [] }],
+    ...overrides,
+  };
+}
+
+describe("pushTouchesAdrPaths", () => {
+  it("matches a default-branch push adding a file under an enrolled dir", () => {
+    expect(pushTouchesAdrPaths(push(), ["docs/adr"])).toBe(true);
+  });
+
+  it("matches modified and removed files too", () => {
+    expect(
+      pushTouchesAdrPaths(
+        push({ commits: [{ modified: ["docs/adr/0001-x.md"] }] }),
+        ["docs/adr"],
+      ),
+    ).toBe(true);
+    expect(
+      pushTouchesAdrPaths(
+        push({ commits: [{ removed: ["docs/adr/0001-x.md"] }] }),
+        ["docs/adr"],
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores pushes to non-default branches", () => {
+    expect(
+      pushTouchesAdrPaths(push({ ref: "refs/heads/feature-x" }), ["docs/adr"]),
+    ).toBe(false);
+  });
+
+  it("ignores tag pushes and unknown default branches", () => {
+    expect(pushTouchesAdrPaths(push({ ref: "refs/tags/v1" }), ["docs/adr"])).toBe(
+      false,
+    );
+    expect(
+      pushTouchesAdrPaths(
+        push({ repository: { full_name: "acme/api" } }),
+        ["docs/adr"],
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores pushes touching only files outside enrolled dirs", () => {
+    expect(
+      pushTouchesAdrPaths(
+        push({ commits: [{ modified: ["src/index.ts", "docs/README.md"] }] }),
+        ["docs/adr"],
+      ),
+    ).toBe(false);
+    // Prefix must be a DIRECTORY prefix — "docs/adr-notes.md" is not under docs/adr.
+    expect(
+      pushTouchesAdrPaths(push({ commits: [{ added: ["docs/adr-notes.md"] }] }), [
+        "docs/adr",
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("triggerAdrSyncFromPush", () => {
+  beforeEach(() => {
+    mockReset(db);
+  });
+
+  it("runs a sync for each matching enrolment of the pushed repo", async () => {
+    db.adrSyncConfig.findMany.mockResolvedValue([
+      { id: "cfg1", adrPaths: ["docs/adr"] },
+      { id: "cfg2", adrPaths: ["decisions"] }, // other workspace, other dir
+    ] as never);
+    const runSync = vi.fn().mockResolvedValue({ status: "success" });
+
+    const result = await triggerAdrSyncFromPush(db, push(), { runSync });
+
+    expect(runSync).toHaveBeenCalledTimes(1);
+    expect(runSync).toHaveBeenCalledWith(db, "cfg1", "webhook", expect.anything());
+    expect(result.triggered).toEqual([{ configId: "cfg1", status: "success" }]);
+    // Disconnected configs are never triggered.
+    expect(db.adrSyncConfig.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          enabled: true,
+          integrationId: { not: null },
+          repository: { fullName: "acme/api" },
+        }),
+      }),
+    );
+  });
+
+  it("does nothing for a push that touches no enrolled dir", async () => {
+    db.adrSyncConfig.findMany.mockResolvedValue([
+      { id: "cfg1", adrPaths: ["docs/adr"] },
+    ] as never);
+    const runSync = vi.fn();
+
+    const result = await triggerAdrSyncFromPush(
+      db,
+      push({ commits: [{ modified: ["src/app.ts"] }] }),
+      { runSync },
+    );
+
+    expect(runSync).not.toHaveBeenCalled();
+    expect(result.triggered).toEqual([]);
+  });
+
+  it("one enrolment's failure doesn't block another workspace's", async () => {
+    db.adrSyncConfig.findMany.mockResolvedValue([
+      { id: "cfg-bad", adrPaths: ["docs/adr"] },
+      { id: "cfg-good", adrPaths: ["docs/adr"] },
+    ] as never);
+    const runSync = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ status: "success" });
+
+    const result = await triggerAdrSyncFromPush(db, push(), { runSync });
+
+    expect(result.triggered).toEqual([
+      { configId: "cfg-bad", status: "error" },
+      { configId: "cfg-good", status: "success" },
+    ]);
+  });
+});

--- a/src/server/services/adrSync/webhookTrigger.ts
+++ b/src/server/services/adrSync/webhookTrigger.ts
@@ -1,0 +1,92 @@
+import type { PrismaClient } from "@prisma/client";
+import { runAdrSync } from "./engine";
+import type { AdrRemoteFactory } from "./github";
+
+/**
+ * adrSync/webhookTrigger — turn a GitHub `push` delivery into an immediate
+ * sync run, so a merged ADR lands in the Decision Log within seconds instead
+ * of at the next hourly cron tick.
+ *
+ * Scope guards (the acceptance criteria, verbatim):
+ * - only pushes to the repo's DEFAULT branch count;
+ * - only pushes whose commits touch an enrolled `adrPaths` dir count;
+ * - the existing GitHubActivity processing is upstream and untouched — this
+ *   trigger runs after it and its failure must never break that handler.
+ *
+ * Redelivery safety: the route's delivery pipeline processes each delivery
+ * once, and a re-delivered (or overlapping) push is idempotent here anyway —
+ * the engine short-circuits on the unchanged tree SHA and records the run as
+ * `unchanged` at a cost of ~1 API call, so duplicate triggers cannot do
+ * duplicate work.
+ */
+
+export interface PushEventLike {
+  ref: string;
+  repository: { full_name: string; default_branch?: string };
+  commits?: Array<{
+    added?: string[];
+    modified?: string[];
+    removed?: string[];
+  }>;
+}
+
+/** Pure: does this push (default branch only) touch any enrolled ADR dir? */
+export function pushTouchesAdrPaths(
+  push: PushEventLike,
+  adrPaths: string[],
+): boolean {
+  if (!push.ref.startsWith("refs/heads/")) return false;
+  const branch = push.ref.slice("refs/heads/".length);
+  const defaultBranch = push.repository.default_branch;
+  if (!defaultBranch || branch !== defaultBranch) return false;
+
+  const changed = (push.commits ?? []).flatMap((commit) => [
+    ...(commit.added ?? []),
+    ...(commit.modified ?? []),
+    ...(commit.removed ?? []),
+  ]);
+  return changed.some((file) =>
+    adrPaths.some((dir) => {
+      const normalized = dir.replace(/^\/+|\/+$/g, "");
+      return normalized.length > 0 && file.startsWith(`${normalized}/`);
+    }),
+  );
+}
+
+export async function triggerAdrSyncFromPush(
+  db: PrismaClient,
+  push: PushEventLike,
+  deps?: { remoteFactory?: AdrRemoteFactory; runSync?: typeof runAdrSync },
+): Promise<{ triggered: Array<{ configId: string; status: string }> }> {
+  const runSync = deps?.runSync ?? runAdrSync;
+
+  // A repo may be tracked by more than one workspace; each enrolment gets
+  // its own run. Disconnected configs are never triggered (ADR-0042).
+  const configs = await db.adrSyncConfig.findMany({
+    where: {
+      enabled: true,
+      integrationId: { not: null },
+      repository: { fullName: push.repository.full_name },
+    },
+    select: { id: true, adrPaths: true },
+  });
+
+  const triggered: Array<{ configId: string; status: string }> = [];
+  for (const config of configs) {
+    if (!pushTouchesAdrPaths(push, config.adrPaths)) continue;
+    try {
+      const result = await runSync(db, config.id, "webhook", {
+        remoteFactory: deps?.remoteFactory,
+      });
+      triggered.push({ configId: config.id, status: result.status });
+    } catch (error) {
+      // One enrolment's failure must not block another workspace's.
+      console.error(
+        `[AdrSync] webhook trigger failed for config ${config.id}:`,
+        error,
+      );
+      triggered.push({ configId: config.id, status: "error" });
+    }
+  }
+  return { triggered };
+}

--- a/src/server/services/adrSync/webhookTrigger.ts
+++ b/src/server/services/adrSync/webhookTrigger.ts
@@ -30,6 +30,13 @@ export interface PushEventLike {
   }>;
 }
 
+/**
+ * GitHub truncates the push payload's commits array at this count. Beyond it
+ * the file lists are incomplete, so path filtering would silently miss ADR
+ * edits sitting in older commits.
+ */
+const PUSH_COMMITS_TRUNCATION_LIMIT = 20;
+
 /** Pure: does this push (default branch only) touch any enrolled ADR dir? */
 export function pushTouchesAdrPaths(
   push: PushEventLike,
@@ -40,7 +47,14 @@ export function pushTouchesAdrPaths(
   const defaultBranch = push.repository.default_branch;
   if (!defaultBranch || branch !== defaultBranch) return false;
 
-  const changed = (push.commits ?? []).flatMap((commit) => [
+  const commits = push.commits ?? [];
+  // Possibly-truncated payload: err on the cheap side and trigger — a
+  // no-change sync short-circuits on the tree SHA at ~1 API call, while a
+  // silently missed ADR edit would stay stale until the next qualifying
+  // push or cron tick.
+  if (commits.length >= PUSH_COMMITS_TRUNCATION_LIMIT) return true;
+
+  const changed = commits.flatMap((commit) => [
     ...(commit.added ?? []),
     ...(commit.modified ?? []),
     ...(commit.removed ?? []),
@@ -48,7 +62,9 @@ export function pushTouchesAdrPaths(
   return changed.some((file) =>
     adrPaths.some((dir) => {
       const normalized = dir.replace(/^\/+|\/+$/g, "");
-      return normalized.length > 0 && file.startsWith(`${normalized}/`);
+      // A root enrolment ("/" or "") covers every file — the engine syncs it
+      // from the repo root, so the trigger must match it too.
+      return normalized.length === 0 || file.startsWith(`${normalized}/`);
     }),
   );
 }
@@ -74,6 +90,21 @@ export async function triggerAdrSyncFromPush(
   const triggered: Array<{ configId: string; status: string }> = [];
   for (const config of configs) {
     if (!pushTouchesAdrPaths(push, config.adrPaths)) continue;
+    // Overlap guard, same shape as the scheduler's: two pushes seconds apart
+    // must not run the same config concurrently (the loser could persist the
+    // OLDER head). A skipped push is caught by the hourly cron backstop.
+    const inFlight = await db.adrSyncRun.findFirst({
+      where: {
+        configId: config.id,
+        status: "running",
+        startedAt: { gt: new Date(Date.now() - 30 * 60_000) },
+      },
+      select: { id: true },
+    });
+    if (inFlight) {
+      triggered.push({ configId: config.id, status: "skipped-running" });
+      continue;
+    }
     try {
       const result = await runSync(db, config.id, "webhook", {
         remoteFactory: deps?.remoteFactory,


### PR DESCRIPTION
## What

The Decision Log fast-follows (V4): a decision-network graph at `/w/[slug]/decisions/graph` (ReactFlow, repo-column clustering with header nodes, status-colored ADR nodes, solid labelled SUPERSEDES vs dashed muted MENTIONS with a legend, click-through to detail, read-only) backed by a new member-gated `adr.graph` procedure; and a push-webhook trigger so a default-branch push touching enrolled `adrPaths` lands the ADR within seconds — wired after the existing `GitHubActivity` push handling in its own try/catch, per-enrolment failure isolation, idempotent on redelivery via the engine's tree-SHA short-circuit.

**Feature**: Decision Log — cross-repo ADR viewer (`cmsso8h5w0008i504of0r4nzo`), scope V4. Builds on #590 (V1) and #591 (V2); independent of #592 (V3). No schema changes.

## Acceptance criteria

- [ ] Graph renders the CLEAR figure-scope pair as a dashed cross-repo edge
- [ ] A push to `docs/adr/**` on a default branch triggers a run; pushes elsewhere do not
- [ ] Existing GitHub webhook processing unaffected

---

Ships: giddy.comet

[View in Exponential](https://www.exponential.im/w/syntrofi/tickets/cmssoxkqr000dju04bqg6gwh1)
