### PR TITLE
fix(auth): align Google OAuth scopes with Cloud Console for verification

### DIFF
--- a/dev-docs/testing/calendar-integration-test-plan.md
+++ b/dev-docs/testing/calendar-integration-test-plan.md
@@ -41,7 +41,7 @@ This document outlines the comprehensive testing strategy for the Google Calenda
 - [ ] Complete OAuth flow from button click to callback
 - [ ] Token storage and retrieval
 - [ ] Refresh token handling
-- [ ] Scope verification (calendar.readonly, calendar.events)
+- [ ] Scope verification (calendar.events, calendar.calendarlist.readonly)
 
 ### Calendar Service Integration
 - [ ] Events fetching from Google Calendar API

--- a/src/app/(sidemenu)/privacy/page.tsx
+++ b/src/app/(sidemenu)/privacy/page.tsx
@@ -224,6 +224,39 @@ export default function PrivacyPolicy() {
           </ol>
         </div>
 
+        {/* AI/ML disclosure — required by the Google Workspace API User Data
+            and Developer Policy (Limited Use requirements for AI/ML). */}
+        <div className="mb-4">
+          <h3 className="text-xl font-semibold mb-3">AI Features and Google User Data</h3>
+          <p className="text-text-secondary mb-3">
+            Some {PRODUCT_NAME} features use large language models to generate content you request,
+            such as daily briefings, meeting preparation, and assistant chat responses. When you use
+            these features, relevant Google user data (for example, calendar event details) may be
+            processed transiently by our AI service providers, OpenAI and Anthropic, through their
+            commercial APIs. Under the terms of those APIs, and our configuration of them, this data
+            is not used to train or improve their models.
+          </p>
+          <ul className="list-disc pl-5 text-text-secondary space-y-2">
+            <li>
+              We do not use Google user data — raw, aggregated, anonymized, or derived — to create,
+              train, or improve any machine learning or artificial intelligence models, whether our
+              own or a third party&apos;s.
+            </li>
+            <li>
+              We do not transfer or sell Google user data to third-party AI tools, data brokers, or
+              advertising platforms, and we do not allow any third party to use it for model training.
+            </li>
+            <li>
+              AI processing happens only when you actively use an AI feature, and only with the data
+              needed to fulfil your request.
+            </li>
+          </ul>
+          <p className="text-text-secondary mt-3">
+            The use of raw or derived user data received from Workspace APIs will adhere to the
+            Google User Data Policy, including the Limited Use requirements.
+          </p>
+        </div>
+
         <p className="text-text-secondary mt-4 pt-4 border-t border-border-primary">
           Our use of Google user data adheres to the{' '}
           <a

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/_components/ImportDialog.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/_components/ImportDialog.tsx
@@ -27,6 +27,7 @@ import { api } from "~/trpc/react";
 import { notifications } from "@mantine/notifications";
 import { subMonths, subYears } from "date-fns";
 import { GooglePremiumFeature } from "~/app/_components/GooglePremiumFeature";
+import { getGoogleAuthUrl } from "~/lib/googleScopes";
 
 interface ImportDialogProps {
   opened: boolean;
@@ -119,8 +120,7 @@ export function ImportDialog({
 
   // Handle OAuth redirect - request the contacts scope set (calendar + contacts)
   const handleConnectGoogle = () => {
-    const returnUrl = window.location.pathname;
-    window.location.href = `/api/auth/google-calendar?type=contacts&returnUrl=${encodeURIComponent(returnUrl)}`;
+    window.location.href = getGoogleAuthUrl("contacts", window.location.pathname);
   };
 
   // Handle import start

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/_components/ImportDialog.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/_components/ImportDialog.tsx
@@ -117,10 +117,10 @@ export function ImportDialog({
     onClose();
   };
 
-  // Handle OAuth redirect - request CRM scopes (calendar + contacts + gmail)
+  // Handle OAuth redirect - request the contacts scope set (calendar + contacts)
   const handleConnectGoogle = () => {
     const returnUrl = window.location.pathname;
-    window.location.href = `/api/auth/google-calendar?type=crm&returnUrl=${encodeURIComponent(returnUrl)}`;
+    window.location.href = `/api/auth/google-calendar?type=contacts&returnUrl=${encodeURIComponent(returnUrl)}`;
   };
 
   // Handle import start
@@ -152,7 +152,7 @@ export function ImportDialog({
       closeOnEscape={step !== "progress"}
     >
       <Stack gap="lg">
-        {/* Gated: contacts/Gmail scopes are still awaiting Google verification */}
+        {/* Gated: contacts scopes are still awaiting Google verification */}
         {step === "connect" && connection?.gated && (
           <GooglePremiumFeature feature="contacts" variant="alert" />
         )}
@@ -176,8 +176,8 @@ export function ImportDialog({
               </Alert>
             ) : (
               <Text size="sm" c="dimmed">
-                Connect your Google account to import contacts from Gmail and
-                Google Calendar.
+                Connect your Google account to import contacts from Google
+                Contacts and Google Calendar.
               </Text>
             )}
 
@@ -193,12 +193,11 @@ export function ImportDialog({
                 <List size="sm" spacing="xs">
                   <List.Item>
                     <strong>Google Contacts</strong> - Read your contacts
+                    (read-only)
                   </List.Item>
                   <List.Item>
-                    <strong>Gmail</strong> - Read email metadata (read-only)
-                  </List.Item>
-                  <List.Item>
-                    <strong>Google Calendar</strong> - Read calendar events
+                    <strong>Google Calendar</strong> - View and edit calendar
+                    events, and see your list of calendars
                   </List.Item>
                 </List>
               </Stack>
@@ -242,7 +241,7 @@ export function ImportDialog({
                       <IconMail size={16} />
                       <IconCalendar size={16} />
                       <Text size="sm">
-                        <strong>Gmail & Calendar</strong> - Import from both
+                        <strong>Contacts & Calendar</strong> - Import from both
                         sources (Recommended)
                       </Text>
                     </Group>
@@ -255,12 +254,12 @@ export function ImportDialog({
                     <Group gap="xs">
                       <IconMail size={16} />
                       <Text size="sm">
-                        <strong>Gmail Contacts Only</strong> - Import from
-                        Google Contacts
+                        <strong>Google Contacts Only</strong> - Import from
+                        your saved contacts
                       </Text>
                     </Group>
                   }
-                  description="Import saved contacts from your Gmail address book"
+                  description="Import saved contacts from your Google Contacts address book"
                 />
                 <Radio
                   value="CALENDAR"

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/_components/ImportDialog.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/_components/ImportDialog.tsx
@@ -11,7 +11,6 @@ import {
   Progress,
   Badge,
   Alert,
-  List,
   Divider,
   Paper,
 } from "@mantine/core";
@@ -21,13 +20,11 @@ import {
   IconMail,
   IconAlertCircle,
   IconCheck,
-  IconBrandGoogle,
 } from "@tabler/icons-react";
 import { api } from "~/trpc/react";
 import { notifications } from "@mantine/notifications";
 import { subMonths, subYears } from "date-fns";
 import { GooglePremiumFeature } from "~/app/_components/GooglePremiumFeature";
-import { getGoogleAuthUrl } from "~/lib/googleScopes";
 
 interface ImportDialogProps {
   opened: boolean;
@@ -118,11 +115,6 @@ export function ImportDialog({
     onClose();
   };
 
-  // Handle OAuth redirect - request the contacts scope set (calendar + contacts)
-  const handleConnectGoogle = () => {
-    window.location.href = getGoogleAuthUrl("contacts", window.location.pathname);
-  };
-
   // Handle import start
   const handleStartImport = () => {
     importMutation.mutate({
@@ -152,72 +144,13 @@ export function ImportDialog({
       closeOnEscape={step !== "progress"}
     >
       <Stack gap="lg">
-        {/* Gated: contacts scopes are still awaiting Google verification */}
-        {step === "connect" && connection?.gated && (
+        {/* Connect step: there is deliberately no connect button. Requesting
+            the contacts scope is paused while Google's OAuth verification is
+            in progress (see googleScopes.ts), so new grants cannot be
+            started — only accounts that already granted access can import,
+            and those skip straight to the options step. */}
+        {step === "connect" && (
           <GooglePremiumFeature feature="contacts" variant="alert" />
-        )}
-
-        {/* Connect Step */}
-        {step === "connect" && !connection?.gated && (
-          <>
-            {connection?.connected && (!connection.hasAllScopes || !connection.hasRefreshToken) ? (
-              <Alert icon={<IconAlertCircle />} color="yellow" mb="md">
-                <Stack gap="xs">
-                  <Text size="sm" fw={500}>
-                    Additional permissions required
-                  </Text>
-                  <Text size="sm">
-                    {!connection.hasRefreshToken
-                      ? "Your Google connection is missing the refresh token needed for importing contacts. "
-                      : "Your Google account needs additional permissions to import contacts. "}
-                    Please reconnect to grant the required access.
-                  </Text>
-                </Stack>
-              </Alert>
-            ) : (
-              <Text size="sm" c="dimmed">
-                Connect your Google account to import contacts from Google
-                Contacts and Google Calendar.
-              </Text>
-            )}
-
-            <Paper p="md" withBorder>
-              <Stack gap="sm">
-                <Group gap="xs">
-                  <IconBrandGoogle size={20} />
-                  <Text fw={500}>Google Account</Text>
-                </Group>
-                <Text size="sm" c="dimmed">
-                  We&apos;ll request access to:
-                </Text>
-                <List size="sm" spacing="xs">
-                  <List.Item>
-                    <strong>Google Contacts</strong> - Read your contacts
-                    (read-only)
-                  </List.Item>
-                  <List.Item>
-                    <strong>Google Calendar</strong> - View and edit calendar
-                    events, and see your list of calendars
-                  </List.Item>
-                </List>
-              </Stack>
-            </Paper>
-
-            <Alert icon={<IconAlertCircle />} color="blue">
-              Your data is encrypted and stored securely. We only access
-              information necessary for contact management.
-            </Alert>
-
-            <Button
-              leftSection={<IconBrandGoogle />}
-              onClick={handleConnectGoogle}
-              loading={connectionLoading}
-            >
-              {connection?.connected
-                ? "Reconnect Google Account"
-                : "Connect Google Account"}
-            </Button>
-          </>
         )}
 
         {/* Options Step */}

--- a/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/page.tsx
+++ b/src/app/(sidemenu)/w/[workspaceSlug]/crm/contacts/page.tsx
@@ -377,7 +377,7 @@ export default function ContactsPage() {
                 leftSection={<IconUpload size={14} />}
                 onClick={openImportDialog}
               >
-                Import contacts from Gmail/Calendar
+                Import contacts from Google Contacts/Calendar
               </Menu.Item>
               <Menu.Item leftSection={<IconDownload size={14} />}>
                 Export to CSV

--- a/src/app/api/auth/google-calendar/callback/route.ts
+++ b/src/app/api/auth/google-calendar/callback/route.ts
@@ -7,6 +7,9 @@ import { headers } from "next/headers";
 interface OAuthState {
   userId: string;
   returnUrl: string;
+  // "contacts" is retained even though no live flow starts a contacts request
+  // anymore: state round-trips through Google, so a consent begun before a
+  // deploy can still land here carrying the old value.
   scopeType?: "calendar" | "contacts";
 }
 

--- a/src/app/api/auth/google-calendar/callback/route.ts
+++ b/src/app/api/auth/google-calendar/callback/route.ts
@@ -7,7 +7,7 @@ import { headers } from "next/headers";
 interface OAuthState {
   userId: string;
   returnUrl: string;
-  scopeType?: "calendar" | "contacts" | "crm";
+  scopeType?: "calendar" | "contacts";
 }
 
 function parseState(state: string | null): OAuthState | null {
@@ -197,7 +197,7 @@ export async function GET(request: NextRequest) {
         console.log("✅ Created new Google calendar connection");
       }
     } else {
-      // CRM / contacts flow → legacy Account path (unchanged). Account also
+      // Contacts (CRM import) flow → legacy Account path (unchanged). Account also
       // backs sign-in, so its (provider, providerAccountId) is globally unique
       // and we never reassign it across users.
       const existingAccount = await db.account.findUnique({
@@ -235,7 +235,7 @@ export async function GET(request: NextRequest) {
           where: { id: existingAccount.id },
           data: updateData,
         });
-        console.log("✅ Updated existing Google account (CRM scopes)");
+        console.log("✅ Updated existing Google account (contacts scopes)");
       } else {
         if (!tokens.refresh_token) {
           console.error("❌ Cannot create Google account without refresh token!");
@@ -255,7 +255,7 @@ export async function GET(request: NextRequest) {
             providerEmail: googleUserInfo.email,
           },
         });
-        console.log("✅ Created new Google account record (CRM scopes)");
+        console.log("✅ Created new Google account record (contacts scopes)");
       }
     }
 

--- a/src/app/api/auth/google-calendar/route.ts
+++ b/src/app/api/auth/google-calendar/route.ts
@@ -12,15 +12,13 @@ import type { GooglePremiumFeatureKind } from "~/types/google";
 /**
  * Which explainer a gated user sees per scope set. Exhaustive over
  * `GOOGLE_SCOPE_SETS`, so adding a scope set is a type error here rather than
- * a silent fallback that shows the wrong copy. `contacts` is only ever
- * started from the CRM contact-import flow.
+ * a silent fallback that shows the wrong copy.
  */
 const GATED_FEATURE_BY_SCOPE_TYPE: Record<
   GoogleScopeType,
   GooglePremiumFeatureKind
 > = {
   calendar: "calendar",
-  contacts: "contacts",
 };
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/auth/google-calendar/route.ts
+++ b/src/app/api/auth/google-calendar/route.ts
@@ -12,8 +12,8 @@ import type { GooglePremiumFeatureKind } from "~/types/google";
 /**
  * Which explainer a gated user sees per scope set. Exhaustive over
  * `GOOGLE_SCOPE_SETS`, so adding a scope set is a type error here rather than
- * a silent fallback that shows the wrong copy. `crm` bundles contacts + Gmail
- * and is only ever started from the contact-import flow.
+ * a silent fallback that shows the wrong copy. `contacts` is only ever
+ * started from the CRM contact-import flow.
  */
 const GATED_FEATURE_BY_SCOPE_TYPE: Record<
   GoogleScopeType,
@@ -21,7 +21,6 @@ const GATED_FEATURE_BY_SCOPE_TYPE: Record<
 > = {
   calendar: "calendar",
   contacts: "contacts",
-  crm: "contacts",
 };
 
 export async function GET(request: NextRequest) {

--- a/src/lib/__tests__/googleAuth.test.ts
+++ b/src/lib/__tests__/googleAuth.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for checkGoogleScopes — verifies the helper aggregates scopes
  * across MULTIPLE Google accounts. The motivating bug: a user connects a
  * second, calendar-only Google account and it must NOT hide the calendar/
- * contacts/Gmail scopes already granted on their first account.
+ * contacts scopes already granted on their first account.
  *
  * `~/server/db` is mocked so this stays a pure, DB-free unit test (per
  * CLAUDE.md "Test database safety").
@@ -27,7 +27,10 @@ import {
 
 const CAL = GOOGLE_SCOPES.CALENDAR;
 const CONTACTS = GOOGLE_SCOPES.CONTACTS;
-const GMAIL = GOOGLE_SCOPES.GMAIL;
+// A third, distinct scope for split-across-accounts scenarios. Not in
+// GOOGLE_SCOPES because no feature checks for it individually — it is only
+// requested alongside CALENDAR as part of the calendar scope set.
+const CAL_LIST = "https://www.googleapis.com/auth/calendar.calendarlist.readonly";
 
 describe("checkGoogleScopes (multi-account)", () => {
   beforeEach(() => {
@@ -48,24 +51,24 @@ describe("checkGoogleScopes (multi-account)", () => {
   });
 
   it("is satisfied when a SECOND account carries the required scope", async () => {
-    // Account A is calendar-only; account B has the CRM scopes.
+    // Account A is calendar-only; account B has the contacts scopes.
     findMany.mockResolvedValue([
       { scope: CAL },
-      { scope: `${CAL} ${CONTACTS} ${GMAIL}` },
+      { scope: `${CAL} ${CAL_LIST} ${CONTACTS}` },
     ]);
-    const result = await checkGoogleScopes("u1", [GMAIL]);
+    const result = await checkGoogleScopes("u1", [CONTACTS]);
     expect(result.hasScopes).toBe(true);
-    expect(result.currentScopes).toContain(GMAIL);
+    expect(result.currentScopes).toContain(CONTACTS);
   });
 
   it("requires ALL requested scopes to live on a SINGLE account", async () => {
-    // Gmail and contacts are split across two accounts — neither alone
-    // satisfies a request for both, so it must report false.
+    // The calendar-list and contacts scopes are split across two accounts —
+    // neither alone satisfies a request for both, so it must report false.
     findMany.mockResolvedValue([
       { scope: `${CAL} ${CONTACTS}` },
-      { scope: `${CAL} ${GMAIL}` },
+      { scope: `${CAL} ${CAL_LIST}` },
     ]);
-    const both = await checkGoogleScopes("u1", [CONTACTS, GMAIL]);
+    const both = await checkGoogleScopes("u1", [CONTACTS, CAL_LIST]);
     expect(both.hasScopes).toBe(false);
     // Falls back to the broadest account's scopes for context.
     expect(both.currentScopes.length).toBeGreaterThan(0);
@@ -73,7 +76,7 @@ describe("checkGoogleScopes (multi-account)", () => {
 
   it("returns false when no account has the scope, exposing broadest scopes", async () => {
     findMany.mockResolvedValue([{ scope: CAL }, { scope: `${CAL} ${CONTACTS}` }]);
-    const result = await checkGoogleScopes("u1", [GMAIL]);
+    const result = await checkGoogleScopes("u1", [CAL_LIST]);
     expect(result.hasScopes).toBe(false);
     expect(result.currentScopes).toEqual([CAL, CONTACTS]);
   });

--- a/src/lib/googleAuth.ts
+++ b/src/lib/googleAuth.ts
@@ -11,9 +11,14 @@ import { db } from "~/server/db";
  * Google OAuth scope sets for incremental authorization.
  *
  * We use incremental authorization to minimize permissions requested during onboarding:
- * - "calendar": Only calendar access (sensitive scope, faster Google verification)
- * - "contacts": Calendar + Contacts (sensitive scopes)
- * - "crm": Calendar + Contacts + Gmail (includes restricted scope, requires security audit)
+ * - "calendar": Only calendar access (sensitive scopes)
+ * - "contacts": Calendar + Contacts, for the CRM contact import (sensitive scopes)
+ *
+ * Google's OAuth verification requires a STRICT string match between the
+ * scopes the app requests in its authorization URIs and the scopes registered
+ * on the Cloud Console consent screen (Data Access) — the review fails when
+ * they diverge by even one scope. Any change to these sets must be mirrored
+ * in the Console configuration and re-demonstrated to Google.
  */
 /**
  * Identity scopes requested alongside every set. Without these the
@@ -30,13 +35,16 @@ const GOOGLE_IDENTITY_SCOPES = [
   "https://www.googleapis.com/auth/userinfo.profile",
 ] as const;
 
-// Calendar access. `calendar.events` grants read/write of events on any
-// calendar the user can access, but it does NOT permit `calendarList.list`
-// (listing the user's calendars) — that needs `calendar.readonly`. The
-// multi-calendar sidebar lists calendars per account, so both are required.
+// Calendar access, kept to the narrowest granular scopes that cover the two
+// Calendar API surfaces the app uses. `calendar.events` grants read/write of
+// events on any calendar the user can access (events.list / events.insert),
+// but it does NOT permit `calendarList.list` — the multi-calendar sidebar
+// needs `calendar.calendarlist.readonly` to enumerate the user's calendars.
+// The broad `calendar.readonly` ("see and download any calendar") is
+// deliberately NOT requested: Google's least-privilege review rejected it.
 const GOOGLE_CALENDAR_SCOPES = [
   "https://www.googleapis.com/auth/calendar.events",
-  "https://www.googleapis.com/auth/calendar.readonly",
+  "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
 ] as const;
 
 export const GOOGLE_SCOPE_SETS = {
@@ -49,19 +57,13 @@ export const GOOGLE_SCOPE_SETS = {
     ...GOOGLE_CALENDAR_SCOPES,
     "https://www.googleapis.com/auth/contacts.readonly",
   ],
-  crm: [
-    ...GOOGLE_IDENTITY_SCOPES,
-    ...GOOGLE_CALENDAR_SCOPES,
-    "https://www.googleapis.com/auth/contacts.readonly",
-    "https://www.googleapis.com/auth/gmail.readonly",
-  ],
 } as const;
 
 export type GoogleScopeType = keyof typeof GOOGLE_SCOPE_SETS;
 
 /**
  * Whether this user may use the Google features that depend on scopes Google
- * has not verified yet (calendar, contacts, Gmail).
+ * has not verified yet (calendar, contacts).
  *
  * Verification for those scopes is still pending, so only the accounts
  * registered as test users on the Google Cloud Console project can actually
@@ -90,12 +92,16 @@ export function isGoogleOAuthTester(email: string | null | undefined): boolean {
 }
 
 /**
- * Individual Google OAuth scopes used in the application
+ * Individual Google OAuth scopes used in the application.
+ *
+ * No Gmail scope on purpose: the app has no Gmail API integration (email sync
+ * is IMAP-based via app passwords), and `gmail.readonly` is a RESTRICTED
+ * scope whose verification requires a CASA security assessment. Do not add it
+ * back without a feature that actually calls the Gmail API.
  */
 export const GOOGLE_SCOPES = {
   CALENDAR: "https://www.googleapis.com/auth/calendar.events",
   CONTACTS: "https://www.googleapis.com/auth/contacts.readonly",
-  GMAIL: "https://www.googleapis.com/auth/gmail.readonly",
 } as const;
 
 /**
@@ -157,21 +163,13 @@ export async function hasContactsAccess(userId: string): Promise<boolean> {
 }
 
 /**
- * Check if user has Gmail access (for CRM email sync)
- */
-export async function hasGmailAccess(userId: string): Promise<boolean> {
-  const { hasScopes } = await checkGoogleScopes(userId, [GOOGLE_SCOPES.GMAIL]);
-  return hasScopes;
-}
-
-/**
  * Get the OAuth URL for requesting additional scopes
  *
  * @param scopeType - The scope set to request
  * @param returnUrl - Where to redirect after authorization
  */
 export function getGoogleAuthUrl(
-  scopeType: "calendar" | "contacts" | "crm",
+  scopeType: GoogleScopeType,
   returnUrl: string
 ): string {
   const params = new URLSearchParams({

--- a/src/lib/googleAuth.ts
+++ b/src/lib/googleAuth.ts
@@ -3,63 +3,18 @@
  *
  * This module provides helpers to check which Google scopes a user has authorized,
  * enabling incremental authorization where we only request permissions as needed.
+ *
+ * The scope registry itself lives in `./googleScopes` (pure constants, safe
+ * for client components); it is re-exported here so server code keeps a
+ * single import path.
  */
 
 import { db } from "~/server/db";
+import { GOOGLE_SCOPES } from "./googleScopes";
 
-/**
- * Google OAuth scope sets for incremental authorization.
- *
- * We use incremental authorization to minimize permissions requested during onboarding:
- * - "calendar": Only calendar access (sensitive scopes)
- * - "contacts": Calendar + Contacts, for the CRM contact import (sensitive scopes)
- *
- * Google's OAuth verification requires a STRICT string match between the
- * scopes the app requests in its authorization URIs and the scopes registered
- * on the Cloud Console consent screen (Data Access) — the review fails when
- * they diverge by even one scope. Any change to these sets must be mirrored
- * in the Console configuration and re-demonstrated to Google.
- */
-/**
- * Identity scopes requested alongside every set. Without these the
- * `oauth2/v2/userinfo` call returns 401, so the OAuth callback can't read the
- * Google account id/email it needs to upsert the Account by
- * (provider, providerAccountId). These are non-sensitive and don't affect
- * Google's verification tier. They also make the calendar account's
- * providerAccountId match the one stored at NextAuth sign-in, so reconnecting
- * dedupes onto the same row instead of creating a duplicate.
- */
-const GOOGLE_IDENTITY_SCOPES = [
-  "openid",
-  "https://www.googleapis.com/auth/userinfo.email",
-  "https://www.googleapis.com/auth/userinfo.profile",
-] as const;
-
-// Calendar access, kept to the narrowest granular scopes that cover the two
-// Calendar API surfaces the app uses. `calendar.events` grants read/write of
-// events on any calendar the user can access (events.list / events.insert),
-// but it does NOT permit `calendarList.list` — the multi-calendar sidebar
-// needs `calendar.calendarlist.readonly` to enumerate the user's calendars.
-// The broad `calendar.readonly` ("see and download any calendar") is
-// deliberately NOT requested: Google's least-privilege review rejected it.
-const GOOGLE_CALENDAR_SCOPES = [
-  "https://www.googleapis.com/auth/calendar.events",
-  "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
-] as const;
-
-export const GOOGLE_SCOPE_SETS = {
-  calendar: [
-    ...GOOGLE_IDENTITY_SCOPES,
-    ...GOOGLE_CALENDAR_SCOPES,
-  ],
-  contacts: [
-    ...GOOGLE_IDENTITY_SCOPES,
-    ...GOOGLE_CALENDAR_SCOPES,
-    "https://www.googleapis.com/auth/contacts.readonly",
-  ],
-} as const;
-
-export type GoogleScopeType = keyof typeof GOOGLE_SCOPE_SETS;
+export { GOOGLE_SCOPE_SETS, getGoogleAuthUrl } from "./googleScopes";
+export type { GoogleScopeType } from "./googleScopes";
+export { GOOGLE_SCOPES };
 
 /**
  * Whether this user may use the Google features that depend on scopes Google
@@ -90,19 +45,6 @@ export function isGoogleOAuthTester(email: string | null | undefined): boolean {
     .filter((entry) => entry.length > 0)
     .includes(normalized);
 }
-
-/**
- * Individual Google OAuth scopes used in the application.
- *
- * No Gmail scope on purpose: the app has no Gmail API integration (email sync
- * is IMAP-based via app passwords), and `gmail.readonly` is a RESTRICTED
- * scope whose verification requires a CASA security assessment. Do not add it
- * back without a feature that actually calls the Gmail API.
- */
-export const GOOGLE_SCOPES = {
-  CALENDAR: "https://www.googleapis.com/auth/calendar.events",
-  CONTACTS: "https://www.googleapis.com/auth/contacts.readonly",
-} as const;
 
 /**
  * Check if a user has authorized specific Google scopes.
@@ -160,21 +102,4 @@ export async function hasCalendarAccess(userId: string): Promise<boolean> {
 export async function hasContactsAccess(userId: string): Promise<boolean> {
   const { hasScopes } = await checkGoogleScopes(userId, [GOOGLE_SCOPES.CONTACTS]);
   return hasScopes;
-}
-
-/**
- * Get the OAuth URL for requesting additional scopes
- *
- * @param scopeType - The scope set to request
- * @param returnUrl - Where to redirect after authorization
- */
-export function getGoogleAuthUrl(
-  scopeType: GoogleScopeType,
-  returnUrl: string
-): string {
-  const params = new URLSearchParams({
-    type: scopeType,
-    returnUrl,
-  });
-  return `/api/auth/google-calendar?${params.toString()}`;
 }

--- a/src/lib/googleScopes.ts
+++ b/src/lib/googleScopes.ts
@@ -1,0 +1,89 @@
+/**
+ * Google OAuth scope registry — pure constants and URL helpers, safe to
+ * import from client components (no server imports; `~/lib/googleAuth`
+ * layers the db-backed helpers on top and re-exports everything here).
+ *
+ * Google's OAuth verification requires a STRICT string match between the
+ * scopes the app requests in its authorization URIs and the scopes registered
+ * on the Cloud Console consent screen (Data Access) — the review fails when
+ * they diverge by even one scope. Any change to these sets must be mirrored
+ * in the Console configuration and re-demonstrated to Google.
+ */
+
+/**
+ * Identity scopes requested alongside every set. Without these the
+ * `oauth2/v2/userinfo` call returns 401, so the OAuth callback can't read the
+ * Google account id/email it needs to upsert the Account by
+ * (provider, providerAccountId). These are non-sensitive and don't affect
+ * Google's verification tier. They also make the calendar account's
+ * providerAccountId match the one stored at NextAuth sign-in, so reconnecting
+ * dedupes onto the same row instead of creating a duplicate.
+ */
+const GOOGLE_IDENTITY_SCOPES = [
+  "openid",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/userinfo.profile",
+] as const;
+
+// Calendar access, kept to the narrowest granular scopes that cover the two
+// Calendar API surfaces the app uses. `calendar.events` grants read/write of
+// events on any calendar the user can access (events.list / events.insert),
+// but it does NOT permit `calendarList.list` — the multi-calendar sidebar
+// needs `calendar.calendarlist.readonly` to enumerate the user's calendars.
+// The broad `calendar.readonly` ("see and download any calendar") is
+// deliberately NOT requested: Google's least-privilege review rejected it.
+const GOOGLE_CALENDAR_SCOPES = [
+  "https://www.googleapis.com/auth/calendar.events",
+  "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+] as const;
+
+/**
+ * Google OAuth scope sets for incremental authorization.
+ *
+ * We use incremental authorization to minimize permissions requested during onboarding:
+ * - "calendar": Only calendar access (sensitive scopes)
+ * - "contacts": Calendar + Contacts, for the CRM contact import (sensitive scopes)
+ */
+export const GOOGLE_SCOPE_SETS = {
+  calendar: [
+    ...GOOGLE_IDENTITY_SCOPES,
+    ...GOOGLE_CALENDAR_SCOPES,
+  ],
+  contacts: [
+    ...GOOGLE_IDENTITY_SCOPES,
+    ...GOOGLE_CALENDAR_SCOPES,
+    "https://www.googleapis.com/auth/contacts.readonly",
+  ],
+} as const;
+
+export type GoogleScopeType = keyof typeof GOOGLE_SCOPE_SETS;
+
+/**
+ * Individual Google OAuth scopes used in the application.
+ *
+ * No Gmail scope on purpose: the app has no Gmail API integration (email sync
+ * is IMAP-based via app passwords), and `gmail.readonly` is a RESTRICTED
+ * scope whose verification requires a CASA security assessment. Do not add it
+ * back without a feature that actually calls the Gmail API.
+ */
+export const GOOGLE_SCOPES = {
+  CALENDAR: "https://www.googleapis.com/auth/calendar.events",
+  CONTACTS: "https://www.googleapis.com/auth/contacts.readonly",
+} as const;
+
+/**
+ * Get the OAuth URL for requesting additional scopes
+ *
+ * @param scopeType - The scope set to request
+ * @param returnUrl - Where to redirect after authorization
+ */
+export function getGoogleAuthUrl(
+  scopeType: GoogleScopeType,
+  returnUrl: string
+): string {
+  const params = new URLSearchParams({
+    type: scopeType,
+    returnUrl,
+  });
+  return `/api/auth/google-calendar?${params.toString()}`;
+}

--- a/src/lib/googleScopes.ts
+++ b/src/lib/googleScopes.ts
@@ -40,19 +40,23 @@ const GOOGLE_CALENDAR_SCOPES = [
 /**
  * Google OAuth scope sets for incremental authorization.
  *
- * We use incremental authorization to minimize permissions requested during onboarding:
- * - "calendar": Only calendar access (sensitive scopes)
- * - "contacts": Calendar + Contacts, for the CRM contact import (sensitive scopes)
+ * "calendar" (identity + the two calendar scopes) is currently the ONLY set —
+ * it is exactly what is registered on the Cloud Console consent screen and
+ * what the verification demo shows.
+ *
+ * There is deliberately no "contacts" set: `contacts.readonly` is not part of
+ * the current Google verification, and the app must not request any scope the
+ * Console doesn't register (the repo is public, and Google's reviewers
+ * compare the codebase against the Console). To re-enable the CRM contact
+ * import for new grants: add a `contacts` set here ([...GOOGLE_IDENTITY_SCOPES,
+ * ...GOOGLE_CALENDAR_SCOPES, GOOGLE_SCOPES.CONTACTS]), restore the connect
+ * button in the CRM ImportDialog, register the scope in the Console, and
+ * re-submit for verification with an updated demo video.
  */
 export const GOOGLE_SCOPE_SETS = {
   calendar: [
     ...GOOGLE_IDENTITY_SCOPES,
     ...GOOGLE_CALENDAR_SCOPES,
-  ],
-  contacts: [
-    ...GOOGLE_IDENTITY_SCOPES,
-    ...GOOGLE_CALENDAR_SCOPES,
-    "https://www.googleapis.com/auth/contacts.readonly",
   ],
 } as const;
 
@@ -60,6 +64,10 @@ export type GoogleScopeType = keyof typeof GOOGLE_SCOPE_SETS;
 
 /**
  * Individual Google OAuth scopes used in the application.
+ *
+ * CONTACTS is check-only: it appears in no scope set above, so the app never
+ * REQUESTS it — it exists to recognise accounts that granted it before the
+ * verification freeze, which keeps the CRM import working for them.
  *
  * No Gmail scope on purpose: the app has no Gmail API integration (email sync
  * is IMAP-based via app passwords), and `gmail.readonly` is a RESTRICTED

--- a/src/server/api/routers/calendar.ts
+++ b/src/server/api/routers/calendar.ts
@@ -5,7 +5,7 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { GoogleCalendarService } from "~/server/services/GoogleCalendarService";
 import { MicrosoftCalendarService } from "~/server/services/MicrosoftCalendarService";
 import type { CalendarInfo, CalendarProvider } from "~/server/services/CalendarProvider";
-import { isGoogleOAuthTester } from "~/lib/googleAuth";
+import { GOOGLE_SCOPES, isGoogleOAuthTester } from "~/lib/googleAuth";
 import { encryptToBase64 } from "~/server/utils/encryption";
 import { syncFeed } from "~/server/services/calendar/CalendarSyncService";
 import { assertSafeFeedUrl, UnsafeFeedUrlError } from "~/server/services/calendar/feedUrlGuard";
@@ -57,7 +57,7 @@ function isGoogleCalendarGated(
 function calendarScopeFor(accountProvider: string): string {
   return accountProvider === "microsoft-entra-id"
     ? "Calendars.Read"
-    : "https://www.googleapis.com/auth/calendar.events";
+    : GOOGLE_SCOPES.CALENDAR;
 }
 
 /** Whether an account currently has a usable (scoped + non-expired-or-refreshable) calendar connection */

--- a/src/server/api/routers/crmContact.ts
+++ b/src/server/api/routers/crmContact.ts
@@ -12,7 +12,7 @@ import {
   enqueueContactEnrichment,
 } from "~/server/services/crm/enrichment/dispatchContactEnrichment";
 import { uploadToBlob, deleteFromBlob } from "~/lib/blob";
-import { isGoogleOAuthTester } from "~/lib/googleAuth";
+import { GOOGLE_SCOPES, isGoogleOAuthTester } from "~/lib/googleAuth";
 
 // Workspace roles allowed to spend enrichment budget (a paid web search + LLM
 // call per run). Viewers and project-only "guests" are excluded (ADR-0036).
@@ -1332,13 +1332,9 @@ export const crmContactRouter = createTRPCRouter({
         };
       }
 
-      // Check if account has all required scopes. Must stay a subset of
-      // GOOGLE_SCOPE_SETS.contacts — the set the import dialog's connect
-      // button actually requests — or hasAllScopes can never become true.
-      const requiredScopes = [
-        "https://www.googleapis.com/auth/calendar.events",
-        "https://www.googleapis.com/auth/contacts.readonly",
-      ];
+      // Check if account has all the scopes the import dialog's connect
+      // button requests (GOOGLE_SCOPE_SETS.contacts, minus identity scopes).
+      const requiredScopes = [GOOGLE_SCOPES.CALENDAR, GOOGLE_SCOPES.CONTACTS];
 
       const hasAllScopes = GoogleTokenManager.hasRequiredScopes(
         connection,

--- a/src/server/api/routers/crmContact.ts
+++ b/src/server/api/routers/crmContact.ts
@@ -1299,7 +1299,7 @@ export const crmContactRouter = createTRPCRouter({
         });
       }
 
-      // Contacts/Gmail scopes are still awaiting Google verification, so for
+      // Contacts scopes are still awaiting Google verification, so for
       // non-testers report the integration as unavailable rather than probing
       // for a connection they could never have completed.
       if (!isGoogleOAuthTester(ctx.session.user.email)) {
@@ -1332,11 +1332,12 @@ export const crmContactRouter = createTRPCRouter({
         };
       }
 
-      // Check if account has all required scopes
+      // Check if account has all required scopes. Must stay a subset of
+      // GOOGLE_SCOPE_SETS.contacts — the set the import dialog's connect
+      // button actually requests — or hasAllScopes can never become true.
       const requiredScopes = [
         "https://www.googleapis.com/auth/calendar.events",
         "https://www.googleapis.com/auth/contacts.readonly",
-        "https://www.googleapis.com/auth/gmail.readonly",
       ];
 
       const hasAllScopes = GoogleTokenManager.hasRequiredScopes(

--- a/src/server/api/routers/crmContact.ts
+++ b/src/server/api/routers/crmContact.ts
@@ -1332,8 +1332,10 @@ export const crmContactRouter = createTRPCRouter({
         };
       }
 
-      // Check if account has all the scopes the import dialog's connect
-      // button requests (GOOGLE_SCOPE_SETS.contacts, minus identity scopes).
+      // Check if account has all the scopes the Google import needs. The app
+      // no longer REQUESTS contacts.readonly (paused pending Google
+      // verification — see googleScopes.ts), so only accounts that granted
+      // it before the freeze can import.
       const requiredScopes = [GOOGLE_SCOPES.CALENDAR, GOOGLE_SCOPES.CONTACTS];
 
       const hasAllScopes = GoogleTokenManager.hasRequiredScopes(

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -7,7 +7,7 @@ import { isGoogleOAuthTester } from "~/lib/googleAuth";
 export const userRouter = createTRPCRouter({
   /**
    * Whether this user may use the Google features whose scopes Google has not
-   * verified yet (calendar, contacts, Gmail). The UI uses this to show the
+   * verified yet (calendar, contacts). The UI uses this to show the
    * "premium feature" message instead of connect buttons that would dead-end
    * on Google's unverified-app screen. Google *sign-in* is not affected.
    */

--- a/src/server/services/GoogleContactsService.ts
+++ b/src/server/services/GoogleContactsService.ts
@@ -1,5 +1,6 @@
 import { GoogleTokenManager } from "./GoogleTokenManager";
 import { google } from "googleapis";
+import { GOOGLE_SCOPES } from "~/lib/googleAuth";
 
 export interface GoogleContact {
   resourceName: string;
@@ -76,7 +77,7 @@ export class GoogleContactsService {
   ): Promise<{ contacts: GoogleContact[]; nextPageToken?: string }> {
     const accessToken = await GoogleTokenManager.getValidAccessToken(
       userId,
-      "https://www.googleapis.com/auth/contacts.readonly",
+      GOOGLE_SCOPES.CONTACTS,
     );
 
     const people = google.people({ version: "v1" });
@@ -129,7 +130,7 @@ export class GoogleContactsService {
   ): Promise<GoogleCalendarEvent[]> {
     const accessToken = await GoogleTokenManager.getValidAccessToken(
       userId,
-      "https://www.googleapis.com/auth/calendar.events",
+      GOOGLE_SCOPES.CALENDAR,
     );
 
     const oauth2Client = new google.auth.OAuth2(

--- a/src/server/services/GoogleTokenManager.ts
+++ b/src/server/services/GoogleTokenManager.ts
@@ -22,7 +22,7 @@ interface GoogleAccountRow {
 /**
  * Choose which Google account to use when a user has connected more than one.
  * Prefers (in order): an account that has the required scope, an account with a
- * refresh token, then the account granting the most scopes. This keeps Gmail/CRM
+ * refresh token, then the account granting the most scopes. This keeps CRM
  * features working even after the user adds a calendar-only second Google account.
  */
 function pickBestGoogleAccount<T extends GoogleAccountRow>(

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -5,6 +5,7 @@ import { listMeetingCalendarEvents } from './calendar/meetingEventRead';
 import type { CalendarProvider } from './CalendarProvider';
 import type { PrismaClient } from '@prisma/client';
 import { db } from '~/server/db';
+import { GOOGLE_SCOPES } from '~/lib/googleAuth';
 
 const googleService = new GoogleCalendarService();
 const microsoftService = new MicrosoftCalendarService();
@@ -63,7 +64,7 @@ export async function checkProviderConnection(
 ): Promise<{ isConnected: boolean; hasCalendarScope: boolean }> {
   const providerName = provider === 'google' ? 'google' : 'microsoft-entra-id';
   const requiredScope = provider === 'google'
-    ? 'https://www.googleapis.com/auth/calendar.events'
+    ? GOOGLE_SCOPES.CALENDAR
     : 'Calendars.Read';
 
   const account = await db.account.findFirst({


### PR DESCRIPTION
## Why

Google's OAuth verification failed (review email, Aug 11) because the scopes the app requests must be a **strict string match** with the scopes registered in the Cloud Console, and they weren't:

| | Scopes |
|---|---|
| Requested by code (before) | `calendar.events`, `calendar.readonly` |
| Configured in Console | `calendar.events`, `calendar.events.readonly` |

Matching the Console verbatim was not an option: `calendar.events.readonly` is a redundant subset of `calendar.events` (violates the least-privilege rule the reviewer cited), and neither scope permits `calendarList.list`, which the multi-calendar sidebar depends on. The correct granular pair, verified against Google's Calendar API reference, is:

```
https://www.googleapis.com/auth/calendar.events
https://www.googleapis.com/auth/calendar.calendarlist.readonly
```

These cover the app's entire Calendar API surface: `events.list`, `events.insert`, `calendarList.list`.

## What changed

- **`src/lib/googleAuth.ts`** (single scope registry): `calendar.readonly` → `calendar.calendarlist.readonly`, with a comment explaining the strict-match constraint.
- **`gmail.readonly` removed everywhere.** The audit found zero Gmail API usage in this repo or the mastra repo (email sync is IMAP/app-password based) — yet the CRM import flow requested this *restricted* scope, which would have failed the next review round and triggered a CASA audit requirement. The `crm` scope set collapses into `contacts`; the import dialog now requests `type=contacts`.
- **CRM connection check** no longer demands the Gmail scope (`hasAllScopes` could never become true again otherwise).
- **Import dialog copy** no longer promises "Gmail – Read email metadata"; the permission list now mirrors the real consent screen.
- **`/privacy`**: new "AI Features and Google User Data" section with the affirmative Limited Use statement required by the Workspace API User Data and Developer Policy.

Existing tester grants keep working: old tokens hold `calendar.readonly` (a superset of the new pair) and connection checks key off `calendar.events`, which is unchanged.

## Verification

- Repo-wide `tsc --noEmit` clean; ESLint clean; all 3065 unit tests pass.
- Live end-to-end check: seeded the dev fixture, minted a session, ran the dev server with the fixture allowlisted in `GOOGLE_OAUTH_TESTER_EMAILS`, and decoded the actual `accounts.google.com` redirect. `type=calendar` requests exactly `openid userinfo.email userinfo.profile calendar.events calendar.calendarlist.readonly`; `type=contacts` adds only `contacts.readonly`; a stale `type=crm` link falls back to the calendar set. No Gmail scope anywhere.
- `/privacy` renders the new Limited Use section.

## After merge (outside the repo)

1. Cloud Console → Data Access: set exactly `calendar.events`, `calendar.calendarlist.readonly` (+ `contacts.readonly` only if submitting CRM import for verification now); **remove `calendar.events.readonly`**.
2. Re-record the demo video against production showing each configured scope in use.
3. Reply to the review email with the AI-provider list (OpenAI API, Anthropic API — neither trains on API data; Mastra is self-hosted orchestration) and point to the privacy-policy statement.
