### PR TITLE
fix(recordings): move Keywords section below Topics Discussed

### DIFF
--- a/src/app/_components/FirefliesSummaryRenderer.tsx
+++ b/src/app/_components/FirefliesSummaryRenderer.tsx
@@ -47,23 +47,6 @@ export function FirefliesSummaryDisplay({ summary }: FirefliesSummaryProps) {
 function renderSummarySections(summary: FirefliesSummary) {
   return (
     <>
-      {summary.keywords && summary.keywords.length > 0 && (
-        <Accordion.Item value="keywords">
-          <Accordion.Control>
-            <Title order={5}>Keywords</Title>
-          </Accordion.Control>
-          <Accordion.Panel>
-            <Group gap="xs">
-              {summary.keywords.map((keyword: string, index: number) => (
-                <Badge key={index} variant="light" size="sm">
-                  {keyword}
-                </Badge>
-              ))}
-            </Group>
-          </Accordion.Panel>
-        </Accordion.Item>
-      )}
-
       {summary.action_items &&
         (Array.isArray(summary.action_items)
           ? summary.action_items.length > 0
@@ -218,6 +201,23 @@ function renderSummarySections(summary: FirefliesSummary) {
                 ),
               )}
             </List>
+          </Accordion.Panel>
+        </Accordion.Item>
+      )}
+
+      {summary.keywords && summary.keywords.length > 0 && (
+        <Accordion.Item value="keywords">
+          <Accordion.Control>
+            <Title order={5}>Keywords</Title>
+          </Accordion.Control>
+          <Accordion.Panel>
+            <Group gap="xs">
+              {summary.keywords.map((keyword: string, index: number) => (
+                <Badge key={index} variant="light" size="sm">
+                  {keyword}
+                </Badge>
+              ))}
+            </Group>
           </Accordion.Panel>
         </Accordion.Item>
       )}


### PR DESCRIPTION
## What

- Move the Keywords accordion section in the Fireflies summary renderer from the top of the list to directly after the Topics Discussed section.

## Why

On the recording detail page, Keywords should appear under Topics Discussed.