### PR TITLE
feat: V2 unified busy-time sync (Google + Microsoft into CalendarEvent)

### DIFF
--- a/prisma/migrations/20260816152820_connected_account_busy_time_sync/migration.sql
+++ b/prisma/migrations/20260816152820_connected_account_busy_time_sync/migration.sql
@@ -1,0 +1,15 @@
+-- AlterTable
+ALTER TABLE "ConnectedAccount" ADD COLUMN     "calendarLastSyncAttemptAt" TIMESTAMP(3),
+ADD COLUMN     "calendarLastSyncError" TEXT,
+ADD COLUMN     "calendarLastSyncedAt" TIMESTAMP(3),
+ADD COLUMN     "calendarSyncStatus" TEXT NOT NULL DEFAULT 'pending';
+
+-- CreateIndex
+CREATE INDEX "CalendarEvent_connectedAccountId_idx" ON "CalendarEvent"("connectedAccountId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CalendarEvent_connectedAccountId_providerCalendarId_externa_key" ON "CalendarEvent"("connectedAccountId", "providerCalendarId", "externalId", "startsAt");
+
+-- AddForeignKey
+ALTER TABLE "CalendarEvent" ADD CONSTRAINT "CalendarEvent_connectedAccountId_fkey" FOREIGN KEY ("connectedAccountId") REFERENCES "ConnectedAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,10 +57,17 @@ model ConnectedAccount {
   expires_at         Int?
   token_type         String?
   scope              String?
+  // Server-side busy-time sync bookkeeping (V2 calendar sync) — mirrors the
+  // CalendarFeed fields. Attempt-stamped so the cron sweep can order fairly.
+  calendarSyncStatus        String    @default("pending") // pending | ok | error
+  calendarLastSyncedAt      DateTime?
+  calendarLastSyncAttemptAt DateTime?
+  calendarLastSyncError     String?
   createdAt          DateTime            @default(now())
   updatedAt          DateTime            @updatedAt
   user               User                @relation(fields: [userId], references: [id], onDelete: Cascade)
   calendarPreference CalendarPreference?
+  calendarEvents     CalendarEvent[]
 
   @@unique([userId, provider, providerAccountId])
   @@index([userId])
@@ -2068,13 +2075,17 @@ model CalendarEvent {
   syncedAt           DateTime
   user               User          @relation(fields: [userId], references: [id], onDelete: Cascade)
   calendarFeed       CalendarFeed? @relation(fields: [calendarFeedId], references: [id], onDelete: Cascade)
+  connectedAccount   ConnectedAccount? @relation(fields: [connectedAccountId], references: [id], onDelete: Cascade)
 
   /// Feed-scoped so the same event (UID + start) appearing in two of a
   /// user's feeds keeps both rows — each feed owns its copy independently.
-  /// V2's provider rows (null calendarFeedId) add their own key shape.
   @@unique([calendarFeedId, externalId, startsAt])
+  /// Provider rows (V2): scoped per account + calendar, so a shared event
+  /// visible in two calendars keeps both busy blocks.
+  @@unique([connectedAccountId, providerCalendarId, externalId, startsAt])
   @@index([userId, startsAt, endsAt])
   @@index([calendarFeedId])
+  @@index([connectedAccountId])
 }
 
 model ScheduledNotification {

--- a/src/app/_components/calendar/CalendarSidebar.tsx
+++ b/src/app/_components/calendar/CalendarSidebar.tsx
@@ -9,8 +9,10 @@ import {
   Menu,
   ActionIcon,
   Loader,
+  Tooltip,
 } from "@mantine/core";
 import {
+  IconAlertTriangle,
   IconBrandGoogle,
   IconBrandWindows,
   IconPlus,
@@ -182,6 +184,25 @@ export function CalendarSidebar({
                     >
                       {account.email ?? account.name ?? "Calendar account"}
                     </Text>
+                    {/* Busy-time sync status (V2) — display fetches are
+                        live, so only surface the background sync's error. */}
+                    {account.syncStatus === "error" && (
+                      <Tooltip
+                        label={account.lastSyncError ?? "Background calendar sync failed."}
+                        multiline
+                        maw={280}
+                        withinPortal
+                      >
+                        <ActionIcon
+                          variant="transparent"
+                          size="sm"
+                          aria-label={`Background sync failed: ${account.lastSyncError ?? "unknown error"}`}
+                          className="flex-shrink-0 cursor-default"
+                        >
+                          <IconAlertTriangle size={14} className="text-brand-warning" />
+                        </ActionIcon>
+                      </Tooltip>
+                    )}
                     <Menu position="bottom-end" withinPortal>
                       <Menu.Target>
                         <ActionIcon

--- a/src/server/api/routers/calendar.ts
+++ b/src/server/api/routers/calendar.ts
@@ -475,6 +475,9 @@ export const calendarRouter = createTRPCRouter({
         access_token: true,
         refresh_token: true,
         providerEmail: true,
+        calendarSyncStatus: true,
+        calendarLastSyncedAt: true,
+        calendarLastSyncError: true,
         user: { select: { email: true, name: true } },
       },
       orderBy: { id: "asc" },
@@ -512,6 +515,11 @@ export const calendarRouter = createTRPCRouter({
           name: account.user.name,
           selectedCalendarIds,
           calendars,
+          // Server-side busy-time sync bookkeeping (V2) for the sidebar's
+          // per-account status display.
+          syncStatus: account.calendarSyncStatus,
+          lastSyncedAt: account.calendarLastSyncedAt,
+          lastSyncError: account.calendarLastSyncError,
         };
       }),
     );

--- a/src/server/services/calendar/CalendarSyncService.ts
+++ b/src/server/services/calendar/CalendarSyncService.ts
@@ -591,10 +591,11 @@ export interface CalendarSweepResult {
 }
 
 /**
- * Providers included in the busy-time account sweep. Microsoft only for now
- * — the Google path follows once the OAuth-tester gate is threaded through.
+ * Providers included in the busy-time account sweep. Google accounts are
+ * additionally gated per user by the OAuth-tester allowlist — non-testers'
+ * tokens must not be exercised against Google's unverified scopes.
  */
-const SWEEP_ACCOUNT_PROVIDERS = ["microsoft-entra-id"];
+const SWEEP_ACCOUNT_PROVIDERS = ["microsoft-entra-id", "google"];
 
 /**
  * One bounded cron sweep: re-sync the enabled ICS feeds and the connected
@@ -637,15 +638,22 @@ export async function runCalendarSync(
   // Busy-time account sweep — same fairness ordering, its own batch cap.
   // Only accounts with a usable token are worth attempting; a token-less row
   // would just churn into error state every 15 minutes.
-  const accounts = await db.connectedAccount.findMany({
+  const candidates = await db.connectedAccount.findMany({
     where: {
       provider: { in: SWEEP_ACCOUNT_PROVIDERS },
       access_token: { not: null },
     },
-    select: { id: true },
+    select: { id: true, provider: true, user: { select: { email: true } } },
     orderBy: { calendarLastSyncAttemptAt: { sort: "asc", nulls: "first" } },
     take: ACCOUNT_SYNC_BATCH_SIZE,
   });
+
+  // Same lazy-import rationale as the provider services.
+  const { isGoogleOAuthTester } = await import("~/lib/googleAuth");
+  const accounts = candidates.filter(
+    (account) =>
+      account.provider !== "google" || isGoogleOAuthTester(account.user.email),
+  );
 
   result.accounts.processed = accounts.length;
   for (const account of accounts) {

--- a/src/server/services/calendar/CalendarSyncService.ts
+++ b/src/server/services/calendar/CalendarSyncService.ts
@@ -12,6 +12,7 @@ import type { PrismaClient } from "@prisma/client";
 
 import { decryptFromBase64 } from "~/server/utils/encryption";
 import { type ResolveHost } from "~/server/utils/privateAddress";
+import type { CalendarEvent as ProviderEvent, CalendarProvider } from "../CalendarProvider";
 import { assertSafeFeedUrl } from "./feedUrlGuard";
 
 /** Rolling sync window: −1 week / +8 weeks around "now". */
@@ -395,16 +396,211 @@ export async function syncFeed(
  */
 const SYNC_BATCH_SIZE = 50;
 
+/** Connected accounts per cron invocation — same bounding rationale. */
+const ACCOUNT_SYNC_BATCH_SIZE = 25;
+
+/** Per-calendar page size for provider fetches (no pagination in V2). */
+const PROVIDER_MAX_RESULTS = 500;
+
+/** Selected calendars synced per account, mirroring the display path's cap. */
+const MAX_CALENDARS_PER_ACCOUNT = 10;
+
+/**
+ * Instantiated lazily so importing this module (e.g. the pure parse tests)
+ * doesn't pull the provider services' env/db dependencies.
+ */
+async function providerServiceFor(provider: string): Promise<CalendarProvider | null> {
+  if (provider === "microsoft-entra-id") {
+    const { MicrosoftCalendarService } = await import("../MicrosoftCalendarService");
+    return new MicrosoftCalendarService();
+  }
+  if (provider === "google") {
+    const { GoogleCalendarService } = await import("../GoogleCalendarService");
+    return new GoogleCalendarService();
+  }
+  return null;
+}
+
+/**
+ * Parse a provider event's start/end into a concrete instant.
+ *
+ * Google emits RFC 3339 with an offset; Microsoft Graph emits a local-time
+ * string with NO offset plus a separate timeZone (UTC unless a Prefer header
+ * asked otherwise). A bare string parsed with `new Date()` would be read in
+ * the *server's* zone, so UTC-declared strings get an explicit Z.
+ */
+function providerInstant(
+  point: { dateTime?: string; date?: string; timeZone?: string },
+): { at: Date; isAllDay: boolean } | null {
+  if (point.date) {
+    const [y, m, d] = point.date.split("-").map(Number);
+    if (!y || !m || !d) return null;
+    return { at: new Date(Date.UTC(y, m - 1, d)), isAllDay: true };
+  }
+  if (!point.dateTime) return null;
+  const hasOffset = /(?:Z|[+-]\d\d:?\d\d)$/i.test(point.dateTime);
+  const raw =
+    !hasOffset && (point.timeZone === undefined || point.timeZone === "UTC")
+      ? `${point.dateTime}Z`
+      : point.dateTime;
+  const at = new Date(raw);
+  if (Number.isNaN(at.getTime())) return null;
+  return { at, isAllDay: false };
+}
+
+/** Normalize one provider event; null = skip (cancelled or unparseable). */
+export function normalizeProviderEvent(event: ProviderEvent): NormalizedEvent | null {
+  if (event.status === "cancelled") return null;
+  const start = providerInstant(event.start);
+  const end = event.end ? providerInstant(event.end) : null;
+  if (!start) return null;
+  return {
+    externalId: event.id,
+    title: event.summary ?? null,
+    location: event.location ?? null,
+    startsAt: start.at,
+    endsAt: end?.at ?? start.at,
+    isAllDay: start.isAllDay,
+  };
+}
+
+export type SyncAccountResult =
+  | { ok: true; eventCount: number }
+  | { ok: false; error: string };
+
+/**
+ * Server-side busy-time sync for one connected account (V2): fetch the
+ * account's selected calendars via the provider service — which refreshes
+ * tokens from the stored refresh_token, no user session in hand — and
+ * delete-and-replace its CalendarEvent rows. Failures retain prior rows and
+ * land on the account's calendarSyncStatus, mirroring feed sync.
+ */
+export async function syncConnectedAccount(
+  db: PrismaClient,
+  accountId: string,
+): Promise<SyncAccountResult> {
+  const account = await db.connectedAccount.findUnique({
+    where: { id: accountId },
+    select: {
+      id: true,
+      userId: true,
+      provider: true,
+      calendarSyncStatus: true,
+      calendarPreference: { select: { selectedCalendarIds: true } },
+    },
+  });
+  if (!account) return { ok: false, error: "Account not found" };
+
+  const syncedAt = new Date();
+  await db.connectedAccount.update({
+    where: { id: accountId },
+    data: { calendarLastSyncAttemptAt: syncedAt },
+  });
+
+  const recordFailure = async (message: string, cause?: unknown): Promise<SyncAccountResult> => {
+    if (account.calendarSyncStatus !== "error") {
+      try {
+        const { reportHandledErrorServer } = await import(
+          "~/server/utils/reportHandledErrorServer"
+        );
+        reportHandledErrorServer(cause ?? new Error(message), {
+          area: "calendar.syncConnectedAccount",
+          context: { accountId, provider: account.provider },
+        });
+      } catch {
+        // Reporting must never break the sync flow.
+      }
+    }
+    await db.connectedAccount.update({
+      where: { id: accountId },
+      data: { calendarSyncStatus: "error", calendarLastSyncError: message.slice(0, 500) },
+    });
+    return { ok: false, error: message };
+  };
+
+  const service = await providerServiceFor(account.provider);
+  if (!service) return recordFailure(`Unsupported provider: ${account.provider}`);
+
+  const sourceType = account.provider === "google" ? "google" : "microsoft";
+  const window = getSyncWindow(syncedAt);
+  const calendarIds = (account.calendarPreference?.selectedCalendarIds ?? [])
+    .slice(0, MAX_CALENDARS_PER_ACCOUNT);
+  if (calendarIds.length === 0) calendarIds.push("primary");
+
+  const rows: (NormalizedEvent & { providerCalendarId: string })[] = [];
+  try {
+    for (const calendarId of calendarIds) {
+      const events = await service.getEvents(account.userId, {
+        accountId: account.id,
+        calendarId,
+        timeMin: window.from,
+        timeMax: window.to,
+        maxResults: PROVIDER_MAX_RESULTS,
+        useCache: false,
+      });
+      for (const event of events) {
+        const normalized = normalizeProviderEvent(event);
+        if (normalized) rows.push({ ...normalized, providerCalendarId: calendarId });
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown sync error";
+    return recordFailure(message, error);
+  }
+
+  await db.$transaction([
+    db.calendarEvent.deleteMany({ where: { connectedAccountId: accountId } }),
+    db.calendarEvent.createMany({
+      data: rows.map((row) => ({
+        userId: account.userId,
+        sourceType,
+        connectedAccountId: accountId,
+        providerCalendarId: row.providerCalendarId,
+        externalId: row.externalId,
+        title: row.title,
+        location: row.location,
+        startsAt: row.startsAt,
+        endsAt: row.endsAt,
+        isAllDay: row.isAllDay,
+        syncedAt,
+      })),
+      skipDuplicates: true,
+    }),
+    db.connectedAccount.update({
+      where: { id: accountId },
+      data: {
+        calendarSyncStatus: "ok",
+        calendarLastSyncedAt: syncedAt,
+        calendarLastSyncError: null,
+      },
+    }),
+  ]);
+
+  return { ok: true, eventCount: rows.length };
+}
+
 export interface CalendarSweepResult {
   processed: number;
   succeeded: number;
   failed: { feedId: string; error: string }[];
+  accounts: {
+    processed: number;
+    succeeded: number;
+    failed: { accountId: string; error: string }[];
+  };
 }
 
 /**
- * One bounded cron sweep: re-sync the enabled feeds that have gone longest
- * without a sync (never-synced first). Failures are recorded per-feed by
- * `syncFeed` and reported here; one broken feed never stops the sweep.
+ * Providers included in the busy-time account sweep. Microsoft only for now
+ * — the Google path follows once the OAuth-tester gate is threaded through.
+ */
+const SWEEP_ACCOUNT_PROVIDERS = ["microsoft-entra-id"];
+
+/**
+ * One bounded cron sweep: re-sync the enabled ICS feeds and the connected
+ * accounts (busy-time, V2) that have gone longest without a sync
+ * (never-synced first). Failures are recorded per-source by the sync
+ * functions and reported here; one broken source never stops the sweep.
  */
 export async function runCalendarSync(
   db: PrismaClient,
@@ -420,7 +616,12 @@ export async function runCalendarSync(
     take: SYNC_BATCH_SIZE,
   });
 
-  const result: CalendarSweepResult = { processed: feeds.length, succeeded: 0, failed: [] };
+  const result: CalendarSweepResult = {
+    processed: feeds.length,
+    succeeded: 0,
+    failed: [],
+    accounts: { processed: 0, succeeded: 0, failed: [] },
+  };
 
   // Sequential on purpose: feed hosts are third parties, and a serverless
   // function fanning out N concurrent fetches is how timeouts get flaky.
@@ -430,6 +631,29 @@ export async function runCalendarSync(
       result.succeeded += 1;
     } else {
       result.failed.push({ feedId: feed.id, error: outcome.error });
+    }
+  }
+
+  // Busy-time account sweep — same fairness ordering, its own batch cap.
+  // Only accounts with a usable token are worth attempting; a token-less row
+  // would just churn into error state every 15 minutes.
+  const accounts = await db.connectedAccount.findMany({
+    where: {
+      provider: { in: SWEEP_ACCOUNT_PROVIDERS },
+      access_token: { not: null },
+    },
+    select: { id: true },
+    orderBy: { calendarLastSyncAttemptAt: { sort: "asc", nulls: "first" } },
+    take: ACCOUNT_SYNC_BATCH_SIZE,
+  });
+
+  result.accounts.processed = accounts.length;
+  for (const account of accounts) {
+    const outcome = await syncConnectedAccount(db, account.id);
+    if (outcome.ok) {
+      result.accounts.succeeded += 1;
+    } else {
+      result.accounts.failed.push({ accountId: account.id, error: outcome.error });
     }
   }
 

--- a/src/server/services/calendar/__tests__/freeBusy.test.ts
+++ b/src/server/services/calendar/__tests__/freeBusy.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the free/busy contract. The load-bearing assertions are the
+ * privacy ones: the Prisma select must request ONLY the four busy fields (+
+ * userId for grouping), and the returned blocks must not carry event details
+ * even if the db hands extra columns back.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { mockDeep, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import { listBusyBlocksByUser } from "../freeBusy";
+
+const RANGE = {
+  from: new Date("2026-08-17T00:00:00Z"),
+  to: new Date("2026-08-24T00:00:00Z"),
+};
+
+describe("listBusyBlocksByUser", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = mockDeep<PrismaClient>();
+  });
+
+  it("selects ONLY the free/busy fields — title/location/attendee columns are never requested", async () => {
+    db.calendarEvent.findMany.mockResolvedValue([] as never);
+
+    await listBusyBlocksByUser(db, ["user-a"], RANGE);
+
+    const arg = db.calendarEvent.findMany.mock.calls[0]![0] as {
+      select: Record<string, boolean>;
+    };
+    expect(arg.select).toEqual({
+      userId: true,
+      startsAt: true,
+      endsAt: true,
+      isAllDay: true,
+      sourceType: true,
+    });
+  });
+
+  it("strips any extra fields a sloppy caller-side row might carry", async () => {
+    // Simulate a row that (wrongly) includes details — the mapped output
+    // must still be details-free.
+    db.calendarEvent.findMany.mockResolvedValue([
+      {
+        userId: "user-a",
+        startsAt: new Date("2026-08-18T09:00:00Z"),
+        endsAt: new Date("2026-08-18T10:00:00Z"),
+        isAllDay: false,
+        sourceType: "microsoft",
+        title: "SECRET board meeting",
+        location: "SECRET room",
+      },
+    ] as never);
+
+    const result = await listBusyBlocksByUser(db, ["user-a"], RANGE);
+    const block = result.get("user-a")![0]!;
+
+    expect(block).toEqual({
+      startsAt: new Date("2026-08-18T09:00:00Z"),
+      endsAt: new Date("2026-08-18T10:00:00Z"),
+      isAllDay: false,
+      sourceType: "microsoft",
+    });
+    expect(JSON.stringify(result.get("user-a"))).not.toMatch(/SECRET/);
+  });
+
+  it("groups blocks per user and includes empty entries for block-less users", async () => {
+    db.calendarEvent.findMany.mockResolvedValue([
+      {
+        userId: "user-a",
+        startsAt: new Date("2026-08-18T09:00:00Z"),
+        endsAt: new Date("2026-08-18T10:00:00Z"),
+        isAllDay: false,
+        sourceType: "ics",
+      },
+    ] as never);
+
+    const result = await listBusyBlocksByUser(db, ["user-a", "user-b"], RANGE);
+
+    expect(result.get("user-a")).toHaveLength(1);
+    // Present-but-empty ≠ missing: "free all week" is an answer.
+    expect(result.get("user-b")).toEqual([]);
+  });
+
+  it("scopes to the requested users and range, counting only enabled ICS feeds", async () => {
+    db.calendarEvent.findMany.mockResolvedValue([] as never);
+
+    await listBusyBlocksByUser(db, ["user-a", "user-b"], RANGE);
+
+    const arg = db.calendarEvent.findMany.mock.calls[0]![0] as {
+      where: Record<string, unknown>;
+    };
+    expect(arg.where).toMatchObject({
+      userId: { in: ["user-a", "user-b"] },
+      startsAt: { lt: RANGE.to },
+      endsAt: { gt: RANGE.from },
+      OR: [{ sourceType: { not: "ics" } }, { calendarFeed: { isEnabled: true } }],
+    });
+  });
+
+  it("returns empty map without querying when no users are requested", async () => {
+    const result = await listBusyBlocksByUser(db, [], RANGE);
+
+    expect(result.size).toBe(0);
+    expect(db.calendarEvent.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/calendar/__tests__/normalizeProviderEvent.test.ts
+++ b/src/server/services/calendar/__tests__/normalizeProviderEvent.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for normalizeProviderEvent — the pure mapping from a provider
+ * service's CalendarEvent payload to a persistable row. The interesting part
+ * is instant parsing: Google emits RFC 3339 with an offset, Microsoft Graph
+ * emits local-time strings with NO offset plus a separate timeZone.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { normalizeProviderEvent } from "../CalendarSyncService";
+
+const base = {
+  id: "evt-1",
+  summary: "Busy block",
+  htmlLink: "",
+  status: "confirmed",
+};
+
+describe("normalizeProviderEvent", () => {
+  it("parses a Microsoft-style UTC string without offset as UTC", () => {
+    const row = normalizeProviderEvent({
+      ...base,
+      start: { dateTime: "2026-08-18T09:00:00.0000000", timeZone: "UTC" },
+      end: { dateTime: "2026-08-18T10:00:00.0000000", timeZone: "UTC" },
+    });
+
+    expect(row!.startsAt.toISOString()).toBe("2026-08-18T09:00:00.000Z");
+    expect(row!.endsAt.toISOString()).toBe("2026-08-18T10:00:00.000Z");
+    expect(row!.isAllDay).toBe(false);
+  });
+
+  it("parses a Google-style RFC 3339 string with offset", () => {
+    const row = normalizeProviderEvent({
+      ...base,
+      start: { dateTime: "2026-08-18T11:00:00+02:00" },
+      end: { dateTime: "2026-08-18T12:00:00+02:00" },
+    });
+
+    expect(row!.startsAt.toISOString()).toBe("2026-08-18T09:00:00.000Z");
+    expect(row!.endsAt.toISOString()).toBe("2026-08-18T10:00:00.000Z");
+  });
+
+  it("anchors all-day dates to UTC midnight", () => {
+    const row = normalizeProviderEvent({
+      ...base,
+      start: { date: "2026-08-20" },
+      end: { date: "2026-08-21" },
+    });
+
+    expect(row!.isAllDay).toBe(true);
+    expect(row!.startsAt.toISOString()).toBe("2026-08-20T00:00:00.000Z");
+    expect(row!.endsAt.toISOString()).toBe("2026-08-21T00:00:00.000Z");
+  });
+
+  it("skips cancelled events", () => {
+    expect(
+      normalizeProviderEvent({
+        ...base,
+        status: "cancelled",
+        start: { dateTime: "2026-08-18T09:00:00Z" },
+        end: { dateTime: "2026-08-18T10:00:00Z" },
+      }),
+    ).toBeNull();
+  });
+
+  it("skips events with an unparseable start", () => {
+    expect(
+      normalizeProviderEvent({
+        ...base,
+        start: { dateTime: "not a date", timeZone: "Pacific/Fiji" },
+        end: { dateTime: "2026-08-18T10:00:00Z" },
+      }),
+    ).toBeNull();
+  });
+
+  it("defaults a missing end to the start instant", () => {
+    const row = normalizeProviderEvent({
+      ...base,
+      start: { dateTime: "2026-08-18T09:00:00Z" },
+      end: {},
+    });
+
+    expect(row!.endsAt.getTime()).toBe(row!.startsAt.getTime());
+  });
+});

--- a/src/server/services/calendar/__tests__/syncConnectedAccount.integration.test.ts
+++ b/src/server/services/calendar/__tests__/syncConnectedAccount.integration.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Integration test for the V2 busy-time account sync: a Microsoft
+ * ConnectedAccount's events land in CalendarEvent via the stored token, with
+ * the same delete-and-replace and failure-retention contract as feed sync.
+ *
+ * Microsoft Graph is stubbed at the fetch layer; the account carries a
+ * non-expired access token so no token-refresh round trip happens. Only
+ * Postgres is real.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { getTestDb } from "~/test/test-db";
+import { createUser } from "~/test/factories";
+import { syncConnectedAccount, runCalendarSync } from "../CalendarSyncService";
+
+const DAY = 24 * 60 * 60 * 1000;
+const startA = new Date(Date.now() + 2 * DAY);
+const endA = new Date(startA.getTime() + 60 * 60 * 1000);
+
+/** Graph calendarView payload: UTC local-time strings without offset. */
+function graphPayload(events: { id: string; subject: string; start: Date; end: Date }[]) {
+  const fmt = (d: Date) => d.toISOString().replace(/Z$/, "0000");
+  return {
+    value: events.map((e) => ({
+      id: e.id,
+      subject: e.subject,
+      bodyPreview: "",
+      start: { dateTime: fmt(e.start), timeZone: "UTC" },
+      end: { dateTime: fmt(e.end), timeZone: "UTC" },
+      location: { displayName: "Room 1" },
+      attendees: [],
+      webLink: "https://outlook.example/e",
+      showAs: "busy",
+      isCancelled: false,
+      isAllDay: false,
+    })),
+  };
+}
+
+function stubGraph(payload: unknown, status = 200) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response(JSON.stringify(payload), { status })),
+  );
+}
+
+describe("syncConnectedAccount — Microsoft busy-time sync", () => {
+  let db: ReturnType<typeof getTestDb>;
+
+  beforeEach(() => {
+    db = getTestDb();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  async function seedAccount() {
+    const user = await createUser(db);
+    const account = await db.connectedAccount.create({
+      data: {
+        userId: user.id,
+        provider: "microsoft-entra-id",
+        providerAccountId: `ms-${user.id}`,
+        access_token: "test-access-token",
+        refresh_token: "test-refresh-token",
+        // Non-expired, so getAccessToken uses the stored token directly.
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        scope: "Calendars.Read",
+      },
+    });
+    return { user, account };
+  }
+
+  it("persists busy rows queryable server-side with no session in hand", async () => {
+    const { user, account } = await seedAccount();
+    stubGraph(graphPayload([{ id: "graph-1", subject: "Design sync", start: startA, end: endA }]));
+
+    const result = await syncConnectedAccount(db, account.id);
+
+    expect(result).toMatchObject({ ok: true, eventCount: 1 });
+    const rows = await db.calendarEvent.findMany({ where: { userId: user.id } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      sourceType: "microsoft",
+      connectedAccountId: account.id,
+      providerCalendarId: "primary",
+      externalId: "graph-1",
+      title: "Design sync",
+      isAllDay: false,
+    });
+    // The UTC-without-offset Graph string round-trips to the exact instant.
+    expect(rows[0]!.startsAt.getTime()).toBe(startA.getTime());
+
+    const updated = await db.connectedAccount.findUniqueOrThrow({ where: { id: account.id } });
+    expect(updated.calendarSyncStatus).toBe("ok");
+    expect(updated.calendarLastSyncedAt).not.toBeNull();
+  });
+
+  it("keeps prior rows and marks the account on API failure, stamping the attempt", async () => {
+    const { user, account } = await seedAccount();
+    stubGraph(graphPayload([{ id: "graph-1", subject: "Keep me", start: startA, end: endA }]));
+    await syncConnectedAccount(db, account.id);
+
+    stubGraph({ error: { code: "InvalidAuthenticationToken" } }, 401);
+    const result = await syncConnectedAccount(db, account.id);
+
+    expect(result.ok).toBe(false);
+    const rows = await db.calendarEvent.findMany({ where: { userId: user.id } });
+    expect(rows.map((r) => r.externalId)).toEqual(["graph-1"]);
+
+    const updated = await db.connectedAccount.findUniqueOrThrow({ where: { id: account.id } });
+    expect(updated.calendarSyncStatus).toBe("error");
+    expect(updated.calendarLastSyncError).toBeTruthy();
+    expect(updated.calendarLastSyncAttemptAt).not.toBeNull();
+  });
+
+  it("replaces rows on re-sync (events removed upstream disappear)", async () => {
+    const { user, account } = await seedAccount();
+    stubGraph(
+      graphPayload([
+        { id: "graph-1", subject: "A", start: startA, end: endA },
+        { id: "graph-2", subject: "B", start: endA, end: new Date(endA.getTime() + DAY) },
+      ]),
+    );
+    await syncConnectedAccount(db, account.id);
+
+    stubGraph(graphPayload([{ id: "graph-1", subject: "A", start: startA, end: endA }]));
+    await syncConnectedAccount(db, account.id);
+
+    const rows = await db.calendarEvent.findMany({ where: { userId: user.id } });
+    expect(rows.map((r) => r.externalId)).toEqual(["graph-1"]);
+  });
+
+  it("runCalendarSync sweeps Microsoft accounts alongside feeds", async () => {
+    const { user, account } = await seedAccount();
+    stubGraph(graphPayload([{ id: "graph-1", subject: "Swept", start: startA, end: endA }]));
+
+    const result = await runCalendarSync(db);
+
+    expect(result.accounts.processed).toBe(1);
+    expect(result.accounts.succeeded).toBe(1);
+    const rows = await db.calendarEvent.findMany({ where: { userId: user.id } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.connectedAccountId).toBe(account.id);
+  });
+});

--- a/src/server/services/calendar/__tests__/syncConnectedAccount.integration.test.ts
+++ b/src/server/services/calendar/__tests__/syncConnectedAccount.integration.test.ts
@@ -133,6 +133,53 @@ describe("syncConnectedAccount — Microsoft busy-time sync", () => {
     expect(rows.map((r) => r.externalId)).toEqual(["graph-1"]);
   });
 
+  it("skips Google accounts of non-testers, sweeps Google testers", async () => {
+    const nonTester = await createUser(db, { email: "regular@example.com" });
+    await db.connectedAccount.create({
+      data: {
+        userId: nonTester.id,
+        provider: "google",
+        providerAccountId: `g-${nonTester.id}`,
+        access_token: "tok",
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      },
+    });
+    const tester = await createUser(db, { email: "tester@example.com" });
+    const testerAccount = await db.connectedAccount.create({
+      data: {
+        userId: tester.id,
+        provider: "google",
+        providerAccountId: `g-${tester.id}`,
+        access_token: "tok",
+        refresh_token: "ref",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      },
+    });
+
+    vi.stubEnv("GOOGLE_OAUTH_TESTER_EMAILS", "tester@example.com");
+    // Whatever the Google client does under the hood, this run must never
+    // reach the real API — a failing stub still proves "attempted".
+    stubGraph({ error: "stubbed" }, 500);
+    try {
+      const result = await runCalendarSync(db);
+
+      // Only the tester's account was attempted at all.
+      expect(result.accounts.processed).toBe(1);
+      const testerRow = await db.connectedAccount.findUniqueOrThrow({
+        where: { id: testerAccount.id },
+      });
+      expect(testerRow.calendarLastSyncAttemptAt).not.toBeNull();
+
+      const nonTesterRow = await db.connectedAccount.findFirstOrThrow({
+        where: { userId: nonTester.id },
+      });
+      expect(nonTesterRow.calendarLastSyncAttemptAt).toBeNull();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("runCalendarSync sweeps Microsoft accounts alongside feeds", async () => {
     const { user, account } = await seedAccount();
     stubGraph(graphPayload([{ id: "graph-1", subject: "Swept", start: startA, end: endA }]));

--- a/src/server/services/calendar/__tests__/syncConnectedAccount.integration.test.ts
+++ b/src/server/services/calendar/__tests__/syncConnectedAccount.integration.test.ts
@@ -133,6 +133,28 @@ describe("syncConnectedAccount — Microsoft busy-time sync", () => {
     expect(rows.map((r) => r.externalId)).toEqual(["graph-1"]);
   });
 
+  it("marks the account without wiping rows when the token refresh itself fails", async () => {
+    const { user, account } = await seedAccount();
+    stubGraph(graphPayload([{ id: "graph-1", subject: "Keep me", start: startA, end: endA }]));
+    await syncConnectedAccount(db, account.id);
+
+    // Expire the token; the refresh endpoint rejects (revoked consent).
+    await db.connectedAccount.update({
+      where: { id: account.id },
+      data: { expires_at: Math.floor(Date.now() / 1000) - 60 },
+    });
+    stubGraph({ error: "invalid_grant" }, 400);
+
+    const result = await syncConnectedAccount(db, account.id);
+
+    expect(result.ok).toBe(false);
+    const rows = await db.calendarEvent.findMany({ where: { userId: user.id } });
+    expect(rows.map((r) => r.externalId)).toEqual(["graph-1"]);
+    const updated = await db.connectedAccount.findUniqueOrThrow({ where: { id: account.id } });
+    expect(updated.calendarSyncStatus).toBe("error");
+    expect(updated.calendarLastSyncError).toMatch(/reconnect/i);
+  });
+
   it("skips Google accounts of non-testers, sweeps Google testers", async () => {
     const nonTester = await createUser(db, { email: "regular@example.com" });
     await db.connectedAccount.create({

--- a/src/server/services/calendar/freeBusy.ts
+++ b/src/server/services/calendar/freeBusy.ts
@@ -1,0 +1,67 @@
+/**
+ * The free/busy read contract (V2 → consumed by V3 scheduling).
+ *
+ * PRIVACY INVARIANT (hard, per the feature PRD and ADR-0057): cross-user
+ * calendar reads expose ONLY start/end/all-day/source. Never title, location,
+ * or attendees. The enforcement is structural — the Prisma `select` below is
+ * the whole contract, not a post-filter — so a future procedure can only leak
+ * event details by visibly editing this select, which fails review.
+ *
+ * Any V3 procedure that reads other users' CalendarEvent rows MUST go
+ * through this helper rather than querying the table directly.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+export interface BusyBlock {
+  startsAt: Date;
+  endsAt: Date;
+  isAllDay: boolean;
+  sourceType: string;
+}
+
+/**
+ * Busy blocks for each requested user overlapping [from, to), from every
+ * synced source: ICS feed rows (enabled feeds only — a disabled feed is the
+ * owner saying "this calendar doesn't count") and provider busy-time rows.
+ *
+ * Returns a map keyed by userId; users with no rows are present with an
+ * empty array so callers can tell "free all day" from "not queried".
+ */
+export async function listBusyBlocksByUser(
+  db: PrismaClient,
+  userIds: string[],
+  range: { from: Date; to: Date },
+): Promise<Map<string, BusyBlock[]>> {
+  const byUser = new Map<string, BusyBlock[]>(userIds.map((id) => [id, []]));
+  if (userIds.length === 0) return byUser;
+
+  const rows = await db.calendarEvent.findMany({
+    where: {
+      userId: { in: userIds },
+      startsAt: { lt: range.to },
+      endsAt: { gt: range.from },
+      OR: [{ sourceType: { not: "ics" } }, { calendarFeed: { isEnabled: true } }],
+    },
+    // THE free/busy contract. Do not add fields here — see module doc.
+    select: {
+      userId: true,
+      startsAt: true,
+      endsAt: true,
+      isAllDay: true,
+      sourceType: true,
+    },
+    orderBy: { startsAt: "asc" },
+  });
+
+  for (const row of rows) {
+    byUser.get(row.userId)?.push({
+      startsAt: row.startsAt,
+      endsAt: row.endsAt,
+      isAllDay: row.isAllDay,
+      sourceType: row.sourceType,
+    });
+  }
+
+  return byUser;
+}


### PR DESCRIPTION
## What

**V2 — unified busy-time sync**: the calendar cron sweep now pulls each connected Google/Microsoft account's events server-side — via refresh tokens already stored on `ConnectedAccount`, no user session in hand — into the same `CalendarEvent` table (`sourceType: "google" | "microsoft"`). Cross-workspace availability becomes a single DB query for every connected member, and the free/busy read contract V3's scheduling consumes ships here: `listBusyBlocksByUser` exposes only `startsAt/endsAt/isAllDay/sourceType`, enforced structurally in the Prisma select.

Google accounts are gated per user by the OAuth-tester allowlist (non-testers' tokens are never exercised). Token-refresh failure marks the account's sync status without wiping rows; per-account status surfaces in the calendar sidebar. Existing UI read paths stay live-fetch — this scope is invisible to end users.

**Migration** (`connected_account_busy_time_sync`): ConnectedAccount sync bookkeeping columns + CalendarEvent provider-row unique key and cascade FK — applies on merge via the production migrate step.

Handles the Graph quirk where `dateTime` strings carry no offset (declared-UTC strings get an explicit Z so stored instants don't depend on server timezone).

## Acceptance criteria

- [x] Both V2 requirement rows met (server-side Google+Microsoft sync on the shared cadence; free/busy-only cross-user reads as a CONSTRAINT)
- [x] No existing UI read path migrated onto the table (explicitly out of scope)
- [x] Cron work bounded per invocation (batch of 25 accounts, oldest-attempt-first)

---

Ships: frosty.gecko
