### PR TITLE
fix(cycles): scope cycle date-overlap validation per product

### DIFF
--- a/prisma/migrations/20260816090000_add_product_scope_to_cycles/migration.sql
+++ b/prisma/migrations/20260816090000_add_product_scope_to_cycles/migration.sql
@@ -1,0 +1,26 @@
+-- Cycles (List rows with listType SPRINT) become product-scoped so different
+-- products can run cycles with overlapping dates. NULL productId = legacy
+-- workspace-shared cycle.
+
+-- AlterTable
+ALTER TABLE "List" ADD COLUMN "productId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "List_productId_idx" ON "List"("productId");
+
+-- AddForeignKey
+ALTER TABLE "List" ADD CONSTRAINT "List_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Backfill: a cycle whose tickets all belong to exactly one product is that
+-- product's cycle. Cycles with no tickets or mixed-product tickets stay NULL
+-- (workspace-shared) and remain visible on every product's Cycles tab.
+UPDATE "List" l
+SET "productId" = t.pid
+FROM (
+  SELECT "cycleId", MIN("productId") AS pid
+  FROM "Ticket"
+  WHERE "cycleId" IS NOT NULL AND "productId" IS NOT NULL
+  GROUP BY "cycleId"
+  HAVING COUNT(DISTINCT "productId") = 1
+) t
+WHERE l.id = t."cycleId" AND l."listType" = 'SPRINT';

--- a/prisma/migrations/20260816090000_add_product_scope_to_cycles/migration.sql
+++ b/prisma/migrations/20260816090000_add_product_scope_to_cycles/migration.sql
@@ -9,11 +9,16 @@ ALTER TABLE "List" ADD COLUMN "productId" TEXT;
 CREATE INDEX "List_productId_idx" ON "List"("productId");
 
 -- AddForeignKey
-ALTER TABLE "List" ADD CONSTRAINT "List_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+-- SET NULL: deleting a product reverts its cycles to workspace-shared instead
+-- of destroying them (and their SprintMetrics/SprintSnapshot history).
+ALTER TABLE "List" ADD CONSTRAINT "List_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- Backfill: a cycle whose tickets all belong to exactly one product is that
 -- product's cycle. Cycles with no tickets or mixed-product tickets stay NULL
 -- (workspace-shared) and remain visible on every product's Cycles tab.
