### PR TITLE
feat: V3 workspace meeting scheduling

### DIFF
--- a/prisma/migrations/20260816154709_meetings/migration.sql
+++ b/prisma/migrations/20260816154709_meetings/migration.sql
@@ -1,0 +1,56 @@
+-- CreateTable
+CREATE TABLE "Meeting" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "organizerId" TEXT NOT NULL,
+    "projectId" TEXT,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "location" TEXT,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "endsAt" TIMESTAMP(3) NOT NULL,
+    "icalUid" TEXT NOT NULL,
+    "sequence" INTEGER NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'confirmed',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Meeting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MeetingAttendee" (
+    "id" TEXT NOT NULL,
+    "meetingId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "MeetingAttendee_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Meeting_icalUid_key" ON "Meeting"("icalUid");
+
+-- CreateIndex
+CREATE INDEX "Meeting_workspaceId_startsAt_idx" ON "Meeting"("workspaceId", "startsAt");
+
+-- CreateIndex
+CREATE INDEX "MeetingAttendee_userId_idx" ON "MeetingAttendee"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MeetingAttendee_meetingId_userId_key" ON "MeetingAttendee"("meetingId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "Meeting" ADD CONSTRAINT "Meeting_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Meeting" ADD CONSTRAINT "Meeting_organizerId_fkey" FOREIGN KEY ("organizerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Meeting" ADD CONSTRAINT "Meeting_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingAttendee" ADD CONSTRAINT "MeetingAttendee_meetingId_fkey" FOREIGN KEY ("meetingId") REFERENCES "Meeting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingAttendee" ADD CONSTRAINT "MeetingAttendee_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -134,6 +134,8 @@ model User {
   calendarPreferences            CalendarPreference[]
   calendarFeeds                  CalendarFeed[]
   calendarEvents                 CalendarEvent[]
+  meetingsOrganized              Meeting[]                       @relation("MeetingOrganizer")
+  meetingAttendances             MeetingAttendee[]
   outcomes                       Outcome[]
   posts                          Post[]
   projects                       Project[]
@@ -401,6 +403,7 @@ model Workspace {
 
   owner                   User                            @relation("WorkspaceOwner", fields: [ownerId], references: [id])
   members                 WorkspaceUser[]
+  meetings                Meeting[]
   projects                Project[]
   epics                   Epic[]
   goals                   Goal[]
@@ -1036,6 +1039,7 @@ model Project {
   slackConfig           SlackChannelConfig?
   channelLinks          ChannelLink[]
   transcriptionSessions TranscriptionSession[]
+  meetings              Meeting[]
   workflows             Workflow[]
   goals                 Goal[]                     @relation("GoalProjects")
   outcomes              Outcome[]                  @relation("ProjectOutcomes")
@@ -2086,6 +2090,50 @@ model CalendarEvent {
   @@index([userId, startsAt, endsAt])
   @@index([calendarFeedId])
   @@index([connectedAccountId])
+}
+
+/// A scheduled workspace meeting (V3 calendar scheduling) — forward-looking,
+/// distinct from the retrospective TranscriptionSession. The write path to
+/// attendees' real calendars is exclusively the iCalendar email invite
+/// (METHOD:REQUEST / METHOD:CANCEL against icalUid, monotonic sequence) —
+/// no API write-back. Reschedule = cancel + rebook (V3 non-goal).
+model Meeting {
+  id          String   @id @default(cuid())
+  workspaceId String
+  organizerId String
+  projectId   String?
+  title       String
+  /// Markdown (ADR-0017).
+  description String?
+  /// Manual free-text location or meeting link — no auto conference links.
+  location    String?
+  startsAt    DateTime
+  endsAt      DateTime
+  /// Stable across the meeting's lifetime; what external calendars key on.
+  icalUid     String   @unique
+  /// Bumped on every outbound iCalendar change (cancel included).
+  sequence    Int      @default(0)
+  status      String   @default("confirmed") // confirmed | cancelled
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  workspace Workspace         @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  organizer User              @relation("MeetingOrganizer", fields: [organizerId], references: [id])
+  project   Project?          @relation(fields: [projectId], references: [id])
+  attendees MeetingAttendee[]
+
+  @@index([workspaceId, startsAt])
+}
+
+model MeetingAttendee {
+  id        String  @id @default(cuid())
+  meetingId String
+  userId    String
+  meeting   Meeting @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+  user      User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([meetingId, userId])
+  @@index([userId])
 }
 
 model ScheduledNotification {

--- a/src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { Suspense } from 'react';
-import { Container, Skeleton, Stack, Text } from '@mantine/core';
+import { Suspense, useState } from 'react';
+import { Button, Container, Group, Skeleton, Stack, Text } from '@mantine/core';
+import { IconCalendarPlus } from '@tabler/icons-react';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
+import { ScheduleMeetingModal } from '~/app/_components/calendar/ScheduleMeetingModal';
 import { WorkspaceHomeConceptD as WorkspaceHomeCommand } from '~/app/_components/home/WorkspaceHomeConceptD';
 import { WorkspaceHomeActivity } from '~/app/_components/home/WorkspaceHomeActivity';
 import { WorkspaceHomeCoaching } from '~/app/_components/home/WorkspaceHomeCoaching';
@@ -12,6 +14,7 @@ import { validateHomeLayout } from '~/app/_components/home/HomeLayoutPicker';
 
 function WorkspaceHomeContent() {
   const { workspace, isLoading: workspaceLoading } = useWorkspace();
+  const [scheduleOpen, setScheduleOpen] = useState(false);
 
   if (workspaceLoading) {
     return (
@@ -50,6 +53,22 @@ function WorkspaceHomeContent() {
       {/* Activity layout shows GitHub in the rail widget; other layouts have no
           rail, so they keep the top Connect banner. */}
       {layout !== 'activity' && <GithubConnectCta />}
+      {/* Workspace-page entry point for cross-member scheduling (V3). */}
+      <Group justify="flex-end" px="md" pt="sm">
+        <Button
+          size="xs"
+          variant="light"
+          leftSection={<IconCalendarPlus size={14} />}
+          onClick={() => setScheduleOpen(true)}
+        >
+          Schedule meeting
+        </Button>
+      </Group>
+      <ScheduleMeetingModal
+        opened={scheduleOpen}
+        onClose={() => setScheduleOpen(false)}
+        defaultWorkspaceId={workspace.id}
+      />
       {layoutContent}
     </>
   );

--- a/src/app/_components/calendar/CalendarHeader.tsx
+++ b/src/app/_components/calendar/CalendarHeader.tsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
 } from "@mantine/core";
 import {
+  IconCalendarPlus,
   IconChevronLeft,
   IconChevronRight,
   IconRefresh,
@@ -31,6 +32,7 @@ interface CalendarHeaderProps {
   isDisconnecting?: boolean;
   onRefresh?: () => void;
   isRefreshing?: boolean;
+  onScheduleMeeting?: () => void;
 }
 
 export function CalendarHeader({
@@ -47,6 +49,7 @@ export function CalendarHeader({
   isDisconnecting,
   onRefresh,
   isRefreshing,
+  onScheduleMeeting,
 }: CalendarHeaderProps) {
   // Format the header text based on view
   const headerText =
@@ -100,6 +103,16 @@ export function CalendarHeader({
           ]}
           size="sm"
         />
+        {onScheduleMeeting && (
+          <Button
+            size="sm"
+            variant="light"
+            leftSection={<IconCalendarPlus size={16} />}
+            onClick={onScheduleMeeting}
+          >
+            Schedule meeting
+          </Button>
+        )}
         {isConnected && onRefresh && (
           <Tooltip label="Refresh events" position="bottom">
             <ActionIcon

--- a/src/app/_components/calendar/CalendarPageContent.tsx
+++ b/src/app/_components/calendar/CalendarPageContent.tsx
@@ -21,6 +21,7 @@ import {
   TimezonePromptModal,
   TZ_PROMPT_DISMISSED_KEY,
 } from "./TimezonePromptModal";
+import { ScheduleMeetingModal } from "./ScheduleMeetingModal";
 import type { ScheduledAction, CalendarTimeEntry } from "./types";
 
 export function CalendarPageContent() {
@@ -64,6 +65,7 @@ export function CalendarPageContent() {
   // X-WR-TIMEZONE handed up from the sidebar's feed-add flow — this page owns
   // the single prompt, so the section doesn't open a second stacked modal.
   const [tzSuggestion, setTzSuggestion] = useState<string | null>(null);
+  const [scheduleOpen, setScheduleOpen] = useState(false);
   const tzPromptOpen =
     calendarConnected && tzData !== undefined && tzData.timezone === null && !tzPromptDismissed;
   const dismissTzPrompt = () => {
@@ -501,7 +503,9 @@ export function CalendarPageContent() {
         isDisconnecting={disconnectCalendar.isPending}
         onRefresh={handleRefresh}
         isRefreshing={isRefreshing}
+        onScheduleMeeting={() => setScheduleOpen(true)}
       />
+      <ScheduleMeetingModal opened={scheduleOpen} onClose={() => setScheduleOpen(false)} />
       <TimezonePromptModal
         opened={tzPromptOpen}
         onClose={dismissTzPrompt}

--- a/src/app/_components/calendar/CalendarPageContent.tsx
+++ b/src/app/_components/calendar/CalendarPageContent.tsx
@@ -82,7 +82,10 @@ export function CalendarPageContent() {
   // set, and with both components mounted — shows one toast, not two.
   useCalendarConnectionToast(calendarConnected);
 
-  // Fetch calendar events from all selected calendars
+  // Fetch calendar events from all selected calendars. Deliberately NOT
+  // gated on having a connected source: DB-backed sources (workspace
+  // meetings, ICS feeds) exist without any OAuth connection, and for a
+  // connection-less user the query is a cheap DB read.
   const { data: events, isLoading: eventsLoading } =
     api.calendar.getEventsMultiCalendar.useQuery(
       {
@@ -91,12 +94,15 @@ export function CalendarPageContent() {
         maxResults: view === "week" ? 100 : 50,
       },
       {
-        enabled: calendarConnected,
         retry: false,
         staleTime: 5 * 60 * 1000,
         refetchOnWindowFocus: false,
       }
     );
+
+  // A user whose only calendar content is meetings still gets the grid —
+  // the connect-a-calendar empty state is for users with nothing to show.
+  const hasRenderableEvents = (events?.length ?? 0) > 0;
 
   // Fetch scheduled actions for the date range
   const { data: scheduledActionsData } =
@@ -397,7 +403,7 @@ export function CalendarPageContent() {
       );
     }
 
-    if (!calendarConnected) {
+    if (!calendarConnected && !hasRenderableEvents) {
       // With Google gated, Outlook is the only calendar we can actually
       // connect — lead with the premium message rather than a broken option.
       if (googleGated) {

--- a/src/app/_components/calendar/ScheduleMeetingModal.tsx
+++ b/src/app/_components/calendar/ScheduleMeetingModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Button,
   Checkbox,
@@ -19,6 +19,7 @@ import { modals } from "@mantine/modals";
 import { api } from "~/trpc/react";
 import { ActionIcon, Tooltip } from "@mantine/core";
 import { useSession } from "next-auth/react";
+import { MarkdownInput } from "~/app/_components/shared/MarkdownInput";
 
 /**
  * "Schedule meeting" (V3 workspace scheduling), first cut: pick a workspace,
@@ -30,9 +31,12 @@ import { useSession } from "next-auth/react";
 export function ScheduleMeetingModal({
   opened,
   onClose,
+  defaultWorkspaceId,
 }: {
   opened: boolean;
   onClose: () => void;
+  /** Preselects the workspace — the workspace-page entry point sets this. */
+  defaultWorkspaceId?: string;
 }) {
   const utils = api.useUtils();
 
@@ -40,12 +44,23 @@ export function ScheduleMeetingModal({
     enabled: opened,
   });
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  useEffect(() => {
+    if (opened && defaultWorkspaceId) setWorkspaceId(defaultWorkspaceId);
+  }, [opened, defaultWorkspaceId]);
   const [attendeeIds, setAttendeeIds] = useState<string[]>([]);
   const [durationMinutes, setDurationMinutes] = useState("30");
   const [title, setTitle] = useState("");
+  const [location, setLocation] = useState("");
+  const [description, setDescription] = useState("");
+  const [projectId, setProjectId] = useState<string | null>(null);
   const [selectedSlot, setSelectedSlot] = useState<{ startsAt: Date; endsAt: Date } | null>(null);
   const [searching, setSearching] = useState(false);
   const [includeOutsideWorkHours, setIncludeOutsideWorkHours] = useState(false);
+
+  const { data: projects } = api.project.getAll.useQuery(
+    { workspaceId: workspaceId ?? undefined },
+    { enabled: opened && !!workspaceId },
+  );
 
   const { data: members } = api.workspaceScheduling.listSchedulableMembers.useQuery(
     { workspaceId: workspaceId! },
@@ -131,6 +146,9 @@ export function ScheduleMeetingModal({
   const handleClose = () => {
     setAttendeeIds([]);
     setTitle("");
+    setLocation("");
+    setDescription("");
+    setProjectId(null);
     setSelectedSlot(null);
     setSearching(false);
     onClose();
@@ -301,13 +319,41 @@ export function ScheduleMeetingModal({
         )}
 
         {selectedSlot && (
-          <TextInput
-            label="Title"
-            placeholder="What's the meeting about?"
-            value={title}
-            onChange={(e) => setTitle(e.currentTarget.value)}
-            data-autofocus
-          />
+          <>
+            <TextInput
+              label="Title"
+              placeholder="What's the meeting about?"
+              value={title}
+              onChange={(e) => setTitle(e.currentTarget.value)}
+              data-autofocus
+            />
+            <TextInput
+              label="Location / meeting link"
+              placeholder="Room, address, or a video-call link"
+              value={location}
+              onChange={(e) => setLocation(e.currentTarget.value)}
+            />
+            <Select
+              label="Project"
+              placeholder="Link to a project (optional)"
+              data={(projects ?? []).map((p) => ({ value: p.id, label: p.name }))}
+              value={projectId}
+              onChange={setProjectId}
+              searchable
+              clearable
+            />
+            <div>
+              <Text size="sm" fw={500} mb={4}>
+                Description
+              </Text>
+              <MarkdownInput
+                value={description}
+                onChange={setDescription}
+                placeholder="Agenda, links, context… (Markdown)"
+                minRows={3}
+              />
+            </div>
+          </>
         )}
 
         <Group justify="flex-end" mt="xs">
@@ -324,6 +370,9 @@ export function ScheduleMeetingModal({
               createMeeting.mutate({
                 workspaceId,
                 title: title.trim(),
+                location: location.trim() || undefined,
+                description: description.trim() || undefined,
+                projectId: projectId ?? undefined,
                 startsAt: selectedSlot.startsAt,
                 endsAt: selectedSlot.endsAt,
                 attendeeUserIds: attendeeIds,

--- a/src/app/_components/calendar/ScheduleMeetingModal.tsx
+++ b/src/app/_components/calendar/ScheduleMeetingModal.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Button,
+  Group,
+  Modal,
+  MultiSelect,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+  UnstyledButton,
+} from "@mantine/core";
+import { IconCalendarPlus } from "@tabler/icons-react";
+import { notifications } from "@mantine/notifications";
+import { api } from "~/trpc/react";
+
+/**
+ * "Schedule meeting" (V3 workspace scheduling), first cut: pick a workspace,
+ * attendees (members only — availability-unknown ones are labelled but
+ * invitable), duration → suggested slots over the next 7 days → confirm.
+ * Confirming creates the Meeting and emails every attendee a METHOD:REQUEST
+ * invite their mail client renders natively.
+ */
+export function ScheduleMeetingModal({
+  opened,
+  onClose,
+}: {
+  opened: boolean;
+  onClose: () => void;
+}) {
+  const utils = api.useUtils();
+
+  const { data: workspaces } = api.workspace.list.useQuery(undefined, {
+    enabled: opened,
+  });
+  const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const [attendeeIds, setAttendeeIds] = useState<string[]>([]);
+  const [durationMinutes, setDurationMinutes] = useState("30");
+  const [title, setTitle] = useState("");
+  const [selectedSlot, setSelectedSlot] = useState<{ startsAt: Date; endsAt: Date } | null>(null);
+  const [searching, setSearching] = useState(false);
+
+  const { data: members } = api.workspaceScheduling.listSchedulableMembers.useQuery(
+    { workspaceId: workspaceId! },
+    { enabled: opened && !!workspaceId },
+  );
+
+  // Rolling week starting "now" — good enough for the first cut.
+  const range = useMemo(
+    () => ({
+      rangeStart: new Date(),
+      rangeEnd: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    }),
+    // Recompute per open so a long-lived tab doesn't search the past.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [opened],
+  );
+
+  const slotsQuery = api.workspaceScheduling.suggestSlots.useQuery(
+    {
+      workspaceId: workspaceId!,
+      attendeeUserIds: attendeeIds,
+      durationMinutes: Number(durationMinutes),
+      ...range,
+    },
+    { enabled: searching && !!workspaceId && attendeeIds.length > 0, retry: false },
+  );
+
+  const createMeeting = api.workspaceScheduling.createMeeting.useMutation({
+    onSuccess: async (meeting) => {
+      await utils.calendar.getEventsMultiCalendar.invalidate();
+      notifications.show({
+        title: "Meeting scheduled",
+        message: `${meeting.title} — ${meeting.invitesSent} invite${meeting.invitesSent === 1 ? "" : "s"} sent.`,
+        color: "blue",
+      });
+      handleClose();
+    },
+    onError: (error) => {
+      notifications.show({ title: "Couldn't schedule", message: error.message, color: "red" });
+    },
+  });
+
+  const handleClose = () => {
+    setAttendeeIds([]);
+    setTitle("");
+    setSelectedSlot(null);
+    setSearching(false);
+    onClose();
+  };
+
+  const memberOptions = (members ?? []).map((member) => ({
+    value: member.id,
+    label:
+      (member.name ?? member.email ?? "Unknown") +
+      (member.availabilityKnown ? "" : " (no availability data)"),
+  }));
+
+  const unknownCount = (members ?? []).filter(
+    (m) => attendeeIds.includes(m.id) && !m.availabilityKnown,
+  ).length;
+
+  const slotLabel = (slot: { startsAt: Date; endsAt: Date }) =>
+    `${slot.startsAt.toLocaleString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    })} – ${slot.endsAt.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}`;
+
+  return (
+    <Modal opened={opened} onClose={handleClose} title="Schedule meeting" centered size="lg">
+      <Stack gap="sm">
+        <Select
+          label="Workspace"
+          data={(workspaces ?? []).map((w) => ({ value: w.id, label: w.name }))}
+          value={workspaceId}
+          onChange={(value) => {
+            setWorkspaceId(value);
+            setAttendeeIds([]);
+            setSearching(false);
+            setSelectedSlot(null);
+          }}
+          searchable
+          placeholder="Pick a workspace"
+        />
+
+        <MultiSelect
+          label="Attendees"
+          data={memberOptions}
+          value={attendeeIds}
+          onChange={(value) => {
+            setAttendeeIds(value);
+            setSearching(false);
+            setSelectedSlot(null);
+          }}
+          searchable
+          disabled={!workspaceId}
+          placeholder={workspaceId ? "Pick workspace members" : "Pick a workspace first"}
+        />
+
+        <Group grow>
+          <Select
+            label="Duration"
+            data={[
+              { value: "30", label: "30 minutes" },
+              { value: "60", label: "1 hour" },
+            ]}
+            value={durationMinutes}
+            onChange={(value) => value && setDurationMinutes(value)}
+          />
+          <Button
+            mt="xl"
+            variant="light"
+            onClick={() => setSearching(true)}
+            disabled={!workspaceId || attendeeIds.length === 0}
+            loading={searching && slotsQuery.isLoading}
+          >
+            Find times (next 7 days)
+          </Button>
+        </Group>
+
+        {unknownCount > 0 && (
+          <Text size="xs" c="dimmed">
+            {unknownCount} attendee{unknownCount === 1 ? " has" : "s have"} no calendar
+            connected — they can be invited, but their availability doesn&apos;t constrain
+            the suggestions.
+          </Text>
+        )}
+
+        {searching && slotsQuery.data && (
+          <Stack gap={4}>
+            <Text size="sm" fw={600}>
+              Suggested times
+            </Text>
+            <Text size="xs" c="dimmed">
+              Availability can be up to ~15 minutes stale — a very recent booking may
+              not show yet.
+            </Text>
+            {slotsQuery.data.slots.length === 0 ? (
+              <Text size="sm" c="dimmed">
+                No free slots in the next 7 days — try a shorter duration or fewer
+                attendees.
+              </Text>
+            ) : (
+              slotsQuery.data.slots.slice(0, 8).map((slot) => (
+                <UnstyledButton
+                  key={slot.startsAt.toISOString()}
+                  onClick={() => setSelectedSlot(slot)}
+                  className={`rounded border px-3 py-2 text-sm transition-colors ${
+                    selectedSlot?.startsAt.getTime() === slot.startsAt.getTime()
+                      ? "border-border-focus bg-surface-hover"
+                      : "border-border-primary hover:bg-surface-hover"
+                  }`}
+                >
+                  {slotLabel(slot)}
+                </UnstyledButton>
+              ))
+            )}
+          </Stack>
+        )}
+
+        {selectedSlot && (
+          <TextInput
+            label="Title"
+            placeholder="What's the meeting about?"
+            value={title}
+            onChange={(e) => setTitle(e.currentTarget.value)}
+            data-autofocus
+          />
+        )}
+
+        <Group justify="flex-end" mt="xs">
+          <Button variant="subtle" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            leftSection={<IconCalendarPlus size={16} />}
+            disabled={!workspaceId || !selectedSlot || title.trim().length === 0}
+            loading={createMeeting.isPending}
+            onClick={() =>
+              workspaceId &&
+              selectedSlot &&
+              createMeeting.mutate({
+                workspaceId,
+                title: title.trim(),
+                startsAt: selectedSlot.startsAt,
+                endsAt: selectedSlot.endsAt,
+                attendeeUserIds: attendeeIds,
+              })
+            }
+          >
+            Schedule & send invites
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/app/_components/calendar/ScheduleMeetingModal.tsx
+++ b/src/app/_components/calendar/ScheduleMeetingModal.tsx
@@ -13,9 +13,12 @@ import {
   TextInput,
   UnstyledButton,
 } from "@mantine/core";
-import { IconCalendarPlus } from "@tabler/icons-react";
+import { IconCalendarPlus, IconCalendarX } from "@tabler/icons-react";
 import { notifications } from "@mantine/notifications";
+import { modals } from "@mantine/modals";
 import { api } from "~/trpc/react";
+import { ActionIcon, Tooltip } from "@mantine/core";
+import { useSession } from "next-auth/react";
 
 /**
  * "Schedule meeting" (V3 workspace scheduling), first cut: pick a workspace,
@@ -48,6 +51,45 @@ export function ScheduleMeetingModal({
     { workspaceId: workspaceId! },
     { enabled: opened && !!workspaceId },
   );
+
+  const { data: session } = useSession();
+  const { data: upcomingMeetings } = api.workspaceScheduling.listMeetings.useQuery(
+    { workspaceId: workspaceId!, from: new Date() },
+    { enabled: opened && !!workspaceId },
+  );
+
+  const cancelMeeting = api.workspaceScheduling.cancelMeeting.useMutation({
+    onSuccess: async (result) => {
+      await Promise.all([
+        utils.workspaceScheduling.listMeetings.invalidate(),
+        utils.calendar.getEventsMultiCalendar.invalidate(),
+      ]);
+      notifications.show({
+        title: "Meeting cancelled",
+        message: `${result.invitesSent} cancellation${result.invitesSent === 1 ? "" : "s"} sent to attendees' calendars.`,
+        color: "blue",
+      });
+    },
+    onError: (error) => {
+      notifications.show({ title: "Couldn't cancel", message: error.message, color: "red" });
+    },
+  });
+
+  const confirmCancel = (meeting: { id: string; title: string }) => {
+    if (!workspaceId) return;
+    modals.openConfirmModal({
+      title: "Cancel meeting?",
+      children: (
+        <Text size="sm">
+          Attendees will receive a cancellation that removes “{meeting.title}”
+          from their calendars. Rescheduling means booking a new meeting.
+        </Text>
+      ),
+      labels: { confirm: "Cancel meeting", cancel: "Keep meeting" },
+      confirmProps: { color: "red" },
+      onConfirm: () => cancelMeeting.mutate({ workspaceId, meetingId: meeting.id }),
+    });
+  };
 
   // Rolling week starting "now" — good enough for the first cut.
   const range = useMemo(
@@ -130,6 +172,48 @@ export function ScheduleMeetingModal({
           searchable
           placeholder="Pick a workspace"
         />
+
+        {workspaceId && (upcomingMeetings?.length ?? 0) > 0 && (
+          <Stack gap={4}>
+            <Text size="sm" fw={600}>
+              Upcoming meetings
+            </Text>
+            {upcomingMeetings!.filter((m) => m.status !== "cancelled").map((meeting) => (
+              <Group key={meeting.id} gap="xs" wrap="nowrap" className="rounded border border-border-primary px-3 py-2">
+                <div className="min-w-0 flex-1">
+                  <Text size="sm" className="truncate">
+                    {meeting.title}
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    {meeting.startsAt.toLocaleString(undefined, {
+                      weekday: "short",
+                      month: "short",
+                      day: "numeric",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                    {" · "}
+                    {meeting.attendees.length} attendee{meeting.attendees.length === 1 ? "" : "s"}
+                  </Text>
+                </div>
+                {meeting.organizer.id === session?.user?.id && (
+                  <Tooltip label="Cancel meeting" withinPortal>
+                    <ActionIcon
+                      variant="subtle"
+                      color="red"
+                      size="sm"
+                      aria-label={`Cancel ${meeting.title}`}
+                      loading={cancelMeeting.isPending}
+                      onClick={() => confirmCancel(meeting)}
+                    >
+                      <IconCalendarX size={16} />
+                    </ActionIcon>
+                  </Tooltip>
+                )}
+              </Group>
+            ))}
+          </Stack>
+        )}
 
         <MultiSelect
           label="Attendees"

--- a/src/app/_components/calendar/ScheduleMeetingModal.tsx
+++ b/src/app/_components/calendar/ScheduleMeetingModal.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import {
   Button,
+  Checkbox,
   Group,
   Modal,
   MultiSelect,
@@ -41,6 +42,7 @@ export function ScheduleMeetingModal({
   const [title, setTitle] = useState("");
   const [selectedSlot, setSelectedSlot] = useState<{ startsAt: Date; endsAt: Date } | null>(null);
   const [searching, setSearching] = useState(false);
+  const [includeOutsideWorkHours, setIncludeOutsideWorkHours] = useState(false);
 
   const { data: members } = api.workspaceScheduling.listSchedulableMembers.useQuery(
     { workspaceId: workspaceId! },
@@ -63,6 +65,7 @@ export function ScheduleMeetingModal({
       workspaceId: workspaceId!,
       attendeeUserIds: attendeeIds,
       durationMinutes: Number(durationMinutes),
+      includeOutsideWorkHours,
       ...range,
     },
     { enabled: searching && !!workspaceId && attendeeIds.length > 0, retry: false },
@@ -162,6 +165,16 @@ export function ScheduleMeetingModal({
             Find times (next 7 days)
           </Button>
         </Group>
+
+        <Checkbox
+          size="xs"
+          label="Include times outside attendees' working hours"
+          checked={includeOutsideWorkHours}
+          onChange={(e) => {
+            setIncludeOutsideWorkHours(e.currentTarget.checked);
+            setSelectedSlot(null);
+          }}
+        />
 
         {unknownCount > 0 && (
           <Text size="xs" c="dimmed">

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -23,6 +23,7 @@ import { teamRouter } from "./routers/team";
 import { slackRouter } from "./routers/slack";
 import { aiInteractionRouter } from "./routers/aiInteraction";
 import { calendarRouter } from "./routers/calendar";
+import { workspaceSchedulingRouter } from "./routers/workspaceScheduling";
 import { feedbackRouter } from "./routers/feedback";
 import { featureRequestRouter } from "./routers/featureRequest";
 import { whatsappRouter } from "./routers/whatsapp";
@@ -121,6 +122,7 @@ export const appRouter = createTRPCRouter({
   slack: slackRouter,
   aiInteraction: aiInteractionRouter,
   calendar: calendarRouter,
+  workspaceScheduling: workspaceSchedulingRouter,
   feedback: feedbackRouter,
   featureRequest: featureRequestRouter,
   whatsapp: whatsappRouter,

--- a/src/server/api/routers/__tests__/workspaceScheduling.test.ts
+++ b/src/server/api/routers/__tests__/workspaceScheduling.test.ts
@@ -149,6 +149,17 @@ describe("workspaceScheduling router (mocked)", () => {
       expect(sendMeetingInviteEmailMock).not.toHaveBeenCalled();
     });
 
+    it("rejects viewers on cancelMeeting", async () => {
+      const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
+      await expect(
+        caller.workspaceScheduling.cancelMeeting({
+          workspaceId: WORKSPACE_ID,
+          meetingId: "meeting-1",
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      expect(dbMock.meeting.update).not.toHaveBeenCalled();
+    });
+
     it("rejects viewers on listMeetings", async () => {
       const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
       await expect(
@@ -255,6 +266,85 @@ describe("workspaceScheduling router (mocked)", () => {
 
       expect(result.id).toBe("meeting-1");
       expect(result.invitesSent).toBe(0);
+    });
+  });
+
+  describe("cancelMeeting", () => {
+    const storedMeeting = {
+      id: "meeting-1",
+      workspaceId: WORKSPACE_ID,
+      organizerId: ORGANIZER_ID,
+      title: "Design sync",
+      description: null,
+      location: null,
+      startsAt: new Date("2026-08-18T09:00:00Z"),
+      endsAt: new Date("2026-08-18T10:00:00Z"),
+      icalUid: "uid-1@exponential.im",
+      sequence: 0,
+      status: "confirmed",
+      organizer: { id: ORGANIZER_ID, name: "Org", email: "org@example.com" },
+      attendees: [{ user: { id: "user-a", name: "A", email: "a@example.com" } }],
+    };
+
+    beforeEach(() => {
+      dbMock.workspaceUser.findFirst.mockResolvedValue({ role: "member" } as never);
+    });
+
+    it("only the organizer can cancel", async () => {
+      dbMock.meeting.findFirst.mockResolvedValue(storedMeeting as never);
+
+      const caller = createMockCaller({ userId: "user-a", db: dbMock });
+      await expect(
+        caller.workspaceScheduling.cancelMeeting({
+          workspaceId: WORKSPACE_ID,
+          meetingId: "meeting-1",
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      expect(dbMock.meeting.update).not.toHaveBeenCalled();
+    });
+
+    it("bumps SEQUENCE, flips status, and sends METHOD:CANCEL against the original UID", async () => {
+      dbMock.meeting.findFirst.mockResolvedValue(storedMeeting as never);
+      dbMock.meeting.update.mockResolvedValue({ sequence: 1 } as never);
+
+      const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
+      const result = await caller.workspaceScheduling.cancelMeeting({
+        workspaceId: WORKSPACE_ID,
+        meetingId: "meeting-1",
+      });
+
+      expect(result).toMatchObject({ status: "cancelled", invitesSent: 1 });
+      expect(dbMock.meeting.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { status: "cancelled", sequence: { increment: 1 } },
+        }),
+      );
+      const call = sendMeetingInviteEmailMock.mock.calls[0]![0] as {
+        method: string;
+        icsContent: string;
+      };
+      expect(call.method).toBe("CANCEL");
+      expect(call.icsContent).toContain("METHOD:CANCEL");
+      expect(call.icsContent).toContain("STATUS:CANCELLED");
+      expect(call.icsContent).toContain("UID:uid-1@exponential.im");
+      expect(call.icsContent).toContain("SEQUENCE:1");
+    });
+
+    it("cancelling an already-cancelled meeting is a no-op", async () => {
+      dbMock.meeting.findFirst.mockResolvedValue({
+        ...storedMeeting,
+        status: "cancelled",
+      } as never);
+
+      const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
+      const result = await caller.workspaceScheduling.cancelMeeting({
+        workspaceId: WORKSPACE_ID,
+        meetingId: "meeting-1",
+      });
+
+      expect(result.invitesSent).toBe(0);
+      expect(dbMock.meeting.update).not.toHaveBeenCalled();
+      expect(sendMeetingInviteEmailMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/api/routers/__tests__/workspaceScheduling.test.ts
+++ b/src/server/api/routers/__tests__/workspaceScheduling.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Unit tests for the workspaceScheduling router (V3).
+ *
+ * Mocked Prisma; the workspace-membership middleware is stubbed to pass so
+ * these tests isolate what THIS router owns: the explicit viewer rejection
+ * on every procedure (the middleware's "view" level is deliberately not
+ * trusted — cf. the feature.update viewer gap), member-only attendees, and
+ * the invite dispatch with a well-formed METHOD:REQUEST payload.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+vi.hoisted(() => {
+  process.env.OPENAI_API_KEY ??= "sk-test-dummy";
+  process.env.AUTH_SECRET ??= "test-secret-for-unit-tests";
+  process.env.SKIP_ENV_VALIDATION ??= "true";
+  process.env.NODE_ENV ??= "test";
+  process.env.GOOGLE_CLIENT_ID ??= "test";
+  process.env.GOOGLE_CLIENT_SECRET ??= "test";
+  process.env.MASTRA_API_URL ??= "http://localhost:4111";
+  process.env.AUTH_DISCORD_ID ??= "test";
+  process.env.AUTH_DISCORD_SECRET ??= "test";
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+  process.env.DATABASE_ENCRYPTION_KEY ??= "MMeRcJFimqp98NsQ5i2cawtF4LbcftnfiCNJWLhO/YQ=";
+});
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    constructor(_opts?: unknown) {
+      // intentionally empty
+    }
+  },
+}));
+
+vi.mock("next-auth", () => ({
+  default: () => ({ auth: () => null, handlers: {}, signIn: vi.fn(), signOut: vi.fn() }),
+}));
+vi.mock("next-auth/providers/discord", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/google", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/notion", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/postmark", () => ({ default: vi.fn() }));
+vi.mock("next-auth/providers/microsoft-entra-id", () => ({ default: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({
+  auth: () => null,
+  handlers: {},
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+// The membership middleware is covered by the access-control suites; pass it
+// through so these tests exercise the router's own checks.
+vi.mock("~/server/services/access/middleware", async (importOriginal) => {
+  const original = await importOriginal<
+    typeof import("~/server/services/access/middleware")
+  >();
+  return {
+    ...original,
+    requireWorkspaceMembership: () => (opts: { next: () => unknown }) => opts.next(),
+  };
+});
+
+const { sendMeetingInviteEmailMock } = vi.hoisted(() => ({
+  sendMeetingInviteEmailMock: vi.fn(),
+}));
+vi.mock("~/server/services/EmailService", async (importOriginal) => {
+  const original = await importOriginal<typeof import("~/server/services/EmailService")>();
+  return { ...original, sendMeetingInviteEmail: sendMeetingInviteEmailMock };
+});
+
+import { createMockCaller } from "~/test/trpc-helpers";
+
+const WORKSPACE_ID = "ws-1";
+const ORGANIZER_ID = "user-organizer";
+
+describe("workspaceScheduling router (mocked)", () => {
+  let dbMock: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    dbMock = getDbMock();
+    mockReset(dbMock);
+    sendMeetingInviteEmailMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  function memberRoster(userIds: string[]) {
+    dbMock.workspaceUser.findMany.mockResolvedValue(
+      userIds.map((userId) => ({ userId })) as never,
+    );
+    dbMock.teamUser.findMany.mockResolvedValue([] as never);
+  }
+
+  describe("viewer exclusion (every procedure)", () => {
+    beforeEach(() => {
+      dbMock.workspaceUser.findFirst.mockResolvedValue({ role: "viewer" } as never);
+    });
+
+    it("rejects viewers on listSchedulableMembers", async () => {
+      const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
+      await expect(
+        caller.workspaceScheduling.listSchedulableMembers({ workspaceId: WORKSPACE_ID }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("rejects viewers on suggestSlots", async () => {
+      const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
+      await expect(
+        caller.workspaceScheduling.suggestSlots({
+          workspaceId: WORKSPACE_ID,
+          attendeeUserIds: ["user-a"],
+          durationMinutes: 30,
+          rangeStart: new Date("2026-08-18T00:00:00Z"),
+          rangeEnd: new Date("2026-08-19T00:00:00Z"),
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("rejects viewers on createMeeting", async () => {
+      const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
+      await expect(
+        caller.workspaceScheduling.createMeeting({
+          workspaceId: WORKSPACE_ID,
+          title: "Nope",
+          startsAt: new Date("2026-08-18T09:00:00Z"),
+          endsAt: new Date("2026-08-18T10:00:00Z"),
+          attendeeUserIds: ["user-a"],
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      expect(dbMock.meeting.create).not.toHaveBeenCalled();
+      expect(sendMeetingInviteEmailMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects viewers on listMeetings", async () => {
+      const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
+      await expect(
+        caller.workspaceScheduling.listMeetings({ workspaceId: WORKSPACE_ID }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+  });
+
+  describe("createMeeting", () => {
+    beforeEach(() => {
+      dbMock.workspaceUser.findFirst.mockResolvedValue({ role: "member" } as never);
+    });
+
+    it("rejects attendees who are not workspace members", async () => {
+      memberRoster([ORGANIZER_ID, "user-a"]);
+
+      const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
+      await expect(
+        caller.workspaceScheduling.createMeeting({
+          workspaceId: WORKSPACE_ID,
+          title: "With an outsider",
+          startsAt: new Date("2026-08-18T09:00:00Z"),
+          endsAt: new Date("2026-08-18T10:00:00Z"),
+          attendeeUserIds: ["user-a", "user-outsider"],
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(dbMock.meeting.create).not.toHaveBeenCalled();
+    });
+
+    it("creates the meeting and emails each attendee a METHOD:REQUEST invite", async () => {
+      memberRoster([ORGANIZER_ID, "user-a"]);
+      dbMock.meeting.create.mockResolvedValue({
+        id: "meeting-1",
+        title: "Design sync",
+        description: null,
+        location: null,
+        startsAt: new Date("2026-08-18T09:00:00Z"),
+        endsAt: new Date("2026-08-18T10:00:00Z"),
+        icalUid: "uid-1@exponential.im",
+        sequence: 0,
+        status: "confirmed",
+        organizer: { id: ORGANIZER_ID, name: "Org", email: "org@example.com" },
+        attendees: [
+          { user: { id: "user-a", name: "A", email: "a@example.com" } },
+          { user: { id: ORGANIZER_ID, name: "Org", email: "org@example.com" } },
+        ],
+      } as never);
+
+      const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
+      const result = await caller.workspaceScheduling.createMeeting({
+        workspaceId: WORKSPACE_ID,
+        title: "Design sync",
+        startsAt: new Date("2026-08-18T09:00:00Z"),
+        endsAt: new Date("2026-08-18T10:00:00Z"),
+        attendeeUserIds: ["user-a"],
+      });
+
+      expect(result.invitesSent).toBe(2);
+      expect(sendMeetingInviteEmailMock).toHaveBeenCalledTimes(2);
+      const call = sendMeetingInviteEmailMock.mock.calls[0]![0] as {
+        method: string;
+        icsContent: string;
+        to: string;
+      };
+      expect(call.method).toBe("REQUEST");
+      expect(call.icsContent).toContain("METHOD:REQUEST");
+      expect(call.icsContent).toContain("UID:uid-1@exponential.im");
+      expect(call.icsContent).toContain("SEQUENCE:0");
+
+      // The organizer rides along as an attendee.
+      const createArg = dbMock.meeting.create.mock.calls[0]![0] as {
+        data: { attendees: { create: { userId: string }[] } };
+      };
+      expect(createArg.data.attendees.create.map((a) => a.userId)).toEqual(
+        expect.arrayContaining(["user-a", ORGANIZER_ID]),
+      );
+    });
+
+    it("a failed invite send does not roll back the meeting", async () => {
+      memberRoster([ORGANIZER_ID, "user-a"]);
+      sendMeetingInviteEmailMock.mockRejectedValue(new Error("postmark down"));
+      dbMock.meeting.create.mockResolvedValue({
+        id: "meeting-1",
+        title: "Design sync",
+        description: null,
+        location: null,
+        startsAt: new Date("2026-08-18T09:00:00Z"),
+        endsAt: new Date("2026-08-18T10:00:00Z"),
+        icalUid: "uid-1@exponential.im",
+        sequence: 0,
+        status: "confirmed",
+        organizer: { id: ORGANIZER_ID, name: "Org", email: "org@example.com" },
+        attendees: [{ user: { id: "user-a", name: "A", email: "a@example.com" } }],
+      } as never);
+
+      const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
+      const result = await caller.workspaceScheduling.createMeeting({
+        workspaceId: WORKSPACE_ID,
+        title: "Design sync",
+        startsAt: new Date("2026-08-18T09:00:00Z"),
+        endsAt: new Date("2026-08-18T10:00:00Z"),
+        attendeeUserIds: ["user-a"],
+      });
+
+      expect(result.id).toBe("meeting-1");
+      expect(result.invitesSent).toBe(0);
+    });
+  });
+
+  describe("suggestSlots", () => {
+    beforeEach(() => {
+      dbMock.workspaceUser.findFirst.mockResolvedValue({ role: "member" } as never);
+    });
+
+    it("rejects attendees outside the workspace", async () => {
+      memberRoster([ORGANIZER_ID, "user-a"]);
+
+      const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
+      await expect(
+        caller.workspaceScheduling.suggestSlots({
+          workspaceId: WORKSPACE_ID,
+          attendeeUserIds: ["user-outsider"],
+          durationMinutes: 30,
+          rangeStart: new Date("2026-08-18T00:00:00Z"),
+          rangeEnd: new Date("2026-08-19T00:00:00Z"),
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("returns free slots and flags attendees with no calendar data", async () => {
+      memberRoster([ORGANIZER_ID, "user-a", "user-nodata"]);
+      // Free/busy read (the structural contract) returns one block for user-a.
+      dbMock.calendarEvent.findMany.mockResolvedValue([
+        {
+          userId: "user-a",
+          startsAt: new Date("2026-08-18T09:00:00Z"),
+          endsAt: new Date("2026-08-18T17:00:00Z"),
+          isAllDay: false,
+          sourceType: "microsoft",
+        },
+      ] as never);
+      // user-nodata has no synced rows at all → truly unknown.
+      dbMock.calendarEvent.groupBy.mockResolvedValue([] as never);
+
+      const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
+      const result = await caller.workspaceScheduling.suggestSlots({
+        workspaceId: WORKSPACE_ID,
+        attendeeUserIds: ["user-a", "user-nodata"],
+        durationMinutes: 60,
+        rangeStart: new Date("2026-08-18T08:00:00Z"),
+        rangeEnd: new Date("2026-08-18T19:00:00Z"),
+      });
+
+      // 08:00 works; 09:00–17:00 blocked; 17:00 and 17:30 fit before 19:00.
+      expect(result.slots.map((s) => s.startsAt.toISOString())).toEqual([
+        "2026-08-18T08:00:00.000Z",
+        "2026-08-18T17:00:00.000Z",
+        "2026-08-18T17:30:00.000Z",
+        "2026-08-18T18:00:00.000Z",
+      ]);
+      expect(result.availabilityUnknownUserIds).toEqual(["user-nodata"]);
+    });
+  });
+});

--- a/src/server/api/routers/__tests__/workspaceScheduling.test.ts
+++ b/src/server/api/routers/__tests__/workspaceScheduling.test.ts
@@ -292,6 +292,26 @@ describe("workspaceScheduling router (mocked)", () => {
       ] as never);
       // user-nodata has no synced rows at all → truly unknown.
       dbMock.calendarEvent.groupBy.mockResolvedValue([] as never);
+      // Work hours off for both attendees — this test is about free/busy.
+      dbMock.user.findMany.mockResolvedValue([
+        {
+          id: "user-a",
+          workHoursEnabled: false,
+          workDaysJson: null,
+          workHoursStart: null,
+          workHoursEnd: null,
+          timezone: null,
+        },
+        {
+          id: "user-nodata",
+          workHoursEnabled: false,
+          workDaysJson: null,
+          workHoursStart: null,
+          workHoursEnd: null,
+          timezone: null,
+        },
+      ] as never);
+      dbMock.user.findUnique.mockResolvedValue({ timezone: null } as never);
 
       const caller = createMockCaller({ userId: ORGANIZER_ID, db: dbMock });
       const result = await caller.workspaceScheduling.suggestSlots({

--- a/src/server/api/routers/calendar.ts
+++ b/src/server/api/routers/calendar.ts
@@ -10,6 +10,7 @@ import { encryptToBase64 } from "~/server/utils/encryption";
 import { syncFeed } from "~/server/services/calendar/CalendarSyncService";
 import { assertSafeFeedUrl, UnsafeFeedUrlError } from "~/server/services/calendar/feedUrlGuard";
 import { listIcsCalendarEvents } from "~/server/services/calendar/icsEventRead";
+import { listMeetingCalendarEvents } from "~/server/services/calendar/meetingEventRead";
 import { todayWindow } from "~/server/services/calendar/todayWindow";
 import { reportHandledErrorServer } from "~/server/utils/reportHandledErrorServer";
 
@@ -552,12 +553,22 @@ export const calendarRouter = createTRPCRouter({
         reportHandledErrorServer(error, { area: "calendar.getTodayEvents.icsMerge" });
         return [];
       });
+      const meetingEvents = await listMeetingCalendarEvents(
+        ctx.db as PrismaClient,
+        userId,
+        todayStart,
+        todayEnd,
+      ).catch((error) => {
+        reportHandledErrorServer(error, { area: "calendar.getTodayEvents.meetingMerge" });
+        return [];
+      });
+      const dbEvents = [...icsEvents, ...meetingEvents];
 
-      if (isGoogleCalendarGated(ctx.session.user.email, provider)) return icsEvents;
+      if (isGoogleCalendarGated(ctx.session.user.email, provider)) return dbEvents;
 
       const service = getCalendarService(provider);
       const providerEvents = await service.getTodayEvents(userId);
-      return [...providerEvents, ...icsEvents].sort((a, b) => {
+      return [...providerEvents, ...dbEvents].sort((a, b) => {
         const aTime = a.start?.dateTime ?? a.start?.date ?? "";
         const bTime = b.start?.dateTime ?? b.start?.date ?? "";
         return aTime.localeCompare(bTime);
@@ -864,7 +875,7 @@ export const calendarRouter = createTRPCRouter({
         calendarId: string;
         calendarName?: string;
         calendarColor?: string;
-        provider: "google" | "microsoft" | "ics";
+        provider: "google" | "microsoft" | "ics" | "meeting";
         id: string;
         summary: string;
         description?: string;
@@ -888,6 +899,15 @@ export const calendarRouter = createTRPCRouter({
         icsTimeMax,
       ).catch((error) => {
         reportHandledErrorServer(error, { area: "calendar.getEventsMultiCalendar.icsMerge" });
+        return [];
+      });
+      const meetingEventsPromise = listMeetingCalendarEvents(
+        ctx.db as PrismaClient,
+        userId,
+        icsTimeMin,
+        icsTimeMax,
+      ).catch((error) => {
+        reportHandledErrorServer(error, { area: "calendar.getEventsMultiCalendar.meetingMerge" });
         return [];
       });
 
@@ -925,6 +945,7 @@ export const calendarRouter = createTRPCRouter({
       }
 
       allEvents.push(...(await icsEventsPromise));
+      allEvents.push(...(await meetingEventsPromise));
 
       // Sort all events by start time
       return allEvents.sort((a, b) => {

--- a/src/server/api/routers/workspaceScheduling.ts
+++ b/src/server/api/routers/workspaceScheduling.ts
@@ -325,6 +325,95 @@ export const workspaceSchedulingRouter = createTRPCRouter({
       };
     }),
 
+  /**
+   * Cancel = the only mutation after create (reschedule is cancel + rebook,
+   * a V3 non-goal). Bumps SEQUENCE and emails METHOD:CANCEL against the
+   * original UID, which is what removes the event from attendees' real
+   * calendars. Organizer-only.
+   */
+  cancelMeeting: protectedProcedure
+    .input(z.object({ workspaceId: z.string(), meetingId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
+    .mutation(async ({ ctx, input }) => {
+      const db = ctx.db as PrismaClient;
+      const userId = ctx.session.user.id;
+      await assertNotViewer(db, userId, input.workspaceId);
+
+      const meeting = await db.meeting.findFirst({
+        where: { id: input.meetingId, workspaceId: input.workspaceId },
+        include: {
+          attendees: { include: { user: { select: { id: true, name: true, email: true } } } },
+          organizer: { select: { id: true, name: true, email: true } },
+        },
+      });
+      if (!meeting) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meeting not found" });
+      }
+      if (meeting.organizerId !== userId) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only the organizer can cancel a meeting",
+        });
+      }
+      if (meeting.status === "cancelled") {
+        return { id: meeting.id, status: meeting.status, invitesSent: 0 };
+      }
+
+      const cancelled = await db.meeting.update({
+        where: { id: meeting.id },
+        data: { status: "cancelled", sequence: { increment: 1 } },
+        select: { sequence: true },
+      });
+
+      const organizer = {
+        name: meeting.organizer.name,
+        email: meeting.organizer.email ?? "noreply@exponential.im",
+      };
+      const recipients = meeting.attendees
+        .map((a) => a.user)
+        .filter((u): u is typeof u & { email: string } => !!u.email);
+      const ics = buildInviteIcs({
+        method: "CANCEL",
+        uid: meeting.icalUid,
+        sequence: cancelled.sequence,
+        organizer,
+        attendees: recipients.map((u) => ({ name: u.name, email: u.email })),
+        title: meeting.title,
+        description: meeting.description,
+        location: meeting.location,
+        startsAt: meeting.startsAt,
+        endsAt: meeting.endsAt,
+      });
+
+      let invitesSent = 0;
+      for (const recipient of recipients) {
+        try {
+          await sendMeetingInviteEmail({
+            to: recipient.email,
+            method: "CANCEL",
+            meetingTitle: meeting.title,
+            organizerName: organizer.name ?? organizer.email,
+            startsAt: meeting.startsAt,
+            endsAt: meeting.endsAt,
+            location: meeting.location,
+            icsContent: ics,
+            workspaceId: input.workspaceId,
+          });
+          invitesSent += 1;
+        } catch (error) {
+          const { reportHandledErrorServer } = await import(
+            "~/server/utils/reportHandledErrorServer"
+          );
+          reportHandledErrorServer(error, {
+            area: "workspaceScheduling.cancelMeeting.invite",
+            context: { meetingId: meeting.id },
+          });
+        }
+      }
+
+      return { id: meeting.id, status: "cancelled", invitesSent };
+    }),
+
   listMeetings: protectedProcedure
     .input(
       z.object({

--- a/src/server/api/routers/workspaceScheduling.ts
+++ b/src/server/api/routers/workspaceScheduling.ts
@@ -117,6 +117,7 @@ export const workspaceSchedulingRouter = createTRPCRouter({
         durationMinutes: z.number().int().min(15).max(8 * 60),
         rangeStart: z.date(),
         rangeEnd: z.date(),
+        includeOutsideWorkHours: z.boolean().default(false),
       }),
     )
     .use(requireWorkspaceMembership("view"))
@@ -143,8 +144,56 @@ export const workspaceSchedulingRouter = createTRPCRouter({
         (id) => (busyBlocksByUser.get(id) ?? []).length === 0,
       );
 
+      // Work-hours settings for every attendee (self-describing fields, not
+      // event data — no privacy concern) + the organizer's timezone as the
+      // fallback zone for attendees who never set one.
+      const [attendeeRows, organizerRow] = await Promise.all([
+        db.user.findMany({
+          where: { id: { in: input.attendeeUserIds } },
+          select: {
+            id: true,
+            workHoursEnabled: true,
+            workDaysJson: true,
+            workHoursStart: true,
+            workHoursEnd: true,
+            timezone: true,
+          },
+        }),
+        db.user.findUnique({
+          where: { id: ctx.session.user.id },
+          select: { timezone: true },
+        }),
+      ]);
+      const attendeeSettings = new Map(
+        attendeeRows.map((row) => {
+          let workDays: string[] = [];
+          if (row.workDaysJson) {
+            try {
+              workDays = (JSON.parse(row.workDaysJson) as string[]).map((d) =>
+                d.toLowerCase(),
+              );
+            } catch {
+              workDays = [];
+            }
+          }
+          return [
+            row.id,
+            {
+              workHoursEnabled: row.workHoursEnabled,
+              workDays,
+              workHoursStart: row.workHoursStart,
+              workHoursEnd: row.workHoursEnd,
+              timezone: row.timezone,
+            },
+          ] as const;
+        }),
+      );
+
       const slots = computeSlots({
         busyBlocksByUser,
+        attendeeSettings,
+        organizerTimezone: organizerRow?.timezone ?? null,
+        includeOutsideWorkHours: input.includeOutsideWorkHours,
         durationMinutes: input.durationMinutes,
         range: { from: input.rangeStart, to: input.rangeEnd },
       });

--- a/src/server/api/routers/workspaceScheduling.ts
+++ b/src/server/api/routers/workspaceScheduling.ts
@@ -1,0 +1,326 @@
+import { z } from "zod";
+import type { PrismaClient } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { requireWorkspaceMembership } from "~/server/services/access/middleware";
+import { listBusyBlocksByUser } from "~/server/services/calendar/freeBusy";
+import { computeSlots } from "~/server/services/calendar/slotEngine";
+import { buildInviteIcs } from "~/server/services/calendar/inviteIcs";
+import { sendMeetingInviteEmail } from "~/server/services/EmailService";
+
+/**
+ * Workspace meeting scheduling (V3 of calendar sync).
+ *
+ * Access model: every procedure requires workspace membership AND explicitly
+ * rejects the "viewer" role server-side. The middleware's "view" level alone
+ * is deliberately not trusted for this — cf. the known feature.update viewer
+ * gap — so the role check is its own step in each procedure.
+ *
+ * Privacy: availability is read exclusively through listBusyBlocksByUser
+ * (the structural free/busy contract). No procedure here ever selects
+ * another user's event title/location/attendees.
+ */
+
+const MAX_RANGE_DAYS = 30;
+
+/**
+ * Reject workspace viewers. Direct members carry their WorkspaceUser role;
+ * team-based members have no direct row and count as "member" (the same
+ * synthesis workspace.list applies), so absence of a direct row is fine —
+ * the membership middleware has already vouched for access.
+ */
+async function assertNotViewer(db: PrismaClient, userId: string, workspaceId: string) {
+  const direct = await db.workspaceUser.findFirst({
+    where: { workspaceId, userId },
+    select: { role: true },
+  });
+  if (direct?.role === "viewer") {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Workspace viewers cannot schedule meetings",
+    });
+  }
+}
+
+/** The attendee universe: direct members + members via a linked team. */
+async function listWorkspaceMemberIds(db: PrismaClient, workspaceId: string): Promise<Set<string>> {
+  const [direct, viaTeam] = await Promise.all([
+    db.workspaceUser.findMany({ where: { workspaceId }, select: { userId: true } }),
+    db.teamUser.findMany({
+      where: { team: { workspaceId } },
+      select: { userId: true },
+    }),
+  ]);
+  return new Set([...direct.map((m) => m.userId), ...viaTeam.map((m) => m.userId)]);
+}
+
+function assertSaneRange(rangeStart: Date, rangeEnd: Date) {
+  if (rangeEnd <= rangeStart) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "Range end must be after start" });
+  }
+  if (rangeEnd.getTime() - rangeStart.getTime() > MAX_RANGE_DAYS * 24 * 60 * 60 * 1000) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `Range must be at most ${MAX_RANGE_DAYS} days`,
+    });
+  }
+}
+
+export const workspaceSchedulingRouter = createTRPCRouter({
+  /**
+   * Workspace members offerable as attendees, with an availability flag:
+   * a member with no synced calendar source is availability-unknown — still
+   * invitable, never constraining suggestions.
+   */
+  listSchedulableMembers: protectedProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(requireWorkspaceMembership("view"))
+    .query(async ({ ctx, input }) => {
+      const db = ctx.db as PrismaClient;
+      await assertNotViewer(db, ctx.session.user.id, input.workspaceId);
+
+      const userSelect = { id: true, name: true, email: true, image: true } as const;
+      const [direct, viaTeam] = await Promise.all([
+        db.workspaceUser.findMany({
+          where: { workspaceId: input.workspaceId },
+          select: { user: { select: userSelect } },
+        }),
+        db.teamUser.findMany({
+          where: { team: { workspaceId: input.workspaceId } },
+          select: { user: { select: userSelect } },
+        }),
+      ]);
+
+      const byId = new Map<string, { id: string; name: string | null; email: string | null; image: string | null }>();
+      for (const row of [...direct, ...viaTeam]) byId.set(row.user.id, row.user);
+      const members = [...byId.values()];
+
+      // Availability = at least one synced CalendarEvent row exists. This is
+      // an existence probe, not an event read — no details leave the table.
+      const withData = await db.calendarEvent.groupBy({
+        by: ["userId"],
+        where: { userId: { in: members.map((m) => m.id) } },
+      });
+      const hasData = new Set(withData.map((row) => row.userId));
+
+      return members.map((member) => ({
+        ...member,
+        availabilityKnown: hasData.has(member.id),
+      }));
+    }),
+
+  suggestSlots: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        attendeeUserIds: z.array(z.string()).min(1).max(50),
+        durationMinutes: z.number().int().min(15).max(8 * 60),
+        rangeStart: z.date(),
+        rangeEnd: z.date(),
+      }),
+    )
+    .use(requireWorkspaceMembership("view"))
+    .query(async ({ ctx, input }) => {
+      const db = ctx.db as PrismaClient;
+      await assertNotViewer(db, ctx.session.user.id, input.workspaceId);
+      assertSaneRange(input.rangeStart, input.rangeEnd);
+
+      const memberIds = await listWorkspaceMemberIds(db, input.workspaceId);
+      const outsiders = input.attendeeUserIds.filter((id) => !memberIds.has(id));
+      if (outsiders.length > 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Attendees must be members of the workspace",
+        });
+      }
+
+      const busyBlocksByUser = await listBusyBlocksByUser(db, input.attendeeUserIds, {
+        from: input.rangeStart,
+        to: input.rangeEnd,
+      });
+
+      const availabilityUnknownUserIds = input.attendeeUserIds.filter(
+        (id) => (busyBlocksByUser.get(id) ?? []).length === 0,
+      );
+
+      const slots = computeSlots({
+        busyBlocksByUser,
+        durationMinutes: input.durationMinutes,
+        range: { from: input.rangeStart, to: input.rangeEnd },
+      });
+
+      return {
+        slots,
+        // Blocks-in-range is a heuristic for "has data" here; a member can be
+        // genuinely free all range. Cross-checked against synced sources so a
+        // truly connected-but-free attendee isn't mislabelled.
+        availabilityUnknownUserIds: await filterTrulyUnknown(
+          db,
+          availabilityUnknownUserIds,
+        ),
+      };
+    }),
+
+  createMeeting: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        title: z.string().trim().min(1).max(200),
+        description: z.string().max(10_000).optional(),
+        location: z.string().max(500).optional(),
+        projectId: z.string().optional(),
+        startsAt: z.date(),
+        endsAt: z.date(),
+        attendeeUserIds: z.array(z.string()).min(1).max(50),
+      }),
+    )
+    .use(requireWorkspaceMembership("view"))
+    .mutation(async ({ ctx, input }) => {
+      const db = ctx.db as PrismaClient;
+      const organizerId = ctx.session.user.id;
+      await assertNotViewer(db, organizerId, input.workspaceId);
+
+      if (input.endsAt <= input.startsAt) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Meeting must end after it starts" });
+      }
+
+      const memberIds = await listWorkspaceMemberIds(db, input.workspaceId);
+      if (input.attendeeUserIds.some((id) => !memberIds.has(id))) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Attendees must be members of the workspace",
+        });
+      }
+
+      // The organizer is always an attendee — their calendar gets the invite too.
+      const attendeeIds = [...new Set([...input.attendeeUserIds, organizerId])];
+
+      const meeting = await db.meeting.create({
+        data: {
+          workspaceId: input.workspaceId,
+          organizerId,
+          projectId: input.projectId,
+          title: input.title,
+          description: input.description,
+          location: input.location,
+          startsAt: input.startsAt,
+          endsAt: input.endsAt,
+          // Stable for the meeting's lifetime; the domain suffix keeps UIDs
+          // globally unique across calendar systems.
+          icalUid: `${crypto.randomUUID()}@exponential.im`,
+          attendees: { create: attendeeIds.map((userId) => ({ userId })) },
+        },
+        include: {
+          attendees: { include: { user: { select: { id: true, name: true, email: true } } } },
+          organizer: { select: { id: true, name: true, email: true } },
+        },
+      });
+
+      // Email every attendee with a real address. Send failures must not
+      // roll back the meeting — the record is the source of truth and a
+      // resend is cheaper than a phantom double-booking.
+      const organizer = {
+        name: meeting.organizer.name,
+        email: meeting.organizer.email ?? "noreply@exponential.im",
+      };
+      const recipients = meeting.attendees
+        .map((a) => a.user)
+        .filter((u): u is typeof u & { email: string } => !!u.email);
+      const ics = buildInviteIcs({
+        method: "REQUEST",
+        uid: meeting.icalUid,
+        sequence: meeting.sequence,
+        organizer,
+        attendees: recipients.map((u) => ({ name: u.name, email: u.email })),
+        title: meeting.title,
+        description: meeting.description,
+        location: meeting.location,
+        startsAt: meeting.startsAt,
+        endsAt: meeting.endsAt,
+      });
+
+      const invitesSent: string[] = [];
+      for (const recipient of recipients) {
+        try {
+          await sendMeetingInviteEmail({
+            to: recipient.email,
+            method: "REQUEST",
+            meetingTitle: meeting.title,
+            organizerName: organizer.name ?? organizer.email,
+            startsAt: meeting.startsAt,
+            endsAt: meeting.endsAt,
+            location: meeting.location,
+            icsContent: ics,
+            workspaceId: input.workspaceId,
+          });
+          invitesSent.push(recipient.email);
+        } catch (error) {
+          const { reportHandledErrorServer } = await import(
+            "~/server/utils/reportHandledErrorServer"
+          );
+          reportHandledErrorServer(error, {
+            area: "workspaceScheduling.createMeeting.invite",
+            context: { meetingId: meeting.id },
+          });
+        }
+      }
+
+      return {
+        id: meeting.id,
+        title: meeting.title,
+        startsAt: meeting.startsAt,
+        endsAt: meeting.endsAt,
+        status: meeting.status,
+        attendeeCount: meeting.attendees.length,
+        invitesSent: invitesSent.length,
+      };
+    }),
+
+  listMeetings: protectedProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        from: z.date().optional(),
+        to: z.date().optional(),
+      }),
+    )
+    .use(requireWorkspaceMembership("view"))
+    .query(async ({ ctx, input }) => {
+      const db = ctx.db as PrismaClient;
+      await assertNotViewer(db, ctx.session.user.id, input.workspaceId);
+
+      return db.meeting.findMany({
+        where: {
+          workspaceId: input.workspaceId,
+          ...(input.from ? { endsAt: { gt: input.from } } : {}),
+          ...(input.to ? { startsAt: { lt: input.to } } : {}),
+        },
+        select: {
+          id: true,
+          title: true,
+          location: true,
+          startsAt: true,
+          endsAt: true,
+          status: true,
+          organizer: { select: { id: true, name: true } },
+          attendees: { select: { user: { select: { id: true, name: true } } } },
+        },
+        orderBy: { startsAt: "asc" },
+      });
+    }),
+});
+
+/**
+ * An attendee with zero blocks in range is only availability-UNKNOWN when
+ * they also have no synced calendar source at all — an empty week from a
+ * connected calendar is real availability.
+ */
+async function filterTrulyUnknown(db: PrismaClient, userIds: string[]): Promise<string[]> {
+  if (userIds.length === 0) return [];
+  const withAnyData = await db.calendarEvent.groupBy({
+    by: ["userId"],
+    where: { userId: { in: userIds } },
+  });
+  const hasData = new Set(withAnyData.map((row) => row.userId));
+  return userIds.filter((id) => !hasData.has(id));
+}

--- a/src/server/services/CalendarProvider.ts
+++ b/src/server/services/CalendarProvider.ts
@@ -41,7 +41,7 @@ export interface CalendarEventWithSource extends CalendarEvent {
   calendarId: string;
   calendarName?: string;
   calendarColor?: string;
-  provider?: "google" | "microsoft" | "ics";
+  provider?: "google" | "microsoft" | "ics" | "meeting";
 }
 
 export interface CreateEventInput {

--- a/src/server/services/EmailService.ts
+++ b/src/server/services/EmailService.ts
@@ -99,6 +99,13 @@ export async function resolvePostmark(
 // Source of truth is `colorTokens.light.brand.primary` in `src/styles/colors.ts`.
 const EMAIL_BRAND_COLOR = colorTokens.light.brand.primary;
 
+interface EmailAttachment {
+  Name: string;
+  /** Base64-encoded file content. */
+  Content: string;
+  ContentType: string;
+}
+
 interface SendEmailParams {
   to: string;
   subject: string;
@@ -109,9 +116,11 @@ interface SendEmailParams {
    * preferred over the env default. Omit for pre-login / non-workspace emails.
    */
   workspaceId?: string;
+  /** Postmark Attachments array — e.g. an iCalendar invite. */
+  attachments?: EmailAttachment[];
 }
 
-async function sendEmail({ to, subject, htmlBody, textBody, workspaceId }: SendEmailParams): Promise<void> {
+async function sendEmail({ to, subject, htmlBody, textBody, workspaceId, attachments }: SendEmailParams): Promise<void> {
   const { apiKey, from } = await resolvePostmark(workspaceId);
 
   if (!apiKey) {
@@ -135,6 +144,7 @@ async function sendEmail({ to, subject, htmlBody, textBody, workspaceId }: SendE
       HtmlBody: htmlBody,
       TextBody: textBody,
       MessageStream: "outbound",
+      ...(attachments && attachments.length > 0 ? { Attachments: attachments } : {}),
     }),
   });
 
@@ -1278,6 +1288,74 @@ Unsubscribe: ${params.unsubscribeUrl}`;
   return { subject: params.subject, htmlBody, textBody };
 }
 
+/**
+ * Send a meeting invite (or cancellation) with the iCalendar payload as a
+ * Postmark attachment. The .ics IS the write path to the attendee's real
+ * calendar — Outlook and Gmail render METHOD:REQUEST natively with
+ * Accept/Decline, and METHOD:CANCEL against the same UID removes it.
+ */
+export async function sendMeetingInviteEmail(params: {
+  to: string;
+  method: "REQUEST" | "CANCEL";
+  meetingTitle: string;
+  organizerName: string;
+  startsAt: Date;
+  endsAt: Date;
+  location?: string | null;
+  icsContent: string;
+  workspaceId?: string;
+}): Promise<void> {
+  const { to, method, meetingTitle, organizerName, startsAt, endsAt, location, icsContent, workspaceId } = params;
+
+  const cancelled = method === "CANCEL";
+  const subject = cancelled
+    ? `Cancelled: ${meetingTitle}`
+    : `Invitation: ${meetingTitle}`;
+  const when = `${startsAt.toUTCString()} – ${endsAt.toUTCString()}`;
+
+  const textBody = [
+    cancelled
+      ? `${organizerName} cancelled the meeting "${meetingTitle}".`
+      : `${organizerName} invited you to "${meetingTitle}".`,
+    ``,
+    `When: ${when}`,
+    ...(location ? [`Where: ${location}`] : []),
+    ``,
+    cancelled
+      ? `The attached calendar file removes the event from your calendar.`
+      : `Open the attached calendar file or use your mail client's Accept/Decline buttons to respond.`,
+  ].join("\n");
+
+  const htmlBody = `
+    <div style="font-family: sans-serif; max-width: 560px;">
+      <h2 style="color: ${EMAIL_BRAND_COLOR};">${cancelled ? "Meeting cancelled" : "Meeting invitation"}</h2>
+      <p>${organizerName} ${cancelled ? "cancelled" : "invited you to"} <strong>${meetingTitle}</strong>.</p>
+      <p><strong>When:</strong> ${when}</p>
+      ${location ? `<p><strong>Where:</strong> ${location}</p>` : ""}
+      <p style="color: #4b5563;">${
+        cancelled
+          ? "The attached calendar file removes the event from your calendar."
+          : "Your mail client should offer Accept / Decline directly; otherwise open the attached invite."
+      }</p>
+    </div>
+  `;
+
+  await sendEmail({
+    to,
+    subject,
+    htmlBody,
+    textBody,
+    workspaceId,
+    attachments: [
+      {
+        Name: "invite.ics",
+        Content: Buffer.from(icsContent, "utf8").toString("base64"),
+        ContentType: `text/calendar; charset=utf-8; method=${method}`,
+      },
+    ],
+  });
+}
+
 export const EmailService = {
   sendSignInCodeEmail,
   sendWelcomeEmail,
@@ -1289,4 +1367,5 @@ export const EmailService = {
   sendCrmOnboardingWelcomeEmail,
   sendCrmAutomationEmail,
   sendBroadcastDigestEmail,
+  sendMeetingInviteEmail,
 };

--- a/src/server/services/calendar/__tests__/inviteIcs.test.ts
+++ b/src/server/services/calendar/__tests__/inviteIcs.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Golden-file tests for the iCalendar invite builder. The exact byte output
+ * matters: Outlook and Gmail's native Accept/Decline rendering depends on a
+ * well-formed METHOD + UID + SEQUENCE, and folding/escaping bugs surface as
+ * silently broken invites.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { buildInviteIcs } from "../inviteIcs";
+
+const NOW = new Date("2026-08-16T12:00:00Z");
+
+const baseInput = {
+  uid: "meeting-abc123@exponential.im",
+  sequence: 0,
+  organizer: { name: "James Farrell", email: "james@example.com" },
+  attendees: [
+    { name: "Andi Stanner", email: "andi@example.com" },
+    { name: null, email: "noname@example.com" },
+  ],
+  title: "Design sync",
+  startsAt: new Date("2026-08-18T09:00:00Z"),
+  endsAt: new Date("2026-08-18T10:00:00Z"),
+  now: NOW,
+} as const;
+
+describe("buildInviteIcs", () => {
+  it("produces the golden METHOD:REQUEST invite", () => {
+    const ics = buildInviteIcs({ ...baseInput, method: "REQUEST" });
+
+    expect(ics).toBe(
+      [
+        "BEGIN:VCALENDAR",
+        "PRODID:-//Exponential//Workspace Scheduling//EN",
+        "VERSION:2.0",
+        "CALSCALE:GREGORIAN",
+        "METHOD:REQUEST",
+        "BEGIN:VEVENT",
+        "UID:meeting-abc123@exponential.im",
+        "DTSTAMP:20260816T120000Z",
+        "DTSTART:20260818T090000Z",
+        "DTEND:20260818T100000Z",
+        "SEQUENCE:0",
+        "SUMMARY:Design sync",
+        "STATUS:CONFIRMED",
+        "ORGANIZER;CN=James Farrell:mailto:james@example.com",
+        "ATTENDEE;CN=Andi Stanner;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TR",
+        " UE:mailto:andi@example.com",
+        "ATTENDEE;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE:mailto:noname",
+        " @example.com",
+        "END:VEVENT",
+        "END:VCALENDAR",
+        "",
+      ].join("\r\n"),
+    );
+  });
+
+  it("produces the golden METHOD:CANCEL against the same UID with a bumped sequence", () => {
+    const ics = buildInviteIcs({ ...baseInput, method: "CANCEL", sequence: 1 });
+
+    expect(ics).toContain("METHOD:CANCEL");
+    expect(ics).toContain("STATUS:CANCELLED");
+    expect(ics).toContain("SEQUENCE:1");
+    expect(ics).toContain("UID:meeting-abc123@exponential.im");
+    expect(ics).not.toContain("STATUS:CONFIRMED");
+  });
+
+  it("escapes commas, semicolons, backslashes, and newlines in text values", () => {
+    const ics = buildInviteIcs({
+      ...baseInput,
+      method: "REQUEST",
+      title: "Planning; Q3, part 1",
+      description: "Line one\nLine two\\end",
+      location: "Room 1; Building A",
+    });
+
+    expect(ics).toContain("SUMMARY:Planning\\; Q3\\, part 1");
+    expect(ics).toContain("DESCRIPTION:Line one\\nLine two\\\\end");
+    expect(ics).toContain("LOCATION:Room 1\\; Building A");
+  });
+
+  it("folds every line to at most 75 octets, unfolding losslessly", () => {
+    const ics = buildInviteIcs({
+      ...baseInput,
+      method: "REQUEST",
+      description: "long ".repeat(60) + "end",
+    });
+
+    const encoder = new TextEncoder();
+    for (const line of ics.split("\r\n")) {
+      expect(encoder.encode(line).length).toBeLessThanOrEqual(75);
+    }
+    // Unfolding (CRLF + space removal) restores the full description.
+    const unfolded = ics.replace(/\r\n /g, "");
+    expect(unfolded).toContain("DESCRIPTION:" + ("long ".repeat(60) + "end").replace(/\n/g, "\\n"));
+  });
+
+  it("folds on byte length, never splitting a multi-byte character", () => {
+    const ics = buildInviteIcs({
+      ...baseInput,
+      method: "REQUEST",
+      description: "ü".repeat(200),
+    });
+
+    const encoder = new TextEncoder();
+    for (const line of ics.split("\r\n")) {
+      expect(encoder.encode(line).length).toBeLessThanOrEqual(75);
+    }
+    const unfolded = ics.replace(/\r\n /g, "");
+    expect(unfolded).toContain("ü".repeat(200));
+  });
+});

--- a/src/server/services/calendar/__tests__/meetingEventRead.test.ts
+++ b/src/server/services/calendar/__tests__/meetingEventRead.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the Meeting → calendar-surface read path: attendee scoping,
+ * confirmed-only, and the provider-payload shape the merge points expect.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { mockDeep, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+import { listMeetingCalendarEvents } from "../meetingEventRead";
+
+const RANGE = [new Date("2026-08-17T00:00:00Z"), new Date("2026-08-24T00:00:00Z")] as const;
+
+describe("listMeetingCalendarEvents", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = mockDeep<PrismaClient>();
+  });
+
+  it("scopes to meetings the user attends, confirmed only, in range", async () => {
+    db.meeting.findMany.mockResolvedValue([] as never);
+
+    await listMeetingCalendarEvents(db, "user-a", RANGE[0], RANGE[1]);
+
+    const arg = db.meeting.findMany.mock.calls[0]![0] as { where: Record<string, unknown> };
+    expect(arg.where).toMatchObject({
+      status: "confirmed",
+      startsAt: { lt: RANGE[1] },
+      endsAt: { gt: RANGE[0] },
+      attendees: { some: { userId: "user-a" } },
+    });
+  });
+
+  it("maps meetings into the multi-calendar payload shape", async () => {
+    db.meeting.findMany.mockResolvedValue([
+      {
+        id: "meeting-1",
+        workspaceId: "ws-1",
+        title: "Design sync",
+        location: "Room 1",
+        startsAt: new Date("2026-08-18T09:00:00Z"),
+        endsAt: new Date("2026-08-18T10:00:00Z"),
+        workspace: { name: "Syntrofi" },
+      },
+    ] as never);
+
+    const events = await listMeetingCalendarEvents(db, "user-a", RANGE[0], RANGE[1]);
+
+    expect(events).toEqual([
+      {
+        accountId: "meetings-ws-1",
+        accountEmail: null,
+        calendarId: "meetings-ws-1",
+        calendarName: "Syntrofi meetings",
+        provider: "meeting",
+        id: "meeting-1",
+        summary: "Design sync",
+        start: { dateTime: "2026-08-18T09:00:00.000Z" },
+        end: { dateTime: "2026-08-18T10:00:00.000Z" },
+        location: "Room 1",
+        htmlLink: "",
+        status: "confirmed",
+      },
+    ]);
+  });
+});

--- a/src/server/services/calendar/__tests__/slotEngine.test.ts
+++ b/src/server/services/calendar/__tests__/slotEngine.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the V1 slot engine: aligned candidates, busy-block
+ * exclusion across all attendees, and non-constraining unknown attendees.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { computeSlots } from "../slotEngine";
+import type { BusyBlock } from "../freeBusy";
+
+const RANGE = {
+  from: new Date("2026-08-18T09:00:00Z"),
+  to: new Date("2026-08-18T12:00:00Z"),
+};
+
+function busy(startIso: string, endIso: string): BusyBlock {
+  return {
+    startsAt: new Date(startIso),
+    endsAt: new Date(endIso),
+    isAllDay: false,
+    sourceType: "microsoft",
+  };
+}
+
+describe("computeSlots", () => {
+  it("suggests aligned slots across a free range", () => {
+    const slots = computeSlots({
+      busyBlocksByUser: new Map([["a", []]]),
+      durationMinutes: 60,
+      range: RANGE,
+    });
+
+    expect(slots[0]!.startsAt.toISOString()).toBe("2026-08-18T09:00:00.000Z");
+    expect(slots[0]!.endsAt.toISOString()).toBe("2026-08-18T10:00:00.000Z");
+    // 30-min grid, 60-min duration, 3h range → 09:00…11:00 starts.
+    expect(slots).toHaveLength(5);
+    expect(slots.at(-1)!.startsAt.toISOString()).toBe("2026-08-18T11:00:00.000Z");
+  });
+
+  it("drops slots clashing with ANY attendee's busy block", () => {
+    const slots = computeSlots({
+      busyBlocksByUser: new Map([
+        ["a", [busy("2026-08-18T09:00:00Z", "2026-08-18T10:00:00Z")]],
+        ["b", [busy("2026-08-18T11:30:00Z", "2026-08-18T12:00:00Z")]],
+      ]),
+      durationMinutes: 60,
+      range: RANGE,
+    });
+
+    // 09:00, 09:30 clash with a; 11:00, 11:30 clash with b → only 10:00, 10:30.
+    expect(slots.map((s) => s.startsAt.toISOString())).toEqual([
+      "2026-08-18T10:00:00.000Z",
+      "2026-08-18T10:30:00.000Z",
+    ]);
+  });
+
+  it("attendees with no data add no constraints", () => {
+    const constrained = computeSlots({
+      busyBlocksByUser: new Map([
+        ["a", [busy("2026-08-18T09:00:00Z", "2026-08-18T10:00:00Z")]],
+      ]),
+      durationMinutes: 60,
+      range: RANGE,
+    });
+    const withUnknown = computeSlots({
+      busyBlocksByUser: new Map([
+        ["a", [busy("2026-08-18T09:00:00Z", "2026-08-18T10:00:00Z")]],
+        ["unknown", []],
+      ]),
+      durationMinutes: 60,
+      range: RANGE,
+    });
+
+    expect(withUnknown).toEqual(constrained);
+  });
+
+  it("never suggests a slot that would run past the range end", () => {
+    const slots = computeSlots({
+      busyBlocksByUser: new Map(),
+      durationMinutes: 120,
+      range: RANGE,
+    });
+
+    for (const slot of slots) {
+      expect(slot.endsAt.getTime()).toBeLessThanOrEqual(RANGE.to.getTime());
+    }
+  });
+
+  it("caps the number of suggestions", () => {
+    const slots = computeSlots({
+      busyBlocksByUser: new Map(),
+      durationMinutes: 15,
+      range: { from: new Date("2026-08-18T00:00:00Z"), to: new Date("2026-08-25T00:00:00Z") },
+      maxSlots: 7,
+    });
+
+    expect(slots).toHaveLength(7);
+  });
+});

--- a/src/server/services/calendar/__tests__/slotEngine.test.ts
+++ b/src/server/services/calendar/__tests__/slotEngine.test.ts
@@ -96,4 +96,113 @@ describe("computeSlots", () => {
 
     expect(slots).toHaveLength(7);
   });
+
+  describe("work hours ∩ timezones", () => {
+    const nineToFive = (timezone: string | null) => ({
+      workHoursEnabled: true,
+      workDays: ["monday", "tuesday", "wednesday", "thursday", "friday"],
+      workHoursStart: "09:00",
+      workHoursEnd: "17:00",
+      timezone,
+    });
+
+    // Tue 2026-08-18, whole day UTC.
+    const DAY_RANGE = {
+      from: new Date("2026-08-18T00:00:00Z"),
+      to: new Date("2026-08-19T00:00:00Z"),
+    };
+
+    it("clamps slots to an attendee's hours in THEIR timezone", () => {
+      // Berlin (UTC+2 in August): 9–17 local = 07:00–15:00Z.
+      const slots = computeSlots({
+        busyBlocksByUser: new Map([["a", []]]),
+        attendeeSettings: new Map([["a", nineToFive("Europe/Berlin")]]),
+        durationMinutes: 60,
+        range: DAY_RANGE,
+      });
+
+      expect(slots[0]!.startsAt.toISOString()).toBe("2026-08-18T07:00:00.000Z");
+      expect(slots.at(-1)!.endsAt.toISOString()).toBe("2026-08-18T15:00:00.000Z");
+    });
+
+    it("intersects two attendees' hours across timezones", () => {
+      // Berlin 9–17 = 07:00–15:00Z; Los Angeles (UTC-7) 9–17 = 16:00–24:00Z.
+      // No overlap on this day → no slots.
+      const slots = computeSlots({
+        busyBlocksByUser: new Map([
+          ["berlin", []],
+          ["la", []],
+        ]),
+        attendeeSettings: new Map([
+          ["berlin", nineToFive("Europe/Berlin")],
+          ["la", nineToFive("America/Los_Angeles")],
+        ]),
+        durationMinutes: 60,
+        range: DAY_RANGE,
+      });
+
+      expect(slots).toHaveLength(0);
+    });
+
+    it("the outside-hours escape hatch bypasses the filter", () => {
+      const slots = computeSlots({
+        busyBlocksByUser: new Map([
+          ["berlin", []],
+          ["la", []],
+        ]),
+        attendeeSettings: new Map([
+          ["berlin", nineToFive("Europe/Berlin")],
+          ["la", nineToFive("America/Los_Angeles")],
+        ]),
+        includeOutsideWorkHours: true,
+        durationMinutes: 60,
+        range: DAY_RANGE,
+        maxSlots: 5,
+      });
+
+      expect(slots).toHaveLength(5);
+    });
+
+    it("excludes non-work days in the attendee's zone", () => {
+      // Sat 2026-08-22 UTC — a Mon–Fri attendee blocks the whole day.
+      const slots = computeSlots({
+        busyBlocksByUser: new Map([["a", []]]),
+        attendeeSettings: new Map([["a", nineToFive("Europe/Berlin")]]),
+        durationMinutes: 60,
+        range: {
+          from: new Date("2026-08-22T00:00:00Z"),
+          to: new Date("2026-08-23T00:00:00Z"),
+        },
+      });
+
+      expect(slots).toHaveLength(0);
+    });
+
+    it("attendees with work hours disabled are unconstrained", () => {
+      const slots = computeSlots({
+        busyBlocksByUser: new Map([["a", []]]),
+        attendeeSettings: new Map([
+          ["a", { ...nineToFive("Europe/Berlin"), workHoursEnabled: false }],
+        ]),
+        durationMinutes: 60,
+        range: DAY_RANGE,
+      });
+
+      // Full UTC day on a 30-min grid, capped at the default 20.
+      expect(slots).toHaveLength(20);
+      expect(slots[0]!.startsAt.toISOString()).toBe("2026-08-18T00:00:00.000Z");
+    });
+
+    it("falls back to the organizer's timezone when the attendee has none", () => {
+      const slots = computeSlots({
+        busyBlocksByUser: new Map([["a", []]]),
+        attendeeSettings: new Map([["a", nineToFive(null)]]),
+        organizerTimezone: "Europe/Berlin",
+        durationMinutes: 60,
+        range: DAY_RANGE,
+      });
+
+      expect(slots[0]!.startsAt.toISOString()).toBe("2026-08-18T07:00:00.000Z");
+    });
+  });
 });

--- a/src/server/services/calendar/inviteIcs.ts
+++ b/src/server/services/calendar/inviteIcs.ts
@@ -1,0 +1,130 @@
+/**
+ * iCalendar invite builder (RFC 5545) — the ONLY write path from Exponential
+ * to attendees' real calendars. Hand-rolled deliberately: METHOD:REQUEST /
+ * METHOD:CANCEL against a stable UID with a monotonic SEQUENCE is a small,
+ * fully-specified surface, and Outlook/Gmail render it natively with
+ * Accept/Decline — no provider API write-back needed.
+ *
+ * Pure: text in, text out. Golden-file tested.
+ */
+
+export interface InviteParticipant {
+  name: string | null;
+  email: string;
+}
+
+export interface BuildInviteInput {
+  method: "REQUEST" | "CANCEL";
+  uid: string;
+  /** Monotonic per meeting; bump on every outbound change, cancel included. */
+  sequence: number;
+  organizer: InviteParticipant;
+  attendees: InviteParticipant[];
+  title: string;
+  description?: string | null;
+  location?: string | null;
+  startsAt: Date;
+  endsAt: Date;
+  /** DTSTAMP — injectable for deterministic tests. */
+  now?: Date;
+}
+
+/** TEXT value escaping per RFC 5545 §3.3.11. */
+function escapeText(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\r?\n/g, "\\n");
+}
+
+/** UTC date-time: 20260816T140000Z. */
+function utcStamp(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
+ * Fold a content line at 75 octets (RFC 5545 §3.1): continuation lines start
+ * with a single space. Folds on UTF-8 byte length, never splitting a
+ * multi-byte character.
+ */
+function foldLine(line: string): string[] {
+  const encoder = new TextEncoder();
+  if (encoder.encode(line).length <= 75) return [line];
+
+  const out: string[] = [];
+  let current = "";
+  let currentBytes = 0;
+  // First line gets 75 octets, continuations 74 (the leading space costs one).
+  let budget = 75;
+  for (const char of line) {
+    const charBytes = encoder.encode(char).length;
+    if (currentBytes + charBytes > budget) {
+      out.push(current);
+      current = " ";
+      currentBytes = 1;
+      budget = 75;
+    }
+    current += char;
+    currentBytes += charBytes;
+  }
+  if (current.length > 0) out.push(current);
+  return out;
+}
+
+function participantLine(
+  property: "ORGANIZER" | "ATTENDEE",
+  participant: InviteParticipant,
+  params: string[] = [],
+): string {
+  const cn = participant.name ? [`CN=${escapeText(participant.name)}`] : [];
+  const allParams = [...cn, ...params].map((p) => `;${p}`).join("");
+  return `${property}${allParams}:mailto:${participant.email}`;
+}
+
+export function buildInviteIcs(input: BuildInviteInput): string {
+  const {
+    method,
+    uid,
+    sequence,
+    organizer,
+    attendees,
+    title,
+    description,
+    location,
+    startsAt,
+    endsAt,
+  } = input;
+  const now = input.now ?? new Date();
+
+  const lines: string[] = [
+    "BEGIN:VCALENDAR",
+    "PRODID:-//Exponential//Workspace Scheduling//EN",
+    "VERSION:2.0",
+    "CALSCALE:GREGORIAN",
+    `METHOD:${method}`,
+    "BEGIN:VEVENT",
+    `UID:${uid}`,
+    `DTSTAMP:${utcStamp(now)}`,
+    `DTSTART:${utcStamp(startsAt)}`,
+    `DTEND:${utcStamp(endsAt)}`,
+    `SEQUENCE:${sequence}`,
+    `SUMMARY:${escapeText(title)}`,
+    method === "CANCEL" ? "STATUS:CANCELLED" : "STATUS:CONFIRMED",
+    participantLine("ORGANIZER", organizer),
+    ...attendees.map((attendee) =>
+      participantLine("ATTENDEE", attendee, [
+        "ROLE=REQ-PARTICIPANT",
+        "PARTSTAT=NEEDS-ACTION",
+        "RSVP=TRUE",
+      ]),
+    ),
+  ];
+
+  if (description) lines.push(`DESCRIPTION:${escapeText(description)}`);
+  if (location) lines.push(`LOCATION:${escapeText(location)}`);
+
+  lines.push("END:VEVENT", "END:VCALENDAR");
+
+  return lines.flatMap(foldLine).join("\r\n") + "\r\n";
+}

--- a/src/server/services/calendar/meetingEventRead.ts
+++ b/src/server/services/calendar/meetingEventRead.ts
@@ -1,0 +1,73 @@
+/**
+ * Read path for workspace Meetings (V3) onto the calendar surfaces, shaped
+ * like the provider payloads so every multi-calendar merge point treats them
+ * as one more source. Attendee-scoped: a meeting appears on your calendar
+ * because you're on it, whichever workspace it lives in.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+
+export interface MeetingCalendarEvent {
+  accountId: string;
+  accountEmail: string | null;
+  calendarId: string;
+  calendarName?: string;
+  provider: "meeting";
+  id: string;
+  summary: string;
+  description?: string;
+  start: { dateTime?: string; date?: string };
+  end: { dateTime?: string; date?: string };
+  location?: string;
+  htmlLink: string;
+  status: string;
+}
+
+/**
+ * Confirmed meetings the user attends (or organizes — organizers are always
+ * attendees) overlapping [timeMin, timeMax). Cancelled meetings don't render:
+ * the METHOD:CANCEL email is their tombstone on external calendars, and the
+ * in-app surfaces mirror that.
+ */
+export async function listMeetingCalendarEvents(
+  db: PrismaClient,
+  userId: string,
+  timeMin: Date,
+  timeMax: Date,
+): Promise<MeetingCalendarEvent[]> {
+  const meetings = await db.meeting.findMany({
+    where: {
+      status: "confirmed",
+      startsAt: { lt: timeMax },
+      endsAt: { gt: timeMin },
+      attendees: { some: { userId } },
+    },
+    select: {
+      id: true,
+      workspaceId: true,
+      title: true,
+      location: true,
+      startsAt: true,
+      endsAt: true,
+      workspace: { select: { name: true } },
+    },
+    orderBy: { startsAt: "asc" },
+  });
+
+  return meetings.map((meeting) => ({
+    // Keyed per workspace so eventHue gives each workspace's meetings a
+    // stable colour, like a calendar of their own.
+    accountId: `meetings-${meeting.workspaceId}`,
+    accountEmail: null,
+    calendarId: `meetings-${meeting.workspaceId}`,
+    calendarName: `${meeting.workspace.name} meetings`,
+    provider: "meeting" as const,
+    id: meeting.id,
+    summary: meeting.title,
+    start: { dateTime: meeting.startsAt.toISOString() },
+    end: { dateTime: meeting.endsAt.toISOString() },
+    location: meeting.location ?? undefined,
+    htmlLink: "",
+    status: "confirmed",
+  }));
+}

--- a/src/server/services/calendar/slotEngine.ts
+++ b/src/server/services/calendar/slotEngine.ts
@@ -1,11 +1,14 @@
 /**
  * Slot suggestion engine (V3 scheduling) — pure.
  *
- * V1 of the engine: candidate slots on a fixed increment across the range,
- * keeping those free for EVERY attendee with availability data. Attendees
- * with no busy blocks contribute no constraints — the caller flags them
- * availability-unknown; they never shrink the result. Work-hours ∩ timezone
- * filtering layers on next.
+ * Candidate slots on a fixed increment across the range, keeping those that
+ * are (a) free for EVERY attendee with availability data and (b) inside each
+ * attendee's working hours interpreted in THEIR timezone (organizer timezone
+ * as fallback), unless the organizer opts into outside-hours times.
+ * Attendees with no busy blocks contribute no free/busy constraints — the
+ * caller flags them availability-unknown — but their work hours still apply
+ * when known. Chronological order; ranking heuristics are a deliberate
+ * non-goal for V1.
  */
 
 import type { BusyBlock } from "./freeBusy";
@@ -15,9 +18,26 @@ export interface Slot {
   endsAt: Date;
 }
 
+export interface AttendeeWorkSettings {
+  workHoursEnabled: boolean;
+  /** Lowercase day names, e.g. ["monday", ...]. Empty/absent → Mon–Fri. */
+  workDays: string[];
+  /** "HH:MM". */
+  workHoursStart: string | null;
+  workHoursEnd: string | null;
+  /** IANA name; null falls back to the organizer's timezone. */
+  timezone: string | null;
+}
+
 export interface ComputeSlotsInput {
   /** Busy blocks per attendee, from the free/busy contract. */
   busyBlocksByUser: Map<string, BusyBlock[]>;
+  /** Work-hours settings per attendee; missing entries are unconstrained. */
+  attendeeSettings?: Map<string, AttendeeWorkSettings>;
+  /** Fallback zone for attendees without their own User.timezone. */
+  organizerTimezone?: string | null;
+  /** Skip the work-hours filter entirely (the organizer's escape hatch). */
+  includeOutsideWorkHours?: boolean;
   durationMinutes: number;
   range: { from: Date; to: Date };
   /** Candidate grid step. */
@@ -28,13 +48,74 @@ export interface ComputeSlotsInput {
 
 const DEFAULT_INCREMENT_MINUTES = 30;
 const DEFAULT_MAX_SLOTS = 20;
+const DEFAULT_WORK_DAYS = ["monday", "tuesday", "wednesday", "thursday", "friday"];
 
 function overlaps(aStart: Date, aEnd: Date, bStart: Date, bEnd: Date): boolean {
   return aStart < bEnd && aEnd > bStart;
 }
 
+/** "09:30" → minutes since local midnight; null on unparseable input. */
+function parseHhMm(value: string | null): number | null {
+  if (!value) return null;
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value);
+  if (!match) return null;
+  const minutes = Number(match[1]) * 60 + Number(match[2]);
+  return minutes <= 24 * 60 ? minutes : null;
+}
+
+/** The instant's wall-clock position in `timeZone`: weekday + minutes-of-day. */
+function wallClock(date: Date, timeZone: string | null): { weekday: string; minutes: number } {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    ...(timeZone ? { timeZone } : {}),
+    hour12: false,
+    weekday: "long",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const parts = Object.fromEntries(
+    dtf.formatToParts(date).map((p) => [p.type, p.value]),
+  ) as Record<string, string>;
+  const hour = parts.hour === "24" ? 0 : Number(parts.hour);
+  return { weekday: (parts.weekday ?? "").toLowerCase(), minutes: hour * 60 + Number(parts.minute) };
+}
+
+/**
+ * Whether [startsAt, endsAt) sits inside one attendee's working hours,
+ * judged on their wall clock. A slot that crosses their midnight or leaves
+ * their work window at either end is out.
+ */
+function withinWorkHours(
+  startsAt: Date,
+  endsAt: Date,
+  settings: AttendeeWorkSettings,
+  organizerTimezone: string | null,
+): boolean {
+  if (!settings.workHoursEnabled) return true;
+
+  const startMinutes = parseHhMm(settings.workHoursStart) ?? 9 * 60;
+  const endMinutes = parseHhMm(settings.workHoursEnd) ?? 17 * 60;
+  const workDays = settings.workDays.length > 0 ? settings.workDays : DEFAULT_WORK_DAYS;
+  const timeZone = settings.timezone ?? organizerTimezone;
+
+  const start = wallClock(startsAt, timeZone);
+  const end = wallClock(endsAt, timeZone);
+
+  if (!workDays.includes(start.weekday)) return false;
+  if (start.minutes < startMinutes) return false;
+  // End on the boundary is fine (a 16:00–17:00 slot for 9-to-5 hours). An
+  // end wall-clock earlier than the start means the slot crossed midnight.
+  const endOfDayAdjusted = end.minutes === 0 && start.minutes > 0 ? 24 * 60 : end.minutes;
+  if (endOfDayAdjusted < start.minutes) return false;
+  if (endOfDayAdjusted > endMinutes) return false;
+
+  return true;
+}
+
 export function computeSlots({
   busyBlocksByUser,
+  attendeeSettings,
+  organizerTimezone = null,
+  includeOutsideWorkHours = false,
   durationMinutes,
   range,
   incrementMinutes = DEFAULT_INCREMENT_MINUTES,
@@ -46,6 +127,9 @@ export function computeSlots({
   // One merged busy list — a slot must dodge every attendee's blocks, so
   // whose block it is doesn't matter here.
   const allBusy = [...busyBlocksByUser.values()].flat();
+  const workConstraints = includeOutsideWorkHours
+    ? []
+    : [...(attendeeSettings?.values() ?? [])];
 
   const slots: Slot[] = [];
   // Align the grid to the increment so suggestions land on round times.
@@ -61,7 +145,12 @@ export function computeSlots({
     const clashes = allBusy.some((block) =>
       overlaps(startsAt, endsAt, block.startsAt, block.endsAt),
     );
-    if (!clashes) slots.push({ startsAt, endsAt });
+    if (clashes) continue;
+    const outsideSomeonesHours = workConstraints.some(
+      (settings) => !withinWorkHours(startsAt, endsAt, settings, organizerTimezone),
+    );
+    if (outsideSomeonesHours) continue;
+    slots.push({ startsAt, endsAt });
   }
 
   return slots;

--- a/src/server/services/calendar/slotEngine.ts
+++ b/src/server/services/calendar/slotEngine.ts
@@ -1,0 +1,68 @@
+/**
+ * Slot suggestion engine (V3 scheduling) — pure.
+ *
+ * V1 of the engine: candidate slots on a fixed increment across the range,
+ * keeping those free for EVERY attendee with availability data. Attendees
+ * with no busy blocks contribute no constraints — the caller flags them
+ * availability-unknown; they never shrink the result. Work-hours ∩ timezone
+ * filtering layers on next.
+ */
+
+import type { BusyBlock } from "./freeBusy";
+
+export interface Slot {
+  startsAt: Date;
+  endsAt: Date;
+}
+
+export interface ComputeSlotsInput {
+  /** Busy blocks per attendee, from the free/busy contract. */
+  busyBlocksByUser: Map<string, BusyBlock[]>;
+  durationMinutes: number;
+  range: { from: Date; to: Date };
+  /** Candidate grid step. */
+  incrementMinutes?: number;
+  /** Stop after this many suggestions (chronological). */
+  maxSlots?: number;
+}
+
+const DEFAULT_INCREMENT_MINUTES = 30;
+const DEFAULT_MAX_SLOTS = 20;
+
+function overlaps(aStart: Date, aEnd: Date, bStart: Date, bEnd: Date): boolean {
+  return aStart < bEnd && aEnd > bStart;
+}
+
+export function computeSlots({
+  busyBlocksByUser,
+  durationMinutes,
+  range,
+  incrementMinutes = DEFAULT_INCREMENT_MINUTES,
+  maxSlots = DEFAULT_MAX_SLOTS,
+}: ComputeSlotsInput): Slot[] {
+  const durationMs = durationMinutes * 60 * 1000;
+  const incrementMs = incrementMinutes * 60 * 1000;
+
+  // One merged busy list — a slot must dodge every attendee's blocks, so
+  // whose block it is doesn't matter here.
+  const allBusy = [...busyBlocksByUser.values()].flat();
+
+  const slots: Slot[] = [];
+  // Align the grid to the increment so suggestions land on round times.
+  const firstAligned = Math.ceil(range.from.getTime() / incrementMs) * incrementMs;
+
+  for (
+    let start = firstAligned;
+    start + durationMs <= range.to.getTime() && slots.length < maxSlots;
+    start += incrementMs
+  ) {
+    const startsAt = new Date(start);
+    const endsAt = new Date(start + durationMs);
+    const clashes = allBusy.some((block) =>
+      overlaps(startsAt, endsAt, block.startsAt, block.endsAt),
+    );
+    if (!clashes) slots.push({ startsAt, endsAt });
+  }
+
+  return slots;
+}

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -1,6 +1,7 @@
 import { GoogleCalendarService } from './GoogleCalendarService';
 import { MicrosoftCalendarService } from './MicrosoftCalendarService';
 import { listIcsCalendarEvents } from './calendar/icsEventRead';
+import { listMeetingCalendarEvents } from './calendar/meetingEventRead';
 import type { CalendarProvider } from './CalendarProvider';
 import type { PrismaClient } from '@prisma/client';
 import { db } from '~/server/db';
@@ -20,10 +21,11 @@ export async function getEventsMultiCalendar(
 ) {
   const timeMinDate = new Date(timeMin);
   const timeMaxDate = new Date(timeMax);
-  const [googleEvents, microsoftEvents, icsEvents] = await Promise.allSettled([
+  const [googleEvents, microsoftEvents, icsEvents, meetingEvents] = await Promise.allSettled([
     googleService.getEvents(userId, { timeMin: timeMinDate, timeMax: timeMaxDate, maxResults }),
     microsoftService.getEvents(userId, { timeMin: timeMinDate, timeMax: timeMaxDate, maxResults }),
     listIcsCalendarEvents(db, userId, timeMinDate, timeMaxDate),
+    listMeetingCalendarEvents(db, userId, timeMinDate, timeMaxDate),
   ]);
 
   const allEvents = [];
@@ -39,6 +41,11 @@ export async function getEventsMultiCalendar(
   if (icsEvents.status === 'fulfilled') {
     // Already carries provider: 'ics'.
     allEvents.push(...icsEvents.value);
+  }
+
+  if (meetingEvents.status === 'fulfilled') {
+    // Already carries provider: 'meeting'.
+    allEvents.push(...meetingEvents.value);
   }
 
   // Sort by start time


### PR DESCRIPTION
## What

**V3 — workspace meeting scheduling**: a member picks attendees (workspace members, direct + via-team; calendar-less members flagged availability-unknown but invitable), duration, and gets suggested slots that are free for everyone with availability data AND inside each attendee's working hours interpreted in their own timezone (organizer-timezone fallback, outside-hours escape hatch). Confirming creates a workspace-scoped `Meeting` and emails every attendee a hand-rolled RFC 5545 **METHOD:REQUEST** invite via Postmark attachments — Outlook/Gmail render Accept/Decline natively, so the meeting lands on real calendars with no API write-back. Cancel bumps SEQUENCE and sends **METHOD:CANCEL** against the same UID. Meetings render on attendees' /calendar and Today via the shared read paths. Viewers are rejected server-side on every procedure. Entry points on /calendar and the workspace home; full fields (location/link, project link, Markdown description per ADR-0017).

**Migration** (`meetings`): `Meeting` + `MeetingAttendee` — applies on merge via the production migrate step.

Verified end-to-end in the browser against a scratch DB with a two-member workspace: teammate busy 09:00–14:00 Berlin with 9–17 work hours → suggestions started exactly at Mon 14:00, stopped at 17:00, skipped the weekend, resumed Tue 09:00; created meeting persisted with stable UID + organizer auto-attending and rendered on the week grid. The demo also caught (and this PR fixes) the grid being hidden for users whose only events are DB-backed.

## Acceptance criteria

- [x] All 7 V3 requirement rows met (slots free for all with data; viewer rejection; work-hours/timezone filter; member-only picker with availability-unknown; Meeting record + METHOD:REQUEST on confirm; METHOD:CANCEL on cancel; meetings on shared read paths)
- [x] Free/busy stripping enforced structurally (Prisma select), asserted in router tests via createMockCaller
- [x] No reschedule flow, no external attendees, no auto-conference links (explicit non-goals)

---

Ships: brave.maple
