### PR TITLE
fix(transcriptions): keep screenshot refs paired to the right actions when a create fails mid-list

### DIFF
--- a/src/server/services/TranscriptionProcessingService.ts
+++ b/src/server/services/TranscriptionProcessingService.ts
@@ -206,13 +206,16 @@ export class TranscriptionProcessingService {
       result.errors = actionResult.errors;
       result.success = actionResult.errors.length === 0;
 
-      // Create screenshot-action associations based on AI screenshotRefs
+      // Create screenshot-action associations based on AI screenshotRefs.
+      // itemResults is index-parallel with the input actionItems (null where a
+      // create failed), so a mid-list failure can't shift the pairings.
+      const itemResults = actionResult.itemResults ?? [];
       if (screenshots.length > 0 && actionResult.createdItems.length > 0) {
         const junctionData: { actionId: string; screenshotId: string }[] = [];
 
-        for (let i = 0; i < actionResult.createdItems.length && i < processedData.actionItems.length; i++) {
+        for (let i = 0; i < itemResults.length && i < processedData.actionItems.length; i++) {
           const item = processedData.actionItems[i];
-          const created = actionResult.createdItems[i];
+          const created = itemResults[i];
           if (!item?.screenshotRefs?.length || !created) continue;
 
           for (const ref of item.screenshotRefs) {

--- a/src/server/services/__tests__/TranscriptionProcessingService.screenshotPairing.test.ts
+++ b/src/server/services/__tests__/TranscriptionProcessingService.screenshotPairing.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression guard for screenshot→action pairing when a create fails mid-list.
+ *
+ * `InternalActionProcessor.processActionItems` skips failed creates, so its
+ * `createdItems` array is NOT index-parallel with the input action items. The
+ * screenshot junction loop in `generateDraftActions` used to pair
+ * `createdItems[i]` with `actionItems[i]`, so one failed create shifted every
+ * subsequent pairing and attached screenshots to the wrong actions. The fix is
+ * the index-parallel `itemResults` array (null placeholder on failure).
+ *
+ * Uses `vitest-mock-extended`'s `mockDeep<PrismaClient>()` — no real DB, ever
+ * (see CLAUDE.md "Test database safety").
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDeep, mockReset, type DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "@prisma/client";
+
+const dbHolder: { current: DeepMockProxy<PrismaClient> | null } = { current: null };
+function getDbMock(): DeepMockProxy<PrismaClient> {
+  if (!dbHolder.current) dbHolder.current = mockDeep<PrismaClient>();
+  return dbHolder.current;
+}
+vi.mock("~/server/db", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        const m = getDbMock() as unknown as Record<string | symbol, unknown>;
+        return m[prop as string];
+      },
+    },
+  );
+  return { db: proxy };
+});
+
+vi.mock("../FirefliesService", () => ({
+  FirefliesService: { parseActionItems: vi.fn(() => []) },
+}));
+
+vi.mock("../ActionExtractionService", () => ({
+  ActionExtractionService: { extractFromTranscript: vi.fn() },
+  numberScreenshotMarkers: vi.fn((text: string) => ({ numberedText: text, count: 0 })),
+}));
+
+vi.mock("../notifications/NotificationServiceFactory", () => ({
+  NotificationServiceFactory: {},
+}));
+vi.mock("../SlackChannelResolver", () => ({ SlackChannelResolver: {} }));
+vi.mock("../notifications/SlackNotificationService", () => ({
+  SlackNotificationService: {},
+}));
+vi.mock("../access", () => ({
+  getProjectAccess: vi.fn(),
+  hasProjectAccess: vi.fn(),
+}));
+vi.mock("../meetings/assignMeetingPlacement", () => ({
+  assignMeetingPlacement: vi.fn(),
+}));
+
+import { TranscriptionProcessingService } from "../TranscriptionProcessingService";
+import { InternalActionProcessor } from "../processors/InternalActionProcessor";
+import { ActionExtractionService } from "../ActionExtractionService";
+
+const USER_ID = "user-1";
+const TRANSCRIPTION_ID = "session-1";
+
+/** db.action.create mock that fails for one specific action name. */
+function mockActionCreateFailingOn(db: DeepMockProxy<PrismaClient>, failName: string) {
+  db.action.create.mockImplementation(((args: { data: { name: string } }) => {
+    if (args.data.name === failName) {
+      return Promise.reject(new Error("simulated create failure"));
+    }
+    return Promise.resolve({ id: `id-${args.data.name}`, name: args.data.name });
+  }) as never);
+}
+
+describe("screenshot pairing survives a failed create mid-list", () => {
+  let db: DeepMockProxy<PrismaClient>;
+
+  beforeEach(() => {
+    db = getDbMock();
+    mockReset(db);
+  });
+
+  it("InternalActionProcessor.itemResults stays index-parallel with its input", async () => {
+    mockActionCreateFailingOn(db, "Second action");
+
+    const processor = new InternalActionProcessor({
+      userId: USER_ID,
+      transcriptionId: TRANSCRIPTION_ID,
+      actionStatus: "DRAFT",
+    });
+
+    const result = await processor.processActionItems([
+      { text: "First action" },
+      { text: "Second action" },
+      { text: "Third action" },
+    ]);
+
+    expect(result.processedCount).toBe(2);
+    expect(result.createdItems).toHaveLength(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.itemResults).toEqual([
+      { id: "id-First action", title: "First action" },
+      null,
+      { id: "id-Third action", title: "Third action" },
+    ]);
+  });
+
+  it("generateDraftActions attaches screenshotRefs to the correct actions", async () => {
+    db.transcriptionSession.findUnique.mockResolvedValue({
+      id: TRANSCRIPTION_ID,
+      userId: USER_ID,
+      projectId: null,
+      project: null,
+      user: { id: USER_ID },
+      title: "Test meeting",
+      summary: null,
+      transcription: "some transcript text with [SCREENSHOT] markers",
+    } as never);
+    db.screenshot.findMany.mockResolvedValue([
+      { id: "shot-1" },
+      { id: "shot-2" },
+      { id: "shot-3" },
+    ] as never);
+    db.action.count.mockResolvedValue(0);
+    db.actionScreenshot.createMany.mockResolvedValue({ count: 2 } as never);
+    db.transcriptionSession.update.mockResolvedValue({} as never);
+
+    vi.mocked(ActionExtractionService.extractFromTranscript).mockResolvedValue([
+      { text: "First action", screenshotRefs: [1] },
+      { text: "Second action", screenshotRefs: [2] },
+      { text: "Third action", screenshotRefs: [3] },
+    ]);
+
+    // The middle create fails — before the fix this shifted "Third action"
+    // onto the second item's refs, attaching shot-2 to the wrong action.
+    mockActionCreateFailingOn(db, "Second action");
+
+    await TranscriptionProcessingService.generateDraftActions(
+      TRANSCRIPTION_ID,
+      USER_ID,
+    );
+
+    expect(db.actionScreenshot.createMany).toHaveBeenCalledTimes(1);
+    expect(db.actionScreenshot.createMany).toHaveBeenCalledWith({
+      data: [
+        { actionId: "id-First action", screenshotId: "shot-1" },
+        { actionId: "id-Third action", screenshotId: "shot-3" },
+      ],
+      skipDuplicates: true,
+    });
+  });
+});

--- a/src/server/services/__tests__/TranscriptionProcessingService.screenshotPairing.test.ts
+++ b/src/server/services/__tests__/TranscriptionProcessingService.screenshotPairing.test.ts
@@ -39,8 +39,13 @@ vi.mock("../FirefliesService", () => ({
 }));
 
 vi.mock("../ActionExtractionService", () => ({
-  ActionExtractionService: { extractFromTranscript: vi.fn() },
+  ActionExtractionService: {
+    extractFromNotes: vi.fn(),
+    extractFromTranscript: vi.fn(),
+  },
   numberScreenshotMarkers: vi.fn((text: string) => ({ numberedText: text, count: 0 })),
+  filterNearDuplicateActions: vi.fn((items: unknown[]) => items),
+  mergeActionItems: vi.fn((a: unknown[], b: unknown[]) => [...a, ...b]),
 }));
 
 vi.mock("../notifications/NotificationServiceFactory", () => ({
@@ -117,6 +122,7 @@ describe("screenshot pairing survives a failed create mid-list", () => {
       user: { id: USER_ID },
       title: "Test meeting",
       summary: null,
+      notes: "- a curated notes action",
       transcription: "some transcript text with [SCREENSHOT] markers",
     } as never);
     db.screenshot.findMany.mockResolvedValue([
@@ -128,14 +134,20 @@ describe("screenshot pairing survives a failed create mid-list", () => {
     db.actionScreenshot.createMany.mockResolvedValue({ count: 2 } as never);
     db.transcriptionSession.update.mockResolvedValue({} as never);
 
+    // Mirrors the post-PR-600 shape: a notes-derived item (no screenshotRefs)
+    // sits ahead of the transcript items (with refs) in the merged array.
+    vi.mocked(ActionExtractionService.extractFromNotes).mockResolvedValue([
+      { text: "Notes action" },
+    ]);
     vi.mocked(ActionExtractionService.extractFromTranscript).mockResolvedValue([
       { text: "First action", screenshotRefs: [1] },
       { text: "Second action", screenshotRefs: [2] },
       { text: "Third action", screenshotRefs: [3] },
     ]);
 
-    // The middle create fails — before the fix this shifted "Third action"
-    // onto the second item's refs, attaching shot-2 to the wrong action.
+    // A mid-list create fails — before the fix this shifted "Third action"
+    // onto the second transcript item's refs, attaching shot-2 to the wrong
+    // action.
     mockActionCreateFailingOn(db, "Second action");
 
     await TranscriptionProcessingService.generateDraftActions(

--- a/src/server/services/processors/ActionProcessor.ts
+++ b/src/server/services/processors/ActionProcessor.ts
@@ -7,16 +7,24 @@ export interface ParsedActionItem {
   screenshotRefs?: number[];
 }
 
+export interface CreatedActionItem {
+  id: string;
+  externalId?: string;
+  title: string;
+  url?: string;
+}
+
 export interface ActionProcessorResult {
   success: boolean;
   processedCount: number;
   errors: string[];
-  createdItems: Array<{
-    id: string;
-    externalId?: string;
-    title: string;
-    url?: string;
-  }>;
+  createdItems: CreatedActionItem[];
+  /**
+   * Index-parallel with the input actionItems: itemResults[i] is the created
+   * item for actionItems[i], or null if that create failed. Use this (not
+   * createdItems) when pairing outputs back to inputs by index.
+   */
+  itemResults?: Array<CreatedActionItem | null>;
 }
 
 export interface ActionProcessorConfig {

--- a/src/server/services/processors/InternalActionProcessor.ts
+++ b/src/server/services/processors/InternalActionProcessor.ts
@@ -1,4 +1,4 @@
-import { ActionProcessor, type ParsedActionItem, type ActionProcessorResult, type ActionProcessorConfig } from './ActionProcessor';
+import { ActionProcessor, type ParsedActionItem, type ActionProcessorResult, type ActionProcessorConfig, type CreatedActionItem } from './ActionProcessor';
 import { db } from '~/server/db';
 import { type PRIORITY_VALUES } from '~/types/priority';
 
@@ -11,23 +11,30 @@ export class InternalActionProcessor extends ActionProcessor {
   }
 
   async processActionItems(actionItems: ParsedActionItem[]): Promise<ActionProcessorResult> {
+    // Index-parallel with actionItems: null marks a failed create so callers
+    // can pair inputs to outputs by index (see ActionProcessorResult.itemResults)
+    const itemResults: Array<CreatedActionItem | null> = [];
     const result: ActionProcessorResult = {
       success: true,
       processedCount: 0,
       errors: [],
-      createdItems: []
+      createdItems: [],
+      itemResults
     };
 
     try {
       for (const item of actionItems) {
         try {
           const action = await this.createAction(item);
-          result.createdItems.push({
+          const created = {
             id: action.id,
             title: action.name,
-          });
+          };
+          result.createdItems.push(created);
+          itemResults.push(created);
           result.processedCount++;
         } catch (error) {
+          itemResults.push(null);
           result.errors.push(`Failed to create action "${item.text}": ${error instanceof Error ? error.message : 'Unknown error'}`);
         }
       }


### PR DESCRIPTION
## Problem

`InternalActionProcessor.processActionItems` pushes to `createdItems` only on successful creates and continues past failures. The screenshot junction loop in `TranscriptionProcessingService.generateDraftActions` paired `createdItems[i]` with the input `actionItems[i]` when attaching `screenshotRefs` — so one failed create mid-list shifted all subsequent pairings and attached screenshots to the **wrong actions**.

This became more likely after PR 600, which puts notes-derived items (no screenshotRefs) ahead of transcript items (with refs) in the same array.

## Fix

- `ActionProcessorResult` gains an optional `itemResults` array that is **index-parallel with the input** (`null` placeholder where a create failed). `createdItems` is unchanged, so the Monday/Slack processors and existing consumers are unaffected.
- `InternalActionProcessor` populates `itemResults` alongside `createdItems`.
- The screenshot junction loop now iterates `itemResults`, so a mid-list failure can't shift pairings.

## Test

New unit test (`mockDeep<PrismaClient>`, no real DB) with two cases:
1. `processActionItems` with the middle of three creates failing → `itemResults` is `[created, null, created]`.
2. `generateDraftActions` end-to-end with the second create failing → `actionScreenshot.createMany` receives exactly shot-1→action-1 and shot-3→action-3. Under the old pairing, action 3 would have received item 2's ref (shot-2), so the test is discriminating.

Verified: full unit suite (3045 tests), targeted ESLint, and `tsc --noEmit` all clean.