+-- The EXISTS guard skips dirty legacy rows where a ticket's cycle lives in a
+-- different workspace than its product (no DB constraint prevents that), so a
+-- List is never assigned to a product outside its own workspace.
 UPDATE "List" l
 SET "productId" = t.pid
 FROM (
@@ -23,4 +28,8 @@ FROM (
   GROUP BY "cycleId"
   HAVING COUNT(DISTINCT "productId") = 1
 ) t
-WHERE l.id = t."cycleId" AND l."listType" = 'SPRINT';
+WHERE l.id = t."cycleId" AND l."listType" = 'SPRINT'
+  AND EXISTS (
+    SELECT 1 FROM "Product" p
+    WHERE p."id" = t.pid AND p."workspaceId" = l."workspaceId"
+  );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -712,11 +712,15 @@ model List {
   displayOrder Int @default(0)
 
   workspaceId String
+  // Cycles (listType SPRINT) are scoped to a single product; null = legacy
+  // workspace-shared cycle. Overlap validation only applies within one product.
+  productId   String?
   createdById String
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
   workspace      Workspace        @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  product        Product?         @relation("ProductCycles", fields: [productId], references: [id], onDelete: Cascade)
   createdBy      User             @relation("ListsCreated", fields: [createdById], references: [id])
   actions        ActionList[]
   tickets        Ticket[]         @relation("TicketCycle")
@@ -727,6 +731,7 @@ model List {
 
   @@unique([workspaceId, slug])
   @@index([workspaceId])
+  @@index([productId])
   @@index([createdById])
   @@index([status])
 }
@@ -4160,6 +4165,7 @@ model Product {
   featureDrafts     MeetingFeatureDraft[]
   epics             Epic[]
   repositories      WorkspaceRepository[]
+  cycles            List[]                @relation("ProductCycles")
 
   @@unique([workspaceId, slug])
   @@index([workspaceId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -713,14 +713,16 @@ model List {
 
   workspaceId String
   // Cycles (listType SPRINT) are scoped to a single product; null = legacy
-  // workspace-shared cycle. Overlap validation only applies within one product.
+  // workspace-shared cycle. Overlap validation only applies within one
+  // product. On product delete the cycle reverts to workspace-shared
+  // (SetNull) so sprint history survives.
   productId   String?
   createdById String
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
   workspace      Workspace        @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  product        Product?         @relation("ProductCycles", fields: [productId], references: [id], onDelete: Cascade)
+  product        Product?         @relation("ProductCycles", fields: [productId], references: [id], onDelete: SetNull)
   createdBy      User             @relation("ListsCreated", fields: [createdById], references: [id])
   actions        ActionList[]
   tickets        Ticket[]         @relation("TicketCycle")

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/CycleDetailClient.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/[cycleId]/CycleDetailClient.tsx
@@ -67,11 +67,7 @@ export function CycleDetailClient() {
   const updateCycle = api.product.cycle.update.useMutation({
     onSuccess: async () => {
       await utils.product.cycle.getById.invalidate({ id: cycleId });
-      if (cycle?.workspaceId) {
-        await utils.product.cycle.list.invalidate({
-          workspaceId: cycle.workspaceId,
-        });
-      }
+      await utils.product.cycle.list.invalidate();
     },
   });
 
@@ -80,22 +76,14 @@ export function CycleDetailClient() {
       setHeaderError(null);
       setIsEditingHeader(false);
       await utils.product.cycle.getById.invalidate({ id: cycleId });
-      if (cycle?.workspaceId) {
-        await utils.product.cycle.list.invalidate({
-          workspaceId: cycle.workspaceId,
-        });
-      }
+      await utils.product.cycle.list.invalidate();
     },
     onError: (err) => setHeaderError(err.message),
   });
 
   const deleteCycle = api.product.cycle.delete.useMutation({
     onSuccess: async () => {
-      if (cycle?.workspaceId) {
-        await utils.product.cycle.list.invalidate({
-          workspaceId: cycle.workspaceId,
-        });
-      }
+      await utils.product.cycle.list.invalidate();
       router.push(`/w/${workspaceSlug}/products/${productSlug}/cycles`);
     },
   });

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/new/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/new/page.tsx
@@ -31,11 +31,14 @@ export default function NewCyclePage() {
   const [description, setDescription] = useState("");
   const [error, setError] = useState<string | null>(null);
 
+  const { data: product } = api.product.product.getBySlug.useQuery(
+    { workspaceId: workspaceId ?? "", slug: productSlug },
+    { enabled: !!workspaceId && !!productSlug },
+  );
+
   const createCycle = api.product.cycle.create.useMutation({
     onSuccess: async (cycle) => {
-      if (workspaceId) {
-        await utils.product.cycle.list.invalidate({ workspaceId });
-      }
+      await utils.product.cycle.list.invalidate();
       if (workspace) {
         router.push(
           `/w/${workspace.slug}/products/${productSlug}/cycles/${cycle.id}`,
@@ -49,9 +52,11 @@ export default function NewCyclePage() {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (!product) return;
     setError(null);
     createCycle.mutate({
       workspaceId,
+      productId: product.id,
       name: name.trim(),
       startDate: startDate ?? undefined,
       endDate: endDate ?? undefined,
@@ -133,7 +138,7 @@ export default function NewCyclePage() {
                 type="submit"
                 color="brand"
                 loading={createCycle.isPending}
-                disabled={!name.trim()}
+                disabled={!name.trim() || !product}
               >
                 Create cycle
               </Button>

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/new/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/new/page.tsx
@@ -31,10 +31,11 @@ export default function NewCyclePage() {
   const [description, setDescription] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  const { data: product } = api.product.product.getBySlug.useQuery(
-    { workspaceId: workspaceId ?? "", slug: productSlug },
-    { enabled: !!workspaceId && !!productSlug },
-  );
+  const { data: product, isError: isProductError } =
+    api.product.product.getBySlug.useQuery(
+      { workspaceId: workspaceId ?? "", slug: productSlug },
+      { enabled: !!workspaceId && !!productSlug },
+    );
 
   const createCycle = api.product.cycle.create.useMutation({
     onSuccess: async (cycle) => {
@@ -121,6 +122,12 @@ export default function NewCyclePage() {
               autosize
               minRows={2}
             />
+            {isProductError && (
+              <Text size="sm" className="text-text-error">
+                Product not found. It may have been renamed or deleted — check
+                the URL.
+              </Text>
+            )}
             {error && (
               <Text size="sm" className="text-text-error">
                 {error}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/page.tsx
@@ -50,22 +50,33 @@ export default function CyclesListPage() {
   const { workspace, workspaceId } = useWorkspace();
   const [autoCreatePaused, setAutoCreatePaused] = useState(false);
 
+  const { data: product } = api.product.product.getBySlug.useQuery(
+    { workspaceId: workspaceId ?? "", slug: productSlug },
+    { enabled: !!workspaceId && !!productSlug },
+  );
+
   const { data: cycles, isLoading } = api.product.cycle.list.useQuery(
-    { workspaceId: workspaceId ?? "", autoCreate: !autoCreatePaused },
-    { enabled: !!workspaceId },
+    {
+      workspaceId: workspaceId ?? "",
+      productId: product?.id,
+      autoCreate: !autoCreatePaused,
+    },
+    // Wait for the product so auto-generation runs product-scoped, never
+    // against the whole workspace.
+    { enabled: !!workspaceId && !!product?.id },
   );
 
   const utils = api.useUtils();
 
   const deleteCycle = api.product.cycle.delete.useMutation({
     onSuccess: () => {
-      void utils.product.cycle.list.invalidate({ workspaceId: workspaceId ?? "" });
+      void utils.product.cycle.list.invalidate();
     },
   });
 
   const updateCycle = api.product.cycle.update.useMutation({
     onSuccess: () => {
-      void utils.product.cycle.list.invalidate({ workspaceId: workspaceId ?? "" });
+      void utils.product.cycle.list.invalidate();
     },
   });
 
@@ -181,7 +192,7 @@ export default function CyclesListPage() {
         </div>
       )}
 
-      {isLoading ? (
+      {isLoading || !product ? (
         <Stack gap="sm">
           {[1, 2].map((i) => (
             <Skeleton key={i} height={80} />

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/cycles/page.tsx
@@ -50,10 +50,11 @@ export default function CyclesListPage() {
   const { workspace, workspaceId } = useWorkspace();
   const [autoCreatePaused, setAutoCreatePaused] = useState(false);
 
-  const { data: product } = api.product.product.getBySlug.useQuery(
-    { workspaceId: workspaceId ?? "", slug: productSlug },
-    { enabled: !!workspaceId && !!productSlug },
-  );
+  const { data: product, isError: isProductError } =
+    api.product.product.getBySlug.useQuery(
+      { workspaceId: workspaceId ?? "", slug: productSlug },
+      { enabled: !!workspaceId && !!productSlug },
+    );
 
   const { data: cycles, isLoading } = api.product.cycle.list.useQuery(
     {
@@ -192,7 +193,12 @@ export default function CyclesListPage() {
         </div>
       )}
 
-      {isLoading || !product ? (
+      {isProductError ? (
+        <EmptyState
+          icon={IconCalendarClock}
+          message="Product not found. It may have been renamed or deleted — check the URL."
+        />
+      ) : isLoading || !product ? (
         <Stack gap="sm">
           {[1, 2].map((i) => (
             <Skeleton key={i} height={80} />

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/retrospectives/new/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/retrospectives/new/page.tsx
@@ -31,8 +31,8 @@ export default function NewRetrospectivePage() {
   );
 
   const { data: cycles } = api.product.cycle.list.useQuery(
-    { workspaceId: workspaceId ?? "" },
-    { enabled: !!workspaceId },
+    { workspaceId: workspaceId ?? "", productId: product?.id },
+    { enabled: !!workspaceId && !!product?.id },
   );
 
   const [title, setTitle] = useState("");

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/[ticketId]/page.tsx
@@ -245,8 +245,8 @@ export default function TicketDetailPage() {
   // Data for selectors
   const members = workspace?.members ?? [];
   const { data: cycles } = api.product.cycle.list.useQuery(
-    { workspaceId: workspaceId ?? "" },
-    { enabled: !!workspaceId },
+    { workspaceId: workspaceId ?? "", productId: ticket?.product.id },
+    { enabled: !!workspaceId && !!ticket?.product.id },
   );
   // Only this ticket's own product's epics are linkable — the router rejects
   // another product's epic, so offering it would be a dead option.

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/new/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/new/page.tsx
@@ -79,8 +79,8 @@ export default function NewTicketPage() {
   );
 
   const { data: cycles } = api.product.cycle.list.useQuery(
-    { workspaceId: workspaceId ?? "" },
-    { enabled: !!workspaceId },
+    { workspaceId: workspaceId ?? "", productId: product?.id },
+    { enabled: !!workspaceId && !!product?.id },
   );
 
   const [title, setTitle] = useState("");

--- a/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/products/[productSlug]/tickets/page.tsx
@@ -452,8 +452,8 @@ export default function TicketsBacklogPage() {
   );
 
   const { data: cycles } = api.product.cycle.list.useQuery(
-    { workspaceId: workspaceId ?? "" },
-    { enabled: !!workspaceId },
+    { workspaceId: workspaceId ?? "", productId: product?.id },
+    { enabled: !!workspaceId && !!product?.id },
   );
 
   // Epics are per-product. `includeUnassigned` keeps pre-backfill epics (no

--- a/src/app/_components/product/peek/TicketPeek.tsx
+++ b/src/app/_components/product/peek/TicketPeek.tsx
@@ -77,8 +77,8 @@ export function TicketPeek({ ticketId, basePath }: { ticketId: string; basePath:
     { enabled: !!workspaceId && !!ticket?.product.id },
   );
   const { data: cycles } = api.product.cycle.list.useQuery(
-    { workspaceId: workspaceId ?? "" },
-    { enabled: !!workspaceId },
+    { workspaceId: workspaceId ?? "", productId: ticket?.product.id },
+    { enabled: !!workspaceId && !!ticket?.product.id },
   );
   const { data: tags } = api.tag.list.useQuery(
     { workspaceId: workspaceId ?? "" },

--- a/src/plugins/product/server/routers/__tests__/cycle-retro.integration.test.ts
+++ b/src/plugins/product/server/routers/__tests__/cycle-retro.integration.test.ts
@@ -7,6 +7,7 @@ import {
   createWorkspace,
   createProduct,
   createCycle,
+  createTicket,
 } from "~/test/factories";
 
 describe("cycle router", () => {
@@ -121,6 +122,169 @@ describe("cycle router", () => {
       endDate: new Date("2030-02-17"),
     });
     expect(cycle.productId).toBe(product.id);
+  });
+
+  it("scopes the update overlap check per product", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const productA = await createProduct(db, {
+      workspaceId: ws.id,
+      createdById: user.id,
+    });
+    const productB = await createProduct(db, {
+      workspaceId: ws.id,
+      createdById: user.id,
+    });
+
+    const caller = createTestCaller(user.id);
+    const a1 = await caller.product.cycle.create({
+      workspaceId: ws.id,
+      productId: productA.id,
+      name: "A1",
+      startDate: new Date("2030-03-04"),
+      endDate: new Date("2030-03-18"),
+    });
+    await caller.product.cycle.create({
+      workspaceId: ws.id,
+      productId: productA.id,
+      name: "A2",
+      startDate: new Date("2030-04-01"),
+      endDate: new Date("2030-04-15"),
+    });
+    await caller.product.cycle.create({
+      workspaceId: ws.id,
+      productId: productB.id,
+      name: "B1",
+      startDate: new Date("2030-05-06"),
+      endDate: new Date("2030-05-20"),
+    });
+
+    // Moving A1 onto B1's dates is fine — different product
+    const moved = await caller.product.cycle.update({
+      id: a1.id,
+      startDate: new Date("2030-05-06"),
+      endDate: new Date("2030-05-20"),
+    });
+    expect(moved.startDate).toEqual(new Date("2030-05-06"));
+
+    // Moving A1 onto sibling A2's dates still conflicts
+    await expect(
+      caller.product.cycle.update({
+        id: a1.id,
+        startDate: new Date("2030-04-08"),
+        endDate: new Date("2030-04-22"),
+      }),
+    ).rejects.toThrow(/overlap/i);
+
+    // A legacy shared cycle (productId null) may move onto a product cycle's
+    // dates — null is its own scope
+    const legacy = await createCycle(db, {
+      workspaceId: ws.id,
+      createdById: user.id,
+    });
+    const legacyMoved = await caller.product.cycle.update({
+      id: legacy.id,
+      startDate: new Date("2030-04-01"),
+      endDate: new Date("2030-04-15"),
+    });
+    expect(legacyMoved.startDate).toEqual(new Date("2030-04-01"));
+  });
+
+  it("auto-generates cycles per product, suppressed by legacy shared coverage", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const productA = await createProduct(db, {
+      workspaceId: ws.id,
+      createdById: user.id,
+    });
+    const productB = await createProduct(db, {
+      workspaceId: ws.id,
+      createdById: user.id,
+    });
+
+    const caller = createTestCaller(user.id);
+
+    // Each product's Cycles tab generates its own upcoming cycles
+    const aCycles = await caller.product.cycle.list({
+      workspaceId: ws.id,
+      productId: productA.id,
+      autoCreate: true,
+    });
+    expect(aCycles.length).toBeGreaterThan(0);
+    expect(aCycles.every((c) => c.productId === productA.id)).toBe(true);
+
+    const bCycles = await caller.product.cycle.list({
+      workspaceId: ws.id,
+      productId: productB.id,
+      autoCreate: true,
+    });
+    const bOwned = bCycles.filter((c) => c.productId === productB.id);
+    expect(bOwned.length).toBeGreaterThan(0);
+    // B's listing never contains A's cycles (only its own + shared)
+    expect(bCycles.some((c) => c.productId === productA.id)).toBe(false);
+
+    // A workspace with legacy shared coverage generates nothing new
+    const ws2 = await createWorkspace(db, { ownerId: user.id });
+    const productC = await createProduct(db, {
+      workspaceId: ws2.id,
+      createdById: user.id,
+    });
+    const now = new Date();
+    const legacyEnd = new Date(now);
+    legacyEnd.setDate(legacyEnd.getDate() + 60); // beyond the lookahead horizon
+    await createCycle(db, {
+      workspaceId: ws2.id,
+      createdById: user.id,
+      startDate: now,
+      endDate: legacyEnd,
+    });
+    const cCycles = await caller.product.cycle.list({
+      workspaceId: ws2.id,
+      productId: productC.id,
+      autoCreate: true,
+    });
+    expect(cCycles.filter((c) => c.productId === productC.id)).toHaveLength(0);
+    expect(cCycles.filter((c) => c.productId === null)).toHaveLength(1);
+  });
+
+  it("rejects linking a ticket to another product's cycle, allows shared cycles", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const productA = await createProduct(db, {
+      workspaceId: ws.id,
+      createdById: user.id,
+    });
+    const productB = await createProduct(db, {
+      workspaceId: ws.id,
+      createdById: user.id,
+    });
+
+    const caller = createTestCaller(user.id);
+    const bCycle = await caller.product.cycle.create({
+      workspaceId: ws.id,
+      productId: productB.id,
+      name: "B only",
+    });
+    const ticket = await createTicket(db, {
+      productId: productA.id,
+      createdById: user.id,
+    });
+
+    // Product A's ticket may not join product B's cycle
+    await expect(
+      caller.product.ticket.update({ id: ticket.id, cycleId: bCycle.id }),
+    ).rejects.toThrow(TRPCError);
+
+    // A legacy shared cycle (productId null) is joinable from any product
+    const shared = await createCycle(db, {
+      workspaceId: ws.id,
+      createdById: user.id,
+    });
+    const updated = await caller.product.ticket.update({
+      id: ticket.id,
+      cycleId: shared.id,
+    });
+    expect(updated.cycleId).toBe(shared.id);
   });
 
   it("rejects a productId from another workspace", async () => {

--- a/src/plugins/product/server/routers/__tests__/cycle-retro.integration.test.ts
+++ b/src/plugins/product/server/routers/__tests__/cycle-retro.integration.test.ts
@@ -51,6 +51,98 @@ describe("cycle router", () => {
     expect(updated.achievements).toBe("Shipped email");
   });
 
+  it("allows overlapping dates on cycles of different products", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const productA = await createProduct(db, {
+      workspaceId: ws.id,
+      createdById: user.id,
+    });
+    const productB = await createProduct(db, {
+      workspaceId: ws.id,
+      createdById: user.id,
+    });
+
+    const start = new Date("2030-01-06");
+    const end = new Date("2030-01-20");
+
+    const caller = createTestCaller(user.id);
+    await caller.product.cycle.create({
+      workspaceId: ws.id,
+      productId: productA.id,
+      name: "A Cycle 1",
+      startDate: start,
+      endDate: end,
+    });
+
+    // Same window on another product is fine — independent timelines
+    const bCycle = await caller.product.cycle.create({
+      workspaceId: ws.id,
+      productId: productB.id,
+      name: "B Cycle 1",
+      startDate: start,
+      endDate: end,
+    });
+    expect(bCycle.productId).toBe(productB.id);
+
+    // But the same window on the SAME product still conflicts
+    await expect(
+      caller.product.cycle.create({
+        workspaceId: ws.id,
+        productId: productB.id,
+        name: "B Cycle 2",
+        startDate: new Date("2030-01-13"),
+        endDate: new Date("2030-01-27"),
+      }),
+    ).rejects.toThrow(/overlap/i);
+  });
+
+  it("does not let a legacy workspace-shared cycle block a product cycle", async () => {
+    const user = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const product = await createProduct(db, {
+      workspaceId: ws.id,
+      createdById: user.id,
+    });
+    // Legacy cycle with no product (pre-migration shape)
+    await createCycle(db, {
+      workspaceId: ws.id,
+      createdById: user.id,
+      startDate: new Date("2030-02-03"),
+      endDate: new Date("2030-02-17"),
+    });
+
+    const caller = createTestCaller(user.id);
+    const cycle = await caller.product.cycle.create({
+      workspaceId: ws.id,
+      productId: product.id,
+      name: "Product Cycle 1",
+      startDate: new Date("2030-02-03"),
+      endDate: new Date("2030-02-17"),
+    });
+    expect(cycle.productId).toBe(product.id);
+  });
+
+  it("rejects a productId from another workspace", async () => {
+    const user = await createUser(db);
+    const otherUser = await createUser(db);
+    const ws = await createWorkspace(db, { ownerId: user.id });
+    const otherWs = await createWorkspace(db, { ownerId: otherUser.id });
+    const foreignProduct = await createProduct(db, {
+      workspaceId: otherWs.id,
+      createdById: otherUser.id,
+    });
+
+    const caller = createTestCaller(user.id);
+    await expect(
+      caller.product.cycle.create({
+        workspaceId: ws.id,
+        productId: foreignProduct.id,
+        name: "Bad cycle",
+      }),
+    ).rejects.toThrow(TRPCError);
+  });
+
   it("rejects getById when the list isn't a SPRINT", async () => {
     const user = await createUser(db);
     const ws = await createWorkspace(db, { ownerId: user.id });

--- a/src/plugins/product/server/routers/cycle.ts
+++ b/src/plugins/product/server/routers/cycle.ts
@@ -9,6 +9,12 @@ import { TEXT_LIMITS, boundedText } from "~/lib/text-limits";
  * Cycles are thin wrappers around the existing `List` model with
  * `listType = SPRINT`. This router exposes only the fields the Product
  * plugin cares about (dates, goal, achievements, ticket count).
+ *
+ * Cycles are scoped to a product via `List.productId` — different products
+ * run independent cycle timelines, so overlap validation and auto-generation
+ * only consider cycles of the same product. `productId = null` marks a legacy
+ * workspace-shared cycle: visible on every product's Cycles tab, but never a
+ * date conflict for a product-scoped cycle.
  */
 
 // ---------------------------------------------------------------------------
@@ -22,7 +28,7 @@ async function loadCycleWithAccess(
 ) {
   const cycle = await db.list.findUnique({
     where: { id: cycleId },
-    select: { id: true, workspaceId: true, listType: true },
+    select: { id: true, workspaceId: true, productId: true, listType: true },
   });
   if (!cycle) {
     throw new TRPCError({ code: "NOT_FOUND", message: "Cycle not found" });
@@ -153,18 +159,27 @@ async function reconcileCycleStatuses(
  * - Names are auto-assigned as "Cycle N" (incrementing).
  * - Generates up to `config.lookahead` cycles into the future
  *   from today.
+ *
+ * When `productId` is set, only that product's cycles (plus legacy
+ * workspace-shared ones, which still count as coverage) are considered,
+ * and new cycles are created scoped to that product.
  */
 async function ensureUpcomingCycles(
   db: PrismaClient,
   workspaceId: string,
   userId: string,
+  productId: string | null,
   config: CycleConfig = DEFAULT_CONFIG,
 ): Promise<void> {
   if (!config.enabled) return;
 
   // Fetch all existing cycles ordered by end date
   const existing = await db.list.findMany({
-    where: { workspaceId, listType: "SPRINT" },
+    where: {
+      workspaceId,
+      listType: "SPRINT",
+      ...(productId ? { OR: [{ productId }, { productId: null }] } : {}),
+    },
     orderBy: { endDate: "asc" },
     select: { id: true, name: true, startDate: true, endDate: true, status: true },
   });
@@ -255,6 +270,7 @@ async function ensureUpcomingCycles(
     await db.list.create({
       data: {
         workspaceId,
+        productId,
         createdById: userId,
         name: c.name,
         slug,
@@ -276,6 +292,12 @@ export const cycleRouter = createTRPCRouter({
     .input(
       z.object({
         workspaceId: z.string(),
+        /**
+         * Scope to one product's cycles. Legacy workspace-shared cycles
+         * (productId null) are always included so pre-migration cycles stay
+         * visible. Omit to list every cycle in the workspace.
+         */
+        productId: z.string().optional(),
         status: z.enum(["PLANNED", "ACTIVE", "COMPLETED", "ARCHIVED"]).optional(),
         /** Pass false to skip auto-generation (e.g. when paused) */
         autoCreate: z.boolean().optional().default(true),
@@ -297,6 +319,7 @@ export const cycleRouter = createTRPCRouter({
           ctx.db,
           input.workspaceId,
           ctx.session.user.id,
+          input.productId ?? null,
           DEFAULT_CONFIG,
         );
       }
@@ -305,6 +328,9 @@ export const cycleRouter = createTRPCRouter({
         where: {
           workspaceId: input.workspaceId,
           listType: "SPRINT",
+          ...(input.productId
+            ? { OR: [{ productId: input.productId }, { productId: null }] }
+            : {}),
           ...(input.status ? { status: input.status } : {}),
         },
         orderBy: [{ startDate: "desc" }, { createdAt: "desc" }],
@@ -357,6 +383,8 @@ export const cycleRouter = createTRPCRouter({
     .input(
       z.object({
         workspaceId: z.string(),
+        /** Product this cycle belongs to. Omit for a workspace-shared cycle. */
+        productId: z.string().optional(),
         name: boundedText("Name", 120, { min: 1 }).optional(),
         slug: boundedText("Slug", 60).optional(),
         description: boundedText("Description", TEXT_LIMITS.MEDIUM).optional(),
@@ -372,6 +400,19 @@ export const cycleRouter = createTRPCRouter({
         input.workspaceId,
       );
 
+      if (input.productId) {
+        const product = await ctx.db.product.findUnique({
+          where: { id: input.productId },
+          select: { workspaceId: true },
+        });
+        if (!product || product.workspaceId !== input.workspaceId) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Product not found in this workspace",
+          });
+        }
+      }
+
       if (input.startDate && input.endDate && input.endDate <= input.startDate) {
         throw new TRPCError({
           code: "BAD_REQUEST",
@@ -379,11 +420,18 @@ export const cycleRouter = createTRPCRouter({
         });
       }
 
-      // Auto-name if not provided
+      // Auto-name if not provided (numbering scoped like the Cycles tab list:
+      // this product's cycles plus legacy shared ones)
       let name = input.name?.trim();
       if (!name) {
         const existing = await ctx.db.list.findMany({
-          where: { workspaceId: input.workspaceId, listType: "SPRINT" },
+          where: {
+            workspaceId: input.workspaceId,
+            listType: "SPRINT",
+            ...(input.productId
+              ? { OR: [{ productId: input.productId }, { productId: null }] }
+              : {}),
+          },
           select: { name: true },
         });
         const nextNum = maxCycleNumber(existing.map((c) => c.name)) + 1;
@@ -410,6 +458,9 @@ export const cycleRouter = createTRPCRouter({
           where: {
             workspaceId: input.workspaceId,
             listType: "SPRINT",
+            // Cycles only conflict within the same product — other products
+            // (and legacy workspace-shared cycles) run independent timelines.
+            productId: input.productId ?? null,
             // Cancelled cycles are dead — they shouldn't block new dates
             status: { not: "ARCHIVED" },
             ...(input.startDate ? { endDate: { gt: input.startDate } } : {}),
@@ -428,6 +479,7 @@ export const cycleRouter = createTRPCRouter({
       return ctx.db.list.create({
         data: {
           workspaceId: input.workspaceId,
+          productId: input.productId,
           createdById: ctx.session.user.id,
           name,
           slug,
@@ -481,6 +533,9 @@ export const cycleRouter = createTRPCRouter({
               workspaceId: cycle.workspaceId,
               listType: "SPRINT",
               id: { not: input.id },
+              // Cycles only conflict within the same product — other products
+              // (and legacy workspace-shared cycles) run independent timelines.
+              productId: cycle.productId,
               // Cancelled cycles are dead — they shouldn't block new dates
               status: { not: "ARCHIVED" },
               ...(newStart ? { endDate: { gt: newStart } } : {}),

--- a/src/plugins/product/server/routers/product.ts
+++ b/src/plugins/product/server/routers/product.ts
@@ -215,9 +215,10 @@ export const productRouter = createTRPCRouter({
 
       // Read-only "current cycle" predicate, shared with the workspace-home
       // cycle block — see ../currentCycle.ts for the reconcile-tolerance
-      // rationale. Cycles are workspace-scoped (List, listType SPRINT), so
-      // this matches any current sprint in the workspace; we prefer the one
-      // holding this product's tickets below.
+      // rationale. Cycles are product-scoped (List.productId, listType
+      // SPRINT); legacy workspace-shared cycles have productId null. We
+      // prefer this product's own cycle (or one holding its tickets) and
+      // fall back to a shared one — never another product's cycle.
       const cycleWhere = currentCycleWhere(product.workspaceId, now);
       const currentCycleSelect = {
         id: true,
@@ -252,20 +253,29 @@ export const productRouter = createTRPCRouter({
             },
           },
         }),
-        // Prefer a current cycle that actually holds this product's tickets, so
-        // the hero shows "their" cycle rather than an unrelated workspace one.
+        // Prefer a current cycle owned by this product, or one that actually
+        // holds this product's tickets, so the hero shows "their" cycle
+        // rather than an unrelated workspace one.
         ctx.db.list.findFirst({
           where: {
-            ...cycleWhere,
-            tickets: { some: { productId: input.productId } },
+            AND: [
+              cycleWhere,
+              {
+                OR: [
+                  { productId: input.productId },
+                  { tickets: { some: { productId: input.productId } } },
+                ],
+              },
+            ],
           },
           orderBy: currentCycleOrder,
           select: currentCycleSelect,
         }),
-        // Fallback: the workspace's current cycle even if this product has no
-        // tickets in it yet — the hero then prompts to commit tickets.
+        // Fallback: a current legacy workspace-shared cycle (productId null)
+        // even if this product has no tickets in it yet — the hero then
+        // prompts to commit tickets. Another product's cycle never qualifies.
         ctx.db.list.findFirst({
-          where: cycleWhere,
+          where: { ...cycleWhere, productId: null },
           orderBy: currentCycleOrder,
           select: currentCycleSelect,
         }),

--- a/src/plugins/product/server/routers/ticket.ts
+++ b/src/plugins/product/server/routers/ticket.ts
@@ -390,7 +390,8 @@ export const ticketRouter = createTRPCRouter({
 
       // A linked epic/feature/cycle/scope must live in the product's own
       // workspace, or its fields leak back through this ticket's includes.
-      // The trailing product id additionally holds an epic to this product.
+      // The trailing product id additionally holds an epic or cycle to this
+      // product (legacy product-less rows are exempt).
       await assertWorkspaceScopedRefs(
         ctx.db,
         ctx.session.user.id,

--- a/src/server/api/routers/mastra.ts
+++ b/src/server/api/routers/mastra.ts
@@ -4784,10 +4784,12 @@ export const mastraRouter = createTRPCRouter({
     }),
 
   // List the cycles (SPRINT lists) an agent can reference. Cycles are
-  // workspace-scoped; pass a productId to resolve the workspace from a product
-  // the agent already knows. Pure read — unlike the plugin's cycle.list, this
-  // never auto-creates upcoming cycles. Declared as a query per ADR-0041
-  // (agent tools POST; allowMethodOverride accepts it).
+  // product-scoped (List.productId; null = legacy workspace-shared): passing a
+  // productId returns that product's cycles plus shared ones, matching the
+  // plugin's cycle.list; passing only a workspaceId returns every cycle in the
+  // workspace. Pure read — unlike the plugin's cycle.list, this never
+  // auto-creates upcoming cycles. Declared as a query per ADR-0041 (agent
+  // tools POST; allowMethodOverride accepts it).
   listCycles: protectedProcedure
     .input(
       z.object({
@@ -4808,7 +4810,13 @@ export const mastraRouter = createTRPCRouter({
       }
 
       const cycles = await ctx.db.list.findMany({
-        where: { workspaceId, listType: "SPRINT" },
+        where: {
+          workspaceId,
+          listType: "SPRINT",
+          ...(input.productId
+            ? { OR: [{ productId: input.productId }, { productId: null }] }
+            : {}),
+        },
         select: {
           id: true,
           name: true,

--- a/src/server/services/access/workspaceRefs.ts
+++ b/src/server/services/access/workspaceRefs.ts
@@ -54,13 +54,14 @@ export async function assertWorkspaceScopedRefs(
   refs: WorkspaceScopedRefs,
   /**
    * The pointing row's product, when it has one (tickets always do; actions
-   * never do). Supplying it additionally requires that an epic belong to that
-   * same product — epics are per-product, so a ticket may not borrow another
-   * product's epic even inside one workspace.
+   * never do). Supplying it additionally requires that an epic or cycle
+   * belong to that same product — both are per-product, so a ticket may not
+   * borrow another product's epic or cycle even inside one workspace.
    *
-   * An epic with no product yet (pre-backfill) is exempt: it is still
-   * workspace-scoped in practice, and rejecting it would break every existing
-   * ticket→epic link the moment this ships.
+   * An epic with no product yet (pre-backfill), or a cycle with no product
+   * (legacy workspace-shared), is exempt: it is still workspace-scoped in
+   * practice, and rejecting it would break every existing link the moment
+   * this ships.
    */
   productId?: string,
 ): Promise<void> {
@@ -114,12 +115,20 @@ export async function assertWorkspaceScopedRefs(
       db.list
         .findUnique({
           where: { id: refs.cycleId },
-          select: { workspaceId: true },
+          select: { workspaceId: true, productId: true },
         })
-        .then((row) => ({
-          label: "Cycle",
-          refWorkspaceId: row?.workspaceId ?? null,
-        })),
+        .then((row) => {
+          if (row && productId && row.productId && row.productId !== productId) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Cycle not found in this product",
+            });
+          }
+          return {
+            label: "Cycle",
+            refWorkspaceId: row?.workspaceId ?? null,
+          };
+        }),
     );
   }
 

--- a/src/test/factories/index.ts
+++ b/src/test/factories/index.ts
@@ -428,18 +428,24 @@ export async function createCycle(
   overrides: {
     workspaceId: string;
     createdById: string;
+    productId?: string;
     name?: string;
     slug?: string;
+    startDate?: Date;
+    endDate?: Date;
   },
 ) {
   return db.list.create({
     data: {
       workspaceId: overrides.workspaceId,
       createdById: overrides.createdById,
+      productId: overrides.productId,
       name: overrides.name ?? `Test Cycle ${uid()}`,
       slug: overrides.slug ?? `test-cycle-${uid()}`,
       listType: "SPRINT",
       status: "PLANNED",
+      startDate: overrides.startDate,
+      endDate: overrides.endDate,
     },
   });
 }


### PR DESCRIPTION
## Problem

Creating the first cycle for a product (e.g. Roots) failed with **"Cycle dates overlap with 'Cycle 8'"** even though Cycle 8 belongs to a different product's timeline. Cycles (`List` rows with `listType = SPRINT`) were purely workspace-scoped — there was no product↔cycle relationship at all — so every product in a workspace shared one cycle pool and one overlap constraint.

## Fix

- **Schema**: add `List.productId` (nullable FK to `Product`, indexed, cascade delete). `null` = legacy workspace-shared cycle.
- **Migration backfill**: each existing SPRINT cycle whose tickets all belong to exactly one product is assigned to that product; cycles with no tickets or mixed-product tickets stay shared (`null`).
- **Overlap validation** (`cycle.create` / `cycle.update`): only cycles of the *same product* conflict. Different products — and legacy shared cycles — run independent timelines.
- **Auto-generation / auto-numbering / `cycle.list`**: product-scoped. A product's Cycles tab generates cycles owned by that product; listing returns the product's cycles plus legacy shared ones.
- **Product overview hero**: prefers the product's own current cycle (or one holding its tickets), falls back only to a shared cycle — never another product's.
- **UI**: new-cycle page, Cycles tab, ticket pages, TicketPeek, and retro page pass `productId`, so cycle dropdowns only offer relevant cycles.

## Testing

- 3 new integration tests: overlapping dates allowed across products, still rejected within one product, legacy shared cycle doesn't block a product cycle, foreign-workspace `productId` rejected.
- Full suites pass locally: 2,934 unit + 364 integration (testcontainers ran `migrate deploy`, validating the hand-written migration SQL end to end).
- Migration also applied and verified on the local dev DB.

## Migration note

Contains a DB migration (`20260816090000_add_product_scope_to_cycles`). Independent of the in-flight calendar-feeds branch migration (different tables); merge order doesn't matter. Check the Prisma Migrate Production run after merge.