### PR TITLE
fix(meetings): show Schedule meeting button only on workspace meetings page

### DIFF
--- a/src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/home/page.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { Suspense, useState } from 'react';
-import { Button, Container, Group, Skeleton, Stack, Text } from '@mantine/core';
-import { IconCalendarPlus } from '@tabler/icons-react';
+import { Suspense } from 'react';
+import { Container, Skeleton, Stack, Text } from '@mantine/core';
 import { useWorkspace } from '~/providers/WorkspaceProvider';
-import { ScheduleMeetingModal } from '~/app/_components/calendar/ScheduleMeetingModal';
 import { WorkspaceHomeConceptD as WorkspaceHomeCommand } from '~/app/_components/home/WorkspaceHomeConceptD';
 import { WorkspaceHomeActivity } from '~/app/_components/home/WorkspaceHomeActivity';
 import { WorkspaceHomeCoaching } from '~/app/_components/home/WorkspaceHomeCoaching';
@@ -14,7 +12,6 @@ import { validateHomeLayout } from '~/app/_components/home/HomeLayoutPicker';
 
 function WorkspaceHomeContent() {
   const { workspace, isLoading: workspaceLoading } = useWorkspace();
-  const [scheduleOpen, setScheduleOpen] = useState(false);
 
   if (workspaceLoading) {
     return (
@@ -53,22 +50,6 @@ function WorkspaceHomeContent() {
       {/* Activity layout shows GitHub in the rail widget; other layouts have no
           rail, so they keep the top Connect banner. */}
       {layout !== 'activity' && <GithubConnectCta />}
-      {/* Workspace-page entry point for cross-member scheduling (V3). */}
-      <Group justify="flex-end" px="md" pt="sm">
-        <Button
-          size="xs"
-          variant="light"
-          leftSection={<IconCalendarPlus size={14} />}
-          onClick={() => setScheduleOpen(true)}
-        >
-          Schedule meeting
-        </Button>
-      </Group>
-      <ScheduleMeetingModal
-        opened={scheduleOpen}
-        onClose={() => setScheduleOpen(false)}
-        defaultWorkspaceId={workspace.id}
-      />
       {layoutContent}
     </>
   );

--- a/src/app/_components/MeetingsContent.tsx
+++ b/src/app/_components/MeetingsContent.tsx
@@ -51,6 +51,7 @@ import {
   IconChevronDown,
   IconArrowRight,
   IconCheckbox,
+  IconCalendarPlus,
 } from "@tabler/icons-react";
 import { TranscriptView } from "./meeting/TranscriptView";
 import { MeetingProjectPicker } from "./meeting/MeetingProjectPicker";
@@ -63,6 +64,7 @@ import {
 } from "~/lib/meetingCardViewModel";
 import type { WeeklyMeetingStatsResult } from "~/server/services/meetings/weeklyMeetingStats";
 import { CreateTranscriptionModal } from "./CreateTranscriptionModal";
+import { ScheduleMeetingModal } from "./calendar/ScheduleMeetingModal";
 
 type MeetingType =
   | "all"
@@ -523,6 +525,9 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
   // Slack Summary Modal state
   const [slackModalOpened, setSlackModalOpened] = useState(false);
   const [selectedMeetingForSlack, setSelectedMeetingForSlack] = useState<any>(null);
+
+  // Cross-member scheduling modal state (V3)
+  const [scheduleModalOpened, setScheduleModalOpened] = useState(false);
 
   // Fireflies settings modal state
   const [firefliesModalOpened, setFirefliesModalOpened] = useState(false);
@@ -1085,9 +1090,28 @@ export function MeetingsContent({ workspaceId }: MeetingsContentProps = {}) {
                 Connect Fireflies
               </button>
             )}
+            {/* Workspace-page entry point for cross-member scheduling (V3);
+                hidden on the legacy non-workspace /meetings page. */}
+            {workspaceId && (
+              <Button
+                size="xs"
+                variant="light"
+                leftSection={<IconCalendarPlus size={14} />}
+                onClick={() => setScheduleModalOpened(true)}
+              >
+                Schedule meeting
+              </Button>
+            )}
             <CreateTranscriptionModal workspaceId={workspaceId} />
           </Group>
         </Group>
+        {workspaceId && (
+          <ScheduleMeetingModal
+            opened={scheduleModalOpened}
+            onClose={() => setScheduleModalOpened(false)}
+            defaultWorkspaceId={workspaceId}
+          />
+        )}
         <div className="mt-6 h-px w-full bg-border-primary" />
       </div>
 


### PR DESCRIPTION
## What

- Move the "Schedule meeting" button (cross-member scheduling entry point, V3) off the workspace home page
- Add it to the meetings page header, between the Fireflies pill and Add Meeting
- Gate button and modal on workspaceId so the legacy non-workspace /meetings page is unaffected

## Why

The schedule-meeting entry point should live on the workspace meetings page, not the home page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)