### PR TITLE
fix(crm): edit-contact drawer opens bottom-left instead of docked right

### DIFF
--- a/src/app/_components/crm/EditContactDrawer.tsx
+++ b/src/app/_components/crm/EditContactDrawer.tsx
@@ -370,7 +370,12 @@ export function EditContactDrawer({
       size={wide ? 720 : 540}
     >
       <Drawer.Overlay />
-      <Drawer.Content style={{ display: 'flex', flexDirection: 'column' }}>
+      {/* Flex column must go through `styles.content` — a plain `style` prop is
+          also spread onto the fixed inner wrapper, flipping the drawer's flex
+          axis so it renders bottom-left instead of docked right. */}
+      <Drawer.Content
+        styles={{ content: { display: 'flex', flexDirection: 'column' } }}
+      >
         <Drawer.Header>
           <div className="flex w-full items-center gap-3">
             <Avatar radius="md" color="brand">


### PR DESCRIPTION
## Problem

Opening **Edit contact** from the CRM contact detail page rendered the form as a panel stuck in the **bottom-left corner** of the viewport instead of a drawer sliding in from the right.

## Cause

`EditContactDrawer` passed `style={{ display: 'flex', flexDirection: 'column' }}` to `Drawer.Content` (to make the footer stick and the body scroll). In Mantine v7, `DrawerContent` spreads that `style` prop onto **both** the content `<section>` **and** the fixed full-screen `.mantine-Drawer-inner` flex wrapper (`innerProps: ctx.getStyles('inner', { style, ... })`).

The inner wrapper is the element that positions the drawer via `justify-content: flex-end` (right) with a row flex axis. Forcing `flex-direction: column` on it flipped the axis, so:
- `justify-content: flex-end` → pinned to the **bottom** instead of the right
- `align-items` default → pinned to the **left**
- the 540px `--drawer-size` flex-basis → became the **height** instead of the width

## Fix

Move the flex column into `styles={{ content: { ... } }}`, which targets only the content section. One-line change plus a comment explaining the trap.

## Verification

Reproduced locally, then verified after the fix: drawer docks right at 540×full-height, wide toggle gives 720px, sticky footer and scrolling body unchanged. `npx tsc --noEmit` and ESLint clean; all 3065 unit tests pass (pre-commit hook).