### PR TITLE
fix(crm): show uploaded contact image as avatar on detail and list pages

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/[id]/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/[id]/page.tsx
@@ -558,7 +558,7 @@ export default function ContactDetailPage() {
 
       {/* Contact Header */}
       <div className="flex items-center gap-4 border-b border-border-primary bg-background-primary px-6 py-4">
-        <Avatar size="lg" radius="xl">
+        <Avatar size="lg" radius="xl" src={contact.imageUrl}>
           {getInitialFromName(contact.firstName ?? contact.lastName)}
         </Avatar>
         <div className="flex-1">

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/page.tsx
@@ -494,7 +494,7 @@ export default function ContactsPage() {
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-3">
-                        <Avatar size="sm" radius="xl">
+                        <Avatar size="sm" radius="xl" src={contact.imageUrl}>
                           {contact.firstName?.[0]?.toUpperCase() ??
                             contact.lastName?.[0]?.toUpperCase() ??
                             contact.email?.[0]?.toUpperCase() ??

--- a/src/app/_components/crm/EditContactDrawer.tsx
+++ b/src/app/_components/crm/EditContactDrawer.tsx
@@ -221,6 +221,9 @@ export function EditContactDrawer({
   const removeScreenshot = api.crmContact.removeScreenshot.useMutation({
     onSuccess: () => {
       void utils.crmContact.listScreenshots.invalidate({ contactId: contact.id });
+      // The latest image doubles as the contact's avatar on getById/getAll.
+      void utils.crmContact.getById.invalidate({ id: contact.id });
+      void utils.crmContact.getAll.invalidate();
     },
     onError: (error) => {
       notifications.show({ title: 'Error', message: error.message, color: 'red' });
@@ -323,6 +326,9 @@ export function EditContactDrawer({
           .map((s) => s.id);
         setPastedScreenshots((prev) => prev.filter((s) => failedIds.includes(s.id)));
         void utils.crmContact.listScreenshots.invalidate({ contactId: contact.id });
+        // The latest image doubles as the contact's avatar on getById/getAll.
+        void utils.crmContact.getById.invalidate({ id: contact.id });
+        void utils.crmContact.getAll.invalidate();
 
         if (failedIds.length > 0) {
           // Contact saved, but some images didn't upload — keep the drawer open

--- a/src/server/api/routers/crmContact.ts
+++ b/src/server/api/routers/crmContact.ts
@@ -267,6 +267,12 @@ export const crmContactRouter = createTRPCRouter({
               image: true,
             },
           },
+          // Latest uploaded image doubles as the contact's avatar.
+          screenshots: {
+            orderBy: { createdAt: "desc" },
+            take: 1,
+            select: { screenshot: { select: { url: true } } },
+          },
         },
         orderBy: [
           { lastInteractionAt: { sort: "desc", nulls: "last" } },
@@ -278,8 +284,9 @@ export const crmContactRouter = createTRPCRouter({
 
       // Decrypt PII fields before returning
       const decrypted = contacts.map((c) => {
+        const imageUrl = c.screenshots[0]?.screenshot.url ?? null;
         try {
-          return decryptContactPII(c);
+          return { ...decryptContactPII(c), imageUrl };
         } catch (e) {
           console.error("PII decryption failed for contact", c.id, e);
           // Return with null PII fields on decryption failure
@@ -292,6 +299,7 @@ export const crmContactRouter = createTRPCRouter({
             twitter: null,
             github: null,
             bluesky: null,
+            imageUrl,
           };
         }
       });
@@ -357,6 +365,12 @@ export const crmContactRouter = createTRPCRouter({
                 take: 20,
               }
             : false,
+          // Latest uploaded image doubles as the contact's avatar.
+          screenshots: {
+            orderBy: { createdAt: "desc" },
+            take: 1,
+            select: { screenshot: { select: { url: true } } },
+          },
         },
       });
 
@@ -369,8 +383,9 @@ export const crmContactRouter = createTRPCRouter({
       }
 
       // Decrypt PII fields before returning
+      const imageUrl = contact.screenshots[0]?.screenshot.url ?? null;
       try {
-        return decryptContactPII(contact);
+        return { ...decryptContactPII(contact), imageUrl };
       } catch (e) {
         console.error("PII decryption failed for contact", contact.id, e);
         return {
@@ -382,6 +397,7 @@ export const crmContactRouter = createTRPCRouter({
           twitter: null,
           github: null,
           bluesky: null,
+          imageUrl,
         };
       }
     }),


### PR DESCRIPTION
## Problem

Images uploaded to a contact via the Edit drawer were saved (Vercel Blob + `CrmContactScreenshot`) but never displayed anywhere except the drawer's own Images gallery. The contact detail header and the contacts list rendered initials-only `<Avatar>` components, so /w/{workspace}/crm/contacts and the contact detail page showed no image.

## Fix

- `crmContact.getAll` and `crmContact.getById` now include the most recently uploaded image (`take: 1`) and return it as a new `imageUrl` field
- The detail-page header Avatar and the list-row Avatar pass `src={contact.imageUrl}`, keeping the initials fallback when no image exists
- `EditContactDrawer` invalidates `getById`/`getAll` after image upload or removal, so the avatar refreshes without a page reload

If a contact has multiple images, the newest upload is used as the avatar.

## Verification

- Verified in a local dev server with a seeded contact: detail header and list row both render the uploaded image; contacts without images still show initials
- Typecheck and lint clean on all changed files; full unit suite (3065 tests) passed in pre-commit
- No schema changes — UI + query shape only